### PR TITLE
ButtonSelect: Render option custom component

### DIFF
--- a/packages/grafana-data/src/types/select.ts
+++ b/packages/grafana-data/src/types/select.ts
@@ -11,7 +11,7 @@ export interface SelectableValue<T = any> {
   description?: string;
   // Adds a simple native title attribute to each option.
   title?: string;
-  // Optional component that will be shown together with other options. Does not get past any props.
+  // Optional component that will be shown together with other options. Does not get passed any props.
   component?: React.ComponentType;
   isDisabled?: boolean;
   [key: string]: any;

--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -101,6 +101,7 @@ const ButtonSelectComponent = <T,>(props: Props<T>) => {
                   ariaChecked={item.value === value?.value}
                   ariaLabel={item.ariaLabel || item.label}
                   disabled={item.isDisabled}
+                  component={item.component}
                   role="menuitemradio"
                 />
               ))}

--- a/packages/grafana-ui/src/components/Menu/MenuItem.test.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.test.tsx
@@ -88,4 +88,10 @@ describe('MenuItem', () => {
     render(<MenuItem label="URL Item" url="/some-url" role="menuitem" />);
     expect(screen.getByRole('menuitem', { name: 'URL Item' })).toBeInTheDocument();
   });
+
+  it('renders extra component if provided', async () => {
+    render(<MenuItem label="main label" component={() => <p>extra content</p>} />);
+    expect(screen.getByText('main label')).toBeInTheDocument();
+    expect(screen.getByText('extra content')).toBeInTheDocument();
+  });
 });

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -59,6 +59,8 @@ export interface MenuItemProps<T = unknown> {
   shortcut?: string;
   /** Test id for e2e tests and fullstory*/
   testId?: string;
+  /* Optional component that will be shown together with other options. Does not get passed any props. */
+  component?: React.ComponentType;
 }
 
 /** @internal */
@@ -202,6 +204,7 @@ export const MenuItem = React.memo(
             {description}
           </div>
         )}
+        {props.component ? <props.component /> : null}
       </ItemElement>
     );
   })


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

`ButtonSelect` options accept `component` property, but it is not actually rendered by the underlying `MenuItem`. This PR makes underlying `MenuItem` render the custom component, aligning `ButtonSelect` with `Select` in this regard.

**Why do we need this feature?**

It is sometimes useful to add extra custom conent to options. For example, a link to configuration page or docs, like here for App o11y: 
![menu item component](https://github.com/grafana/grafana/assets/847684/db1b210f-f376-44dd-ad41-098c59d06662)



Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
