### PR TITLE
Plugins: Re-introduce and deprecate the `generated` field in the plugin.json

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -556,6 +556,36 @@
         }
       }
     },
+    "generated": {
+      "type": "object",
+      "description": "Deprecated! Please update your plugin by running `npx @grafana/create-plugin@latest update` to update the format of your generated plugin.json file.",
+      "deprecated": true,
+      "properties": {
+        "extensions": {
+          "type": "array",
+          "description": "List of the extensions that the plugin registers.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "extensionPointId": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": ["link", "component"]
+              }
+            },
+            "required": ["extensionPointId", "title", "description", "type"]
+          }
+        }
+      }
+    },
     "extensions": {
       "type": "array",
       "description": "The list of extensions that the plugin registers under other extension points.",


### PR DESCRIPTION
### What changed?

In https://github.com/grafana/grafana/pull/88288 I have removed the automatically added `"generated"` field from the plugin.json schema, which is causing warnings in our plugin submission validation pipelines. This PR is fixing this by re-introducing the property and deprecating it. 

(The property will be automatically removed from the generated plugin.json once the developer updates their plugin using `npx @grafana/create-plugin@latest update`).