### PR TITLE
[v10.3.x] docs: update dashboard list visualization

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
@@ -28,27 +28,63 @@ Dashboard lists allow you to display dynamic links to other dashboards. The list
 
 On each dashboard load, this panel queries the dashboard list, always providing the most up-to-date results.
 
+You can use a dashboard list visualization to display a list of important dashboards that you want to track.
+
+## Configure a dashboard list visualization
+
+Once you’ve created a [dashboard](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-dashboard/), the following video shows you how to configure a dashboard list visualization:
+
+{{< youtube id="MserjWGWsh8" >}}
+
 {{< docs/play title="Dashboard List Visualization" url="https://play.grafana.org/d/fdlojrg7daebka/" >}}
 
-## Options
+## Dashboard list options
 
-Use these options to refine your visualization.
+Use the following options to refine your dashboard list visualization.
 
-- **Include current time range -** Select this option to propagate the time range of the current dashboard to the dashboard links. When the user clicks a link, the linked dashboard opens with the indicated time range already set.
-- **Include current template variable values -** Select this option to include template variables currently used as query parameters in a link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. Learn more about [Dashboard URL variables][].
-- **Starred -** Display starred dashboards in alphabetical order.
-- **Recently viewed -** Display recently viewed dashboards in alphabetical order.
-- **Search -** Display dashboards by search query or tags. You must enter at least one value in **Query** or **Tags**. For the **Query** and **Tags** fields. Variable interpolation is supported, for example,`$my_var` or `${my_var}`.
-- **Show headings -** The chosen list selection (Starred, Recently viewed, Search) is shown as a heading.
-- **Max items -** Sets the maximum number of items to list per section. For example, if you left this at the default value of 10 and displayed Starred and Recently viewed dashboards, then the panel would display up to 20 total dashboards, ten in each section.
+### Include current time range
 
-## Search
+Select this option to propagate the time range of the current dashboard to the dashboard links. When you click a link, the linked dashboard opens with the indicated time range already set.
+
+### Include current template variable values
+
+Select this option to include template variables currently used as query parameters in a link. When you click the link, any matching templates in the linked dashboard are set to the values from the link. Learn more in [Dashboard URL variables](ref:dashboard-url-variables).
+
+### Starred
+
+Display starred dashboards in alphabetical order.
+
+### Recently viewed
+
+Display recently viewed dashboards in alphabetical order.
+
+### Search
+
+Display dashboards by search query or tags. You must enter at least one value in **Query** or **Tags**. For the **Query** and **Tags** fields, variable interpolation is supported. For example, `$my_var` or `${my_var}`.
+
+### Show headings
+
+The selected list section (**Starred**, **Recently viewed**, **Search**) is shown as a heading.
+
+### Max items
+
+Sets the maximum number of items to list per section. For example, if you leave this at the default value of 10 and select **Starred** and **Recently viewed** dashboards, then the panel displays up to 20 total dashboards, 10 in each section.
+
+## Search options
 
 These options only apply if the **Search** option is selected.
 
-- **Query -** Enter the query you want to search by. Queries are case-insensitive, and partial values are accepted.
-- **Folder -** Select the dashboard folders that you want to display.
-- **Tags -** Here is where you enter your tags you want to search by. Note that existing tags will not appear as you type, and they _are_ case sensitive.
+### Query
+
+Enter the query by which you want to search. Queries are case-insensitive and partial values are accepted.
+
+### Folder
+
+Select the dashboard folders that you want to display.
+
+### Tags
+
+Enter tags by which you want to search. Note that existing tags don't appear as you type, and they _are_ case sensitive.
 
 > **Note:** When multiple tags and strings appear, the dashboard list displays those matching _all_ conditions.
 

--- a/docs/sources/panels-visualizations/visualizations/text/index.md
+++ b/docs/sources/panels-visualizations/visualizations/text/index.md
@@ -35,7 +35,11 @@ Use a text visualization when you need to:
 - Provide instructions or guidance on how to interpret different panels, configure settings, or take specific actions based on the displayed data.
 - Announce any scheduled maintenance or downtime that might impact your dashboards.
 
-## Mode
+## Text options
+
+Use the following options to refine your text visualization.
+
+### Mode
 
 **Mode** determines how embedded content appears.
 


### PR DESCRIPTION
Backport fa319f36fb8c86b00e948a8feca4c929ee1b45fc from #87494

---

**What is this feature?**

Updates to the dashboard list visualization docs to include:
- how to configure a dashboard list visualization (video TBA)
- rearranging sections to match other visualization types

Also adding sections in text visualization and adding panel options shared file to flame graph
**NOTE**: Don't backport the panel options shared file changes in flame graph back to versions 10.4 and 10.3

**Why do we need this feature?**

To explain to our users how to configure a dashboard list visualization easily and when to use it.

**Who is this feature for?**

Grafana OSS and Cloud users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
