### PR TITLE
sql performance experiments: signed in user cache

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -120,7 +120,7 @@ func (s *UserSync) FetchSyncedUserHook(ctx context.Context, identity *authn.Iden
 		return nil
 	}
 
-	usr, err := s.userService.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{
+	usr, err := s.userService.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
 		UserID: userID,
 		OrgID:  r.OrgID,
 	})

--- a/pkg/services/grpcserver/interceptors/auth.go
+++ b/pkg/services/grpcserver/interceptors/auth.go
@@ -99,7 +99,7 @@ func (a *authenticator) getSignedInUser(ctx context.Context, token string) (*use
 	}
 
 	querySignedInUser := user.GetSignedInUserQuery{UserID: *apikey.ServiceAccountId, OrgID: apikey.OrgID}
-	signedInUser, err := a.UserService.GetSignedInUserWithCacheCtx(ctx, &querySignedInUser)
+	signedInUser, err := a.UserService.GetSignedInUser(ctx, &querySignedInUser)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/grpcserver/interceptors/auth_test.go
+++ b/pkg/services/grpcserver/interceptors/auth_test.go
@@ -140,7 +140,7 @@ type fakeUserService struct {
 	OrgRole org.RoleType
 }
 
-func (f *fakeUserService) GetSignedInUserWithCacheCtx(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
+func (f *fakeUserService) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
 	return &user.SignedInUser{
 		UserID:      1,
 		OrgID:       1,

--- a/pkg/services/user/user.go
+++ b/pkg/services/user/user.go
@@ -17,7 +17,6 @@ type Service interface {
 	GetByEmail(context.Context, *GetUserByEmailQuery) (*User, error)
 	Update(context.Context, *UpdateUserCommand) error
 	UpdateLastSeenAt(context.Context, *UpdateUserLastSeenAtCommand) error
-	GetSignedInUserWithCacheCtx(context.Context, *GetSignedInUserQuery) (*SignedInUser, error)
 	GetSignedInUser(context.Context, *GetSignedInUserQuery) (*SignedInUser, error)
 	Search(context.Context, *SearchUsersQuery) (*SearchUserQueryResult, error)
 	BatchDisableUsers(context.Context, *BatchDisableUsersCommand) error

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -292,7 +292,7 @@ func (s *Service) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLast
 	))
 	defer span.End()
 
-	u, err := s.GetSignedInUserWithCacheCtx(ctx, &user.GetSignedInUserQuery{
+	u, err := s.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
 		UserID: cmd.UserID,
 		OrgID:  cmd.OrgID,
 	})
@@ -312,7 +312,7 @@ func shouldUpdateLastSeen(t time.Time) bool {
 	return time.Since(t) > time.Minute*5
 }
 
-func (s *Service) GetSignedInUserWithCacheCtx(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
+func (s *Service) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
 	ctx, span := s.tracer.Start(ctx, "user.GetSignedInUserWithCacheCtx", trace.WithAttributes(
 		attribute.Int64("userID", query.UserID),
 		attribute.Int64("orgID", query.OrgID),
@@ -322,22 +322,27 @@ func (s *Service) GetSignedInUserWithCacheCtx(ctx context.Context, query *user.G
 	var signedInUser *user.SignedInUser
 
 	// only check cache if we have a user ID and an org ID in query
-	if query.OrgID > 0 && query.UserID > 0 {
-		cacheKey := newSignedInUserCacheKey(query.OrgID, query.UserID)
-		if cached, found := s.cacheService.Get(cacheKey); found {
-			cachedUser := cached.(user.SignedInUser)
-			signedInUser = &cachedUser
-			return signedInUser, nil
+	if s.cacheService != nil {
+		if query.OrgID > 0 && query.UserID > 0 {
+			cacheKey := newSignedInUserCacheKey(query.OrgID, query.UserID)
+			if cached, found := s.cacheService.Get(cacheKey); found {
+				cachedUser := cached.(user.SignedInUser)
+				signedInUser = &cachedUser
+				return signedInUser, nil
+			}
 		}
 	}
 
-	result, err := s.GetSignedInUser(ctx, query)
+	result, err := s.getSignedInUser(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
-	cacheKey := newSignedInUserCacheKey(result.OrgID, result.UserID)
-	s.cacheService.Set(cacheKey, *result, time.Second*5)
+	if s.cacheService != nil {
+		cacheKey := newSignedInUserCacheKey(result.OrgID, result.UserID)
+		s.cacheService.Set(cacheKey, *result, time.Second*5)
+	}
+
 	return result, nil
 }
 
@@ -345,8 +350,8 @@ func newSignedInUserCacheKey(orgID, userID int64) string {
 	return fmt.Sprintf("signed-in-user-%d-%d", userID, orgID)
 }
 
-func (s *Service) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
-	ctx, span := s.tracer.Start(ctx, "user.GetSignedInUser", trace.WithAttributes(
+func (s *Service) getSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
+	ctx, span := s.tracer.Start(ctx, "user.getSignedInUser", trace.WithAttributes(
 		attribute.Int64("userID", query.UserID),
 		attribute.Int64("orgID", query.OrgID),
 	))

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -117,13 +117,13 @@ func TestUserService(t *testing.T) {
 		query1 := &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}
 		userStore.ExpectedSignedInUser = usr
 		orgService.ExpectedUserOrgDTO = []*org.UserOrgDTO{{OrgID: 0}, {OrgID: 1}}
-		result, err := userService.GetSignedInUserWithCacheCtx(context.Background(), query1)
+		result, err := userService.GetSignedInUser(context.Background(), query1)
 		require.Nil(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, query1.OrgID, result.OrgID)
 		userStore.ExpectedSignedInUser = usr2
 		query2 := &user.GetSignedInUserQuery{OrgID: 0, UserID: 1}
-		result2, err := userService.GetSignedInUserWithCacheCtx(context.Background(), query2)
+		result2, err := userService.GetSignedInUser(context.Background(), query2)
 		require.Nil(t, err)
 		require.NotNil(t, result2)
 		assert.Equal(t, query2.OrgID, result2.OrgID)

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -75,10 +75,6 @@ func (f *FakeUserService) UpdateLastSeenAt(ctx context.Context, cmd *user.Update
 	return f.ExpectedError
 }
 
-func (f *FakeUserService) GetSignedInUserWithCacheCtx(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
-	return f.GetSignedInUser(ctx, query)
-}
-
 func (f *FakeUserService) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
 	if f.GetSignedInUserFn != nil {
 		return f.GetSignedInUserFn(ctx, query)


### PR DESCRIPTION
We were not consistently using the UserService localcache when getting a signed in user, so I've made that the default behavior. It will do nothing if there's no local cache (which should only happen in tests); otherwise behavior is unchanged (if the record is not in the cache, getSignedInUser is called). 

Changes:
* `GetSignedInUser` unexported (renamed to `getSignedInUser`)
* `GetSignedInUserWithCacheCtx` renamed to `GetSignedInUser`
* added a check for a nil cacheservice (as defensive programming / test convenience)