### PR TITLE
InfluxDB: backendmode performance optimization

### DIFF
--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -23,10 +23,6 @@ func ResponseParse(buf io.ReadCloser, statusCode int, query *models.Query) *back
 func parse(buf io.Reader, statusCode int, query *models.Query) *backend.DataResponse {
 	response, jsonErr := parseJSON(buf)
 
-	if statusCode/100 != 2 {
-		return &backend.DataResponse{Error: fmt.Errorf("InfluxDB returned error: %s", response.Error)}
-	}
-
 	if jsonErr != nil {
 		return &backend.DataResponse{Error: jsonErr}
 	}

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -87,7 +87,7 @@ func newTimeField(rows []models.Row) *data.Field {
 	var timeArray []time.Time
 	for _, row := range rows {
 		for _, valuePair := range row.Values {
-			timestamp, timestampErr := util.ParseTimestamp2(valuePair[0])
+			timestamp, timestampErr := util.ParseTimestamp(valuePair[0])
 			// we only add this row if the timestamp is valid
 			if timestampErr != nil {
 				continue
@@ -277,7 +277,7 @@ func newFrameWithTimeField(row models.Row, column string, colIndex int, query mo
 	valType := util.Typeof(row.Values, colIndex)
 
 	for _, valuePair := range row.Values {
-		timestamp, timestampErr := util.ParseTimestamp2(valuePair[0])
+		timestamp, timestampErr := util.ParseTimestamp(valuePair[0])
 		// we only add this row if the timestamp is valid
 		if timestampErr != nil {
 			continue

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -237,12 +237,6 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 
 		if !hasTimeCol {
 			newFrame := newFrameWithoutTimeField(row, query)
-			if len(frames) == 0 {
-				newFrame.Meta = &data.FrameMeta{
-					ExecutedQueryString:    query.RawQuery,
-					PreferredVisualization: util.GetVisType(query.ResultFormat),
-				}
-			}
 			frames = append(frames, newFrame)
 		} else {
 			for colIndex, column := range row.Columns {
@@ -250,14 +244,15 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 					continue
 				}
 				newFrame := newFrameWithTimeField(row, column, colIndex, query, frameName)
-				if len(frames) == 0 {
-					newFrame.Meta = &data.FrameMeta{
-						ExecutedQueryString:    query.RawQuery,
-						PreferredVisualization: util.GetVisType(query.ResultFormat),
-					}
-				}
 				frames = append(frames, newFrame)
 			}
+		}
+	}
+
+	if len(frames) > 0 {
+		frames[0].Meta = &data.FrameMeta{
+			ExecutedQueryString:    query.RawQuery,
+			PreferredVisualization: util.GetVisType(query.ResultFormat),
 		}
 	}
 

--- a/pkg/tsdb/influxdb/influxql/influxql.go
+++ b/pkg/tsdb/influxdb/influxql/influxql.go
@@ -181,7 +181,7 @@ func execute(ctx context.Context, tracer trace.Tracer, dsInfo *models.Datasource
 	_, endSpan := startTrace(ctx, tracer, "datasource.influxdb.influxql.parseResponse")
 
 	var reader io.ReadCloser
-	if encoding := res.Header.Get("Accept-Encoding"); encoding == "gzip" {
+	if encoding := res.Header.Get("Content-Encoding"); encoding == "gzip" {
 		reader, err = gzip.NewReader(res.Body)
 		defer func(reader io.ReadCloser) {
 			err := reader.Close()

--- a/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
+++ b/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
@@ -23,10 +23,6 @@ func ResponseParse(buf io.ReadCloser, statusCode int, query *models.Query) *back
 	iter := jsoniter.Parse(jsoniter.ConfigDefault, buf, 1024)
 	r := converter.ReadInfluxQLStyleResult(iter, query)
 
-	if statusCode/100 != 2 {
-		return &backend.DataResponse{Error: fmt.Errorf("InfluxDB returned error: %s", r.Error)}
-	}
-
 	// The ExecutedQueryString can be viewed in QueryInspector in UI
 	for i, frame := range r.Frames {
 		if i == 0 {

--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -114,6 +114,19 @@ func ParseTimestamp(value any) (time.Time, error) {
 	return t, nil
 }
 
+func ParseTimestamp2(value any) (time.Time, error) {
+	timestampNumber, ok := value.(float64)
+	if !ok {
+		return time.Time{}, fmt.Errorf("timestamp-value has invalid type: %#v", value)
+	}
+
+	// currently in the code the influxdb-timestamps are requested with
+	// milliseconds-precision, meaning these values are milliseconds
+	t := time.UnixMilli(int64(timestampNumber)).UTC()
+
+	return t, nil
+}
+
 func Typeof(values [][]any, colIndex int) string {
 	for _, value := range values {
 		if value != nil && value[colIndex] != nil {

--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -98,23 +98,6 @@ func BuildFrameNameFromQuery(rowName, column string, tags map[string]string, fra
 }
 
 func ParseTimestamp(value any) (time.Time, error) {
-	timestampNumber, ok := value.(json.Number)
-	if !ok {
-		return time.Time{}, fmt.Errorf("timestamp-value has invalid type: %#v", value)
-	}
-	timestampInMilliseconds, err := timestampNumber.Int64()
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	// currently in the code the influxdb-timestamps are requested with
-	// milliseconds-precision, meaning these values are milliseconds
-	t := time.UnixMilli(timestampInMilliseconds).UTC()
-
-	return t, nil
-}
-
-func ParseTimestamp2(value any) (time.Time, error) {
 	timestampNumber, ok := value.(float64)
 	if !ok {
 		return time.Time{}, fmt.Errorf("timestamp-value has invalid type: %#v", value)


### PR DESCRIPTION
**What is this feature?**

Small response (9 values each value has 17 items ) difference

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/tsdb/influxdb/influxql
             │ buffered.txt │            buffered3.txt            │
             │    sec/op    │   sec/op     vs base                │
ParseJson-10   119.97µ ± 0%   91.65µ ± 1%  -23.61% (p=0.000 n=10)

             │ buffered.txt │            buffered3.txt            │
             │     B/op     │     B/op      vs base               │
ParseJson-10   123.7Ki ± 0%   117.3Ki ± 0%  -5.17% (p=0.000 n=10)

             │ buffered.txt │           buffered3.txt            │
             │  allocs/op   │  allocs/op   vs base               │
ParseJson-10    2.527k ± 0%   2.510k ± 0%  -0.67% (p=0.000 n=10)

```

Big response (55318 values each value has 2 items) difference:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/tsdb/influxdb/influxql
             │ buffered.txt │            buffered3.txt            │
             │    sec/op    │   sec/op     vs base                │
ParseJson-10    23.25m ± 0%   10.96m ± 0%  -52.86% (p=0.000 n=10)

             │ buffered.txt │            buffered3.txt             │
             │     B/op     │     B/op      vs base                │
ParseJson-10   26.62Mi ± 0%   21.23Mi ± 0%  -20.24% (p=0.000 n=10)

             │ buffered.txt │            buffered3.txt            │
             │  allocs/op   │  allocs/op   vs base                │
ParseJson-10    386.9k ± 0%   278.0k ± 0%  -28.13% (p=0.000 n=10)

```

