### PR TITLE
data trails: alternate legend display for missing label value

### DIFF
--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -21,7 +21,7 @@ import {
   VariableDependencyConfig,
   VizPanel,
 } from '@grafana/scenes';
-import { DataQuery } from '@grafana/schema/dist/esm/index';
+import { DataQuery } from '@grafana/schema';
 import { Button, Field, useStyles2 } from '@grafana/ui';
 import { ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 

--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -21,6 +21,7 @@ import {
   VariableDependencyConfig,
   VizPanel,
 } from '@grafana/scenes';
+import { DataQuery } from '@grafana/schema/dist/esm/index';
 import { Button, Field, useStyles2 } from '@grafana/ui';
 import { ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
@@ -303,6 +304,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
       )
       .setHeaderActions(new SelectLabelAction({ labelName: String(option.value) }))
       .setUnit(unit)
+      .setBehaviors([fixLegendForUnspecifiedLabelValueBehavior])
       .build();
 
     vizPanel.addActivationHandler(() => {
@@ -455,4 +457,28 @@ function getBreakdownSceneFor(model: SceneObject): BreakdownScene {
   }
 
   throw new Error('Unable to find breakdown scene');
+}
+
+function fixLegendForUnspecifiedLabelValueBehavior(vizPanel: VizPanel) {
+  vizPanel.state.$data?.subscribeToState((newState, prevState) => {
+    const target = newState.data?.request?.targets[0];
+    if (hasLegendFormat(target)) {
+      const { legendFormat } = target;
+      // Assume {{label}}
+      const label = legendFormat.slice(2, -2);
+
+      newState.data?.series.forEach((series, index) => {
+        if (!series.fields[1].labels?.[label]) {
+          const labels = series.fields[1].labels;
+          if (labels) {
+            labels[label] = `<unspecified ${label}>`;
+          }
+        }
+      });
+    }
+  });
+}
+
+function hasLegendFormat(target: DataQuery | undefined): target is DataQuery & { legendFormat: string } {
+  return target !== undefined && 'legendFormat' in target && typeof target.legendFormat === 'string';
 }

--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -467,7 +467,7 @@ function fixLegendForUnspecifiedLabelValueBehavior(vizPanel: VizPanel) {
       // Assume {{label}}
       const label = legendFormat.slice(2, -2);
 
-      newState.data?.series.forEach((series, index) => {
+      newState.data?.series.forEach((series) => {
         if (!series.fields[1].labels?.[label]) {
           const labels = series.fields[1].labels;
           if (labels) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When the data doesn't have a label value, the default "Value" is used.
![image](https://github.com/grafana/grafana/assets/38694490/4fbb2443-3a69-4e58-a39a-9abdc3308663)

This PR replaces it with `<unspecified ${label}>`
![image](https://github.com/grafana/grafana/assets/38694490/79a80481-7818-4768-9aa5-065eca7bc18b)

This is similar to what we do in the title of the label-specific breakdown view:

![image](https://github.com/grafana/grafana/assets/38694490/b0de72b9-e433-4411-a3e3-7b58cf49e191)



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
