### PR TITLE
TooltipPlugin: Fix console error when data updates while anchored

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -404,6 +404,7 @@ export const TooltipPlugin2 = ({
     config.addHook('setData', (u) => {
       yZoomed = false;
       yDrag = false;
+      dismiss();
     });
 
     // fires on series focus/proximity changes

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -526,6 +526,10 @@ export const TooltipPlugin2 = ({
     return () => {
       window.removeEventListener('resize', updateWinSize);
       window.removeEventListener('scroll', onscroll, true);
+
+      // in case this component unmounts while anchored (due to data auto-refresh + re-config)
+      document.removeEventListener('mousedown', downEventOutside, true);
+      document.removeEventListener('keydown', downEventOutside, true);
     };
   }, [config]);
 


### PR DESCRIPTION
we're seeing some rare console errors in our telemetry:

```
Error: null is not an object (evaluating 'C.current.contains')\n  at ? (webpack://grafana/./packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx:211:27)
```

this happens here:

https://github.com/grafana/grafana/blob/ae11e5440396b5f061c69de33397567b3fba6298/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx#L209-L214

my theory is that this function remains on the document when the component unmounts and re-initializes while the tooltip is anchored. the re-init can happen without user interaction due to auto data refresh if there are new fields or config in the new dataframes.

this PR adds the removal of these listeners into the cleanup of the `useLayoutEffect` hook.

i'm not sure if this is the correct fix, since it's difficult to repro.