### PR TITLE
[v11.0.x] [docs/sources/release-notes] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/release-notes/release-notes-7-5-10.md
+++ b/docs/sources/release-notes/release-notes-7-5-10.md
@@ -15,4 +15,4 @@ title: Release notes for Grafana 7.5.10
 
 ### Bug fixes
 
-- *[v7.5.x][] Transformations:** add 'prepare time series' transformer. [#36749](https://github.com/grafana/grafana/pull/36749), [@mckn](https://github.com/mckn)
+- \*[v7.5.x][] Transformations:\*\* add 'prepare time series' transformer. [#36749](https://github.com/grafana/grafana/pull/36749), [@mckn](https://github.com/mckn)

--- a/docs/sources/release-notes/release-notes-7-5-10.md
+++ b/docs/sources/release-notes/release-notes-7-5-10.md
@@ -15,4 +15,4 @@ title: Release notes for Grafana 7.5.10
 
 ### Bug fixes
 
-- **[v7.5.x] Transformations:** add 'prepare time series' transformer. [#36749](https://github.com/grafana/grafana/pull/36749), [@mckn](https://github.com/mckn)
+- *[v7.5.x][] Transformations:** add 'prepare time series' transformer. [#36749](https://github.com/grafana/grafana/pull/36749), [@mckn](https://github.com/mckn)

--- a/docs/sources/release-notes/release-notes-7-5-13.md
+++ b/docs/sources/release-notes/release-notes-7-5-13.md
@@ -15,4 +15,4 @@ title: Release notes for Grafana 7.5.13
 
 ### Bug fixes
 
-- **[v7.5.x] Alerting:** Fix NoDataFound for alert rules using AND operator (#41305). [#44066](https://github.com/grafana/grafana/pull/44066), [@armandgrillet](https://github.com/armandgrillet)
+- *[v7.5.x][] Alerting:** Fix NoDataFound for alert rules using AND operator (#41305). [#44066](https://github.com/grafana/grafana/pull/44066), [@armandgrillet](https://github.com/armandgrillet)

--- a/docs/sources/release-notes/release-notes-7-5-13.md
+++ b/docs/sources/release-notes/release-notes-7-5-13.md
@@ -15,4 +15,4 @@ title: Release notes for Grafana 7.5.13
 
 ### Bug fixes
 
-- *[v7.5.x][] Alerting:** Fix NoDataFound for alert rules using AND operator (#41305). [#44066](https://github.com/grafana/grafana/pull/44066), [@armandgrillet](https://github.com/armandgrillet)
+- \*[v7.5.x][] Alerting:\*\* Fix NoDataFound for alert rules using AND operator (#41305). [#44066](https://github.com/grafana/grafana/pull/44066), [@armandgrillet](https://github.com/armandgrillet)

--- a/docs/sources/release-notes/release-notes-8-1-0-beta3.md
+++ b/docs/sources/release-notes/release-notes-8-1-0-beta3.md
@@ -19,7 +19,7 @@ title: Release notes for Grafana 8.1.0-beta3
 - **IconButton:** Put tooltip text as aria-label. [#36760](https://github.com/grafana/grafana/pull/36760), [@tskarhed](https://github.com/tskarhed)
 - **Live:** Experimental HA with Redis. [#36787](https://github.com/grafana/grafana/pull/36787), [@FZambia](https://github.com/FZambia)
 - **UI:** FileDropzone component. [#36646](https://github.com/grafana/grafana/pull/36646), [@zoltanbedi](https://github.com/zoltanbedi)
-- **[v8.1.x] CloudWatch:** Add AWS LookoutMetrics. [#37329](https://github.com/grafana/grafana/pull/37329), [@ilyastoli](https://github.com/ilyastoli)
+- *[v8.1.x][] CloudWatch:** Add AWS LookoutMetrics. [#37329](https://github.com/grafana/grafana/pull/37329), [@ilyastoli](https://github.com/ilyastoli)
 
 ### Bug fixes
 

--- a/docs/sources/release-notes/release-notes-8-1-0-beta3.md
+++ b/docs/sources/release-notes/release-notes-8-1-0-beta3.md
@@ -19,7 +19,7 @@ title: Release notes for Grafana 8.1.0-beta3
 - **IconButton:** Put tooltip text as aria-label. [#36760](https://github.com/grafana/grafana/pull/36760), [@tskarhed](https://github.com/tskarhed)
 - **Live:** Experimental HA with Redis. [#36787](https://github.com/grafana/grafana/pull/36787), [@FZambia](https://github.com/FZambia)
 - **UI:** FileDropzone component. [#36646](https://github.com/grafana/grafana/pull/36646), [@zoltanbedi](https://github.com/zoltanbedi)
-- *[v8.1.x][] CloudWatch:** Add AWS LookoutMetrics. [#37329](https://github.com/grafana/grafana/pull/37329), [@ilyastoli](https://github.com/ilyastoli)
+- \*[v8.1.x][] CloudWatch:\*\* Add AWS LookoutMetrics. [#37329](https://github.com/grafana/grafana/pull/37329), [@ilyastoli](https://github.com/ilyastoli)
 
 ### Bug fixes
 

--- a/docs/sources/release-notes/release-notes-8-5-4.md
+++ b/docs/sources/release-notes/release-notes-8-5-4.md
@@ -29,8 +29,8 @@ title: Release notes for Grafana 8.5.4
 - **Reporting:** Improve PDF file size using grid layout. (Enterprise)
 - **Transformations:** Add an All Unique Values Reducer. [#48653](https://github.com/grafana/grafana/pull/48653), [@josiahg](https://github.com/josiahg)
 - **Transformers:** avoid error when the ExtractFields source field is missing. [#49368](https://github.com/grafana/grafana/pull/49368), [@wardbekker](https://github.com/wardbekker)
-- **[v8.5.x] Alerting:** Update migration to migrate only alerts that belong to existing org\dashboard. [#49199](https://github.com/grafana/grafana/pull/49199), [@grafanabot](https://github.com/grafanabot)
-- **[v8.5.x] Reporting:** Improve PDF file size using grid layout. (Enterprise)
+- *[v8.5.x][] Alerting:** Update migration to migrate only alerts that belong to existing org\dashboard. [#49199](https://github.com/grafana/grafana/pull/49199), [@grafanabot](https://github.com/grafanabot)
+- *[v8.5.x][] Reporting:** Improve PDF file size using grid layout. (Enterprise)
 
 ### Bug fixes
 
@@ -56,9 +56,9 @@ title: Release notes for Grafana 8.5.4
 - **Tooltip:** Sort decimals using standard numeric compare. [#49084](https://github.com/grafana/grafana/pull/49084), [@dprokop](https://github.com/dprokop)
 - **Transforms:** Labels to fields, fix label picker layout. [#49304](https://github.com/grafana/grafana/pull/49304), [@torkelo](https://github.com/torkelo)
 - **Variables:** Fixes issue with data source variables not updating queries with variable. [#49478](https://github.com/grafana/grafana/pull/49478), [@torkelo](https://github.com/torkelo)
-- **[v8.5.x] Alerting:** Fix RBAC actions for notification policies (#49185). [#49348](https://github.com/grafana/grafana/pull/49348), [@yuri-tceretian](https://github.com/yuri-tceretian)
-- **[v8.5.x] Alerting:** Fix access to alerts for viewer with editor permissions when RBAC is disabled. [#49427](https://github.com/grafana/grafana/pull/49427), [@konrad147](https://github.com/konrad147)
-- **[v8.5.x] Alerting:** Fix anonymous access to alerting. [#49268](https://github.com/grafana/grafana/pull/49268), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- *[v8.5.x][] Alerting:** Fix RBAC actions for notification policies (#49185). [#49348](https://github.com/grafana/grafana/pull/49348), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- *[v8.5.x][] Alerting:** Fix access to alerts for viewer with editor permissions when RBAC is disabled. [#49427](https://github.com/grafana/grafana/pull/49427), [@konrad147](https://github.com/konrad147)
+- *[v8.5.x][] Alerting:** Fix anonymous access to alerting. [#49268](https://github.com/grafana/grafana/pull/49268), [@yuri-tceretian](https://github.com/yuri-tceretian)
 
 ### Breaking changes
 

--- a/docs/sources/release-notes/release-notes-8-5-4.md
+++ b/docs/sources/release-notes/release-notes-8-5-4.md
@@ -29,8 +29,8 @@ title: Release notes for Grafana 8.5.4
 - **Reporting:** Improve PDF file size using grid layout. (Enterprise)
 - **Transformations:** Add an All Unique Values Reducer. [#48653](https://github.com/grafana/grafana/pull/48653), [@josiahg](https://github.com/josiahg)
 - **Transformers:** avoid error when the ExtractFields source field is missing. [#49368](https://github.com/grafana/grafana/pull/49368), [@wardbekker](https://github.com/wardbekker)
-- *[v8.5.x][] Alerting:** Update migration to migrate only alerts that belong to existing org\dashboard. [#49199](https://github.com/grafana/grafana/pull/49199), [@grafanabot](https://github.com/grafanabot)
-- *[v8.5.x][] Reporting:** Improve PDF file size using grid layout. (Enterprise)
+- \*[v8.5.x][] Alerting:\*\* Update migration to migrate only alerts that belong to existing org\dashboard. [#49199](https://github.com/grafana/grafana/pull/49199), [@grafanabot](https://github.com/grafanabot)
+- \*[v8.5.x][] Reporting:\*\* Improve PDF file size using grid layout. (Enterprise)
 
 ### Bug fixes
 
@@ -56,9 +56,9 @@ title: Release notes for Grafana 8.5.4
 - **Tooltip:** Sort decimals using standard numeric compare. [#49084](https://github.com/grafana/grafana/pull/49084), [@dprokop](https://github.com/dprokop)
 - **Transforms:** Labels to fields, fix label picker layout. [#49304](https://github.com/grafana/grafana/pull/49304), [@torkelo](https://github.com/torkelo)
 - **Variables:** Fixes issue with data source variables not updating queries with variable. [#49478](https://github.com/grafana/grafana/pull/49478), [@torkelo](https://github.com/torkelo)
-- *[v8.5.x][] Alerting:** Fix RBAC actions for notification policies (#49185). [#49348](https://github.com/grafana/grafana/pull/49348), [@yuri-tceretian](https://github.com/yuri-tceretian)
-- *[v8.5.x][] Alerting:** Fix access to alerts for viewer with editor permissions when RBAC is disabled. [#49427](https://github.com/grafana/grafana/pull/49427), [@konrad147](https://github.com/konrad147)
-- *[v8.5.x][] Alerting:** Fix anonymous access to alerting. [#49268](https://github.com/grafana/grafana/pull/49268), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- \*[v8.5.x][] Alerting:\*\* Fix RBAC actions for notification policies (#49185). [#49348](https://github.com/grafana/grafana/pull/49348), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- \*[v8.5.x][] Alerting:\*\* Fix access to alerts for viewer with editor permissions when RBAC is disabled. [#49427](https://github.com/grafana/grafana/pull/49427), [@konrad147](https://github.com/konrad147)
+- \*[v8.5.x][] Alerting:\*\* Fix anonymous access to alerting. [#49268](https://github.com/grafana/grafana/pull/49268), [@yuri-tceretian](https://github.com/yuri-tceretian)
 
 ### Breaking changes
 

--- a/docs/sources/release-notes/release-notes-9-0-0-beta2.md
+++ b/docs/sources/release-notes/release-notes-9-0-0-beta2.md
@@ -48,7 +48,7 @@ title: Release notes for Grafana 9.0.0-beta2
 
 ### Breaking changes
 
-Drop support for deprecated setting ldap_sync_ttl under [auth.proxy]
+Drop support for deprecated setting ldap_sync_ttl under[auth.proxy][]
 Only sync_ttl will work from now on Issue [#49902](https://github.com/grafana/grafana/issues/49902)
 
 Removes support for deprecated `heading` and `description` props. Moving forward, the `Card.Heading` and `Card.Description` components should be used. Issue [#49885](https://github.com/grafana/grafana/issues/49885)

--- a/docs/sources/release-notes/release-notes-9-0-0-beta3.md
+++ b/docs/sources/release-notes/release-notes-9-0-0-beta3.md
@@ -33,7 +33,7 @@ title: Release notes for Grafana 9.0.0-beta3
 - **RBAC:** Make RBAC action names more consistent. [#49730](https://github.com/grafana/grafana/pull/49730), [@IevaVasiljeva](https://github.com/IevaVasiljeva)
 - **RBAC:** Make RBAC action names more consistent. (Enterprise)
 - **Settings:** Sunset non-duration based login lifetime config. [#49944](https://github.com/grafana/grafana/pull/49944), [@sakjur](https://github.com/sakjur)
-- **[9.0.x] Alerting:** Update alert rule diff to not see difference between nil and empty map. [#50198](https://github.com/grafana/grafana/pull/50198), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- *[9.0.x][] Alerting:** Update alert rule diff to not see difference between nil and empty map. [#50198](https://github.com/grafana/grafana/pull/50198), [@yuri-tceretian](https://github.com/yuri-tceretian)
 
 ### Bug fixes
 

--- a/docs/sources/release-notes/release-notes-9-0-0-beta3.md
+++ b/docs/sources/release-notes/release-notes-9-0-0-beta3.md
@@ -33,7 +33,7 @@ title: Release notes for Grafana 9.0.0-beta3
 - **RBAC:** Make RBAC action names more consistent. [#49730](https://github.com/grafana/grafana/pull/49730), [@IevaVasiljeva](https://github.com/IevaVasiljeva)
 - **RBAC:** Make RBAC action names more consistent. (Enterprise)
 - **Settings:** Sunset non-duration based login lifetime config. [#49944](https://github.com/grafana/grafana/pull/49944), [@sakjur](https://github.com/sakjur)
-- *[9.0.x][] Alerting:** Update alert rule diff to not see difference between nil and empty map. [#50198](https://github.com/grafana/grafana/pull/50198), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- \*[9.0.x][] Alerting:\*\* Update alert rule diff to not see difference between nil and empty map. [#50198](https://github.com/grafana/grafana/pull/50198), [@yuri-tceretian](https://github.com/yuri-tceretian)
 
 ### Bug fixes
 

--- a/docs/sources/release-notes/release-notes-9-0-3.md
+++ b/docs/sources/release-notes/release-notes-9-0-3.md
@@ -67,4 +67,4 @@ title: Release notes for Grafana 9.0.3
 - **Table:** Fix scrollbar being hidden by pagination. [#51501](https://github.com/grafana/grafana/pull/51501), [@zoltanbedi](https://github.com/zoltanbedi)
 - **Templating:** Changing between variables with the same name now correctly triggers a dashboard refresh. [#51490](https://github.com/grafana/grafana/pull/51490), [@ashharrison90](https://github.com/ashharrison90)
 - **Time series panel:** Fix an issue with stacks being not complete due to the incorrect data frame length. [#51910](https://github.com/grafana/grafana/pull/51910), [@dprokop](https://github.com/dprokop)
-- *[v9.0.x][] Snapshots:** Fix deleting external snapshots when using RBAC (#51897). [#51904](https://github.com/grafana/grafana/pull/51904), [@idafurjes](https://github.com/idafurjes)
+- \*[v9.0.x][] Snapshots:\*\* Fix deleting external snapshots when using RBAC (#51897). [#51904](https://github.com/grafana/grafana/pull/51904), [@idafurjes](https://github.com/idafurjes)

--- a/docs/sources/release-notes/release-notes-9-0-3.md
+++ b/docs/sources/release-notes/release-notes-9-0-3.md
@@ -67,4 +67,4 @@ title: Release notes for Grafana 9.0.3
 - **Table:** Fix scrollbar being hidden by pagination. [#51501](https://github.com/grafana/grafana/pull/51501), [@zoltanbedi](https://github.com/zoltanbedi)
 - **Templating:** Changing between variables with the same name now correctly triggers a dashboard refresh. [#51490](https://github.com/grafana/grafana/pull/51490), [@ashharrison90](https://github.com/ashharrison90)
 - **Time series panel:** Fix an issue with stacks being not complete due to the incorrect data frame length. [#51910](https://github.com/grafana/grafana/pull/51910), [@dprokop](https://github.com/dprokop)
-- **[v9.0.x] Snapshots:** Fix deleting external snapshots when using RBAC (#51897). [#51904](https://github.com/grafana/grafana/pull/51904), [@idafurjes](https://github.com/idafurjes)
+- *[v9.0.x][] Snapshots:** Fix deleting external snapshots when using RBAC (#51897). [#51904](https://github.com/grafana/grafana/pull/51904), [@idafurjes](https://github.com/idafurjes)

--- a/docs/sources/release-notes/release-notes-9-1-0.md
+++ b/docs/sources/release-notes/release-notes-9-1-0.md
@@ -50,7 +50,7 @@ title: Release notes for Grafana 9.1.0
 - **Reports:** Fix inconsistency reports. (Enterprise)
 - **Tracing:** Fix OpenTelemetry Jaeger context propagation. [#53269](https://github.com/grafana/grafana/pull/53269), [@zhichli](https://github.com/zhichli)
 - **Tracing:** Fix OpenTelemetry Jaeger context propagation (#53269). [#53724](https://github.com/grafana/grafana/pull/53724), [@idafurjes](https://github.com/idafurjes)
-- *[9.1.x][] Alerting:** AlertingProxy to elevate permissions for request forwarded to data proxy when RBAC enabled. [#53679](https://github.com/grafana/grafana/pull/53679), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- \*[9.1.x][] Alerting:\*\* AlertingProxy to elevate permissions for request forwarded to data proxy when RBAC enabled. [#53679](https://github.com/grafana/grafana/pull/53679), [@yuri-tceretian](https://github.com/yuri-tceretian)
 
 ### Breaking changes
 

--- a/docs/sources/release-notes/release-notes-9-1-0.md
+++ b/docs/sources/release-notes/release-notes-9-1-0.md
@@ -50,7 +50,7 @@ title: Release notes for Grafana 9.1.0
 - **Reports:** Fix inconsistency reports. (Enterprise)
 - **Tracing:** Fix OpenTelemetry Jaeger context propagation. [#53269](https://github.com/grafana/grafana/pull/53269), [@zhichli](https://github.com/zhichli)
 - **Tracing:** Fix OpenTelemetry Jaeger context propagation (#53269). [#53724](https://github.com/grafana/grafana/pull/53724), [@idafurjes](https://github.com/idafurjes)
-- **[9.1.x] Alerting:** AlertingProxy to elevate permissions for request forwarded to data proxy when RBAC enabled. [#53679](https://github.com/grafana/grafana/pull/53679), [@yuri-tceretian](https://github.com/yuri-tceretian)
+- *[9.1.x][] Alerting:** AlertingProxy to elevate permissions for request forwarded to data proxy when RBAC enabled. [#53679](https://github.com/grafana/grafana/pull/53679), [@yuri-tceretian](https://github.com/yuri-tceretian)
 
 ### Breaking changes
 


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
