### PR TITLE
DateTimePicker: Return cleared value in onChange

### DIFF
--- a/packages/grafana-sql/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/AwesomeQueryBuilder.tsx
@@ -80,7 +80,7 @@ export const widgets: Widgets = {
       return (
         <DateTimePicker
           onChange={(e) => {
-            props?.setValue(e.format(BasicConfig.widgets.datetime.valueFormat));
+            props?.setValue(e?.format(BasicConfig.widgets.datetime.valueFormat));
           }}
           date={dateValue}
         />

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.story.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.story.tsx
@@ -58,7 +58,9 @@ export const OnlyWorkingHoursEnabled: StoryFn<typeof DateTimePicker> = ({ label,
       showSeconds={showSeconds}
       onChange={(newValue) => {
         action('on change')(newValue);
-        setDate(newValue);
+        if (newValue) {
+          setDate(newValue);
+        }
       }}
     />
   );
@@ -81,7 +83,9 @@ export const Basic: StoryFn<typeof DateTimePicker> = ({ label, minDate, maxDate,
       clearable={clearable}
       onChange={(newValue) => {
         action('on change')(newValue);
-        setDate(newValue);
+        if (newValue) {
+          setDate(newValue);
+        }
       }}
     />
   );
@@ -101,7 +105,9 @@ export const Clearable: StoryFn<typeof DateTimePicker> = ({ label, showSeconds, 
       clearable={clearable}
       onChange={(newValue) => {
         action('on change')(newValue);
-        setDate(newValue);
+        if (newValue) {
+          setDate(newValue);
+        }
       }}
     />
   );

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -35,7 +35,7 @@ export interface Props {
   /** Input date for the component */
   date?: DateTime;
   /** Callback for returning the selected date */
-  onChange: (date: DateTime) => void;
+  onChange: (date?: DateTime) => void;
   /** label for the input field */
   label?: ReactNode;
   /** Set the latest selectable date */
@@ -200,15 +200,10 @@ interface DateTimeCalendarProps {
   disabledSeconds?: () => number[];
 }
 
-interface InputProps {
-  label?: ReactNode;
-  date?: DateTime;
+type InputProps = Pick<Props, 'onChange' | 'label' | 'date' | 'showSeconds' | 'clearable'> & {
   isFullscreen: boolean;
-  onChange: (date: DateTime) => void;
   onOpen: (event: FormEvent<HTMLElement>) => void;
-  showSeconds?: boolean;
-  clearable?: boolean;
-}
+};
 
 type InputState = {
   value: string;
@@ -249,7 +244,8 @@ const DateTimeInput = React.forwardRef<HTMLInputElement, InputProps>(
 
     const clearInternalDate = useCallback(() => {
       setInternalDate({ value: '', invalid: false });
-    }, []);
+      onChange();
+    }, [onChange]);
 
     const icon = <Button aria-label="Time picker" icon="calendar-alt" variant="secondary" onClick={onOpen} />;
     return (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A `clearable` prop was added in https://github.com/grafana/grafana/pull/88215. However, the changes only set the cleared value internally, which doesn't allow to reset a selected value inside a form. This PR fixes that issue by passing the cleared value (`undefined`) to the `onChange` prop.

**Why do we need this feature?**

To properly reset selected value in form.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
