### PR TITLE
Alerting: Remove dead `evalRunning` guard in rule routine

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -203,7 +203,6 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 	logger := a.logger.FromContext(grafanaCtx)
 	logger.Debug("Alert rule routine started")
 
-	evalRunning := false
 	var currentFingerprint fingerprint
 	defer a.stopApplied(key)
 	for {
@@ -225,19 +224,14 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 				logger.Debug("Evaluation channel has been closed. Exiting")
 				return nil
 			}
-			if evalRunning {
-				continue
-			}
 
 			func() {
 				orgID := fmt.Sprint(key.OrgID)
 				evalDuration := a.metrics.EvalDuration.WithLabelValues(orgID)
 				evalTotal := a.metrics.EvalTotal.WithLabelValues(orgID)
 
-				evalRunning = true
 				evalStart := a.clock.Now()
 				defer func() {
-					evalRunning = false
 					a.evalApplied(key, ctx.scheduledAt)
 					evalDuration.Observe(a.clock.Now().Sub(evalStart).Seconds())
 				}()


### PR DESCRIPTION
**What is this feature?**

This guard seems intended to shed evaluations if the previous one is long-running.

However, it doesn't work, and appears to be dead code.

The guard is entirely handled in the rule routine, which is entirely single-threaded. (Much of the code here heavily depends on this, so this is not likely to change.) In the case of a long-running evaluation, the rule routine will simply keep processing the current one, and eventually set evalRunning back to false before consuming the next evaluation.

So, `evalRunning` can only ever possibly be false when it's read.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
