### PR TITLE
Modify Prometheus Plugin Proxy paths to use datasources:query

### DIFF
--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -50,19 +50,19 @@
       "method": "DELETE",
       "path": "/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "datasources:query"
     },
     {
       "method": "DELETE",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "datasources:query"
     }
   ],
   "includes": [

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -44,7 +44,7 @@
       "method": "POST",
       "path": "/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "datasources:query"
     },
     {
       "method": "DELETE",

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -56,13 +56,13 @@
       "method": "DELETE",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:query"
+      "reqAction": "datasources:write"
     },
     {
       "method": "POST",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:query"
+      "reqAction": "datasources:write"
     }
   ],
   "includes": [

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -56,13 +56,13 @@
       "method": "DELETE",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "datasources:query"
     },
     {
       "method": "POST",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "datasources:query"
     }
   ],
   "includes": [


### PR DESCRIPTION
**What:**
Modifies the Prometheus Plugin proxy `/rules` route to require **datasources:query** and not **datasources:write:**

**Other:**
By default, the `grafanacloud-prom` datasource only allocates "Query" permissions to "Editor" basic roles which includes: **datasources:query** and **datasources:read.** By similar logic, the corresponding plugin proxy paths should also only require **datasources:query.**

The **datasources:write** permission should only be used to modify the actual datasource configuration.

![Screenshot 2024-05-29 at 12 30 41 PM](https://github.com/grafana/grafana/assets/73451363/df906828-b9a6-4a2b-bdd2-2cca1c523ecf)


screenshot - of the default grafanacloud-prom datasource permissions, which shows that Editor roles are only designated the "Query" permission of datasources:query and datasources:read by default. I do not think we should enforce datasources:write permissions on the plugin proxy paths.

Fixes #88444 