### PR TITLE
[v10.4.x] Docs: Add thresholds shared content

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -207,6 +207,10 @@ You can set standard min/max options to define hard limits of the Y-axis. For mo
 
 {{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+2" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
@@ -136,6 +136,10 @@ Automatically show y-axis scrollbar when there's a large amount of data.
 This option only applies when bar size is set to manual.
 {{% /admonition %}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -128,6 +128,10 @@ The candlestick visualization is based on the time series visualization. It can 
 
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -161,6 +161,10 @@ If multiple elements use the same field name, and you want to control which elem
 
 {{< video-embed src="/media/docs/grafana/canvas-data-links-9-4-0.mp4" max-width="750px" caption="Data links demo" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -111,6 +111,10 @@ Adjust the sizes of the gauge text.
 - **Title -** Enter a numeric value for the gauge title size.
 - **Value -** Enter a numeric value for the gauge value size.
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -614,6 +614,10 @@ Displays debug information in the upper right corner. This can be useful for deb
 - **None** displays tooltips only when a data point is clicked.
 - **Details** displays tooltips when a mouse pointer hovers over a data point.
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -141,3 +141,7 @@ Gradient color is generated based on the hue of the line color.
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -195,6 +195,10 @@ Adjust the sizes of the gauge text.
 - **Title -** Enter a numeric value for the gauge title size.
 - **Value -** Enter a numeric value for the gauge value size.
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -149,6 +149,10 @@ The visualization can be used with time series data as well. In this case, the t
 
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -129,6 +129,10 @@ To assign colors to boolean or string values, use the [Value mappings](ref:value
 
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -248,6 +248,10 @@ The system applies the calculation to all numeric fields if you do not select a 
 
 If you want to show the number of rows in the dataset instead of the number of values in the selected fields, select the **Count** calculation and enable **Count rows**.
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -326,6 +326,10 @@ The following image shows a bar chart with the **Green-Yellow-Red (by value)** c
 
 {{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_bars.png" max-width="1200px" caption="Color scheme: Green-Yellow-Red" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/trend/index.md
+++ b/docs/sources/panels-visualizations/visualizations/trend/index.md
@@ -52,6 +52,10 @@ For example, you could represent engine power and torque versus speed where spee
 
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
+## Thresholds
+
+{{< docs/shared lookup="visualizations/thresholds-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/shared/visualizations/thresholds-options-1.md
+++ b/docs/sources/shared/visualizations/thresholds-options-1.md
@@ -1,0 +1,19 @@
+---
+title: Thresholds options
+comments: |
+  There are two thresholds shared files, thresholds-options-1.md and thresholds-options-2.md, to cover the most common combinations of options. 
+  Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
+  This file is used in the following visualizations: bar chart, candlestick, time series, trend
+---
+
+A threshold is a value or limit you set for a metric that’s reflected visually when it’s met or exceeded. Thresholds are one way you can conditionally style and color your visualizations based on query results.
+
+Set the following options:
+
+- **Value** - Set the value for each threshold.
+- **Thresholds mode** - Choose from:
+  - **Absolute**
+  - **Percentage**
+- **Show thresholds** - Choose from a variety of display options including not displaying thresholds at all.
+
+To learn more, refer to [Configure thresholds](../../configure-thresholds/).

--- a/docs/sources/shared/visualizations/thresholds-options-2.md
+++ b/docs/sources/shared/visualizations/thresholds-options-2.md
@@ -1,0 +1,18 @@
+---
+title: Thresholds options
+comments: |
+  There are two thresholds shared files, thresholds-options-1.md and thresholds-options-2.md, to cover the most common combinations of options. 
+  Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
+  This file is used in the following visualizations: bar gauge, canvas, gauge, geomap, histogram, stat, state timeline, status history, table
+---
+
+A threshold is a value or limit you set for a metric that’s reflected visually when it’s met or exceeded. Thresholds are one way you can conditionally style and color your visualizations based on query results.
+
+Set the following options:
+
+- **Value** - Set the value for each threshold.
+- **Thresholds mode** - Choose from:
+  - **Absolute**
+  - **Percentage**
+
+To learn more, refer to [Configure thresholds](../../configure-thresholds/).


### PR DESCRIPTION
Backport 406fe8c85a5722c5f405d745f018a6ca820d9caf from #87009

---

This PR adds shared files for the thresholds options for visualizations. Two files have been added to cover the two most common sets of options. Using two shared files ensures two things:

1. Content remains consistent across visualizations that share the same options
2. Users reading about a visualization don't have to figure out which options don't apply to a specific visualization because they'll only be presented with the ones that apply.

This PR:

- Adds and updates shared files for thresholds content (2)
- Adds shared files to appropriate visualizations
