### PR TITLE
TextLink: Honor className provided via props

### DIFF
--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { AnchorHTMLAttributes, forwardRef } from 'react';
 
 import { GrafanaTheme2, locationUtil, textUtil, ThemeTypographyVariantTypes } from '@grafana/data';
@@ -45,7 +45,18 @@ const svgSizes: {
 
 export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
   (
-    { href, color = 'link', external = false, inline = true, variant = 'body', weight, icon, children, ...rest },
+    {
+      href,
+      color = 'link',
+      external = false,
+      inline = true,
+      variant = 'body',
+      weight,
+      icon,
+      children,
+      className,
+      ...rest
+    },
     ref
   ) => {
     const validUrl = textUtil.sanitizeUrl(href ?? '');
@@ -56,7 +67,7 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
 
     if (external) {
       return (
-        <a href={validUrl} ref={ref} {...rest} target="_blank" rel="noreferrer" className={styles}>
+        <a href={validUrl} ref={ref} {...rest} target="_blank" rel="noreferrer" className={cx(styles, className)}>
           {children}
           <Icon size={svgSizes[variant] || 'md'} name={externalIcon} />
         </a>
@@ -66,7 +77,7 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
     const strippedUrl = locationUtil.stripBaseFromUrl(validUrl);
 
     return (
-      <Link ref={ref} href={strippedUrl} {...rest} className={styles}>
+      <Link ref={ref} href={strippedUrl} {...rest} className={cx(styles, className)}>
         {children}
         {icon && <Icon name={icon} size={svgSizes[variant] || 'md'} />}
       </Link>


### PR DESCRIPTION
**What is this feature?**

`TextLink`  accepts `className` prop but does not use it. This PR makes `TextLink` honor the `className` prop.

**Why do we need this feature?**

Have a use case to add a class name to a `TextLink` to adjust positioning :bow: 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
