### PR TITLE
Alerting: Add optional metadata via query param to silence GET requests

### DIFF
--- a/pkg/services/ngalert/accesscontrol/fakes/rules.go
+++ b/pkg/services/ngalert/accesscontrol/fakes/rules.go
@@ -22,6 +22,7 @@ type FakeRuleService struct {
 	AuthorizeDatasourceAccessForRuleGroupFunc func(context.Context, identity.Requester, models.RulesGroup) error
 	HasAccessToRuleGroupFunc                  func(context.Context, identity.Requester, models.RulesGroup) (bool, error)
 	AuthorizeAccessToRuleGroupFunc            func(context.Context, identity.Requester, models.RulesGroup) error
+	HasAccessInFolderFunc                     func(context.Context, identity.Requester, accesscontrol.Namespaced) (bool, error)
 	AuthorizeAccessInFolderFunc               func(context.Context, identity.Requester, accesscontrol.Namespaced) error
 	AuthorizeRuleChangesFunc                  func(context.Context, identity.Requester, *store.GroupDelta) error
 
@@ -74,6 +75,14 @@ func (s *FakeRuleService) AuthorizeAccessToRuleGroup(ctx context.Context, user i
 		return s.AuthorizeAccessToRuleGroupFunc(ctx, user, rules)
 	}
 	return nil
+}
+
+func (s *FakeRuleService) HasAccessInFolder(ctx context.Context, user identity.Requester, namespaced accesscontrol.Namespaced) (bool, error) {
+	s.Calls = append(s.Calls, Call{"HasAccessInFolder", []interface{}{ctx, user, namespaced}})
+	if s.HasAccessInFolderFunc != nil {
+		return s.HasAccessInFolderFunc(ctx, user, namespaced)
+	}
+	return false, nil
 }
 
 func (s *FakeRuleService) AuthorizeAccessInFolder(ctx context.Context, user identity.Requester, namespaced accesscontrol.Namespaced) error {

--- a/pkg/services/ngalert/accesscontrol/fakes/silences.go
+++ b/pkg/services/ngalert/accesscontrol/fakes/silences.go
@@ -17,7 +17,7 @@ type FakeSilenceService struct {
 	Calls []Call
 }
 
-func (s FakeSilenceService) FilterByAccess(ctx context.Context, user identity.Requester, silences ...*models.Silence) ([]*models.Silence, error) {
+func (s *FakeSilenceService) FilterByAccess(ctx context.Context, user identity.Requester, silences ...*models.Silence) ([]*models.Silence, error) {
 	s.Calls = append(s.Calls, Call{"FilterByAccess", []interface{}{ctx, user, silences}})
 	if s.FilterByAccessFunc != nil {
 		return s.FilterByAccessFunc(ctx, user, silences...)
@@ -25,7 +25,7 @@ func (s FakeSilenceService) FilterByAccess(ctx context.Context, user identity.Re
 	return nil, nil
 }
 
-func (s FakeSilenceService) AuthorizeReadSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
+func (s *FakeSilenceService) AuthorizeReadSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
 	s.Calls = append(s.Calls, Call{"AuthorizeReadSilence", []interface{}{ctx, user, silence}})
 	if s.AuthorizeReadSilenceFunc != nil {
 		return s.AuthorizeReadSilenceFunc(ctx, user, silence)
@@ -33,7 +33,7 @@ func (s FakeSilenceService) AuthorizeReadSilence(ctx context.Context, user ident
 	return nil
 }
 
-func (s FakeSilenceService) AuthorizeCreateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
+func (s *FakeSilenceService) AuthorizeCreateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
 	s.Calls = append(s.Calls, Call{"AuthorizeCreateSilence", []interface{}{ctx, user, silence}})
 	if s.AuthorizeCreateSilenceFunc != nil {
 		return s.AuthorizeCreateSilenceFunc(ctx, user, silence)
@@ -41,7 +41,7 @@ func (s FakeSilenceService) AuthorizeCreateSilence(ctx context.Context, user ide
 	return nil
 }
 
-func (s FakeSilenceService) AuthorizeUpdateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
+func (s *FakeSilenceService) AuthorizeUpdateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
 	s.Calls = append(s.Calls, Call{"AuthorizeUpdateSilence", []interface{}{ctx, user, silence}})
 	if s.AuthorizeUpdateSilenceFunc != nil {
 		return s.AuthorizeUpdateSilenceFunc(ctx, user, silence)
@@ -49,7 +49,7 @@ func (s FakeSilenceService) AuthorizeUpdateSilence(ctx context.Context, user ide
 	return nil
 }
 
-func (s FakeSilenceService) SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error) {
+func (s *FakeSilenceService) SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error) {
 	s.Calls = append(s.Calls, Call{"SilenceAccess", []interface{}{ctx, user, silences}})
 	if s.SilenceAccessFunc != nil {
 		return s.SilenceAccessFunc(ctx, user, silences)

--- a/pkg/services/ngalert/accesscontrol/fakes/silences.go
+++ b/pkg/services/ngalert/accesscontrol/fakes/silences.go
@@ -1,0 +1,58 @@
+package fakes
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/auth/identity"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type FakeSilenceService struct {
+	FilterByAccessFunc         func(ctx context.Context, user identity.Requester, silences ...*models.Silence) ([]*models.Silence, error)
+	AuthorizeReadSilenceFunc   func(ctx context.Context, user identity.Requester, silence *models.Silence) error
+	AuthorizeCreateSilenceFunc func(ctx context.Context, user identity.Requester, silence *models.Silence) error
+	AuthorizeUpdateSilenceFunc func(ctx context.Context, user identity.Requester, silence *models.Silence) error
+	SilenceAccessFunc          func(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error)
+
+	Calls []Call
+}
+
+func (s FakeSilenceService) FilterByAccess(ctx context.Context, user identity.Requester, silences ...*models.Silence) ([]*models.Silence, error) {
+	s.Calls = append(s.Calls, Call{"FilterByAccess", []interface{}{ctx, user, silences}})
+	if s.FilterByAccessFunc != nil {
+		return s.FilterByAccessFunc(ctx, user, silences...)
+	}
+	return nil, nil
+}
+
+func (s FakeSilenceService) AuthorizeReadSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
+	s.Calls = append(s.Calls, Call{"AuthorizeReadSilence", []interface{}{ctx, user, silence}})
+	if s.AuthorizeReadSilenceFunc != nil {
+		return s.AuthorizeReadSilenceFunc(ctx, user, silence)
+	}
+	return nil
+}
+
+func (s FakeSilenceService) AuthorizeCreateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
+	s.Calls = append(s.Calls, Call{"AuthorizeCreateSilence", []interface{}{ctx, user, silence}})
+	if s.AuthorizeCreateSilenceFunc != nil {
+		return s.AuthorizeCreateSilenceFunc(ctx, user, silence)
+	}
+	return nil
+}
+
+func (s FakeSilenceService) AuthorizeUpdateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error {
+	s.Calls = append(s.Calls, Call{"AuthorizeUpdateSilence", []interface{}{ctx, user, silence}})
+	if s.AuthorizeUpdateSilenceFunc != nil {
+		return s.AuthorizeUpdateSilenceFunc(ctx, user, silence)
+	}
+	return nil
+}
+
+func (s FakeSilenceService) SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error) {
+	s.Calls = append(s.Calls, Call{"SilenceAccess", []interface{}{ctx, user, silences}})
+	if s.SilenceAccessFunc != nil {
+		return s.SilenceAccessFunc(ctx, user, silences)
+	}
+	return nil, nil
+}

--- a/pkg/services/ngalert/accesscontrol/silences.go
+++ b/pkg/services/ngalert/accesscontrol/silences.go
@@ -314,7 +314,7 @@ func (s SilenceService) SilenceAccess(ctx context.Context, user identity.Request
 
 		permSet := make(map[models.SilencePermission]struct{})
 		if !canReadAll {
-			if err := s.authorizeUpdateSilence(ctx, user, silWithFolder); err != nil {
+			if err := s.authorizeReadSilence(ctx, user, silWithFolder); err != nil {
 				// Read permission is required for all actions. If user can't read the silence, we don't need to check other permissions.
 				result[silWithFolder.Silence] = permSet
 				namespacesByAccess[silWithFolder.folderUID] = permSet

--- a/pkg/services/ngalert/accesscontrol/silences.go
+++ b/pkg/services/ngalert/accesscontrol/silences.go
@@ -284,6 +284,8 @@ func (s SilenceService) authorizeUpdateSilence(ctx context.Context, user identit
 	})
 }
 
+// SilenceAccess returns the permission sets for a slice of silences. The permission set includes read, write, and
+// create which corresponds the given user being able to read, write, and create each given silence, respectively.
 func (s SilenceService) SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error) {
 	basePerms := make(models.SilencePermissionSet, 3)
 	canReadAll, err := s.authorizeReadSilencePreConditions(ctx, user)

--- a/pkg/services/ngalert/accesscontrol/silences_test.go
+++ b/pkg/services/ngalert/accesscontrol/silences_test.go
@@ -217,8 +217,7 @@ func TestAuthorizeReadSilence(t *testing.T) {
 					permSets, err := svc.SilenceAccess(context.Background(), testCase.user, []*models.Silence{silence})
 					assert.NoError(t, err)
 					assert.Len(t, permSets, 1)
-					_, has := permSets[silence][models.SilencePermissionRead]
-					assert.Equal(t, testCase.expectedErr == nil, has)
+					assert.Equal(t, testCase.expectedErr == nil, permSets[silence].Has(models.SilencePermissionRead))
 				})
 			}
 		})
@@ -395,8 +394,7 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 					permSets, err := svc.SilenceAccess(context.Background(), testCase.user, []*models.Silence{silence})
 					assert.NoError(t, err)
 					assert.Len(t, permSets, 1)
-					_, has := permSets[silence][models.SilencePermissionCreate]
-					assert.Equal(t, expectedErr == nil, has)
+					assert.Equal(t, expectedErr == nil, permSets[silence].Has(models.SilencePermissionCreate))
 				})
 			}
 		})
@@ -573,8 +571,7 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 					permSets, err := svc.SilenceAccess(context.Background(), testCase.user, []*models.Silence{silence})
 					assert.NoError(t, err)
 					assert.Len(t, permSets, 1)
-					_, has := permSets[silence][models.SilencePermissionWrite]
-					assert.Equal(t, expectedErr == nil, has)
+					assert.Equal(t, expectedErr == nil, permSets[silence].Has(models.SilencePermissionWrite))
 				})
 			}
 		})

--- a/pkg/services/ngalert/accesscontrol/silences_test.go
+++ b/pkg/services/ngalert/accesscontrol/silences_test.go
@@ -212,6 +212,13 @@ func TestAuthorizeReadSilence(t *testing.T) {
 					} else {
 						require.Equal(t, 0, store.Calls)
 					}
+
+					// Verify SilenceAccess.
+					permSets, err := svc.SilenceAccess(context.Background(), testCase.user, []*models.Silence{silence})
+					assert.NoError(t, err)
+					assert.Len(t, permSets, 1)
+					_, has := permSets[silence][models.SilencePermissionRead]
+					assert.Equal(t, testCase.expectedErr == nil, has)
 				})
 			}
 		})
@@ -383,6 +390,13 @@ func TestAuthorizeCreateSilence(t *testing.T) {
 					} else {
 						require.Equal(t, 0, store.Calls)
 					}
+
+					// Verify SilenceAccess.
+					permSets, err := svc.SilenceAccess(context.Background(), testCase.user, []*models.Silence{silence})
+					assert.NoError(t, err)
+					assert.Len(t, permSets, 1)
+					_, has := permSets[silence][models.SilencePermissionCreate]
+					assert.Equal(t, expectedErr == nil, has)
 				})
 			}
 		})
@@ -554,6 +568,13 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 					} else {
 						require.Equal(t, 0, store.Calls)
 					}
+
+					// Verify SilenceAccess.
+					permSets, err := svc.SilenceAccess(context.Background(), testCase.user, []*models.Silence{silence})
+					assert.NoError(t, err)
+					assert.Len(t, permSets, 1)
+					_, has := permSets[silence][models.SilencePermissionWrite]
+					assert.Equal(t, expectedErr == nil, has)
 				})
 			}
 		})

--- a/pkg/services/ngalert/accesscontrol/silences_test.go
+++ b/pkg/services/ngalert/accesscontrol/silences_test.go
@@ -578,6 +578,263 @@ func TestAuthorizeUpdateSilence(t *testing.T) {
 	}
 }
 
+func TestSilenceAccess(t *testing.T) {
+	global := testSilence("global", nil)
+	ruleSilence1 := testSilence("rule-1", utils.Pointer("rule-1-uid"))
+	folder1 := "rule-1-folder-uid"
+	folder1Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder1)
+	ruleSilence2 := testSilence("rule-2", utils.Pointer("rule-2-uid"))
+	folder2 := "rule-2-folder-uid"
+	folder2Scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder2)
+	notFoundRule := testSilence("unknown-rule", utils.Pointer("unknown-rule-uid"))
+
+	silences := []*models.Silence{
+		global,
+		ruleSilence1,
+		ruleSilence2,
+		notFoundRule,
+	}
+
+	type override struct {
+		expectedPermissions models.SilencePermissionSet
+	}
+
+	permit := func(permission ...models.SilencePermission) override {
+		o := override{expectedPermissions: models.SilencePermissionSet{}}
+		for _, p := range permission {
+			o.expectedPermissions[p] = true
+		}
+		return o
+	}
+
+	deny := func(permission ...models.SilencePermission) override {
+		o := override{expectedPermissions: models.SilencePermissionSet{}}
+		for _, p := range permission {
+			o.expectedPermissions[p] = false
+		}
+		return o
+	}
+
+	testCases := []struct {
+		name                string
+		user                identity.Requester
+		expectedPermissions models.SilencePermissionSet
+		expectedDbAccess    bool
+		overrides           map[*models.Silence]override
+	}{
+		{
+			name: "not authorized without permissions",
+			user: newUser(),
+		},
+		{
+			name: "instance read gives read access to everything",
+			user: newUser(ac.Permission{Action: instancesRead}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead: true,
+			},
+		},
+		{
+			name: "silence wildcard read gives read access to everything",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead: true,
+			},
+		},
+		{
+			name: "silence read in folders gives read access to global and folders",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceRead, Scope: folder2Scope}),
+			overrides: map[*models.Silence]override{
+				global:       permit(models.SilencePermissionRead),
+				ruleSilence1: permit(models.SilencePermissionRead),
+				ruleSilence2: permit(models.SilencePermissionRead),
+			},
+			expectedPermissions: models.SilencePermissionSet{},
+			expectedDbAccess:    true,
+		},
+		{
+			name: "instance reade+write+create can do everything",
+			user: newUser(ac.Permission{Action: instancesRead}, ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesCreate}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:   true,
+				models.SilencePermissionCreate: true,
+				models.SilencePermissionWrite:  true,
+			},
+		},
+		{
+			name: "silence wildcard read + instance write+create can do everything",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesCreate}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:   true,
+				models.SilencePermissionCreate: true,
+				models.SilencePermissionWrite:  true,
+			},
+		},
+		{
+			name: "instance readr+write can read and write",
+			user: newUser(ac.Permission{Action: instancesRead}, ac.Permission{Action: instancesWrite}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:  true,
+				models.SilencePermissionWrite: true,
+			},
+		},
+		{
+			name: "silence wildcard read + instance write can read and write",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesWrite}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:  true,
+				models.SilencePermissionWrite: true,
+			},
+		},
+		{
+			name: "instance reader+create can read and create",
+			user: newUser(ac.Permission{Action: instancesRead}, ac.Permission{Action: instancesCreate}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:   true,
+				models.SilencePermissionCreate: true,
+			},
+		},
+		{
+			name: "silence wildcard read + instance create can read and create",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: instancesCreate}),
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:   true,
+				models.SilencePermissionCreate: true,
+			},
+		},
+		{
+			name:                "cannot write/create without read - instance permissions",
+			user:                newUser(ac.Permission{Action: instancesWrite}, ac.Permission{Action: instancesCreate}),
+			expectedPermissions: models.SilencePermissionSet{},
+		},
+		{
+			name:                "cannot write/create without read - silence permissions",
+			user:                newUser(ac.Permission{Action: silenceWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			expectedPermissions: models.SilencePermissionSet{},
+		},
+		{
+			name: "instance read + silence write in folder",
+			user: newUser(ac.Permission{Action: silenceWrite, Scope: folder1Scope}, ac.Permission{Action: instancesRead}),
+			overrides: map[*models.Silence]override{
+				ruleSilence1: permit(models.SilencePermissionWrite),
+			},
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead: true,
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "instance read + silence create in folder",
+			user: newUser(ac.Permission{Action: silenceCreate, Scope: folder1Scope}, ac.Permission{Action: instancesRead}),
+			overrides: map[*models.Silence]override{
+				ruleSilence1: permit(models.SilencePermissionCreate),
+			},
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead: true,
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence read in folder + instance write also provides global write",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: instancesWrite}),
+			overrides: map[*models.Silence]override{
+				global:       permit(models.SilencePermissionRead, models.SilencePermissionWrite),
+				ruleSilence1: permit(models.SilencePermissionRead, models.SilencePermissionWrite),
+			},
+			expectedPermissions: models.SilencePermissionSet{},
+			expectedDbAccess:    true,
+		},
+		{
+			name: "silence read in folder + instance create also provides global create",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: instancesCreate}),
+			overrides: map[*models.Silence]override{
+				global:       permit(models.SilencePermissionRead, models.SilencePermissionCreate),
+				ruleSilence1: permit(models.SilencePermissionRead, models.SilencePermissionCreate),
+			},
+			expectedPermissions: models.SilencePermissionSet{},
+			expectedDbAccess:    true,
+		},
+		{
+			name: "silence wildcard write doesn't provide global write but does provide unknown rule write",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			overrides: map[*models.Silence]override{
+				global:       deny(models.SilencePermissionWrite),
+				notFoundRule: deny(models.SilencePermissionWrite), // This is arguable, can consider changing this in the future.
+			},
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:  true,
+				models.SilencePermissionWrite: true,
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence wildcard create doesn't provide global create but does provide unknown rule create",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}, ac.Permission{Action: silenceCreate, Scope: dashboards.ScopeFoldersProvider.GetResourceAllScope()}),
+			overrides: map[*models.Silence]override{
+				global:       deny(models.SilencePermissionCreate),
+				notFoundRule: deny(models.SilencePermissionCreate), // This is arguable, can consider changing this in the future.
+			},
+			expectedPermissions: models.SilencePermissionSet{
+				models.SilencePermissionRead:   true,
+				models.SilencePermissionCreate: true,
+			},
+			expectedDbAccess: true,
+		},
+		{
+			name: "silence read + write in single folder",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceWrite, Scope: folder1Scope}),
+			overrides: map[*models.Silence]override{
+				global:       permit(models.SilencePermissionRead),
+				ruleSilence1: permit(models.SilencePermissionRead, models.SilencePermissionWrite),
+			},
+			expectedPermissions: models.SilencePermissionSet{},
+			expectedDbAccess:    true,
+		},
+		{
+			name: "silence read + create in single folder",
+			user: newUser(ac.Permission{Action: silenceRead, Scope: folder1Scope}, ac.Permission{Action: silenceCreate, Scope: folder1Scope}),
+			overrides: map[*models.Silence]override{
+				global:       permit(models.SilencePermissionRead),
+				ruleSilence1: permit(models.SilencePermissionRead, models.SilencePermissionCreate),
+			},
+			expectedPermissions: models.SilencePermissionSet{},
+			expectedDbAccess:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ac := &recordingAccessControlFake{}
+			store := &fakeRuleUIDToNamespaceStore{
+				Response: map[string]string{
+					*ruleSilence1.GetRuleUID(): folder1,
+					*ruleSilence2.GetRuleUID(): folder2,
+				},
+			}
+			svc := NewSilenceService(ac, store)
+
+			perms, err := svc.SilenceAccess(context.Background(), tc.user, silences)
+			assert.NoError(t, err)
+			if tc.expectedDbAccess {
+				assert.Equalf(t, 1, store.Calls, "expected 1 db access, but got %d store calls", store.Calls)
+			} else {
+				assert.Equalf(t, 0, store.Calls, "expected no db access, but got %d store calls", store.Calls)
+			}
+
+			for _, silence := range silences {
+				expectedPermissions := tc.expectedPermissions.Clone()
+				if s, ok := tc.overrides[silence]; ok {
+					for k, v := range s.expectedPermissions {
+						expectedPermissions[k] = v
+					}
+				}
+				for _, permission := range models.SilencePermissions() {
+					assert.Equalf(t, expectedPermissions.Has(permission), perms[silence].Has(permission), "expected %s=%t permission for silence %s but got %t", permission, expectedPermissions.Has(permission), *silence.ID, perms[silence].Has(permission))
+				}
+			}
+		})
+	}
+}
+
 func testSilence(id string, ruleUID *string) *models.Silence {
 	s := &models.Silence{ID: &id}
 	if ruleUID != nil {

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -95,11 +95,18 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		api.DatasourceCache,
 		NewLotexAM(proxy, logger),
 		&AlertmanagerSrv{
-			crypto:     api.MultiOrgAlertmanager.Crypto,
-			log:        logger,
-			ac:         api.AccessControl,
-			mam:        api.MultiOrgAlertmanager,
-			silenceSvc: notifier.NewSilenceService(accesscontrol.NewSilenceService(api.AccessControl, api.RuleStore), api.TransactionManager, logger, api.MultiOrgAlertmanager),
+			crypto: api.MultiOrgAlertmanager.Crypto,
+			log:    logger,
+			ac:     api.AccessControl,
+			mam:    api.MultiOrgAlertmanager,
+			silenceSvc: notifier.NewSilenceService(
+				accesscontrol.NewSilenceService(api.AccessControl, api.RuleStore),
+				api.TransactionManager,
+				logger,
+				api.MultiOrgAlertmanager,
+				api.RuleStore,
+				ruleAuthzService,
+			),
 		},
 	), m)
 	// Register endpoints for proxying to Prometheus-compatible backends.

--- a/pkg/services/ngalert/api/api_alertmanager_silences.go
+++ b/pkg/services/ngalert/api/api_alertmanager_silences.go
@@ -56,7 +56,7 @@ func (srv AlertmanagerSrv) RouteGetSilences(c *contextmodel.ReqContext) response
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to list silence", err)
 	}
 
-	silencesWithMetadata := withNoMetadata(silences...)
+	silencesWithMetadata := withEmptyMetadata(silences...)
 	if c.QueryBool("accesscontrol") {
 		if err := srv.silenceSvc.WithAccessControlMetadata(c.Req.Context(), c.SignedInUser, silencesWithMetadata...); err != nil {
 			srv.log.Error("failed to get silence access control metadata", "error", err)
@@ -99,7 +99,9 @@ func (srv AlertmanagerSrv) RouteDeleteSilence(c *contextmodel.ReqContext, silenc
 	return response.JSON(http.StatusOK, util.DynMap{"message": "silence deleted"})
 }
 
-func withNoMetadata(silences ...*models.Silence) []*models.SilenceWithMetadata {
+// withEmptyMetadata creates a slice of SilenceWithMetadata from a slice of Silence where the metadata for each silence
+// is empty.
+func withEmptyMetadata(silences ...*models.Silence) []*models.SilenceWithMetadata {
 	silencesWithMetadata := make([]*models.SilenceWithMetadata, 0, len(silences))
 	for _, silence := range silences {
 		silencesWithMetadata = append(silencesWithMetadata, &models.SilenceWithMetadata{

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -633,12 +633,13 @@ func createSut(t *testing.T) AlertmanagerSrv {
 	log := log.NewNopLogger()
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
 	ruleStore := ngfakes.NewRuleStore(t)
+	ruleAuthzService := accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures()))
 	return AlertmanagerSrv{
 		mam:        mam,
 		crypto:     mam.Crypto,
 		ac:         ac,
 		log:        log,
-		silenceSvc: notifier.NewSilenceService(accesscontrol.NewSilenceService(ac, ruleStore), ruleStore, log, mam),
+		silenceSvc: notifier.NewSilenceService(accesscontrol.NewSilenceService(ac, ruleStore), ruleStore, log, mam, ruleStore, ruleAuthzService),
 	}
 }
 

--- a/pkg/services/ngalert/api/compat_silences.go
+++ b/pkg/services/ngalert/api/compat_silences.go
@@ -13,11 +13,7 @@ func SilenceToGettableGrafanaSilence(s *models.SilenceWithMetadata) definitions.
 	gettable := definitions.GettableGrafanaSilence{
 		GettableSilence: (*definitions.GettableSilence)(s.Silence),
 	}
-	if s.Metadata.Permissions == nil && s.Metadata.RuleMetadata == nil {
-		return gettable
-	}
 
-	gettable.Metadata = &definitions.SilenceMetadata{}
 	if s.Metadata.Permissions != nil {
 		gettable.Permissions = make(map[definitions.SilencePermission]bool, len(*s.Metadata.Permissions))
 		for _, permission := range models.SilencePermissions() {
@@ -31,9 +27,11 @@ func SilenceToGettableGrafanaSilence(s *models.SilenceWithMetadata) definitions.
 	}
 
 	if s.Metadata.RuleMetadata != nil {
-		gettable.Metadata.RuleUID = s.Metadata.RuleMetadata.RuleUID
-		gettable.Metadata.RuleTitle = s.Metadata.RuleMetadata.RuleTitle
-		gettable.Metadata.FolderUID = s.Metadata.RuleMetadata.FolderUID
+		gettable.Metadata = &definitions.SilenceMetadata{
+			RuleUID:   s.Metadata.RuleMetadata.RuleUID,
+			RuleTitle: s.Metadata.RuleMetadata.RuleTitle,
+			FolderUID: s.Metadata.RuleMetadata.FolderUID,
+		}
 	}
 
 	return gettable

--- a/pkg/services/ngalert/api/compat_silences.go
+++ b/pkg/services/ngalert/api/compat_silences.go
@@ -19,14 +19,14 @@ func SilenceToGettableGrafanaSilence(s *models.SilenceWithMetadata) definitions.
 
 	gettable.Metadata = &definitions.SilenceMetadata{}
 	if s.Metadata.Permissions != nil {
-		gettable.Metadata.Permissions = make(map[definitions.SilencePermission]bool, len(*s.Metadata.Permissions))
+		gettable.Permissions = make(map[definitions.SilencePermission]bool, len(*s.Metadata.Permissions))
 		for _, permission := range models.SilencePermissions() {
 			p, err := SilencePermissionToAPI(permission)
 			if err != nil {
 				// Skip unknown permissions in response.
 				continue
 			}
-			gettable.Metadata.Permissions[p] = s.Metadata.Permissions.Has(permission)
+			gettable.Permissions[p] = s.Metadata.Permissions.Has(permission)
 		}
 	}
 

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -30,4 +30,5 @@ type RuleStore interface {
 	IncreaseVersionForAllRulesInNamespace(ctx context.Context, orgID int64, namespaceUID string) ([]ngmodels.AlertRuleKeyWithVersion, error)
 
 	accesscontrol.RuleUIDToNamespaceStore
+	GetAlertRulesGroupsByRuleUIDs(ctx context.Context, query *ngmodels.GetAlertRulesGroupsByRuleUIDsQuery) (map[ngmodels.AlertRuleGroupKey]ngmodels.RulesGroup, error)
 }

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -30,5 +30,4 @@ type RuleStore interface {
 	IncreaseVersionForAllRulesInNamespace(ctx context.Context, orgID int64, namespaceUID string) ([]ngmodels.AlertRuleKeyWithVersion, error)
 
 	accesscontrol.RuleUIDToNamespaceStore
-	GetAlertRulesGroupsByRuleUIDs(ctx context.Context, query *ngmodels.GetAlertRulesGroupsByRuleUIDsQuery) (map[ngmodels.AlertRuleGroupKey]ngmodels.RulesGroup, error)
 }

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -390,8 +390,14 @@ type GetDeleteSilenceParams struct {
 type GetSilencesParams struct {
 	// in:query
 	Filter []string `json:"filter"`
+	// Return rule metadata with silence.
 	// in:query
-	WithMetadata bool `json:"withMetadata"`
+	// required:false
+	RuleMetadata bool `json:"ruleMetadata"`
+	// Return access control metadata with silence.
+	// in:query
+	// required:false
+	AccessControl bool `json:"accesscontrol"`
 }
 
 // swagger:model
@@ -489,10 +495,11 @@ type GettableGrafanaSilence struct {
 }
 
 type SilenceMetadata struct {
-	RuleUID     string                         `json:"rule_uid,omitempty"`
-	RuleTitle   string                         `json:"rule_title,omitempty"`
-	FolderUID   string                         `json:"folder_uid,omitempty"`
-	Permissions map[SilencePermission]struct{} `json:"permissions,omitempty"`
+	RuleUID   string `json:"rule_uid,omitempty"`
+	RuleTitle string `json:"rule_title,omitempty"`
+	FolderUID string `json:"folder_uid,omitempty"`
+	// example: {"read": true, "write": false, "create": false}
+	Permissions map[SilencePermission]bool `json:"accessControl,omitempty"`
 }
 
 type SilencePermission string

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -492,14 +492,14 @@ type GettableSilence = amv2.GettableSilence
 type GettableGrafanaSilence struct {
 	*GettableSilence `json:",inline"`
 	Metadata         *SilenceMetadata `json:"metadata,omitempty"`
+	// example: {"read": true, "write": false, "create": false}
+	Permissions map[SilencePermission]bool `json:"accessControl,omitempty"`
 }
 
 type SilenceMetadata struct {
 	RuleUID   string `json:"rule_uid,omitempty"`
 	RuleTitle string `json:"rule_title,omitempty"`
 	FolderUID string `json:"folder_uid,omitempty"`
-	// example: {"read": true, "write": false, "create": false}
-	Permissions map[SilencePermission]bool `json:"accessControl,omitempty"`
 }
 
 type SilencePermission string
@@ -525,6 +525,10 @@ func (s GettableGrafanaSilence) MarshalJSON() ([]byte, error) {
 
 	if s.Metadata != nil {
 		data["metadata"] = s.Metadata
+	}
+
+	if s.Permissions != nil {
+		data["accessControl"] = s.Permissions
 	}
 
 	return json.Marshal(data)

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -434,10 +434,6 @@ type AlertRuleGroupKey struct {
 	RuleGroup    string
 }
 
-func (k AlertRuleGroupKey) LogContext() []any {
-	return []any{"org_id", k.OrgID, "namespace_uid", k.NamespaceUID, "rule_group", k.RuleGroup}
-}
-
 func (k AlertRuleGroupKey) String() string {
 	return fmt.Sprintf("{orgID: %d, namespaceUID: %s, groupName: %s}", k.OrgID, k.NamespaceUID, k.RuleGroup)
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	alertingModels "github.com/grafana/alerting/models"
@@ -433,6 +434,10 @@ type AlertRuleGroupKey struct {
 	RuleGroup    string
 }
 
+func (k AlertRuleGroupKey) LogContext() []any {
+	return []any{"org_id", k.OrgID, "namespace_uid", k.NamespaceUID, "rule_group", k.RuleGroup}
+}
+
 func (k AlertRuleGroupKey) String() string {
 	return fmt.Sprintf("{orgID: %d, namespaceUID: %s, groupName: %s}", k.OrgID, k.NamespaceUID, k.RuleGroup)
 }
@@ -603,6 +608,12 @@ type GetAlertRuleByUIDQuery struct {
 // GetAlertRulesGroupByRuleUIDQuery is the query for retrieving a group of alerts by UID of a rule that belongs to that group
 type GetAlertRulesGroupByRuleUIDQuery struct {
 	UID   string
+	OrgID int64
+}
+
+// GetAlertRulesGroupsByRuleUIDsQuery is the query for retrieving all groups of alerts that contain any of the rule UIDs provided.
+type GetAlertRulesGroupsByRuleUIDsQuery struct {
+	UIDs  []string
 	OrgID int64
 }
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -611,15 +611,10 @@ type GetAlertRulesGroupByRuleUIDQuery struct {
 	OrgID int64
 }
 
-// GetAlertRulesGroupsByRuleUIDsQuery is the query for retrieving all groups of alerts that contain any of the rule UIDs provided.
-type GetAlertRulesGroupsByRuleUIDsQuery struct {
-	UIDs  []string
-	OrgID int64
-}
-
 // ListAlertRulesQuery is the query for listing alert rules
 type ListAlertRulesQuery struct {
 	OrgID         int64
+	RuleUIDs      []string
 	NamespaceUIDs []string
 	ExcludeOrgs   []int64
 	RuleGroups    []string

--- a/pkg/services/ngalert/models/silence.go
+++ b/pkg/services/ngalert/models/silence.go
@@ -35,3 +35,23 @@ func isEqualMatcher(m amv2.Matcher) bool {
 	// If IsEqual is nil, it is considered to be true.
 	return (m.IsEqual == nil || *m.IsEqual) && (m.IsRegex == nil || !*m.IsRegex)
 }
+
+type SilenceWithMetadata struct {
+	*Silence
+	Metadata *SilenceMetadata
+}
+
+type SilenceMetadata struct {
+	RuleUID     string
+	RuleTitle   string
+	FolderUID   string
+	Permissions map[SilencePermission]struct{}
+}
+
+type SilencePermission string
+
+const (
+	SilencePermissionRead   SilencePermission = "read"
+	SilencePermissionCreate SilencePermission = "create"
+	SilencePermissionWrite  SilencePermission = "write"
+)

--- a/pkg/services/ngalert/models/silence.go
+++ b/pkg/services/ngalert/models/silence.go
@@ -37,18 +37,26 @@ func isEqualMatcher(m amv2.Matcher) bool {
 	return (m.IsEqual == nil || *m.IsEqual) && (m.IsRegex == nil || !*m.IsRegex)
 }
 
+// SilenceWithMetadata is a helper type for managing a silence with associated metadata.
 type SilenceWithMetadata struct {
 	*Silence
-	Metadata *SilenceMetadata
+	Metadata SilenceMetadata
 }
 
+// SilenceMetadata contains metadata about a silence. Fields are pointers to allow for metadata to be optionally loaded.
 type SilenceMetadata struct {
-	RuleUID     string
-	RuleTitle   string
-	FolderUID   string
-	Permissions SilencePermissionSet
+	RuleMetadata *SilenceRuleMetadata
+	Permissions  *SilencePermissionSet
 }
 
+// SilenceRuleMetadata contains metadata about the rule associated with a silence.
+type SilenceRuleMetadata struct {
+	RuleUID   string
+	RuleTitle string
+	FolderUID string
+}
+
+// SilencePermission is a type for representing a silence permission.
 type SilencePermission string
 
 const (
@@ -66,7 +74,7 @@ func SilencePermissions() [3]SilencePermission {
 	}
 }
 
-// SilencePermissionSet is a helper type for managing a set of silence permissions.
+// SilencePermissionSet represents a set of permissions for a silence.
 type SilencePermissionSet map[SilencePermission]bool
 
 // Clone returns a deep copy of the permission set.

--- a/pkg/services/ngalert/models/silence.go
+++ b/pkg/services/ngalert/models/silence.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
+	"golang.org/x/exp/maps"
 
 	alertingModels "github.com/grafana/alerting/models"
 	"github.com/grafana/alerting/notify"
@@ -45,7 +46,7 @@ type SilenceMetadata struct {
 	RuleUID     string
 	RuleTitle   string
 	FolderUID   string
-	Permissions map[SilencePermission]struct{}
+	Permissions SilencePermissionSet
 }
 
 type SilencePermission string
@@ -55,3 +56,35 @@ const (
 	SilencePermissionCreate SilencePermission = "create"
 	SilencePermissionWrite  SilencePermission = "write"
 )
+
+// SilencePermissions returns all possible silence permissions.
+func SilencePermissions() [3]SilencePermission {
+	return [3]SilencePermission{
+		SilencePermissionRead,
+		SilencePermissionCreate,
+		SilencePermissionWrite,
+	}
+}
+
+// SilencePermissionSet is a helper type for managing a set of silence permissions.
+type SilencePermissionSet map[SilencePermission]bool
+
+// Clone returns a deep copy of the permission set.
+func (p SilencePermissionSet) Clone() SilencePermissionSet {
+	return maps.Clone(p)
+}
+
+// AllSet returns true if all possible permissions are set.
+func (p SilencePermissionSet) AllSet() bool {
+	for _, permission := range SilencePermissions() {
+		if _, ok := p[permission]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Has returns true if the given permission is allowed in the set.
+func (p SilencePermissionSet) Has(permission SilencePermission) bool {
+	return p[permission]
+}

--- a/pkg/services/ngalert/models/silence_test.go
+++ b/pkg/services/ngalert/models/silence_test.go
@@ -139,5 +139,4 @@ func TestSilencePermissionSet(t *testing.T) {
 			})
 		}
 	})
-
 }

--- a/pkg/services/ngalert/models/silence_test.go
+++ b/pkg/services/ngalert/models/silence_test.go
@@ -48,3 +48,96 @@ func TestSilenceGetRuleUID(t *testing.T) {
 		})
 	}
 }
+
+func TestSilencePermissionSet(t *testing.T) {
+	t.Run("Clone", func(t *testing.T) {
+		perms := SilencePermissionSet{
+			SilencePermissionRead:  true,
+			SilencePermissionWrite: false,
+		}
+		clone := perms.Clone()
+		assert.Equal(t, perms, clone)
+		clone[SilencePermissionRead] = false
+		assert.NotEqual(t, perms, clone)
+	})
+
+	t.Run("AllSet + SilencePermissions", func(t *testing.T) {
+		readPerms := SilencePermissionSet{
+			SilencePermissionRead: true,
+		}
+		assert.False(t, readPerms.AllSet())
+
+		allPerms := SilencePermissionSet{}
+		for _, perm := range SilencePermissions() {
+			allPerms[perm] = true
+		}
+		assert.True(t, allPerms.AllSet())
+	})
+
+	t.Run("Has", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			permissionSet SilencePermissionSet
+			expectedHas   map[SilencePermission]bool
+		}{
+			{
+				name: "all false",
+				permissionSet: SilencePermissionSet{
+					SilencePermissionRead:   false,
+					SilencePermissionWrite:  false,
+					SilencePermissionCreate: false,
+				},
+				expectedHas: map[SilencePermission]bool{
+					SilencePermissionRead:   false,
+					SilencePermissionWrite:  false,
+					SilencePermissionCreate: false,
+				},
+			},
+			{
+				name: "all true",
+				permissionSet: SilencePermissionSet{
+					SilencePermissionRead:   true,
+					SilencePermissionWrite:  true,
+					SilencePermissionCreate: true,
+				},
+				expectedHas: map[SilencePermission]bool{
+					SilencePermissionRead:   true,
+					SilencePermissionWrite:  true,
+					SilencePermissionCreate: true,
+				},
+			},
+			{
+				name: "mixed",
+				permissionSet: SilencePermissionSet{
+					SilencePermissionRead:   true,
+					SilencePermissionWrite:  false,
+					SilencePermissionCreate: true,
+				},
+				expectedHas: map[SilencePermission]bool{
+					SilencePermissionRead:   true,
+					SilencePermissionWrite:  false,
+					SilencePermissionCreate: true,
+				},
+			},
+			{
+				name: "not set = false",
+				permissionSet: SilencePermissionSet{
+					SilencePermissionRead: true,
+				},
+				expectedHas: map[SilencePermission]bool{
+					SilencePermissionRead:   true,
+					SilencePermissionWrite:  false,
+					SilencePermissionCreate: false,
+				},
+			},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for perm, expected := range tc.expectedHas {
+					assert.Equal(t, expected, tc.permissionSet.Has(perm))
+				}
+			})
+		}
+	})
+
+}

--- a/pkg/services/ngalert/notifier/silence_svc.go
+++ b/pkg/services/ngalert/notifier/silence_svc.go
@@ -2,18 +2,31 @@ package notifier
 
 import (
 	"context"
+	"fmt"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
 )
 
 // SilenceService is the authenticated service for managing alertmanager silences.
 type SilenceService struct {
-	authz SilenceAccessControlService
-	xact  transactionManager
-	log   log.Logger
-	store SilenceStore
+	authz     SilenceAccessControlService
+	xact      transactionManager
+	log       log.Logger
+	store     SilenceStore
+	ruleStore RuleStore
+	ruleAuthz RuleAccessControlService
+}
+
+type RuleAccessControlService interface {
+	HasAccessToRuleGroup(ctx context.Context, user identity.Requester, rules models.RulesGroup) (bool, error)
+	AuthorizeAccessToRuleGroup(ctx context.Context, user identity.Requester, rules models.RulesGroup) error
+	AuthorizeRuleChanges(ctx context.Context, user identity.Requester, change *store.GroupDelta) error
+	AuthorizeDatasourceAccessForRule(ctx context.Context, user identity.Requester, rule *models.AlertRule) error
 }
 
 // SilenceAccessControlService provides access control for silences.
@@ -22,6 +35,7 @@ type SilenceAccessControlService interface {
 	AuthorizeReadSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error
 	AuthorizeCreateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error
 	AuthorizeUpdateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error
+	SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]map[models.SilencePermission]struct{}, error)
 }
 
 // SilenceStore is the interface for storing and retrieving silences. Currently, this is implemented by
@@ -34,43 +48,72 @@ type SilenceStore interface {
 	DeleteSilence(ctx context.Context, orgID int64, id string) error
 }
 
+type RuleStore interface {
+	GetAlertRulesGroupsByRuleUIDs(ctx context.Context, query *models.GetAlertRulesGroupsByRuleUIDsQuery) (map[models.AlertRuleGroupKey]models.RulesGroup, error)
+}
+
 func NewSilenceService(
 	authz SilenceAccessControlService,
 	xact transactionManager,
 	log log.Logger,
 	store SilenceStore,
+	ruleStore RuleStore,
+	ruleAuthz RuleAccessControlService,
 ) *SilenceService {
 	return &SilenceService{
-		authz: authz,
-		xact:  xact,
-		log:   log,
-		store: store,
+		authz:     authz,
+		xact:      xact,
+		log:       log,
+		store:     store,
+		ruleStore: ruleStore,
+		ruleAuthz: ruleAuthz,
 	}
 }
 
 // GetSilence retrieves a silence by its ID.
-func (s *SilenceService) GetSilence(ctx context.Context, user identity.Requester, silenceID string) (*models.Silence, error) {
-	gettableSilence, err := s.store.GetSilence(ctx, user.GetOrgID(), silenceID)
+func (s *SilenceService) GetSilence(ctx context.Context, user identity.Requester, silenceID string, withMetadata bool) (*models.SilenceWithMetadata, error) {
+	silence, err := s.store.GetSilence(ctx, user.GetOrgID(), silenceID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := s.authz.AuthorizeReadSilence(ctx, user, gettableSilence); err != nil {
+	if err := s.authz.AuthorizeReadSilence(ctx, user, silence); err != nil {
 		return nil, err
 	}
 
-	return gettableSilence, nil
+	if withMetadata {
+		if silencesWithMetadata, err := s.WithMetadata(ctx, user, silence); err == nil && len(silencesWithMetadata) == 1 {
+			return silencesWithMetadata[0], nil
+		}
+		s.log.Error("failed to get silence metadata", "silenceID", silenceID, "error", err)
+	}
+
+	return &models.SilenceWithMetadata{
+		Silence: silence,
+	}, nil
 }
 
 // ListSilences retrieves all silences that match the given filter. This will include all rule-specific silences that
 // the user has access to as well as all general silences.
-func (s *SilenceService) ListSilences(ctx context.Context, user identity.Requester, filter []string) ([]*models.Silence, error) {
-	gettableSilences, err := s.store.ListSilences(ctx, user.GetOrgID(), filter)
+func (s *SilenceService) ListSilences(ctx context.Context, user identity.Requester, filter []string, withMetadata bool) ([]*models.SilenceWithMetadata, error) {
+	silences, err := s.store.ListSilences(ctx, user.GetOrgID(), filter)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.authz.FilterByAccess(ctx, user, gettableSilences...)
+	filtered, err := s.authz.FilterByAccess(ctx, user, silences...)
+	if err != nil {
+		return nil, err
+	}
+
+	if withMetadata {
+		if silencesWithMetadata, err := s.WithMetadata(ctx, user, filtered...); err != nil {
+			s.log.Error("failed to get silences metadata", "error", err)
+		} else {
+			return silencesWithMetadata, nil
+		}
+	}
+	return withNoMetadata(filtered...), nil
 }
 
 // CreateSilence creates a new silence.
@@ -109,12 +152,12 @@ func (s *SilenceService) UpdateSilence(ctx context.Context, user identity.Reques
 // For rule-specific silences, the user needs permission to update silences in the folder that the associated rule is in.
 // For general silences, the user needs broader permissions.
 func (s *SilenceService) DeleteSilence(ctx context.Context, user identity.Requester, silenceID string) error {
-	silence, err := s.GetSilence(ctx, user, silenceID)
+	silence, err := s.GetSilence(ctx, user, silenceID, false)
 	if err != nil {
 		return err
 	}
 
-	if err := s.authz.AuthorizeUpdateSilence(ctx, user, silence); err != nil {
+	if err := s.authz.AuthorizeUpdateSilence(ctx, user, silence.Silence); err != nil {
 		return err
 	}
 
@@ -124,4 +167,87 @@ func (s *SilenceService) DeleteSilence(ctx context.Context, user identity.Reques
 	}
 
 	return nil
+}
+
+func (s *SilenceService) WithMetadata(ctx context.Context, user identity.Requester, silences ...*models.Silence) ([]*models.SilenceWithMetadata, error) {
+	permissions, err := s.authz.SilenceAccess(ctx, user, silences)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(permissions) != len(silences) {
+		return nil, fmt.Errorf("failed to get metadata for all silences")
+	}
+
+	silencesWithMetadata := make([]*models.SilenceWithMetadata, 0, len(silences))
+	for _, silence := range silences {
+		silencesWithMetadata = append(silencesWithMetadata, &models.SilenceWithMetadata{
+			Silence: silence,
+			Metadata: &models.SilenceMetadata{
+				Permissions: permissions[silence],
+			},
+		})
+	}
+
+	return s.addRuleMetadata(ctx, user, silencesWithMetadata...)
+}
+
+func (s *SilenceService) addRuleMetadata(ctx context.Context, user identity.Requester, silences ...*models.SilenceWithMetadata) ([]*models.SilenceWithMetadata, error) {
+	byRuleUID := make(map[string][]*models.SilenceWithMetadata, len(silences))
+	for _, silence := range silences {
+		ruleUID := silence.GetRuleUID()
+		if ruleUID != nil {
+			byRuleUID[*ruleUID] = append(byRuleUID[*ruleUID], silence)
+		}
+	}
+
+	if len(byRuleUID) == 0 {
+		return silences, nil
+	}
+
+	q := models.GetAlertRulesGroupsByRuleUIDsQuery{
+		UIDs:  maps.Keys(byRuleUID),
+		OrgID: user.GetOrgID(),
+	}
+
+	groups, err := s.ruleStore.GetAlertRulesGroupsByRuleUIDs(ctx, &q)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check access to the rule groups.
+	for groupKey, rulesGroup := range groups {
+		hasAccess, err := s.ruleAuthz.HasAccessToRuleGroup(ctx, user, rulesGroup)
+		if err != nil {
+			s.log.Error("failed to check access to rule group", append(groupKey.LogContext(), "error", err)...)
+		}
+		if !hasAccess {
+			continue
+		}
+
+		for _, rule := range rulesGroup {
+			if ruleSilences, ok := byRuleUID[rule.UID]; ok {
+				for _, sil := range ruleSilences {
+					if sil.Metadata == nil {
+						sil.Metadata = &models.SilenceMetadata{}
+					}
+					sil.Metadata.RuleUID = rule.UID
+					sil.Metadata.RuleTitle = rule.Title
+					sil.Metadata.FolderUID = rule.NamespaceUID
+				}
+			}
+		}
+	}
+
+	return silences, nil
+}
+
+func withNoMetadata(silences ...*models.Silence) []*models.SilenceWithMetadata {
+	silencesWithMetadata := make([]*models.SilenceWithMetadata, 0, len(silences))
+	for _, silence := range silences {
+		silencesWithMetadata = append(silencesWithMetadata, &models.SilenceWithMetadata{
+			Silence: silence,
+		})
+	}
+	return silencesWithMetadata
 }

--- a/pkg/services/ngalert/notifier/silence_svc.go
+++ b/pkg/services/ngalert/notifier/silence_svc.go
@@ -35,7 +35,7 @@ type SilenceAccessControlService interface {
 	AuthorizeReadSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error
 	AuthorizeCreateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error
 	AuthorizeUpdateSilence(ctx context.Context, user identity.Requester, silence *models.Silence) error
-	SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]map[models.SilencePermission]struct{}, error)
+	SilenceAccess(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error)
 }
 
 // SilenceStore is the interface for storing and retrieving silences. Currently, this is implemented by

--- a/pkg/services/ngalert/notifier/silence_svc.go
+++ b/pkg/services/ngalert/notifier/silence_svc.go
@@ -156,7 +156,7 @@ func (s *SilenceService) WithAccessControlMetadata(ctx context.Context, user ide
 	}
 
 	if len(permissions) != len(silences) {
-		s.log.Error("failed to get metadata for all silences")
+		s.log.Warn("failed to get metadata for all silences")
 	}
 
 	for _, silence := range silencesWithMetadata {

--- a/pkg/services/ngalert/notifier/silence_svc.go
+++ b/pkg/services/ngalert/notifier/silence_svc.go
@@ -88,12 +88,7 @@ func (s *SilenceService) ListSilences(ctx context.Context, user identity.Request
 		return nil, err
 	}
 
-	filtered, err := s.authz.FilterByAccess(ctx, user, silences...)
-	if err != nil {
-		return nil, err
-	}
-
-	return filtered, nil
+	return s.authz.FilterByAccess(ctx, user, silences...)
 }
 
 // CreateSilence creates a new silence.

--- a/pkg/services/ngalert/notifier/silence_svc.go
+++ b/pkg/services/ngalert/notifier/silence_svc.go
@@ -175,6 +175,9 @@ func (s *SilenceService) WithRuleMetadata(ctx context.Context, user identity.Req
 		ruleUID := silence.GetRuleUID()
 		if ruleUID != nil {
 			byRuleUID[*ruleUID] = append(byRuleUID[*ruleUID], silence)
+			silence.Metadata.RuleMetadata = &models.SilenceRuleMetadata{ // Attach metadata with rule UID regardless of access.
+				RuleUID: *ruleUID,
+			}
 		}
 	}
 
@@ -212,11 +215,11 @@ func (s *SilenceService) WithRuleMetadata(ctx context.Context, user identity.Req
 
 		if ruleSilences, ok := byRuleUID[rule.UID]; ok {
 			for _, sil := range ruleSilences {
-				sil.Metadata.RuleMetadata = &models.SilenceRuleMetadata{
-					RuleUID:   rule.UID,
-					RuleTitle: rule.Title,
-					FolderUID: rule.NamespaceUID,
+				if sil.Metadata.RuleMetadata == nil {
+					sil.Metadata.RuleMetadata = &models.SilenceRuleMetadata{}
 				}
+				sil.Metadata.RuleMetadata.RuleTitle = rule.Title
+				sil.Metadata.RuleMetadata.FolderUID = rule.NamespaceUID
 			}
 		}
 	}

--- a/pkg/services/ngalert/notifier/silence_svc_test.go
+++ b/pkg/services/ngalert/notifier/silence_svc_test.go
@@ -1,0 +1,162 @@
+package notifier
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	alertingmodels "github.com/grafana/alerting/models"
+	ngfakes "github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
+
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/auth/identity"
+	"github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/accesscontrol/fakes"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func TestWithAccessControlMetadata(t *testing.T) {
+	user := ac.BackgroundUser("test", 1, org.RoleNone, nil)
+	silencesWithMetadata := []*models.SilenceWithMetadata{
+		{Silence: util.Pointer(models.SilenceGen()())},
+		{Silence: util.Pointer(models.SilenceGen()())},
+		{Silence: util.Pointer(models.SilenceGen()())},
+	}
+	randPerm := func() models.SilencePermissionSet {
+		return models.SilencePermissionSet{
+			models.SilencePermissionRead:   rand.Intn(2) == 1,
+			models.SilencePermissionWrite:  rand.Intn(2) == 1,
+			models.SilencePermissionCreate: rand.Intn(2) == 1,
+		}
+	}
+	t.Run("Attach permissions to silences", func(t *testing.T) {
+		authz := fakes.FakeSilenceService{}
+		response := map[*models.Silence]models.SilencePermissionSet{
+			silencesWithMetadata[0].Silence: randPerm(),
+			silencesWithMetadata[1].Silence: randPerm(),
+			silencesWithMetadata[2].Silence: randPerm(),
+		}
+		authz.SilenceAccessFunc = func(ctx context.Context, user identity.Requester, silences []*models.Silence) (map[*models.Silence]models.SilencePermissionSet, error) {
+			return response, nil
+		}
+		svc := SilenceService{
+			authz: &authz,
+		}
+
+		require.NoError(t, svc.WithAccessControlMetadata(context.Background(), user, silencesWithMetadata...))
+		for _, silence := range silencesWithMetadata {
+			assert.Equal(t, response[silence.Silence], *silence.Metadata.Permissions)
+		}
+	})
+}
+
+func TestWithRuleMetadata(t *testing.T) {
+	user := ac.BackgroundUser("test", 1, org.RoleNone, nil)
+	t.Run("Attach rule metadata to silences", func(t *testing.T) {
+		ruleAuthz := fakes.FakeRuleService{}
+		ruleAuthz.HasAccessInFolderFunc = func(ctx context.Context, user identity.Requester, silence accesscontrol.Namespaced) (bool, error) {
+			return true, nil
+		}
+
+		rules := []*models.AlertRule{
+			{UID: "rule1", NamespaceUID: "folder1"},
+			{UID: "rule2", NamespaceUID: "folder2"},
+			{UID: "rule3", NamespaceUID: "folder3"},
+		}
+		ruleStore := ngfakes.NewRuleStore(t)
+		ruleStore.Rules[1] = rules
+		svc := SilenceService{
+			ruleAuthz: &ruleAuthz,
+			ruleStore: ruleStore,
+		}
+
+		silencesWithMetadata := []*models.SilenceWithMetadata{
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule1", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule2", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule3", labels.MatchEqual))())},
+		}
+
+		require.NoError(t, svc.WithRuleMetadata(context.Background(), user, silencesWithMetadata...))
+		for i, silence := range silencesWithMetadata {
+			metadata := &models.SilenceRuleMetadata{
+				RuleUID:   rules[i].UID,
+				RuleTitle: rules[i].Title,
+				FolderUID: rules[i].NamespaceUID,
+			}
+			assert.Equal(t, silence.Metadata, models.SilenceMetadata{RuleMetadata: metadata})
+		}
+	})
+	t.Run("Don't attach rule metadata if no access or global", func(t *testing.T) {
+		ruleAuthz := fakes.FakeRuleService{}
+		ruleAuthz.HasAccessInFolderFunc = func(ctx context.Context, user identity.Requester, silence accesscontrol.Namespaced) (bool, error) {
+			return silence.GetNamespaceUID() == "folder1", nil
+		}
+
+		rules := []*models.AlertRule{
+			{UID: "rule1", NamespaceUID: "folder1"},
+			{UID: "rule2", NamespaceUID: "folder2"},
+			{UID: "rule3", NamespaceUID: "folder3"},
+		}
+		ruleStore := ngfakes.NewRuleStore(t)
+		ruleStore.Rules[1] = rules
+		svc := SilenceService{
+			ruleAuthz: &ruleAuthz,
+			ruleStore: ruleStore,
+		}
+
+		silencesWithMetadata := []*models.SilenceWithMetadata{
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule1", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule2", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule3", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen()())},
+		}
+
+		require.NoError(t, svc.WithRuleMetadata(context.Background(), user, silencesWithMetadata...))
+		for i, silence := range silencesWithMetadata {
+			var metadata *models.SilenceRuleMetadata
+			if silence.GetRuleUID() != nil && *silence.GetRuleUID() == "rule1" {
+				metadata = &models.SilenceRuleMetadata{
+					RuleUID:   rules[i].UID,
+					RuleTitle: rules[i].Title,
+					FolderUID: rules[i].NamespaceUID,
+				}
+			}
+			assert.Equal(t, silence.Metadata, models.SilenceMetadata{RuleMetadata: metadata})
+		}
+	})
+	t.Run("Don't check same namespace access more than once", func(t *testing.T) {
+		ruleAuthz := fakes.FakeRuleService{}
+		ruleAuthz.HasAccessInFolderFunc = func(ctx context.Context, user identity.Requester, silence accesscontrol.Namespaced) (bool, error) {
+			return true, nil
+		}
+
+		rules := []*models.AlertRule{
+			{UID: "rule1", NamespaceUID: "folder1"},
+			{UID: "rule2", NamespaceUID: "folder1"},
+			{UID: "rule3", NamespaceUID: "folder1"},
+		}
+		ruleStore := ngfakes.NewRuleStore(t)
+		ruleStore.Rules[1] = rules
+		svc := SilenceService{
+			ruleAuthz: &ruleAuthz,
+			ruleStore: ruleStore,
+		}
+
+		silencesWithMetadata := []*models.SilenceWithMetadata{
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule1", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule2", labels.MatchEqual))())},
+			{Silence: util.Pointer(models.SilenceGen(models.SilenceMuts.WithMatcher(alertingmodels.RuleUIDLabel, "rule3", labels.MatchEqual))())},
+		}
+
+		require.NoError(t, svc.WithRuleMetadata(context.Background(), user, silencesWithMetadata...))
+		assert.Lenf(t, ruleAuthz.Calls, 1, "HasAccessInFolder should be called only once per namespace")
+		assert.Equal(t, "HasAccessInFolder", ruleAuthz.Calls[0].MethodName)
+		assert.Equal(t, "folder1", ruleAuthz.Calls[0].Arguments[2].(accesscontrol.Namespaced).GetNamespaceUID())
+	})
+}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -120,6 +120,29 @@ func (st DBstore) GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmode
 	return result, err
 }
 
+// GetAlertRulesGroupsByRuleUIDs is a handler for retrieving groups of alert rules from that database by UIDs and organisation ID of any rule that belong to the groups.
+func (st DBstore) GetAlertRulesGroupsByRuleUIDs(ctx context.Context, query *ngmodels.GetAlertRulesGroupsByRuleUIDsQuery) (map[ngmodels.AlertRuleGroupKey]ngmodels.RulesGroup, error) {
+	var rules []*ngmodels.AlertRule
+	err := st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
+		err := sess.Table("alert_rule").Alias("a").Join(
+			"INNER",
+			"alert_rule AS b", "a.org_id = b.org_id AND a.namespace_uid = b.namespace_uid AND a.rule_group = b.rule_group",
+		).Where("a.org_id = ?", query.OrgID).In("b.uid", query.UIDs).Distinct("a.*").Asc("a.namespace_uid", "a.rule_group", "a.rule_group_idx", "a.id").Find(&rules)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// Group rules by rule group
+	result := make(map[ngmodels.AlertRuleGroupKey]ngmodels.RulesGroup)
+	for _, rule := range rules {
+		groupKey := rule.GetGroupKey()
+		result[groupKey] = append(result[groupKey], rule)
+	}
+	return result, err
+}
+
 // InsertAlertRules is a handler for creating/updating alert rules.
 // Returns the UID and ID of rules that were created in the same order as the input rules.
 func (st DBstore) InsertAlertRules(ctx context.Context, rules []ngmodels.AlertRule) ([]ngmodels.AlertRuleKeyWithId, error) {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -176,6 +176,43 @@ func (f *RuleStore) GetAlertRulesGroupByRuleUID(_ context.Context, q *models.Get
 	return ruleList, nil
 }
 
+func (f *RuleStore) GetAlertRulesGroupsByRuleUIDs(_ context.Context, q *models.GetAlertRulesGroupsByRuleUIDsQuery) (map[models.AlertRuleGroupKey]models.RulesGroup, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = append(f.RecordedOps, *q)
+	if err := f.Hook(*q); err != nil {
+		return nil, err
+	}
+	rules, ok := f.Rules[q.OrgID]
+	if !ok {
+		return nil, nil
+	}
+
+	uids := make(map[string]struct{}, len(q.UIDs))
+	for _, uid := range q.UIDs {
+		uids[uid] = struct{}{}
+	}
+
+	result := make(map[models.AlertRuleGroupKey]models.RulesGroup)
+	for _, rule := range rules {
+		if _, ok := uids[rule.UID]; ok {
+			groupKey := rule.GetGroupKey()
+			result[groupKey] = models.RulesGroup{}
+		}
+	}
+	if len(result) == 0 {
+		return result, nil
+	}
+
+	for _, rule := range rules {
+		groupKey := rule.GetGroupKey()
+		if _, ok := result[groupKey]; ok {
+			result[groupKey] = append(result[groupKey], rule)
+		}
+	}
+	return result, nil
+}
+
 func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()


### PR DESCRIPTION
**What is this feature?**

Adds a query param options `ruleMetadata=true` and `accesscontrol=true` to `/alertmanager/grafana/api/v2/silences` and `alertmanager/grafana/api/v2/silence/{SilenceId}`

`ruleMetadata=true` will add a new metadata field containing `rule_uid`, `rule_title`, `folder_uid` for rule-specific silences.
`accessconntrol=true` will add a top-level `accessControl` field containing user permissions on each silence (`read`/`write`/`create`)

Ex:

```json
{
  "accessControl": {
    "create": false,
    "read": true,
    "write": false
  },
  "comment": "test comment",
  "createdBy": "someone",
  "endsAt": "2026-04-18T18:07:26.993Z",
  "id": "e95bcdc3-97a2-44c1-9361-5ec1d12f9f9e",
  "matchers": [{"isEqual": true,"isRegex": false,"name": "__alert_rule_uid__","value": "load_folder0_group3_alert1"}],
  "metadata": {
    "rule_uid": "load_folder0_group3_alert1",
    "rule_title": "group3_alert1",
    "folder_uid": "edmpbowggnm68d"
  },
  "startsAt": "2024-05-24T20:06:18.670Z",
  "status": {
    "state": "active"
  },
  "updatedAt": "2024-05-24T20:06:18.670Z"
}
```

**Why do we need this feature?**

This is needed to:
- Allow the UI to display useful rule information for rule-specific silences without heavy cross-reference API calls.
- Allow the UI to simplify logic on access control for deciding when to display permission-specific components.

