### PR TITLE
Transformations: Add variable support to select groupingToMatrix

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -2,7 +2,12 @@ import { map } from 'rxjs/operators';
 
 import { getFieldDisplayName } from '../../field/fieldState';
 import { DataFrame, Field, FieldType } from '../../types/dataFrame';
-import { SpecialValue, DataTransformerInfo, TransformationApplicabilityLevels, DataTransformContext} from '../../types/transformations';
+import {
+  SpecialValue,
+  DataTransformerInfo,
+  TransformationApplicabilityLevels,
+  DataTransformContext,
+} from '../../types/transformations';
 import { fieldMatchers } from '../matchers';
 import { FieldMatcherID } from '../matchers/ids';
 

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -2,7 +2,7 @@ import { map } from 'rxjs/operators';
 
 import { getFieldDisplayName } from '../../field/fieldState';
 import { DataFrame, Field, FieldType } from '../../types/dataFrame';
-import { SpecialValue, DataTransformerInfo, TransformationApplicabilityLevels } from '../../types/transformations';
+import { SpecialValue, DataTransformerInfo, TransformationApplicabilityLevels, DataTransformContext} from '../../types/transformations';
 import { fieldMatchers } from '../matchers';
 import { FieldMatcherID } from '../matchers/ids';
 
@@ -57,12 +57,12 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
 
     return `Grouping to matrix requiers at least 3 fields to work. Currently there are ${numFields} fields.`;
   },
-  operator: (options) => (source) =>
+  operator: (options: GroupingToMatrixTransformerOptions, ctx: DataTransformContext) => (source) =>
     source.pipe(
       map((data) => {
-        const columnFieldMatch = options.columnField || DEFAULT_COLUMN_FIELD;
-        const rowFieldMatch = options.rowField || DEFAULT_ROW_FIELD;
-        const valueFieldMatch = options.valueField || DEFAULT_VALUE_FIELD;
+        const columnFieldMatch = ctx.interpolate(options.columnField || DEFAULT_COLUMN_FIELD);
+        const rowFieldMatch = ctx.interpolate(options.rowField || DEFAULT_ROW_FIELD);
+        const valueFieldMatch = ctx.interpolate(options.valueField || DEFAULT_VALUE_FIELD);
         const emptyValue = options.emptyValue || DEFAULT_EMPTY_VALUE;
 
         // Accept only single queries

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -13,6 +13,7 @@ import {
 import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
+import { getTemplateSrv } from '@grafana/runtime';
 import { useAllFieldNamesFromDataFrames } from '../utils';
 
 export const GroupingToMatrixTransformerEditor = ({
@@ -21,6 +22,11 @@ export const GroupingToMatrixTransformerEditor = ({
   onChange,
 }: TransformerUIProps<GroupingToMatrixTransformerOptions>) => {
   const fieldNames = useAllFieldNamesFromDataFrames(input).map((item: string) => ({ label: item, value: item }));
+  const variables = getTemplateSrv()
+    .getVariables()
+    .map((v) => {
+      return { value: '$' + v.name, label: '$' + v.name };
+    });
 
   const onSelectColumn = useCallback(
     (value: SelectableValue<string>) => {
@@ -73,13 +79,13 @@ export const GroupingToMatrixTransformerEditor = ({
     <>
       <InlineFieldRow>
         <InlineField label="Column" labelWidth={8}>
-          <Select options={fieldNames} value={options.columnField} onChange={onSelectColumn} isClearable />
+          <Select options={[...fieldNames, ...variables]} value={options.columnField} onChange={onSelectColumn} isClearable />
         </InlineField>
         <InlineField label="Row" labelWidth={8}>
-          <Select options={fieldNames} value={options.rowField} onChange={onSelectRow} isClearable />
+          <Select options={[...fieldNames, ...variables]} value={options.rowField} onChange={onSelectRow} isClearable />
         </InlineField>
         <InlineField label="Cell Value" labelWidth={10}>
-          <Select options={fieldNames} value={options.valueField} onChange={onSelectValue} isClearable />
+          <Select options={[...fieldNames, ...variables]} value={options.valueField} onChange={onSelectValue} isClearable />
         </InlineField>
         <InlineField label="Empty Value">
           <Select options={specialValueOptions} value={options.emptyValue} onChange={onSelectEmptyValue} isClearable />

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -79,13 +79,23 @@ export const GroupingToMatrixTransformerEditor = ({
     <>
       <InlineFieldRow>
         <InlineField label="Column" labelWidth={8}>
-          <Select options={[...fieldNames, ...variables]} value={options.columnField} onChange={onSelectColumn} isClearable />
+          <Select
+            options={[...fieldNames, ...variables]}
+            value={options.columnField}
+            onChange={onSelectColumn}
+            isClearable
+          />
         </InlineField>
         <InlineField label="Row" labelWidth={8}>
           <Select options={[...fieldNames, ...variables]} value={options.rowField} onChange={onSelectRow} isClearable />
         </InlineField>
         <InlineField label="Cell Value" labelWidth={10}>
-          <Select options={[...fieldNames, ...variables]} value={options.valueField} onChange={onSelectValue} isClearable />
+          <Select
+            options={[...fieldNames, ...variables]}
+            value={options.valueField}
+            onChange={onSelectValue}
+            isClearable
+          />
         </InlineField>
         <InlineField label="Empty Value">
           <Select options={specialValueOptions} value={options.emptyValue} onChange={onSelectEmptyValue} isClearable />

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -10,10 +10,10 @@ import {
   SpecialValue,
   TransformerCategory,
 } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
-import { getTemplateSrv } from '@grafana/runtime';
 import { useAllFieldNamesFromDataFrames } from '../utils';
 
 export const GroupingToMatrixTransformerEditor = ({


### PR DESCRIPTION
**What is this feature?**

This feature adds support to select the input for the groupingToMatrix transformation based on variables.

**Why do we need this feature?**

We do expose some plots where the groupby options are dynamically loaded using variables so users without editor access can still change the output of the plots, extending this to the groupingToMatrix transformation was needed as currently this transformation was not "dynamic" enough.

**Who is this feature for?**

This is mainly for editors that want to make their viewers able to play with more options in their dashboards

**Which issue(s) does this PR fix?**:

Don't think there's a related issue

**Special notes for your reviewer:**

I'm not sure how to categorize this change (in the sense of "notable improvement"), this was fully inspired by similar commit:
https://github.com/grafana/grafana/commit/df9e7671d9243a574d7f5095b6b03cd76f235c7f
