### PR TITLE
Docker: Fix renderer plugin in custom Dockerfile

### DIFF
--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -34,7 +34,7 @@ USER grafana
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
       grafana-cli \
         --pluginsDir "$GF_PATHS_PLUGINS" \
-        --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-linux-x64-glibc-no-chromium.zip \
+        --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-alpine-x64-no-chromium.zip \
         plugins install grafana-image-renderer; \
     fi
 

--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -32,10 +32,17 @@ RUN mkdir -p "$GF_PATHS_PLUGINS" && \
 USER grafana
 
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
-      grafana-cli \
-        --pluginsDir "$GF_PATHS_PLUGINS" \
-        --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-alpine-x64-no-chromium.zip \
-        plugins install grafana-image-renderer; \
+      if grep -i -q alpine /etc/issue; then \
+        grafana-cli \
+          --pluginsDir "$GF_PATHS_PLUGINS" \
+          --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-alpine-x64-no-chromium.zip \
+          plugins install grafana-image-renderer; \
+      else \
+        grafana-cli \
+          --pluginsDir "$GF_PATHS_PLUGINS" \
+          --pluginUrl https://github.com/grafana/grafana-image-renderer/releases/latest/download/plugin-linux-x64-glibc-no-chromium.zip \
+          plugins install grafana-image-renderer; \
+      fi \
     fi
 
 ARG GF_INSTALL_PLUGINS=""


### PR DESCRIPTION
**What is this feature?**
This PR downloads the Alpine asset for the image renderer plugin instead of the Linux glibc one. 

**Why do we need this feature?**
It fixes issues using the Grafana Alpine base image. 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-image-renderer/issues/505

**Special notes for your reviewer:**
This is also working using the `grafana/grafana:latest-ubuntu` base image.
