### PR TITLE
AdHoc filters: add support for groups in adhoc filters + fix group styling

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -601,6 +601,7 @@ export interface QueryHint {
 export interface MetricFindValue {
   text: string;
   value?: string | number;
+  group?: string;
   expandable?: boolean;
 }
 

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -23,6 +23,7 @@ import { InputControl } from './InputControl';
 import { MultiValueContainer, MultiValueRemove } from './MultiValue';
 import { SelectContainer } from './SelectContainer';
 import { SelectMenu, SelectMenuOptions, VirtualizedSelectMenu } from './SelectMenu';
+import { SelectOptionGroup } from './SelectOptionGroup';
 import { SelectOptionGroupHeader } from './SelectOptionGroupHeader';
 import { Props, SingleValue } from './SingleValue';
 import { ValueContainer } from './ValueContainer';
@@ -330,6 +331,7 @@ export function SelectBase<T, Rest = {}>({
         ref={reactSelectRef}
         components={{
           MenuList: SelectMenuComponent,
+          Group: SelectOptionGroup,
           GroupHeading: SelectOptionGroupHeader,
           ValueContainer,
           IndicatorsContainer: CustomIndicatorsContainer,

--- a/packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectOptionGroup.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { GroupProps } from 'react-select';
+
+import { useStyles2 } from '../../themes/ThemeContext';
+
+import { getSelectStyles } from './getSelectStyles';
+
+export const SelectOptionGroup = ({
+  children,
+  cx,
+  getClassNames,
+  getStyles,
+  Heading,
+  headingProps,
+  label,
+  selectProps,
+  theme,
+}: GroupProps) => {
+  const styles = useStyles2(getSelectStyles);
+  return (
+    <div className={styles.group}>
+      <Heading
+        cx={cx}
+        getClassNames={getClassNames}
+        getStyles={getStyles}
+        selectProps={selectProps}
+        theme={theme}
+        {...headingProps}
+      >
+        {label}
+      </Heading>
+      {children}
+    </div>
+  );
+};

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -141,7 +141,15 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {
     groupHeader: css({
       padding: theme.spacing(1, 1, 1, 0.75),
       borderLeft: '2px solid transparent',
-      borderTop: `1px solid ${theme.colors.border.weak}`,
+    }),
+    group: css({
+      '&:not(:first-child)': {
+        borderTop: `1px solid ${theme.colors.border.weak}`,
+      },
+      // ensure there's a bottom border if there are options following the group
+      ':has(+ [role="option"])': {
+        borderBottom: `1px solid ${theme.colors.border.weak}`,
+      },
     }),
   };
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds an optional `group` key to the `MetricFindValue` interface. multiple options with the same `group` value will be grouped under that header in the options menu
- fixes styling for option groups to:
  - avoid showing a top dividing line if it's the first option
  - avoid doubling up dividing lines between option groups 

**Why do we need this feature?**

- to show groups in adhoc filter values

**Who is this feature for?**

- anyone who wants groups in adhoc filter values

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/hyperion-planning/issues/33

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
