### PR TITLE
Alerting: Add filters for RouteGetRuleStatuses

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -235,7 +235,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 	return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 }
 
-func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager, store RuleStore, opts RuleGroupStatusesOptions) apimodels.RuleResponse {
+func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager, store ListAlertRulesStore, opts RuleGroupStatusesOptions) apimodels.RuleResponse {
 	ruleResponse := apimodels.RuleResponse{
 		DiscoveryBase: apimodels.DiscoveryBase{
 			Status: "success",

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -235,6 +235,9 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 	return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 }
 
+// TODO: Refactor this function to reduce the cylomatic complexity
+//
+//nolint:gocyclo
 func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager, store ListAlertRulesStore, opts RuleGroupStatusesOptions) apimodels.RuleResponse {
 	ruleResponse := apimodels.RuleResponse{
 		DiscoveryBase: apimodels.DiscoveryBase{

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -304,12 +304,7 @@ func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager
 		}
 	}
 
-	var ruleGroups []string
-	rgParam := opts.Query.Get("rule_group")
-	if rgParam != "" {
-		rgParamSplit := strings.Split(rgParam, ",")
-		ruleGroups = rgParamSplit
-	}
+	ruleGroups := opts.Query["rule_group"]
 
 	alertRuleQuery := ngmodels.ListAlertRulesQuery{
 		OrgID:         opts.OrgID,
@@ -326,11 +321,7 @@ func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager
 		return ruleResponse
 	}
 
-	var ruleNames []string
-	rnParam := opts.Query.Get("rule_name")
-	if rnParam != "" {
-		ruleNames = strings.Split(rnParam, ",")
-	}
+	ruleNames := opts.Query["rule_name"]
 	ruleNamesSet := make(map[string]struct{}, len(ruleNames))
 	for _, rn := range ruleNames {
 		ruleNamesSet[rn] = struct{}{}

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -629,8 +629,6 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			require.Len(t, result.Data.RuleGroups[0].Rules, 1)
 			require.Len(t, result.Data.RuleGroups[1].Rules, 1)
 
-			fmt.Println(result.Data.RuleGroups[0], result.Data.RuleGroups[1])
-			require.True(t, false)
 			if result.Data.RuleGroups[0].Name == "rule-group-2" {
 				require.Equal(t, expectedRuleInGroup2.Title, result.Data.RuleGroups[0].Rules[0].Name)
 				require.Equal(t, expectedRuleInGroup3.Title, result.Data.RuleGroups[1].Rules[0].Name)

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -586,7 +586,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		})
 
 		t.Run("should only return rule groups under given rule_group list", func(t *testing.T) {
-			r, err := http.NewRequest("GET", "/api/v1/rules?rule_group=rule-group-1,rule-group-2", nil)
+			r, err := http.NewRequest("GET", "/api/v1/rules?rule_group=rule-group-1&rule_group=rule-group-2", nil)
 			require.NoError(t, err)
 
 			c.Context = &web.Context{Req: r}
@@ -609,7 +609,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			expectedRuleInGroup2 := rulesInGroup2[0]
 			expectedRuleInGroup3 := rulesInGroup3[0]
 
-			r, err := http.NewRequest("GET", fmt.Sprintf("/api/v1/rules?rule_name=%s,%s", expectedRuleInGroup2.Title, expectedRuleInGroup3.Title), nil)
+			r, err := http.NewRequest("GET", fmt.Sprintf("/api/v1/rules?rule_name=%s&rule_name=%s", expectedRuleInGroup2.Title, expectedRuleInGroup3.Title), nil)
 			require.NoError(t, err)
 
 			c.Context = &web.Context{Req: r}

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -524,6 +525,119 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 					require.Fail(t, fmt.Sprintf("rules are not sorted by group index. Expected: %v. Actual: %v", expectedNames, actualNames))
 				}
 			}
+		})
+	})
+
+	t.Run("test folder, group and rule name query params", func(t *testing.T) {
+		ruleStore := fakes.NewRuleStore(t)
+		fakeAIM := NewFakeAlertInstanceManager(t)
+
+		rulesInGroup1 := gen.With(gen.WithGroupKey(ngmodels.AlertRuleGroupKey{
+			RuleGroup:    "rule-group-1",
+			NamespaceUID: "folder-1",
+			OrgID:        orgID,
+		})).GenerateManyRef(1)
+
+		rulesInGroup2 := gen.With(gen.WithGroupKey(ngmodels.AlertRuleGroupKey{
+			RuleGroup:    "rule-group-2",
+			NamespaceUID: "folder-2",
+			OrgID:        orgID,
+		})).GenerateManyRef(2)
+
+		rulesInGroup3 := gen.With(gen.WithGroupKey(ngmodels.AlertRuleGroupKey{
+			RuleGroup:    "rule-group-3",
+			NamespaceUID: "folder-1",
+			OrgID:        orgID,
+		})).GenerateManyRef(3)
+
+		ruleStore.PutRule(context.Background(), rulesInGroup1...)
+		ruleStore.PutRule(context.Background(), rulesInGroup2...)
+		ruleStore.PutRule(context.Background(), rulesInGroup3...)
+
+		api := PrometheusSrv{
+			log:     log.NewNopLogger(),
+			manager: fakeAIM,
+			store:   ruleStore,
+			authz:   accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures())),
+		}
+
+		permissions := createPermissionsForRules(slices.Concat(rulesInGroup1, rulesInGroup2, rulesInGroup3), orgID)
+		user := &user.SignedInUser{
+			OrgID:       orgID,
+			Permissions: permissions,
+		}
+		c := &contextmodel.ReqContext{
+			SignedInUser: user,
+		}
+		t.Run("should only return rule groups under given folder_uid", func(t *testing.T) {
+			r, err := http.NewRequest("GET", "/api/v1/rules?folder_uid=folder-1", nil)
+			require.NoError(t, err)
+
+			c.Context = &web.Context{Req: r}
+
+			resp := api.RouteGetRuleStatuses(c)
+			require.Equal(t, http.StatusOK, resp.Status())
+			result := &apimodels.RuleResponse{}
+			require.NoError(t, json.Unmarshal(resp.Body(), result))
+
+			require.Len(t, result.Data.RuleGroups, 2)
+			require.Equal(t, "rule-group-1", result.Data.RuleGroups[0].Name)
+			require.Equal(t, "rule-group-3", result.Data.RuleGroups[1].Name)
+		})
+
+		t.Run("should only return rule groups under given rule_group", func(t *testing.T) {
+			r, err := http.NewRequest("GET", "/api/v1/rules?rule_group=rule-group-1", nil)
+			require.NoError(t, err)
+
+			c.Context = &web.Context{Req: r}
+
+			resp := api.RouteGetRuleStatuses(c)
+			require.Equal(t, http.StatusOK, resp.Status())
+			result := &apimodels.RuleResponse{}
+			require.NoError(t, json.Unmarshal(resp.Body(), result))
+
+			require.Len(t, result.Data.RuleGroups, 1)
+			require.Equal(t, "rule-group-1", result.Data.RuleGroups[0].Name)
+			require.Len(t, result.Data.RuleGroups[0].Rules, 1)
+		})
+
+		t.Run("should only return rule with given rule_name", func(t *testing.T) {
+			expectedRule := rulesInGroup3[0]
+			r, err := http.NewRequest("GET", fmt.Sprintf("/api/v1/rules?rule_name=%s", expectedRule.Title), nil)
+			require.NoError(t, err)
+
+			c.Context = &web.Context{Req: r}
+
+			resp := api.RouteGetRuleStatuses(c)
+			require.Equal(t, http.StatusOK, resp.Status())
+			result := &apimodels.RuleResponse{}
+			require.NoError(t, json.Unmarshal(resp.Body(), result))
+
+			require.Len(t, result.Data.RuleGroups, 1)
+			require.Equal(t, "rule-group-3", result.Data.RuleGroups[0].Name)
+			require.Len(t, result.Data.RuleGroups[0].Rules, 1)
+			require.Equal(t, expectedRule.Title, result.Data.RuleGroups[0].Rules[0].Name)
+		})
+
+		t.Run("should only return rule with given folder_uid, rule_group and rule_name", func(t *testing.T) {
+			expectedRule := rulesInGroup3[2]
+			r, err := http.NewRequest("GET", fmt.Sprintf("/api/v1/rules?folder_uid=folder-1&rule_group=rule-group-3&rule_name=%s", expectedRule.Title), nil)
+			require.NoError(t, err)
+
+			c.Context = &web.Context{Req: r}
+
+			resp := api.RouteGetRuleStatuses(c)
+			require.Equal(t, http.StatusOK, resp.Status())
+			result := &apimodels.RuleResponse{}
+			require.NoError(t, json.Unmarshal(resp.Body(), result))
+
+			require.Len(t, result.Data.RuleGroups, 1)
+			folder, err := api.store.GetNamespaceByUID(context.Background(), "folder-1", orgID, user)
+			require.NoError(t, err)
+			require.Equal(t, folder.Fullpath, result.Data.RuleGroups[0].File)
+			require.Equal(t, "rule-group-3", result.Data.RuleGroups[0].Name)
+			require.Len(t, result.Data.RuleGroups[0].Rules, 1)
+			require.Equal(t, expectedRule.Title, result.Data.RuleGroups[0].Rules[0].Name)
 		})
 	})
 


### PR DESCRIPTION
**What is this feature?**
Adds filters for `folder_uid`, `rule_group` and `rule_name` in the `/api/prometheus/grafana/api/v1/rules` endpoint, for example: `/api/prometheus/grafana/api/v1/rules?folder_uid=folder&rule_group=group&rule_name=name`

**Why do we need this feature?**
Allows the optimization of the frontend to be able to render the View and Edit rule pages for GMA much faster (see https://github.com/grafana/grafana/pull/87625)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
