### PR TITLE
Dashboards: Fix persisting timeRangeUpdated that should not be persisted

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -117,7 +117,7 @@ export class DashboardModel implements TimeModel {
     appEventsSubscription: true,
     panelsAffectedByVariableChange: true,
     lastRefresh: true,
-    timeRangeUpdatedDuringEdit: true,
+    timeRangeUpdatedDuringEditOrView: true,
     originalDashboard: true,
   };
 


### PR DESCRIPTION
When the property on DashboardModel changed name in #83418, the object holding the non persisted objects was not updated. This is causing change detection to trigger unnecessarily.
![Screenshot 2024-05-21 at 11 09 52](https://github.com/grafana/grafana/assets/468940/db35a41f-b5d1-4720-a723-c73ba295e597)
