### PR TITLE
DataSource: Use the same struct for both Add+Update commands

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -437,7 +437,7 @@ func evaluateTeamHTTPHeaderPermissions(hs *HTTPServer, c *contextmodel.ReqContex
 // 409: conflictError
 // 500: internalServerError
 func (hs *HTTPServer) AddDataSource(c *contextmodel.ReqContext) response.Response {
-	cmd := datasources.AddDataSourceCommand{}
+	cmd := datasources.DataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -509,7 +509,7 @@ func (hs *HTTPServer) AddDataSource(c *contextmodel.ReqContext) response.Respons
 // 500: internalServerError
 
 func (hs *HTTPServer) UpdateDataSourceByID(c *contextmodel.ReqContext) response.Response {
-	cmd := datasources.UpdateDataSourceCommand{}
+	cmd := datasources.DataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -559,7 +559,7 @@ func (hs *HTTPServer) UpdateDataSourceByID(c *contextmodel.ReqContext) response.
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) UpdateDataSourceByUID(c *contextmodel.ReqContext) response.Response {
-	cmd := datasources.UpdateDataSourceCommand{}
+	cmd := datasources.DataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -602,7 +602,7 @@ func getEncodedString(jsonData *simplejson.Json, key string) string {
 	return string(val)
 }
 
-func checkTeamHTTPHeaderPermissions(hs *HTTPServer, c *contextmodel.ReqContext, ds *datasources.DataSource, cmd datasources.UpdateDataSourceCommand) (bool, error) {
+func checkTeamHTTPHeaderPermissions(hs *HTTPServer, c *contextmodel.ReqContext, ds *datasources.DataSource, cmd datasources.DataSourceCommand) (bool, error) {
 	currentTeamHTTPHeaders := getEncodedString(ds.JsonData, "teamHttpHeaders")
 	newTeamHTTPHeaders := getEncodedString(cmd.JsonData, "teamHttpHeaders")
 	if (currentTeamHTTPHeaders != "" || newTeamHTTPHeaders != "") && currentTeamHTTPHeaders != newTeamHTTPHeaders {
@@ -611,7 +611,7 @@ func checkTeamHTTPHeaderPermissions(hs *HTTPServer, c *contextmodel.ReqContext, 
 	return true, nil
 }
 
-func (hs *HTTPServer) updateDataSourceByID(c *contextmodel.ReqContext, ds *datasources.DataSource, cmd datasources.UpdateDataSourceCommand) response.Response {
+func (hs *HTTPServer) updateDataSourceByID(c *contextmodel.ReqContext, ds *datasources.DataSource, cmd datasources.DataSourceCommand) response.Response {
 	if ds.ReadOnly {
 		return response.Error(http.StatusForbidden, "Cannot update read-only data source", nil)
 	}
@@ -1051,14 +1051,14 @@ type GetDataSourceIdByNameParams struct {
 type AddDataSourceParams struct {
 	// in:body
 	// required:true
-	Body datasources.AddDataSourceCommand
+	Body datasources.DataSourceCommand
 }
 
 // swagger:parameters updateDataSourceByID
 type UpdateDataSourceByIDParams struct {
 	// in:body
 	// required:true
-	Body datasources.UpdateDataSourceCommand
+	Body datasources.DataSourceCommand
 	// in:path
 	// required:true
 	DatasourceID string `json:"id"`
@@ -1068,7 +1068,7 @@ type UpdateDataSourceByIDParams struct {
 type UpdateDataSourceByUIDParams struct {
 	// in:body
 	// required:true
-	Body datasources.UpdateDataSourceCommand
+	Body datasources.DataSourceCommand
 	// in:path
 	// required:true
 	DatasourceUID string `json:"uid"`

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -90,7 +90,7 @@ func TestAddDataSource_InvalidURL(t *testing.T) {
 	}
 
 	sc.m.Post(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Name:   "Test",
 			URL:    "invalid:url",
 			Access: "direct",
@@ -122,7 +122,7 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 	sc := setupScenarioContext(t, "/api/datasources")
 
 	sc.m.Post(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Name:   name,
 			URL:    url,
 			Access: "direct",
@@ -153,7 +153,7 @@ func TestAddDataSource_InvalidJSONData(t *testing.T) {
 	jsonData.Set("httpHeaderName1", hs.Cfg.AuthProxy.HeaderName)
 
 	sc.m.Post(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Name:     "Test",
 			URL:      "localhost:5432",
 			Access:   "direct",
@@ -178,7 +178,7 @@ func TestUpdateDataSource_InvalidURL(t *testing.T) {
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
 	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Name:   "Test",
 			URL:    "invalid:url",
 			Access: "direct",
@@ -207,7 +207,7 @@ func TestUpdateDataSource_InvalidJSONData(t *testing.T) {
 	jsonData.Set("httpHeaderName1", hs.Cfg.AuthProxy.HeaderName)
 
 	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Name:     "Test",
 			URL:      "localhost:5432",
 			Access:   "direct",
@@ -302,7 +302,7 @@ func TestUpdateDataSourceTeamHTTPHeaders_InvalidJSONData(t *testing.T) {
 			jsonData := simplejson.New()
 			jsonData.Set("teamHttpHeaders", tc.data)
 			sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-				c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+				c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 					Name:     "Test",
 					URL:      "localhost:5432",
 					Access:   "direct",
@@ -339,7 +339,7 @@ func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
 	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Name:   name,
 			URL:    url,
 			Access: "direct",
@@ -360,7 +360,7 @@ func TestUpdateDataSourceByID_DataSourceNameExists(t *testing.T) {
 	hs := &HTTPServer{
 		DataSourcesService: &dataSourcesServiceMock{
 			expectedDatasource: &datasources.DataSource{},
-			mockUpdateDataSource: func(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+			mockUpdateDataSource: func(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 				return nil, datasources.ErrDataSourceNameExists
 			},
 		},
@@ -374,7 +374,7 @@ func TestUpdateDataSourceByID_DataSourceNameExists(t *testing.T) {
 
 	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
 		c.Req = web.SetURLParams(c.Req, map[string]string{":id": "1"})
-		c.Req.Body = mockRequestBody(datasources.UpdateDataSourceCommand{
+		c.Req.Body = mockRequestBody(datasources.DataSourceCommand{
 			Access: "direct",
 			Type:   "test",
 			Name:   "test",
@@ -528,7 +528,7 @@ type dataSourcesServiceMock struct {
 	expectedDatasource  *datasources.DataSource
 	expectedError       error
 
-	mockUpdateDataSource func(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error)
+	mockUpdateDataSource func(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error)
 }
 
 func (m *dataSourcesServiceMock) GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
@@ -547,11 +547,11 @@ func (m *dataSourcesServiceMock) DeleteDataSource(ctx context.Context, cmd *data
 	return m.expectedError
 }
 
-func (m *dataSourcesServiceMock) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
+func (m *dataSourcesServiceMock) AddDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	return m.expectedDatasource, m.expectedError
 }
 
-func (m *dataSourcesServiceMock) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+func (m *dataSourcesServiceMock) UpdateDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	if m.mockUpdateDataSource != nil {
 		return m.mockUpdateDataSource(ctx, cmd)
 	}

--- a/pkg/services/accesscontrol/filter_bench_test.go
+++ b/pkg/services/accesscontrol/filter_bench_test.go
@@ -56,7 +56,7 @@ func setupFilterBenchmark(b *testing.B, numDs, numPermissions int) (db.DB, []acc
 	sqlStore := db.InitTestDB(b)
 	store := dsService.CreateStore(sqlStore, log.New("accesscontrol.test"))
 	for i := 1; i <= numDs; i++ {
-		_, err := store.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		_, err := store.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			Name:  fmt.Sprintf("ds:%d", i),
 			OrgID: 1,
 		})

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -177,7 +177,7 @@ func TestFilter_Datasources(t *testing.T) {
 				// seed 10 data sources
 				for i := 1; i <= 10; i++ {
 					dsStore := dsService.CreateStore(store, log.New("accesscontrol.test"))
-					_, err := dsStore.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{Name: fmt.Sprintf("ds:%d", i), UID: fmt.Sprintf("uid%d", i)})
+					_, err := dsStore.AddDataSource(context.Background(), &datasources.DataSourceCommand{Name: fmt.Sprintf("ds:%d", i), UID: fmt.Sprintf("uid%d", i)})
 					require.NoError(t, err)
 				}
 

--- a/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_bench_test.go
@@ -84,7 +84,7 @@ func setupResourceBenchmark(b *testing.B, dsNum, usersNum int) (*store, []int64)
 func GenerateDatasourcePermissions(b *testing.B, db db.DB, cfg *setting.Cfg, ac *store, dsNum, usersNum, permissionsPerDs int) []int64 {
 	dataSources := make([]int64, 0)
 	for i := 0; i < dsNum; i++ {
-		addDSCommand := &datasources.AddDataSourceCommand{
+		addDSCommand := &datasources.DataSourceCommand{
 			OrgID:  0,
 			Name:   fmt.Sprintf("ds_%d", i),
 			Type:   datasources.DS_GRAPHITE,

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -24,7 +26,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/gcom"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Service Define the cloudmigration.Service Implementation.
@@ -402,14 +403,14 @@ func (s *Service) getMigrationDataJSON(ctx context.Context) (*cloudmigration.Mig
 	return migrationData, nil
 }
 
-func (s *Service) getDataSources(ctx context.Context) ([]datasources.AddDataSourceCommand, error) {
+func (s *Service) getDataSources(ctx context.Context) ([]datasources.DataSourceCommand, error) {
 	dataSources, err := s.dsService.GetAllDataSources(ctx, &datasources.GetAllDataSourcesQuery{})
 	if err != nil {
 		s.log.Error("Failed to get all datasources", "err", err)
 		return nil, err
 	}
 
-	result := []datasources.AddDataSourceCommand{}
+	result := []datasources.DataSourceCommand{}
 	for _, dataSource := range dataSources {
 		// Decrypt secure json to send raw credentials
 		decryptedData, err := s.secretsService.DecryptJsonData(ctx, dataSource.SecureJsonData)
@@ -417,7 +418,7 @@ func (s *Service) getDataSources(ctx context.Context) ([]datasources.AddDataSour
 			s.log.Error("Failed to decrypt secure json data", "err", err)
 			return nil, err
 		}
-		dataSourceCmd := datasources.AddDataSourceCommand{
+		dataSourceCmd := datasources.DataSourceCommand{
 			OrgID:           dataSource.OrgID,
 			Name:            dataSource.Name,
 			Type:            dataSource.Type,

--- a/pkg/services/datasources/datasources.go
+++ b/pkg/services/datasources/datasources.go
@@ -28,13 +28,13 @@ type DataSourceService interface {
 	GetDataSourcesByType(ctx context.Context, query *GetDataSourcesByTypeQuery) ([]*DataSource, error)
 
 	// AddDataSource adds a new datasource.
-	AddDataSource(ctx context.Context, cmd *AddDataSourceCommand) (*DataSource, error)
+	AddDataSource(ctx context.Context, cmd *DataSourceCommand) (*DataSource, error)
 
 	// DeleteDataSource deletes an existing datasource.
 	DeleteDataSource(ctx context.Context, cmd *DeleteDataSourceCommand) error
 
 	// UpdateDataSource updates an existing datasource.
-	UpdateDataSource(ctx context.Context, cmd *UpdateDataSourceCommand) (*DataSource, error)
+	UpdateDataSource(ctx context.Context, cmd *DataSourceCommand) (*DataSource, error)
 
 	// GetHTTPTransport gets a datasource specific HTTP transport.
 	GetHTTPTransport(ctx context.Context, ds *DataSource, provider httpclient.Provider, customMiddlewares ...sdkhttpclient.Middleware) (http.RoundTripper, error)

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -69,7 +69,7 @@ func (s *FakeDataSourceService) GetDataSourcesByType(ctx context.Context, query 
 	return dataSources, nil
 }
 
-func (s *FakeDataSourceService) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
+func (s *FakeDataSourceService) AddDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	if s.lastID == 0 {
 		s.lastID = int64(len(s.DataSources) - 1)
 	}
@@ -97,7 +97,7 @@ func (s *FakeDataSourceService) DeleteDataSource(ctx context.Context, cmd *datas
 	return datasources.ErrDataSourceNotFound
 }
 
-func (s *FakeDataSourceService) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+func (s *FakeDataSourceService) UpdateDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	for _, datasource := range s.DataSources {
 		idMatch := cmd.ID != 0 && cmd.ID == datasource.ID
 		uidMatch := cmd.UID != "" && cmd.UID == datasource.UID

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -150,8 +150,8 @@ func (e ErrDatasourceSecretsPluginUserFriendly) Error() string {
 // ----------------------
 // COMMANDS
 
-// Also acts as api DTO
-type AddDataSourceCommand struct {
+// Add|Update Command (Also acts as api DTO)
+type DataSourceCommand struct {
 	Name            string            `json:"name"`
 	Type            string            `json:"type" binding:"Required"`
 	Access          DsAccess          `json:"access" binding:"Required"`
@@ -165,45 +165,23 @@ type AddDataSourceCommand struct {
 	JsonData        *simplejson.Json  `json:"jsonData"`
 	SecureJsonData  map[string]string `json:"secureJsonData"`
 	UID             string            `json:"uid"`
+	Version         int               `json:"version,omitempty"`
 	// swagger:ignore
 	APIVersion string `json:"apiVersion"`
 	// swagger:ignore
 	IsPrunable bool
 
 	OrgID                   int64             `json:"-"`
-	UserID                  int64             `json:"-"`
 	ReadOnly                bool              `json:"-"`
 	EncryptedSecureJsonData map[string][]byte `json:"-"`
 	UpdateSecretFn          UpdateSecretFn    `json:"-"`
-}
 
-// Also acts as api DTO
-type UpdateDataSourceCommand struct {
-	Name            string            `json:"name" binding:"Required"`
-	Type            string            `json:"type" binding:"Required"`
-	Access          DsAccess          `json:"access" binding:"Required"`
-	URL             string            `json:"url"`
-	User            string            `json:"user"`
-	Database        string            `json:"database"`
-	BasicAuth       bool              `json:"basicAuth"`
-	BasicAuthUser   string            `json:"basicAuthUser"`
-	WithCredentials bool              `json:"withCredentials"`
-	IsDefault       bool              `json:"isDefault"`
-	JsonData        *simplejson.Json  `json:"jsonData"`
-	SecureJsonData  map[string]string `json:"secureJsonData"`
-	Version         int               `json:"version"`
-	UID             string            `json:"uid"`
-	// swagger:ignore
-	APIVersion string `json:"apiVersion"`
-	// swagger:ignore
-	IsPrunable bool
+	// Only used in the Add command
+	UserID int64 `json:"-"`
 
-	OrgID                   int64             `json:"-"`
-	ID                      int64             `json:"-"`
-	ReadOnly                bool              `json:"-"`
-	EncryptedSecureJsonData map[string][]byte `json:"-"`
-	UpdateSecretFn          UpdateSecretFn    `json:"-"`
-	IgnoreOldSecureJsonData bool              `json:"-"`
+	// Only Valid for the Update Command
+	ID                      int64 `json:"-"`
+	IgnoreOldSecureJsonData bool  `json:"-"`
 }
 
 // DeleteDataSourceCommand will delete a DataSource based on OrgID as well as the UID (preferred), ID, or Name.

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -166,6 +166,7 @@ type DataSourceCommand struct {
 	SecureJsonData  map[string]string `json:"secureJsonData"`
 	UID             string            `json:"uid"`
 	Version         int               `json:"version,omitempty"`
+
 	// swagger:ignore
 	APIVersion string `json:"apiVersion"`
 	// swagger:ignore
@@ -176,7 +177,7 @@ type DataSourceCommand struct {
 	EncryptedSecureJsonData map[string][]byte `json:"-"`
 	UpdateSecretFn          UpdateSecretFn    `json:"-"`
 
-	// Only used in the Add command
+	// If this is set on the "add" command, the user is given admin permissions
 	UserID int64 `json:"-"`
 
 	// Only Valid for the Update Command

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -190,7 +190,7 @@ func (s *Service) GetDataSourcesByType(ctx context.Context, query *datasources.G
 	return s.SQLStore.GetDataSourcesByType(ctx, query)
 }
 
-func (s *Service) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
+func (s *Service) AddDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	dataSources, err := s.SQLStore.GetDataSources(ctx, &datasources.GetDataSourcesQuery{OrgID: cmd.OrgID})
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (s *Service) DeleteDataSource(ctx context.Context, cmd *datasources.DeleteD
 	})
 }
 
-func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	var dataSource *datasources.DataSource
 
 	if err := s.validateFields(ctx, cmd.Name, cmd.URL, cmd.Type, cmd.APIVersion); err != nil {
@@ -687,7 +687,7 @@ func awsServiceNamespace(dsType string, jsonData *simplejson.Json) string {
 	}
 }
 
-func (s *Service) fillWithSecureJSONData(ctx context.Context, cmd *datasources.UpdateDataSourceCommand, ds *datasources.DataSource) error {
+func (s *Service) fillWithSecureJSONData(ctx context.Context, cmd *datasources.DataSourceCommand, ds *datasources.DataSource) error {
 	decrypted, err := s.DecryptedValues(ctx, ds)
 	if err != nil {
 		return err

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -74,7 +74,7 @@ func TestService_AddDataSource(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		cmd := &datasources.AddDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			OrgID: 1,
 			Name:  string(make([]byte, 256)),
 		}
@@ -82,7 +82,7 @@ func TestService_AddDataSource(t *testing.T) {
 		_, err = dsService.AddDataSource(context.Background(), cmd)
 		require.EqualError(t, err, "[datasource.nameInvalid] max length is 190")
 
-		cmd = &datasources.AddDataSourceCommand{
+		cmd = &datasources.DataSourceCommand{
 			OrgID: 1,
 			URL:   string(make([]byte, 256)),
 		}
@@ -90,7 +90,7 @@ func TestService_AddDataSource(t *testing.T) {
 		_, err = dsService.AddDataSource(context.Background(), cmd)
 		require.EqualError(t, err, "[datasource.urlInvalid] max length is 255")
 
-		cmd = &datasources.AddDataSourceCommand{
+		cmd = &datasources.DataSourceCommand{
 			OrgID:      1,
 			Name:       "test",
 			APIVersion: "v0alpha2",
@@ -192,7 +192,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 		dsService, err := ProvideService(sqlStore, secretsService, secretsStore, cfg, featuremgmt.WithFeatures(), actest.FakeAccessControl{}, mockPermission, quotaService, &pluginstore.FakePluginStore{})
 		require.NoError(t, err)
 
-		cmd := &datasources.UpdateDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			UID:   uuid.New().String(),
 			ID:    1,
 			OrgID: 1,
@@ -211,7 +211,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 		dsService, err := ProvideService(sqlStore, secretsService, secretsStore, cfg, featuremgmt.WithFeatures(), actest.FakeAccessControl{}, mockPermission, quotaService, &pluginstore.FakePluginStore{})
 		require.NoError(t, err)
 
-		cmd := &datasources.UpdateDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			ID:    1,
 			OrgID: 1,
 			Name:  string(make([]byte, 256)),
@@ -220,7 +220,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 		_, err = dsService.UpdateDataSource(context.Background(), cmd)
 		require.EqualError(t, err, "[datasource.nameInvalid] max length is 190")
 
-		cmd = &datasources.UpdateDataSourceCommand{
+		cmd = &datasources.DataSourceCommand{
 			ID:    1,
 			OrgID: 1,
 			URL:   string(make([]byte, 256)),
@@ -241,13 +241,13 @@ func TestService_UpdateDataSource(t *testing.T) {
 
 		mockPermission.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
 
-		ds, err := dsService.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		ds, err := dsService.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID: 1,
 			Name:  "test-datasource",
 		})
 		require.NoError(t, err)
 
-		cmd := &datasources.UpdateDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			ID:    ds.ID,
 			OrgID: ds.OrgID,
 			Name:  "test-datasource-updated",
@@ -268,19 +268,19 @@ func TestService_UpdateDataSource(t *testing.T) {
 
 		mockPermission.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
 
-		dsToUpdate, err := dsService.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		dsToUpdate, err := dsService.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID: 1,
 			Name:  "test-datasource",
 		})
 		require.NoError(t, err)
 
-		existingDs, err := dsService.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		existingDs, err := dsService.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID: 1,
 			Name:  "name already taken",
 		})
 		require.NoError(t, err)
 
-		cmd := &datasources.UpdateDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			ID:    dsToUpdate.ID,
 			OrgID: dsToUpdate.OrgID,
 			Name:  existingDs.Name,
@@ -303,7 +303,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 
 		expectedDbKey := "db-secure-key"
 		expectedDbValue := "db-secure-value"
-		ds, err := dsService.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		ds, err := dsService.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID: 1,
 			Name:  "test-datasource",
 			SecureJsonData: map[string]string{
@@ -315,7 +315,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 		expectedOgKey := "cmd-secure-key"
 		expectedOgValue := "cmd-secure-value"
 
-		cmd := &datasources.UpdateDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			ID:    ds.ID,
 			OrgID: ds.OrgID,
 			Name:  "test-datasource-updated",
@@ -347,7 +347,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 
 		notExpectedDbKey := "db-secure-key"
 		dbValue := "db-secure-value"
-		ds, err := dsService.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		ds, err := dsService.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID: 1,
 			Name:  "test-datasource",
 			SecureJsonData: map[string]string{
@@ -359,7 +359,7 @@ func TestService_UpdateDataSource(t *testing.T) {
 		expectedOgKey := "cmd-secure-key"
 		expectedOgValue := "cmd-secure-value"
 
-		cmd := &datasources.UpdateDataSourceCommand{
+		cmd := &datasources.DataSourceCommand{
 			ID:    ds.ID,
 			OrgID: ds.OrgID,
 			Name:  "test-datasource-updated",

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -28,8 +28,8 @@ type Store interface {
 	GetDataSources(context.Context, *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error)
 	GetDataSourcesByType(context.Context, *datasources.GetDataSourcesByTypeQuery) ([]*datasources.DataSource, error)
 	DeleteDataSource(context.Context, *datasources.DeleteDataSourceCommand) error
-	AddDataSource(context.Context, *datasources.AddDataSourceCommand) (*datasources.DataSource, error)
-	UpdateDataSource(context.Context, *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error)
+	AddDataSource(context.Context, *datasources.DataSourceCommand) (*datasources.DataSource, error)
+	UpdateDataSource(context.Context, *datasources.DataSourceCommand) (*datasources.DataSource, error)
 	GetAllDataSources(ctx context.Context, query *datasources.GetAllDataSourcesQuery) (res []*datasources.DataSource, err error)
 	GetPrunableProvisionedDataSources(ctx context.Context) (res []*datasources.DataSource, err error)
 
@@ -236,7 +236,7 @@ func (ss *SqlStore) Count(ctx context.Context, scopeParams *quota.ScopeParameter
 	return u, nil
 }
 
-func (ss *SqlStore) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
+func (ss *SqlStore) AddDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	var ds *datasources.DataSource
 
 	return ds, ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
@@ -326,7 +326,7 @@ func updateIsDefaultFlag(ds *datasources.DataSource, sess *db.Session) error {
 	return nil
 }
 
-func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+func (ss *SqlStore) UpdateDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	var ds *datasources.DataSource
 	return ds, ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		if cmd.JsonData == nil {

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -21,7 +21,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	defaultAddDatasourceCommand := datasources.AddDataSourceCommand{
+	defaultAddDatasourceCommand := datasources.DataSourceCommand{
 		OrgID:  10,
 		Name:   "nisse",
 		Type:   datasources.DS_GRAPHITE,
@@ -29,7 +29,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 		URL:    "http://test",
 	}
 
-	defaultUpdateDatasourceCommand := datasources.UpdateDataSourceCommand{
+	defaultUpdateDatasourceCommand := datasources.DataSourceCommand{
 		OrgID:  10,
 		Name:   "nisse_updated",
 		Type:   datasources.DS_GRAPHITE,
@@ -55,7 +55,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 		t.Run("Can add datasource", func(t *testing.T) {
 			db := db.InitTestDB(t)
 			ss := SqlStore{db: db}
-			_, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			_, err := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 				OrgID:      10,
 				Name:       "laban",
 				Type:       datasources.DS_GRAPHITE,
@@ -177,7 +177,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ds := initDatasource(db)
 			ss := SqlStore{db: db}
 
-			cmd := datasources.UpdateDataSourceCommand{
+			cmd := datasources.DataSourceCommand{
 				ID:      ds.ID,
 				OrgID:   10,
 				Name:    "nisse",
@@ -201,7 +201,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ds := initDatasource(db)
 			ss := SqlStore{db: db}
 
-			cmd := &datasources.UpdateDataSourceCommand{
+			cmd := &datasources.DataSourceCommand{
 				ID:     ds.ID,
 				OrgID:  10,
 				Name:   "nisse",
@@ -219,7 +219,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ds := initDatasource(db)
 			ss := SqlStore{db: db}
 
-			cmd := &datasources.UpdateDataSourceCommand{
+			cmd := &datasources.DataSourceCommand{
 				ID:      ds.ID,
 				OrgID:   10,
 				Name:    "nisse",
@@ -396,7 +396,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ss := SqlStore{db: db}
 			datasourceLimit := 6
 			for i := 0; i < datasourceLimit+1; i++ {
-				_, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+				_, err := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 					OrgID:    10,
 					Name:     "laban" + strconv.Itoa(i),
 					Type:     datasources.DS_GRAPHITE,
@@ -420,7 +420,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ss := SqlStore{db: db}
 			numberOfDatasource := 5100
 			for i := 0; i < numberOfDatasource; i++ {
-				_, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+				_, err := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 					OrgID:    10,
 					Name:     "laban" + strconv.Itoa(i),
 					Type:     datasources.DS_GRAPHITE,
@@ -444,7 +444,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			ss := SqlStore{db: db}
 			numberOfDatasource := 5100
 			for i := 0; i < numberOfDatasource; i++ {
-				_, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+				_, err := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 					OrgID:    10,
 					Name:     "laban" + strconv.Itoa(i),
 					Type:     datasources.DS_GRAPHITE,
@@ -469,7 +469,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			db := db.InitTestDB(t)
 			ss := SqlStore{db: db}
 
-			_, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			_, err := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 				OrgID:    10,
 				Name:     "Elasticsearch",
 				Type:     datasources.DS_ES,
@@ -480,7 +480,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			_, err = ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			_, err = ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 				OrgID:    10,
 				Name:     "Graphite",
 				Type:     datasources.DS_GRAPHITE,
@@ -514,7 +514,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			db := db.InitTestDB(t)
 			ss := SqlStore{db: db}
 
-			_, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			_, err := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 				OrgID:    10,
 				Name:     "Elasticsearch",
 				Type:     "other",
@@ -537,7 +537,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			db := db.InitTestDB(t)
 			ss := SqlStore{db: db}
 
-			_, errPrunable := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			_, errPrunable := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 				OrgID:      10,
 				Name:       "ElasticsearchPrunable",
 				Type:       "other",
@@ -549,7 +549,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 			})
 			require.NoError(t, errPrunable)
 
-			_, errNotPrunable := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+			_, errNotPrunable := ss.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 				OrgID:    10,
 				Name:     "ElasticsearchNotPrunable",
 				Type:     "other",

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -449,9 +449,9 @@ func (m *mockCorrelationsStore) DeleteCorrelationsByTargetUID(c context.Context,
 }
 
 type spyStore struct {
-	inserted []*datasources.AddDataSourceCommand
+	inserted []*datasources.DataSourceCommand
 	deleted  []*datasources.DeleteDataSourceCommand
-	updated  []*datasources.UpdateDataSourceCommand
+	updated  []*datasources.DataSourceCommand
 	items    []*datasources.DataSource
 }
 
@@ -486,14 +486,14 @@ func (s *spyStore) DeleteDataSource(ctx context.Context, cmd *datasources.Delete
 	return nil
 }
 
-func (s *spyStore) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error) {
+func (s *spyStore) AddDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	s.inserted = append(s.inserted, cmd)
 	newDataSource := &datasources.DataSource{UID: cmd.UID, Name: cmd.Name, OrgID: cmd.OrgID, IsPrunable: cmd.IsPrunable}
 	s.items = append(s.items, newDataSource)
 	return newDataSource, nil
 }
 
-func (s *spyStore) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error) {
+func (s *spyStore) UpdateDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error) {
 	s.updated = append(s.updated, cmd)
 	return nil, nil
 }

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -5,18 +5,19 @@ import (
 	"errors"
 	"fmt"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/org"
-	jsoniter "github.com/json-iterator/go"
 )
 
 type Store interface {
 	GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error)
 	GetPrunableProvisionedDataSources(ctx context.Context) ([]*datasources.DataSource, error)
-	AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) (*datasources.DataSource, error)
-	UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) (*datasources.DataSource, error)
+	AddDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error)
+	UpdateDataSource(ctx context.Context, cmd *datasources.DataSourceCommand) (*datasources.DataSource, error)
 	DeleteDataSource(ctx context.Context, cmd *datasources.DeleteDataSourceCommand) error
 }
 

--- a/pkg/services/provisioning/datasources/types.go
+++ b/pkg/services/provisioning/datasources/types.go
@@ -199,7 +199,7 @@ func (cfg *configsV0) mapToDatasourceFromConfig(apiVersion int64) *configs {
 	return r
 }
 
-func createInsertCommand(ds *upsertDataSourceFromConfig) *datasources.AddDataSourceCommand {
+func createInsertCommand(ds *upsertDataSourceFromConfig) *datasources.DataSourceCommand {
 	jsonData := simplejson.New()
 	if len(ds.JSONData) > 0 {
 		for k, v := range ds.JSONData {
@@ -207,7 +207,7 @@ func createInsertCommand(ds *upsertDataSourceFromConfig) *datasources.AddDataSou
 		}
 	}
 
-	cmd := &datasources.AddDataSourceCommand{
+	cmd := &datasources.DataSourceCommand{
 		OrgID:           ds.OrgID,
 		Name:            ds.Name,
 		Type:            ds.Type,
@@ -239,7 +239,7 @@ func safeUIDFromName(name string) string {
 	return strings.ToUpper(fmt.Sprintf("P%x", bs[:8]))
 }
 
-func createUpdateCommand(ds *upsertDataSourceFromConfig, id int64) *datasources.UpdateDataSourceCommand {
+func createUpdateCommand(ds *upsertDataSourceFromConfig, id int64) *datasources.DataSourceCommand {
 	jsonData := simplejson.New()
 	if len(ds.JSONData) > 0 {
 		for k, v := range ds.JSONData {
@@ -247,7 +247,7 @@ func createUpdateCommand(ds *upsertDataSourceFromConfig, id int64) *datasources.
 		}
 	}
 
-	return &datasources.UpdateDataSourceCommand{
+	return &datasources.DataSourceCommand{
 		ID:                      id,
 		Version:                 ds.Version,
 		UID:                     ds.UID,

--- a/pkg/services/publicdashboards/api/query_test.go
+++ b/pkg/services/publicdashboards/api/query_test.go
@@ -262,7 +262,7 @@ func TestIntegrationUnauthenticatedUserCanGetPubdashPanelQueryData(t *testing.T)
 	cacheService := datasourcesService.ProvideCacheService(localcache.ProvideService(), db, guardian.ProvideGuardian())
 	qds := buildQueryDataService(t, cacheService, nil, db)
 	dsStore := datasourcesService.CreateStore(db, log.New("publicdashboards.test"))
-	_, _ = dsStore.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+	_, _ = dsStore.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 		UID:      "ds1",
 		OrgID:    1,
 		Name:     "laban",

--- a/pkg/services/secrets/kvstore/migrations/datasource_mig.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig.go
@@ -68,7 +68,7 @@ func (s *DataSourceSecretMigrationService) Migrate(ctx context.Context) error {
 
 			// Secrets are set by the update data source function if the SecureJsonData is set in the command
 			// Secrets are deleted by the update data source function if the disableSecretsCompatibility flag is enabled
-			_, err = s.dataSourcesService.UpdateDataSource(ctx, &datasources.UpdateDataSourceCommand{
+			_, err = s.dataSourcesService.UpdateDataSource(ctx, &datasources.DataSourceCommand{
 				ID:             ds.ID,
 				OrgID:          ds.OrgID,
 				UID:            ds.UID,

--- a/pkg/services/secrets/kvstore/migrations/datasource_mig_test.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig_test.go
@@ -52,7 +52,7 @@ func TestMigrate(t *testing.T) {
 		ds := dsservice.CreateStore(sqlStore, log.NewNopLogger())
 		dataSourceName := "Test"
 		dataSourceOrg := int64(1)
-		_, err := ds.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		_, err := ds.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID:  dataSourceOrg,
 			Name:   dataSourceName,
 			Type:   datasources.DS_MYSQL,
@@ -118,7 +118,7 @@ func TestMigrate(t *testing.T) {
 		dataSourceOrg := int64(1)
 
 		// Add test data source
-		_, err := ds.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		_, err := ds.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID:  dataSourceOrg,
 			Name:   dataSourceName,
 			Type:   datasources.DS_MYSQL,
@@ -186,7 +186,7 @@ func TestMigrate(t *testing.T) {
 		dataSourceOrg := int64(1)
 
 		// Add test data source
-		_, err := ds.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		_, err := ds.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID:  dataSourceOrg,
 			Name:   dataSourceName,
 			Type:   datasources.DS_MYSQL,
@@ -277,7 +277,7 @@ func TestMigrate(t *testing.T) {
 		dataSourceOrg := int64(1)
 
 		// Add test data source
-		_, err := ds.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+		_, err := ds.AddDataSource(context.Background(), &datasources.DataSourceCommand{
 			OrgID:  dataSourceOrg,
 			Name:   dataSourceName,
 			Type:   datasources.DS_MYSQL,

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -130,7 +130,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 
 	// Add an alertmanager datasource
 	{
-		cmd := datasources.AddDataSourceCommand{
+		cmd := datasources.DataSourceCommand{
 			OrgID:  1,
 			Name:   "AM1",
 			Type:   datasources.DS_ALERTMANAGER,
@@ -157,7 +157,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 
 	// Add another alertmanager datasource
 	{
-		cmd := datasources.AddDataSourceCommand{
+		cmd := datasources.DataSourceCommand{
 			OrgID:  1,
 			Name:   "AM2",
 			Type:   datasources.DS_ALERTMANAGER,
@@ -286,7 +286,7 @@ func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing
 
 	// Add an alertmanager datasource fot the other organisation
 	{
-		cmd := datasources.AddDataSourceCommand{
+		cmd := datasources.DataSourceCommand{
 			OrgID:  2,
 			Name:   "AM3",
 			Type:   datasources.DS_ALERTMANAGER,

--- a/pkg/tests/api/alerting/api_backtesting_test.go
+++ b/pkg/tests/api/alerting/api_backtesting_test.go
@@ -57,7 +57,7 @@ func TestBacktesting(t *testing.T) {
 			continue
 		}
 		t.Logf("Creating a new test data source with UID %s", query.DatasourceUID)
-		dsCmd := &datasources.AddDataSourceCommand{
+		dsCmd := &datasources.DataSourceCommand{
 			Name:   "Backtesting-TestDatasource",
 			Type:   "testdata",
 			Access: datasources.DS_ACCESS_PROXY,

--- a/pkg/tests/api/alerting/api_testing_test.go
+++ b/pkg/tests/api/alerting/api_testing_test.go
@@ -58,7 +58,7 @@ func TestGrafanaRuleConfig(t *testing.T) {
 
 	apiCli.CreateFolder(t, "NamespaceUID", "NamespaceTitle")
 
-	dsCmd := &datasources.AddDataSourceCommand{
+	dsCmd := &datasources.DataSourceCommand{
 		Name:   "TestDatasource",
 		Type:   "testdata",
 		Access: datasources.DS_ACCESS_PROXY,

--- a/pkg/tests/api/azuremonitor/azuremonitor_test.go
+++ b/pkg/tests/api/azuremonitor/azuremonitor_test.go
@@ -69,7 +69,7 @@ func TestIntegrationAzureMonitor(t *testing.T) {
 	}
 
 	uid := "azuremonitor"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "Azure Monitor",

--- a/pkg/tests/api/correlations/common_test.go
+++ b/pkg/tests/api/correlations/common_test.go
@@ -176,7 +176,7 @@ func (c TestContext) createUser(cmd user.CreateUserCommand) User {
 	}
 }
 
-func (c TestContext) createDs(cmd *datasources.AddDataSourceCommand) *datasources.DataSource {
+func (c TestContext) createDs(cmd *datasources.DataSourceCommand) *datasources.DataSource {
 	c.t.Helper()
 
 	dataSource, err := c.env.Server.HTTPServer.DataSourcesService.AddDataSource(context.Background(), cmd)

--- a/pkg/tests/api/correlations/correlations_create_test.go
+++ b/pkg/tests/api/correlations/correlations_create_test.go
@@ -34,7 +34,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 		OrgID:          adminUser.User.OrgID,
 	})
 
-	createDsCommand := &datasources.AddDataSourceCommand{
+	createDsCommand := &datasources.DataSourceCommand{
 		Name:     "read-only",
 		Type:     "loki",
 		ReadOnly: true,
@@ -43,7 +43,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 	dataSource := ctx.createDs(createDsCommand)
 	readOnlyDS := dataSource.UID
 
-	createDsCommand = &datasources.AddDataSourceCommand{
+	createDsCommand = &datasources.DataSourceCommand{
 		Name:  "writable",
 		Type:  "loki",
 		OrgID: adminUser.User.OrgID,

--- a/pkg/tests/api/correlations/correlations_delete_test.go
+++ b/pkg/tests/api/correlations/correlations_delete_test.go
@@ -34,7 +34,7 @@ func TestIntegrationDeleteCorrelation(t *testing.T) {
 		OrgID:          adminUser.User.OrgID,
 	})
 
-	createDsCommand := &datasources.AddDataSourceCommand{
+	createDsCommand := &datasources.DataSourceCommand{
 		Name:     "read-only",
 		Type:     "loki",
 		ReadOnly: true,
@@ -43,7 +43,7 @@ func TestIntegrationDeleteCorrelation(t *testing.T) {
 	dataSource := ctx.createDs(createDsCommand)
 	readOnlyDS := dataSource.UID
 
-	createDsCommand = &datasources.AddDataSourceCommand{
+	createDsCommand = &datasources.DataSourceCommand{
 		Name:  "writable",
 		Type:  "loki",
 		OrgID: adminUser.User.OrgID,

--- a/pkg/tests/api/correlations/correlations_provisioning_api_test.go
+++ b/pkg/tests/api/correlations/correlations_provisioning_api_test.go
@@ -26,7 +26,7 @@ func TestIntegrationCreateOrUpdateCorrelation(t *testing.T) {
 		Login:          "admin",
 	})
 
-	createDsCommand := &datasources.AddDataSourceCommand{
+	createDsCommand := &datasources.DataSourceCommand{
 		Name:  "loki",
 		Type:  "loki",
 		OrgID: adminUser.User.OrgID,

--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -67,7 +67,7 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 		})
 	})
 
-	createDsCommand := &datasources.AddDataSourceCommand{
+	createDsCommand := &datasources.DataSourceCommand{
 		Name:  "with-correlations",
 		Type:  "loki",
 		OrgID: 1,
@@ -87,14 +87,14 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 		},
 	})
 
-	createDsCommand = &datasources.AddDataSourceCommand{
+	createDsCommand = &datasources.DataSourceCommand{
 		Name:  "without-correlations",
 		Type:  "loki",
 		OrgID: 1,
 	}
 	dsWithoutCorrelations := ctx.createDs(createDsCommand)
 
-	createDsCommand = &datasources.AddDataSourceCommand{
+	createDsCommand = &datasources.DataSourceCommand{
 		Name:  "with-correlations",
 		UID:   dsWithCorrelations.UID, // reuse UID
 		Type:  "loki",

--- a/pkg/tests/api/correlations/correlations_update_test.go
+++ b/pkg/tests/api/correlations/correlations_update_test.go
@@ -36,7 +36,7 @@ func TestIntegrationUpdateCorrelation(t *testing.T) {
 		OrgID:          adminUser.User.OrgID,
 	})
 
-	createDsCommand := &datasources.AddDataSourceCommand{
+	createDsCommand := &datasources.DataSourceCommand{
 		Name:  "writable",
 		Type:  "loki",
 		OrgID: adminUser.User.OrgID,

--- a/pkg/tests/api/elasticsearch/elasticsearch_test.go
+++ b/pkg/tests/api/elasticsearch/elasticsearch_test.go
@@ -60,7 +60,7 @@ func TestIntegrationElasticsearch(t *testing.T) {
 	}
 
 	uid := "es"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "Elasticsearch",

--- a/pkg/tests/api/graphite/graphite_test.go
+++ b/pkg/tests/api/graphite/graphite_test.go
@@ -59,7 +59,7 @@ func TestIntegrationGraphite(t *testing.T) {
 	}
 
 	uid := "graphite"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "graphite",

--- a/pkg/tests/api/influxdb/influxdb_test.go
+++ b/pkg/tests/api/influxdb/influxdb_test.go
@@ -59,7 +59,7 @@ func TestIntegrationInflux(t *testing.T) {
 	}
 
 	uid := "influxdb"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "InfluxDB",

--- a/pkg/tests/api/loki/loki_test.go
+++ b/pkg/tests/api/loki/loki_test.go
@@ -59,7 +59,7 @@ func TestIntegrationLoki(t *testing.T) {
 	}
 
 	uid := "loki"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "Loki",

--- a/pkg/tests/api/opentdsb/opentdsb_test.go
+++ b/pkg/tests/api/opentdsb/opentdsb_test.go
@@ -59,7 +59,7 @@ func TestIntegrationOpenTSDB(t *testing.T) {
 	}
 
 	uid := "influxdb"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "opentsdb",

--- a/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
+++ b/pkg/tests/api/plugins/backendplugin/backendplugin_test.go
@@ -403,7 +403,7 @@ type testScenarioContext struct {
 }
 
 type testScenarioInput struct {
-	ds                         *datasources.AddDataSourceCommand
+	ds                         *datasources.DataSourceCommand
 	token                      *oauth2.Token
 	modifyIncomingRequest      func(req *http.Request)
 	modifyCallResourceResponse func(sender backend.CallResourceResponseSender) error
@@ -507,7 +507,7 @@ func newTestScenario(t *testing.T, name string, opts []testScenarioOption, callb
 	secureJSONData := map[string]string{}
 
 	tsCtx.uid = "test-plugin"
-	cmd := &datasources.AddDataSourceCommand{
+	cmd := &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "TestPlugin",

--- a/pkg/tests/api/prometheus/prometheus_test.go
+++ b/pkg/tests/api/prometheus/prometheus_test.go
@@ -59,7 +59,7 @@ func TestIntegrationPrometheus(t *testing.T) {
 	}
 
 	uid := "prometheus"
-	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+	_, err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.DataSourceCommand{
 		OrgID:          u.OrgID,
 		Access:         datasources.DS_ACCESS_PROXY,
 		Name:           "Prometheus",

--- a/pkg/tests/apis/datasource/testdata_test.go
+++ b/pkg/tests/apis/datasource/testdata_test.go
@@ -32,7 +32,7 @@ func TestIntegrationTestDatasource(t *testing.T) {
 	})
 
 	// Create a single datasource
-	ds := helper.CreateDS(&datasources.AddDataSourceCommand{
+	ds := helper.CreateDS(&datasources.DataSourceCommand{
 		Name:  "test",
 		Type:  datasources.DS_TESTDATA,
 		UID:   "test",

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -491,7 +491,7 @@ func (c *K8sTestHelper) GetGroupVersionInfoJSON(group string) string {
 	return ""
 }
 
-func (c *K8sTestHelper) CreateDS(cmd *datasources.AddDataSourceCommand) *datasources.DataSource {
+func (c *K8sTestHelper) CreateDS(cmd *datasources.DataSourceCommand) *datasources.DataSource {
 	c.t.Helper()
 
 	dataSource, err := c.env.Server.HTTPServer.DataSourcesService.AddDataSource(context.Background(), cmd)

--- a/pkg/tests/apis/query/query_test.go
+++ b/pkg/tests/apis/query/query_test.go
@@ -35,7 +35,7 @@ func TestIntegrationSimpleQuery(t *testing.T) {
 	})
 
 	// Create a single datasource
-	ds := helper.CreateDS(&datasources.AddDataSourceCommand{
+	ds := helper.CreateDS(&datasources.DataSourceCommand{
 		Name:  "test",
 		Type:  datasources.DS_TESTDATA,
 		UID:   "test",

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -2065,54 +2065,6 @@
         }
       }
     },
-    "AddDataSourceCommand": {
-      "description": "Also acts as api DTO",
-      "type": "object",
-      "properties": {
-        "access": {
-          "$ref": "#/definitions/DsAccess"
-        },
-        "basicAuth": {
-          "type": "boolean"
-        },
-        "basicAuthUser": {
-          "type": "string"
-        },
-        "database": {
-          "type": "string"
-        },
-        "isDefault": {
-          "type": "boolean"
-        },
-        "jsonData": {
-          "$ref": "#/definitions/Json"
-        },
-        "name": {
-          "type": "string"
-        },
-        "secureJsonData": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        },
-        "uid": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "user": {
-          "type": "string"
-        },
-        "withCredentials": {
-          "type": "boolean"
-        }
-      }
-    },
     "AddInviteForm": {
       "type": "object",
       "properties": {
@@ -3956,6 +3908,58 @@
           "type": "string"
         },
         "typeLogoUrl": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "withCredentials": {
+          "type": "boolean"
+        }
+      }
+    },
+    "DataSourceCommand": {
+      "description": "Add|Update Command (Also acts as api DTO)",
+      "type": "object",
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/DsAccess"
+        },
+        "basicAuth": {
+          "type": "boolean"
+        },
+        "basicAuthUser": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "isDefault": {
+          "type": "boolean"
+        },
+        "jsonData": {
+          "$ref": "#/definitions/Json"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secureJsonData": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "type": {
           "type": "string"
         },
         "uid": {
@@ -7502,58 +7506,6 @@
           "items": {
             "$ref": "#/definitions/DashboardACLUpdateItem"
           }
-        }
-      }
-    },
-    "UpdateDataSourceCommand": {
-      "description": "Also acts as api DTO",
-      "type": "object",
-      "properties": {
-        "access": {
-          "$ref": "#/definitions/DsAccess"
-        },
-        "basicAuth": {
-          "type": "boolean"
-        },
-        "basicAuthUser": {
-          "type": "string"
-        },
-        "database": {
-          "type": "string"
-        },
-        "isDefault": {
-          "type": "boolean"
-        },
-        "jsonData": {
-          "$ref": "#/definitions/Json"
-        },
-        "name": {
-          "type": "string"
-        },
-        "secureJsonData": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        },
-        "uid": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "user": {
-          "type": "string"
-        },
-        "version": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "withCredentials": {
-          "type": "boolean"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -3521,7 +3521,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/AddDataSourceCommand"
+              "$ref": "#/definitions/DataSourceCommand"
             }
           }
         ],
@@ -4182,7 +4182,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/UpdateDataSourceCommand"
+              "$ref": "#/definitions/DataSourceCommand"
             }
           },
           {
@@ -4559,7 +4559,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/UpdateDataSourceCommand"
+              "$ref": "#/definitions/DataSourceCommand"
             }
           },
           {
@@ -11539,54 +11539,6 @@
         }
       }
     },
-    "AddDataSourceCommand": {
-      "description": "Also acts as api DTO",
-      "type": "object",
-      "properties": {
-        "access": {
-          "$ref": "#/definitions/DsAccess"
-        },
-        "basicAuth": {
-          "type": "boolean"
-        },
-        "basicAuthUser": {
-          "type": "string"
-        },
-        "database": {
-          "type": "string"
-        },
-        "isDefault": {
-          "type": "boolean"
-        },
-        "jsonData": {
-          "$ref": "#/definitions/Json"
-        },
-        "name": {
-          "type": "string"
-        },
-        "secureJsonData": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        },
-        "uid": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "user": {
-          "type": "string"
-        },
-        "withCredentials": {
-          "type": "boolean"
-        }
-      }
-    },
     "AddInviteForm": {
       "type": "object",
       "properties": {
@@ -14104,6 +14056,58 @@
           "type": "string"
         },
         "typeLogoUrl": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "withCredentials": {
+          "type": "boolean"
+        }
+      }
+    },
+    "DataSourceCommand": {
+      "description": "Add|Update Command (Also acts as api DTO)",
+      "type": "object",
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/DsAccess"
+        },
+        "basicAuth": {
+          "type": "boolean"
+        },
+        "basicAuthUser": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "isDefault": {
+          "type": "boolean"
+        },
+        "jsonData": {
+          "$ref": "#/definitions/Json"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secureJsonData": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "type": {
           "type": "string"
         },
         "uid": {
@@ -20592,58 +20596,6 @@
           "items": {
             "$ref": "#/definitions/DashboardACLUpdateItem"
           }
-        }
-      }
-    },
-    "UpdateDataSourceCommand": {
-      "description": "Also acts as api DTO",
-      "type": "object",
-      "properties": {
-        "access": {
-          "$ref": "#/definitions/DsAccess"
-        },
-        "basicAuth": {
-          "type": "boolean"
-        },
-        "basicAuthUser": {
-          "type": "string"
-        },
-        "database": {
-          "type": "string"
-        },
-        "isDefault": {
-          "type": "boolean"
-        },
-        "jsonData": {
-          "$ref": "#/definitions/Json"
-        },
-        "name": {
-          "type": "string"
-        },
-        "secureJsonData": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "type": {
-          "type": "string"
-        },
-        "uid": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string"
-        },
-        "user": {
-          "type": "string"
-        },
-        "version": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "withCredentials": {
-          "type": "boolean"
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2060,54 +2060,6 @@
         },
         "type": "object"
       },
-      "AddDataSourceCommand": {
-        "description": "Also acts as api DTO",
-        "properties": {
-          "access": {
-            "$ref": "#/components/schemas/DsAccess"
-          },
-          "basicAuth": {
-            "type": "boolean"
-          },
-          "basicAuthUser": {
-            "type": "string"
-          },
-          "database": {
-            "type": "string"
-          },
-          "isDefault": {
-            "type": "boolean"
-          },
-          "jsonData": {
-            "$ref": "#/components/schemas/Json"
-          },
-          "name": {
-            "type": "string"
-          },
-          "secureJsonData": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "type": {
-            "type": "string"
-          },
-          "uid": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          },
-          "user": {
-            "type": "string"
-          },
-          "withCredentials": {
-            "type": "boolean"
-          }
-        },
-        "type": "object"
-      },
       "AddInviteForm": {
         "properties": {
           "loginOrEmail": {
@@ -4624,6 +4576,58 @@
             "type": "string"
           },
           "typeLogoUrl": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "withCredentials": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "DataSourceCommand": {
+        "description": "Add|Update Command (Also acts as api DTO)",
+        "properties": {
+          "access": {
+            "$ref": "#/components/schemas/DsAccess"
+          },
+          "basicAuth": {
+            "type": "boolean"
+          },
+          "basicAuthUser": {
+            "type": "string"
+          },
+          "database": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "jsonData": {
+            "$ref": "#/components/schemas/Json"
+          },
+          "name": {
+            "type": "string"
+          },
+          "secureJsonData": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "type": {
             "type": "string"
           },
           "uid": {
@@ -11115,58 +11119,6 @@
         },
         "type": "object"
       },
-      "UpdateDataSourceCommand": {
-        "description": "Also acts as api DTO",
-        "properties": {
-          "access": {
-            "$ref": "#/components/schemas/DsAccess"
-          },
-          "basicAuth": {
-            "type": "boolean"
-          },
-          "basicAuthUser": {
-            "type": "string"
-          },
-          "database": {
-            "type": "string"
-          },
-          "isDefault": {
-            "type": "boolean"
-          },
-          "jsonData": {
-            "$ref": "#/components/schemas/Json"
-          },
-          "name": {
-            "type": "string"
-          },
-          "secureJsonData": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "type": {
-            "type": "string"
-          },
-          "uid": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          },
-          "user": {
-            "type": "string"
-          },
-          "version": {
-            "format": "int64",
-            "type": "integer"
-          },
-          "withCredentials": {
-            "type": "boolean"
-          }
-        },
-        "type": "object"
-      },
       "UpdateFolderCommand": {
         "description": "UpdateFolderCommand captures the information required by the folder service\nto update a folder. Use Move to update a folder's parent folder.",
         "properties": {
@@ -16253,7 +16205,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AddDataSourceCommand"
+                "$ref": "#/components/schemas/DataSourceCommand"
               }
             }
           },
@@ -17021,7 +16973,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDataSourceCommand"
+                "$ref": "#/components/schemas/DataSourceCommand"
               }
             }
           },
@@ -17451,7 +17403,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateDataSourceCommand"
+                "$ref": "#/components/schemas/DataSourceCommand"
               }
             }
           },


### PR DESCRIPTION
See an alternative approach https://github.com/grafana/grafana/pull/88036

----

In https://github.com/grafana/grafana/pull/87718 -- we need to [duplicate the validation functions](https://github.com/grafana/grafana/pull/87718/files#diff-e75b2165866a30555409a61945b14cb5ab7b8270b5b4db8b45759a0e606014e4R345) because the commands for Add/Update are almost identical -- but not identical.

An alternative approach would be to make a base class for the common properties and extend the explicit ones for each -- but that seems like more work than it is worth.

The difference is that Update has a version and internal ID -- and Add has a UserID 🤷🏻 