### PR TITLE
Mildwonkey/usersync tune

### DIFF
--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -290,7 +290,7 @@ func (ss *sqlStore) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLa
 	if cmd.UserID <= 0 {
 		return user.ErrUpdateInvalidID
 	}
-	return ss.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	return ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		user := user.User{
 			ID:         cmd.UserID,
 			LastSeenAt: time.Now(),

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -309,7 +309,7 @@ func (s *Service) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLast
 }
 
 func shouldUpdateLastSeen(t time.Time) bool {
-	return time.Since(t) > time.Minute*5
+	return time.Since(t) > time.Minute*15
 }
 
 func (s *Service) GetSignedInUser(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {


### PR DESCRIPTION
(one small) Part of [#314](https://github.com/grafana/grafana-bench/issues/314) 

This PR replaces the `transaction` in the UpdateUserLastSeen with a regular `session` and increases the interval between those updates. I started with `15 minutes` at @bergquist's suggestion, but we need a second opinion on that in case it (also) impacts license checks. 

I can also make that configurable, of course, if folks prefer. 