### PR TITLE
Logs: Added multi-line display control to the "wrap lines" option

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -308,6 +308,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               pinned={this.props.pinned}
               mouseIsOver={this.state.mouseIsOver}
               onBlur={this.onMouseLeave}
+              expanded={this.state.showDetails}
             />
           )}
         </tr>

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -165,7 +165,7 @@ describe('LogRowMessage', () => {
     const entry = `Line1
 line2
 line3`;
-    const singleLineEntry = entry.replace(/(\r\n|\n|\r)/g, '')
+    const singleLineEntry = entry.replace(/(\r\n|\n|\r)/g, '');
     it('Displays the original log line when wrapping is enabled', () => {
       setup({
         row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000 }),

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -160,4 +160,41 @@ describe('LogRowMessage', () => {
       });
     });
   });
+
+  describe('For multi-line logs', () => {
+    const entry = `Line1
+line2
+line3`;
+    const singleLineEntry = entry.replace(/(\r\n|\n|\r)/g, '')
+    it('Displays the original log line when wrapping is enabled', () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000 }),
+        wrapLogMessage: true,
+      });
+      expect(screen.getByText(/Line1/)).toBeInTheDocument();
+      expect(screen.getByText(/line2/)).toBeInTheDocument();
+      expect(screen.getByText(/line3/)).toBeInTheDocument();
+      expect(screen.queryByText(singleLineEntry)).not.toBeInTheDocument();
+    });
+
+    it('Removes new lines from the original log line when wrapping is disabled', () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000 }),
+        wrapLogMessage: false,
+      });
+      expect(screen.getByText(singleLineEntry)).toBeInTheDocument();
+    });
+
+    it('Displays the original log line when the line is expanded', () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000 }),
+        wrapLogMessage: true,
+        expanded: true,
+      });
+      expect(screen.getByText(/Line1/)).toBeInTheDocument();
+      expect(screen.getByText(/line2/)).toBeInTheDocument();
+      expect(screen.getByText(/line3/)).toBeInTheDocument();
+      expect(screen.queryByText(singleLineEntry)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -62,9 +62,7 @@ const restructureLog = (line: string, prettifyLogMessage: boolean, wrapLogMessag
   if (prettifyLogMessage) {
     try {
       return JSON.stringify(JSON.parse(line), undefined, 2);
-    } catch (error) {
-      return line;
-    }
+    } catch (error) {}
   }
   // With wrapping disabled, we also want to turn it into a single-line log entry
   if (!wrapLogMessage) {

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -70,7 +70,7 @@ const restructureLog = (
       return JSON.stringify(JSON.parse(line), undefined, 2);
     } catch (error) {}
   }
-  // With wrapping disabled, we also want to turn it into a single-line log entry
+  // With wrapping disabled, we want to turn it into a single-line log entry unless the line is expanded
   if (!wrapLogMessage && !expanded) {
     line = line.replace(/(\r\n|\n|\r)/g, '');
   }

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -29,6 +29,7 @@ interface Props {
   styles: LogRowStyles;
   mouseIsOver: boolean;
   onBlur: () => void;
+  expanded?: boolean;
 }
 
 interface LogMessageProps {
@@ -58,14 +59,19 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
   return <>{entry}</>;
 };
 
-const restructureLog = (line: string, prettifyLogMessage: boolean, wrapLogMessage: boolean): string => {
+const restructureLog = (
+  line: string,
+  prettifyLogMessage: boolean,
+  wrapLogMessage: boolean,
+  expanded: boolean
+): string => {
   if (prettifyLogMessage) {
     try {
       return JSON.stringify(JSON.parse(line), undefined, 2);
     } catch (error) {}
   }
   // With wrapping disabled, we also want to turn it into a single-line log entry
-  if (!wrapLogMessage) {
+  if (!wrapLogMessage && !expanded) {
     line = line.replace(/(\r\n|\n|\r)/g, '');
   }
   return line;
@@ -86,9 +92,13 @@ export const LogRowMessage = React.memo((props: Props) => {
     mouseIsOver,
     onBlur,
     getRowContextQuery,
+    expanded,
   } = props;
   const { hasAnsi, raw } = row;
-  const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage, wrapLogMessage), [raw, prettifyLogMessage, wrapLogMessage]);
+  const restructuredEntry = useMemo(
+    () => restructureLog(raw, prettifyLogMessage, wrapLogMessage, Boolean(expanded)),
+    [raw, prettifyLogMessage, wrapLogMessage, expanded]
+  );
   const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -58,13 +58,17 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
   return <>{entry}</>;
 };
 
-const restructureLog = (line: string, prettifyLogMessage: boolean): string => {
+const restructureLog = (line: string, prettifyLogMessage: boolean, wrapLogMessage: boolean): string => {
   if (prettifyLogMessage) {
     try {
       return JSON.stringify(JSON.parse(line), undefined, 2);
     } catch (error) {
       return line;
     }
+  }
+  // With wrapping disabled, we also want to turn it into a single-line log entry
+  if (!wrapLogMessage) {
+    line = line.replace(/(\r\n|\n|\r)/g, '');
   }
   return line;
 };
@@ -86,7 +90,7 @@ export const LogRowMessage = React.memo((props: Props) => {
     getRowContextQuery,
   } = props;
   const { hasAnsi, raw } = row;
-  const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage), [raw, prettifyLogMessage]);
+  const restructuredEntry = useMemo(() => restructureLog(raw, prettifyLogMessage, wrapLogMessage), [raw, prettifyLogMessage, wrapLogMessage]);
   const shouldShowMenu = useMemo(() => mouseIsOver || pinned, [mouseIsOver, pinned]);
   return (
     <>


### PR DESCRIPTION
With this PR we are improving how we handle and display multi-line logs lines. This has been pointed out multiple times, even in some external contributions, by people that, for example, stores stack traces as log lines.

![imagen](https://github.com/grafana/grafana/assets/1069378/0438e397-1fce-45ec-8442-f73d99856356)

With this PR, when `Wrap lines` is toggled off, we also unwrap new lines, thus collapsing all multi-lines logs. Analogously, when `Wrap lines` is enabled, log lines are wrapped and new lines are rendered in the screen.

An additional change to this behavor is that, even with `Wrap lines` disabled, when the user opens log details, we display the full log line with new lines, as suggested by https://github.com/grafana/grafana/pull/87368

**What is this feature?**

Log line visualization improvement.

**Why do we need this feature?**

Better support of log lines with new lines, like those from stack traces.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/74262

**Special notes for your reviewer:**

Demo:

https://github.com/grafana/grafana/assets/1069378/701c7ac5-1dc1-4590-a4e9-4fff6f6778eb

