### PR TITLE
[v11.0.x] [docs/sources/developers] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/developers/http_api/dashboard_public.md
+++ b/docs/sources/developers/http_api/dashboard_public.md
@@ -17,9 +17,9 @@ title: Public Dashboard HTTP API
 refs:
   role-based-access-control-permissions:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
 ---
 
 # Public Dashboard API

--- a/docs/sources/developers/http_api/dashboard_public.md
+++ b/docs/sources/developers/http_api/dashboard_public.md
@@ -14,13 +14,19 @@ labels:
     - enterprise
     - oss
 title: Public Dashboard HTTP API
+refs:
+  role-based-access-control-permissions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
 ---
 
 # Public Dashboard API
 
 {{% admonition type="note" %}}
 
-If you're running Grafana Enterprise, you'll need to have specific permissions for some endpoints. Refer to [Role-based access control permissions][] for more information.
+If you're running Grafana Enterprise, you'll need to have specific permissions for some endpoints. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 
 {{% /admonition %}}
 
@@ -320,7 +326,3 @@ Content-Type: application/json
 }
 ```
 
-{{% docs/reference %}}
-[Role-based access control permissions]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes"
-[Role-based access control permissions]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes"
-{{% /docs/reference %}}

--- a/docs/sources/developers/http_api/dashboard_public.md
+++ b/docs/sources/developers/http_api/dashboard_public.md
@@ -325,4 +325,3 @@ Content-Type: application/json
     "perPage": 2
 }
 ```
-

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -17,9 +17,9 @@ title: User HTTP API
 refs:
   role-based-access-control-permissions:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
 ---
 
 # User API

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -689,4 +689,3 @@ Content-Type: application/json
   "message": "User auth token revoked"
 }
 ```
-

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -14,6 +14,12 @@ labels:
     - enterprise
     - oss
 title: User HTTP API
+refs:
+  role-based-access-control-permissions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/
 ---
 
 # User API
@@ -24,7 +30,7 @@ user must have the Grafana Admin role.
 
 API Tokens can be used with Organization HTTP API to get users of specific organization.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions][] for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 
 ## Search Users
 
@@ -684,7 +690,3 @@ Content-Type: application/json
 }
 ```
 
-{{% docs/reference %}}
-[Role-based access control permissions]: "/docs/grafana/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes"
-[Role-based access control permissions]: "/docs/grafana-cloud/ -> /docs/grafana/<GRAFANA VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes"
-{{% /docs/reference %}}


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
