### PR TITLE
[v10.4.x] [docs/sources/whatsnew] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v10-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-0.md
@@ -24,7 +24,7 @@ For even more detail about all the changes in this release, refer to the [change
 <!-- Template below
 ## Feature
 <!-- Name of contributor -->
-<!-- [Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced]
+<!--[Generally available | Available in private/public preview | Experimental][] in Grafana[Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced][]
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 {{% admonition type="note" %}}
 You must use relative references when linking to docs within the Grafana repo. Please do not use absolute URLs. For more information about relrefs, refer to [Links and references](/docs/writers-toolkit/writing-guide/references/).

--- a/docs/sources/whatsnew/whats-new-in-v10-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-1.md
@@ -24,7 +24,7 @@ For even more detail about all the changes in this release, refer to the [change
 <!-- Template below
 ## Feature
 <!-- Name of contributor -->
-<!-- _[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced]_
+<!-- [Generally available | Available in private/public preview | Experimental][] in Grafana [Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 {{% admonition type="note" %}}
 You must use relative references when linking to docs within the Grafana repo. Please do not use absolute URLs. For more information about relrefs, refer to [Links and references](/docs/writers-toolkit/writing-guide/references/).

--- a/docs/sources/whatsnew/whats-new-in-v10-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-2.md
@@ -27,7 +27,7 @@ For even more detail about all the changes in this release, refer to the [change
 
 ## Feature
 <!-- Name of contributor -->
-<!-- _[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise]_
+<!-- [Generally available | Available in private/public preview | Experimental][] in Grafana [Open Source, Enterprise]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 {{% admonition type="note" %}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".

--- a/docs/sources/whatsnew/whats-new-in-v10-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-3.md
@@ -32,7 +32,7 @@ For Grafana v10.3, we've also provided a list of [breaking changes](https://graf
 
 ## Feature
 <!-- Name of contributor -->
-<!--_[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
+<!--[Generally available | Available in private/public preview | Experimental][] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 {{% admonition type="note" %}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".

--- a/docs/sources/whatsnew/whats-new-in-v10-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v10-4.md
@@ -25,7 +25,7 @@ For even more detail about all the changes in this release, refer to the [change
 
 ## Feature
 <!-- Name of contributor -->
-<!--_[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
+<!--[Generally available | Available in private/public preview | Experimental][] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 {{% admonition type="note" %}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".

--- a/docs/sources/whatsnew/whats-new-in-v11-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v11-0.md
@@ -35,7 +35,7 @@ For Grafana v11.0-preview, we've also provided a list of [breaking changes](http
 
 ## Feature
 <!-- Name of contributor -->
-<!--_[Generally available | Available in private/public preview | Experimental] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
+<!--[Generally available | Available in private/public preview | Experimental][] in Grafana [Open Source, Enterprise, all editions of Grafana, some combination of self-managed and Cloud]_
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 {{% admonition type="note" %}}
 Use full URLs for links. When linking to versioned docs, replace the version with the version interpolation placeholder (for example, <GRAFANA_VERSION>, <TEMPO_VERSION>, <MIMIR_VERSION>) so the system can determine the correct set of docs to point to. For example, "https://grafana.com/docs/grafana/latest/administration/" becomes "https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/".

--- a/docs/sources/whatsnew/whats-new-in-v9-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-5.md
@@ -84,8 +84,7 @@ Here's what you can do with the metric encyclopedia:
 - Fuzzy search for metrics by name, type, and description
 - Filter metrics by Prometheus types (gauge, counter, histogram, summary)
 - Display metrics in a paginated list, sort the results, and choose a number of results per page, so that you don't wait a long time for search results
-- View metric details, like type and description
--[Expert feature][] Search metric names by regex using the backend only
+- View metric details, like type and description -[Expert feature][] Search metric names by regex using the backend only
 
 ### Prometheus browser cache
 

--- a/docs/sources/whatsnew/whats-new-in-v9-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-5.md
@@ -24,7 +24,7 @@ For more detail about all the changes in this release, refer to the [changelog](
 <!-- Template below
 
 ## Feature
-[Generally available | Available in experimental/beta] in Grafana [Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced]
+[Generally available | Available in experimental/beta][] in Grafana[Open Source, Enterprise, Cloud Free, Cloud Pro, Cloud Advanced][]
 
 Description. Include an overview of the feature and problem it solves, and where to learn more (like a link to the docs).
 
@@ -85,7 +85,7 @@ Here's what you can do with the metric encyclopedia:
 - Filter metrics by Prometheus types (gauge, counter, histogram, summary)
 - Display metrics in a paginated list, sort the results, and choose a number of results per page, so that you don't wait a long time for search results
 - View metric details, like type and description
-- [Expert feature] Search metric names by regex using the backend only
+-[Expert feature][] Search metric names by regex using the backend only
 
 ### Prometheus browser cache
 


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
