### PR TITLE
ExploreMetrics: Adjust wording to improve clarity

### DIFF
--- a/public/app/features/trails/DataTrailsHome.tsx
+++ b/public/app/features/trails/DataTrailsHome.tsx
@@ -65,7 +65,7 @@ export class DataTrailsHome extends SceneObjectBase<DataTrailsHomeState> {
 
         <Stack gap={5}>
           <div className={styles.column}>
-            <Text variant="h4">Recent metrics</Text>
+            <Text variant="h4">Recent metrics explorations</Text>
             <div className={styles.trailList}>
               {getTrailStore().recent.map((trail, index) => {
                 const resolvedTrail = trail.resolve();


### PR DESCRIPTION
## What is this change?

Per discussion with @darrenjaneczek, this PR slightly rewords the recent metrics section of `/explore/metrics`, in hopes of improving clarity:

![explore metrics rewording of recent metrics section in explore metrics home](https://github.com/grafana/grafana/assets/5732000/65e991f3-9e02-48c2-81b7-67ae67d5e080)

## Who is this feature for?

Explore Metrics users.