### PR TITLE
Add latency metrics to mode2

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -124,7 +124,7 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
 		return res, async, err
 	}
-	d.recordLegacyDuration(false, mode1Str, options.Kind, method, startLegacy)
+		d.recordLegacyDuration(false, mode1, name, method, startLegacy)
 
 	go func() {
 		startStorage := time.Now()

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -76,15 +76,6 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 		log.Error(errLegacy, "unable to get object in legacy storage")
 	}
 	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
-=======
-	startLegacy := time.Now().UTC()
-	res, errLegacy := d.Legacy.Get(ctx, name, options)
-	if errLegacy != nil {
-		log.Error(errLegacy, "unable to get object in legacy storage")
-		d.recordLegacyDuration(errLegacy != nil, mode, name, method, startLegacy)
-	}
-	d.recordLegacyDuration(errLegacy != nil, mode, name, method, startLegacy)
->>>>>>> c250b3d8caa (Return error from legacy write)
 
 	go func() {
 		startStorage := time.Now()

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -19,9 +19,7 @@ type DualWriterMode1 struct {
 	Log klog.Logger
 }
 
-const (
-	mode1Str = "1"
-)
+const mode1Str = "1"
 
 // NewDualWriterMode1 returns a new DualWriter in mode 1.
 // Mode 1 represents writing to and reading from LegacyStorage.
@@ -69,7 +67,10 @@ func (d *DualWriterMode1) Create(ctx context.Context, original runtime.Object, c
 
 // Get overrides the behavior of the generic DualWriter and reads only from LegacyStorage.
 func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	log := d.Log.WithValues("kind", options.Kind)
 	ctx = klog.NewContext(ctx, log)
+	var method = "get"
+
 	startLegacy := time.Now()
 	res, errLegacy := d.Legacy.Get(ctx, name, options)
 	if errLegacy != nil {
@@ -124,7 +125,7 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 		d.recordLegacyDuration(true, mode1Str, options.Kind, method, startLegacy)
 		return res, async, err
 	}
-		d.recordLegacyDuration(false, mode1, name, method, startLegacy)
+	d.recordLegacyDuration(false, mode1Str, name, method, startLegacy)
 
 	go func() {
 		startStorage := time.Now()

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -69,16 +69,22 @@ func (d *DualWriterMode1) Create(ctx context.Context, original runtime.Object, c
 
 // Get overrides the behavior of the generic DualWriter and reads only from LegacyStorage.
 func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	log := d.Log.WithValues("name", name, "resourceVersion", options.ResourceVersion, "kind", options.Kind)
 	ctx = klog.NewContext(ctx, log)
-	var method = "get"
-
 	startLegacy := time.Now()
 	res, errLegacy := d.Legacy.Get(ctx, name, options)
 	if errLegacy != nil {
 		log.Error(errLegacy, "unable to get object in legacy storage")
 	}
 	d.recordLegacyDuration(errLegacy != nil, mode1Str, options.Kind, method, startLegacy)
+=======
+	startLegacy := time.Now().UTC()
+	res, errLegacy := d.Legacy.Get(ctx, name, options)
+	if errLegacy != nil {
+		log.Error(errLegacy, "unable to get object in legacy storage")
+		d.recordLegacyDuration(errLegacy != nil, mode, name, method, startLegacy)
+	}
+	d.recordLegacyDuration(errLegacy != nil, mode, name, method, startLegacy)
+>>>>>>> c250b3d8caa (Return error from legacy write)
 
 	go func() {
 		startStorage := time.Now()

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -164,8 +164,10 @@ func (d *DualWriterMode2) DeleteCollection(ctx context.Context, deleteValidation
 	deleted, err := d.Legacy.DeleteCollection(ctx, deleteValidation, options, listOptions)
 	if err != nil {
 		log.WithValues("deleted", deleted).Error(err, "failed to delete collection successfully from legacy storage")
+		d.recordLegacyDuration(true, mode2Str, options.Kind, method, startLegacy)
+		return deleted, err
 	}
-	d.recordLegacyDuration(err != nil, mode2Str, options.Kind, method, startLegacy)
+	d.recordLegacyDuration(false, mode2Str, options.Kind, method, startLegacy)
 
 	legacyList, err := meta.ExtractList(deleted)
 	if err != nil {

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -219,7 +219,7 @@ func (d *DualWriterMode2) Update(ctx context.Context, name string, objInfo rest.
 
 		objInfo = &updateWrapper{
 			upstream: objInfo,
-			updated:  obj,
+			updated:  updated,
 		}
 	}
 

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -77,14 +77,14 @@ func (d *DualWriterMode2) Get(ctx context.Context, name string, options *metav1.
 	res, err := d.Legacy.Get(ctx, name, options)
 	if err != nil {
 		log.Error(err, "unable to get object in legacy storage")
-		d.recordLegacyDuration(true, mode2Str, name, method, startLegacy)
+		d.recordLegacyDuration(true, mode2Str, options.Kind, method, startLegacy)
 		return res, err
 	}
-	d.recordLegacyDuration(false, mode2Str, name, method, startLegacy)
+	d.recordLegacyDuration(false, mode2Str, options.Kind, method, startLegacy)
 
 	startStorage := time.Now()
 	res, err = d.Storage.Get(ctx, name, options)
-	d.recordStorageDuration(err != nil, mode2Str, name, method, startStorage)
+	d.recordStorageDuration(err != nil, mode2Str, options.Kind, method, startStorage)
 
 	return res, err
 }

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -211,6 +211,7 @@ func (d *DualWriterMode2) Update(ctx context.Context, name string, objInfo rest.
 		return obj, created, err
 	}
 
+	// if the object is found, create a new updateWrapper with the object found
 	if foundObj != nil {
 		obj, err = enrichLegacyObject(foundObj, obj, false)
 		if err != nil {

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -45,7 +45,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, original runtime.Object, c
 	var method = "create"
 
 	startLegacy := time.Now()
-	created, err := d.Legacy.Create(ctx, obj, createValidation, options)
+	created, err := d.Legacy.Create(ctx, original, createValidation, options)
 	if err != nil {
 		log.Error(err, "unable to create object in legacy storage")
 		d.recordLegacyDuration(true, mode2Str, options.Kind, method, startLegacy)

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -53,6 +53,7 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
+// no-lint: unused
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -53,7 +53,7 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
-// no-lint: unused
+// nolint:unused
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -5,6 +5,11 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+<<<<<<< HEAD
+=======
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+>>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 )
 
 type dualWriterMetrics struct {
@@ -19,7 +24,11 @@ var DualWriterStorageDuration = prometheus.NewHistogramVec(prometheus.HistogramO
 	Help:                        "Histogram for the runtime of dual writer storage duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
+<<<<<<< HEAD
 }, []string{"is_error", "mode", "kind", "method"})
+=======
+}, []string{"is_error", "mode", "name", "method"})
+>>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 
 // DualWriterLegacyDuration is a metric summary for dual writer legacy duration per mode
 var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -27,7 +36,11 @@ var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOp
 	Help:                        "Histogram for the runtime of dual writer legacy duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
+<<<<<<< HEAD
 }, []string{"is_error", "mode", "kind", "method"})
+=======
+}, []string{"is_error", "mode", "name", "method"})
+>>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 
 // DualWriterOutcome is a metric summary for dual writer outcome comparison between the 2 stores per mode
 var DualWriterOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -46,6 +59,7 @@ func (m *dualWriterMetrics) init() {
 func (m *dualWriterMetrics) recordLegacyDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
 	duration := time.Since(startFrom).Seconds()
 	m.legacy.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
+<<<<<<< HEAD
 }
 
 func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
@@ -54,10 +68,36 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 }
 
 // nolint:unused
+=======
+}
+
+func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
+	duration := time.Since(startFrom).Seconds()
+	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
+}
+
+// TODO: change this into a validation function
+>>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {
 		observeValue = 1
 	}
 	m.outcome.WithLabelValues(mode, name, method).Observe(observeValue)
+<<<<<<< HEAD
+=======
+}
+
+func compareResourceVersion(obj1, obj2 runtime.Object) (bool, error) {
+	accessor1, err := meta.Accessor(obj1)
+	if err != nil {
+		return false, err
+	}
+	accessor2, err := meta.Accessor(obj2)
+	if err != nil {
+		return false, err
+	}
+	return accessor1.GetResourceVersion() == accessor2.GetResourceVersion(), nil
+
+>>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 }

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -5,11 +5,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-<<<<<<< HEAD
-=======
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
->>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 )
 
 type dualWriterMetrics struct {
@@ -24,11 +19,7 @@ var DualWriterStorageDuration = prometheus.NewHistogramVec(prometheus.HistogramO
 	Help:                        "Histogram for the runtime of dual writer storage duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-<<<<<<< HEAD
 }, []string{"is_error", "mode", "kind", "method"})
-=======
-}, []string{"is_error", "mode", "name", "method"})
->>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 
 // DualWriterLegacyDuration is a metric summary for dual writer legacy duration per mode
 var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -36,11 +27,7 @@ var DualWriterLegacyDuration = prometheus.NewHistogramVec(prometheus.HistogramOp
 	Help:                        "Histogram for the runtime of dual writer legacy duration per mode",
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
-<<<<<<< HEAD
 }, []string{"is_error", "mode", "kind", "method"})
-=======
-}, []string{"is_error", "mode", "name", "method"})
->>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 
 // DualWriterOutcome is a metric summary for dual writer outcome comparison between the 2 stores per mode
 var DualWriterOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -59,7 +46,6 @@ func (m *dualWriterMetrics) init() {
 func (m *dualWriterMetrics) recordLegacyDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
 	duration := time.Since(startFrom).Seconds()
 	m.legacy.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
-<<<<<<< HEAD
 }
 
 func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
@@ -67,37 +53,10 @@ func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, nam
 	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
 }
 
-// nolint:unused
-=======
-}
-
-func (m *dualWriterMetrics) recordStorageDuration(isError bool, mode string, name string, method string, startFrom time.Time) {
-	duration := time.Since(startFrom).Seconds()
-	m.storage.WithLabelValues(strconv.FormatBool(isError), mode, name, method).Observe(duration)
-}
-
-// TODO: change this into a validation function
->>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool, method string) {
 	var observeValue float64
 	if outcome {
 		observeValue = 1
 	}
 	m.outcome.WithLabelValues(mode, name, method).Observe(observeValue)
-<<<<<<< HEAD
-=======
-}
-
-func compareResourceVersion(obj1, obj2 runtime.Object) (bool, error) {
-	accessor1, err := meta.Accessor(obj1)
-	if err != nil {
-		return false, err
-	}
-	accessor2, err := meta.Accessor(obj2)
-	if err != nil {
-		return false, err
-	}
-	return accessor1.GetResourceVersion() == accessor2.GetResourceVersion(), nil
-
->>>>>>> 450c2086608 (Also call storage on mode1. Add metrics)
 }


### PR DESCRIPTION
**What is this feature?**

Add latency metrics in mode2: in this mode, an error is returned if either of the stores fail.
To be merged after https://github.com/grafana/grafana/pull/87739

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/search-and-storage-team/issues/29

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
