### PR TITLE
API Server: Add temporary request log for queries

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
 	errorsK8s "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,10 +23,12 @@ import (
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/web"
 )
 
 type queryREST struct {
+	logger  log.Logger
 	builder *QueryAPIBuilder
 }
 
@@ -35,6 +39,13 @@ var (
 	_ rest.Scoper               = (*queryREST)(nil)
 	_ rest.StorageMetadata      = (*queryREST)(nil)
 )
+
+func newQueryREST(builder *QueryAPIBuilder) *queryREST {
+	return &queryREST{
+		logger:  log.New("query"),
+		builder: builder,
+	}
+}
 
 func (r *queryREST) New() runtime.Object {
 	// This is added as the "ResponseType" regarless what ProducesObject() says :)
@@ -67,7 +78,7 @@ func (r *queryREST) NewConnectOptions() (runtime.Object, bool, string) {
 	return nil, false, "" // true means you can use the trailing path as a variable
 }
 
-func (r *queryREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+func (r *queryREST) Connect(ctx context.Context, name string, opts runtime.Object, incomingResponder rest.Responder) (http.Handler, error) {
 	// See: /pkg/apiserver/builder/helper.go#L34
 	// The name is set with a rewriter hack
 	if name != "name" {
@@ -76,8 +87,29 @@ func (r *queryREST) Connect(ctx context.Context, name string, opts runtime.Objec
 	b := r.builder
 
 	return http.HandlerFunc(func(w http.ResponseWriter, httpreq *http.Request) {
+		start := time.Now()
 		ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
 		defer span.End()
+
+		logger := r.logger.FromContext(ctx)
+
+		responder := newResponderWrapper(incomingResponder,
+			func(statusCode int, obj runtime.Object) {
+				if statusCode >= 400 {
+					span.SetStatus(codes.Error, fmt.Sprintf("error with HTTP status code %s", strconv.Itoa(statusCode)))
+				}
+
+				logRequest(logger, start, statusCode)
+			},
+			func(err error) {
+				span.SetStatus(codes.Error, "request failed")
+				if err == nil {
+					return
+				}
+
+				span.RecordError(err)
+				logRequestError(logger, start, err)
+			})
 
 		raw := &query.QueryDataRequest{}
 		err := web.Bind(httpreq, raw)
@@ -336,4 +368,52 @@ func (b *QueryAPIBuilder) handleExpressions(ctx context.Context, req parsedReque
 		}
 	}
 	return qdr, nil
+}
+
+// logRequest short-term hack until k8s have added support for traceIDs in request logs.
+func logRequest(logger log.Logger, startTime time.Time, statusCode int) {
+	duration := time.Since(startTime)
+	logger.Debug("Query request completed", "status", statusCode, "duration", duration.String())
+}
+
+func logRequestError(logger log.Logger, startTime time.Time, err error) {
+	var args []any
+	var gfErr errutil.Error
+	if !errors.As(err, &gfErr) {
+		args = []any{"error", err.Error()}
+	} else {
+		args = []any{
+			"errorReason", gfErr.Reason,
+			"errorMessageID", gfErr.MessageID,
+			"error", gfErr.LogMessage,
+		}
+	}
+
+	duration := time.Since(startTime)
+	args = append(args, "duration", duration.String())
+	logger.Error("Query request completed", args...)
+}
+
+type responderWrapper struct {
+	wrapped    rest.Responder
+	onObjectFn func(statusCode int, obj runtime.Object)
+	onErrorFn  func(err error)
+}
+
+func newResponderWrapper(responder rest.Responder, onObjectFn func(statusCode int, obj runtime.Object), onErrorFn func(err error)) *responderWrapper {
+	return &responderWrapper{
+		wrapped:    responder,
+		onObjectFn: onObjectFn,
+		onErrorFn:  onErrorFn,
+	}
+}
+
+func (r responderWrapper) Object(statusCode int, obj runtime.Object) {
+	r.onObjectFn(statusCode, obj)
+	r.wrapped.Object(statusCode, obj)
+}
+
+func (r responderWrapper) Error(err error) {
+	r.onErrorFn(err)
+	r.wrapped.Error(err)
 }

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -145,7 +145,7 @@ func (b *QueryAPIBuilder) GetAPIGroupInfo(
 	}
 
 	// The query endpoint -- NOTE, this uses a rewrite hack to allow requests without a name parameter
-	storage["query"] = &queryREST{builder: b}
+	storage["query"] = newQueryREST(b)
 
 	apiGroupInfo.VersionedResourcesStorageMap[gv.Version] = storage
 	return &apiGroupInfo, nil


### PR DESCRIPTION
**What is this feature?**

Adds a temporary request log for requests to query api server to include the traceID since k8s currently doesn't include traceID in request logs. This also marks and record response errors in span. Didn't want to overwork this since temporary, but think it should be enough?

**Why do we need this feature?**

Better observability to correlate logs with traces.

**Who is this feature for?**

Operators.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**
Tested with embedded mode running as part of grafana:
<img width="742" alt="Screenshot 2024-05-20 at 20 25 51" src="https://github.com/grafana/grafana/assets/1668778/c17a7f1d-e635-4f7c-8ed7-0c6ebeca0e2a">
<img width="742" alt="image" src="https://github.com/grafana/grafana/assets/1668778/f54c31da-a17b-4bb5-a9e1-c0db8c2b2c0e">

```
DEBUG[05-20|20:35:39] Query request completed                  logger=query traceID=6a1257ecf8f08bcdc2150f4ae75cad02 status=200 duration=8.196666ms
ERROR[05-20|20:35:41] Query request completed                  logger=query traceID=77e8e5a237c652c46338ca300d64d8f9 error="datasource not found" duration=546.917µs
```