### PR TITLE
Docs: add decoupled plugin commands to developer guide

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -81,11 +81,22 @@ Once `yarn start` has built the assets, it will continue to do so whenever any o
 
 > Troubleshooting: if your first build works, but after pulling updates you see unexpected errors in the "Type-checking in progress..." stage, these can be caused by the [tsbuildinfo cache supporting incremental builds](https://www.typescriptlang.org/tsconfig#incremental). You can `rm tsconfig.tsbuildinfo` and re-try.
 
-#### External plugins
+#### Plugins
 
-If you are looking to contribute to any of the plugins found within the `public/app/plugins` directory they require running additional commands to watch and rebuild them.
+If you are looking to contribute to any of the plugins listed below (that are found within the `public/app/plugins` directory) they require running additional commands to watch and rebuild them.
 
-To build and watch all plugins you can run the following command. Note this can be quite resource intensive as it will start separate build processes for each external plugin.
+- azuremonitor
+- cloud-monitoring
+- grafana-postgresql-datasource
+- grafana-pyroscope-datasource
+- grafana-testdata-datasource
+- jaegar
+- mysql
+- parca
+- tempo
+- zipkin
+
+To build and watch all these plugins you can run the following command. Note this can be quite resource intensive as it will start separate build processes for each plugin.
 
 ```
 yarn plugin:build:dev

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -81,9 +81,11 @@ Once `yarn start` has built the assets, it will continue to do so whenever any o
 
 > Troubleshooting: if your first build works, but after pulling updates you see unexpected errors in the "Type-checking in progress..." stage, these can be caused by the [tsbuildinfo cache supporting incremental builds](https://www.typescriptlang.org/tsconfig#incremental). You can `rm tsconfig.tsbuildinfo` and re-try.
 
+#### External plugins
+
 If you are looking to contribute to any of the external plugins found within the `public/app/plugins` directory they require running additional commands to watch and rebuild them.
 
-To build and watch all external plugins you can run the following command. Please be aware this can be quite resource intensive as it will spin up separate build processes for each external plugin.
+To build and watch all external plugins you can run the following command. Note this can be quite resource intensive as it will start separate build processes for each external plugin.
 
 ```
 yarn plugin:build:dev

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -83,15 +83,15 @@ Once `yarn start` has built the assets, it will continue to do so whenever any o
 
 #### External plugins
 
-If you are looking to contribute to any of the external plugins found within the `public/app/plugins` directory they require running additional commands to watch and rebuild them.
+If you are looking to contribute to any of the plugins found within the `public/app/plugins` directory they require running additional commands to watch and rebuild them.
 
-To build and watch all external plugins you can run the following command. Note this can be quite resource intensive as it will start separate build processes for each external plugin.
+To build and watch all plugins you can run the following command. Note this can be quite resource intensive as it will start separate build processes for each external plugin.
 
 ```
 yarn plugin:build:dev
 ```
 
-If, instead, you would like to build and watch a specific external plugin you can run the following command. Make sure to substitute `<name_of_plugin>` with the plugins name field found in its package.json. e.g. `@grafana-plugins/tempo`.
+If, instead, you would like to build and watch a specific plugin you can run the following command. Make sure to substitute `<name_of_plugin>` with the plugins name field found in its package.json. e.g. `@grafana-plugins/tempo`.
 
 ```
 yarn workspace <name_of_plugin> dev

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -77,9 +77,23 @@ yarn start
 ```
 
 This command will generate sass theme files, build all external plugins, then build the frontend assets.
-Once `yarn start` has built the assets, it will continue to do so whenever any of the files change. This means you don't have to manually build the assets every time you change the code.
+Once `yarn start` has built the assets, it will continue to do so whenever any of the core Grafana application files change. This means you don't have to manually build the assets every time you change the code.
 
 > Troubleshooting: if your first build works, but after pulling updates you see unexpected errors in the "Type-checking in progress..." stage, these can be caused by the [tsbuildinfo cache supporting incremental builds](https://www.typescriptlang.org/tsconfig#incremental). You can `rm tsconfig.tsbuildinfo` and re-try.
+
+If you are looking to contribute to any of the external plugins found within the `public/app/plugins` directory they require running additional commands to watch and rebuild them.
+
+To build and watch all external plugins you can run the following command. Please be aware this can be quite resource intensive as it will spin up separate build processes for each external plugin.
+
+```
+yarn plugin:build:dev
+```
+
+If, instead, you would like to build and watch a specific external plugin you can run the following command. Make sure to substitute `<name_of_plugin>` with the plugins name field found in its package.json. e.g. `@grafana-plugins/tempo`.
+
+```
+yarn workspace <name_of_plugin> dev
+```
 
 Next, we'll build & run the web server that will serve the frontend assets we just built.
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates the developer guide to include commands for building / watching the frontend portion of decoupled plugins.

**Why do we need this feature?**

So contributors have reference to which commands to run to develop which part of the codebase.

**Who is this feature for?**

Grafana contributors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
