### PR TITLE
Select: Very poor search performance replication story 

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -5,7 +5,7 @@ import Chance from 'chance';
 import React, { useState } from 'react';
 
 import { SelectableValue, toIconName } from '@grafana/data';
-import { Icon, Select, AsyncSelect, MultiSelect, AsyncMultiSelect } from '@grafana/ui';
+import { Icon, Select, AsyncSelect, MultiSelect, AsyncMultiSelect, Stack } from '@grafana/ui';
 
 import { getAvailableIcons } from '../../types';
 
@@ -143,6 +143,26 @@ export const BasicVirtualizedList: StoryFn<StoryProps> = (args) => {
         {...args}
       />
     </>
+  );
+};
+
+export const BasicVirtualizedListManyOptions: StoryFn<StoryProps> = (args) => {
+  const [value, setValue] = useState<SelectableValue<string>>();
+
+  return (
+    <Stack direction="column">
+      100K random options
+      <Select
+        options={generateThousandsOfOptions(100000)}
+        virtualized
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          action('onChange')(v);
+        }}
+        {...args}
+      />
+    </Stack>
   );
 };
 

--- a/packages/grafana-ui/src/components/Select/mockOptions.tsx
+++ b/packages/grafana-ui/src/components/Select/mockOptions.tsx
@@ -34,12 +34,23 @@ export const generateOptions = (desc = false) => {
   }));
 };
 
-export const generateThousandsOfOptions = () => {
-  const options: Array<SelectableValue<string>> = new Array(10000).fill(null).map((_, index) => ({
-    value: String(index),
-    label: 'Option ' + index,
-    description: 'This is option number ' + index,
+export function generateThousandsOfOptions(count = 10000): Array<SelectableValue<string>> {
+  return new Array(count).fill(null).map((_, index) => ({
+    value: makeString(50),
+    label: makeString(50),
   }));
+}
 
-  return options;
-};
+function makeString(length: number) {
+  let result = '';
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charactersLength = characters.length;
+  let counter = 0;
+
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+
+  return result;
+}


### PR DESCRIPTION
In the new scene-based dashboards we use the design system Select for variable value selects. 

We hit an issue with a variable with 100K values where there is a huge performance difference between old custom select dropdown and design system Select when it comes to search performance. Each keystroke takes 3-4 seconds in the story text example I added in this PR. Compared to our custom select where it's almost instant with the same number of options. 

Does anyone have time to investigate and see if there is anything we can do (without replacing Select). 