### PR TITLE
Chore: Remove msagl related config in yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -21,10 +21,6 @@ packageExtensions:
     peerDependencies:
       react: 17.0.1
       react-dom: 17.0.1
-  '@msagl/drawing@*':
-    dependencies:
-      queue-typescript: '^1.0.1'
-      '@esfx/collections-sortedmap': '^1.0.0'
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-outdated.cjs


### PR DESCRIPTION
The msagl library was removed recently https://github.com/grafana/grafana/pull/87905 but I missed this part that seems to still make yarn try to install it.