### PR TITLE
Alerting: Feature toggle to disallow sending alerts externally

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -190,4 +190,5 @@ export interface FeatureToggles {
   notificationBanner?: boolean;
   dashboardRestore?: boolean;
   datasourceProxyDisableRBAC?: boolean;
+  alertingDisableSendAlertsExternal?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1282,6 +1282,15 @@ var (
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,
 		},
+		{
+			Name:              "alertingDisableSendAlertsExternal",
+			Description:       "Disables the ability to send alerts to an external Alertmanager datasource.",
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaAlertingSquad,
+			AllowSelfServe:    false,
+			HideFromDocs:      true,
+			HideFromAdminPage: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -171,3 +171,4 @@ newDashboardSharingComponent,experimental,@grafana/sharing-squad,false,false,tru
 notificationBanner,experimental,@grafana/grafana-frontend-platform,false,false,false
 dashboardRestore,experimental,@grafana/grafana-frontend-platform,false,false,false
 datasourceProxyDisableRBAC,GA,@grafana/identity-access-team,false,false,false
+alertingDisableSendAlertsExternal,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -694,4 +694,8 @@ const (
 	// FlagDatasourceProxyDisableRBAC
 	// Disables applying a plugin route&#39;s ReqAction field to authorization
 	FlagDatasourceProxyDisableRBAC = "datasourceProxyDisableRBAC"
+
+	// FlagAlertingDisableSendAlertsExternal
+	// Disables the ability to send alerts to an external Alertmanager datasource.
+	FlagAlertingDisableSendAlertsExternal = "alertingDisableSendAlertsExternal"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5,714 +5,35 @@
   "items": [
     {
       "metadata": {
-        "name": "extractFieldsNameDeduplication",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "disableNumericMetricsSortingInExpressions",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Make sure extracted field names are unique in the dataframe",
+        "description": "In server-side expressions, disable the sorting of numeric-kind metrics by their metric name or labels.",
         "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRowsPopoverMenu",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable filtering menu displayed when text of a log line is selected",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "oauthRequireSubClaim",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Require that sub claims is present in oauth tokens.",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableEnvelopeEncryption",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Disable envelope encryption (emergency only)",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiPredefinedOperations",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Adds predefined query operations to Loki query editor",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "addFieldFromCalculationStatFunctions",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Add cumulative and window functions to the add field from calculation transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedRequestLog",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Writes error logs to the request logger",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-group"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableNativeHTTPHistogram",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables native HTTP Histograms",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "ssoSettingsSAML",
-        "resourceVersion": "1715255671680",
-        "creationTimestamp": "2024-04-19T16:50:44Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-05-09 11:54:31.680389 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Use the new SSO Settings API to configure the SAML connector",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "wargamesTesting",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Placeholder feature flag for internal testing",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesNewFormStyling",
-        "resourceVersion": "1715590364201",
-        "creationTimestamp": "2024-04-19T16:50:44Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-05-13 08:52:44.201182 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Applies new form styling for configuration and query editors in AWS plugins",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "aiGeneratedDashboardChanges",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable AI powered features for dashboards to auto-summary changes when saving",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "topnav",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
-        "stage": "deprecated",
-        "codeowner": "@grafana/grafana-frontend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "sqlDatasourceDatabaseSelection",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables previous SQL data source dataset dropdown behavior",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelNesting",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Allow elements nesting",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "returnToPrevious",
-        "resourceVersion": "1713870623848",
-        "creationTimestamp": "2024-04-19T16:50:44Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-04-23 11:10:23.848446 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Enables the return to previous context functionality",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiFormatQuery",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the ability to format Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "angularDeprecationUI",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Display Angular warnings in dashboards and panels",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupToNestedTableTransformation",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the group to nested table transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboards",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
-        "stage": "GA",
-        "codeowner": "@grafana/sharing-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "storage",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Configurable storage for dashboards, datasources, and resources",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusMetricEncyclopedia",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
-        "stage": "GA",
         "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerEnsureKubectlAccess",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Start an additional https handler and write kubectl options",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
         "requiresRestart": true
       }
     },
     {
       "metadata": {
-        "name": "nodeGraphDotLayout",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "lokiMetricDataplane",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Changed the layout algorithm for the node graph",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigratePiechartPanel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoNormalState",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Stop maintaining state of alerts that are not firing",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesPlaylists",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "teamHttpHeaders",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "live-service-web-worker",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "This will use a webworker thread to processes events rather than the main thread",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateTablePanel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "onPremToCloudMigrations",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "correlations",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Correlations page",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grpcServer",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Run the GRPC server",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedStorage",
-        "resourceVersion": "1714723955745",
-        "creationTimestamp": "2024-04-19T16:50:44Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-05-03 08:12:35.745103 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "SQL-based k8s storage",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolderPicker",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "editPanelCSVDragAndDrop",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables drag and drop for CSV and Excel files",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sseGroupByDatasource",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateStatPanel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableAngular",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "reportingRetries",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables rendering retries for the reporting feature",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "accessActionSets",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Introduces action sets for resource permissions",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "mysqlAnsiQuotes",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Use double quotes to escape keyword in a MySQL query",
-        "stage": "experimental",
-        "codeowner": "@grafana/search-and-storage"
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbBackendMigration",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Query InfluxDB InfluxQL without the proxy",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiSecondary",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsVariableSupport",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Allows using variables in transformations",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiStructuredMetadata",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the loki data source to request structured metadata from the Loki server",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "managedPluginsInstall",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Install managed plugins directly from plugins catalog",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemotePrimary",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "regressionTransformation",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables regression analysis transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateGraphPanel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSSEDataplane",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Disables dataplane specific processing in server side expressions.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableElasticsearchBackendQuerying",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
+        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
         "stage": "GA",
         "codeowner": "@grafana/observability-logs",
         "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "flameGraphItemCollapsing",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Allow collapsing of flame graph items",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxqlStreamingParser",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
       }
     },
     {
       "metadata": {
         "name": "dataplaneFrontendFallback",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
         "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
@@ -724,309 +45,35 @@
     },
     {
       "metadata": {
-        "name": "pluginsFrontendSandbox",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "traceQLStreaming",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables the plugins frontend sandbox",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQueryHints",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables query hints for Loki",
+        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
         "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
+        "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "autoMigrateWorldmapPanel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "returnToPrevious",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolders",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable folder nesting",
+        "description": "Enables the return to previous context functionality",
         "stage": "GA",
-        "codeowner": "@grafana/search-and-storage"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableDatagridEditing",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the edit functionality in the datagrid panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureToggleAdminPage",
-        "resourceVersion": "1715364932183",
-        "creationTimestamp": "2024-04-19T16:50:44Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-05-10 18:15:32.183828 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Enable admin page for managing feature toggles from the Grafana front-end. Grafana Cloud only.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusConfigOverhaulAuth",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Update the Prometheus configuration page with the new auth component",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardScene",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using scenes for all roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsInfiniteScrolling",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesAggregator",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable grafana aggregator",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiOnly",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "faroDatasourceSelector",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
-        "stage": "preview",
-        "codeowner": "@grafana/app-o11y",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "frontendSandboxMonitorOnly",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "annotationPermissionUpdate",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Change the way annotation permissions work by scoping them to folders and dashboards.",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelFilterVariable",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupByVariable",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable groupBy variable support in scenes dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQuerySplittingConfig",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Give users the option to configure split durations for Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiLogsDataplane",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneSolo",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables rendering dashboards using scenes for solo panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "authAPIAccessTokenAuth",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the use of Auth API access tokens for authentication",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusDataplane",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusCodeModeMetricNamesSearch",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables search for metric names in Code Mode, to improve performance when working with an enormous number of metric names",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
+        "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true
       }
     },
     {
       "metadata": {
         "name": "lokiQuerySplitting",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
         "description": "Split large interval queries into subqueries with smaller time intervals",
@@ -1038,781 +85,9 @@
     },
     {
       "metadata": {
-        "name": "awsDatasourcesTempCredentials",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
-        "stage": "experimental",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerWithExperimentalAPIs",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Register experimental APIs with the k8s API server",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsSkipHostEnvVars",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Disables passing host environment variable to plugin processes",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSaveStatePeriodic",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "expressionParser",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable new expression parser",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSecretsCompatibility",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Disable duplicated secret storage in legacy tables",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchCrossAccountQuerying",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables cross-account querying in CloudWatch datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "mlExpressions",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable support for Machine Learning in server-side expressions",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalCorePlugins",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Allow core plugins to be loaded as external",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "idForwarding",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesSnapshots",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Routes snapshot requests from /api to the /apis endpoint",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusPromQAIL",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Prometheus and AI/ML to assist users in creating a query",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recordedQueriesMulti",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables writing multiple items from a single query within Recorded Queries",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsExploreTableVisualisation",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "A table visualisation for logs in Explore",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "formatString",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable format string transformer",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "ssoSettingsApi",
-        "resourceVersion": "1714649014456",
-        "creationTimestamp": "2024-04-19T16:50:44Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-05-02 11:23:34.456131 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchNewLabelParsing",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Updates CloudWatch label parsing to be more accurate",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiMetricDataplane",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingInsights",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Show the new alerting insights landing page",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsAsyncQueryCaching",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "libraryPanelRBAC",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables RBAC support for library panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAccounts",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Automatic service account and token setup for plugins",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudRBACRoles",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enabled grafana cloud specific RBAC roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sqlExpressions",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables using SQL and DuckDB functions as Expressions.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "scenes",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Experimental framework to build interactive dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiPrimary",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable a remote Loki instance as the primary source for state history reads.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsRedesign",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the transformations redesign",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recoveryThreshold",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearchInV1",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable searching for dashboards using panel title in search v1",
-        "stage": "experimental",
-        "codeowner": "@grafana/search-and-storage",
-        "requiresDevMode": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteSecondary",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboardsScene",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables public dashboard rendering using scenes",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusIncrementalQueryInstrumentation",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Adds RudderStack events to incremental queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingBacktesting",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Rule backtesting API for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsContextDatasourceUi",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Allow datasource to provide custom UI for context view",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "refactorVariablesTimeRange",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "extraThemes",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables extra themes",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "metricsSummary",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables metrics summary queries in the Tempo data source",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelMonitoring",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables panel monitoring through logs and measurements",
-        "stage": "GA",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "showDashboardValidationWarnings",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Show warnings when dashboards do not validate against the schema",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "accessControlOnCall",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Access control primitives for OnCall",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryServiceRewrite",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Rewrite requests targeting /ds/query to the query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelPanZoom",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Allow pan and zoom in canvas panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "tableSharedCrosshair",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables shared crosshair in table panel",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesFeatureToggles",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API for feature toggle management in the frontend",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureHighlights",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Highlight Grafana Enterprise features",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "datasourceQueryMultiStatus",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "scopeFilters",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables the use of scope filters in Grafana",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboardsEmailSharing",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables public dashboard sharing to be restricted to only allowed emails",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "newPDFRendering",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "New implementation for the dashboard-to-PDF rendering",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiRunQueriesInParallel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables running Loki queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryService",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Register /apis/query.grafana.app/ -- will eventually replace /api/ds/query",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchBatchQueries",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Runs CloudWatch metrics queries as separate batches",
-        "stage": "preview",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "betterPageScrolling",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearch",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Search for dashboards using panel title",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateOldPanels",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashgpt",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enable AI powered features in dashboards",
-        "stage": "GA",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneForViewers",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using Scenes for viewer roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryOverLive",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Use Grafana Live WebSocket to execute backend queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiExperimentalStreaming",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryServiceFromUI",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Routes requests to the new query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
         "name": "exploreMetrics",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
         "description": "Enables the new Explore Metrics core app",
@@ -1823,200 +98,276 @@
     },
     {
       "metadata": {
-        "name": "newDashboardWithFiltersAndGroupBy",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "prometheusConfigOverhaulAuth",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "individualCookiePreferences",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Support overriding cookie preferences per user",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-group"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoDataErrorExecution",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Changes how Alerting state manager handles execution of NoData/Error",
+        "description": "Update the Prometheus configuration page with the new auth component",
         "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
+        "codeowner": "@grafana/observability-metrics"
       }
     },
     {
       "metadata": {
-        "name": "disableNumericMetricsSortingInExpressions",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "annotationPermissionUpdate",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "In server-side expressions, disable the sorting of numeric-kind metrics by their metric name or labels.",
+        "description": "Change the way annotation permissions work by scoping them to folders and dashboards.",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newPDFRendering",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "New implementation for the dashboard-to-PDF rendering",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboards",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
+        "stage": "GA",
+        "codeowner": "@grafana/sharing-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolders",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable folder nesting",
+        "stage": "GA",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiPredefinedOperations",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Adds predefined query operations to Loki query editor",
         "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "requiresRestart": true
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "logRequestsInstrumentedAsUnknown",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "pluginsSkipHostEnvVars",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Logs the path for requests that are instrumented as unknown",
+        "description": "Disables passing host environment variable to plugin processes",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableAngular",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "wargamesTesting",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Placeholder feature flag for internal testing",
         "stage": "experimental",
         "codeowner": "@grafana/hosted-grafana-team"
       }
     },
     {
       "metadata": {
-        "name": "vizAndWidgetSplit",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "queryServiceFromUI",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Split panels between visualizations and widgets",
+        "description": "Routes requests to the new query service",
         "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
+        "codeowner": "@grafana/grafana-app-platform-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "pluginsAPIMetrics",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "prometheusDataplane",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Sends metrics of public grafana packages usage by plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteOnly",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Disable the internal Alertmanager and only use the external one defined.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "jitterAlertRulesWithinGroups",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "promQLScope",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow injection of labels into prometheus queries.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxdbRunQueriesInParallel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables running InfluxDB Influxql queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "traceQLStreaming",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
         "stage": "GA",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
+        "codeowner": "@grafana/observability-metrics",
+        "allowSelfServe": true
       }
     },
     {
       "metadata": {
-        "name": "newFolderPicker",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "cachingOptimizeSerializationMemoryUsage",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables the nested folder picker without having nested folders enabled",
+        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
         "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedStorage",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "SQL-based k8s storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolderPicker",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the new folder picker to work with nested folders. Requires the nestedFolders feature toggle",
+        "stage": "GA",
         "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusMetricEncyclopedia",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableElasticsearchBackendQuerying",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchBatchQueries",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Runs CloudWatch metrics queries as separate batches",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "onPremToCloudMigrations",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureHighlights",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Highlight Grafana Enterprise features",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateXYChartPanel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Migrate old XYChart panel to new XYChart2 model",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "renderAuthJWT",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "refactorVariablesTimeRange",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
         "stage": "preview",
-        "codeowner": "@grafana/grafana-as-code",
+        "codeowner": "@grafana/dashboards-squad",
         "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
-        "name": "alertingQueryOptimization",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Optimizes eligible queries in order to reduce load on datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
         "name": "configurableSchedulerTick",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
         "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
@@ -2028,62 +379,115 @@
     },
     {
       "metadata": {
-        "name": "cachingOptimizeSerializationMemoryUsage",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "awsDatasourcesNewFormStyling",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "permissionsFilterRemoveSubquery",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-group"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pdfTables",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Enables generating table data as PDF in reporting",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreContentOutline",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
-      },
-      "spec": {
-        "description": "Content outline sidebar",
+        "description": "Applies new form styling for configuration and query editors in AWS plugins",
         "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemotePrimary",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesFeatureToggles",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API for feature toggle management in the frontend",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryOverLive",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Use Grafana Live WebSocket to execute backend queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchCrossAccountQuerying",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables cross-account querying in CloudWatch datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
         "allowSelfServe": true
       }
     },
     {
       "metadata": {
-        "name": "autoMigrateXYChartPanel",
-        "resourceVersion": "1713545444177",
-        "creationTimestamp": "2024-04-19T16:50:44Z"
+        "name": "pluginsFrontendSandbox",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Migrate old XYChart panel to new XYChart2 model",
+        "description": "Enables the plugins frontend sandbox",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsAsyncQueryCaching",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelMonitoring",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables panel monitoring through logs and measurements",
+        "stage": "GA",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelPanZoom",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Allow pan and zoom in canvas panel",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true
@@ -2091,129 +495,100 @@
     },
     {
       "metadata": {
-        "name": "grafanaManagedRecordingRules",
-        "resourceVersion": "1713795659477",
-        "creationTimestamp": "2024-04-22T14:20:59Z"
+        "name": "live-service-web-worker",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables Grafana-managed recording rules.",
+        "description": "This will use a webworker thread to processes events rather than the main thread",
         "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryLibrary",
-        "resourceVersion": "1713260947272",
-        "creationTimestamp": "2024-04-16T07:18:28Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-04-16 09:49:07.272595 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Enables Query Library feature in Explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/explore-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "autofixDSUID",
-        "resourceVersion": "1714386506243",
-        "creationTimestamp": "2024-04-29T10:28:26Z"
-      },
-      "spec": {
-        "description": "Automatically migrates invalid datasource UIDs",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsExploreTableDefaultVisualization",
-        "resourceVersion": "1714583478121",
-        "creationTimestamp": "2024-05-01T17:05:57Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2024-05-01 17:11:18.121837 +0000 UTC"
-        }
-      },
-      "spec": {
-        "description": "Sets the logs table as default visualisation in logs explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
+        "codeowner": "@grafana/grafana-app-platform-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "newDashboardSharingComponent",
-        "resourceVersion": "1713982966391",
-        "creationTimestamp": "2024-04-24T18:22:46Z"
+        "name": "autoMigrateTablePanel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables the new sharing drawer design",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad",
+        "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "tlsMemcached",
-        "resourceVersion": "1715012300933",
-        "creationTimestamp": "2024-05-06T16:18:20Z",
-        "deletionTimestamp": "2024-05-06T16:20:46Z"
+        "name": "scenes",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Use TLS-enabled memcached in the enterprise caching feature",
+        "description": "Experimental framework to build interactive dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureToggleAdminPage",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable admin page for managing feature toggles from the Grafana front-end. Grafana Cloud only.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
+        "requiresRestart": true,
         "hideFromDocs": true
       }
     },
     {
       "metadata": {
-        "name": "notificationBanner",
-        "resourceVersion": "1715582792356",
-        "creationTimestamp": "2024-05-13T06:46:32Z"
+        "name": "transformationsVariableSupport",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables the notification banner UI and API",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform"
+        "description": "Allows using variables in transformations",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "dualWritePlaylistsMode2",
-        "resourceVersion": "1715369873132",
-        "creationTimestamp": "2024-05-10T19:37:53Z"
+        "name": "queryService",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables dual writing of playlists to both legacy and k8s storage in mode 2",
+        "description": "Register /apis/query.grafana.app/ -- will eventually replace /api/ds/query",
         "stage": "experimental",
-        "codeowner": "@grafana/search-and-storage"
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
       }
     },
     {
       "metadata": {
-        "name": "dualWritePlaylistsMode3",
-        "resourceVersion": "1715369873132",
-        "creationTimestamp": "2024-05-10T19:37:53Z"
+        "name": "alertingQueryOptimization",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
-        "description": "Enables dual writing of playlists to both legacy and k8s storage in mode 3",
-        "stage": "experimental",
-        "codeowner": "@grafana/search-and-storage"
+        "description": "Optimizes eligible queries in order to reduce load on datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad"
       }
     },
     {
       "metadata": {
         "name": "dashboardRestore",
-        "resourceVersion": "1708455041047",
-        "creationTimestamp": "2024-02-20T18:50:41Z"
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
         "description": "Enables deleted dashboard restore feature",
@@ -2225,15 +600,1629 @@
     },
     {
       "metadata": {
+        "name": "canvasPanelNesting",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Allow elements nesting",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "showDashboardValidationWarnings",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Show warnings when dashboards do not validate against the schema",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiLogsDataplane",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "recoveryThreshold",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearchInV1",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable searching for dashboards using panel title in search v1",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsContextDatasourceUi",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Allow datasource to provide custom UI for context view",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "recordedQueriesMulti",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables writing multiple items from a single query within Recorded Queries",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "angularDeprecationUI",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Display Angular warnings in dashboards and panels",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "metricsSummary",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables metrics summary queries in the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSimplifiedRouting",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesAggregator",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable grafana aggregator",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "expressionParser",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable new expression parser",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "authAPIAccessTokenAuth",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the use of Auth API access tokens for authentication",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourceQueryMultiStatus",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiOnly",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "mlExpressions",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable support for Machine Learning in server-side expressions",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingDisableSendAlertsExternal",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Disables the ability to send alerts to an external Alertmanager datasource.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "editPanelCSVDragAndDrop",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables drag and drop for CSV and Excel files",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "teamHttpHeaders",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "tableSharedCrosshair",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables shared crosshair in table panel",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "renderAuthJWT",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "frontendSandboxMonitorOnly",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableVisualisation",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "A table visualisation for logs in Explore",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "addFieldFromCalculationStatFunctions",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Add cumulative and window functions to the add field from calculation transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "tlsMemcached",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Use TLS-enabled memcached in the enterprise caching feature",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableEnvelopeEncryption",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Disable envelope encryption (emergency only)",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "storage",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Configurable storage for dashboards, datasources, and resources",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateGraphPanel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauthRequireSubClaim",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Require that sub claims is present in oauth tokens.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchNewLabelParsing",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Updates CloudWatch label parsing to be more accurate",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelFilterVariable",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryLibrary",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables Query Library feature in Explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/explore-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiFormatQuery",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the ability to format Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalCorePlugins",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Allow core plugins to be loaded as external",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableNativeHTTPHistogram",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables native HTTP Histograms",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableSecretsCompatibility",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Disable duplicated secret storage in legacy tables",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "idForwarding",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsInfiniteScrolling",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateWorldmapPanel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "aiGeneratedDashboardChanges",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable AI powered features for dashboards to auto-summary changes when saving",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "managedPluginsInstall",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Install managed plugins directly from plugins catalog",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newDashboardWithFiltersAndGroupBy",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboardsScene",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables public dashboard rendering using scenes",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerWithExperimentalAPIs",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Register experimental APIs with the k8s API server",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "scopeFilters",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the use of scope filters in Grafana",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pdfTables",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables generating table data as PDF in reporting",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "promQLScope",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow injection of labels into prometheus queries.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsSAML",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Use the new SSO Settings API to configure the SAML connector",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbBackendMigration",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Query InfluxDB InfluxQL without the proxy",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedRequestLog",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Writes error logs to the request logger",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-group"
+      }
+    },
+    {
+      "metadata": {
+        "name": "extraThemes",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables extra themes",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryServiceRewrite",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Rewrite requests targeting /ds/query to the query service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusPromQAIL",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Prometheus and AI/ML to assist users in creating a query",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusCodeModeMetricNamesSearch",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables search for metric names in Code Mode, to improve performance when working with an enormous number of metric names",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneSolo",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables rendering dashboards using scenes for solo panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autofixDSUID",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Automatically migrates invalid datasource UIDs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigratePiechartPanel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiPrimary",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable a remote Loki instance as the primary source for state history reads.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "libraryPanelRBAC",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables RBAC support for library panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlDatasourceDatabaseSelection",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables previous SQL data source dataset dropdown behavior",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardScene",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using scenes for all roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "regressionTransformation",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables regression analysis transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateStatPanel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRequestsInstrumentedAsUnknown",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Logs the path for requests that are instrumented as unknown",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "topnav",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesSnapshots",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Routes snapshot requests from /api to the /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteOnly",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Disable the internal Alertmanager and only use the external one defined.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboardsEmailSharing",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables public dashboard sharing to be restricted to only allowed emails",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "faroDatasourceSelector",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
+        "stage": "preview",
+        "codeowner": "@grafana/app-o11y",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoDataErrorExecution",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Changes how Alerting state manager handles execution of NoData/Error",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiRunQueriesInParallel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables running Loki queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingInsights",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Show the new alerting insights landing page",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalServiceAccounts",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Automatic service account and token setup for plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQueryHints",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables query hints for Loki",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "jitterAlertRulesWithinGroups",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxqlStreamingParser",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiSecondary",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusIncrementalQueryInstrumentation",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Adds RudderStack events to incremental queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupToNestedTableTransformation",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the group to nested table transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "accessActionSets",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Introduces action sets for resource permissions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newDashboardSharingComponent",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the new sharing drawer design",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsRedesign",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the transformations redesign",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "formatString",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable format string transformer",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRowsPopoverMenu",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable filtering menu displayed when text of a log line is selected",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "notificationBanner",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the notification banner UI and API",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableDatagridEditing",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the edit functionality in the datagrid panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "reportingRetries",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables rendering retries for the reporting feature",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesPlaylists",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsApi",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudRBACRoles",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enabled grafana cloud specific RBAC roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grpcServer",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Run the GRPC server",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoNormalState",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Stop maintaining state of alerts that are not firing",
+        "stage": "preview",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "vizAndWidgetSplit",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Split panels between visualizations and widgets",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "nodeGraphDotLayout",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Changed the layout algorithm for the node graph",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupByVariable",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable groupBy variable support in scenes dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlExpressions",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables using SQL and DuckDB functions as Expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableDefaultVisualization",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Sets the logs table as default visualisation in logs explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiExperimentalStreaming",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashgpt",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable AI powered features in dashboards",
+        "stage": "GA",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sseGroupByDatasource",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiStructuredMetadata",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the loki data source to request structured metadata from the Loki server",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "extractFieldsNameDeduplication",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Make sure extracted field names are unique in the dataframe",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneForViewers",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using Scenes for viewer roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "flameGraphItemCollapsing",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Allow collapsing of flame graph items",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "newFolderPicker",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables the nested folder picker without having nested folders enabled",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dualWritePlaylistsMode2",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables dual writing of playlists to both legacy and k8s storage in mode 2",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "accessControlOnCall",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Access control primitives for OnCall",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQuerySplittingConfig",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Give users the option to configure split durations for Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesTempCredentials",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
+        "stage": "experimental",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaAPIServerEnsureKubectlAccess",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Start an additional https handler and write kubectl options",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsAPIMetrics",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Sends metrics of public grafana packages usage by plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreContentOutline",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Content outline sidebar",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "mysqlAnsiQuotes",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Use double quotes to escape keyword in a MySQL query",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "individualCookiePreferences",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Support overriding cookie preferences per user",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-group"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingBacktesting",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Rule backtesting API for alerting",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSaveStatePeriodic",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaManagedRecordingRules",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables Grafana-managed recording rules.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "datasourceProxyDisableRBAC",
-        "resourceVersion": "1715889033198",
-        "creationTimestamp": "2024-05-16T19:50:33Z"
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
       },
       "spec": {
         "description": "Disables applying a plugin route's ReqAction field to authorization",
         "stage": "GA",
         "codeowner": "@grafana/identity-access-team",
         "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearch",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Search for dashboards using panel title",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "correlations",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Correlations page",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateOldPanels",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "permissionsFilterRemoveSubquery",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-group"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteSecondary",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "betterPageScrolling",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dualWritePlaylistsMode3",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables dual writing of playlists to both legacy and k8s storage in mode 3",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "influxdbRunQueriesInParallel",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Enables running InfluxDB Influxql queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableSSEDataplane",
+        "resourceVersion": "1716448665531",
+        "creationTimestamp": "2024-05-23T07:17:45Z"
+      },
+      "spec": {
+        "description": "Disables dataplane specific processing in server side expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
       }
     }
   ]

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -144,6 +144,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 			store:                api.AdminConfigStore,
 			log:                  logger,
 			alertmanagerProvider: api.AlertsRouter,
+			featureManager:       api.FeatureManager,
 		},
 	), m)
 

--- a/pkg/services/ngalert/api/api_configuration.go
+++ b/pkg/services/ngalert/api/api_configuration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -24,6 +25,7 @@ type ConfigSrv struct {
 	alertmanagerProvider ExternalAlertmanagerProvider
 	store                store.AdminConfigurationStore
 	log                  log.Logger
+	featureManager       featuremgmt.FeatureToggles
 }
 
 func (srv ConfigSrv) RouteGetAlertmanagers(c *contextmodel.ReqContext) response.Response {
@@ -73,6 +75,11 @@ func (srv ConfigSrv) RoutePostNGalertConfig(c *contextmodel.ReqContext, body api
 	sendAlertsTo, err := ngmodels.StringToAlertmanagersChoice(string(body.AlertmanagersChoice))
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "Invalid alertmanager choice specified", err)
+	}
+
+	disableExternal := srv.featureManager.IsEnabled(c.Req.Context(), featuremgmt.FlagAlertingDisableSendAlertsExternal)
+	if disableExternal && sendAlertsTo != ngmodels.InternalAlertmanager {
+		return response.Error(http.StatusBadRequest, "Sending alerts to external alertmanagers is disallowed on this instance", err)
 	}
 
 	externalAlertmanagers, err := srv.externalAlertmanagers(c.Req.Context(), c.SignedInUser.GetOrgID())

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -250,10 +250,10 @@ func (ng *AlertNG) init() error {
 	clk := clock.New()
 
 	alertsRouter := sender.NewAlertsRouter(ng.MultiOrgAlertmanager, ng.store, clk, appUrl, ng.Cfg.UnifiedAlerting.DisabledOrgs,
-		ng.Cfg.UnifiedAlerting.AdminConfigPollInterval, ng.DataSourceService, ng.SecretsService)
+		ng.Cfg.UnifiedAlerting.AdminConfigPollInterval, ng.DataSourceService, ng.SecretsService, ng.FeatureToggles)
 
 	// Make sure we sync at least once as Grafana starts to get the router up and running before we start sending any alerts.
-	if err := alertsRouter.SyncAndApplyConfigFromDatabase(); err != nil {
+	if err := alertsRouter.SyncAndApplyConfigFromDatabase(initCtx); err != nil {
 		return fmt.Errorf("failed to initialize alerting because alert notifications router failed to warm up: %w", err)
 	}
 

--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/datasource"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
@@ -48,11 +49,12 @@ type AlertsRouter struct {
 
 	datasourceService datasources.DataSourceService
 	secretService     secrets.Service
+	featureManager    featuremgmt.FeatureToggles
 }
 
 func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store store.AdminConfigurationStore,
 	clk clock.Clock, appURL *url.URL, disabledOrgs map[int64]struct{}, configPollInterval time.Duration,
-	datasourceService datasources.DataSourceService, secretService secrets.Service) *AlertsRouter {
+	datasourceService datasources.DataSourceService, secretService secrets.Service, featureManager featuremgmt.FeatureToggles) *AlertsRouter {
 	d := &AlertsRouter{
 		logger:           log.New("ngalert.sender.router"),
 		clock:            clk,
@@ -71,13 +73,14 @@ func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store stor
 
 		datasourceService: datasourceService,
 		secretService:     secretService,
+		featureManager:    featureManager,
 	}
 	return d
 }
 
 // SyncAndApplyConfigFromDatabase looks for the admin configuration in the database
 // and adjusts the sender(s) and alert handling mechanism accordingly.
-func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
+func (d *AlertsRouter) SyncAndApplyConfigFromDatabase(ctx context.Context) error {
 	cfgs, err := d.adminConfigStore.GetAdminConfigurations()
 	if err != nil {
 		return err
@@ -85,12 +88,19 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
 
 	d.logger.Debug("Attempting to sync admin configs", "count", len(cfgs))
 
+	disableExternal := d.featureManager.IsEnabled(ctx, featuremgmt.FlagAlertingDisableSendAlertsExternal)
+
 	orgsFound := make(map[int64]struct{}, len(cfgs))
 	d.adminConfigMtx.Lock()
 	for _, cfg := range cfgs {
 		_, isDisabledOrg := d.disabledOrgs[cfg.OrgID]
 		if isDisabledOrg {
 			continue
+		}
+
+		if disableExternal && cfg.SendAlertsTo != models.InternalAlertmanager {
+			d.logger.Warn("Alertmanager choice in configuration will be ignored due to feature flags", "org", cfg.OrgID, "choice", cfg.SendAlertsTo)
+			cfg.SendAlertsTo = models.InternalAlertmanager
 		}
 
 		// Update the Alertmanagers choice for the organization.
@@ -363,7 +373,7 @@ func (d *AlertsRouter) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-time.After(d.adminConfigPollInterval):
-			if err := d.SyncAndApplyConfigFromDatabase(); err != nil {
+			if err := d.SyncAndApplyConfigFromDatabase(ctx); err != nil {
 				d.logger.Error("Unable to sync admin configuration", "error", err)
 			}
 		case <-ctx.Done():

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -63,14 +63,14 @@ func TestIntegrationSendingToExternalAlertmanager(t *testing.T) {
 		}),
 	}
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{}, 10*time.Minute,
-		&fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds1}}, fake_secrets.NewFakeSecretsService())
+		&fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds1}}, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures())
 
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey.OrgID, SendAlertsTo: models.AllAlertmanagers},
 	}, nil)
 	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
 	// when the first alert triggers.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
@@ -93,7 +93,7 @@ func TestIntegrationSendingToExternalAlertmanager(t *testing.T) {
 	// Now, let's remove the Alertmanager from the admin configuration.
 	mockedGetAdminConfigurations.Return(nil, nil)
 	// Again, make sure we sync and verify the externalAlertmanagers.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 0, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 0, len(alertsRouter.externalAlertmanagersCfgHash))
 
@@ -134,7 +134,7 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 	}
 	fakeDs := &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds1}}
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{}, 10*time.Minute,
-		fakeDs, fake_secrets.NewFakeSecretsService())
+		fakeDs, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures())
 
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey1.OrgID, SendAlertsTo: models.AllAlertmanagers},
@@ -142,7 +142,7 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 
 	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
 	// when the first alert triggers.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
@@ -167,7 +167,7 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 	}, nil)
 
 	// If we sync again, new externalAlertmanagers must have spawned.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 2, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 2, len(alertsRouter.externalAlertmanagersCfgHash))
 
@@ -216,7 +216,7 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 	currentHash := alertsRouter.externalAlertmanagersCfgHash[ruleKey2.OrgID]
 
 	// Now, sync again.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 
 	// The hash for org two should not be the same and we should still have two externalAlertmanagers.
 	require.NotEqual(t, alertsRouter.externalAlertmanagersCfgHash[ruleKey2.OrgID], currentHash)
@@ -236,7 +236,7 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 	currentHash = alertsRouter.externalAlertmanagersCfgHash[ruleKey1.OrgID]
 
 	// Now, sync again.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 
 	// The old configuration should not be running.
 	require.NotEqual(t, alertsRouter.externalAlertmanagersCfgHash[ruleKey1.OrgID], currentHash)
@@ -249,13 +249,13 @@ func TestIntegrationSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T)
 		{OrgID: ruleKey2.OrgID},
 	}, nil)
 
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.NotEqual(t, alertsRouter.externalAlertmanagersCfgHash[ruleKey1.OrgID], currentHash)
 
 	// Finally, remove everything.
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{}, nil)
 
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 
 	require.Equal(t, 0, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 0, len(alertsRouter.externalAlertmanagersCfgHash))
@@ -293,14 +293,14 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 		}),
 	}
 	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{},
-		10*time.Minute, &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds}}, fake_secrets.NewFakeSecretsService())
+		10*time.Minute, &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds}}, fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures())
 
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey.OrgID, SendAlertsTo: models.AllAlertmanagers},
 	}, nil)
 	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
 	// when the first alert triggers.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 	require.Equal(t, models.AllAlertmanagers, alertsRouter.sendAlertsTo[ruleKey.OrgID])
@@ -325,7 +325,7 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 		{OrgID: ruleKey.OrgID, SendAlertsTo: models.ExternalAlertmanagers},
 	}, nil)
 	// Again, make sure we sync and verify the externalAlertmanagers.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
@@ -339,7 +339,7 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 
 	// Again, make sure we sync and verify the externalAlertmanagers.
 	// externalAlertmanagers should be running even though alerts are being handled externally.
-	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
@@ -352,6 +352,86 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 	am, err := moa.AlertmanagerFor(ruleKey.OrgID)
 	require.NoError(t, err)
 	actualAlerts, err := am.GetAlerts(context.Background(), true, true, true, nil, "")
+	require.NoError(t, err)
+	require.Len(t, actualAlerts, len(expected))
+}
+
+func TestAlertmanagersChoiceWithDisableExternalFeatureToggle(t *testing.T) {
+	ruleKey := models.GenerateRuleKey(1)
+
+	fakeAM := NewFakeExternalAlertmanager(t)
+	defer fakeAM.Close()
+
+	fakeAdminConfigStore := &store.AdminConfigurationStoreMock{}
+	mockedGetAdminConfigurations := fakeAdminConfigStore.EXPECT().GetAdminConfigurations()
+
+	mockedClock := clock.NewMock()
+	mockedClock.Set(time.Now())
+
+	moa := createMultiOrgAlertmanager(t, []int64{1})
+
+	appUrl := &url.URL{
+		Scheme: "http",
+		Host:   "localhost",
+	}
+
+	ds := datasources.DataSource{
+		URL:   fakeAM.Server.URL,
+		OrgID: ruleKey.OrgID,
+		Type:  datasources.DS_ALERTMANAGER,
+		JsonData: simplejson.NewFromAny(map[string]any{
+			"handleGrafanaManagedAlerts": true,
+			"implementation":             "prometheus",
+		}),
+	}
+
+	var expected []*models2.PostableAlert
+	alerts := definitions.PostableAlerts{}
+	for i := 0; i < rand.Intn(5)+1; i++ {
+		alert := generatePostableAlert(t, mockedClock)
+		expected = append(expected, &alert)
+		alerts.PostableAlerts = append(alerts.PostableAlerts, alert)
+	}
+
+	alertsRouter := NewAlertsRouter(moa, fakeAdminConfigStore, mockedClock, appUrl, map[int64]struct{}{},
+		10*time.Minute, &fake_ds.FakeDataSourceService{DataSources: []*datasources.DataSource{&ds}},
+		fake_secrets.NewFakeSecretsService(), featuremgmt.WithFeatures(featuremgmt.FlagAlertingDisableSendAlertsExternal))
+
+	// Test that we only send to the internal Alertmanager even though the configuration specifies AllAlertmanagers.
+
+	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
+		{OrgID: ruleKey.OrgID, SendAlertsTo: models.AllAlertmanagers},
+	}, nil)
+
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagersCfgHash))
+	require.Equal(t, models.InternalAlertmanager, alertsRouter.sendAlertsTo[ruleKey.OrgID])
+
+	alertsRouter.Send(context.Background(), ruleKey, alerts)
+
+	am, err := moa.AlertmanagerFor(ruleKey.OrgID)
+	require.NoError(t, err)
+	actualAlerts, err := am.GetAlerts(context.Background(), true, true, true, nil, "")
+	require.NoError(t, err)
+	require.Len(t, actualAlerts, len(expected))
+
+	// Test that we still only send to the internal alertmanager even though the configuration specifies ExternalAlertmanagers.
+
+	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
+		{OrgID: ruleKey.OrgID, SendAlertsTo: models.ExternalAlertmanagers},
+	}, nil)
+
+	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase(context.Background()))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagersCfgHash))
+	require.Equal(t, models.InternalAlertmanager, alertsRouter.sendAlertsTo[ruleKey.OrgID])
+
+	alertsRouter.Send(context.Background(), ruleKey, alerts)
+
+	am, err = moa.AlertmanagerFor(ruleKey.OrgID)
+	require.NoError(t, err)
+	actualAlerts, err = am.GetAlerts(context.Background(), true, true, true, nil, "")
 	require.NoError(t, err)
 	require.Len(t, actualAlerts, len(expected))
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a feature toggle to disallow sending alerts to external Alertmanager datasources.

- If a user already has an admin configuration, this is ignored and a warning logged.
- If a user tries to write an admin configuration to send to external Alertmanagers, it is rejected.

Note that when reading the admin configuration, the persisted configuration is returned. I'm not entirely convinced this is correct, perhaps we should return the effective configuration.

Note this commit does not include frontend changes. We will likely want to modify the Settings page to not show the option to configure external Alertmanagers.

**Why do we need this feature?**

Site policy may dictate that alerts should be handled only internally, or if they are sent externally, should be done via the new Remote Alertmanager feature. 

_**Note: There is no intention to remove the ability to send externally, this is merely being provided as an option for site administrators who want to disallow it.**_

**Who is this feature for?**

Site administrators of Grafana instances.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
