### PR TITLE
Gops: Fix wrong endpoint for incidents check

### DIFF
--- a/public/app/features/alerting/unified/api/incidentsApi.ts
+++ b/public/app/features/alerting/unified/api/incidentsApi.ts
@@ -14,7 +14,8 @@ export const incidentsApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
     getIncidentsPluginConfig: build.query<IncidentsPluginConfigDto, void>({
       query: (integration) => ({
-        url: getProxyApiUrl('/api/internal/v1/organization/config-checks/'),
+        url: getProxyApiUrl('/api/ConfigurationTrackerService.GetConfigurationTracker'),
+        data: integration,
         method: 'POST',
         showErrorAlert: false,
       }),


### PR DESCRIPTION
This PR fix using wrong url for incidents checks in the IRM configuration tracker. 

the error was introduced in [here](https://github.com/grafana/grafana/pull/85838/commits/0b98077706b6e12e367f0499690b05caffe4fb38#diff-c80d6d07e0cffd5e64dca9e0cfc5d10b5c43f5001dcfb557ce45db14fc8fc5d4L17-L19)
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
