### PR TITLE
Tempo: Support standard span convention

### DIFF
--- a/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
@@ -2,7 +2,7 @@ import { TraceSpan } from '../types';
 import { findHeaderTags } from './trace-viewer';
 
 describe('findHeaderTags()', () => {
-  it('returns an empty object when no spans are provided', () => {
+  it('return empty object when no spans are provided', () => {
     const spans: TraceSpan[] = [];
     expect(findHeaderTags(spans)).toEqual({});
   });

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
@@ -1,4 +1,5 @@
 import { TraceSpan } from '../types';
+
 import { findHeaderTags } from './trace-viewer';
 
 describe('findHeaderTags()', () => {

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
@@ -1,13 +1,15 @@
+import { TraceSpan } from '../types';
 import { findHeaderTags } from './trace-viewer';
 
 describe('findHeaderTags()', () => {
   it('returns an empty object when no spans are provided', () => {
-    const spans: any[] = [];
+    const spans: TraceSpan[] = [];
     expect(findHeaderTags(spans)).toEqual({});
   });
 
   it('return the header tags when spans follow the OTEL semantic convention', () => {
-    const spans: any[] = [
+    const spans: TraceSpan[] = [
+      // @ts-ignore
       {
         tags: [
           { key: 'http.request.method', value: 'GET' },
@@ -24,7 +26,8 @@ describe('findHeaderTags()', () => {
   });
 
   it('return the header tags when spans follow the alternative convention', () => {
-    const spans: any[] = [
+    const spans: TraceSpan[] = [
+      // @ts-ignore
       {
         tags: [
           { key: 'http.method', value: 'GET' },
@@ -32,6 +35,7 @@ describe('findHeaderTags()', () => {
           { key: 'http.path', value: '/api/users' },
         ],
       },
+      // @ts-ignore
       {
         tags: [
           { key: 'http.method', value: 'POST' },
@@ -48,7 +52,8 @@ describe('findHeaderTags()', () => {
   });
 
   it('return the header tags, prioritizing the spans that follow the OTEL semantinc convention', () => {
-    const spans: any[] = [
+    const spans: TraceSpan[] = [
+      // @ts-ignore
       {
         tags: [
           { key: 'http.method', value: 'GET' },
@@ -56,6 +61,7 @@ describe('findHeaderTags()', () => {
           { key: 'http.path', value: '/api/users' },
         ],
       },
+      // @ts-ignore
       {
         tags: [
           { key: 'http.request.method', value: 'POST' },

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.test.ts
@@ -7,7 +7,7 @@ describe('findHeaderTags()', () => {
     expect(findHeaderTags(spans)).toEqual({});
   });
 
-  it('return the header tags when spans follow the OTEL semantic convention', () => {
+  it('return header tags when spans follow the OTEL semantic convention', () => {
     const spans: TraceSpan[] = [
       // @ts-ignore
       {
@@ -25,7 +25,7 @@ describe('findHeaderTags()', () => {
     });
   });
 
-  it('return the header tags when spans follow the alternative convention', () => {
+  it('return header tags when spans follow the alternative convention', () => {
     const spans: TraceSpan[] = [
       // @ts-ignore
       {
@@ -51,7 +51,7 @@ describe('findHeaderTags()', () => {
     });
   });
 
-  it('return the header tags, prioritizing the spans that follow the OTEL semantinc convention', () => {
+  it('return header tags, prioritizing the spans that follow the OTEL semantinc convention', () => {
     const spans: TraceSpan[] = [
       // @ts-ignore
       {

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.ts
@@ -56,6 +56,8 @@ export const getTraceName = memoize(_getTraceNameImpl, (spans: TraceSpan[]) => {
   return spans[0].traceID;
 });
 
+// Find header tags according to either old standard (e..g, `http.method`) or the
+// standard semantic convention, as per https://opentelemetry.io/docs/specs/semconv/http/http-spans (e.g., `http.request.method`).
 export function findHeaderTags(spans: TraceSpan[]) {
   for (let i = 0; i < spans.length; i++) {
     const method = spans[i].tags.filter((tag) => {

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.ts
@@ -59,15 +59,15 @@ export const getTraceName = memoize(_getTraceNameImpl, (spans: TraceSpan[]) => {
 export function findHeaderTags(spans: TraceSpan[]) {
   for (let i = 0; i < spans.length; i++) {
     const method = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.method';
+      return tag.key === 'http.method' || tag.key === 'http.request.method';
     });
 
     const status = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.status_code';
+      return tag.key === 'http.status_code' || tag.key === 'http.response.status_code';
     });
 
     const url = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.url' || tag.key === 'http.target' || tag.key === 'http.path';
+      return tag.key === 'http.url' || tag.key === 'http.target' || tag.key === 'http.path' || tag.key === 'http.route';
     });
 
     if (method.length > 0 || status.length > 0 || url.length > 0) {

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.ts
@@ -57,26 +57,51 @@ export const getTraceName = memoize(_getTraceNameImpl, (spans: TraceSpan[]) => {
 });
 
 // Find header tags according to either old standard (e..g, `http.method`) or the
-// standard semantic convention, as per https://opentelemetry.io/docs/specs/semconv/http/http-spans 
-// (e.g., `http.request.method`). The standard semantic convention is preferred.
+// standard OTEL semantic convention, as per https://opentelemetry.io/docs/specs/semconv/http/http-spans
+// (e.g., `http.request.method`). Spans following the OTEL semantic convention are prioritized.
+//
+// Note that we are ignoring these cases:
+// - conventions are mixed, e.g., a span with method in `http.method` but status code in `http.response.status_code`
+// - tags are not in the same span, e.g., method in spans[0] but status in spans[1]
 export function findHeaderTags(spans: TraceSpan[]) {
+  // OTEL semantic convention
   for (let i = 0; i < spans.length; i++) {
     const method = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.request.method' || tag.key === 'http.method';
+      return tag.key === 'http.request.method';
     });
 
     const status = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.status_code' || tag.key === 'http.response.status_code';
+      return tag.key === 'http.response.status_code';
     });
 
     const url = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.route' || tag.key === 'http.url' || tag.key === 'http.target' || tag.key === 'http.path';
+      return tag.key === 'http.route';
     });
 
     if (method.length > 0 || status.length > 0 || url.length > 0) {
       return { method, status, url };
     }
   }
+
+  // Non-standard convention
+  for (let i = 0; i < spans.length; i++) {
+    const method = spans[i].tags.filter((tag) => {
+      return tag.key === 'http.method';
+    });
+
+    const status = spans[i].tags.filter((tag) => {
+      return tag.key === 'http.status_code';
+    });
+
+    const url = spans[i].tags.filter((tag) => {
+      return tag.key === 'http.url' || tag.key === 'http.target' || tag.key === 'http.path';
+    });
+
+    if (method.length > 0 || status.length > 0 || url.length > 0) {
+      return { method, status, url };
+    }
+  }
+
   return {};
 }
 

--- a/public/app/features/explore/TraceView/components/model/trace-viewer.ts
+++ b/public/app/features/explore/TraceView/components/model/trace-viewer.ts
@@ -57,11 +57,12 @@ export const getTraceName = memoize(_getTraceNameImpl, (spans: TraceSpan[]) => {
 });
 
 // Find header tags according to either old standard (e..g, `http.method`) or the
-// standard semantic convention, as per https://opentelemetry.io/docs/specs/semconv/http/http-spans (e.g., `http.request.method`).
+// standard semantic convention, as per https://opentelemetry.io/docs/specs/semconv/http/http-spans 
+// (e.g., `http.request.method`). The standard semantic convention is preferred.
 export function findHeaderTags(spans: TraceSpan[]) {
   for (let i = 0; i < spans.length; i++) {
     const method = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.method' || tag.key === 'http.request.method';
+      return tag.key === 'http.request.method' || tag.key === 'http.method';
     });
 
     const status = spans[i].tags.filter((tag) => {
@@ -69,7 +70,7 @@ export function findHeaderTags(spans: TraceSpan[]) {
     });
 
     const url = spans[i].tags.filter((tag) => {
-      return tag.key === 'http.url' || tag.key === 'http.target' || tag.key === 'http.path' || tag.key === 'http.route';
+      return tag.key === 'http.route' || tag.key === 'http.url' || tag.key === 'http.target' || tag.key === 'http.path';
     });
 
     if (method.length > 0 || status.length > 0 || url.length > 0) {


### PR DESCRIPTION
Add support for the [standard convention for spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/), thus allowing trace headers to be properly displayed, as with the old standard:
<img width="354" alt="image" src="https://github.com/grafana/grafana/assets/135109076/16c0adb0-5deb-4644-a7fb-929689b42f43">
