### PR TITLE
Alerting: Update ListAlertRulesQuery to take a slice of RuleGroups

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -669,7 +669,7 @@ func (srv RulerSrv) getAuthorizedRuleGroup(ctx context.Context, c *contextmodel.
 	q := ngmodels.ListAlertRulesQuery{
 		OrgID:         ruleGroupKey.OrgID,
 		NamespaceUIDs: []string{ruleGroupKey.NamespaceUID},
-		RuleGroup:     ruleGroupKey.RuleGroup,
+		RuleGroups:    []string{ruleGroupKey.RuleGroup},
 	}
 	rules, err := srv.store.ListAlertRules(ctx, &q)
 	if err != nil {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -606,7 +606,7 @@ type ListAlertRulesQuery struct {
 	OrgID         int64
 	NamespaceUIDs []string
 	ExcludeOrgs   []int64
-	RuleGroup     string
+	RuleGroups    []string
 
 	// DashboardUID and PanelID are optional and allow filtering rules
 	// to return just those for a dashboard and panel.

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -295,7 +295,7 @@ func (service *AlertRuleService) GetRuleGroup(ctx context.Context, user identity
 	q := models.ListAlertRulesQuery{
 		OrgID:         user.GetOrgID(),
 		NamespaceUIDs: []string{namespaceUID},
-		RuleGroup:     group,
+		RuleGroups:    []string{group},
 	}
 	ruleList, err := service.ruleStore.ListAlertRules(ctx, &q)
 	if err != nil {
@@ -337,7 +337,7 @@ func (service *AlertRuleService) UpdateRuleGroup(ctx context.Context, user ident
 		query := &models.ListAlertRulesQuery{
 			OrgID:         user.GetOrgID(),
 			NamespaceUIDs: []string{namespaceUID},
-			RuleGroup:     ruleGroup,
+			RuleGroups:    []string{ruleGroup},
 		}
 		ruleList, err := service.ruleStore.ListAlertRules(ctx, query)
 		if err != nil {
@@ -465,7 +465,7 @@ func (service *AlertRuleService) calcDelta(ctx context.Context, user identity.Re
 		listRulesQuery := models.ListAlertRulesQuery{
 			OrgID:         user.GetOrgID(),
 			NamespaceUIDs: []string{group.FolderUID},
-			RuleGroup:     group.Title,
+			RuleGroups:    []string{group.Title},
 		}
 		ruleList, err := service.ruleStore.ListAlertRules(ctx, &listRulesQuery)
 		if err != nil {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -363,17 +363,13 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 		}
 
 		if len(query.NamespaceUIDs) > 0 {
-			args := make([]any, 0, len(query.NamespaceUIDs))
-			in := make([]string, 0, len(query.NamespaceUIDs))
-			for _, namespaceUID := range query.NamespaceUIDs {
-				args = append(args, namespaceUID)
-				in = append(in, "?")
-			}
+			args, in := createINSubQuery(query.NamespaceUIDs)
 			q = q.Where(fmt.Sprintf("namespace_uid IN (%s)", strings.Join(in, ",")), args...)
 		}
 
-		if query.RuleGroup != "" {
-			q = q.Where("rule_group = ?", query.RuleGroup)
+		if len(query.RuleGroups) > 0 {
+			args, in := createINSubQuery(query.NamespaceUIDs)
+			q = q.Where(fmt.Sprintf("rule_group IN (%s)", strings.Join(in, ",")), args...)
 		}
 
 		if query.ReceiverName != "" {
@@ -788,4 +784,15 @@ func (st DBstore) GetNamespacesByRuleUID(ctx context.Context, orgID int64, uids 
 		return nil
 	})
 	return result, err
+}
+
+func createINSubQuery[T any](inputSlice []T) ([]any, []string) {
+	args := make([]any, 0, len(inputSlice))
+	in := make([]string, 0, len(inputSlice))
+	for _, t := range inputSlice {
+		args = append(args, t)
+		in = append(in, "?")
+	}
+
+	return args, in
 }

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -363,12 +363,12 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 		}
 
 		if len(query.NamespaceUIDs) > 0 {
-			args, in := getQueryArgs(query.NamespaceUIDs)
+			args, in := getINSubQueryArgs(query.NamespaceUIDs)
 			q = q.Where(fmt.Sprintf("namespace_uid IN (%s)", strings.Join(in, ",")), args...)
 		}
 
 		if len(query.RuleGroups) > 0 {
-			args, in := getQueryArgs(query.NamespaceUIDs)
+			args, in := getINSubQueryArgs(query.NamespaceUIDs)
 			q = q.Where(fmt.Sprintf("rule_group IN (%s)", strings.Join(in, ",")), args...)
 		}
 
@@ -786,7 +786,7 @@ func (st DBstore) GetNamespacesByRuleUID(ctx context.Context, orgID int64, uids 
 	return result, err
 }
 
-func getQueryArgs[T any](inputSlice []T) ([]any, []string) {
+func getINSubQueryArgs[T any](inputSlice []T) ([]any, []string) {
 	args := make([]any, 0, len(inputSlice))
 	in := make([]string, 0, len(inputSlice))
 	for _, t := range inputSlice {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -363,12 +363,12 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 		}
 
 		if len(query.NamespaceUIDs) > 0 {
-			args, in := createINSubQuery(query.NamespaceUIDs)
+			args, in := getQueryArgs(query.NamespaceUIDs)
 			q = q.Where(fmt.Sprintf("namespace_uid IN (%s)", strings.Join(in, ",")), args...)
 		}
 
 		if len(query.RuleGroups) > 0 {
-			args, in := createINSubQuery(query.NamespaceUIDs)
+			args, in := getQueryArgs(query.NamespaceUIDs)
 			q = q.Where(fmt.Sprintf("rule_group IN (%s)", strings.Join(in, ",")), args...)
 		}
 
@@ -786,7 +786,7 @@ func (st DBstore) GetNamespacesByRuleUID(ctx context.Context, orgID int64, uids 
 	return result, err
 }
 
-func createINSubQuery[T any](inputSlice []T) ([]any, []string) {
+func getQueryArgs[T any](inputSlice []T) ([]any, []string) {
 	args := make([]any, 0, len(inputSlice))
 	in := make([]string, 0, len(inputSlice))
 	for _, t := range inputSlice {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -368,7 +368,7 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 		}
 
 		if len(query.RuleGroups) > 0 {
-			args, in := getINSubQueryArgs(query.NamespaceUIDs)
+			args, in := getINSubQueryArgs(query.RuleGroups)
 			q = q.Where(fmt.Sprintf("rule_group IN (%s)", strings.Join(in, ",")), args...)
 		}
 

--- a/pkg/services/ngalert/store/deltas.go
+++ b/pkg/services/ngalert/store/deltas.go
@@ -63,7 +63,7 @@ func CalculateChanges(ctx context.Context, ruleReader RuleReader, groupKey model
 	q := &models.ListAlertRulesQuery{
 		OrgID:         groupKey.OrgID,
 		NamespaceUIDs: []string{groupKey.NamespaceUID},
-		RuleGroup:     groupKey.RuleGroup,
+		RuleGroups:    []string{groupKey.RuleGroup},
 	}
 	existingGroupRules, err := ruleReader.ListAlertRules(ctx, q)
 	if err != nil {
@@ -203,7 +203,7 @@ func CalculateRuleUpdate(ctx context.Context, ruleReader RuleReader, rule *model
 	q := &models.ListAlertRulesQuery{
 		OrgID:         rule.OrgID,
 		NamespaceUIDs: []string{rule.NamespaceUID},
-		RuleGroup:     rule.RuleGroup,
+		RuleGroups:    []string{rule.RuleGroup},
 	}
 	existingGroupRules, err := ruleReader.ListAlertRules(ctx, q)
 	if err != nil {
@@ -232,7 +232,7 @@ func CalculateRuleGroupDelete(ctx context.Context, ruleReader RuleReader, groupK
 	q := models.ListAlertRulesQuery{
 		OrgID:         groupKey.OrgID,
 		NamespaceUIDs: []string{groupKey.NamespaceUID},
-		RuleGroup:     groupKey.RuleGroup,
+		RuleGroups:    []string{groupKey.RuleGroup},
 	}
 	ruleList, err := ruleReader.ListAlertRules(ctx, &q)
 	if err != nil {
@@ -288,7 +288,7 @@ func CalculateRuleCreate(ctx context.Context, ruleReader RuleReader, rule *model
 	q := &models.ListAlertRulesQuery{
 		OrgID:         rule.OrgID,
 		NamespaceUIDs: []string{rule.NamespaceUID},
-		RuleGroup:     rule.RuleGroup,
+		RuleGroups:    []string{rule.RuleGroup},
 	}
 	group, err := ruleReader.ListAlertRules(ctx, q)
 	if err != nil {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -198,33 +199,18 @@ func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQu
 		return true
 	}
 
-	hasNamespace := func(r *models.AlertRule, namespaceUIDs []string) bool {
-		if len(namespaceUIDs) > 0 {
-			var ok bool
-			for _, uid := range q.NamespaceUIDs {
-				if uid == r.NamespaceUID {
-					ok = true
-					break
-				}
-			}
-			if !ok {
-				return false
-			}
-		}
-		return true
-	}
-
 	ruleList := models.RulesGroup{}
 	for _, r := range f.Rules[q.OrgID] {
 		if !hasDashboard(r, q.DashboardUID, q.PanelID) {
 			continue
 		}
-		if !hasNamespace(r, q.NamespaceUIDs) {
+		if !slices.Contains(q.NamespaceUIDs, r.NamespaceUID) {
 			continue
 		}
-		if q.RuleGroup != "" && r.RuleGroup != q.RuleGroup {
+		if !slices.Contains(q.RuleGroups, r.RuleGroup) {
 			continue
 		}
+
 		ruleList = append(ruleList, r)
 	}
 

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -204,10 +204,10 @@ func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQu
 		if !hasDashboard(r, q.DashboardUID, q.PanelID) {
 			continue
 		}
-		if !slices.Contains(q.NamespaceUIDs, r.NamespaceUID) {
+		if len(q.NamespaceUIDs) > 0 && !slices.Contains(q.NamespaceUIDs, r.NamespaceUID) {
 			continue
 		}
-		if !slices.Contains(q.RuleGroups, r.RuleGroup) {
+		if len(q.RuleGroups) > 0 && !slices.Contains(q.RuleGroups, r.RuleGroup) {
 			continue
 		}
 

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -141,7 +141,7 @@ func CreateTestAlertRuleWithLabels(t testing.TB, ctx context.Context, dbstore *s
 	q := models.ListAlertRulesQuery{
 		OrgID:         orgID,
 		NamespaceUIDs: []string{folderUID},
-		RuleGroup:     ruleGroup,
+		RuleGroups:    []string{ruleGroup},
 	}
 	ruleList, err := dbstore.ListAlertRules(ctx, &q)
 	require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**
Change `ListAlertRulesQuery` type to take a slice of `RuleGroup`s instead of just a single `RuleGroup`

**Why do we need this feature?**
Will allow the `/api/prometheus/grafana/api/v1/rules` to a comma-separated list of rule groups as a query parameter

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
