### PR TITLE
Fix SSO 204 responses

### DIFF
--- a/pkg/services/ssosettings/api/api.go
+++ b/pkg/services/ssosettings/api/api.go
@@ -160,7 +160,7 @@ func (api *Api) getProviderSettings(c *contextmodel.ReqContext) response.Respons
 // You need to have a permission with action `settings:write` and scope `settings:auth.<provider>:*`.
 //
 // Responses:
-// 204: okResponse
+// 204: description: The provider settings was updated successfully.
 // 400: badRequestError
 // 401: unauthorisedError
 // 403: forbiddenError
@@ -195,7 +195,7 @@ func (api *Api) updateProviderSettings(c *contextmodel.ReqContext) response.Resp
 // You need to have a permission with action `settings:write` and scope `settings:auth.<provider>:*`.
 //
 // Responses:
-// 204: okResponse
+// 204: description: The provider settings was deleted successfully.
 // 400: badRequestError
 // 401: unauthorisedError
 // 403: forbiddenError

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11379,7 +11379,7 @@
         ],
         "responses": {
           "204": {
-            "$ref": "#/responses/okResponse"
+            "description": " The provider settings was updated successfully."
           },
           "400": {
             "$ref": "#/responses/badRequestError"
@@ -11412,7 +11412,7 @@
         ],
         "responses": {
           "204": {
-            "$ref": "#/responses/okResponse"
+            "description": " The provider settings was deleted successfully."
           },
           "400": {
             "$ref": "#/responses/badRequestError"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -24970,7 +24970,7 @@
         ],
         "responses": {
           "204": {
-            "$ref": "#/components/responses/okResponse"
+            "description": " The provider settings was deleted successfully."
           },
           "400": {
             "$ref": "#/components/responses/badRequestError"
@@ -25066,7 +25066,7 @@
         },
         "responses": {
           "204": {
-            "$ref": "#/components/responses/okResponse"
+            "description": " The provider settings was updated successfully."
           },
           "400": {
             "$ref": "#/components/responses/badRequestError"


### PR DESCRIPTION
HTTP 204 code meaning "No content", this is strange that a respnonse body is provided (in the swagger description, which is not really the case in go code).
This PR changes this behaviour