### PR TITLE
Anon: Doc add feature toggle `displayAnonymousStats` in docs

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
@@ -72,6 +72,7 @@ Users can now view anonymous usage statistics, including the count of devices an
 The number of anonymous devices is not limited by default. The configuration option `device_limit` allows you to enforce a limit on the number of anonymous devices. This enables you to have greater control over the usage within your Grafana instance and keep the usage within the limits of your environment. Once the limit is reached, any new devices that try to access Grafana will be denied access.
 
 To display anonymous users and devices for versions 10.2, 10.3, 10.4, this is not needed for v11
+
 ```bash
 [feature_toggles]
 enable = displayAnonymousStats
@@ -82,8 +83,6 @@ enable = displayAnonymousStats
 {{< admonition type="note" >}}
 Anonymous users are charged as active users in Grafana Enterprise
 {{< /admonition >}}
-
-
 
 #### Configuration
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
@@ -71,11 +71,19 @@ Users can now view anonymous usage statistics, including the count of devices an
 
 The number of anonymous devices is not limited by default. The configuration option `device_limit` allows you to enforce a limit on the number of anonymous devices. This enables you to have greater control over the usage within your Grafana instance and keep the usage within the limits of your environment. Once the limit is reached, any new devices that try to access Grafana will be denied access.
 
+To display anonymous users and devices for versions 10.2, 10.3, 10.4, this is not needed for v11
+```bash
+[feature_toggles]
+enable = displayAnonymousStats
+```
+
 #### Anonymous users
 
 {{< admonition type="note" >}}
 Anonymous users are charged as active users in Grafana Enterprise
 {{< /admonition >}}
+
+
 
 #### Configuration
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
@@ -71,7 +71,7 @@ Users can now view anonymous usage statistics, including the count of devices an
 
 The number of anonymous devices is not limited by default. The configuration option `device_limit` allows you to enforce a limit on the number of anonymous devices. This enables you to have greater control over the usage within your Grafana instance and keep the usage within the limits of your environment. Once the limit is reached, any new devices that try to access Grafana will be denied access.
 
-To display anonymous users and devices for versions 10.2, 10.3, 10.4
+To display anonymous users and devices for versions 10.2, 10.3, 10.4, you need to enable the feature toggle `displayAnonymousStats`
 
 ```bash
 [feature_toggles]

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
@@ -71,7 +71,7 @@ Users can now view anonymous usage statistics, including the count of devices an
 
 The number of anonymous devices is not limited by default. The configuration option `device_limit` allows you to enforce a limit on the number of anonymous devices. This enables you to have greater control over the usage within your Grafana instance and keep the usage within the limits of your environment. Once the limit is reached, any new devices that try to access Grafana will be denied access.
 
-To display anonymous users and devices for versions 10.2, 10.3, 10.4, this is not needed for v11
+To display anonymous users and devices for versions 10.2, 10.3, 10.4
 
 ```bash
 [feature_toggles]


### PR DESCRIPTION
**What is this feature?**
We have realized that the feature toggle was not documented in the versions 10.2.3, 10.3, 10.4 for onprem usages.

- This adds documentation for setting up the feature toggle to enable viewing the anonymous devices

**Which issue(s) does this PR fix?**:
https://github.com/grafana/identity-access-team/issues/699