### PR TITLE
DashboardRow: add link to row functionality

### DIFF
--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -22,8 +22,25 @@ export interface DashboardRowProps {
 export class DashboardRow extends React.Component<DashboardRowProps> {
   sub?: Unsubscribable;
 
+  rowId = () => {
+    return 'panel-' + this.props.panel.id.toString();
+  };
+
+  rowAnchor = () => {
+    return '#' + this.rowId();
+  };
+
   componentDidMount() {
     this.sub = this.props.dashboard.events.subscribe(RefreshEvent, this.onVariableUpdated);
+
+    const selectedAnchor = window.location.href.split('#')[1];
+    if (selectedAnchor === this.rowId()) {
+      if (this.props.panel.collapsed) {
+        this.onToggle();
+      }
+
+      document.getElementById(this.rowId())?.click();
+    }
   }
 
   componentWillUnmount() {
@@ -119,6 +136,9 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
         </button>
         {canEdit && (
           <div className="dashboard-row__actions">
+            <button type="button" className="pinter" aria-label="Link to row">
+              <a id={this.rowId()} href={this.rowAnchor()}><Icon name="link" /></a>
+            </button>
             <RowOptionsButton
               title={this.props.panel.title}
               repeat={this.props.panel.repeat}


### PR DESCRIPTION
This adds a new button that has a link to the row. If a dashboard is opened via that link, the row is expanded if it is collapsed.

The new button:

<img width="289" alt="image" src="https://github.com/grafana/grafana/assets/89186/40012aeb-63c4-43c5-8769-41ccb467dfae">

A dashboard with the second row collapsed:

<img width="1552" alt="image" src="https://github.com/grafana/grafana/assets/89186/2cc922d9-44d6-4e10-aa34-cfadad42c8b6">

A dashboard that is opened from a link to the second row:

<img width="1552" alt="image" src="https://github.com/grafana/grafana/assets/89186/9ba26403-90fa-456e-808a-ccd6ca4733cd">

There are two problems marked as `TODO` in the code. I'm hoping that having _something_ working would motivate to get this over the finish line.