### PR TITLE
InfluxDB: adding support to run flux queries via hotkey (Shift+Enter)

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
@@ -9,7 +9,9 @@ import {
   CodeEditorSuggestionItemKind,
   InlineFormLabel,
   LinkButton,
+  Monaco,
   MonacoEditor,
+  monacoTypes,
   Segment,
   Themeable2,
   withTheme2,
@@ -100,6 +102,10 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
     this.props.onChange({ ...this.props.query, query });
     this.props.onRunQuery();
   };
+  
+  onEditorChange = (value: string) => {
+    this.props.onChange({ ...this.props.query, query: value });
+  };
 
   onSampleChange = (val: SelectableValue<string>) => {
     this.props.onChange({
@@ -165,6 +171,18 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
     setTimeout(() => editor.layout(), 100);
   };
 
+  // HotKey support: Run the query when user presses 'Shift+Enter'
+  // See: https://github.com/grafana/grafana/issues/83575
+  setupActions(editor: monacoTypes.editor.IStandaloneCodeEditor, monaco: Monaco, onRunQuery: () => void) {
+    editor.addAction({
+      id: 'run-query',
+      label: 'Run Query',
+      keybindings: [monaco.KeyMod.Shift | monaco.KeyCode.Enter],
+      run: function () {
+        onRunQuery();
+      },
+    });
+  };
   render() {
     const { query, theme } = this.props;
     const styles = getStyles(theme);
@@ -185,10 +203,14 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
           value={query.query || ''}
           onBlur={this.onFluxQueryChange}
           onSave={this.onFluxQueryChange}
+          onChange={this.onEditorChange}
           showMiniMap={false}
           showLineNumbers={true}
           getSuggestions={this.getSuggestions}
-          onEditorDidMount={this.editorDidMountCallbackHack}
+          onEditorDidMount={(editor,monaco) => {
+            this.editorDidMountCallbackHack(editor)
+            this.setupActions(editor,monaco,()=>this.props.onRunQuery())
+          }}
         />
         <div className={cx('gf-form-inline', styles.editorActions)}>
           <LinkButton


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add support to run flux queries via HotKey (Shift+Enter)

**Why do we need this feature?**

Quick means of running the query.

**Who is this feature for?**

All influxdb users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/83575

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
