### PR TITLE
Revert: Tempo: Always use time range even if timeShiftEnabled is false

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -434,8 +434,8 @@ describe('Tempo data source', () => {
       [{ refId: 'refid1', queryType: 'traceql', query: '' } as TempoQuery]
     );
 
-    expect(request.range.from.unix()).toBe(dateTime(new Date(2022, 8, 13, 16, 0, 0, 0)).unix());
-    expect(request.range.to.unix()).toBe(dateTime(new Date(2022, 8, 13, 16, 15, 0, 0)).unix());
+    expect(request.range.from.unix()).toBe(dateTime(0).unix());
+    expect(request.range.to.unix()).toBe(dateTime(0).unix());
   });
 });
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -12,6 +12,7 @@ import {
   DataQueryResponseData,
   DataSourceGetTagValuesOptions,
   DataSourceInstanceSettings,
+  dateTime,
   FieldType,
   LoadingState,
   rangeUtil,
@@ -665,18 +666,18 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       targets,
     };
 
-    request.range = options.range && {
-      ...options.range,
-      from: this.traceQuery?.timeShiftEnabled
-        ? options.range.from.subtract(
-            rangeUtil.intervalToMs(this.traceQuery?.spanStartTimeShift || '30m'),
-            'milliseconds'
-          )
-        : options.range.from,
-      to: this.traceQuery?.timeShiftEnabled
-        ? options.range.to.add(rangeUtil.intervalToMs(this.traceQuery?.spanEndTimeShift || '30m'), 'milliseconds')
-        : options.range.to,
-    };
+    if (this.traceQuery?.timeShiftEnabled) {
+      request.range = options.range && {
+        ...options.range,
+        from: options.range.from.subtract(
+          rangeUtil.intervalToMs(this.traceQuery?.spanStartTimeShift || '30m'),
+          'milliseconds'
+        ),
+        to: options.range.to.add(rangeUtil.intervalToMs(this.traceQuery?.spanEndTimeShift || '30m'), 'milliseconds'),
+      };
+    } else {
+      request.range = { from: dateTime(0), to: dateTime(0), raw: { from: dateTime(0), to: dateTime(0) } };
+    }
 
     return request;
   }


### PR DESCRIPTION
**What is this feature?**

This reverts commit e91136338a24eed4be01d84a0d0c6dc914d689db (https://github.com/grafana/grafana/pull/85477).

**Why do we need this feature?**

The [time range](https://grafana.com/docs/grafana/next/datasources/tempo/configure-tempo-data-source/#traceid-query) can be used when there are performance issues or timeouts since it will narrow down the search to the defined range. This setting is disabled by default. Without this revert, we are expecting the user to know the time range when they paste a traceID, which is not always the case. 

**Who is this feature for?**

Tracing users.