### PR TITLE
Chore: Allow using the Go race detector locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ public/app/plugins/**/dist/
 
 # Go coverage files created with go test -cover -coverprogile=something.out ...
 *.out
+
+# Locally enabling the Go race detector until we can globally do so
+.go-race-enabled-locally

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GO = go
 GO_VERSION = 1.22.3
 GO_FILES ?= ./pkg/... ./pkg/apiserver/... ./pkg/apimachinery/... ./pkg/promlib/...
 SH_FILES ?= $(shell find ./scripts -name *.sh)
-GO_RACE  ?= $(if $(GO_BUILD_DEV),1)
+GO_RACE  := $(shell [ -n "$(GO_BUILD_DEV)$(GO_RACE)" -o -e ".go-race-enabled-locally" ] && echo 1 )
 GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 GO_BUILD_FLAGS += $(if $(GO_RACE),-race)
@@ -410,6 +410,18 @@ scripts/drone/TAGS: $(shell find scripts/drone -name '*.star')
 .PHONY: format-drone
 format-drone:
 	buildifier --lint=fix -r scripts/drone
+
+.PHONY: go-race-is-enabled
+go-race-is-enabled:
+	@if [ -n "$(GO_RACE)" ]; then \
+		echo "The Go race detector is enabled locally, yey!"; \
+	else \
+		echo "The Go race detector is NOT enabled locally, boo!"; \
+	fi;
+
+.PHONY: enable-go-race
+enable-go-race:
+	@touch .go-race-enabled-locally
 
 .PHONY: help
 help: ## Display this help.

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ GO = go
 GO_VERSION = 1.22.3
 GO_FILES ?= ./pkg/... ./pkg/apiserver/... ./pkg/apimachinery/... ./pkg/promlib/...
 SH_FILES ?= $(shell find ./scripts -name *.sh)
+GO_RACE  ?= $(if $(GO_BUILD_DEV),1)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
+GO_BUILD_FLAGS += $(if $(GO_RACE),-race)
 
 targets := $(shell echo '$(sources)' | tr "," " ")
 
@@ -208,6 +210,11 @@ build: build-go build-js ## Build backend and frontend.
 .PHONY: run
 run: $(BRA) ## Build and run web server on filesystem changes.
 	$(BRA) run
+
+.PHONY: run-go
+run-go: ## Build and run web server immediately.
+	$(GO) run -race $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS)) \
+		./pkg/cmd/grafana -- server -packaging=dev cfg:app_mode=development
 
 .PHONY: run-frontend
 run-frontend: deps-js ## Fetch js dependencies and watch frontend for rebuild


### PR DESCRIPTION
**What is this feature?**

- Enable the Go Race Detector, only when running locally the service with `make run`. If you're unfamiliar, please, consider reading [Introducing the Go Race Detector](https://go.dev/blog/race-detector), the original 2013 blog post in the Go Blog.
- Add an opt-in way to always use the Go Race Detector locally by default (including tests), by running `make enable-go-race` (if you're a contributor, please do it).
- To know if you have the Go race detector enabled by default, you can run `make go-race-is-enabled`.
- Add a new `Makefile` target `run-go` that only runs the web server, which is faster for backend development. If this is not interesting, it can be removed.

Quick Facts:
- [Data Races](https://en.wikipedia.org/wiki/Race_condition) are bugs. This is a bug detector.
- The Race Detector has been an integral part of the core standard Go tooling for more than 11 years.
- Our code base currently has many Data Races, both in server runtime code and in test code. To independently verify this claim, you can checkout this branch locally or just add the `-race` flag and run the process a few times.
- Data Races are not detected every time you run the code. Detection is opportunistic. So run the code and tests a few times. There are several Data Races at startup as well, which can cause unpredictable behaviour. A quick list of packages where you can find Data Races as of this writing are:
   - `pkg/web`
   - `pkg/infra/usagestats/service`
   - `pkg/services/ngalert/schedule`
- Data Races detected by the Race Detector only cause a stack dump to stderr with enough information to track the data race. It never stops the running process, so it doesn't disrupt the work of frontend contributors.

**Why do we need this feature?**

- **TL;DR**: To improve code quality in a gradual manner.
- To catch bugs, data inconsistencies, unpredictable behaviour, data corruption, data loss, random failures and other issues before they go into production, as well as fixing those which are already in place.
- To reduce the number of flaky tests. Data Races make tests flaky because the tests will not behave the same every time. Data Races are one of the _runtime_ sources of flakiness in tests (as opposed to _data_ sources of flakiness in tests).
- To allow Go contributors to find bugs in their code as they write it.
- To allow other contributors to see these issues and be able to report them to the appropriate team. Not all Data Races are in a critical path, and the team responsible can appropriately triage and address them when needed.

**NOTE**: This PR only enables the Go Race Detector to be run locally. Not in Drone, not in any pipeline, not in production runtime code, not in release code.

**Who is this feature for?**

Code contributors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
