### PR TITLE
Plugins: Add logging to plugin envvars

### DIFF
--- a/pkg/services/pluginsintegration/pluginconfig/envvars.go
+++ b/pkg/services/pluginsintegration/pluginconfig/envvars.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/envvars"
 )
@@ -21,26 +22,28 @@ var _ envvars.Provider = (*EnvVarsProvider)(nil)
 type EnvVarsProvider struct {
 	cfg     *PluginInstanceCfg
 	license plugins.Licensing
+	logger  log.Logger
 }
 
 func NewEnvVarsProvider(cfg *PluginInstanceCfg, license plugins.Licensing) *EnvVarsProvider {
 	return &EnvVarsProvider{
 		cfg:     cfg,
 		license: license,
+		logger:  log.New("plugins.envvars"),
 	}
 }
 
 func (p *EnvVarsProvider) PluginEnvVars(ctx context.Context, plugin *plugins.Plugin) []string {
 	hostEnv := []string{
-		envVar("GF_VERSION", p.cfg.GrafanaVersion),
+		p.envVar("GF_VERSION", p.cfg.GrafanaVersion),
 	}
 
 	if p.license != nil {
 		hostEnv = append(
 			hostEnv,
-			envVar("GF_EDITION", p.license.Edition()),
-			envVar("GF_ENTERPRISE_LICENSE_PATH", p.license.Path()),
-			envVar("GF_ENTERPRISE_APP_URL", p.license.AppURL()),
+			p.envVar("GF_EDITION", p.license.Edition()),
+			p.envVar("GF_ENTERPRISE_LICENSE_PATH", p.license.Path()),
+			p.envVar("GF_ENTERPRISE_APP_URL", p.license.AppURL()),
 		)
 		hostEnv = append(hostEnv, p.license.Environment()...)
 	}
@@ -48,12 +51,12 @@ func (p *EnvVarsProvider) PluginEnvVars(ctx context.Context, plugin *plugins.Plu
 	if plugin.ExternalService != nil {
 		hostEnv = append(
 			hostEnv,
-			envVar("GF_APP_URL", p.cfg.GrafanaAppURL),
-			envVar("GF_PLUGIN_APP_CLIENT_ID", plugin.ExternalService.ClientID),
-			envVar("GF_PLUGIN_APP_CLIENT_SECRET", plugin.ExternalService.ClientSecret),
+			p.envVar("GF_APP_URL", p.cfg.GrafanaAppURL),
+			p.envVar("GF_PLUGIN_APP_CLIENT_ID", plugin.ExternalService.ClientID),
+			p.envVar("GF_PLUGIN_APP_CLIENT_SECRET", plugin.ExternalService.ClientSecret),
 		)
 		if plugin.ExternalService.PrivateKey != "" {
-			hostEnv = append(hostEnv, envVar("GF_PLUGIN_APP_PRIVATE_KEY", plugin.ExternalService.PrivateKey))
+			hostEnv = append(hostEnv, p.envVar("GF_PLUGIN_APP_PRIVATE_KEY", plugin.ExternalService.PrivateKey))
 		}
 	}
 
@@ -87,7 +90,7 @@ func (p *EnvVarsProvider) featureToggleEnableVars(ctx context.Context) []string 
 		for feat := range enabledFeatures {
 			features = append(features, feat)
 		}
-		variables = append(variables, envVar("GF_INSTANCE_FEATURE_TOGGLES_ENABLE", strings.Join(features, ",")))
+		variables = append(variables, p.envVar("GF_INSTANCE_FEATURE_TOGGLES_ENABLE", strings.Join(features, ",")))
 	}
 
 	return variables
@@ -100,19 +103,19 @@ func (p *EnvVarsProvider) awsEnvVars(pluginID string) []string {
 
 	var variables []string
 	if !p.cfg.AWSAssumeRoleEnabled {
-		variables = append(variables, envVar(awsds.AssumeRoleEnabledEnvVarKeyName, "false"))
+		variables = append(variables, p.envVar(awsds.AssumeRoleEnabledEnvVarKeyName, "false"))
 	}
 	if len(p.cfg.AWSAllowedAuthProviders) > 0 {
-		variables = append(variables, envVar(awsds.AllowedAuthProvidersEnvVarKeyName, strings.Join(p.cfg.AWSAllowedAuthProviders, ",")))
+		variables = append(variables, p.envVar(awsds.AllowedAuthProvidersEnvVarKeyName, strings.Join(p.cfg.AWSAllowedAuthProviders, ",")))
 	}
 	if p.cfg.AWSExternalId != "" {
-		variables = append(variables, envVar(awsds.GrafanaAssumeRoleExternalIdKeyName, p.cfg.AWSExternalId))
+		variables = append(variables, p.envVar(awsds.GrafanaAssumeRoleExternalIdKeyName, p.cfg.AWSExternalId))
 	}
 	if p.cfg.AWSSessionDuration != "" {
-		variables = append(variables, envVar(awsds.SessionDurationEnvVarKeyName, p.cfg.AWSSessionDuration))
+		variables = append(variables, p.envVar(awsds.SessionDurationEnvVarKeyName, p.cfg.AWSSessionDuration))
 	}
 	if p.cfg.AWSListMetricsPageLimit != "" {
-		variables = append(variables, envVar(awsds.ListMetricsPageLimitKeyName, p.cfg.AWSListMetricsPageLimit))
+		variables = append(variables, p.envVar(awsds.ListMetricsPageLimitKeyName, p.cfg.AWSListMetricsPageLimit))
 	}
 
 	return variables
@@ -122,19 +125,19 @@ func (p *EnvVarsProvider) secureSocksProxyEnvVars() []string {
 	if p.cfg.ProxySettings.Enabled {
 		return []string{
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyClientCertFilePathEnvVarName, p.cfg.ProxySettings.ClientCertFilePath),
+			p.envVar(proxy.PluginSecureSocksProxyClientCertFilePathEnvVarName, p.cfg.ProxySettings.ClientCertFilePath),
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyClientKeyFilePathEnvVarName, p.cfg.ProxySettings.ClientKeyFilePath),
+			p.envVar(proxy.PluginSecureSocksProxyClientKeyFilePathEnvVarName, p.cfg.ProxySettings.ClientKeyFilePath),
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyRootCACertFilePathsEnvVarName, strings.Join(p.cfg.ProxySettings.RootCAFilePaths, " ")),
+			p.envVar(proxy.PluginSecureSocksProxyRootCACertFilePathsEnvVarName, strings.Join(p.cfg.ProxySettings.RootCAFilePaths, " ")),
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyAddressEnvVarName, p.cfg.ProxySettings.ProxyAddress),
+			p.envVar(proxy.PluginSecureSocksProxyAddressEnvVarName, p.cfg.ProxySettings.ProxyAddress),
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyServerNameEnvVarName, p.cfg.ProxySettings.ServerName),
+			p.envVar(proxy.PluginSecureSocksProxyServerNameEnvVarName, p.cfg.ProxySettings.ServerName),
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyEnabledEnvVarName, strconv.FormatBool(p.cfg.ProxySettings.Enabled)),
+			p.envVar(proxy.PluginSecureSocksProxyEnabledEnvVarName, strconv.FormatBool(p.cfg.ProxySettings.Enabled)),
 			// nolint:staticcheck
-			envVar(proxy.PluginSecureSocksProxyAllowInsecureEnvVarName, strconv.FormatBool(p.cfg.ProxySettings.AllowInsecure)),
+			p.envVar(proxy.PluginSecureSocksProxyAllowInsecureEnvVarName, strconv.FormatBool(p.cfg.ProxySettings.AllowInsecure)),
 		}
 	}
 	return nil
@@ -146,11 +149,11 @@ func (p *EnvVarsProvider) tracingEnvVars(plugin *plugins.Plugin) []string {
 	}
 
 	vars := []string{
-		envVar("GF_INSTANCE_OTLP_ADDRESS", p.cfg.Tracing.OpenTelemetry.Address),
-		envVar("GF_INSTANCE_OTLP_PROPAGATION", p.cfg.Tracing.OpenTelemetry.Propagation),
-		envVar("GF_INSTANCE_OTLP_SAMPLER_TYPE", p.cfg.Tracing.OpenTelemetry.Sampler),
+		p.envVar("GF_INSTANCE_OTLP_ADDRESS", p.cfg.Tracing.OpenTelemetry.Address),
+		p.envVar("GF_INSTANCE_OTLP_PROPAGATION", p.cfg.Tracing.OpenTelemetry.Propagation),
+		p.envVar("GF_INSTANCE_OTLP_SAMPLER_TYPE", p.cfg.Tracing.OpenTelemetry.Sampler),
 		fmt.Sprintf("GF_INSTANCE_OTLP_SAMPLER_PARAM=%.6f", p.cfg.Tracing.OpenTelemetry.SamplerParam),
-		envVar("GF_INSTANCE_OTLP_SAMPLER_REMOTE_URL", p.cfg.Tracing.OpenTelemetry.SamplerRemoteURL),
+		p.envVar("GF_INSTANCE_OTLP_SAMPLER_REMOTE_URL", p.cfg.Tracing.OpenTelemetry.SamplerRemoteURL),
 	}
 	if plugin.Info.Version != "" {
 		vars = append(vars, fmt.Sprintf("GF_PLUGIN_VERSION=%s", plugin.Info.Version))
@@ -174,6 +177,9 @@ func (p *EnvVarsProvider) pluginSettingsEnvVars(pluginID string) []string {
 	return env
 }
 
-func envVar(key, value string) string {
+func (p *EnvVarsProvider) envVar(key, value string) string {
+	if strings.Contains(value, "\x00") {
+		p.logger.Error("Variable with key '%s' contains a nil character", key)
+	}
 	return fmt.Sprintf("%s=%s", key, value)
 }


### PR DESCRIPTION
**What is this feature?**

We have the case where we export an environment variable with a '\x00' character leading to a Grafana instance failing to even start.
We don't know which variable it is but suspect it is the client secret.
Adding this simple log line to make sure that if this ever happens we know which env var is faulty for sure.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
