### PR TITLE
[v11.0.x] [docs/sources/fundamentals] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/fundamentals/dashboards-overview/index.md
+++ b/docs/sources/fundamentals/dashboards-overview/index.md
@@ -99,4 +99,3 @@ Building a Grafana dashboard is a process that starts with determining your dash
 And with the data source identified and the plugin installed, you can write your query, transform the data, and format the visualization to meet your needs.
 
 This component architecture is part of what makes Grafana so powerful and general. Given the data source plugin and data frame abstraction, any data source you can access can work with the same general approach.
-

--- a/docs/sources/fundamentals/dashboards-overview/index.md
+++ b/docs/sources/fundamentals/dashboards-overview/index.md
@@ -15,6 +15,12 @@ labels:
 menuTitle: Dashboard overview
 title: Grafana dashboards overview
 weight: 390
+refs:
+  transform-data:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/transform-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/transform-data/
 ---
 
 # Grafana dashboards overview
@@ -57,7 +63,7 @@ The following image shows the Query Editor associated with the Prometheus data s
 
 ## Transformations
 
-When the data format in a visualization doesn’t meet your requirements, you can apply a [transformation][transform-data] that manipulates the data returned by a query.
+When the data format in a visualization doesn’t meet your requirements, you can apply a [transformation](ref:transform-data) that manipulates the data returned by a query.
 You might not need to transform data when you're first starting out, but they're powerful and worth mentioning.
 
 Transforming data is useful in the following kinds of situations:
@@ -94,8 +100,3 @@ And with the data source identified and the plugin installed, you can write your
 
 This component architecture is part of what makes Grafana so powerful and general. Given the data source plugin and data frame abstraction, any data source you can access can work with the same general approach.
 
-{{% docs/reference %}}
-
-[transform-data]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/transform-data"
-[transform-data]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/transform-data"
-{{% /docs/reference %}}

--- a/docs/sources/fundamentals/dashboards-overview/index.md
+++ b/docs/sources/fundamentals/dashboards-overview/index.md
@@ -18,9 +18,9 @@ weight: 390
 refs:
   transform-data:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/transform-data/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/query-transform-data/transform-data/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/
 ---
 
 # Grafana dashboards overview

--- a/docs/sources/fundamentals/intro-histograms/index.md
+++ b/docs/sources/fundamentals/intro-histograms/index.md
@@ -17,6 +17,17 @@ labels:
 menuTitle: Histograms and heatmaps
 title: Introduction to histograms and heatmaps
 weight: 650
+refs:
+  histogram:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/histogram/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/histogram/
+  heatmap:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap/
 ---
 
 # Introduction to histograms and heatmaps
@@ -38,7 +49,7 @@ Here is an example showing height distribution of people.
 
 {{< figure src="/static/img/docs/histogram-panel/histogram-example-v8-0.png" max-width="625px" caption="Bar chart example" >}}
 
-For more information about histogram visualization options, refer to [Histogram][histogram].
+For more information about histogram visualization options, refer to [Histogram](ref:histogram).
 
 Histograms only look at _value distributions_ over a specific time range. The problem with histograms is that you cannot see any trends or changes in the distribution over time. This is where heatmaps become useful.
 
@@ -50,7 +61,7 @@ In this example, you can clearly see what values are more common and how they tr
 
 ![Heatmap example](/static/img/docs/v43/heatmap_histogram_over_time.png)
 
-For more information about heatmap visualization options, refer to [Heatmap][heatmap].
+For more information about heatmap visualization options, refer to [Heatmap](ref:heatmap).
 
 ## Pre-bucketed data
 
@@ -75,10 +86,3 @@ If you remove or lower the group by time (or raise maxDataPoints) in your query 
 more accurate, but this can also be very CPU and memory taxing for your browser, possibly causing hangs or crashes if the number of
 data points becomes unreasonably large.
 
-{{% docs/reference %}}
-[heatmap]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
-[heatmap]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap"
-
-[histogram]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/histogram"
-[histogram]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/histogram"
-{{% /docs/reference %}}

--- a/docs/sources/fundamentals/intro-histograms/index.md
+++ b/docs/sources/fundamentals/intro-histograms/index.md
@@ -20,14 +20,14 @@ weight: 650
 refs:
   histogram:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/histogram/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/histogram/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/histogram/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/histogram/
   heatmap:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/heatmap/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/panels-visualizations/visualizations/heatmap/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/heatmap/
 ---
 
 # Introduction to histograms and heatmaps

--- a/docs/sources/fundamentals/intro-histograms/index.md
+++ b/docs/sources/fundamentals/intro-histograms/index.md
@@ -85,4 +85,3 @@ supports doing histogram bucketing on the raw data.
 If you remove or lower the group by time (or raise maxDataPoints) in your query to return more data points, your heatmap will be
 more accurate, but this can also be very CPU and memory taxing for your browser, possibly causing hangs or crashes if the number of
 data points becomes unreasonably large.
-

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -19,14 +19,14 @@ weight: 300
 refs:
   build-dashboards:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/
   prometheus:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/datasources/prometheus/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/datasources/prometheus/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/
 ---
 
 # What is Prometheus?

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -16,6 +16,17 @@ labels:
     - oss
 title: What is Prometheus?
 weight: 300
+refs:
+  build-dashboards:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards/
+  prometheus:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/datasources/prometheus/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/datasources/prometheus/
 ---
 
 # What is Prometheus?
@@ -111,14 +122,7 @@ The combination of Prometheus and Grafana Agent gives you control over the metri
 
 Now that you understand how Prometheus metrics work, what will you build?
 
-- One great next step is to [build a dashboard][build-dashboards] in Grafana and start turning that raw Prometheus telemetry data into insights about what’s going with your services and infrastructure.
+- One great next step is to [build a dashboard](ref:build-dashboards) in Grafana and start turning that raw Prometheus telemetry data into insights about what’s going with your services and infrastructure.
 - Another great step is to learn about [Grafana Mimir](/oss/mimir/), which is essentially a database for Prometheus data. If you’re wondering how to make this work for a large volumes of metrics with a lot of data and fast querying, check out Grafana Mimir.
-- If you’re interested in working with Prometheus data in Grafana directly, check out the [Prometheus data source][prometheus] documentation, or check out [PromQL basics](https://prometheus.io/docs/prometheus/latest/querying/basics/).
+- If you’re interested in working with Prometheus data in Grafana directly, check out the [Prometheus data source](ref:prometheus) documentation, or check out [PromQL basics](https://prometheus.io/docs/prometheus/latest/querying/basics/).
 
-{{% docs/reference %}}
-[build-dashboards]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
-[build-dashboards]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/dashboards/build-dashboards"
-
-[prometheus]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/datasources/prometheus"
-[prometheus]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/datasources/prometheus"
-{{% /docs/reference %}}

--- a/docs/sources/fundamentals/intro-to-prometheus/index.md
+++ b/docs/sources/fundamentals/intro-to-prometheus/index.md
@@ -125,4 +125,3 @@ Now that you understand how Prometheus metrics work, what will you build?
 - One great next step is to [build a dashboard](ref:build-dashboards) in Grafana and start turning that raw Prometheus telemetry data into insights about what’s going with your services and infrastructure.
 - Another great step is to learn about [Grafana Mimir](/oss/mimir/), which is essentially a database for Prometheus data. If you’re wondering how to make this work for a large volumes of metrics with a lot of data and fast querying, check out Grafana Mimir.
 - If you’re interested in working with Prometheus data in Grafana directly, check out the [Prometheus data source](ref:prometheus) documentation, or check out [PromQL basics](https://prometheus.io/docs/prometheus/latest/querying/basics/).
-

--- a/docs/sources/fundamentals/timeseries-dimensions/index.md
+++ b/docs/sources/fundamentals/timeseries-dimensions/index.md
@@ -114,4 +114,3 @@ For more information, see the documentation on [creating alerts with multiple se
 In the case of SQL-like data sources, more than one numeric column can be selected, with or without additional string columns to be used as dimensions. For example, `AVG(Temperature) AS AvgTemp, MAX(Temperature) AS MaxTemp`. This, if combined with multiple dimensions, can result in a lot of series. Selecting multiple values is currently only designed to be used with visualization.
 
 Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series](/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series).
-

--- a/docs/sources/fundamentals/timeseries-dimensions/index.md
+++ b/docs/sources/fundamentals/timeseries-dimensions/index.md
@@ -19,11 +19,22 @@ labels:
     - oss
 title: Time series dimensions
 weight: 500
+refs:
+  create-grafana-managed-rule:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule
+  time-series-databases:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries/#time-series-databases
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries/#time-series-databases
 ---
 
 # Time series dimensions
 
-In [Introduction to time series][time-series-databases], the concept of _labels_, also called _tags_, is introduced:
+In [Introduction to time series](ref:time-series-databases), the concept of _labels_, also called _tags_, is introduced:
 
 > Another feature of a TSDB is the ability to filter measurements using _tags_. Each data point is labeled with a tag that adds context information, such as where the measurement was taken.
 
@@ -95,7 +106,7 @@ More than one dimension is currently only supported in the Logs queries within t
 
 {{% admonition type="note" %}}
 Multiple dimensions are not supported in a way that maps to multiple alerts in Grafana, but rather they are treated as multiple conditions to a single alert.
-For more information, see the documentation on [creating alerts with multiple series][create-grafana-managed-rule].
+For more information, see the documentation on [creating alerts with multiple series](ref:create-grafana-managed-rule).
 {{% /admonition %}}
 
 ### Multiple values
@@ -104,11 +115,3 @@ In the case of SQL-like data sources, more than one numeric column can be select
 
 Additional technical information on tabular time series formats and how dimensions are extracted can be found in [the developer documentation on data frames as time series](/developers/plugin-tools/introduction/data-frames#data-frames-as-time-series).
 
-{{% docs/reference %}}
-
-[create-grafana-managed-rule]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule#single-and-multi-dimensional-rule"
-[create-grafana-managed-rule]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule#single-and-multi-dimensional-rule"
-
-[time-series-databases]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries#time-series-databases"
-[time-series-databases]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries#time-series-databases"
-{{% /docs/reference %}}

--- a/docs/sources/fundamentals/timeseries-dimensions/index.md
+++ b/docs/sources/fundamentals/timeseries-dimensions/index.md
@@ -22,14 +22,14 @@ weight: 500
 refs:
   create-grafana-managed-rule:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/#single-and-multi-dimensional-rule
   time-series-databases:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries/#time-series-databases
+      destination: /docs/grafana/<GRAFANA_VERSION>/fundamentals/timeseries/#time-series-databases
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/fundamentals/timeseries/#time-series-databases
+      destination: /docs/grafana/<GRAFANA_VERSION>/fundamentals/timeseries/#time-series-databases
 ---
 
 # Time series dimensions


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
