### PR TITLE
CodeEditor: Improved styles when the code editor is loading

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5099,8 +5099,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
     "packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx:5381": [

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -527,8 +527,7 @@ export const Components = {
     container: 'data-testid Code editor container',
   },
   ReactMonacoEditor: {
-    editor: 'data-testid Monaco editor',
-    editorLoading: 'data-testid Monaco editor loading',
+    container: 'data-testid ReactMonacoEditor container',
   },
   DashboardImportPage: {
     textarea: 'data-testid-import-dashboard-textarea',

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -526,6 +526,10 @@ export const Components = {
   CodeEditor: {
     container: 'data-testid Code editor container',
   },
+  ReactMonacoEditor: {
+    editor: 'data-testid Monaco editor',
+    editorLoading: 'data-testid Monaco editor loading',
+  },
   DashboardImportPage: {
     textarea: 'data-testid-import-dashboard-textarea',
     submit: 'data-testid-load-dashboard',

--- a/packages/grafana-prometheus/src/components/PromQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/PromQueryField.tsx
@@ -238,7 +238,7 @@ class PromQueryFieldClass extends React.PureComponent<PromQueryFieldProps, PromQ
                   <Icon name={labelBrowserVisible ? 'angle-down' : 'angle-right'} />
                 </button>
 
-                <div className="gf-form gf-form--grow flex-shrink-1 min-width-15">
+                <div className="flex-grow-1 min-width-15">
                   <MonacoQueryFieldWrapper
                     languageProvider={languageProvider}
                     history={history}

--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -83,6 +83,11 @@ const getStyles = (theme: GrafanaTheme2, placeholder: string) => {
     container: css({
       borderRadius: theme.shape.radius.default,
       border: `1px solid ${theme.components.input.borderColor}`,
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'start',
+      alignItems: 'center',
+      height: '100%',
     }),
     placeholder: css({
       '::after': {

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -16,20 +16,14 @@ import type { ReactMonacoEditorProps } from './types';
  * @internal
  * Experimental export
  **/
-export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
+export const ReactMonacoEditorLazyComponent = (props: ReactMonacoEditorProps) => {
   const styles = useStyles2(getStyles);
   const { loading, error, dependency } = useAsyncDependency(
     import(/* webpackChunkName: "react-monaco-editor" */ './ReactMonacoEditor')
   );
 
   if (loading) {
-    return (
-      <LoadingPlaceholder
-        text={''}
-        className={styles.container}
-        data-testid={selectors.components.ReactMonacoEditor.editorLoading}
-      />
-    );
+    return <LoadingPlaceholder text={''} className={styles.container} />;
   }
 
   if (error) {
@@ -43,13 +37,7 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   }
 
   const ReactMonacoEditor = dependency.ReactMonacoEditor;
-  return (
-    <ReactMonacoEditor
-      {...props}
-      loading={props.loading ?? null}
-      data-testid={selectors.components.ReactMonacoEditor.editor}
-    />
-  );
+  return <ReactMonacoEditor {...props} loading={props.loading ?? null} />;
 };
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -60,3 +48,17 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
+
+const withContainer = <P extends object>(Component: React.ComponentType<P>): React.ComponentType<P> => {
+  const WithContainer = (props: P) => (
+    <div data-testid={selectors.components.ReactMonacoEditor.container}>
+      <Component {...props} />
+    </div>
+  );
+
+  WithContainer.displayName = Component.displayName;
+
+  return WithContainer;
+};
+
+export const ReactMonacoEditorLazy = withContainer(ReactMonacoEditorLazyComponent);

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -51,7 +51,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 const withContainer = <P extends object>(Component: React.ComponentType<P>): React.ComponentType<P> => {
   const WithContainer = (props: P) => (
-    // allow tests to easily determine if the code editor has rendered in any of its three forms
+    // allow tests to easily determine if the code editor has rendered in any of its three states (loading, error, or ready)
     <div data-testid={selectors.components.ReactMonacoEditor.container}>
       <Component {...props} />
     </div>

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -1,5 +1,9 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../themes';
 import { useAsyncDependency } from '../../utils/useAsyncDependency';
 import { ErrorWithStack } from '../ErrorBoundary/ErrorWithStack';
 import { LoadingPlaceholder } from '../LoadingPlaceholder/LoadingPlaceholder';
@@ -12,12 +16,13 @@ import type { ReactMonacoEditorProps } from './types';
  * Experimental export
  **/
 export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
+  const styles = useStyles2(getStyles);
   const { loading, error, dependency } = useAsyncDependency(
     import(/* webpackChunkName: "react-monaco-editor" */ './ReactMonacoEditor')
   );
 
   if (loading) {
-    return <LoadingPlaceholder text={''} />;
+    return <LoadingPlaceholder text={''} className={styles.container} />;
   }
 
   if (error) {
@@ -31,5 +36,14 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   }
 
   const ReactMonacoEditor = dependency.ReactMonacoEditor;
-  return <ReactMonacoEditor {...props} />;
+  return <ReactMonacoEditor {...props} loading={props.loading ?? null} />;
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      marginBottom: 'unset',
+      marginLeft: theme.spacing(1),
+    }),
+  };
 };

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -23,7 +23,7 @@ const MonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   );
 
   if (loading) {
-    return <LoadingPlaceholder text={''} className={styles.container} />;
+    return <LoadingPlaceholder text={'Loading editor'} className={styles.container} />;
   }
 
   if (error) {

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -16,7 +16,7 @@ import type { ReactMonacoEditorProps } from './types';
  * @internal
  * Experimental export
  **/
-export const ReactMonacoEditorLazyComponent = (props: ReactMonacoEditorProps) => {
+const MonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   const styles = useStyles2(getStyles);
   const { loading, error, dependency } = useAsyncDependency(
     import(/* webpackChunkName: "react-monaco-editor" */ './ReactMonacoEditor')
@@ -51,6 +51,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 const withContainer = <P extends object>(Component: React.ComponentType<P>): React.ComponentType<P> => {
   const WithContainer = (props: P) => (
+    // allow tests to easily determine if the code editor has rendered in any of its three forms
     <div data-testid={selectors.components.ReactMonacoEditor.container}>
       <Component {...props} />
     </div>
@@ -61,4 +62,4 @@ const withContainer = <P extends object>(Component: React.ComponentType<P>): Rea
   return WithContainer;
 };
 
-export const ReactMonacoEditorLazy = withContainer(ReactMonacoEditorLazyComponent);
+export const ReactMonacoEditorLazy = withContainer(MonacoEditorLazy);

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { useStyles2 } from '../../themes';
 import { useAsyncDependency } from '../../utils/useAsyncDependency';
@@ -22,7 +23,13 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   );
 
   if (loading) {
-    return <LoadingPlaceholder text={''} className={styles.container} />;
+    return (
+      <LoadingPlaceholder
+        text={''}
+        className={styles.container}
+        data-testid={selectors.components.ReactMonacoEditor.editorLoading}
+      />
+    );
   }
 
   if (error) {
@@ -36,7 +43,13 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   }
 
   const ReactMonacoEditor = dependency.ReactMonacoEditor;
-  return <ReactMonacoEditor {...props} loading={props.loading ?? null} />;
+  return (
+    <ReactMonacoEditor
+      {...props}
+      loading={props.loading ?? null}
+      data-testid={selectors.components.ReactMonacoEditor.editor}
+    />
+  );
 };
 
 const getStyles = (theme: GrafanaTheme2) => {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
+
 import { createLokiDatasource } from '../../__mocks__/datasource';
 
 import { MonacoQueryFieldWrapper, Props } from './MonacoQueryFieldWrapper';
@@ -25,7 +27,8 @@ describe('MonacoFieldWrapper', () => {
     renderComponent();
 
     await waitFor(async () => {
-      expect(await screen.findByText('Loading...')).toBeInTheDocument();
+      const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+      expect(monacoEditorLoading).toBeInTheDocument();
     });
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -27,7 +27,7 @@ describe('MonacoFieldWrapper', () => {
     renderComponent();
 
     await waitFor(async () => {
-      const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+      const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
       expect(monacoEditorLoading).toBeInTheDocument();
     });
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -27,8 +27,8 @@ describe('MonacoFieldWrapper', () => {
     renderComponent();
 
     await waitFor(async () => {
-      const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
-      expect(monacoEditorLoading).toBeInTheDocument();
+      const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+      expect(monacoEditor).toBeInTheDocument();
     });
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
+
 import { createLokiDatasource } from '../../__mocks__/datasource';
 
 import MonacoQueryField from './MonacoQueryField';
@@ -31,6 +33,7 @@ describe('MonacoQueryField', () => {
   test('Renders with no errors', async () => {
     renderComponent();
 
-    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+    expect(monacoEditorLoading).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
@@ -33,7 +33,7 @@ describe('MonacoQueryField', () => {
   test('Renders with no errors', async () => {
     renderComponent();
 
-    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
     expect(monacoEditorLoading).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
@@ -33,7 +33,7 @@ describe('MonacoQueryField', () => {
   test('Renders with no errors', async () => {
     renderComponent();
 
-    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
-    expect(monacoEditorLoading).toBeInTheDocument();
+    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+    expect(monacoEditor).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -34,8 +34,8 @@ describe('LokiQueryCodeEditor', () => {
     props.showExplain = true;
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
-    expect(monacoEditorLoading).toBeInTheDocument();
+    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+    expect(monacoEditor).toBeInTheDocument();
     expect(screen.getByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -43,8 +43,8 @@ describe('LokiQueryCodeEditor', () => {
     const props = createDefaultProps();
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
-    expect(monacoEditorLoading).toBeInTheDocument();
+    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+    expect(monacoEditor).toBeInTheDocument();
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -34,7 +34,7 @@ describe('LokiQueryCodeEditor', () => {
     props.showExplain = true;
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
     expect(monacoEditorLoading).toBeInTheDocument();
     expect(screen.getByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
@@ -43,7 +43,7 @@ describe('LokiQueryCodeEditor', () => {
     const props = createDefaultProps();
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
     expect(monacoEditorLoading).toBeInTheDocument();
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
+
 import { createLokiDatasource } from '../../__mocks__/datasource';
 import { LokiQuery } from '../../types';
 
@@ -32,7 +34,8 @@ describe('LokiQueryCodeEditor', () => {
     props.showExplain = true;
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+    expect(monacoEditorLoading).toBeInTheDocument();
     expect(screen.getByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
 
@@ -40,7 +43,8 @@ describe('LokiQueryCodeEditor', () => {
     const props = createDefaultProps();
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    expect(await screen.findByText('Loading...')).toBeInTheDocument();
+    const monacoEditorLoading = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLoading);
+    expect(monacoEditorLoading).toBeInTheDocument();
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

## What is this change?

Style & messaging updates to the Monaco code editor, in the following places:
- `grafana-ui`'s `ReactMonacoEditorLazy` component (exported as `ReactMonacoEditor`), which is currently used by the Prometheus and Loki data sources directly. It's also used in `grafana-ui`'s `CodeEditor` component, which is used in the Azure Monitor, CloudWatch, InfluxDB, Parca, and Tempo data sources, as well as the Panel plugin.
- the Prometheus data source

## Why do we need this feature?

As described in #80861, the loading UI for the Monaco code editor used by the Prometheus data source (and other data sources) has styling that's inconsistent with the rest of the UI.

## Who is this feature for?

Users who rely on code editor UI in various data sources.

## Which issue(s) does this PR fix?

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #80861

## Special notes for your reviewer

Please check that:

- [x] It works as expected from a user's perspective.
  - [x] Prometheus data source
  - [x] Loki data source
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
