### PR TITLE
Alerting: Skip flakey silencing test

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -163,7 +163,7 @@ describe('RuleViewer', () => {
       }
     });
 
-    it('renders silencing form correctly and shows alert rule name', async () => {
+    it.skip('renders silencing form correctly and shows alert rule name', async () => {
       const dataSources = {
         grafana: mockDataSource<AlertManagerDataSourceJsonData>({
           name: GRAFANA_RULES_SOURCE_NAME,


### PR DESCRIPTION
**What is this feature?**

Skips a flakey test

**Why do we need this feature?**

Sanity of everyone opening PRs 😌 

Not sure why this is failing, as it passes locally for me. For now, will skip this one and work it out in Silencing RBAC work

For posterity; here's the output of a failed build from the flakey test
https://drone.grafana.net/grafana/grafana/178375/1/6