### PR TITLE
AzureMonitor: Fix service selection in E2E tests

### DIFF
--- a/e2e/cloud-plugins-suite/azure-monitor.spec.ts
+++ b/e2e/cloud-plugins-suite/azure-monitor.spec.ts
@@ -193,7 +193,7 @@ describe('Azure monitor datasource', () => {
       dataSourceName,
       visitDashboardAtStart: false,
       queriesForm: () => {
-        e2eSelectors.queryEditor.header.select().find('input').type('Logs{enter}');
+        e2eSelectors.queryEditor.header.select().find('input').type('{selectall}Logs{enter}');
         e2eSelectors.queryEditor.resourcePicker.select.button().click();
         e2eSelectors.queryEditor.resourcePicker.search
           .input()
@@ -213,7 +213,7 @@ describe('Azure monitor datasource', () => {
       dataSourceName,
       visitDashboardAtStart: false,
       queriesForm: () => {
-        e2eSelectors.queryEditor.header.select().find('input').type('Azure Resource Graph{enter}');
+        e2eSelectors.queryEditor.header.select().find('input').type('{selectall}Azure Resource Graph{enter}');
         cy.wait(1000); // Need to wait for code editor to completely load
         e2eSelectors.queryEditor.argsQueryEditor.subscriptions
           .input()
@@ -232,7 +232,7 @@ describe('Azure monitor datasource', () => {
       dataSourceName,
       visitDashboardAtStart: false,
       queriesForm: () => {
-        e2eSelectors.queryEditor.header.select().find('input').type('Traces{enter}');
+        e2eSelectors.queryEditor.header.select().find('input').type('{selectall}Traces{enter}');
         e2eSelectors.queryEditor.resourcePicker.select.button().click();
         e2eSelectors.queryEditor.resourcePicker.search
           .input()
@@ -305,7 +305,7 @@ describe('Azure monitor datasource', () => {
         e2eSelectors.queryEditor.resourcePicker.advanced.region.input().find('input').type('$region');
         e2eSelectors.queryEditor.resourcePicker.advanced.resource.input().find('input').type('$resource');
         e2eSelectors.queryEditor.resourcePicker.apply.button().click();
-        e2eSelectors.queryEditor.metricsQueryEditor.metricName.input().find('input').type('Transactions{enter}');
+        e2eSelectors.queryEditor.metricsQueryEditor.metricName.input().find('input').type('Blob Capacity{enter}');
       },
       timeout: 10000,
     });


### PR DESCRIPTION
#87843 changed how the `Select` component works. The previous behaviour would allow all text to be replaced when the component was opened and text was typed. The new behaviour does not replace the text and instead appends it, leading to the failure of these tests.

cc @ashharrison90 @jackw 