### PR TITLE
[v11.0.x] [docs/sources/administration] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/administration/organization-preferences/index.md
+++ b/docs/sources/administration/organization-preferences/index.md
@@ -185,7 +185,7 @@ Some tasks require certain permissions. For more information about roles, refer 
 
 Users with the Grafana Server Admin flag on their account or access to the configuration file can define a JSON file to use as the home dashboard for all users on the server.
 
-####[Optional][] Convert an existing dashboard into a JSON file
+#### Optional: Convert an existing dashboard into a JSON file
 
 1. Navigate to the page of the dashboard you want to use as the home dashboard.
 1. Click the **Share** button at the top right of the screen.

--- a/docs/sources/administration/organization-preferences/index.md
+++ b/docs/sources/administration/organization-preferences/index.md
@@ -185,7 +185,7 @@ Some tasks require certain permissions. For more information about roles, refer 
 
 Users with the Grafana Server Admin flag on their account or access to the configuration file can define a JSON file to use as the home dashboard for all users on the server.
 
-#### [Optional] Convert an existing dashboard into a JSON file
+####[Optional][] Convert an existing dashboard into a JSON file
 
 1. Navigate to the page of the dashboard you want to use as the home dashboard.
 1. Click the **Share** button at the top right of the screen.


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
