### PR TITLE
RBAC: Clean up action set code

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -459,7 +459,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 	folderServiceWithFlagOn := folderimpl.ProvideService(ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore, folderStore, sc.db, features, supportbundlestest.NewFakeBundleService(), nil)
 
 	cfg := setting.NewCfg()
-	actionSets := resourcepermissions.NewActionSetService(ac)
+	actionSets := resourcepermissions.NewActionSetService()
 	acSvc := acimpl.ProvideOSSService(sc.cfg, acdb.ProvideService(sc.db), actionSets, localcache.ProvideService(), features, tracing.InitializeTracerForTest())
 
 	folderPermissions, err := ossaccesscontrol.ProvideFolderPermissions(

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -8,8 +8,8 @@ package server
 
 import (
 	"github.com/google/wire"
+
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore"

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -352,6 +352,7 @@ var wireBasicSet = wire.NewSet(
 	secretsMigrations.ProvideSecretMigrationProvider,
 	wire.Bind(new(secretsMigrations.SecretMigrationProvider), new(*secretsMigrations.SecretMigrationProviderImpl)),
 	resourcepermissions.NewActionSetService,
+	wire.Bind(new(accesscontrol.ActionResolver), new(resourcepermissions.ActionSetService)),
 	acimpl.ProvideAccessControl,
 	navtreeimpl.ProvideService,
 	wire.Bind(new(accesscontrol.AccessControl), new(*acimpl.AccessControl)),

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -8,8 +8,8 @@ package server
 
 import (
 	"github.com/google/wire"
-
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/avatar"
@@ -38,7 +38,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 	"github.com/grafana/grafana/pkg/services/anonymous/anonimpl/anonstore"
@@ -352,8 +351,6 @@ var wireBasicSet = wire.NewSet(
 	secretsMigrations.ProvideSecretMigrationProvider,
 	wire.Bind(new(secretsMigrations.SecretMigrationProvider), new(*secretsMigrations.SecretMigrationProviderImpl)),
 	resourcepermissions.NewActionSetService,
-	wire.Bind(new(accesscontrol.ActionResolver), new(*resourcepermissions.InMemoryActionSets)),
-	wire.Bind(new(resourcepermissions.ActionSetService), new(*resourcepermissions.InMemoryActionSets)),
 	acimpl.ProvideAccessControl,
 	navtreeimpl.ProvideService,
 	wire.Bind(new(accesscontrol.AccessControl), new(*acimpl.AccessControl)),

--- a/pkg/services/accesscontrol/acimpl/accesscontrol.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol.go
@@ -48,10 +48,6 @@ func (a *AccessControl) Evaluate(ctx context.Context, user identity.Requester, e
 		return false, nil
 	}
 
-	if a.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
-		evaluator = evaluator.AppendActionSets(ctx, a.resolvers.GetActionSetResolver())
-	}
-
 	a.debug(ctx, user, "Evaluating permissions", evaluator)
 	// Test evaluation without scope resolver first, this will prevent 403 for wildcard scopes when resource does not exist
 	if evaluator.Evaluate(permissions) {
@@ -72,10 +68,6 @@ func (a *AccessControl) Evaluate(ctx context.Context, user identity.Requester, e
 
 func (a *AccessControl) RegisterScopeAttributeResolver(prefix string, resolver accesscontrol.ScopeAttributeResolver) {
 	a.resolvers.AddScopeAttributeResolver(prefix, resolver)
-}
-
-func (a *AccessControl) RegisterActionResolver(resolver accesscontrol.ActionResolver) {
-	a.resolvers.SetActionResolver(resolver)
 }
 
 func (a *AccessControl) debug(ctx context.Context, ident identity.Requester, msg string, eval accesscontrol.Evaluator) {

--- a/pkg/services/accesscontrol/acimpl/accesscontrol_test.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol_test.go
@@ -2,15 +2,12 @@ package acimpl_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -24,7 +21,6 @@ func TestAccessControl_Evaluate(t *testing.T) {
 		expected       bool
 		expectedErr    error
 		scopeResolver  accesscontrol.ScopeAttributeResolver
-		actionSets     map[string][]string
 	}
 
 	tests := []testCase{
@@ -65,101 +61,6 @@ func TestAccessControl_Evaluate(t *testing.T) {
 			}),
 			expected: true,
 		},
-		{
-			desc: "expect user to have access when resolver translates actions to action sets",
-			user: user.SignedInUser{
-				OrgID: 1,
-				Permissions: map[int64]map[string][]string{
-					1: {"folders:edit": {"folders:uid:test_folder"}},
-				},
-			},
-			evaluator: accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, "folders:uid:test_folder"),
-			actionSets: map[string][]string{
-				"folders:edit": {dashboards.ActionFoldersWrite, dashboards.ActionFoldersRead, dashboards.ActionDashboardsWrite, dashboards.ActionDashboardsRead},
-			},
-			expected: true,
-		},
-		{
-			desc: "expect user to have access when resolver translates scopes, as well as expands actions to action sets",
-			user: user.SignedInUser{
-				OrgID: 1,
-				Permissions: map[int64]map[string][]string{
-					1: {"folders:edit": {"folders:uid:test_folder"}},
-				},
-			},
-			evaluator: accesscontrol.EvalPermission(dashboards.ActionDashboardsRead, "dashboards:uid:test_dashboard"),
-			actionSets: map[string][]string{
-				"folders:edit": {dashboards.ActionFoldersWrite, dashboards.ActionFoldersRead, dashboards.ActionDashboardsWrite, dashboards.ActionDashboardsRead},
-			},
-			resolverPrefix: "dashboards:uid:",
-			scopeResolver: accesscontrol.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
-				return []string{"folders:uid:test_folder"}, nil
-			}),
-			expected: true,
-		},
-		{
-			desc: "expect user to have access with eval all evaluator when resolver translates scopes, as well as expands actions to action sets",
-			user: user.SignedInUser{
-				OrgID: 1,
-				Permissions: map[int64]map[string][]string{
-					1: {"folders:edit": {"folders:uid:test_folder"}},
-				},
-			},
-			evaluator: accesscontrol.EvalAll(
-				accesscontrol.EvalPermission(dashboards.ActionFoldersRead, "folders:uid:test_folder"),
-				accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, "dashboards:uid:test_dashboard"),
-			),
-			actionSets: map[string][]string{
-				"folders:edit": {dashboards.ActionFoldersWrite, dashboards.ActionFoldersRead, dashboards.ActionDashboardsWrite, dashboards.ActionDashboardsRead},
-			},
-			resolverPrefix: "dashboards:uid:",
-			scopeResolver: accesscontrol.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
-				return []string{"folders:uid:test_folder"}, nil
-			}),
-			expected: true,
-		},
-		{
-			desc: "expect user to not have access with eval all evaluator with resolvers when not all permissions resolve to permissions that the user has",
-			user: user.SignedInUser{
-				OrgID: 1,
-				Permissions: map[int64]map[string][]string{
-					1: {"folders:edit": {"folders:uid:test_folder"}},
-				},
-			},
-			evaluator: accesscontrol.EvalAll(
-				accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, "datasources:uid:test_ds"),
-				accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, "dashboards:uid:test_dashboard"),
-			),
-			actionSets: map[string][]string{
-				"folders:edit": {dashboards.ActionFoldersWrite, dashboards.ActionFoldersRead, dashboards.ActionDashboardsWrite, dashboards.ActionDashboardsRead},
-			},
-			resolverPrefix: "dashboards:uid:",
-			scopeResolver: accesscontrol.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
-				return []string{"folders:uid:test_folder"}, nil
-			}),
-			expected: false,
-		},
-		{
-			desc: "expect user to have access with eval any evaluator when resolver translates scopes, as well as expands actions to action sets",
-			user: user.SignedInUser{
-				OrgID: 1,
-				Permissions: map[int64]map[string][]string{
-					1: {"folders:edit": {"folders:uid:test_folder"}},
-				},
-			},
-			evaluator: accesscontrol.EvalAny(
-				accesscontrol.EvalPermission(dashboards.ActionDashboardsDelete, "dashboards:uid:test_dashboard"),
-				accesscontrol.EvalPermission(dashboards.ActionDashboardsWrite, "dashboards:uid:test_dashboard"),
-			),
-			actionSets: map[string][]string{
-				"folders:edit": {dashboards.ActionFoldersWrite, dashboards.ActionFoldersRead, dashboards.ActionDashboardsWrite, dashboards.ActionDashboardsRead},
-			},
-			resolverPrefix: "dashboards:uid:",
-			scopeResolver: accesscontrol.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, scope string) ([]string, error) {
-				return []string{"folders:uid:test_folder"}, nil
-			}),
-			expected: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -168,15 +69,6 @@ func TestAccessControl_Evaluate(t *testing.T) {
 
 			if tt.scopeResolver != nil {
 				ac.RegisterScopeAttributeResolver(tt.resolverPrefix, tt.scopeResolver)
-			}
-
-			if tt.actionSets != nil {
-				actionSetResolver := resourcepermissions.NewActionSetService(ac)
-				for actionSet, actions := range tt.actionSets {
-					splitActionSet := strings.Split(actionSet, ":")
-					actionSetResolver.StoreActionSet(splitActionSet[0], splitActionSet[1], actions)
-				}
-				ac.RegisterActionResolver(actionSetResolver)
 			}
 
 			hasAccess, err := ac.Evaluate(context.Background(), &tt.user, tt.evaluator)

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/migrator"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/pluginutils"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -47,8 +46,8 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
 
 func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl, actionSetSvc resourcepermissions.ActionSetService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
-	service := ProvideOSSService(cfg, database.ProvideService(db), actionSetSvc, cache, features, tracer)
+	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
+	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
@@ -66,16 +65,16 @@ func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegis
 	return service, nil
 }
 
-func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionSetSvc resourcepermissions.ActionSetService, cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
+func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver, cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	s := &Service{
-		actionSetSvc: actionSetSvc,
-		cache:        cache,
-		cfg:          cfg,
-		features:     features,
-		log:          log.New("accesscontrol.service"),
-		roles:        accesscontrol.BuildBasicRoleDefinitions(),
-		store:        store,
-		tracer:       tracer,
+		actionResolver: actionResolver,
+		cache:          cache,
+		cfg:            cfg,
+		features:       features,
+		log:            log.New("accesscontrol.service"),
+		roles:          accesscontrol.BuildBasicRoleDefinitions(),
+		store:          store,
+		tracer:         tracer,
 	}
 
 	return s
@@ -83,15 +82,15 @@ func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionSetSvc
 
 // Service is the service implementing role based access control.
 type Service struct {
-	actionSetSvc  resourcepermissions.ActionSetService
-	cache         *localcache.CacheService
-	cfg           *setting.Cfg
-	features      featuremgmt.FeatureToggles
-	log           log.Logger
-	registrations accesscontrol.RegistrationList
-	roles         map[string]*accesscontrol.RoleDTO
-	store         accesscontrol.Store
-	tracer        tracing.Tracer
+	actionResolver accesscontrol.ActionResolver
+	cache          *localcache.CacheService
+	cfg            *setting.Cfg
+	features       featuremgmt.FeatureToggles
+	log            log.Logger
+	registrations  accesscontrol.RegistrationList
+	roles          map[string]*accesscontrol.RoleDTO
+	store          accesscontrol.Store
+	tracer         tracing.Tracer
 }
 
 func (s *Service) GetUsageStats(_ context.Context) map[string]any {
@@ -142,7 +141,7 @@ func (s *Service) getUserPermissions(ctx context.Context, user identity.Requeste
 		return nil, err
 	}
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
-		dbPermissions = s.actionSetSvc.ExpandActionSets(dbPermissions)
+		dbPermissions = s.actionResolver.ExpandActionSets(dbPermissions)
 	}
 
 	return append(permissions, dbPermissions...), nil
@@ -164,7 +163,7 @@ func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgI
 		RolePrefixes: OSSRolesPrefixes,
 	})
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
-		dbPermissions = s.actionSetSvc.ExpandActionSets(dbPermissions)
+		dbPermissions = s.actionResolver.ExpandActionSets(dbPermissions)
 	}
 
 	return append(permissions, dbPermissions...), err
@@ -182,7 +181,7 @@ func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgI
 
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
 		for teamID, permissions := range teamPermissions {
-			teamPermissions[teamID] = s.actionSetSvc.ExpandActionSets(permissions)
+			teamPermissions[teamID] = s.actionResolver.ExpandActionSets(permissions)
 		}
 	}
 
@@ -216,7 +215,7 @@ func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Re
 	}
 
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
-		permissions = s.actionSetSvc.ExpandActionSets(permissions)
+		permissions = s.actionResolver.ExpandActionSets(permissions)
 	}
 	if s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) {
 		permissions = append(permissions, SharedWithMeFolderPermission)

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
@@ -64,7 +65,7 @@ func TestUsageMetrics(t *testing.T) {
 			s := ProvideOSSService(
 				cfg,
 				database.ProvideService(db.InitTestDB(t)),
-				&actest.FakeActionResolver{},
+				&resourcepermissions.FakeActionSetSvc{},
 				localcache.ProvideService(),
 				featuremgmt.WithFeatures(),
 				tracing.InitializeTracerForTest(),

--- a/pkg/services/accesscontrol/actest/fake.go
+++ b/pkg/services/accesscontrol/actest/fake.go
@@ -156,22 +156,3 @@ func (f *FakePermissionsService) DeleteResourcePermissions(ctx context.Context, 
 func (f *FakePermissionsService) MapActions(permission accesscontrol.ResourcePermission) string {
 	return f.ExpectedMappedAction
 }
-
-type FakeActionResolver struct {
-	ExpectedErr         error
-	ExpectedActionSets  []string
-	ExpectedActions     []string
-	ExpectedPermissions []accesscontrol.Permission
-}
-
-func (f *FakeActionResolver) ResolveAction(action string) []string {
-	return f.ExpectedActionSets
-}
-
-func (f *FakeActionResolver) ResolveActionSet(actionSet string) []string {
-	return f.ExpectedActions
-}
-
-func (f *FakeActionResolver) ExpandActionSets(permissions []accesscontrol.Permission) []accesscontrol.Permission {
-	return f.ExpectedPermissions
-}

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -113,7 +113,11 @@ func TestAPI_getUserPermissions(t *testing.T) {
 				var output util.DynMap
 				err := json.NewDecoder(res.Body).Decode(&output)
 				require.NoError(t, err)
-				require.Equal(t, tt.expectedOutput, output)
+				for k, v := range output {
+					scopes, ok := tt.expectedOutput[k]
+					require.True(t, ok)
+					require.ElementsMatch(t, scopes, v)
+				}
 			}
 		})
 	}

--- a/pkg/services/accesscontrol/resolvers.go
+++ b/pkg/services/accesscontrol/resolvers.go
@@ -30,8 +30,6 @@ func (f ScopeAttributeResolverFunc) Resolve(ctx context.Context, orgID int64, sc
 
 type ScopeAttributeMutator func(context.Context, string) ([]string, error)
 
-type ActionSetResolver func(context.Context, string) []string
-
 const (
 	ttl           = 30 * time.Second
 	cleanInterval = 2 * time.Minute
@@ -49,16 +47,11 @@ type Resolvers struct {
 	log                log.Logger
 	cache              *localcache.CacheService
 	attributeResolvers map[string]ScopeAttributeResolver
-	actionResolver     ActionResolver
 }
 
 func (s *Resolvers) AddScopeAttributeResolver(prefix string, resolver ScopeAttributeResolver) {
 	s.log.Debug("Adding scope attribute resolver", "prefix", prefix)
 	s.attributeResolvers[prefix] = resolver
-}
-
-func (s *Resolvers) SetActionResolver(resolver ActionResolver) {
-	s.actionResolver = resolver
 }
 
 func (s *Resolvers) GetScopeAttributeMutator(orgID int64) ScopeAttributeMutator {
@@ -89,16 +82,4 @@ func (s *Resolvers) GetScopeAttributeMutator(orgID int64) ScopeAttributeMutator 
 // getScopeCacheKey creates an identifier to fetch and store resolution of scopes in the cache
 func getScopeCacheKey(orgID int64, scope string) string {
 	return fmt.Sprintf("%s-%v", scope, orgID)
-}
-
-func (s *Resolvers) GetActionSetResolver() ActionSetResolver {
-	return func(ctx context.Context, action string) []string {
-		if s.actionResolver == nil {
-			return []string{action}
-		}
-		actionSetActions := s.actionResolver.ResolveAction(action)
-		actions := append(actionSetActions, action)
-		s.log.Debug("Resolved action", "action", action, "resolved_actions", actions)
-		return actions
-	}
 }

--- a/pkg/services/accesscontrol/resolvers.go
+++ b/pkg/services/accesscontrol/resolvers.go
@@ -16,8 +16,6 @@ type ScopeAttributeResolver interface {
 }
 
 type ActionResolver interface {
-	ResolveAction(action string) []string
-	ResolveActionSet(actionSet string) []string
 	ExpandActionSets(permissions []Permission) []Permission
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/fake.go
+++ b/pkg/services/accesscontrol/resourcepermissions/fake.go
@@ -1,0 +1,24 @@
+package resourcepermissions
+
+import "github.com/grafana/grafana/pkg/services/accesscontrol"
+
+type FakeActionSetSvc struct {
+	ExpectedErr         error
+	ExpectedActionSets  []string
+	ExpectedActions     []string
+	ExpectedPermissions []accesscontrol.Permission
+}
+
+func (f *FakeActionSetSvc) ResolveAction(action string) []string {
+	return f.ExpectedActionSets
+}
+
+func (f *FakeActionSetSvc) ResolveActionSet(actionSet string) []string {
+	return f.ExpectedActions
+}
+
+func (f *FakeActionSetSvc) ExpandActionSets(permissions []accesscontrol.Permission) []accesscontrol.Permission {
+	return f.ExpectedPermissions
+}
+
+func (f *FakeActionSetSvc) StoreActionSet(resource, permission string, actions []string) {}

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth/identity"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -367,4 +368,36 @@ func (s *Service) declareFixedRoles() error {
 	}
 
 	return s.service.DeclareFixedRoles(readerRole, writerRole)
+}
+
+type ActionSetService interface {
+	ResolveAction(action string) []string
+	ResolveActionSet(actionSet string) []string
+	ExpandActionSets(permissions []accesscontrol.Permission) []accesscontrol.Permission
+
+	StoreActionSet(resource, permission string, actions []string)
+}
+
+// ActionSet is a struct that represents a set of actions that can be performed on a resource.
+// An example of an action set is "folders:edit" which represents the set of RBAC actions that are granted by edit access to a folder.
+type ActionSet struct {
+	Action  string   `json:"action"`
+	Actions []string `json:"actions"`
+}
+
+// InMemoryActionSets is an in-memory implementation of the ActionSetService.
+type InMemoryActionSets struct {
+	log                log.Logger
+	actionSetToActions map[string][]string
+	actionToActionSets map[string][]string
+}
+
+// NewActionSetService returns a new instance of InMemoryActionSetService.
+func NewActionSetService() ActionSetService {
+	actionSets := &InMemoryActionSets{
+		log:                log.New("resourcepermissions.actionsets"),
+		actionSetToActions: make(map[string][]string),
+		actionToActionSets: make(map[string][]string),
+	}
+	return actionSets
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -371,9 +371,12 @@ func (s *Service) declareFixedRoles() error {
 }
 
 type ActionSetService interface {
+	// ActionResolver defines method for expanding permissions from permissions with action sets to fine-grained permissions.
+	// We use an ActionResolver interface to avoid circular dependencies
+	accesscontrol.ActionResolver
+
 	ResolveAction(action string) []string
 	ResolveActionSet(actionSet string) []string
-	ExpandActionSets(permissions []accesscontrol.Permission) []accesscontrol.Permission
 
 	StoreActionSet(resource, permission string, actions []string)
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -375,7 +375,9 @@ type ActionSetService interface {
 	// We use an ActionResolver interface to avoid circular dependencies
 	accesscontrol.ActionResolver
 
+	// ResolveAction returns all the action sets that the action belongs to.
 	ResolveAction(action string) []string
+	// ResolveActionSet resolves an action set to a list of corresponding actions.
 	ResolveActionSet(actionSet string) []string
 
 	StoreActionSet(resource, permission string, actions []string)

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -7,9 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -727,44 +725,6 @@ func managedPermission(action, resource string, resourceID, resourceAttribute st
 		Action: action,
 		Scope:  accesscontrol.Scope(resource, resourceAttribute, resourceID),
 	}
-}
-
-/*
-ACTION SETS
-Stores actionsets IN MEMORY
-*/
-// ActionSet is a struct that represents a set of actions that can be performed on a resource.
-// An example of an action set is "folders:edit" which represents the set of RBAC actions that are granted by edit access to a folder.
-
-type ActionSetService interface {
-	accesscontrol.ActionResolver
-
-	GetActionSet(actionName string) []string
-	//GetActionSetName(resource, permission string) string
-	StoreActionSet(resource, permission string, actions []string)
-}
-
-type ActionSet struct {
-	Action  string   `json:"action"`
-	Actions []string `json:"actions"`
-}
-
-// InMemoryActionSets is an in-memory implementation of the ActionSetService.
-type InMemoryActionSets struct {
-	log                log.Logger
-	actionSetToActions map[string][]string
-	actionToActionSets map[string][]string
-}
-
-// NewActionSetService returns a new instance of InMemoryActionSetService.
-func NewActionSetService(a *acimpl.AccessControl) *InMemoryActionSets {
-	actionSets := &InMemoryActionSets{
-		log:                log.New("resourcepermissions.actionsets"),
-		actionSetToActions: make(map[string][]string),
-		actionToActionSets: make(map[string][]string),
-	}
-	a.RegisterActionResolver(actionSets)
-	return actionSets
 }
 
 func (s *InMemoryActionSets) ResolveAction(action string) []string {

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -782,21 +781,18 @@ func TestStore_StoreActionSet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store, _, _ := setupTestEnv(t)
-			store.features = featuremgmt.WithFeatures(featuremgmt.FlagAccessActionSets)
-			ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
-			asService := NewActionSetService(ac)
+			asService := NewActionSetService()
 			asService.StoreActionSet(tt.resource, tt.action, tt.actions)
 
 			actionSetName := GetActionSetName(tt.resource, tt.action)
-			actionSet := asService.GetActionSet(actionSetName)
+			actionSet := asService.ResolveActionSet(actionSetName)
 			require.Equal(t, tt.actions, actionSet)
 		})
 	}
 }
 
 func TestStore_ResolveActionSet(t *testing.T) {
-	actionSetService := NewActionSetService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures()))
+	actionSetService := NewActionSetService()
 	actionSetService.StoreActionSet("folders", "edit", []string{"folders:read", "folders:write", "dashboards:read", "dashboards:write"})
 	actionSetService.StoreActionSet("folders", "view", []string{"folders:read", "dashboards:read"})
 	actionSetService.StoreActionSet("dashboards", "view", []string{"dashboards:read"})
@@ -839,7 +835,7 @@ func TestStore_ResolveActionSet(t *testing.T) {
 }
 
 func TestStore_ExpandActions(t *testing.T) {
-	actionSetService := NewActionSetService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures()))
+	actionSetService := NewActionSetService()
 	actionSetService.StoreActionSet("folders", "edit", []string{"folders:read", "folders:write", "dashboards:read", "dashboards:write"})
 	actionSetService.StoreActionSet("folders", "view", []string{"folders:read", "dashboards:read"})
 	actionSetService.StoreActionSet("dashboards", "view", []string{"dashboards:read"})

--- a/pkg/services/serviceaccounts/extsvcaccounts/service_test.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/service_test.go
@@ -43,7 +43,7 @@ func setupTestEnv(t *testing.T) *TestEnv {
 	}
 	logger := log.New("extsvcaccounts.test")
 	env.S = &ExtSvcAccountsService{
-		acSvc:    acimpl.ProvideOSSService(cfg, env.AcStore, &actest.FakeActionResolver{}, localcache.New(0, 0), fmgt, tracing.InitializeTracerForTest()),
+		acSvc:    acimpl.ProvideOSSService(cfg, env.AcStore, &actest.FakeActionSetSvc{}, localcache.New(0, 0), fmgt, tracing.InitializeTracerForTest()),
 		features: fmgt,
 		logger:   logger,
 		metrics:  newMetrics(nil, env.SaSvc, logger),

--- a/pkg/services/serviceaccounts/extsvcaccounts/service_test.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/service_test.go
@@ -14,6 +14,7 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -43,7 +44,7 @@ func setupTestEnv(t *testing.T) *TestEnv {
 	}
 	logger := log.New("extsvcaccounts.test")
 	env.S = &ExtSvcAccountsService{
-		acSvc:    acimpl.ProvideOSSService(cfg, env.AcStore, &actest.FakeActionSetSvc{}, localcache.New(0, 0), fmgt, tracing.InitializeTracerForTest()),
+		acSvc:    acimpl.ProvideOSSService(cfg, env.AcStore, &resourcepermissions.FakeActionSetSvc{}, localcache.New(0, 0), fmgt, tracing.InitializeTracerForTest()),
 		features: fmgt,
 		logger:   logger,
 		metrics:  newMetrics(nil, env.SaSvc, logger),


### PR DESCRIPTION
**What is this feature?**

Cleaning up action set code. Notable changes:
* remove action resolvers introduced in https://github.com/grafana/grafana/pull/86801, as we decided to expand actions upon permission read instead (https://github.com/grafana/grafana/pull/87967);
* move action set service definition to the service file;
* remove unused action set creation argument.

**Why do we need this feature?**

Cleaner and simpler code.

**Who is this feature for?**

Internal only

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/identity-access-team/issues/615

**Special notes for your reviewer:**

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/6664
