### PR TITLE
fix: Grafana Fundermentals -> No Grafana Url

### DIFF
--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -110,6 +110,17 @@ To add a link:
 
 To vote for a link, click the triangle icon next to the name of the link.
 
+## Accessing Grafana
+
+Grafana is an open-source platform for monitoring and observability that lets you visualize and explore the state of your systems.
+
+1. Open a new tab.
+1. Browse to [localhost:3000](http://localhost:3000).
+
+The first thing you see is the Home dashboard, which helps you get started.
+
+In the top left corner, you can see the menu icon. Clicking it will open the _sidebar_, the main menu for navigating Grafana.
+
 ## Explore your metrics
 
 Grafana Explore is a workflow for troubleshooting and data exploration. In this step, you'll be using Explore to create ad-hoc queries to understand the metrics exposed by the sample application.


### PR DESCRIPTION

## Fixes
Url was accidentally removed from tutorial.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
