### PR TITLE
Dashboards: Correctly display Admin access to dashboards in the UI

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -170,14 +170,17 @@ func ProvideDashboardPermissions(
 			return nil
 		},
 		InheritedScopesSolver: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
+			wildcards := accesscontrol.WildcardsFromPrefix(dashboards.ScopeFoldersPrefix)
+			scopes := []string(wildcards)
+
 			dashboard, err := getDashboard(ctx, orgID, resourceID)
 			if err != nil {
 				return nil, err
 			}
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.AccessControl).Inc()
 			// nolint:staticcheck
-			if dashboard.FolderID > 0 {
-				query := &dashboards.GetDashboardQuery{ID: dashboard.FolderID, OrgID: orgID}
+			if dashboard.FolderUID != "" {
+				query := &dashboards.GetDashboardQuery{UID: dashboard.FolderUID, OrgID: orgID}
 				queryResult, err := dashboardStore.GetDashboard(ctx, query)
 				if err != nil {
 					return nil, err
@@ -188,9 +191,13 @@ func ProvideDashboardPermissions(
 				if err != nil {
 					return nil, err
 				}
-				return append([]string{parentScope}, nestedScopes...), nil
+
+				scopes = append(scopes, parentScope)
+				scopes = append(scopes, nestedScopes...)
+				return scopes, nil
 			}
-			return []string{dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)}, nil
+			scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
+			return scopes, nil
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -196,8 +196,7 @@ func ProvideDashboardPermissions(
 				scopes = append(scopes, nestedScopes...)
 				return scopes, nil
 			}
-			scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
-			return scopes, nil
+			return append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID)), nil
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,


### PR DESCRIPTION
**What is this feature?**

Fixes the permission evaluation in the backend to ensure that dashboard permission UI correctly displays organization Admin access to dashboards.

Before:
<img width="1132" alt="Screenshot 2024-05-29 at 18 20 10" src="https://github.com/grafana/grafana/assets/9482349/bfc1120d-54a3-4c52-9496-fe200f7f896e">

After:
<img width="1131" alt="Screenshot 2024-05-29 at 18 21 38" src="https://github.com/grafana/grafana/assets/9482349/cc4dfac3-c0af-46db-98c8-b4b7551d6fe2">

For context - we were not taking folder wildcard permissions into account when retrieving the list of everyone that has access to a dashboard. This change only impacts the permissions that we display - organization Admins could still access all dashboards with this bug.

**Why do we need this feature?**

To correctly display who has access to a dashboard.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/709