### PR TITLE
Chore: Return influxdb query error early before parsing the result

### DIFF
--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -23,10 +23,6 @@ func ResponseParse(buf io.ReadCloser, statusCode int, query *models.Query) *back
 func parse(buf io.Reader, statusCode int, query *models.Query) *backend.DataResponse {
 	response, jsonErr := parseJSON(buf)
 
-	if statusCode/100 != 2 {
-		return &backend.DataResponse{Error: fmt.Errorf("InfluxDB returned error: %s", response.Error)}
-	}
-
 	if jsonErr != nil {
 		return &backend.DataResponse{Error: jsonErr}
 	}

--- a/pkg/tsdb/influxdb/influxql/influxql.go
+++ b/pkg/tsdb/influxdb/influxql/influxql.go
@@ -174,6 +174,11 @@ func execute(ctx context.Context, tracer trace.Tracer, dsInfo *models.Datasource
 	if err != nil {
 		return backend.DataResponse{}, err
 	}
+
+	if res.StatusCode/100 != 2 {
+		return backend.DataResponse{Error: fmt.Errorf("InfluxDB returned error: %v", res.Body)}, nil
+	}
+
 	defer func() {
 		if err := res.Body.Close(); err != nil {
 			logger.Warn("Failed to close response body", "err", err)

--- a/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
+++ b/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
@@ -23,10 +23,6 @@ func ResponseParse(buf io.ReadCloser, statusCode int, query *models.Query) *back
 	iter := jsoniter.Parse(jsoniter.ConfigDefault, buf, 1024)
 	r := converter.ReadInfluxQLStyleResult(iter, query)
 
-	if statusCode/100 != 2 {
-		return &backend.DataResponse{Error: fmt.Errorf("InfluxDB returned error: %s", r.Error)}
-	}
-
 	// The ExecutedQueryString can be viewed in QueryInspector in UI
 	for i, frame := range r.Frames {
 		if i == 0 {


### PR DESCRIPTION
**What is this feature?**

Just return the error before trying to parse the result. 
