### PR TITLE
test: cypress update

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "core-js": "3.37.0",
     "css-loader": "7.1.1",
     "css-minimizer-webpack-plugin": "6.0.0",
-    "cypress": "13.1.0",
+    "cypress": "13.2.0",
     "cypress-file-upload": "5.0.8",
     "esbuild": "0.20.2",
     "esbuild-loader": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8654,14 +8654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^16.18.39":
-  version: 16.18.50
-  resolution: "@types/node@npm:16.18.50"
-  checksum: 10/86269db1724621f1a9af9ed37cbb6bc91bfe7a525e99d6aac168fc63371b634d49da15f94db26f593ada226d01fd64aa32a4dd0ee3732c36043056293c586416
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^18.0.0":
+"@types/node@npm:^18.0.0, @types/node@npm:^18.17.5":
   version: 18.19.33
   resolution: "@types/node@npm:18.19.33"
   dependencies:
@@ -13053,13 +13046,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:13.1.0":
-  version: 13.1.0
-  resolution: "cypress@npm:13.1.0"
+"cypress@npm:13.2.0":
+  version: 13.2.0
+  resolution: "cypress@npm:13.2.0"
   dependencies:
     "@cypress/request": "npm:^3.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
-    "@types/node": "npm:^16.18.39"
+    "@types/node": "npm:^18.17.5"
     "@types/sinonjs__fake-timers": "npm:8.1.1"
     "@types/sizzle": "npm:^2.3.2"
     arch: "npm:^2.2.0"
@@ -13102,7 +13095,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10/8e96041503497ca1c1bbcfbd7fa679683ca338fa1b76557fe8f3e4926fc61efd15ccdd0d269146515b6743a1845886aaf1d6cfb72e143a5c57bff6853a18cb92
+  checksum: 10/dde4fde5c543e44dfb7de626b3f2bb7cb1703310fca1c047fbf20e1ac2db939cbe674516be8a406eafe45e6baec397e0fa9c6e73db2eef5f1021a7dffbdda3d2
   languageName: node
   linkType: hard
 
@@ -16844,7 +16837,7 @@ __metadata:
     core-js: "npm:3.37.0"
     css-loader: "npm:7.1.1"
     css-minimizer-webpack-plugin: "npm:6.0.0"
-    cypress: "npm:13.1.0"
+    cypress: "npm:13.2.0"
     cypress-file-upload: "npm:5.0.8"
     d3: "npm:7.9.0"
     d3-force: "npm:3.0.0"


### PR DESCRIPTION
the [cypress-update-pr](https://github.com/grafana/grafana/pull/84140) is failing, so i'm checking which upgrade breaks:

- `13.1.0`: GOOD
- `13.2.0`: BAD
- `13.5.0`: BAD
- `13.8.0`: BAD
- `13.10.0`: BAD