### PR TITLE
Plugins: Update the `plugin.json` schema with UI extensions meta-data

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -556,33 +556,27 @@
         }
       }
     },
-    "generated": {
-      "type": "object",
-      "description": "Auto-generated metadata for the plugin (usually automatically extracted from the source code during build time).",
-      "properties": {
-        "extensions": {
-          "type": "array",
-          "description": "List of the extensions that the plugin registers.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "extensionPointId": {
-                "type": "string"
-              },
-              "title": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              },
-              "type": {
-                "type": "string",
-                "enum": ["link", "component"]
-              }
-            },
-            "required": ["extensionPointId", "title", "description", "type"]
+    "extensions": {
+      "type": "array",
+      "description": "List of the extensions that the plugin registers.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "extensionPointId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["link", "component"]
           }
-        }
+        },
+        "required": ["extensionPointId", "title", "type"]
       }
     },
     "apiVersion": {

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -558,7 +558,7 @@
     },
     "extensions": {
       "type": "array",
-      "description": "List of the extensions that the plugin registers.",
+      "description": "The list of extensions that the plugin registers under other extension points.",
       "items": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
### What changed?

https://github.com/grafana/grafana/pull/86520 updated the schema with a field called `generated: { ... }`, which was planned to be filled automatically by the [plugin meta extractor](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-meta-extractor). Unfortunately we have hit some walls with that tool, in a sense that it cannot reliably analyze the different app plugin implementation patterns, so **we have decided to make this part of the plugin.json manually editable for now.** This decision involves updating the name of property, and also reduces the nesting.

**Breaking change?** 
Ideally the `generated: {}` property only got added to the built bundle for a few plugins, and as such it shouldn't cause any issues getting rid of it (as it was not added to the source code it should not cause issues with schema validation during development). Once we update create-plugin as well the tool will not add this property during build-time to `dist/plugin.json` either, which means that it should be automatically removed in future plugin submissions.