### PR TITLE
Alerting: Test infrastructure for recording rules

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -414,7 +414,6 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 			limits: allowRecording(limits),
 			rule: func() *apimodels.PostableExtendedRuleNode {
 				r := validRule()
-				ConvertToRecordingRule(r)
 				r.GrafanaManagedAlert.Record = &apimodels.Record{Metric: "some_metric", From: "A"}
 				r.GrafanaManagedAlert.Condition = ""
 				r.GrafanaManagedAlert.NoDataState = ""

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -414,6 +414,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 			limits: allowRecording(limits),
 			rule: func() *apimodels.PostableExtendedRuleNode {
 				r := validRule()
+				ConvertToRecordingRule(r)
 				r.GrafanaManagedAlert.Record = &apimodels.Record{Metric: "some_metric", From: "A"}
 				r.GrafanaManagedAlert.Condition = ""
 				r.GrafanaManagedAlert.NoDataState = ""

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -488,6 +488,39 @@ func (a *AlertRuleMutators) WithIsPaused(paused bool) AlertRuleMutator {
 	}
 }
 
+func (a *AlertRuleMutators) WithRandomRecordingRules() AlertRuleMutator {
+	return func(rule *AlertRule) {
+		if rand.Int63()%2 == 0 {
+			return
+		}
+		convertToRecordingRule(rule)
+	}
+}
+
+func (a *AlertRuleMutators) WithAllRecordingRules() AlertRuleMutator {
+	return func(rule *AlertRule) {
+		convertToRecordingRule(rule)
+	}
+}
+
+func (a *AlertRuleMutators) WithMetric(metric string) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		if rule.Record == nil {
+			rule.Record = &Record{}
+		}
+		rule.Record.Metric = metric
+	}
+}
+
+func (a *AlertRuleMutators) WithRecordFrom(from string) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		if rule.Record == nil {
+			rule.Record = &Record{}
+		}
+		rule.Record.From = from
+	}
+}
+
 func (g *AlertRuleGenerator) GenerateLabels(min, max int, prefix string) data.Labels {
 	count := max
 	if min > max {
@@ -1019,4 +1052,21 @@ func (n SilenceMutators) WithEmptyId() Mutator[Silence] {
 	return func(s *Silence) {
 		s.ID = util.Pointer("")
 	}
+}
+
+func convertToRecordingRule(rule *AlertRule) {
+	if rule.Record == nil {
+		rule.Record = &Record{}
+	}
+	if rule.Record.From == "" {
+		rule.Record.From = rule.Condition
+	}
+	if rule.Record.Metric == "" {
+		rule.Record.Metric = fmt.Sprintf("some_metric_%s", util.GenerateShortUID())
+	}
+	rule.Condition = ""
+	rule.NoDataState = ""
+	rule.ExecErrState = ""
+	rule.For = 0
+	rule.NotificationSettings = nil
 }

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -639,6 +639,13 @@ func CopyRule(r *AlertRule, mutators ...AlertRuleMutator) *AlertRule {
 		}
 	}
 
+	if r.Record != nil {
+		result.Record = &Record{
+			From:   r.Record.From,
+			Metric: r.Record.Metric,
+		}
+	}
+
 	for _, s := range r.NotificationSettings {
 		result.NotificationSettings = append(result.NotificationSettings, CopyNotificationSettings(s))
 	}

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -614,24 +614,13 @@ func TestIntegrationInsertAlertRules(t *testing.T) {
 		models.RuleGen.WithOrgID(orgID),
 		models.RuleGen.WithIntervalMatching(store.Cfg.BaseInterval),
 	)
+	recordingRulesGen := gen.With(
+		models.RuleGen.WithAllRecordingRules(),
+		models.RuleGen.WithRecordFrom("A"),
+		models.RuleGen.WithMetric("my_metric"),
+	)
 
-	generateRecordingRules := func(n int) []models.AlertRule {
-		rrs := gen.GenerateMany(n)
-		for i := range rrs {
-			rrs[i].Condition = ""
-			rrs[i].NoDataState = ""
-			rrs[i].ExecErrState = ""
-			rrs[i].For = 0
-			rrs[i].NotificationSettings = nil
-			rrs[i].Record = &models.Record{
-				Metric: "my_metric",
-				From:   "A",
-			}
-		}
-		return rrs
-	}
-
-	rules := append(gen.GenerateMany(5), generateRecordingRules(5)...)
+	rules := append(gen.GenerateMany(5), recordingRulesGen.GenerateMany(5)...)
 
 	ids, err := store.InsertAlertRules(context.Background(), rules)
 	require.NoError(t, err)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -505,10 +505,9 @@ func TestIntegration_CountAlertRules(t *testing.T) {
 	rule := createRule(t, store, gen)
 
 	count := int64(5)
-	many := make([]*models.AlertRule, 0, count)
 	manyGen := gen.With(gen.WithNamespaceUID("many rules"), gen.WithOrgID(123))
 	for i := int64(0); i < count; i++ {
-		many = append(many, createRule(t, store, manyGen))
+		_ = createRule(t, store, manyGen)
 	}
 
 	tests := map[string]struct {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -363,17 +363,21 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 
 	gen := models.RuleGen
 	gen = gen.With(gen.WithIntervalMatching(store.Cfg.BaseInterval), gen.WithUniqueOrgID())
+	recordingGen := gen.With(gen.WithAllRecordingRules())
 
 	rule1 := createRule(t, store, gen)
 	rule2 := createRule(t, store, gen)
+	rule3 := createRule(t, store, recordingGen)
 
 	parentFolderUid := uuid.NewString()
 	parentFolderTitle := "Very Parent Folder"
 	createFolder(t, store, parentFolderUid, parentFolderTitle, rule1.OrgID, "")
 	rule1FolderTitle := "folder-" + rule1.Title
 	rule2FolderTitle := "folder-" + rule2.Title
+	rule3FolderTitle := "folder-" + rule3.Title
 	createFolder(t, store, rule1.NamespaceUID, rule1FolderTitle, rule1.OrgID, parentFolderUid)
 	createFolder(t, store, rule2.NamespaceUID, rule2FolderTitle, rule2.OrgID, "")
+	createFolder(t, store, rule3.NamespaceUID, rule3FolderTitle, rule3.OrgID, "")
 
 	createFolder(t, store, rule2.NamespaceUID, "same UID folder", gen.GenerateRef().OrgID, "") // create a folder with the same UID but in the different org
 
@@ -387,7 +391,7 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 	}{
 		{
 			name:  "without a rule group filter, it returns all created rules",
-			rules: []string{rule1.Title, rule2.Title},
+			rules: []string{rule1.Title, rule2.Title, rule3.Title},
 		},
 		{
 			name:       "with a rule group filter, it only returns the rules that match on rule group",
@@ -397,17 +401,17 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 		{
 			name:         "with a filter on orgs, it returns rules that do not belong to that org",
 			rules:        []string{rule1.Title},
-			disabledOrgs: []int64{rule2.OrgID},
+			disabledOrgs: []int64{rule2.OrgID, rule3.OrgID},
 		},
 		{
 			name:    "with populate folders enabled, it returns them",
-			rules:   []string{rule1.Title, rule2.Title},
-			folders: map[models.FolderKey]string{rule1.GetFolderKey(): rule1FolderTitle, rule2.GetFolderKey(): rule2FolderTitle},
+			rules:   []string{rule1.Title, rule2.Title, rule3.Title},
+			folders: map[models.FolderKey]string{rule1.GetFolderKey(): rule1FolderTitle, rule2.GetFolderKey(): rule2FolderTitle, rule3.GetFolderKey(): rule3FolderTitle},
 		},
 		{
 			name:         "with populate folders enabled and a filter on orgs, it only returns selected information",
 			rules:        []string{rule1.Title},
-			disabledOrgs: []int64{rule2.OrgID},
+			disabledOrgs: []int64{rule2.OrgID, rule3.OrgID},
 			folders:      map[models.FolderKey]string{rule1.GetFolderKey(): rule1FolderTitle},
 		},
 	}
@@ -456,6 +460,7 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 		expected := map[models.FolderKey]string{
 			rule1.GetFolderKey(): parentFolderTitle + "/" + rule1FolderTitle,
 			rule2.GetFolderKey(): rule2FolderTitle,
+			rule3.GetFolderKey(): rule3FolderTitle,
 		}
 		require.Equal(t, expected, query.ResultFoldersTitles)
 	})
@@ -855,7 +860,7 @@ func TestIntegrationGetNamespacesByRuleUID(t *testing.T) {
 		Cfg:           cfg.UnifiedAlerting,
 	}
 
-	rules := models.RuleGen.With(models.RuleMuts.WithOrgID(1)).GenerateMany(5)
+	rules := models.RuleGen.With(models.RuleMuts.WithOrgID(1), models.RuleMuts.WithRandomRecordingRules()).GenerateMany(5)
 	_, err := store.InsertAlertRules(context.Background(), rules)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What is this feature?**

Extends the rule generators in tests to understand recording rules. Adds options to create a mixture of, or all, recording rules in rule lists.

Kept the default of all alert rules, because many tests use it with just one generated rule, and changing this could introduce intermittency.

Adds a few tests for database mechanics (counts, updates, fetch rules for scheduling, etc)

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
