### PR TITLE
Alerting: Fix scheduler to sort rules before evaluation

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -325,6 +327,9 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		step = sch.baseInterval.Nanoseconds() / int64(len(readyToRun))
 	}
 
+	slices.SortFunc(readyToRun, func(a, b readyToRunItem) int {
+		return strings.Compare(a.rule.UID, b.rule.UID)
+	})
 	for i := range readyToRun {
 		item := readyToRun[i]
 


### PR DESCRIPTION
**What is this feature?**
This PR fixes Grafnaa Alerting scheduler to sort the rules that are scheduled for the current tick before spreading them out.

**Why do we need this feature?**
This is needed to guarantee that rule is consistently evaluated every X interval. The order of items scheduled for evaluation is important because the index of element is used to calculate a delay. That delay can be up to 10 second (base interval of tick). Therefore, one time rule can be evaluated at time X + 5 second, and the next time, for example, Y = X+eval interval, at Y + 2 seconds and therefore the rule is evaluated 3 seconds earlier than it is supposed to.

This is especially important in HA mode where we rely on the fact that rules are evaluated at the same time.

**Who is this feature for?**
Alerting users

**Special notes for your reviewer:**

One possible downside of this change is that now all instances in HA mode will send the same query at pretty much the same time, which may cause some contention of the data source side. 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
