### PR TITLE
Geomap: Improve Pan and Zoom Performance

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/dayNightLayer.tsx
@@ -4,7 +4,7 @@ import { Coordinate } from 'ol/coordinate';
 import { MultiLineString } from 'ol/geom';
 import Point from 'ol/geom/Point';
 import { Group as LayerGroup } from 'ol/layer';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import { fromLonLat } from 'ol/proj';
 import VectorSource from 'ol/source/Vector';
 import { Fill, Stroke, Style, Circle } from 'ol/style';
@@ -78,7 +78,7 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
     const sourceLineMethods = Object.getPrototypeOf(sourceLine);
 
     // Night polygon
-    const vectorLayer = new VectorLayer({
+    const vectorLayer = new VectorImage({
       source,
       style: new Style({
         fill: new Fill({
@@ -88,7 +88,7 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
     });
 
     // Night line (for crosshair sharing)
-    const nightLineLayer = new VectorLayer({
+    const nightLineLayer = new VectorImage({
       source: new VectorSource({
         features: [],
       }),
@@ -106,7 +106,7 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
       geometry: new Point([]),
     });
 
-    const sunLayer = new VectorLayer({
+    const sunLayer = new VectorImage({
       source: new VectorSource({
         features: [sunFeature],
       }),
@@ -144,7 +144,7 @@ export const dayNightLayer: MapLayerRegistryItem<DayNightConfig> = {
       }),
     });
 
-    const sunLineLayer = new VectorLayer({
+    const sunLineLayer = new VectorImage({
       source: new VectorSource({
         features: [sunLineFeature],
       }),

--- a/public/app/plugins/panel/geomap/layers/data/geojsonDynamic.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonDynamic.ts
@@ -2,7 +2,7 @@ import { FeatureLike } from 'ol/Feature';
 import OlMap from 'ol/Map';
 import { unByKey } from 'ol/Observable';
 import GeoJSON from 'ol/format/GeoJSON';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import VectorSource from 'ol/source/Vector';
 import { Fill, Stroke, Style } from 'ol/style';
 import { ReplaySubject } from 'rxjs';
@@ -118,7 +118,7 @@ export const dynamicGeoJSONLayer: MapLayerRegistryItem<DynamicGeoJSONMapperConfi
     const style = await getStyleConfigState(config.style);
     const idToIdx = new Map<string, number>();
 
-    const vectorLayer = new VectorLayer({
+    const vectorLayer = new VectorImage({
       source,
       style: (feature: FeatureLike) => {
         const idx = idToIdx.get(feature.getId() as string);

--- a/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
@@ -2,7 +2,7 @@ import { FeatureLike } from 'ol/Feature';
 import Map from 'ol/Map';
 import { unByKey } from 'ol/Observable';
 import GeoJSON from 'ol/format/GeoJSON';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import VectorSource from 'ol/source/Vector';
 import { Style } from 'ol/style';
 import { ReplaySubject } from 'rxjs';
@@ -112,7 +112,7 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
     const polyStyleStrings: string[] = Object.values(GeoJSONPolyStyles);
     const pointStyleStrings: string[] = Object.values(GeoJSONPointStyles);
     const lineStyleStrings: string[] = Object.values(GeoJSONLineStyles);
-    const vectorLayer = new VectorLayer({
+    const vectorLayer = new VectorImage({
       source,
       style: (feature: FeatureLike) => {
         const featureType = feature.getGeometry()?.getType();

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -74,13 +74,9 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
     const style = await getStyleConfigState(config.style);
     const location = await getLocationMatchers(options.location);
     const source = new FrameVectorSource(location);
-    // const vectorLayer = new VectorLayer({
-    //   source,
-    //   declutter: false
-    // });
     const vectorLayer = new VectorImage({
       source,
-      declutter: false
+      declutter: false // TODO consider making this an option or explore grouping strategies
     });
 
     const legendProps = new ReplaySubject<MarkersLegendProps>(1);

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -1,7 +1,7 @@
 import { isNumber } from 'lodash';
 import { FeatureLike } from 'ol/Feature';
 import Map from 'ol/Map';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import React, { ReactNode } from 'react';
 import { ReplaySubject } from 'rxjs';
 
@@ -74,8 +74,13 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
     const style = await getStyleConfigState(config.style);
     const location = await getLocationMatchers(options.location);
     const source = new FrameVectorSource(location);
-    const vectorLayer = new VectorLayer({
+    // const vectorLayer = new VectorLayer({
+    //   source,
+    //   declutter: false
+    // });
+    const vectorLayer = new VectorImage({
       source,
+      declutter: false
     });
 
     const legendProps = new ReplaySubject<MarkersLegendProps>(1);

--- a/public/app/plugins/panel/geomap/layers/data/networkLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/networkLayer.tsx
@@ -3,7 +3,7 @@ import { Feature } from 'ol';
 import { FeatureLike } from 'ol/Feature';
 import Map from 'ol/Map';
 import { Geometry, LineString, Point, SimpleGeometry } from 'ol/geom';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import { Fill, Stroke, Style, Text } from 'ol/style';
 import FlowLine from 'ol-ext/style/FlowLine';
 import React, { ReactNode } from 'react';
@@ -91,7 +91,7 @@ export const networkLayer: MapLayerRegistryItem<NetworkConfig> = {
     const location = await getLocationMatchers(options.location);
     const source = new FrameVectorSource(location);
 
-    const vectorLayer = new VectorLayer({
+    const vectorLayer = new VectorImage({
       source,
     });
     const hasArrows = config.arrow === 1 || config.arrow === -1 || config.arrow === 2;

--- a/public/app/plugins/panel/geomap/layers/data/photosLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/photosLayer.tsx
@@ -1,6 +1,6 @@
 import { FeatureLike } from 'ol/Feature';
 import Map from 'ol/Map';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import { Stroke, Style } from 'ol/style';
 import Photo from 'ol-ext/style/Photo';
 
@@ -86,7 +86,7 @@ export const photosLayer: MapLayerRegistryItem<PhotoConfig> = {
 
     const location = await getLocationMatchers(options.location);
     const source = new FrameVectorSource(location);
-    const vectorLayer = new VectorLayer({
+    const vectorLayer = new VectorImage({
       source,
     });
 

--- a/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/routeLayer.tsx
@@ -3,7 +3,7 @@ import Feature, { FeatureLike } from 'ol/Feature';
 import Map from 'ol/Map';
 import { LineString, Point, SimpleGeometry } from 'ol/geom';
 import { Group as LayerGroup } from 'ol/layer';
-import VectorLayer from 'ol/layer/Vector';
+import VectorImage from 'ol/layer/VectorImage';
 import VectorSource from 'ol/source/Vector';
 import { Fill, Stroke, Style, Circle } from 'ol/style';
 import FlowLine from 'ol-ext/style/FlowLine';
@@ -94,7 +94,7 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
     const style = await getStyleConfigState(config.style);
     const location = await getLocationMatchers(options.location);
     const source = new FrameVectorSource(location);
-    const vectorLayer = new VectorLayer({ source });
+    const vectorLayer = new VectorImage({ source });
     const hasArrows = config.arrow === 1 || config.arrow === -1;
 
     if (!style.fields && !hasArrows) {
@@ -222,14 +222,14 @@ export const routeLayer: MapLayerRegistryItem<RouteConfig> = {
       }),
     });
 
-    const crosshairLayer = new VectorLayer({
+    const crosshairLayer = new VectorImage({
       source: new VectorSource({
         features: [crosshairFeature],
       }),
       style: crosshairStyle,
     });
 
-    const linesLayer = new VectorLayer({
+    const linesLayer = new VectorImage({
       source: new VectorSource({
         features: lineFeatures,
       }),


### PR DESCRIPTION
Pursuing performance improvements for the user experience in Geomap, particularly when panning and zooming.

- [x] Use VectorImage instead of VectorLayer for layers using vector data.
- [ ] ~Explore caching style functions~ #https://github.com/grafana/grafana/issues/88520
- [ ] ~Render modes (webgl)~ #88317

Note from openlayers on VectorImage:  
Vector data is rendered client-side, to an image. This layer type provides great performance during panning and zooming, but point symbols and texts are always rotated with the view and pixels are scaled during zoom animations. For more accurate rendering of vector data, use VectorLayer instead.

Metrics (comparing the same zoom out action on marker layer with 3000 points):
Vector Layer:
![Pasted Graphic](https://github.com/grafana/grafana/assets/60050885/5ebc9533-270e-48de-8df5-00744b518b05)
Image Layer:
![1000 ms](https://github.com/grafana/grafana/assets/60050885/c526a9b4-be8c-44eb-a042-228a54bd4ab5)


Closes https://github.com/grafana/support-escalations/issues/10508