### PR TITLE
DateTimePicker: Add clearable prop

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.mdx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.mdx
@@ -16,7 +16,7 @@ const [date, setDate] = useState<DateTime>(dateTime('2021-05-05 12:00:00'));
 return <DateTimePicker label="Date" date={date} onChange={setDate} />;
 ```
 
-### With disbled hours, minutes or seconds
+### With disabled hours, minutes or seconds
 
 ```tsx
 import React, { useState } from 'react';
@@ -35,6 +35,10 @@ return (
   />
 );
 ```
+
+### Clearable
+
+You can set the `clearable` prop to `true` to enable the clearing of selected values and allow the component to have an empty value instead of the current date/time.
 
 ### Props
 

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.story.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.story.tsx
@@ -27,6 +27,7 @@ const meta: Meta<typeof DateTimePicker> = {
     minDate: { control: 'date' },
     maxDate: { control: 'date' },
     showSeconds: { control: 'boolean' },
+    clearable: { control: 'boolean' },
   },
   args: {
     minDate: minimumDate,
@@ -63,7 +64,7 @@ export const OnlyWorkingHoursEnabled: StoryFn<typeof DateTimePicker> = ({ label,
   );
 };
 
-export const Basic: StoryFn<typeof DateTimePicker> = ({ label, minDate, maxDate, showSeconds }) => {
+export const Basic: StoryFn<typeof DateTimePicker> = ({ label, minDate, maxDate, showSeconds, clearable }) => {
   const [date, setDate] = useState<DateTime>(dateTime(today));
   // the minDate arg can change from Date object to number, we need to handle this
   // scenario to avoid a crash in the component's story.
@@ -77,6 +78,7 @@ export const Basic: StoryFn<typeof DateTimePicker> = ({ label, minDate, maxDate,
       maxDate={maxDateVal}
       date={date}
       showSeconds={showSeconds}
+      clearable={clearable}
       onChange={(newValue) => {
         action('on change')(newValue);
         setDate(newValue);
@@ -87,6 +89,26 @@ export const Basic: StoryFn<typeof DateTimePicker> = ({ label, minDate, maxDate,
 
 Basic.args = {
   label: 'Date',
+};
+
+export const Clearable: StoryFn<typeof DateTimePicker> = ({ label, showSeconds, clearable }) => {
+  const [date, setDate] = useState<DateTime>(dateTime(today));
+  return (
+    <DateTimePicker
+      label={label}
+      date={date}
+      showSeconds={showSeconds}
+      clearable={clearable}
+      onChange={(newValue) => {
+        action('on change')(newValue);
+        setDate(newValue);
+      }}
+    />
+  );
+};
+
+Clearable.args = {
+  clearable: true,
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -404,7 +404,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   clearIcon: css({
     cursor: 'pointer',
-    marginLeft: -theme.spacing(1),
   }),
   field: css({
     marginBottom: 0,

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -247,6 +247,10 @@ const DateTimeInput = React.forwardRef<HTMLInputElement, InputProps>(
       }
     }, [internalDate, onChange]);
 
+    const clearInternalDate = useCallback(() => {
+      setInternalDate({ value: '', invalid: false });
+    }, []);
+
     const icon = <Button aria-label="Time picker" icon="calendar-alt" variant="secondary" onClick={onOpen} />;
     return (
       <InlineField label={label} invalid={!!(internalDate.value && internalDate.invalid)} className={styles.field}>
@@ -263,7 +267,7 @@ const DateTimeInput = React.forwardRef<HTMLInputElement, InputProps>(
               <Icon
                 name="times"
                 className={cx(styles.clearIcon, { [styles.disabled]: !internalDate.value })}
-                onClick={() => setInternalDate({ value: '', invalid: false })}
+                onClick={clearInternalDate}
               />
             )
           }

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -263,13 +263,8 @@ const DateTimeInput = React.forwardRef<HTMLInputElement, InputProps>(
           placeholder="Select date/time"
           ref={ref}
           suffix={
-            clearable && (
-              <Icon
-                name="times"
-                className={cx(styles.clearIcon, { [styles.disabled]: !internalDate.value })}
-                onClick={clearInternalDate}
-              />
-            )
+            clearable &&
+            internalDate.value && <Icon name="times" className={styles.clearIcon} onClick={clearInternalDate} />
           }
         />
       </InlineField>
@@ -407,9 +402,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   field: css({
     marginBottom: 0,
-  }),
-  disabled: css({
-    opacity: 0.5,
-    cursor: 'not-allowed',
+    width: '100%',
   }),
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a `clearable` prop to the picker, which allows clearing selected values and for the picker to support empty value as opposed to current date/time. 

**Why do we need this feature?**

In certain cases having current date/time for the picker as a default value doesn't make sense and we need a way to provide an empty value instead. 

**Special notes for your reviewer:**

![Screenshot 2024-05-23 at 13 23 46](https://github.com/grafana/grafana/assets/8878045/d833a4f7-46e9-4ac8-85c9-307eee46e5e7)
![Screenshot 2024-05-23 at 13 23 58](https://github.com/grafana/grafana/assets/8878045/d871bf5c-002a-42f3-8998-d77e626b7d5d)

