### PR TITLE
Alerting: Add rule_group label to grafana_alerting_rule_group_rules metric

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -121,7 +121,6 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 			},
 			[]string{"org"},
 		),
-		// TODO: partition on rule group as well as tenant, similar to loki|cortex.
 		GroupRules: promauto.With(r).NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: Namespace,
@@ -129,7 +128,7 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Name:      "rule_group_rules",
 				Help:      "The number of alert rules that are scheduled, both active and paused.",
 			},
-			[]string{"org", "state"},
+			[]string{"org", "state", "rule_group"},
 		),
 		Groups: promauto.With(r).NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -467,7 +467,7 @@ type AlertRuleGroupKey struct {
 	RuleGroup    string
 }
 
-type AlertRuleGroupWithFolderTitleKey struct {
+type AlertRuleGroupKeyWithFolderTitle struct {
 	AlertRuleGroupKey
 	FolderTitle string
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -467,9 +467,9 @@ type AlertRuleGroupKey struct {
 	RuleGroup    string
 }
 
-type AlertRuleGroupKeyWithFolderTitle struct {
+type AlertRuleGroupKeyWithFolderFullpath struct {
 	AlertRuleGroupKey
-	FolderTitle string
+	FolderFullpath string
 }
 
 func (k AlertRuleGroupKey) String() string {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -467,6 +467,11 @@ type AlertRuleGroupKey struct {
 	RuleGroup    string
 }
 
+type AlertRuleGroupWithFolderTitleKey struct {
+	AlertRuleGroupKey
+	FolderTitle string
+}
+
 func (k AlertRuleGroupKey) String() string {
 	return fmt.Sprintf("{orgID: %d, namespaceUID: %s, groupName: %s}", k.OrgID, k.NamespaceUID, k.RuleGroup)
 }

--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -32,19 +32,29 @@ func sortedUIDs(alertRules []*models.AlertRule) []string {
 	return uids
 }
 
+// updateRulesMetrics updates metrics for alert rules.
+// Keeps a state in the schedule between calls to delete metrics for rules that are no longer present.
 func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	rulesPerOrgFolderGroup := make(map[models.AlertRuleGroupWithFolderTitleKey]int64)       // AlertRuleGroupWithFolderTitle -> count
 	rulesPerOrgFolderGroupPaused := make(map[models.AlertRuleGroupWithFolderTitleKey]int64) // AlertRuleGroupWithFolderTitle -> count
 	orgsNfSettings := make(map[int64]int64)                                                 // orgID -> count
 	groupsPerOrg := make(map[int64]map[string]struct{})                                     // orgID -> set of groups
 
+	// Remember what orgs and alert groups we process in the current update metrics call,
+	// so we can delete metrics for orgs and groups that are no longer present in the new state.
+	updateMetricsForOrgsAndGroups := map[int64]map[models.AlertRuleGroupWithFolderTitleKey]struct{}{} // orgID -> set of AlertRuleGroupWithFolderTitle
+
 	for _, rule := range alertRules {
 		key := models.AlertRuleGroupWithFolderTitleKey{
 			AlertRuleGroupKey: rule.GetGroupKey(),
 			FolderTitle:       sch.schedulableAlertRules.folderTitles[rule.GetFolderKey()],
 		}
-
 		rulesPerOrgFolderGroup[key]++
+
+		if _, ok := updateMetricsForOrgsAndGroups[rule.OrgID]; !ok {
+			updateMetricsForOrgsAndGroups[rule.OrgID] = make(map[models.AlertRuleGroupWithFolderTitleKey]struct{})
+		}
+		updateMetricsForOrgsAndGroups[rule.OrgID][key] = struct{}{}
 
 		if rule.IsPaused {
 			rulesPerOrgFolderGroupPaused[key]++
@@ -64,21 +74,57 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 
 	for key, numRules := range rulesPerOrgFolderGroup {
 		numRulesPaused := rulesPerOrgFolderGroupPaused[key]
-		ruleGroupLabelValue := fmt.Sprintf("%s;%s", key.FolderTitle, key.AlertRuleGroupKey.RuleGroup)
+		ruleGroupLabelValue := makeRuleGroupLabelValue(key)
 		sch.metrics.GroupRules.WithLabelValues(fmt.Sprint(key.OrgID), metrics.AlertRuleActiveLabelValue, ruleGroupLabelValue).Set(float64(numRules - numRulesPaused))
 		sch.metrics.GroupRules.WithLabelValues(fmt.Sprint(key.OrgID), metrics.AlertRulePausedLabelValue, ruleGroupLabelValue).Set(float64(numRulesPaused))
 	}
 
-	for orgID, count := range orgsNfSettings {
-		sch.metrics.SimpleNotificationRules.WithLabelValues(fmt.Sprint(orgID)).Set(float64(count))
-	}
-
-	for orgID, groups := range groupsPerOrg {
-		sch.metrics.Groups.WithLabelValues(fmt.Sprint(orgID)).Set(float64(len(groups)))
+	for orgID := range updateMetricsForOrgsAndGroups {
+		sch.metrics.SimpleNotificationRules.WithLabelValues(fmt.Sprint(orgID)).Set(float64(orgsNfSettings[orgID]))
+		sch.metrics.Groups.WithLabelValues(fmt.Sprint(orgID)).Set(float64(len(groupsPerOrg[orgID])))
 	}
 
 	// While these are the rules that we iterate over, at the moment there's no 100% guarantee that they'll be
 	// scheduled as rules could be removed before we get a chance to evaluate them.
 	sch.metrics.SchedulableAlertRules.Set(float64(len(alertRules)))
 	sch.metrics.SchedulableAlertRulesHash.Set(float64(hashUIDs(alertRules)))
+
+	// Delete metrics for rule groups and orgs that are no longer present in the new state
+	for orgID, alertRuleGroupsMap := range sch.lastUpdatedMetricsForOrgsAndGroups {
+		if orgOrGroupDeleted(updateMetricsForOrgsAndGroups, orgID, nil) {
+			sch.metrics.SimpleNotificationRules.DeleteLabelValues(fmt.Sprint(orgID))
+			sch.metrics.Groups.DeleteLabelValues(fmt.Sprint(orgID))
+		}
+
+		for key := range alertRuleGroupsMap {
+			if orgOrGroupDeleted(updateMetricsForOrgsAndGroups, orgID, &key) {
+				ruleGroupLabelValue := makeRuleGroupLabelValue(key)
+				sch.metrics.GroupRules.DeleteLabelValues(fmt.Sprint(key.AlertRuleGroupKey.OrgID), metrics.AlertRuleActiveLabelValue, ruleGroupLabelValue)
+				sch.metrics.GroupRules.DeleteLabelValues(fmt.Sprint(key.AlertRuleGroupKey.OrgID), metrics.AlertRulePausedLabelValue, ruleGroupLabelValue)
+			}
+		}
+	}
+
+	// update the call state
+	sch.lastUpdatedMetricsForOrgsAndGroups = updateMetricsForOrgsAndGroups
+}
+
+// makeRuleGroupLabelValue returns a string that can be used as a label (rule_group) value for alert rule group metrics.
+func makeRuleGroupLabelValue(key models.AlertRuleGroupWithFolderTitleKey) string {
+	return fmt.Sprintf("%s;%s", key.FolderTitle, key.AlertRuleGroupKey.RuleGroup)
+}
+
+// orgOrGroupDeleted returns true if the org or group is no longer present in the new update metrics state.
+func orgOrGroupDeleted(updateMetrics map[int64]map[models.AlertRuleGroupWithFolderTitleKey]struct{}, orgID int64, alertRuleGroupKey *models.AlertRuleGroupWithFolderTitleKey) bool {
+	if _, ok := updateMetrics[orgID]; !ok {
+		return true
+	}
+
+	if alertRuleGroupKey != nil {
+		if _, ok := updateMetrics[orgID][*alertRuleGroupKey]; !ok {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -35,24 +35,24 @@ func sortedUIDs(alertRules []*models.AlertRule) []string {
 // updateRulesMetrics updates metrics for alert rules.
 // Keeps a state in the schedule between calls to delete metrics for rules that are no longer present.
 func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
-	rulesPerOrgFolderGroup := make(map[models.AlertRuleGroupKeyWithFolderTitle]int64)       // AlertRuleGroupWithFolderTitle -> count
-	rulesPerOrgFolderGroupPaused := make(map[models.AlertRuleGroupKeyWithFolderTitle]int64) // AlertRuleGroupWithFolderTitle -> count
-	orgsNfSettings := make(map[int64]int64)                                                 // orgID -> count
-	groupsPerOrg := make(map[int64]map[string]struct{})                                     // orgID -> set of groups
+	rulesPerOrgFolderGroup := make(map[models.AlertRuleGroupKeyWithFolderFullpath]int64)       // AlertRuleGroupKeyWithFolderFullpath -> count
+	rulesPerOrgFolderGroupPaused := make(map[models.AlertRuleGroupKeyWithFolderFullpath]int64) // AlertRuleGroupKeyWithFolderFullpath -> count
+	orgsNfSettings := make(map[int64]int64)                                                    // orgID -> count
+	groupsPerOrg := make(map[int64]map[string]struct{})                                        // orgID -> set of groups
 
 	// Remember what orgs and alert groups we process in the current update metrics call,
 	// so we can delete metrics for orgs and groups that are no longer present in the new state.
-	updateMetricsForOrgsAndGroups := map[int64]map[models.AlertRuleGroupKeyWithFolderTitle]struct{}{} // orgID -> set of AlertRuleGroupWithFolderTitle
+	updateMetricsForOrgsAndGroups := map[int64]map[models.AlertRuleGroupKeyWithFolderFullpath]struct{}{} // orgID -> set of AlertRuleGroupWithFolderTitle
 
 	for _, rule := range alertRules {
-		key := models.AlertRuleGroupKeyWithFolderTitle{
+		key := models.AlertRuleGroupKeyWithFolderFullpath{
 			AlertRuleGroupKey: rule.GetGroupKey(),
-			FolderTitle:       sch.schedulableAlertRules.folderTitles[rule.GetFolderKey()],
+			FolderFullpath:    sch.schedulableAlertRules.folderTitles[rule.GetFolderKey()],
 		}
 		rulesPerOrgFolderGroup[key]++
 
 		if _, ok := updateMetricsForOrgsAndGroups[rule.OrgID]; !ok {
-			updateMetricsForOrgsAndGroups[rule.OrgID] = make(map[models.AlertRuleGroupKeyWithFolderTitle]struct{})
+			updateMetricsForOrgsAndGroups[rule.OrgID] = make(map[models.AlertRuleGroupKeyWithFolderFullpath]struct{})
 		}
 		updateMetricsForOrgsAndGroups[rule.OrgID][key] = struct{}{}
 
@@ -110,12 +110,12 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 }
 
 // makeRuleGroupLabelValue returns a string that can be used as a label (rule_group) value for alert rule group metrics.
-func makeRuleGroupLabelValue(key models.AlertRuleGroupKeyWithFolderTitle) string {
-	return fmt.Sprintf("%s;%s", key.FolderTitle, key.AlertRuleGroupKey.RuleGroup)
+func makeRuleGroupLabelValue(key models.AlertRuleGroupKeyWithFolderFullpath) string {
+	return fmt.Sprintf("%s;%s", key.FolderFullpath, key.AlertRuleGroupKey.RuleGroup)
 }
 
 // orgOrGroupDeleted returns true if the org or group is no longer present in the new update metrics state.
-func orgOrGroupDeleted(updateMetrics map[int64]map[models.AlertRuleGroupKeyWithFolderTitle]struct{}, orgID int64, alertRuleGroupKey *models.AlertRuleGroupKeyWithFolderTitle) bool {
+func orgOrGroupDeleted(updateMetrics map[int64]map[models.AlertRuleGroupKeyWithFolderFullpath]struct{}, orgID int64, alertRuleGroupKey *models.AlertRuleGroupKeyWithFolderFullpath) bool {
 	if _, ok := updateMetrics[orgID]; !ok {
 		return true
 	}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -87,6 +87,10 @@ type schedule struct {
 	featureToggles       featuremgmt.FeatureToggles
 
 	metrics *metrics.Scheduler
+	// metricsUpdateCalledWithGroups contains AlertRuleGroupWithFolderTitleKeys that
+	// were passed to updateRulesMetrics in the current tick. This is used to
+	// delete metrics for the rules/groups that are not longer present.
+	lastUpdatedMetricsForOrgsAndGroups map[int64]map[ngmodels.AlertRuleGroupWithFolderTitleKey]struct{} // orgID -> set of AlertRuleGroupWithFolderTitleKey
 
 	alertsSender    AlertsSender
 	minRuleInterval time.Duration
@@ -130,24 +134,25 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 	}
 
 	sch := schedule{
-		registry:              newRuleRegistry(),
-		maxAttempts:           cfg.MaxAttempts,
-		clock:                 cfg.C,
-		baseInterval:          cfg.BaseInterval,
-		log:                   cfg.Log,
-		evaluatorFactory:      cfg.EvaluatorFactory,
-		ruleStore:             cfg.RuleStore,
-		metrics:               cfg.Metrics,
-		appURL:                cfg.AppURL,
-		disableGrafanaFolder:  cfg.DisableGrafanaFolder,
-		jitterEvaluations:     cfg.JitterEvaluations,
-		featureToggles:        cfg.FeatureToggles,
-		stateManager:          stateManager,
-		minRuleInterval:       cfg.MinRuleInterval,
-		schedulableAlertRules: alertRulesRegistry{rules: make(map[ngmodels.AlertRuleKey]*ngmodels.AlertRule)},
-		alertsSender:          cfg.AlertSender,
-		tracer:                cfg.Tracer,
-		recordingWriter:       cfg.RecordingWriter,
+		registry:                           newRuleRegistry(),
+		maxAttempts:                        cfg.MaxAttempts,
+		clock:                              cfg.C,
+		baseInterval:                       cfg.BaseInterval,
+		log:                                cfg.Log,
+		evaluatorFactory:                   cfg.EvaluatorFactory,
+		ruleStore:                          cfg.RuleStore,
+		metrics:                            cfg.Metrics,
+		lastUpdatedMetricsForOrgsAndGroups: make(map[int64]map[ngmodels.AlertRuleGroupWithFolderTitleKey]struct{}),
+		appURL:                             cfg.AppURL,
+		disableGrafanaFolder:               cfg.DisableGrafanaFolder,
+		jitterEvaluations:                  cfg.JitterEvaluations,
+		featureToggles:                     cfg.FeatureToggles,
+		stateManager:                       stateManager,
+		minRuleInterval:                    cfg.MinRuleInterval,
+		schedulableAlertRules:              alertRulesRegistry{rules: make(map[ngmodels.AlertRuleKey]*ngmodels.AlertRule)},
+		alertsSender:                       cfg.AlertSender,
+		tracer:                             cfg.Tracer,
+		recordingWriter:                    cfg.RecordingWriter,
 	}
 
 	return &sch

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -87,10 +87,10 @@ type schedule struct {
 	featureToggles       featuremgmt.FeatureToggles
 
 	metrics *metrics.Scheduler
-	// metricsUpdateCalledWithGroups contains AlertRuleGroupWithFolderTitleKeys that
+	// metricsUpdateCalledWithGroups contains AlertRuleGroupKeyWithFolderTitles that
 	// were passed to updateRulesMetrics in the current tick. This is used to
 	// delete metrics for the rules/groups that are not longer present.
-	lastUpdatedMetricsForOrgsAndGroups map[int64]map[ngmodels.AlertRuleGroupWithFolderTitleKey]struct{} // orgID -> set of AlertRuleGroupWithFolderTitleKey
+	lastUpdatedMetricsForOrgsAndGroups map[int64]map[ngmodels.AlertRuleGroupKeyWithFolderTitle]struct{} // orgID -> set of AlertRuleGroupKeyWithFolderTitle
 
 	alertsSender    AlertsSender
 	minRuleInterval time.Duration
@@ -142,7 +142,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 		evaluatorFactory:                   cfg.EvaluatorFactory,
 		ruleStore:                          cfg.RuleStore,
 		metrics:                            cfg.Metrics,
-		lastUpdatedMetricsForOrgsAndGroups: make(map[int64]map[ngmodels.AlertRuleGroupWithFolderTitleKey]struct{}),
+		lastUpdatedMetricsForOrgsAndGroups: make(map[int64]map[ngmodels.AlertRuleGroupKeyWithFolderTitle]struct{}),
 		appURL:                             cfg.AppURL,
 		disableGrafanaFolder:               cfg.DisableGrafanaFolder,
 		jitterEvaluations:                  cfg.JitterEvaluations,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -87,10 +87,10 @@ type schedule struct {
 	featureToggles       featuremgmt.FeatureToggles
 
 	metrics *metrics.Scheduler
-	// metricsUpdateCalledWithGroups contains AlertRuleGroupKeyWithFolderTitles that
+	// lastUpdatedMetricsForOrgsAndGroups contains AlertRuleGroupKeyWithFolderFullpaths that
 	// were passed to updateRulesMetrics in the current tick. This is used to
 	// delete metrics for the rules/groups that are not longer present.
-	lastUpdatedMetricsForOrgsAndGroups map[int64]map[ngmodels.AlertRuleGroupKeyWithFolderTitle]struct{} // orgID -> set of AlertRuleGroupKeyWithFolderTitle
+	lastUpdatedMetricsForOrgsAndGroups map[int64]map[ngmodels.AlertRuleGroupKeyWithFolderFullpath]struct{} // orgID -> set of AlertRuleGroupKeyWithFolderFullpath
 
 	alertsSender    AlertsSender
 	minRuleInterval time.Duration
@@ -142,7 +142,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 		evaluatorFactory:                   cfg.EvaluatorFactory,
 		ruleStore:                          cfg.RuleStore,
 		metrics:                            cfg.Metrics,
-		lastUpdatedMetricsForOrgsAndGroups: make(map[int64]map[ngmodels.AlertRuleGroupKeyWithFolderTitle]struct{}),
+		lastUpdatedMetricsForOrgsAndGroups: make(map[int64]map[ngmodels.AlertRuleGroupKeyWithFolderFullpath]struct{}),
 		appURL:                             cfg.AppURL,
 		disableGrafanaFolder:               cfg.DisableGrafanaFolder,
 		jitterEvaluations:                  cfg.JitterEvaluations,

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -66,7 +66,7 @@ func (f *fakeRulesStore) GetAlertRulesForScheduling(ctx context.Context, query *
 	query.ResultFoldersTitles = map[models.FolderKey]string{}
 	for _, rule := range f.rules {
 		query.ResultRules = append(query.ResultRules, rule)
-		key := models.FolderKey{OrgID: rule.OrgID, UID: rule.UID}
+		key := models.FolderKey{OrgID: rule.OrgID, UID: rule.NamespaceUID}
 		query.ResultFoldersTitles[key] = f.getNamespaceTitle(rule.NamespaceUID)
 	}
 	return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add `rule_group` label to `grafana_alerting_rule_group_rules` metric (#62361)

---

This PR also addresses the issue where the GroupRules metric (a GaugeVec) keeps its value and is not deleted when an alert rule is removed from the rule registry. 

Previously, when an alert rule with `orgID=1` was active, the metric was:

```
grafana_alerting_rule_group_rules{org="1",state="active"} 1
```

However, after deleting this rule, following calls to `updateRulesMetrics` did not update the gauge value, causing the metric to incorrectly remain at 1.

The fix ensures that when `updateRulesMetrics` is called it also deletes the group rule metrics if needed.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
