### PR TITLE
Alerting docs: adds note on provisioning to main page

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/_index.md
@@ -68,6 +68,11 @@ Choose from the options below to import (or provision) your Grafana Alerting res
 1. Use the [Alerting provisioning HTTP API](ref:alerting_http_provisioning) to manage alerting resources.
 
    {{< admonition type="note" >}}
+
+   The Alerting provisioning HTTP API can be used to create, modify, and delete resources for Grafana-managed alerts.
+
+   To manage resources related to data source-managed alerts, including recording rules, use the Mimir or Cortex tool.
+
    The JSON output from the majority of Alerting HTTP endpoints isn't compatible for provisioning via configuration files.
 
    If you need the alerting resources for file provisioning, use [Export Alerting endpoints](/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/export-alerting-resources#export-api-endpoints) to return or download them in provisioning format.

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -6,9 +6,9 @@ labels:
 title: 'Alerting Provisioning HTTP API '
 ---
 
-The Alerting provisioning API can be used to create, modify, and delete resources relevant to [Grafana Managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}). And is the one used by our [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
+The Alerting provisioning API can be used to create, modify, and delete resources relevant to [Grafana-managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}). It is the one used by our [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 
-For managing resources related to [data source-managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}) including Recording Rules, you can use [Mimir tool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/) and [Cortex tool](https://github.com/grafana/cortex-tools#cortextool) respectively.
+To manage resources related to [data source-managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}), including recording rules, use the [Mimir tool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/) and [Cortex tool](https://github.com/grafana/cortex-tools#cortextool).
 
 ## Information
 


### PR DESCRIPTION
adds note to provisioning docs top level as per https://raintank-corp.slack.com/archives/C01LJ5F8NRX/p1716474171451409?thread_ts=1716469600.544579&cid=C01LJ5F8NRX
