### PR TITLE
POC: Confirmation content inside Drawer

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
@@ -1,0 +1,131 @@
+import { css } from '@emotion/css';
+import React, { useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+
+import { useStyles2 } from '../../themes';
+import { Button, ButtonVariant } from '../Button';
+import { Input } from '../Input/Input';
+import { Box } from '../Layout/Box/Box';
+import { Stack } from '../Layout/Stack/Stack';
+import { Modal } from '../Modal/Modal';
+
+export interface ConfirmContentProps {
+  /** Modal content */
+  body: React.ReactNode;
+  /** Modal description */
+  description?: React.ReactNode;
+  /** Text for confirm button */
+  confirmText: string;
+  /** Variant for confirm button */
+  confirmVariant?: ButtonVariant;
+  /** Text for dismiss button */
+  dismissText?: string;
+  /** Variant for dismiss button */
+  dismissVariant?: ButtonVariant;
+  /** Text user needs to fill in before confirming */
+  confirmationText?: string;
+  /** Text for alternative button */
+  alternativeText?: string;
+  /** Confirm button variant */
+  confirmButtonVariant?: ButtonVariant;
+  /** Confirm action callback
+   * Return a promise to disable the confirm button until the promise is resolved
+   */
+  onConfirm(): void | Promise<void>;
+  /** Dismiss action callback */
+  onDismiss(): void;
+  /** Alternative action callback */
+  onAlternative?(): void;
+}
+
+export const ConfirmContent = ({
+  body,
+  description,
+  confirmText,
+  confirmationText,
+  dismissText = 'Cancel',
+  dismissVariant = 'secondary',
+  alternativeText,
+  onConfirm,
+  onDismiss,
+  onAlternative,
+  confirmButtonVariant = 'destructive',
+}: ConfirmContentProps) => {
+  const [disabled, setDisabled] = useState(Boolean(confirmationText));
+  const styles = useStyles2(getStyles);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const onConfirmationTextChange = (event: React.FormEvent<HTMLInputElement>) => {
+    setDisabled(confirmationText?.toLowerCase().localeCompare(event.currentTarget.value.toLowerCase()) !== 0);
+  };
+
+  const onConfirmClick = async () => {
+    setDisabled(true);
+    try {
+      await onConfirm();
+    } finally {
+      setDisabled(false);
+    }
+  };
+
+  const { handleSubmit } = useForm();
+
+  return (
+    <form onSubmit={handleSubmit(onConfirmClick)}>
+      <div className={styles.modalText}>
+        {body}
+        {description ? <div className={styles.modalDescription}>{description}</div> : null}
+        {confirmationText ? (
+          <div className={styles.modalConfirmationInput}>
+            <Stack alignItems="flex-start">
+              <Box>
+                <Input placeholder={`Type "${confirmationText}" to confirm`} onChange={onConfirmationTextChange} />
+              </Box>
+            </Stack>
+          </div>
+        ) : null}
+      </div>
+      <Modal.ButtonRow
+        leftItems={
+          <>
+            <Button variant={dismissVariant} onClick={onDismiss} fill="outline">
+              {dismissText}
+            </Button>
+            <Button
+              type="submit"
+              variant={confirmButtonVariant}
+              disabled={disabled}
+              ref={buttonRef}
+              data-testid={selectors.pages.ConfirmModal.delete}
+            >
+              {confirmText}
+            </Button>
+            {onAlternative ? (
+              <Button variant="primary" onClick={onAlternative}>
+                {alternativeText}
+              </Button>
+            ) : null}
+          </>
+        }
+      >
+        {' '}
+        <></>{' '}
+      </Modal.ButtonRow>
+    </form>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  modalText: css({
+    fontSize: theme.typography.h5.fontSize,
+    color: theme.colors.text.primary,
+  }),
+  modalDescription: css({
+    fontSize: theme.typography.body.fontSize,
+  }),
+  modalConfirmationInput: css({
+    paddingTop: theme.spacing(1),
+  }),
+});

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
@@ -87,31 +87,24 @@ export const ConfirmContent = ({
           </div>
         ) : null}
       </div>
-      <Modal.ButtonRow
-        leftItems={
-          <>
-            <Button variant={dismissVariant} onClick={onDismiss} fill="outline">
-              {dismissText}
-            </Button>
-            <Button
-              type="submit"
-              variant={confirmButtonVariant}
-              disabled={disabled}
-              ref={buttonRef}
-              data-testid={selectors.pages.ConfirmModal.delete}
-            >
-              {confirmText}
-            </Button>
-            {onAlternative ? (
-              <Button variant="primary" onClick={onAlternative}>
-                {alternativeText}
-              </Button>
-            ) : null}
-          </>
-        }
-      >
-        {' '}
-        <></>{' '}
+      <Modal.ButtonRow>
+        <Button variant={dismissVariant} onClick={onDismiss} fill="outline">
+          {dismissText}
+        </Button>
+        <Button
+          type="submit"
+          variant={confirmButtonVariant}
+          disabled={disabled}
+          ref={buttonRef}
+          data-testid={selectors.pages.ConfirmModal.delete}
+        >
+          {confirmText}
+        </Button>
+        {onAlternative ? (
+          <Button variant="primary" onClick={onAlternative}>
+            {alternativeText}
+          </Button>
+        ) : null}
       </Modal.ButtonRow>
     </form>
   );

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,17 +1,14 @@
 import { css, cx } from '@emotion/css';
-import React, { useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import React, { useEffect, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
 
 import { useStyles2 } from '../../themes';
 import { IconName } from '../../types/icon';
-import { Button, ButtonVariant } from '../Button';
-import { Input } from '../Input/Input';
-import { Box } from '../Layout/Box/Box';
-import { Stack } from '../Layout/Stack/Stack';
+import { ButtonVariant } from '../Button';
 import { Modal } from '../Modal/Modal';
+
+import { ConfirmContent } from './ConfirmContent';
 
 export interface ConfirmModalProps {
   /** Toggle modal's open/closed state */
@@ -53,27 +50,13 @@ export interface ConfirmModalProps {
 export const ConfirmModal = ({
   isOpen,
   title,
-  body,
-  description,
-  confirmText,
-  confirmVariant = 'destructive',
-  confirmationText,
-  dismissText = 'Cancel',
-  dismissVariant = 'secondary',
-  alternativeText,
   modalClass,
   icon = 'exclamation-triangle',
-  onConfirm,
   onDismiss,
-  onAlternative,
-  confirmButtonVariant = 'destructive',
+  ...rest
 }: ConfirmModalProps): JSX.Element => {
-  const [disabled, setDisabled] = useState(Boolean(confirmationText));
   const styles = useStyles2(getStyles);
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const onConfirmationTextChange = (event: React.FormEvent<HTMLInputElement>) => {
-    setDisabled(confirmationText?.toLowerCase().localeCompare(event.currentTarget.value.toLowerCase()) !== 0);
-  };
 
   useEffect(() => {
     // for some reason autoFocus property did no work on this button, but this does
@@ -82,59 +65,9 @@ export const ConfirmModal = ({
     }
   }, [isOpen]);
 
-  useEffect(() => {
-    if (isOpen) {
-      setDisabled(Boolean(confirmationText));
-    }
-  }, [isOpen, confirmationText]);
-
-  const onConfirmClick = async () => {
-    setDisabled(true);
-    try {
-      await onConfirm();
-    } finally {
-      setDisabled(false);
-    }
-  };
-
-  const { handleSubmit } = useForm();
-
   return (
     <Modal className={cx(styles.modal, modalClass)} title={title} icon={icon} isOpen={isOpen} onDismiss={onDismiss}>
-      <form onSubmit={handleSubmit(onConfirmClick)}>
-        <div className={styles.modalText}>
-          {body}
-          {description ? <div className={styles.modalDescription}>{description}</div> : null}
-          {confirmationText ? (
-            <div className={styles.modalConfirmationInput}>
-              <Stack alignItems="flex-start">
-                <Box>
-                  <Input placeholder={`Type "${confirmationText}" to confirm`} onChange={onConfirmationTextChange} />
-                </Box>
-              </Stack>
-            </div>
-          ) : null}
-        </div>
-        <Modal.ButtonRow>
-          <Button variant={dismissVariant} onClick={onDismiss} fill="outline">
-            {dismissText}
-          </Button>
-          <Button
-            type="submit"
-            variant={confirmButtonVariant}
-            disabled={disabled}
-            ref={buttonRef}
-            data-testid={selectors.pages.ConfirmModal.delete}
-          >
-            {confirmText}
-          </Button>
-          {onAlternative ? (
-            <Button variant="primary" onClick={onAlternative}>
-              {alternativeText}
-            </Button>
-          ) : null}
-        </Modal.ButtonRow>
-      </form>
+      <ConfirmContent {...rest} onDismiss={onDismiss} />
     </Modal>
   );
 };

--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -10,10 +10,14 @@ import { selectors } from '@grafana/e2e-selectors';
 
 import { useStyles2 } from '../../themes';
 import { t } from '../../utils/i18n';
+import { ConfirmContent } from '../ConfirmModal/ConfirmContent';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 import { getDragStyles } from '../DragHandle/DragHandle';
 import { IconButton } from '../IconButton/IconButton';
+import { Stack } from '../Layout/Stack/Stack';
 import { Text } from '../Text/Text';
+
+import { DrawerProvider, useDrawerContext } from './DrawerContext';
 
 import 'rc-drawer/assets/index.css';
 
@@ -53,7 +57,15 @@ export interface Props {
   onClose: () => void;
 }
 
-export function Drawer({
+export function Drawer(props: Props) {
+  return (
+    <DrawerProvider>
+      <DrawerContent {...props}>{props.children}</DrawerContent>
+    </DrawerProvider>
+  );
+}
+
+function DrawerContent({
   children,
   onClose,
   closeOnMaskClick = true,
@@ -64,6 +76,7 @@ export function Drawer({
   size = 'md',
   tabs,
 }: Props) {
+  const { confirmContent, setConfirmContent } = useDrawerContext();
   const [drawerWidth, onMouseDown, onTouchStart] = useResizebleDrawer();
 
   const styles = useStyles2(getStyles);
@@ -125,32 +138,75 @@ export function Drawer({
             onMouseDown={onMouseDown}
             onTouchStart={onTouchStart}
           />
-          {typeof title === 'string' && (
-            <div className={cx(styles.header, Boolean(tabs) && styles.headerWithTabs)}>
-              <div className={styles.actions}>
-                <IconButton
-                  name="times"
-                  variant="secondary"
-                  onClick={onClose}
-                  data-testid={selectors.components.Drawer.General.close}
-                  tooltip={t(`grafana-ui.drawer.close`, 'Close')}
-                />
-              </div>
-              <div className={styles.titleWrapper}>
-                <Text element="h3" {...titleProps}>
-                  {title}
-                </Text>
-                {subtitle && (
-                  <div className={styles.subtitle} data-testid={selectors.components.Drawer.General.subtitle}>
-                    {subtitle}
+          {confirmContent ? (
+            <>
+              <div className={styles.header}>
+                <div className={styles.actions}>
+                  <IconButton
+                    name="times"
+                    variant="secondary"
+                    onClick={onClose}
+                    data-testid={selectors.components.Drawer.General.close}
+                    tooltip={t(`grafana-ui.drawer.close`, 'Close')}
+                  />
+                </div>
+                <Stack gap={1.5} alignItems="center">
+                  <IconButton
+                    name="angle-left"
+                    variant="secondary"
+                    size="xl"
+                    onClick={() => setConfirmContent!(undefined)}
+                    tooltip={'Cancel'}
+                  />
+                  <div className={styles.titleWrapper}>
+                    <Text element="h3" {...titleProps}>
+                      {confirmContent.title}
+                    </Text>
                   </div>
-                )}
-                {tabs && <div className={styles.tabsWrapper}>{tabs}</div>}
+                </Stack>
               </div>
-            </div>
+              {!scrollableContent ? (
+                <div className={styles.content}>
+                  <ConfirmContent {...confirmContent} />
+                </div>
+              ) : (
+                <CustomScrollbar>
+                  <div className={styles.content}>
+                    <ConfirmContent {...confirmContent} />
+                  </div>
+                </CustomScrollbar>
+              )}
+            </>
+          ) : (
+            <>
+              {typeof title === 'string' && (
+                <div className={cx(styles.header, Boolean(tabs) && styles.headerWithTabs)}>
+                  <div className={styles.actions}>
+                    <IconButton
+                      name="times"
+                      variant="secondary"
+                      onClick={onClose}
+                      data-testid={selectors.components.Drawer.General.close}
+                      tooltip={t(`grafana-ui.drawer.close`, 'Close')}
+                    />
+                  </div>
+                  <div className={styles.titleWrapper}>
+                    <Text element="h3" {...titleProps}>
+                      {title}
+                    </Text>
+                    {subtitle && (
+                      <div className={styles.subtitle} data-testid={selectors.components.Drawer.General.subtitle}>
+                        {subtitle}
+                      </div>
+                    )}
+                    {tabs && <div className={styles.tabsWrapper}>{tabs}</div>}
+                  </div>
+                </div>
+              )}
+              {typeof title !== 'string' && title}
+              {!scrollableContent ? content : <CustomScrollbar>{content}</CustomScrollbar>}
+            </>
           )}
-          {typeof title !== 'string' && title}
-          {!scrollableContent ? content : <CustomScrollbar>{content}</CustomScrollbar>}
         </div>
       </FocusScope>
     </RcDrawer>

--- a/packages/grafana-ui/src/components/Drawer/DrawerContext.tsx
+++ b/packages/grafana-ui/src/components/Drawer/DrawerContext.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import { ConfirmModalProps } from '../ConfirmModal/ConfirmModal';
+
+type ConfirmContentType = Omit<ConfirmModalProps, 'isOpen' | 'icon'>;
+
+interface Context {
+  confirmContent?: ConfirmContentType;
+  setConfirmContent?: (t: ConfirmContentType | undefined) => void;
+}
+
+const DrawerContext = React.createContext<Context | undefined>(undefined);
+
+type Props = Context & React.PropsWithChildren;
+
+const DrawerProvider = ({ children }: Props) => {
+  const [confirmContent, setConfirmContent] = useState<ConfirmContentType | undefined>();
+
+  const value: Context = {
+    confirmContent,
+    setConfirmContent,
+  };
+
+  return <DrawerContext.Provider value={value}>{children}</DrawerContext.Provider>;
+};
+
+const useDrawerContext = () => {
+  const context = React.useContext(DrawerContext);
+
+  if (context === undefined) {
+    throw new Error('useDrawerContext must be used within a DrawerContext');
+  }
+
+  return context;
+};
+
+export { DrawerProvider, useDrawerContext };

--- a/public/app/features/trails/Integrations/SceneDrawer.tsx
+++ b/public/app/features/trails/Integrations/SceneDrawer.tsx
@@ -4,21 +4,21 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, SceneObject, SceneObjectState } from '@grafana/scenes';
 import { Drawer, useStyles2 } from '@grafana/ui';
-import { Props as DrawerProps } from '@grafana/ui/src/components/Drawer/Drawer';
 import appEvents from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
 
 export type SceneDrawerProps = {
   scene: SceneObject;
-  onClose: () => void;
-} & Partial<Omit<DrawerProps, 'onClose'>>;
+  title: string;
+  onDismiss: () => void;
+};
 
 export function SceneDrawer(props: SceneDrawerProps) {
-  const { scene, title, onClose, size = 'lg', ...rest } = props;
+  const { scene, title, onDismiss } = props;
   const styles = useStyles2(getStyles);
 
   return (
-    <Drawer title={title} onClose={onClose} {...rest} size={size}>
+    <Drawer title={title} onClose={onDismiss} size="lg">
       <div className={styles.drawerInnerWrapper}>
         <scene.Component model={scene} />
       </div>

--- a/public/app/features/trails/Integrations/SceneDrawer.tsx
+++ b/public/app/features/trails/Integrations/SceneDrawer.tsx
@@ -4,21 +4,21 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, SceneObject, SceneObjectState } from '@grafana/scenes';
 import { Drawer, useStyles2 } from '@grafana/ui';
+import { Props as DrawerProps } from '@grafana/ui/src/components/Drawer/Drawer';
 import appEvents from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
 
 export type SceneDrawerProps = {
   scene: SceneObject;
-  title: string;
-  onDismiss: () => void;
-};
+  onClose: () => void;
+} & Partial<Omit<DrawerProps, 'onClose'>>;
 
 export function SceneDrawer(props: SceneDrawerProps) {
-  const { scene, title, onDismiss } = props;
+  const { scene, title, onClose, size = 'lg', ...rest } = props;
   const styles = useStyles2(getStyles);
 
   return (
-    <Drawer title={title} onClose={onDismiss} size="lg">
+    <Drawer title={title} onClose={onClose} {...rest} size={size}>
       <div className={styles.drawerInnerWrapper}>
         <scene.Component model={scene} />
       </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It adds a confirmation flow inside Drawer when an action needs to be confirmed.
We consider it a bad practice to render a Modal over a Drawer which, at the same time, renders over the Content.
This is a possible solution.

**Why do we need this feature?**

We want to be consistent in Grafana. Therefore, we give a way of rendering the Confirmation step inside the Drawer whenever necessary.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**
This is a quick POC. There might be things to improve. 
I decided to reuse the Confirmation content that is used in the ConfirmModal component.

https://github.com/grafana/grafana/assets/11707172/fdbdafab-8948-4db6-9188-bc17883a38f0

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
