### PR TITLE
Alerting: update `Set evaluation behavior` text

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
@@ -28,7 +28,7 @@ export const CloudEvaluationBehavior = () => {
     <RuleEditorSection stepNo={3} title="Set evaluation behavior">
       <Field
         label="Pending period"
-        description="Period in which an alert rule can be in breach of the condition until the alert rule fires."
+        description='Period the threshold condition must be met to trigger the alert. Selecting "None" triggers the alert immediately once the condition is met.'
       >
         <div className={styles.flexRow}>
           <Field invalid={!!errors.forTime?.message} error={errors.forTime?.message} className={styles.inlineField}>

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -202,9 +202,9 @@ export function FolderAndGroup({
       <Stack alignItems="center">
         <div style={{ width: 420 }}>
           <Field
-            label="Evaluation group"
+            label="Evaluation group and interval"
             data-testid="group-picker"
-            description="Rules within the same group are evaluated concurrently over the same time interval."
+            description="Define how often the alert rule is evaluated."
             className={styles.formInput}
             error={errors.group?.message}
             invalid={!!errors.group?.message}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -391,7 +391,11 @@ function EvaluationGroupCreationModal({
       <FormProvider {...formAPI}>
         <form onSubmit={handleSubmit(() => onSubmit())}>
           <Field
-            label={<Label htmlFor={'group'}>Evaluation group name</Label>}
+            label={
+              <Label htmlFor={'group'} description="A group evaluates all its rules over the same evaluation interval.">
+                Evaluation group
+              </Label>
+            }
             error={formState.errors.group?.message}
             invalid={Boolean(formState.errors.group)}
           >

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -181,7 +181,7 @@ function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
         label={
           <Label
             htmlFor="evaluateFor"
-            description="Period in which an alert rule can be in breach of the condition until the alert rule fires."
+            description='Period the threshold condition must be met to trigger the alert. Selecting "None" triggers the alert immediately once the condition is met.'
           >
             Pending period
           </Label>
@@ -232,10 +232,22 @@ function getDescription() {
         Define how the alert rule is evaluated.
       </Text>
       <NeedHelpInfo
-        contentText="Evaluation groups are containers for evaluating alert and recording rules. An evaluation group defines an evaluation interval - how often a rule is checked. Alert rules within the same evaluation group are evaluated sequentially"
+        contentText={
+          <>
+            <p>Evaluation groups are containers for evaluating alert and recording rules.</p>
+            <p>
+              An evaluation group defines an evaluation interval - how often a rule is evaluated. Alert rules within the
+              same evaluation group are evaluated over the same evaluation interval.
+            </p>
+            <p>
+              Pending period specifies how long the threshold condition must be met before the alert starts firing. This
+              option helps prevent alerts from being triggered by temporary issues.
+            </p>
+          </>
+        }
         externalLink={docsLink}
-        linkText={`Read about evaluation`}
-        title="Evaluation"
+        linkText={`Read about evaluation and alert states`}
+        title="Alert rule evaluation"
       />
     </Stack>
   );

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -293,7 +293,14 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               </Stack>
             )}
             <Field
-              label={<Label htmlFor="groupName">Evaluation group name</Label>}
+              label={
+                <Label
+                  htmlFor="groupName"
+                  description="A group evaluates all its rules over the same evaluation interval."
+                >
+                  Evaluation group
+                </Label>
+              }
               invalid={!!errors.groupName}
               error={errors.groupName?.message}
             >


### PR DESCRIPTION
Minor changes to the descriptions of the `Set evaluation behaviour` options in the Alert rule creation.

This change attempts to align the copy with the latest update of the [Alert rule evaluation docs](https://grafana.com/docs/grafana/next/alerting/fundamentals/alert-rule-evaluation/). 


![Screenshot 2024-05-24 at 17 35 36](https://github.com/grafana/grafana/assets/825430/ea2294e1-6da4-4f2a-ab42-51bd1d05ace9)

<img width="660" alt="Screenshot 2024-05-27 at 13 12 15" src="https://github.com/grafana/grafana/assets/825430/7f45d018-3849-4daf-86e8-351b3ddeb036">


<img width="546" alt="Screenshot 2024-05-27 at 13 12 08" src="https://github.com/grafana/grafana/assets/825430/6b24bc84-b336-478c-a92b-ef464dc3b6e0">



