### PR TITLE
CodeEditor: Fix broken styles

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -527,7 +527,7 @@ export const Components = {
     container: 'data-testid Code editor container',
   },
   ReactMonacoEditor: {
-    container: 'data-testid ReactMonacoEditor container',
+    editorLazy: 'data-testid ReactMonacoEditor editorLazy',
   },
   DashboardImportPage: {
     textarea: 'data-testid-import-dashboard-textarea',

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -16,14 +16,20 @@ import type { ReactMonacoEditorProps } from './types';
  * @internal
  * Experimental export
  **/
-const MonacoEditorLazy = (props: ReactMonacoEditorProps) => {
+export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   const styles = useStyles2(getStyles);
   const { loading, error, dependency } = useAsyncDependency(
     import(/* webpackChunkName: "react-monaco-editor" */ './ReactMonacoEditor')
   );
 
   if (loading) {
-    return <LoadingPlaceholder text={'Loading editor'} className={styles.container} />;
+    return (
+      <LoadingPlaceholder
+        text={'Loading editor'}
+        className={styles.container}
+        data-testid={selectors.components.ReactMonacoEditor.editorLazy}
+      />
+    );
   }
 
   if (error) {
@@ -37,7 +43,13 @@ const MonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   }
 
   const ReactMonacoEditor = dependency.ReactMonacoEditor;
-  return <ReactMonacoEditor {...props} loading={props.loading ?? null} />;
+  return (
+    <ReactMonacoEditor
+      {...props}
+      loading={props.loading ?? null}
+      data-testid={selectors.components.ReactMonacoEditor.editorLazy}
+    />
+  );
 };
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -48,18 +60,3 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
-const withContainer = <P extends object>(Component: React.ComponentType<P>): React.ComponentType<P> => {
-  const WithContainer = (props: P) => (
-    // allow tests to easily determine if the code editor has rendered in any of its three states (loading, error, or ready)
-    <div data-testid={selectors.components.ReactMonacoEditor.container}>
-      <Component {...props} />
-    </div>
-  );
-
-  WithContainer.displayName = Component.displayName;
-
-  return WithContainer;
-};
-
-export const ReactMonacoEditorLazy = withContainer(MonacoEditorLazy);

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -47,7 +47,9 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
     <ReactMonacoEditor
       {...props}
       loading={props.loading ?? null}
-      data-testid={selectors.components.ReactMonacoEditor.editorLazy}
+      wrapperProps={{
+        'data-testid': selectors.components.ReactMonacoEditor.editorLazy,
+      }}
     />
   );
 };

--- a/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
+++ b/packages/grafana-ui/src/components/Monaco/ReactMonacoEditorLazy.tsx
@@ -23,13 +23,7 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
   );
 
   if (loading) {
-    return (
-      <LoadingPlaceholder
-        text={'Loading editor'}
-        className={styles.container}
-        data-testid={selectors.components.ReactMonacoEditor.editorLazy}
-      />
-    );
+    return <LoadingPlaceholder text={'Loading editor'} className={styles.container} />;
   }
 
   if (error) {
@@ -37,7 +31,7 @@ export const ReactMonacoEditorLazy = (props: ReactMonacoEditorProps) => {
       <ErrorWithStack
         title="React Monaco Editor failed to load"
         error={error}
-        errorInfo={{ componentStack: error?.stack || '' }}
+        errorInfo={{ componentStack: error?.stack ?? '' }}
       />
     );
   }

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -27,7 +27,7 @@ describe('MonacoFieldWrapper', () => {
     renderComponent();
 
     await waitFor(async () => {
-      const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+      const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLazy);
       expect(monacoEditor).toBeInTheDocument();
     });
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoQueryField.test.tsx
@@ -33,7 +33,7 @@ describe('MonacoQueryField', () => {
   test('Renders with no errors', async () => {
     renderComponent();
 
-    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLazy);
     expect(monacoEditor).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -34,7 +34,7 @@ describe('LokiQueryCodeEditor', () => {
     props.showExplain = true;
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLazy);
     expect(monacoEditor).toBeInTheDocument();
     expect(screen.getByText(EXPLAIN_LABEL_FILTER_CONTENT)).toBeInTheDocument();
   });
@@ -43,7 +43,7 @@ describe('LokiQueryCodeEditor', () => {
     const props = createDefaultProps();
     props.datasource.metadataRequest = jest.fn().mockResolvedValue([]);
     render(<LokiQueryCodeEditor {...props} query={defaultQuery} />);
-    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.container);
+    const monacoEditor = await screen.findByTestId(selectors.components.ReactMonacoEditor.editorLazy);
     expect(monacoEditor).toBeInTheDocument();
     expect(screen.queryByText(EXPLAIN_LABEL_FILTER_CONTENT)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## What is this change?

A fast-follow update to https://github.com/grafana/grafana/pull/88102. It updates `grafana-ui`'s `ReactMonacoEditorLazy` component (exported as `ReactMonacoEditor`), which is used both directly & indirectly (via `grafana-ui`'s `CodeEditor`) by various data sources, panel plugins, dashboard components, etc.

## Why do we need this change?

To address the problems outlined in #88494.

### Demo

#### Before

The `containerStyles` supplied to the `<CodeEditor />` were not working as expected. For example, [in `JsonEditorSettings`](https://github.com/grafana/grafana/blob/8f45003192854a476dbf113b5e718e7d13e8d682/public/app/features/dashboard/components/DashboardSettings/JsonEditorSettings.tsx#L33-L40):

![dashboard settings json model broken styles](https://github.com/grafana/grafana/assets/5732000/95126c6c-9166-4314-850d-b4ef3955940c)

#### After

The `containerStyles` supplied to the `<CodeEditor />` work as they did before. For example, in `JsonEditorSettings`:

![demo monaco editor container fix for dashboard settings json model](https://github.com/grafana/grafana/assets/5732000/96d0f765-430d-4a49-92fe-63b458e34cc2)

## Who is this feature for?

All Grafana users.

## Which issue(s) does this PR fix?

Fixes #88494

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
