### PR TITLE
Alerting: add `NeedHelpInfo` for `Configure No data and error handling`

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -204,6 +204,25 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
   );
 }
 
+function NeedHelpInfoForConfigureNoDataError() {
+  const docsLink =
+    'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/#configure-no-data-and-error-handling';
+
+  return (
+    <Stack direction="row" gap={0.5} alignItems="center">
+      <Text variant="bodySmall" color="secondary">
+        Define the alert behavior when the evaluation fails or the query returns no data.
+      </Text>
+      <NeedHelpInfo
+        contentText="These settings can help mitigate temporary data source issues, preventing alerts from unintentionally firing due to lack of data, errors, or timeouts."
+        externalLink={docsLink}
+        linkText={`Read more about this option`}
+        title="Configure no data and error handling"
+      />
+    </Stack>
+  );
+}
+
 function getDescription() {
   const docsLink = 'https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/rule-evaluation/';
 
@@ -283,6 +302,7 @@ export function GrafanaEvaluationBehavior({
       />
       {showErrorHandling && (
         <>
+          <NeedHelpInfoForConfigureNoDataError />
           <Field htmlFor="no-data-state-input" label="Alert state if no data or all values are null">
             <Controller
               render={({ field: { onChange, ref, ...field } }) => (


### PR DESCRIPTION
## Current version

![Screenshot 2024-05-21 at 17 53 54](https://github.com/grafana/grafana/assets/825430/cf9532e7-59c9-4568-82ec-56513f6ee2b6)


However, the “Configure no data and error handling” option does a bit more than just change the alert state. This PR adds a a NeedHelpInfo UI that provides additional information and links to the docs:

## Update

![Screenshot 2024-05-21 at 17 53 10](https://github.com/grafana/grafana/assets/825430/cd99038a-eff2-4a91-91af-5ce3ac0dc670)
