### PR TITLE
Docs: add pinning of terraform for migration

### DIFF
--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -200,6 +200,7 @@ terraform {
   }
 }
 ```
+
 This section shows you how to migrate your Terraform configuration for API keys to Grafana service accounts. For resources, see [Grafana Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/service_account_token).
 
 For migration your cloud stack api keys, use the `grafana_cloud_stack_service_account` and `gafana_cloud_stack_service_account_token` resources see [Grafana Cloud Stack Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack_service_account).

--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -186,6 +186,18 @@ curl --request GET --url http://localhost:3000/api/folders --header 'Authorizati
 The terraform resource `api_key` has been removed in v3.0.0 from the Grafana Terraform Provider. During your migration path, we suggest that you pin your terraform version to <v2.19.0. See [release notes](https://github.com/grafana/terraform-provider-grafana/releases/tag/v3.0.0) for more information.
 {{% /admonition %}}
 
+If you need to pin the version of terraform to v2.19.0
+```tf
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "2.19.0"
+    }
+  }
+}
+```
+
 This section shows you how to migrate your Terraform configuration for API keys to Grafana service accounts. For resources, see [Grafana Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/service_account_token).
 
 For migration your cloud stack api keys, use the `grafana_cloud_stack_service_account` and `gafana_cloud_stack_service_account_token` resources see [Grafana Cloud Stack Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack_service_account).

--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -182,13 +182,15 @@ curl --request GET --url http://localhost:3000/api/folders --header 'Authorizati
 
 ### Migrate API keys to Grafana service accounts in Terraform
 
-{{% admonition type="note" %}}
-The terraform resource `api_key` has been removed in v3.0.0 from the Grafana Terraform Provider. During your migration path, we suggest that you pin your terraform version to <v2.19.0. See [release notes](https://github.com/grafana/terraform-provider-grafana/releases/tag/v3.0.0) for more information.
-{{% /admonition %}}
+{{< admonition type="note" >}}
+The terraform resource `api_key` is removed from the Grafana Terraform Provider in v3.0.0.
+Before you migrate and remove the use of the resource, you should pin your terraform version to a version less-than or equal-to v2.19.0.
+For more information, refer to the [Grafana Terraform Provider release notes](https://github.com/grafana/terraform-provider-grafana/releases/tag/v3.0.0).
+{{< /admonition >}}
 
-If you need to pin the version of terraform to v2.19.0
+To pin the Grafana Terraform Provider to v2.19.0:
 
-```tf
+```hcl
 terraform {
   required_providers {
     grafana = {
@@ -198,7 +200,6 @@ terraform {
   }
 }
 ```
-
 This section shows you how to migrate your Terraform configuration for API keys to Grafana service accounts. For resources, see [Grafana Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/service_account_token).
 
 For migration your cloud stack api keys, use the `grafana_cloud_stack_service_account` and `gafana_cloud_stack_service_account_token` resources see [Grafana Cloud Stack Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack_service_account).

--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -187,6 +187,7 @@ The terraform resource `api_key` has been removed in v3.0.0 from the Grafana Ter
 {{% /admonition %}}
 
 If you need to pin the version of terraform to v2.19.0
+
 ```tf
 terraform {
   required_providers {

--- a/docs/sources/administration/api-keys/index.md
+++ b/docs/sources/administration/api-keys/index.md
@@ -182,6 +182,10 @@ curl --request GET --url http://localhost:3000/api/folders --header 'Authorizati
 
 ### Migrate API keys to Grafana service accounts in Terraform
 
+{{% admonition type="note" %}}
+The terraform resource `api_key` has been removed in v3.0.0 from the Grafana Terraform Provider. During your migration path, we suggest that you pin your terraform version to <v2.19.0. See [release notes](https://github.com/grafana/terraform-provider-grafana/releases/tag/v3.0.0) for more information.
+{{% /admonition %}}
+
 This section shows you how to migrate your Terraform configuration for API keys to Grafana service accounts. For resources, see [Grafana Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/service_account_token).
 
 For migration your cloud stack api keys, use the `grafana_cloud_stack_service_account` and `gafana_cloud_stack_service_account_token` resources see [Grafana Cloud Stack Service Accounts in Terraform](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack_service_account).


### PR DESCRIPTION
**why**
We are deprecating API keys and in that effort we have migration paths. Since v3.0.0 of terraform we have removed the resource.
https://github.com/grafana/terraform-provider-grafana/releases/tag/v3.0.0

**what**
This adds a recommendation that you can pin your terraform version until you have migrated from API Keys to SATs.

- **Docs: update with terraform version**
- **added the terraform version pinning**
