### PR TITLE
Explore: Convert kebab-case styles to camel-case

### DIFF
--- a/public/app/features/explore/QueryLibrary/QueryTemplatesTable/styles.tsx
+++ b/public/app/features/explore/QueryLibrary/QueryTemplatesTable/styles.tsx
@@ -30,8 +30,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   singleLine: css({
     display: '-webkit-box',
-    '-webkit-box-orient': 'vertical',
-    '-webkit-line-clamp': '1',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 1,
     overflow: 'hidden',
   }),
 });


### PR DESCRIPTION
A small fix to styles for adding "..." to long title lines. 

At the moment it throws:

<img width="757" alt="Screenshot 2024-05-20 at 13 08 47" src="https://github.com/grafana/grafana/assets/745532/67cdf0ec-5dc1-474b-b96a-cc9e956b7f13"> 