### PR TITLE
Scopes: Select scope even without data retrieval

### DIFF
--- a/packages/grafana-prometheus/src/dataquery.ts
+++ b/packages/grafana-prometheus/src/dataquery.ts
@@ -1,5 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/dataquery.ts
-import { Scope, ScopeSpecFilter } from '@grafana/data';
+import { Scope, ScopeSpec, ScopeSpecFilter } from '@grafana/data';
 import * as common from '@grafana/schema';
 
 export enum QueryEditorMode {
@@ -43,7 +43,7 @@ export interface Prometheus extends common.DataQuery {
    * Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series
    */
   range?: boolean;
-  scopes?: Scope[];
+  scopes?: Array<ScopeSpec & Pick<Scope['metadata'], 'name'>>;
   adhocFilters?: ScopeSpecFilter[];
   groupByKeys?: string[];
 }

--- a/packages/grafana-prometheus/src/dataquery.ts
+++ b/packages/grafana-prometheus/src/dataquery.ts
@@ -1,5 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/dataquery.ts
-import { ScopeSpec, ScopeSpecFilter } from '@grafana/data';
+import { Scope, ScopeSpecFilter } from '@grafana/data';
 import * as common from '@grafana/schema';
 
 export enum QueryEditorMode {
@@ -43,7 +43,7 @@ export interface Prometheus extends common.DataQuery {
    * Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series
    */
   range?: boolean;
-  scopes?: ScopeSpec[];
+  scopes?: Scope[];
   adhocFilters?: ScopeSpecFilter[];
   groupByKeys?: string[];
 }

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -374,7 +374,7 @@ export class PrometheusDatasource
     };
 
     if (config.featureToggles.promQLScope) {
-      processedTarget.scopes = (request.scopes ?? []).map((scope) => scope.spec);
+      processedTarget.scopes = request.scopes;
     }
 
     if (config.featureToggles.groupByVariable) {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -374,7 +374,10 @@ export class PrometheusDatasource
     };
 
     if (config.featureToggles.promQLScope) {
-      processedTarget.scopes = request.scopes;
+      processedTarget.scopes = (request.scopes ?? []).map((scope) => ({
+        name: scope.metadata.name,
+        ...scope.spec,
+      }));
     }
 
     if (config.featureToggles.groupByVariable) {

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -76,8 +76,9 @@ type PrometheusQueryProperties struct {
 }
 
 // ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go
-// to avoid import (temp fix)
+// to avoid import (temp fix). This also has metadata.name inlined.
 type ScopeSpec struct {
+	Name        string        `json:"name"` // This is the identifier from metadata.name of the scope model.
 	Title       string        `json:"title"`
 	Type        string        `json:"type"`
 	Description string        `json:"description"`

--- a/pkg/promlib/models/query.panel.schema.json
+++ b/pkg/promlib/models/query.panel.schema.json
@@ -173,9 +173,10 @@
             "description": "A set of filters applied to apply to the query",
             "type": "array",
             "items": {
-              "description": "ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go to avoid import (temp fix)",
+              "description": "ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go to avoid import (temp fix).",
               "type": "object",
               "required": [
+                "name",
                 "title",
                 "type",
                 "description",
@@ -212,6 +213,10 @@
                     },
                     "additionalProperties": false
                   }
+                },
+                "name": {
+                  "description": "This is the identifier from metadata.name of the scope model.",
+                  "type": "string"
                 },
                 "title": {
                   "type": "string"

--- a/pkg/promlib/models/query.request.schema.json
+++ b/pkg/promlib/models/query.request.schema.json
@@ -183,9 +183,10 @@
             "description": "A set of filters applied to apply to the query",
             "type": "array",
             "items": {
-              "description": "ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go to avoid import (temp fix)",
+              "description": "ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go to avoid import (temp fix).",
               "type": "object",
               "required": [
+                "name",
                 "title",
                 "type",
                 "description",
@@ -222,6 +223,10 @@
                     },
                     "additionalProperties": false
                   }
+                },
+                "name": {
+                  "description": "This is the identifier from metadata.name of the scope model.",
+                  "type": "string"
                 },
                 "title": {
                   "type": "string"

--- a/pkg/promlib/models/query.types.json
+++ b/pkg/promlib/models/query.types.json
@@ -8,7 +8,7 @@
     {
       "metadata": {
         "name": "default",
-        "resourceVersion": "1715781995240",
+        "resourceVersion": "1715871691891",
         "creationTimestamp": "2024-03-25T13:19:04Z"
       },
       "spec": {
@@ -96,7 +96,7 @@
               "description": "A set of filters applied to apply to the query",
               "items": {
                 "additionalProperties": false,
-                "description": "ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go to avoid import (temp fix)",
+                "description": "ScopeSpec is a hand copy of the ScopeSpec struct from pkg/apis/scope/v0alpha1/types.go to avoid import (temp fix).",
                 "properties": {
                   "category": {
                     "type": "string"
@@ -128,6 +128,10 @@
                     },
                     "type": "array"
                   },
+                  "name": {
+                    "description": "This is the identifier from metadata.name of the scope model.",
+                    "type": "string"
+                  },
                   "title": {
                     "type": "string"
                   },
@@ -136,6 +140,7 @@
                   }
                 },
                 "required": [
+                  "name",
                   "title",
                   "type",
                   "description",


### PR DESCRIPTION
**What is this feature?**

This PR allows a scope selection even if the scope details endpoint is not returning anything.

**Why do we need this feature?**

Sometimes there might not be details about a specific scope.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
