### PR TITLE
Alerting: Fix "copy link" not including full URL

### DIFF
--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -61,7 +61,7 @@ export function createShareLink(ruleSource: RulesSource, rule: CombinedRule): st
       `/alerting/${encodeURIComponent(ruleSource.name)}/${encodeURIComponent(escapePathSeparators(rule.name))}/find`
     );
   } else if (isGrafanaRulerRule(rule.rulerRule)) {
-    return createUrl(`/alerting/grafana/${rule.rulerRule.grafana_alert.uid}/view`);
+    return createAbsoluteUrl(`/alerting/grafana/${rule.rulerRule.grafana_alert.uid}/view`);
   }
 
   return;

--- a/public/app/features/alerting/unified/utils/url.ts
+++ b/public/app/features/alerting/unified/utils/url.ts
@@ -15,9 +15,7 @@ export function createAbsoluteUrl(
   const searchParamsString = searchParams.toString();
 
   try {
-    const baseUrl = new URL(config.appSubUrl, config.appUrl);
-    baseUrl.pathname = path;
-
+    const baseUrl = new URL(config.appSubUrl + path, config.appUrl);
     return `${baseUrl.href}${searchParamsString ? `?${searchParamsString}` : ''}`;
   } catch (err) {
     return createUrl(path, queryParams);


### PR DESCRIPTION
**What is this feature?**

Copy a Grafana managed rule's link was not including the full URL - it was starting `/alerting/...`, rather than including the host/base URL. This fixes by ensuring we use the correct util method to construct the URL
