### PR TITLE
LibraryPanels/RBAC: Ignore old folder permission check when deleting/patching lib panel

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -240,9 +240,12 @@ func (l *LibraryElementService) deleteLibraryElement(c context.Context, signedIn
 			return err
 		}
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
-		// nolint:staticcheck
-		if err := l.requireEditPermissionsOnFolder(c, signedInUser, element.FolderID); err != nil {
-			return err
+
+		if !l.features.IsEnabled(c, featuremgmt.FlagLibraryPanelRBAC) {
+			// nolint:staticcheck
+			if err := l.requireEditPermissionsOnFolder(c, signedInUser, element.FolderID); err != nil {
+				return err
+			}
 		}
 
 		// Delete any hanging/invalid connections

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -541,17 +541,20 @@ func (l *LibraryElementService) handleFolderIDPatches(ctx context.Context, eleme
 		toFolderID = fromFolderID
 	}
 
-	// FolderID was provided in the PATCH request
-	if toFolderID != -1 && toFolderID != fromFolderID {
-		if err := l.requireEditPermissionsOnFolder(ctx, user, toFolderID); err != nil {
+	if !l.features.IsEnabled(ctx, featuremgmt.FlagLibraryPanelRBAC) {
+		// FolderID was provided in the PATCH request
+		if toFolderID != -1 && toFolderID != fromFolderID {
+			if err := l.requireEditPermissionsOnFolder(ctx, user, toFolderID); err != nil {
+				return err
+			}
+		}
+
+		// Always check permissions for the folder where library element resides
+		if err := l.requireEditPermissionsOnFolder(ctx, user, fromFolderID); err != nil {
 			return err
 		}
 	}
 
-	// Always check permissions for the folder where library element resides
-	if err := l.requireEditPermissionsOnFolder(ctx, user, fromFolderID); err != nil {
-		return err
-	}
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
 	// nolint:staticcheck
 	elementToPatch.FolderID = toFolderID


### PR DESCRIPTION
Changes `deleteLibraryElement` and `handleFolderIDPatches` so we skip the check for folder edit permissions if library panel rbac is enabled, since we do a more granular check for permissions in `api.go`:
https://github.com/grafana/grafana/blob/4d75374f95976eab22eedec9988847321f6691de/pkg/services/libraryelements/api.go#L27

https://github.com/grafana/grafana/blob/4d75374f95976eab22eedec9988847321f6691de/pkg/services/libraryelements/api.go#L32

This fixes an issue where users who have library panel delete/write permissions - but not more general edit permissions  - were unable to delete library panels in the general folder.