### PR TITLE
datatrails: in Components, `model.useState()`, instead of `model.state`

### DIFF
--- a/public/app/features/trails/DataTrailsHistory.tsx
+++ b/public/app/features/trails/DataTrailsHistory.tsx
@@ -200,7 +200,7 @@ export class DataTrailHistory extends SceneObjectBase<DataTrailsHistoryState> {
                   // Specifics per step type
                   styles.stepTypes[stepType],
                   // To highlight selected step
-                  model.state.currentStep === index ? styles.stepSelected : '',
+                  currentStep === index ? styles.stepSelected : '',
                   // To alter the look of steps with distant non-directly preceding parent
                   alternatePredecessorStyle.get(index) ?? '',
                   // To remove direct link for steps that don't have a direct parent

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -369,7 +369,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> {
           </Alert>
         )}
         <StatusWrapper {...{ isLoading, blockingMessage }}>
-          <model.state.body.Component model={model.state.body} />
+          <body.Component model={body} />
         </StatusWrapper>
       </div>
     );

--- a/public/app/features/trails/MetricSelect/SelectMetricAction.tsx
+++ b/public/app/features/trails/MetricSelect/SelectMetricAction.tsx
@@ -16,9 +16,10 @@ export class SelectMetricAction extends SceneObjectBase<SelectMetricActionState>
   };
 
   public static Component = ({ model }: SceneComponentProps<SelectMetricAction>) => {
+    const { title } = model.useState();
     return (
       <Button variant="secondary" size="sm" fill="solid" onClick={model.onClick}>
-        {model.state.title}
+        {title}
       </Button>
     );
   };


### PR DESCRIPTION
Generally, it is better practice. More succinct.
It could also eliminate subtle state bugs.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
