### PR TITLE
Azure Monitor: Fix typo that may cause an API request to fail

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/datasource.ts
@@ -164,7 +164,7 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
   getMetricNamespaces(subscriptionId: string, resourceGroup?: string) {
     let url = `/subscriptions/${subscriptionId}`;
     if (resourceGroup) {
-      url += `/resourceGroups/${resourceGroup};`;
+      url += `/resourceGroups/${resourceGroup}`;
     }
     return this.azureMonitorDatasource.getMetricNamespaces({ resourceUri: url }, true);
   }


### PR DESCRIPTION
**What is this change?**

Fixes a typo that introduces an extra `;` into an Azure api call. Quoting the referenced issue:

> Note that when trying to replicate the call in postman, the following:
> 
> [https://management.azure.com/subscriptions/{subId}/resourceGroups/{rgId};/providers/microsoft.insights/metricNamespaces](https://management.azure.com/subscriptions/%7BsubId%7D/resourceGroups/%7BrgId%7D;/providers/microsoft.insights/metricNamespaces?api-version=2017-12-01-preview&region=wus) fails
> 
> but note that if ; is removed after RG, the call succeeds
> 
> [https://management.azure.com/subscriptions/{subId}/resourceGroups/{rgId}/providers/microsoft.insights/metricNamespaces](https://management.azure.com/subscriptions/%7BsubId%7D/resourceGroups/%7BrgId%7D/providers/microsoft.insights/metricNamespaces?api-version=2017-12-01-preview&region=wus)

The `;` is not allowed in a resource group name: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/

DO NOT MERGE - COPY OF #88320 for CI

**Which issue(s) does this PR fix?**:

Related to (maybe fixes) #79770

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
