### PR TITLE
CloudWatch: Handle permissions error and update docs

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -123,6 +123,12 @@ You can attach these permissions to the IAM role or IAM user you configured in [
       "Effect": "Allow",
       "Action": "tag:GetResources",
       "Resource": "*"
+    },
+    {
+      "Sid": "AmazonRDSPerformanceInsightsGetResourceMetrics",
+      "Effect": "Allow",
+      "Action": "pi:GetResourceMetrics",
+      "Resource": "*"
     }
   ]
 }
@@ -180,6 +186,12 @@ You can attach these permissions to the IAM role or IAM user you configured in [
         "cloudwatch:GetMetricData",
         "cloudwatch:GetInsightRuleReport"
       ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AmazonRDSPerformanceInsightsGetResourceMetrics",
+      "Effect": "Allow",
+      "Action": "pi:GetResourceMetrics",
       "Resource": "*"
     },
     {

--- a/docs/sources/datasources/aws-cloudwatch/_index.md
+++ b/docs/sources/datasources/aws-cloudwatch/_index.md
@@ -125,7 +125,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
       "Resource": "*"
     },
     {
-      "Sid": "AmazonRDSPerformanceInsightsGetResourceMetrics",
+      "Sid": "AllowReadingResourceMetricsFromPerformanceInsights",
       "Effect": "Allow",
       "Action": "pi:GetResourceMetrics",
       "Resource": "*"
@@ -189,7 +189,7 @@ You can attach these permissions to the IAM role or IAM user you configured in [
       "Resource": "*"
     },
     {
-      "Sid": "AmazonRDSPerformanceInsightsGetResourceMetrics",
+      "Sid": "AllowReadingResourceMetricsFromPerformanceInsights",
       "Effect": "Allow",
       "Action": "pi:GetResourceMetrics",
       "Resource": "*"

--- a/pkg/tsdb/cloudwatch/models/query_row_response.go
+++ b/pkg/tsdb/cloudwatch/models/query_row_response.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/aws/aws-sdk-go/service/cloudwatch"
+import (
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+)
 
 // queryRowResponse represents the GetMetricData response for a query row in the query editor.
 type QueryRowResponse struct {
@@ -8,6 +10,8 @@ type QueryRowResponse struct {
 	ErrorCodes             map[string]bool
 	HasArithmeticError     bool
 	ArithmeticErrorMessage string
+	HasPermissionError     bool
+	PermissionErrorMessage string
 	Metrics                []*cloudwatch.MetricDataResult
 	StatusCode             string
 }
@@ -23,6 +27,10 @@ func NewQueryRowResponse(errors map[string]bool) QueryRowResponse {
 }
 
 func (q *QueryRowResponse) AddMetricDataResult(mdr *cloudwatch.MetricDataResult) {
+	if mdr.Label == nil {
+		return
+	}
+
 	if partialData, ok := q.partialDataSet[*mdr.Label]; ok {
 		partialData.Timestamps = append(partialData.Timestamps, mdr.Timestamps...)
 		partialData.Values = append(partialData.Values, mdr.Values...)
@@ -43,4 +51,9 @@ func (q *QueryRowResponse) AddMetricDataResult(mdr *cloudwatch.MetricDataResult)
 func (q *QueryRowResponse) AddArithmeticError(message *string) {
 	q.HasArithmeticError = true
 	q.ArithmeticErrorMessage = *message
+}
+
+func (q *QueryRowResponse) AddPermissionError(message *string) {
+	q.HasPermissionError = true
+	q.PermissionErrorMessage = *message
 }

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -35,6 +35,10 @@ func (e *cloudWatchExecutor) parseResponse(ctx context.Context, startTime time.T
 			dataRes.Error = fmt.Errorf("ArithmeticError in query %q: %s", queryRow.RefId, response.ArithmeticErrorMessage)
 		}
 
+		if response.HasPermissionError {
+			dataRes.Error = fmt.Errorf("PermissionError in query %q: %s", queryRow.RefId, response.PermissionErrorMessage)
+		}
+
 		var err error
 		dataRes.Frames, err = buildDataFrames(ctx, startTime, endTime, response, queryRow)
 		if err != nil {
@@ -78,6 +82,9 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 			for _, message := range r.Messages {
 				if *message.Code == "ArithmeticError" {
 					response.AddArithmeticError(message.Value)
+				}
+				if *message.Code == "Forbidden" {
+					response.AddPermissionError(message.Value)
 				}
 			}
 

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -136,7 +136,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		})
 	})
 
-	t.Run("when recieving a permissions error should pass it to the user", func(t *testing.T) {
+	t.Run("when receiving a permissions error should pass it to the user", func(t *testing.T) {
 		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./testdata/permissions-error-output.json")
 		require.NoError(t, err)
 		aggregatedResponse := aggregateResponse(getMetricDataOutputs)

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -135,6 +135,15 @@ func TestCloudWatchResponseParser(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("when recieving a permissions error should pass it to the user", func(t *testing.T) {
+		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./testdata/permissions-error-output.json")
+		require.NoError(t, err)
+		aggregatedResponse := aggregateResponse(getMetricDataOutputs)
+
+		assert.True(t, aggregatedResponse["a"].HasPermissionError)
+		assert.Equal(t, "Access denied when getting data - please check that you have the pi:GetResourceMetrics permission", aggregatedResponse["a"].PermissionErrorMessage)
+	})
 }
 
 func Test_buildDataFrames_parse_label_to_name_and_labels(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/testdata/permissions-error-output.json
+++ b/pkg/tsdb/cloudwatch/testdata/permissions-error-output.json
@@ -1,0 +1,16 @@
+[
+  {
+    "Messages": null,
+    "MetricDataResults": [
+      {
+        "Id": "a",
+        "Messages": [{
+          "Code": "Forbidden",
+          "Value": "Access denied when getting data - please check that you have the pi:GetResourceMetrics permission"
+        }],
+        "StatusCode": "Forbidden"
+      }
+    ],
+    "NextToken": null
+  }
+]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We added the DB_PERF_INSIGHTS metric math expression, but it requires additional permissions to work. Users weren't seeing that because we weren't passing them the error. This fixes it by adding error handling and adding it to the docs.

**Why do we need this feature?**

We need this so that users know what permissions they need for this query.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #79829 

**Special notes for your reviewer:**
I created a user group called `Cloudwatch_users` and a user called `basic-creds-cloudwatch` in the external dev instance with all the cloudwatch permissions and only the cloudwatch permissions if you want to try it.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
