### PR TITLE
Alerting: Remove regex reference in silences filter tooltip

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
@@ -63,8 +63,8 @@ const NotificationPoliciesFilter = ({
               <Tooltip
                 content={
                   <div>
-                    Filter silences by matchers using a comma separated list of matchers, ie:
-                    <pre>{`severity=critical, instance=~cluster-us-.+`}</pre>
+                    Filter notification policies by using a comma separated list of matchers, e.g.:
+                    <pre>severity=critical, instance=~cluster-us-.+</pre>
                   </div>
                 }
               >

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -43,8 +43,8 @@ export const SilencesFilter = () => {
               <Tooltip
                 content={
                   <div>
-                    Filter silences by matchers using a comma separated list of matchers, ie:
-                    <pre>{`severity=critical, instance=~cluster-us-.+`}</pre>
+                    Filter silences by using a comma separated list of matchers, e.g.:
+                    <pre>severity=critical, env=production</pre>
                   </div>
                 }
               >


### PR DESCRIPTION
**What is this feature?**
Update the tooltip for filtering silences to avoid implying that we support regex matching here. Also fixes a mis-labelled filter option on the notification policies page
