### PR TITLE
Dashboard: Fix Variables query hides fields with non-supported datasources

### DIFF
--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -131,7 +131,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
 
   render() {
     const { extended, variable } = this.props;
-    if (!extended || !extended.dataSource || !extended.VariableQueryEditor) {
+    if (!extended || !extended.dataSource) {
       return null;
     }
 

--- a/public/app/features/variables/query/VariableQueryRunner.test.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.test.ts
@@ -70,6 +70,7 @@ function getTestContext(variable?: QueryVariableModel) {
     runRequest: jest.fn().mockReturnValue(of({ series: [], state: LoadingState.Done })),
   };
   const queryRunners = {
+    isQueryRunnerAvailableForDatasource: jest.fn().mockReturnValue(true),
     getRunnerForDatasource: jest.fn().mockReturnValue(queryRunner),
   } as unknown as QueryRunners;
   const getVariable = jest.fn().mockReturnValue(variable);
@@ -147,15 +148,12 @@ describe('VariableQueryRunner', () => {
   });
 
   describe('error cases', () => {
-    describe('queryRunners.getRunnerForDatasource throws', () => {
+    describe('queryRunners.isQueryRunnerAvailableForDatasource throws', () => {
       it('then it should work as expected', (done) => {
         const { identifier, runner, datasource, getState, getVariable, queryRunners, queryRunner, dispatch } =
           getTestContext();
 
-        queryRunners.getRunnerForDatasource = jest.fn().mockImplementation(() => {
-          throw new Error('getRunnerForDatasource error');
-        });
-
+        queryRunners.isQueryRunnerAvailableForDatasource = jest.fn().mockReturnValue(false);
         expectOnResults({
           identifier,
           runner,
@@ -163,13 +161,17 @@ describe('VariableQueryRunner', () => {
             // verify that the observable works as expected
             expect(results).toEqual([
               { state: LoadingState.Loading, identifier },
-              { state: LoadingState.Error, identifier, error: new Error('getRunnerForDatasource error') },
+              {
+                state: LoadingState.Error,
+                identifier,
+                error: new Error('Query Runner is not available for datasource.'),
+              },
             ]);
 
             // verify that mocks have been called as expected
             expect(getState).toHaveBeenCalledTimes(2);
             expect(getVariable).toHaveBeenCalledTimes(1);
-            expect(queryRunners.getRunnerForDatasource).toHaveBeenCalledTimes(1);
+            expect(queryRunners.isQueryRunnerAvailableForDatasource).toHaveBeenCalledTimes(1);
             expect(queryRunner.getTarget).not.toHaveBeenCalled();
             expect(queryRunner.runRequest).not.toHaveBeenCalled();
             expect(datasource.metricFindQuery).not.toHaveBeenCalled();

--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -113,11 +113,8 @@ export class VariableQueryRunner {
       const runnerArgs = { variable, datasource, searchFilter, timeSrv, runRequest };
       //if query runner is not available for the datasource, we should return early
       if (!queryRunners.isQueryRunnerAvailableForDatasource(datasource)) {
-        this.updateOptionsResults.next({
-          identifier,
-          state: LoadingState.Error,
-          error: 'Query Runner is not available for datasource',
-        });
+        const error = new Error('Query Runner is not available for datasource.');
+        this.updateOptionsResults.next({ identifier, state: LoadingState.Error, error });
         return;
       }
 

--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -111,6 +111,16 @@ export class VariableQueryRunner {
 
       const timeSrv = getTimeSrv();
       const runnerArgs = { variable, datasource, searchFilter, timeSrv, runRequest };
+      //if query runner is not available for the datasource, we should return early
+      if (!queryRunners.isQueryRunnerAvailableForDatasource(datasource)) {
+        this.updateOptionsResults.next({
+          identifier,
+          state: LoadingState.Error,
+          error: 'Query Runner is not available for datasource',
+        });
+        return;
+      }
+
       const runner = queryRunners.getRunnerForDatasource(datasource);
       const target = runner.getTarget({ datasource, variable });
       const request = this.getRequest(variable, args, target);

--- a/public/app/features/variables/query/queryRunners.ts
+++ b/public/app/features/variables/query/queryRunners.ts
@@ -61,6 +61,11 @@ export class QueryRunners {
 
     throw new Error("Couldn't find a query runner that matches supplied arguments.");
   }
+
+  //Check if datasource has a query runner associated with it
+  isQueryRunnerAvailableForDatasource(datasource: DataSourceApi) {
+    return this.runners.some((runner) => runner.canRun(datasource));
+  }
 }
 
 class LegacyQueryRunner implements QueryRunner {


### PR DESCRIPTION
Coming from as [escalation](https://github.com/grafana/support-escalations/issues/10760) and [ OSS issue](https://github.com/grafana/grafana/issues/85730).

#### Problem
When a query variable had a datasource that didn't support variables, we were hiding the whole `VariableQueryEditor`, this made it impossible to change the datasource.
![MissingQueryEditorBug](https://github.com/grafana/grafana/assets/239999/514f0652-cbb3-449c-89d2-727a24da7462)



### Notes for the reviewer:

- The bug was only present in the old architecture(on Dashboard Scene was working). 

Fixes: #85730 