### PR TITLE
LogsTable: Fix default sort by time

### DIFF
--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -174,6 +174,9 @@ export function LogsTable(props: Props) {
       onCellFilterAdded={props.onClickFilterLabel && props.onClickFilterOutLabel ? onCellFilterAdded : undefined}
       height={props.height}
       footerOptions={{ show: true, reducer: ['count'], countRows: true }}
+      initialSortBy={[
+        { displayName: logsFrame?.timeField.name || '', desc: logsSortOrder === LogsSortOrder.Descending },
+      ]}
     />
   );
 }


### PR DESCRIPTION
**What is this feature?**

The LogsTable does not sort by time correctly. This PR adds a fix by setting the build in Table functionality to sort by time field accordingly.


https://github.com/grafana/grafana/assets/8092184/9782b8bd-af89-4bb9-a23b-d38dec0df39b

