### PR TITLE
[v10.3.x] Docs: Rename variables pages

### DIFF
--- a/docs/sources/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/dashboards/variables/add-template-variables/index.md
@@ -40,13 +40,13 @@ labels:
     - cloud
     - enterprise
     - oss
-menuTitle: Manage variables
-title: Add and manage variables
+menuTitle: Add variables
+title: Add variables
 description: Learn about the types of variables you can add to dashboards and how
 weight: 100
 ---
 
-# Add and manage variables
+# Add variables
 
 The following table lists the types of variables shipped with Grafana.
 
@@ -516,16 +516,6 @@ You can change the orders of variables in the dashboard variable list by clickin
 The more layers of dependency you have in variables, the longer it will take to update dashboards after you change variables.
 
 For example, if you have a series of four linked variables (country, region, server, metric) and you change a root variable value (country), then Grafana must run queries for all the dependent variables before it updates the visualizations in the dashboard.
-
-## Manage variables
-
-The variables page lets you [add][] variables and manage existing variables. It also allows you to [inspect][] variables and identify whether a variable is being referenced (or used) in other variables or dashboard.
-
-**Move:** You can move a variable up or down the list using drag and drop.
-
-**Clone:** To clone a variable, click the clone icon from the set of icons on the right. This creates a copy of the variable with the name of the original variable prefixed with `copy_of_`.
-
-**Delete:** To delete a variable, click the trash icon from the set of icons on the right.
 
 ## Filter variables with regex
 

--- a/docs/sources/dashboards/variables/inspect-variable/index.md
+++ b/docs/sources/dashboards/variables/inspect-variable/index.md
@@ -34,7 +34,7 @@ You can take the following actions on the variables page:
 
 ## Inspect variables
 
-The variables page lets you easily identify whether a variable is being referenced (or used) in other variables or dashboard. In addition, you can also [add](ref:add) and [manage variables](#manage-variables) on this page.
+The variables page lets you easily identify whether a variable is being referenced (or used) in other variables or dashboard. In addition, you can also [add][] and [manage variables](#manage-variables) on this page.
 
 {{% admonition type="note" %}}
 This feature is available in Grafana 7.4 and later versions.

--- a/docs/sources/dashboards/variables/inspect-variable/index.md
+++ b/docs/sources/dashboards/variables/inspect-variable/index.md
@@ -14,14 +14,27 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Inspect variables
+title: Manage and inspect variables
+menuTitle: Inspect variables
 description: Review and manage your dashboard variables
 weight: 200
 ---
 
-# Inspect variables
+# Manage and inspect variables
 
-The variables page lets you easily identify whether a variable is being referenced (or used) in other variables or dashboard. In addition, you can also [add][] and [manage variables][] on this page.
+The variables page lets you [add][] variables and [manage](#manage-variables) existing variables. It also allows you to [inspect](#inspect-variables) variables and identify whether a variable is being referenced (or used) in other variables or dashboard.
+
+## Manage variables
+
+You can take the following actions on the variables page:
+
+- **Move:** You can move a variable up or down the list using drag and drop.
+- **Clone:** To clone a variable, click the clone icon from the set of icons on the right. This creates a copy of the variable with the name of the original variable prefixed with `copy_of_`.
+- **Delete:** To delete a variable, click the trash icon from the set of icons on the right.
+
+## Inspect variables
+
+The variables page lets you easily identify whether a variable is being referenced (or used) in other variables or dashboard. In addition, you can also [add](ref:add) and [manage variables](#manage-variables) on this page.
 
 {{% admonition type="note" %}}
 This feature is available in Grafana 7.4 and later versions.


### PR DESCRIPTION
Backport 197ce3042d6760530a32819a924ddbf09bf0af2c from #87844

---

This PR:

- Updates `menuTitle` and page `title` of the **Manage variables** page to **Add variables**
- Updates the `title` of **Inspect variables** page to **Manage and inspect variables** (`menuTitle` remains as is)
- Moves the paragraph of “manage” content from the new **Add variables** page to the new **Manage and inspect variables** page

Justification

- This keeps everything that’s in the configuration UI on one page and everything on the **Variables** page UI on another page
- The original file name of the **Manage variables** page is add-tempate-variables and the content is primarily about adding them and all the different types that you can add
- When I was on the **Inspect variables** (docs) page and realized it was about actions you could take on the main **Variables** page in the UI, I expected to find the rest of the actions I could take on this page here
