### PR TITLE
Alerting/Chore: Remove unused parameters

### DIFF
--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -63,7 +63,7 @@ func NewReceiverService(
 	}
 }
 
-func (rs *ReceiverService) shouldDecrypt(ctx context.Context, user identity.Requester, name string, reqDecrypt bool) (bool, error) {
+func (rs *ReceiverService) shouldDecrypt(ctx context.Context, user identity.Requester, reqDecrypt bool) (bool, error) {
 	// TODO: migrate to new permission
 	eval := accesscontrol.EvalAny(
 		accesscontrol.EvalPermission(accesscontrol.ActionAlertingReceiversReadSecrets),
@@ -108,7 +108,7 @@ func (rs *ReceiverService) GetReceiver(ctx context.Context, q models.GetReceiver
 	receivers := cfg.AlertmanagerConfig.Receivers
 	for _, r := range receivers {
 		if r.Name == q.Name {
-			decrypt, err := rs.shouldDecrypt(ctx, user, q.Name, q.Decrypt)
+			decrypt, err := rs.shouldDecrypt(ctx, user, q.Decrypt)
 			if err != nil {
 				return definitions.GettableApiReceiver{}, err
 			}
@@ -157,7 +157,7 @@ func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceive
 			continue
 		}
 
-		decrypt, err := rs.shouldDecrypt(ctx, user, r.Name, q.Decrypt)
+		decrypt, err := rs.shouldDecrypt(ctx, user, q.Decrypt)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/ngalert/notifier/redis_peer.go
+++ b/pkg/services/ngalert/notifier/redis_peer.go
@@ -448,12 +448,12 @@ func (p *redisPeer) AddState(key string, state alertingCluster.State, _ promethe
 	p.states[key] = state
 	// As we also want to get the state from other nodes, we subscribe to the key.
 	sub := p.redis.Subscribe(context.Background(), p.withPrefix(key))
-	go p.receiveLoop(key, sub)
+	go p.receiveLoop(sub)
 	p.subs[key] = sub
 	return newRedisChannel(p, key, p.withPrefix(key), update)
 }
 
-func (p *redisPeer) receiveLoop(name string, channel *redis.PubSub) {
+func (p *redisPeer) receiveLoop(channel *redis.PubSub) {
 	for {
 		select {
 		case <-p.shutdownc:


### PR DESCRIPTION
This PR removes the unused `name` parameter from `redisPeer.receiveLoop()` and `ReceiverService.shouldDecrypt()`
