### PR TITLE
Scopes: Use Grafana namespace instead of default

### DIFF
--- a/public/app/features/dashboard-scene/scene/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/ScopesFiltersScene.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import React from 'react';
 
 import { AppEvents, GrafanaTheme2, Scope, ScopeSpec, ScopeTreeItemSpec } from '@grafana/data';
-import { getAppEvents, getBackendSrv } from '@grafana/runtime';
+import { config, getAppEvents, getBackendSrv } from '@grafana/runtime';
 import {
   SceneComponentProps,
   SceneObjectBase,
@@ -32,7 +32,7 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
 
   private serverGroup = 'scope.grafana.app';
   private serverVersion = 'v0alpha1';
-  private serverNamespace = 'default';
+  private serverNamespace = config.namespace;
 
   private server = new ScopedResourceClient<ScopeSpec, 'Scope'>({
     group: this.serverGroup,


### PR DESCRIPTION
**What is this feature?**

Use the namespace passed by Grafana config instead of `default`.

**Why do we need this feature?**

Because in Grafana cloud we use other namespace and not `default`.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
