### PR TITLE
Docs: How to access Grafana in fundamentals tutorial

### DIFF
--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -117,6 +117,10 @@ Grafana is an open-source platform for monitoring and observability that lets yo
 1. Open a new tab.
 1. Browse to [localhost:3000](http://localhost:3000).
 
+{{< admonition type="note" >}}
+This demo does not require a login page or credentials. However, if you choose to install Grafana locally, you will need to log in and provide credentials. In that case, the default username and password is `admin`.
+{{< /admonition >}}
+
 The first thing you see is the Home dashboard, which helps you get started.
 
 In the top left corner, you can see the menu icon. Clicking it will open the _sidebar_, the main menu for navigating Grafana.

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -110,6 +110,16 @@ To add a link:
 
 To vote for a link, click the triangle icon next to the name of the link.
 
+## Open Grafana
+Grafana is an open-source platform for monitoring and observability that lets you visualize and explore the state of your systems.
+
+1. Open a new tab.
+1. Browse to [localhost:3000](http://localhost:3000).
+
+The first thing you see is the Home dashboard, which helps you get started.
+
+In the top left corner, you can see the menu icon. Clicking it will open the _sidebar_, the main menu for navigating Grafana.
+
 ## Explore your metrics
 
 Grafana Explore is a workflow for troubleshooting and data exploration. In this step, you'll be using Explore to create ad-hoc queries to understand the metrics exposed by the sample application.

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -111,6 +111,7 @@ To add a link:
 To vote for a link, click the triangle icon next to the name of the link.
 
 ## Open Grafana
+
 Grafana is an open-source platform for monitoring and observability that lets you visualize and explore the state of your systems.
 
 1. Open a new tab.


### PR DESCRIPTION
**What is this feature?**

Updates the Grafana fundamentals tutorial with information on what url to use to access Grafana on which was removed by mistake in in pr #84287 

**Why do we need this feature?**

To make it easy to follow the tutorial

**Who is this feature for?**

Grafana users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

** Before **
![Screenshot 2024-05-30 at 11 38 07](https://github.com/grafana/grafana/assets/457523/678c0018-fac1-4df6-9b8c-9756f1da7edf)

** After **
![Screenshot 2024-05-30 at 11 37 49](https://github.com/grafana/grafana/assets/457523/8bbe4621-a1b5-4a85-808f-adcfe051ff2a)

