### PR TITLE
DashboardGrid: Ensure drag handle always follows the cursor

### DIFF
--- a/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch
+++ b/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch
@@ -1,0 +1,121 @@
+diff --git a/build/GridItem.js b/build/GridItem.js
+index 0a700da9f1180ca532e32e04dc7ea50f2e67b96c..a2e4673fa1133aeaa4018cc01312ca386c3395f5 100644
+--- a/build/GridItem.js
++++ b/build/GridItem.js
+@@ -5,6 +5,7 @@ Object.defineProperty(exports, "__esModule", {
+ });
+ exports.default = void 0;
+ var _react = _interopRequireDefault(require("react"));
++var _reactDOM = require("react-dom");
+ var _propTypes = _interopRequireDefault(require("prop-types"));
+ var _reactDraggable = require("react-draggable");
+ var _reactResizable = require("react-resizable");
+@@ -147,8 +148,10 @@ class GridItem extends _react.default.Component /*:: <Props, State>*/{
+       const pTop = parentRect.top / transformScale;
+       newPosition.left = cLeft - pLeft + offsetParent.scrollLeft;
+       newPosition.top = cTop - pTop + offsetParent.scrollTop;
+-      this.setState({
+-        dragging: newPosition
++      _reactDOM.flushSync(() => {
++        this.setState({
++          dragging: newPosition
++        });
+       });
+ 
+       // Call callback with this data
+@@ -213,8 +216,10 @@ class GridItem extends _react.default.Component /*:: <Props, State>*/{
+         top,
+         left
+       };
+-      this.setState({
+-        dragging: newPosition
++      _reactDOM.flushSync(() => {
++        this.setState({
++          dragging: newPosition
++        });
+       });
+ 
+       // Call callback with this data
+@@ -261,8 +266,10 @@ class GridItem extends _react.default.Component /*:: <Props, State>*/{
+         top,
+         left
+       };
+-      this.setState({
+-        dragging: null
++      _reactDOM.flushSync(() => {
++        this.setState({
++          dragging: null
++        });
+       });
+       const {
+         x,
+@@ -485,8 +492,10 @@ class GridItem extends _react.default.Component /*:: <Props, State>*/{
+     let updatedSize = size;
+     if (node) {
+       updatedSize = (0, _utils.resizeItemInDirection)(handle, position, size, containerWidth);
+-      this.setState({
+-        resizing: handlerName === "onResizeStop" ? null : updatedSize
++      _reactDOM.flushSync(() => {
++        this.setState({
++          resizing: handlerName === "onResizeStop" ? null : updatedSize
++        });
+       });
+     }
+ 
+diff --git a/lib/GridItem.jsx b/lib/GridItem.jsx
+index dbe41f92388f19d3e476690fa0ee5584ab9d5bb4..1e4713667cd7dadd6618fe06176804a02ee3ccc2 100644
+--- a/lib/GridItem.jsx
++++ b/lib/GridItem.jsx
+@@ -1,5 +1,6 @@
+ // @flow
+ import React from "react";
++import { flushSync } from "react-dom";
+ import PropTypes from "prop-types";
+ import { DraggableCore } from "react-draggable";
+ import { Resizable } from "react-resizable";
+@@ -459,7 +460,9 @@ export default class GridItem extends React.Component<Props, State> {
+     const pTop = parentRect.top / transformScale;
+     newPosition.left = cLeft - pLeft + offsetParent.scrollLeft;
+     newPosition.top = cTop - pTop + offsetParent.scrollTop;
+-    this.setState({ dragging: newPosition });
++    flushSync(() => {
++      this.setState({ dragging: newPosition });
++    });
+ 
+     // Call callback with this data
+     const { x, y } = calcXY(
+@@ -516,7 +519,9 @@ export default class GridItem extends React.Component<Props, State> {
+     }
+ 
+     const newPosition: PartialPosition = { top, left };
+-    this.setState({ dragging: newPosition });
++    flushSync(() => {
++      this.setState({ dragging: newPosition });
++    });
+ 
+     // Call callback with this data
+     const { containerPadding } = this.props;
+@@ -549,7 +554,9 @@ export default class GridItem extends React.Component<Props, State> {
+     const { w, h, i, containerPadding } = this.props;
+     const { left, top } = this.state.dragging;
+     const newPosition: PartialPosition = { top, left };
+-    this.setState({ dragging: null });
++    flushSync(() => {
++      this.setState({ dragging: null });
++    });
+ 
+     const { x, y } = calcXY(
+       this.getPositionParams(),
+@@ -605,8 +612,10 @@ export default class GridItem extends React.Component<Props, State> {
+         size,
+         containerWidth
+       );
+-      this.setState({
+-        resizing: handlerName === "onResizeStop" ? null : updatedSize
++      flushSync(() => {
++        this.setState({
++          resizing: handlerName === "onResizeStop" ? null : updatedSize
++        });
+       });
+     }
+ 

--- a/package.json
+++ b/package.json
@@ -355,7 +355,7 @@
     "react-dom": "18.2.0",
     "react-draggable": "4.4.6",
     "react-dropzone": "^14.2.3",
-    "react-grid-layout": "1.4.4",
+    "react-grid-layout": "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch",
     "react-highlight-words": "0.20.0",
     "react-hook-form": "^7.49.2",
     "react-i18next": "^14.0.0",
@@ -414,7 +414,8 @@
     "history@4.10.1": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
     "history@^4.9.0": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
     "redux": "^5.0.0",
-    "@storybook/blocks@npm:8.0.10": "patch:@storybook/blocks@npm%3A8.0.10#~/.yarn/patches/@storybook-blocks-npm-8.0.10-6f477cd35f.patch"
+    "@storybook/blocks@npm:8.0.10": "patch:@storybook/blocks@npm%3A8.0.10#~/.yarn/patches/@storybook-blocks-npm-8.0.10-6f477cd35f.patch",
+    "react-grid-layout": "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -17167,7 +17167,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-draggable: "npm:4.4.6"
     react-dropzone: "npm:^14.2.3"
-    react-grid-layout: "npm:1.4.4"
+    react-grid-layout: "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch"
     react-highlight-words: "npm:0.20.0"
     react-hook-form: "npm:^7.49.2"
     react-i18next: "npm:^14.0.0"
@@ -20465,13 +20465,6 @@ __metadata:
   version: 4.4.0
   resolution: "lodash.intersection@npm:4.4.0"
   checksum: 10/fdd227a84eb2b52b0592121d5b8b7ceaa1d62405f1bd30d76f9f1ccfc58599423ffd28b82800b4ee539ee429d73a9850e1dfc7194bfe6227eb6028c91beac769
-  languageName: node
-  linkType: hard
-
-"lodash.isequal@npm:^4.0.0":
-  version: 4.5.0
-  resolution: "lodash.isequal@npm:4.5.0"
-  checksum: 10/82fc58a83a1555f8df34ca9a2cd300995ff94018ac12cc47c349655f0ae1d4d92ba346db4c19bbfc90510764e0c00ddcc985a358bdcd4b3b965abf8f2a48a214
   languageName: node
   linkType: hard
 
@@ -25107,7 +25100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-draggable@npm:4.4.6, react-draggable@npm:^4.0.0, react-draggable@npm:^4.0.3, react-draggable@npm:^4.4.5":
+"react-draggable@npm:4.4.6, react-draggable@npm:^4.0.3, react-draggable@npm:^4.4.5":
   version: 4.4.6
   resolution: "react-draggable@npm:4.4.6"
   dependencies:
@@ -25183,22 +25176,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-grid-layout@npm:1.3.4":
-  version: 1.3.4
-  resolution: "react-grid-layout@npm:1.3.4"
-  dependencies:
-    clsx: "npm:^1.1.1"
-    lodash.isequal: "npm:^4.0.0"
-    prop-types: "npm:^15.8.1"
-    react-draggable: "npm:^4.0.0"
-    react-resizable: "npm:^3.0.4"
-  peerDependencies:
-    react: ">= 16.3.0"
-    react-dom: ">= 16.3.0"
-  checksum: 10/944ab133e59bfaa5633625f57be9f69133b5cec2de0232d9581e2c988e257ebafe010ee9bbbff6c2754f9d7d8bb0053072bac103f20fc232be2a58e15d14fc64
-  languageName: node
-  linkType: hard
-
 "react-grid-layout@npm:1.4.4":
   version: 1.4.4
   resolution: "react-grid-layout@npm:1.4.4"
@@ -25213,6 +25190,23 @@ __metadata:
     react: ">= 16.3.0"
     react-dom: ">= 16.3.0"
   checksum: 10/43c9bc7e8ce5a902720ebe559b1551724615c617391b040a0a275597748e1927b293c5ddcb73053b1925909e1c293948b4969a35799d541bf9d8886e07ac0085
+  languageName: node
+  linkType: hard
+
+"react-grid-layout@patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch":
+  version: 1.4.4
+  resolution: "react-grid-layout@patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch::version=1.4.4&hash=e69ce6"
+  dependencies:
+    clsx: "npm:^2.0.0"
+    fast-equals: "npm:^4.0.3"
+    prop-types: "npm:^15.8.1"
+    react-draggable: "npm:^4.4.5"
+    react-resizable: "npm:^3.0.5"
+    resize-observer-polyfill: "npm:^1.5.1"
+  peerDependencies:
+    react: ">= 16.3.0"
+    react-dom: ">= 16.3.0"
+  checksum: 10/fcc4fe40e38d723870dbc138af9a4a58dff6459efd191d03a66de2e663e169591a66d77b0f377bad780f64f4e24ca41735e4b2ecd99ae7c48071a0b8a1876a25
   languageName: node
   linkType: hard
 
@@ -25440,7 +25434,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable@npm:3.0.5, react-resizable@npm:^3.0.4, react-resizable@npm:^3.0.5":
+"react-resizable@npm:3.0.5, react-resizable@npm:^3.0.5":
   version: 3.0.5
   resolution: "react-resizable@npm:3.0.5"
   dependencies:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- ensures drag handle always follows the cursor
- does this by patching `react-grid-layout` to use `flushSync`
- have raised a PR upstream [here](https://github.com/react-grid-layout/react-grid-layout/pull/2043)

**Why do we need this feature?**

- prevents desync between cursor when resizing a panel

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/hyperion-planning/issues/8

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
