### PR TITLE
Select: Change `Select` group headers to always be visible

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -640,6 +640,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "packages/grafana-ui/src/components/Forms/Legacy/Select/SelectOptionGroup.tsx:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
     "packages/grafana-ui/src/components/InfoBox/InfoBox.story.tsx:5381": [
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
@@ -683,11 +688,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
-    ],
-    "packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "packages/grafana-ui/src/components/Select/ValueContainer.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -9,7 +9,6 @@ import Creatable from 'react-select/creatable';
 import { SelectableValue, ThemeContext } from '@grafana/data';
 
 import { CustomScrollbar } from '../../../CustomScrollbar/CustomScrollbar';
-import { SelectOptionGroup } from '../../../Select/SelectOptionGroup';
 import { SingleValue } from '../../../Select/SingleValue';
 import resetSelectStyles from '../../../Select/resetSelectStyles';
 import { SelectCommonProps, SelectAsyncProps } from '../../../Select/types';
@@ -18,6 +17,7 @@ import { Tooltip, PopoverContent } from '../../../Tooltip';
 import IndicatorsContainer from './IndicatorsContainer';
 import NoOptionsMessage from './NoOptionsMessage';
 import { SelectOption } from './SelectOption';
+import { SelectOptionGroup } from './SelectOptionGroup';
 
 /**
  * Changes in new selects:

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/SelectOptionGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/SelectOptionGroup.tsx
@@ -4,9 +4,9 @@ import { GroupProps } from 'react-select';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-import { stylesFactory, withTheme2 } from '../../themes';
-import { Themeable2 } from '../../types';
-import { Icon } from '../Icon/Icon';
+import { stylesFactory, withTheme2 } from '../../../../themes';
+import { Themeable2 } from '../../../../types';
+import { Icon } from '../../../Icon/Icon';
 
 interface ExtendedGroupProps extends Omit<GroupProps<any, any>, 'theme'>, Themeable2 {
   data: {

--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -208,8 +208,27 @@ export const MultiSelectWithOptionGroups: StoryFn = (args) => {
     <>
       <MultiSelect
         options={[
-          { label: '1', value: '1' },
-          { label: '2', value: '2', options: [{ label: '5', value: '5' }] },
+          { label: 'Foo', value: '1' },
+          {
+            label: 'Colours',
+            value: '2',
+            options: [
+              { label: 'Blue', value: '5' },
+              { label: 'Red', value: '6' },
+              { label: 'Black', value: '7' },
+              { label: 'Yellow', value: '8' },
+            ],
+          },
+          {
+            label: 'Animals',
+            value: '9',
+            options: [
+              { label: 'Cat', value: '10' },
+              { label: 'Cow', value: '11' },
+              { label: 'Dog', value: '12' },
+              { label: 'Eagle', value: '13' },
+            ],
+          },
         ]}
         value={value}
         onChange={(v) => {

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -23,7 +23,7 @@ import { InputControl } from './InputControl';
 import { MultiValueContainer, MultiValueRemove } from './MultiValue';
 import { SelectContainer } from './SelectContainer';
 import { SelectMenu, SelectMenuOptions, VirtualizedSelectMenu } from './SelectMenu';
-import { SelectOptionGroup, SelectOptionGroupHeader } from './SelectOptionGroupHeader';
+import { SelectOptionGroupHeader } from './SelectOptionGroupHeader';
 import { Props, SingleValue } from './SingleValue';
 import { ValueContainer } from './ValueContainer';
 import { getSelectStyles } from './getSelectStyles';
@@ -330,7 +330,6 @@ export function SelectBase<T, Rest = {}>({
         ref={reactSelectRef}
         components={{
           MenuList: SelectMenuComponent,
-          Group: SelectOptionGroup,
           GroupHeading: SelectOptionGroupHeader,
           ValueContainer,
           IndicatorsContainer: CustomIndicatorsContainer,

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -23,7 +23,7 @@ import { InputControl } from './InputControl';
 import { MultiValueContainer, MultiValueRemove } from './MultiValue';
 import { SelectContainer } from './SelectContainer';
 import { SelectMenu, SelectMenuOptions, VirtualizedSelectMenu } from './SelectMenu';
-import { SelectOptionGroup } from './SelectOptionGroup';
+import { SelectOptionGroup, SelectOptionGroupHeader } from './SelectOptionGroupHeader';
 import { Props, SingleValue } from './SingleValue';
 import { ValueContainer } from './ValueContainer';
 import { getSelectStyles } from './getSelectStyles';
@@ -331,6 +331,7 @@ export function SelectBase<T, Rest = {}>({
         components={{
           MenuList: SelectMenuComponent,
           Group: SelectOptionGroup,
+          GroupHeading: SelectOptionGroupHeader,
           ValueContainer,
           IndicatorsContainer: CustomIndicatorsContainer,
           IndicatorSeparator: IndicatorSeparator,

--- a/packages/grafana-ui/src/components/Select/SelectOptionGroupHeader.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectOptionGroupHeader.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { GroupHeadingProps, GroupProps } from 'react-select';
+
+import { useStyles2 } from '../../themes/ThemeContext';
+import { Text } from '../Text/Text';
+
+import { getSelectStyles } from './getSelectStyles';
+
+export const SelectOptionGroupHeader = (props: GroupHeadingProps) => {
+  const styles = useStyles2(getSelectStyles);
+
+  return (
+    <div className={styles.groupHeader}>
+      <Text weight="bold" variant="bodySmall" color="secondary">
+        {props.children ?? ''}
+      </Text>
+    </div>
+  );
+};
+
+export const SelectOptionGroup = ({
+  children,
+  Heading,
+  headingProps,
+  label,
+  selectProps,
+  theme,
+  getStyles,
+  getClassNames,
+  cx,
+}: GroupProps) => {
+  return (
+    <>
+      <Heading
+        {...headingProps}
+        selectProps={selectProps}
+        theme={theme}
+        getStyles={getStyles}
+        getClassNames={getClassNames}
+        cx={cx}
+      >
+        {label}
+      </Heading>
+      {children}
+    </>
+  );
+};

--- a/packages/grafana-ui/src/components/Select/SelectOptionGroupHeader.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectOptionGroupHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GroupHeadingProps, GroupProps } from 'react-select';
+import { GroupHeadingProps } from 'react-select';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Text } from '../Text/Text';
@@ -15,33 +15,5 @@ export const SelectOptionGroupHeader = (props: GroupHeadingProps) => {
         {props.children ?? ''}
       </Text>
     </div>
-  );
-};
-
-export const SelectOptionGroup = ({
-  children,
-  Heading,
-  headingProps,
-  label,
-  selectProps,
-  theme,
-  getStyles,
-  getClassNames,
-  cx,
-}: GroupProps) => {
-  return (
-    <>
-      <Heading
-        {...headingProps}
-        selectProps={selectProps}
-        theme={theme}
-        getStyles={getStyles}
-        getClassNames={getClassNames}
-        cx={cx}
-      >
-        {label}
-      </Heading>
-      {children}
-    </>
   );
 };

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -138,5 +138,9 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {
         color: theme.colors.text.primary,
       },
     }),
+    groupHeader: css({
+      padding: theme.spacing(1, 1, 1, 0.75),
+      borderLeft: '2px solid transparent',
+    }),
   };
 });

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -141,6 +141,7 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {
     groupHeader: css({
       padding: theme.spacing(1, 1, 1, 0.75),
       borderLeft: '2px solid transparent',
+      borderTop: `1px solid ${theme.colors.border.weak}`,
     }),
   };
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- creates new `SelectOptionGroupHeader` component with basic styles
- moves `SelectOptionGroup` to `Forms/Legacy/Select` since it's still used by that component
- improves the `MultiSelectWithOptionGroups` story to include more options and categories

| before | after |
| --- | --- |
| ![image](https://github.com/grafana/grafana/assets/20999846/d00a0398-6c34-4a71-aea0-de0d94771252) | ![image](https://github.com/grafana/grafana/assets/20999846/418bd02e-92ed-43c1-9054-069acddfd5d2) |

**Why do we need this feature?**

- better styling for select with option groups

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/hyperion-planning/issues/33

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
