### PR TITLE
LBAC datasource: Add swagger updates

### DIFF
--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -761,6 +761,41 @@
       }
     },
     "/datasources/uid/{uid}/lbac/teams": {
+      "get": {
+        "tags": [
+          "enterprise"
+        ],
+        "summary": "Retrieves LBAC rules for a team.",
+        "operationId": "getTeamLBACRulesApi",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "uid",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      },
       "put": {
         "tags": [
           "enterprise"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -4317,8 +4317,46 @@
     },
     "/datasources/uid/{uid}/lbac/teams": {
       "get": {
+        "tags": [
+          "enterprise"
+        ],
         "summary": "Retrieves LBAC rules for a team.",
-        "operationId": "getTeamLBACRulesApiResponse",
+        "operationId": "getTeamLBACRulesApi",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "uid",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "enterprise"
+        ],
+        "summary": "Updates LBAC rules for a team.",
+        "operationId": "updateTeamLBACRulesApi",
         "parameters": [
           {
             "type": "string",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -17145,7 +17145,7 @@
     },
     "/datasources/uid/{uid}/lbac/teams": {
       "get": {
-        "operationId": "getTeamLBACRulesApiResponse",
+        "operationId": "getTeamLBACRulesApi",
         "parameters": [
           {
             "in": "path",
@@ -17176,7 +17176,47 @@
             "$ref": "#/components/responses/internalServerError"
           }
         },
-        "summary": "Retrieves LBAC rules for a team."
+        "summary": "Retrieves LBAC rules for a team.",
+        "tags": [
+          "enterprise"
+        ]
+      },
+      "put": {
+        "operationId": "updateTeamLBACRulesApi",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "uid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Updates LBAC rules for a team.",
+        "tags": [
+          "enterprise"
+        ]
       }
     },
     "/datasources/uid/{uid}/resources/{datasource_proxy_route}": {


### PR DESCRIPTION
**why**
missing swagger-gen for the LBAC updates of the swagger documentation from https://github.com/grafana/grafana-enterprise/pull/6314/files