### PR TITLE
Gops: Fix incidents url adding plugin twice in it

### DIFF
--- a/public/app/features/alerting/unified/api/incidentsApi.ts
+++ b/public/app/features/alerting/unified/api/incidentsApi.ts
@@ -7,8 +7,7 @@ interface IncidentsPluginConfigDto {
   isIncidentCreated: boolean;
 }
 
-const getProxyApiUrl = (path: string) =>
-  `/api/plugins/grafana-incident-app/resources/${SupportedPlugin.Incident}${path}`;
+const getProxyApiUrl = (path: string) => `/api/plugins/${SupportedPlugin.Incident}/resources${path}`;
 
 export const incidentsApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({


### PR DESCRIPTION
This PR fixes incidents check url.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
