### PR TITLE
[v10.3.x] Update doc-validator workflow to support ref URIs

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -7,7 +7,7 @@ jobs:
   doc-validator:
     runs-on: "ubuntu-latest"
     container:
-      image: "grafana/doc-validator:v4.0.0"
+      image: "grafana/doc-validator:v5.0.0"
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
Backport c5217aa632329b6d2b45cf5c9a55841c5797bb32 from #86423

---

- https://github.com/grafana/technical-documentation/releases/tag/doc-validator%2Fv5.0.0
- https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects
