### PR TITLE
Alerting: Scheduled recording rules execute their queries

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -270,6 +270,7 @@ func (ng *AlertNG) init() error {
 		AppURL:               appUrl,
 		EvaluatorFactory:     evalFactory,
 		RuleStore:            ng.store,
+		FeatureToggles:       ng.FeatureToggles,
 		Metrics:              ng.Metrics.GetSchedulerMetrics(),
 		AlertSender:          alertsRouter,
 		Tracer:               ng.tracer,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -66,6 +66,7 @@ func newRuleFactory(
 				evalFactory,
 				logger,
 				met,
+				tracer,
 			)
 		}
 		return newAlertRule(

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -59,7 +59,14 @@ func newRuleFactory(
 ) ruleFactoryFunc {
 	return func(ctx context.Context, rule *ngmodels.AlertRule) Rule {
 		if rule.IsRecordingRule() {
-			return newRecordingRule(ctx, logger)
+			return newRecordingRule(
+				ctx,
+				maxAttempts,
+				clock,
+				evalFactory,
+				logger,
+				met,
+			)
 		}
 		return newAlertRule(
 			ctx,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -51,6 +52,7 @@ func newRuleFactory(
 	evalFactory eval.EvaluatorFactory,
 	ruleProvider ruleProvider,
 	clock clock.Clock,
+	featureToggles featuremgmt.FeatureToggles,
 	met *metrics.Scheduler,
 	logger log.Logger,
 	tracer tracing.Tracer,
@@ -64,6 +66,7 @@ func newRuleFactory(
 				maxAttempts,
 				clock,
 				evalFactory,
+				featureToggles,
 				logger,
 				met,
 				tracer,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -251,7 +251,7 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 
 				for attempt := int64(1); attempt <= a.maxAttempts; attempt++ {
 					isPaused := ctx.rule.IsPaused
-					f := ruleWithFolder{ctx.rule, ctx.folderTitle}.Fingerprint()
+					f := ctx.Fingerprint()
 					// Do not clean up state if the eval loop has just started.
 					var needReset bool
 					if currentFingerprint != 0 && currentFingerprint != f {

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -185,12 +185,12 @@ func TestAlertRule(t *testing.T) {
 			require.False(t, success)
 			require.Nilf(t, dropped, "expected no dropped evaluations but got one")
 		})
-		t.Run("stop should do nothing", func(t *testing.T) {
+		t.Run("calling stop multiple times should not panic", func(t *testing.T) {
 			r := blankRuleForTests(context.Background())
 			r.Stop(nil)
 			r.Stop(nil)
 		})
-		t.Run("stop should do nothing if parent context stopped", func(t *testing.T) {
+		t.Run("stop should not panic if parent context stopped", func(t *testing.T) {
 			ctx, cancelFn := context.WithCancel(context.Background())
 			r := blankRuleForTests(ctx)
 			cancelFn()

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -765,5 +765,5 @@ func TestRuleRoutine(t *testing.T) {
 }
 
 func ruleFactoryFromScheduler(sch *schedule) ruleFactory {
-	return newRuleFactory(sch.appURL, sch.disableGrafanaFolder, sch.maxAttempts, sch.alertsSender, sch.stateManager, sch.evaluatorFactory, &sch.schedulableAlertRules, sch.clock, sch.metrics, sch.log, sch.tracer, sch.evalAppliedFunc, sch.stopAppliedFunc)
+	return newRuleFactory(sch.appURL, sch.disableGrafanaFolder, sch.maxAttempts, sch.alertsSender, sch.stateManager, sch.evaluatorFactory, &sch.schedulableAlertRules, sch.clock, sch.featureToggles, sch.metrics, sch.log, sch.tracer, sch.evalAppliedFunc, sch.stopAppliedFunc)
 }

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -2,30 +2,60 @@ package schedule
 
 import (
 	context "context"
+	"fmt"
+	"time"
 
+	"github.com/benbjohnson/clock"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
 )
 
 type recordingRule struct {
 	ctx    context.Context
+	evalCh chan *Evaluation
 	stopFn util.CancelCauseFunc
 
-	logger log.Logger
+	maxAttempts int64
+
+	clock       clock.Clock
+	evalFactory eval.EvaluatorFactory
+
+	logger  log.Logger
+	metrics *metrics.Scheduler
 }
 
-func newRecordingRule(parent context.Context, logger log.Logger) *recordingRule {
+func newRecordingRule(parent context.Context, maxAttempts int64, clock clock.Clock, evalFactory eval.EvaluatorFactory, logger log.Logger, metrics *metrics.Scheduler) *recordingRule {
 	ctx, stop := util.WithCancelCause(parent)
 	return &recordingRule{
-		ctx:    ctx,
-		stopFn: stop,
-		logger: logger,
+		ctx:         ctx,
+		evalCh:      make(chan *Evaluation),
+		stopFn:      stop,
+		clock:       clock,
+		evalFactory: evalFactory,
+		maxAttempts: maxAttempts,
+		logger:      logger,
+		metrics:     metrics,
 	}
 }
 
 func (r *recordingRule) Eval(eval *Evaluation) (bool, *Evaluation) {
-	return true, nil
+	// read the channel in unblocking manner to make sure that there is no concurrent send operation.
+	var droppedMsg *Evaluation
+	select {
+	case droppedMsg = <-r.evalCh:
+	default:
+	}
+
+	select {
+	case r.evalCh <- eval:
+		return true, droppedMsg
+	case <-r.ctx.Done():
+		return false, droppedMsg
+	}
 }
 
 func (r *recordingRule) Update(lastVersion RuleVersionAndPauseStatus) bool {
@@ -46,9 +76,99 @@ func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
 	// nolint:gosimple
 	for {
 		select {
+		case eval, ok := <-r.evalCh:
+			if !ok {
+				logger.Debug("Evaluation channel has been closed. Exiting")
+				return nil
+			}
+			// TODO: evalRunning shed inprogress?
+
+			r.doEvaluate(ctx, eval)
 		case <-ctx.Done():
 			logger.Debug("Stopping recording rule routine")
 			return nil
 		}
 	}
+}
+
+func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
+	// TODO: Fingerprint or other things in log context
+	logger := r.logger.FromContext(ctx).New("now", ev.scheduledAt)
+	orgID := fmt.Sprint(ev.rule.OrgID)
+	evalDuration := r.metrics.EvalDuration.WithLabelValues(orgID)
+	evalTotal := r.metrics.EvalTotal.WithLabelValues(orgID)
+	// TODO: evalRunning
+	evalStart := r.clock.Now()
+
+	defer func() {
+		evalTotal.Inc()
+		evalDuration.Observe(r.clock.Now().Sub(evalStart).Seconds())
+	}()
+
+	if ev.rule.IsPaused {
+		logger.Debug("Skip recording rule evaluation because it is paused")
+	}
+
+	// TODO: tracing
+
+	for attempt := int64(1); attempt <= r.maxAttempts; attempt++ {
+		logger := logger.New("attempt", attempt)
+		if ctx.Err() != nil {
+			logger.Error("Skipping recording rule evaluation because context has been cancelled")
+			return
+		}
+
+		err := r.tryEvaluate(ctx, ev, logger)
+		if err == nil {
+			return
+		}
+
+		logger.Error("Failed to evaluate rule", "attempt", attempt, "error", err)
+		select {
+		case <-ctx.Done():
+			logger.Error("Context has been cancelled while backing off", "attempt", attempt)
+			return
+		case <-time.After(retryDelay):
+			continue
+		}
+	}
+}
+
+func (r *recordingRule) tryEvaluate(ctx context.Context, ev *Evaluation, logger log.Logger) error {
+	orgID := fmt.Sprint(ev.rule.OrgID)
+	evalAttemptTotal := r.metrics.EvalAttemptTotal.WithLabelValues(orgID)
+	evalAttemptFailures := r.metrics.EvalAttemptFailures.WithLabelValues(orgID)
+	evalTotalFailures := r.metrics.EvalFailures.WithLabelValues(orgID)
+
+	start := r.clock.Now()
+	evalCtx := eval.NewContext(ctx, SchedulerUserFor(ev.rule.OrgID))
+	result, err := r.buildAndExecutePipeline(ctx, evalCtx, ev, logger)
+	dur := r.clock.Now().Sub(start)
+
+	evalAttemptTotal.Inc()
+
+	// TODO: In some cases, err can be nil but the dataframe itself contains embedded error frames. Parse these out like we do when evaluating alert rules.
+	if err != nil {
+		evalAttemptFailures.Inc()
+		// TODO: Only errors embedded in the frame can be considered retryable.
+		// TODO: Since we are not handling these yet per the above TODO, we can blindly consider all errors to be non-retryable for now, and just exit.
+		evalTotalFailures.Inc()
+		return fmt.Errorf("server side expressions pipeline returned an error: %w")
+	}
+
+	logger.Debug("Alert rule evaluated", "results", result, "duration", dur)
+}
+
+func (r *recordingRule) buildAndExecutePipeline(ctx context.Context, evalCtx eval.EvaluationContext, ev *Evaluation, logger log.Logger) (*backend.QueryDataResponse, error) {
+	start := r.clock.Now()
+	evaluator, err := r.evalFactory.Create(evalCtx, ev.rule.GetEvalCondition())
+	if err != nil {
+		logger.Error("Failed to build rule evaluator", "error", err)
+		return nil, err
+	}
+	results, err := evaluator.EvaluateRaw(ctx, ev.scheduledAt)
+	if err != nil {
+		logger.Error("Failed to evaluate rule", "error", err, "duration", r.clock.Now().Sub(start))
+	}
+	return results, err
 }

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -122,6 +122,7 @@ func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
 
 	if ev.rule.IsPaused {
 		logger.Debug("Skip recording rule evaluation because it is paused")
+		return
 	}
 
 	ctx, span := r.tracer.Start(ctx, "recording rule execution", trace.WithAttributes(

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -93,8 +93,7 @@ func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
 }
 
 func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
-	// TODO: Fingerprint or other things in log context
-	logger := r.logger.FromContext(ctx).New("now", ev.scheduledAt)
+	logger := r.logger.FromContext(ctx).New("now", ev.scheduledAt, "fingerprint", ev.Fingerprint())
 	orgID := fmt.Sprint(ev.rule.OrgID)
 	evalDuration := r.metrics.EvalDuration.WithLabelValues(orgID)
 	evalTotal := r.metrics.EvalTotal.WithLabelValues(orgID)
@@ -119,7 +118,7 @@ func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
 			return
 		}
 
-		err := r.tryEvaluate(ctx, ev, logger)
+		err := r.tryEvaluation(ctx, ev, logger)
 		if err == nil {
 			return
 		}
@@ -135,7 +134,7 @@ func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
 	}
 }
 
-func (r *recordingRule) tryEvaluate(ctx context.Context, ev *Evaluation, logger log.Logger) error {
+func (r *recordingRule) tryEvaluation(ctx context.Context, ev *Evaluation, logger log.Logger) error {
 	orgID := fmt.Sprint(ev.rule.OrgID)
 	evalAttemptTotal := r.metrics.EvalAttemptTotal.WithLabelValues(orgID)
 	evalAttemptFailures := r.metrics.EvalAttemptFailures.WithLabelValues(orgID)

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -153,7 +153,7 @@ func (r *recordingRule) tryEvaluate(ctx context.Context, ev *Evaluation, logger 
 		// TODO: Only errors embedded in the frame can be considered retryable.
 		// TODO: Since we are not handling these yet per the above TODO, we can blindly consider all errors to be non-retryable for now, and just exit.
 		evalTotalFailures.Inc()
-		return fmt.Errorf("server side expressions pipeline returned an error: %w")
+		return fmt.Errorf("server side expressions pipeline returned an error: %w", err)
 	}
 
 	logger.Debug("Alert rule evaluated", "results", result, "duration", dur)

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -73,7 +73,6 @@ func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
 	logger := r.logger.FromContext(ctx)
 	logger.Debug("Recording rule routine started")
 
-	// nolint:gosimple
 	for {
 		select {
 		case eval, ok := <-r.evalCh:
@@ -81,6 +80,8 @@ func (r *recordingRule) Run(key ngmodels.AlertRuleKey) error {
 				logger.Debug("Evaluation channel has been closed. Exiting")
 				return nil
 			}
+			// TODO: No-op if feature toggle is not on!
+
 			// TODO: evalRunning shed inprogress?
 
 			r.doEvaluate(ctx, eval)

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -148,6 +148,7 @@ func (r *recordingRule) tryEvaluate(ctx context.Context, ev *Evaluation, logger 
 	evalAttemptTotal.Inc()
 
 	// TODO: In some cases, err can be nil but the dataframe itself contains embedded error frames. Parse these out like we do when evaluating alert rules.
+	// TODO: (Maybe, refactor something in eval package so we can use shared code for this)
 	if err != nil {
 		evalAttemptFailures.Inc()
 		// TODO: Only errors embedded in the frame can be considered retryable.

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -157,6 +157,7 @@ func (r *recordingRule) tryEvaluate(ctx context.Context, ev *Evaluation, logger 
 	}
 
 	logger.Debug("Alert rule evaluated", "results", result, "duration", dur)
+	return nil
 }
 
 func (r *recordingRule) buildAndExecutePipeline(ctx context.Context, evalCtx eval.EvaluationContext, ev *Evaluation, logger log.Logger) (*backend.QueryDataResponse, error) {

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -198,8 +198,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 			grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d"} 0
 			grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d"} 1
 			# HELP grafana_alerting_rule_evaluations_total The total number of rule evaluations.
-        	# TYPE grafana_alerting_rule_evaluations_total counter
-        	grafana_alerting_rule_evaluations_total{org="%[1]d"} 1
+			# TYPE grafana_alerting_rule_evaluations_total counter
+			grafana_alerting_rule_evaluations_total{org="%[1]d"} 1
 			# HELP grafana_alerting_rule_evaluation_attempts_total The total number of rule evaluation attempts.
             # TYPE grafana_alerting_rule_evaluation_attempts_total counter
             grafana_alerting_rule_evaluation_attempts_total{org="%[1]d"} 1

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	models "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
@@ -144,7 +145,8 @@ func TestRecordingRule(t *testing.T) {
 }
 
 func blankRecordingRuleForTests(ctx context.Context) *recordingRule {
-	return newRecordingRule(context.Background(), 0, nil, nil, log.NewNopLogger(), nil, nil)
+	ft := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaManagedRecordingRules)
+	return newRecordingRule(context.Background(), 0, nil, nil, ft, log.NewNopLogger(), nil, nil)
 }
 
 func TestRecordingRule_Integration(t *testing.T) {

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -2,34 +2,122 @@ package schedule
 
 import (
 	context "context"
+	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
 	models "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecordingRule(t *testing.T) {
-	gen := models.RuleGen.With(models.RuleGen.WithRecordingRules())
+	gen := models.RuleGen.With(models.RuleGen.WithAllRecordingRules())
+	// evalRetval carries the return value of Rule.Eval() calls.
+	type evalRetval struct {
+		success     bool
+		droppedEval *Evaluation
+	}
 
 	t.Run("when rule evaluation is not stopped", func(t *testing.T) {
+		t.Run("eval should send to evalCh", func(t *testing.T) {
+			r := blankRecordingRuleForTests(context.Background())
+			expected := time.Now()
+			resultCh := make(chan evalRetval)
+			data := &Evaluation{
+				scheduledAt: expected,
+				rule:        gen.GenerateRef(),
+				folderTitle: util.GenerateShortUID(),
+			}
 
+			go func() {
+				result, dropped := r.Eval(data)
+				resultCh <- evalRetval{result, dropped}
+			}()
+
+			select {
+			case ctx := <-r.evalCh:
+				require.Equal(t, data, ctx)
+				result := <-resultCh // blocks
+				require.True(t, result.success)
+				require.Nilf(t, result.droppedEval, "expected no dropped evaluations but got one")
+			case <-time.After(5 * time.Second):
+				t.Fatal("No message was received on eval channel")
+			}
+		})
 	})
 
 	t.Run("when rule evaluation is stopped", func(t *testing.T) {
 		t.Run("eval should do nothing", func(t *testing.T) {
-			r := blankRuleForTests(context.Background())
+			r := blankRecordingRuleForTests(context.Background())
 			r.Stop(nil)
 			ev := &Evaluation{
 				scheduledAt: time.Now(),
 				rule:        gen.GenerateRef(),
 				folderTitle: util.GenerateShortUID(),
 			}
+
+			success, dropped := r.Eval(ev)
+
+			require.False(t, success)
+			require.Nilf(t, dropped, "expected no dropped evaluations but got one")
+		})
+
+		t.Run("calling stop multiple times should not panic", func(t *testing.T) {
+			r := blankRecordingRuleForTests(context.Background())
+			r.Stop(nil)
+			r.Stop(nil)
+		})
+
+		t.Run("stop should not panic if parent context stopped", func(t *testing.T) {
+			ctx, cancelFn := context.WithCancel(context.Background())
+			r := blankRecordingRuleForTests(ctx)
+			cancelFn()
+			r.Stop(nil)
 		})
 	})
 
 	t.Run("should be thread-safe", func(t *testing.T) {
+		r := blankRecordingRuleForTests(context.Background())
+		wg := sync.WaitGroup{}
+		go func() {
+			for {
+				select {
+				case <-r.evalCh:
+					time.Sleep(time.Microsecond)
+				case <-r.ctx.Done():
+					return
+				}
+			}
+		}()
 
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				for i := 0; i < 20; i++ {
+					max := 3
+					if i <= 10 {
+						max = 2
+					}
+					switch rand.Intn(max) + 1 {
+					case 1:
+						r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
+					case 2:
+						r.Eval(&Evaluation{
+							scheduledAt: time.Now(),
+							rule:        gen.GenerateRef(),
+							folderTitle: util.GenerateShortUID(),
+						})
+					case 3:
+						r.Stop(nil)
+					}
+				}
+				wg.Done()
+			}()
+		}
+
+		wg.Wait()
 	})
 }
 

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -180,10 +180,10 @@ func TestRecordingRule_Integration(t *testing.T) {
 		expectedMetric := fmt.Sprintf(
 			`
 			# HELP grafana_alerting_rule_evaluation_duration_seconds The time to evaluate a rule.
-        	# TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
-        	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
-        	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
-        	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+			# TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
+			grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+			grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+			grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
 			grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
 			grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
 			grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -201,8 +201,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 			# TYPE grafana_alerting_rule_evaluations_total counter
 			grafana_alerting_rule_evaluations_total{org="%[1]d"} 1
 			# HELP grafana_alerting_rule_evaluation_attempts_total The total number of rule evaluation attempts.
-            # TYPE grafana_alerting_rule_evaluation_attempts_total counter
-            grafana_alerting_rule_evaluation_attempts_total{org="%[1]d"} 1
+			 # TYPE grafana_alerting_rule_evaluation_attempts_total counter
+			grafana_alerting_rule_evaluation_attempts_total{org="%[1]d"} 1
 			`,
 			rule.OrgID,
 		)

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -1,0 +1,38 @@
+package schedule
+
+import (
+	context "context"
+	"testing"
+	"time"
+
+	models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+func TestRecordingRule(t *testing.T) {
+	gen := models.RuleGen.With(models.RuleGen.WithRecordingRules())
+
+	t.Run("when rule evaluation is not stopped", func(t *testing.T) {
+
+	})
+
+	t.Run("when rule evaluation is stopped", func(t *testing.T) {
+		t.Run("eval should do nothing", func(t *testing.T) {
+			r := blankRuleForTests(context.Background())
+			r.Stop(nil)
+			ev := &Evaluation{
+				scheduledAt: time.Now(),
+				rule:        gen.GenerateRef(),
+				folderTitle: util.GenerateShortUID(),
+			}
+		})
+	})
+
+	t.Run("should be thread-safe", func(t *testing.T) {
+
+	})
+}
+
+func blankRecordingRuleForTests(ctx context.Context) *recordingRule {
+	return newRecordingRule(context.Background(), 0, nil, nil, nil, nil)
+}

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -87,6 +87,10 @@ type Evaluation struct {
 	folderTitle string
 }
 
+func (e *Evaluation) Fingerprint() fingerprint {
+	return ruleWithFolder{e.rule, e.folderTitle}.Fingerprint()
+}
+
 type alertRulesRegistry struct {
 	rules        map[models.AlertRuleKey]*models.AlertRule
 	folderTitles map[models.FolderKey]string

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -77,6 +78,7 @@ type schedule struct {
 	appURL               *url.URL
 	disableGrafanaFolder bool
 	jitterEvaluations    JitterStrategy
+	featureToggles       featuremgmt.FeatureToggles
 
 	metrics *metrics.Scheduler
 
@@ -99,6 +101,7 @@ type SchedulerCfg struct {
 	C                    clock.Clock
 	MinRuleInterval      time.Duration
 	DisableGrafanaFolder bool
+	FeatureToggles       featuremgmt.FeatureToggles
 	AppURL               *url.URL
 	JitterEvaluations    JitterStrategy
 	EvaluatorFactory     eval.EvaluatorFactory
@@ -129,6 +132,7 @@ func NewScheduler(cfg SchedulerCfg, stateManager *state.Manager) *schedule {
 		appURL:                cfg.AppURL,
 		disableGrafanaFolder:  cfg.DisableGrafanaFolder,
 		jitterEvaluations:     cfg.JitterEvaluations,
+		featureToggles:        cfg.FeatureToggles,
 		stateManager:          stateManager,
 		minRuleInterval:       cfg.MinRuleInterval,
 		schedulableAlertRules: alertRulesRegistry{rules: make(map[ngmodels.AlertRuleKey]*ngmodels.AlertRule)},
@@ -246,6 +250,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		sch.evaluatorFactory,
 		&sch.schedulableAlertRules,
 		sch.clock,
+		sch.featureToggles,
 		sch.metrics,
 		sch.log,
 		sch.tracer,

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -466,6 +466,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 		AppURL:           appUrl,
 		EvaluatorFactory: evaluator,
 		RuleStore:        rs,
+		FeatureToggles:   featuremgmt.WithFeatures(featuremgmt.FlagGrafanaManagedRecordingRules),
 		Metrics:          m.GetSchedulerMetrics(),
 		AlertSender:      senderMock,
 		Tracer:           testTracer,

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -436,7 +436,7 @@ func setupScheduler(t *testing.T, rs *fakeRulesStore, is *state.FakeInstanceStor
 
 	var evaluator = evalMock
 	if evalMock == nil {
-		evaluator = eval.NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, nil, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, featuremgmt.WithFeatures(), nil, tracing.InitializeTracerForTest()), &pluginstore.FakePluginStore{})
+		evaluator = eval.NewEvaluatorFactory(setting.UnifiedAlertingSettings{}, &datasources.FakeCacheService{}, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil, featuremgmt.WithFeatures(), nil, tracing.InitializeTracerForTest()), &pluginstore.FakePluginStore{})
 	}
 
 	if registry == nil {


### PR DESCRIPTION
**What is this feature?**

Extends the recording rule shim to execute the query defined in the rule.

Right now it does nothing with the results other than log them. Queries look like alert rule queries, metrics update accordingly. This is skipped if the feature toggle is disabled.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
