### PR TITLE
datatrails: on histogram breakdowns, show label value in legend

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/query-generators/histogram.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/query-generators/histogram.ts
@@ -68,9 +68,16 @@ function heatMapQuery(groupings: string[] = []): PromQuery {
 function percentileQuery(percentile: number, groupings: string[] = []) {
   const percent = percentile / 100;
 
+  let legendFormat = `${percentile}th Percentile`;
+
+  // For the breakdown view, show the label value variable we are grouping by
+  if (groupings[0]) {
+    legendFormat = `{{${groupings[0]}}}`;
+  }
+
   return {
     refId: `Percentile${percentile}`,
     expr: `histogram_quantile(${percent}, ${baseQuery(groupings)})`,
-    legendFormat: `${percentile}th Percentile`,
+    legendFormat,
   };
 }


### PR DESCRIPTION
**What is this feature?**

Previously, we were always showing "50th percentile" in the legend.
This changes the behavior to match the other metric type breakdowns, and show the label value.

![image](https://github.com/grafana/grafana/assets/38694490/72909d4f-e59d-4462-b591-0a94da85776f)



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
