### PR TITLE
InfluxDB: Set interval value in field config

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -61,6 +61,9 @@ func executeQuery(ctx context.Context, logger log.Logger, query queryModel, runn
 		firstFrame.SetMeta(&data.FrameMeta{})
 	}
 	firstFrame.Meta.ExecutedQueryString = flux
+	if firstFrame.Fields != nil && len(firstFrame.Fields) > 0 {
+		firstFrame.Fields[0].Config = &data.FieldConfig{Interval: float64(query.Interval.Milliseconds())}
+	}
 	return dr
 }
 

--- a/pkg/tsdb/influxdb/fsql/arrow.go
+++ b/pkg/tsdb/influxdb/fsql/arrow.go
@@ -75,6 +75,10 @@ func newQueryDataResponse(reader recordReader, query sqlutil.Query, headers meta
 	}
 
 	resp.Frames = data.Frames{frame}
+
+	if frame != nil && frame.Fields != nil && len(frame.Fields) > 0 {
+		frame.Fields[0].Config = &data.FieldConfig{Interval: float64(query.Interval.Milliseconds())}
+	}
 	return resp
 }
 

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -66,10 +66,6 @@ func transformRowsForTable(rows []models.Row, query models.Query) data.Frames {
 	frames := make([]*data.Frame, 0, 1)
 
 	newFrame := data.NewFrame(rows[0].Name)
-	newFrame.Meta = &data.FrameMeta{
-		ExecutedQueryString:    query.RawQuery,
-		PreferredVisualization: util.GetVisType(query.ResultFormat),
-	}
 
 	conLen := len(rows[0].Columns)
 	if rows[0].Columns[0] == "time" {
@@ -241,12 +237,6 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 
 		if !hasTimeCol {
 			newFrame := newFrameWithoutTimeField(row, query)
-			if len(frames) == 0 {
-				newFrame.Meta = &data.FrameMeta{
-					ExecutedQueryString:    query.RawQuery,
-					PreferredVisualization: util.GetVisType(query.ResultFormat),
-				}
-			}
 			frames = append(frames, newFrame)
 		} else {
 			for colIndex, column := range row.Columns {
@@ -254,12 +244,6 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 					continue
 				}
 				newFrame := newFrameWithTimeField(row, column, colIndex, query, frameName)
-				if len(frames) == 0 {
-					newFrame.Meta = &data.FrameMeta{
-						ExecutedQueryString:    query.RawQuery,
-						PreferredVisualization: util.GetVisType(query.ResultFormat),
-					}
-				}
 				frames = append(frames, newFrame)
 			}
 		}

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser_test.go
@@ -139,7 +139,6 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			newField,
 		)
-		testFrame.Meta = &data.FrameMeta{PreferredVisualization: util.GraphVisType, ExecutedQueryString: "Test raw query"}
 		testFrameWithoutMeta := data.NewFrame("series alias",
 			data.NewField("Time", nil,
 				[]time.Time{
@@ -371,7 +370,6 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				}),
 			newField,
 		)
-		testFrame.Meta = &data.FrameMeta{PreferredVisualization: util.GraphVisType, ExecutedQueryString: "Test raw query"}
 
 		result := ResponseParse(readJsonFile("invalid_timestamp_format"), 200, generateQuery("Test raw query", "time_series", ""))
 

--- a/pkg/tsdb/influxdb/influxql/converter/converter.go
+++ b/pkg/tsdb/influxdb/influxql/converter/converter.go
@@ -385,10 +385,6 @@ func handleTableFormatFirstFrame(rsp *backend.DataResponse, measurement string, 
 	// Add the first and only frame for table format
 	if len(rsp.Frames) == 0 {
 		newFrame := data.NewFrame(measurement)
-		newFrame.Meta = &data.FrameMeta{
-			ExecutedQueryString:    query.RawQuery,
-			PreferredVisualization: util.GetVisType(query.ResultFormat),
-		}
 		rsp.Frames = append(rsp.Frames, newFrame)
 	}
 }

--- a/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
+++ b/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
@@ -5,11 +5,9 @@ import (
 	"io"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/influxql/converter"
-	"github.com/grafana/grafana/pkg/tsdb/influxdb/influxql/util"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
@@ -25,13 +23,6 @@ func ResponseParse(buf io.ReadCloser, statusCode int, query *models.Query) *back
 
 	if statusCode/100 != 2 {
 		return &backend.DataResponse{Error: fmt.Errorf("InfluxDB returned error: %s", r.Error)}
-	}
-
-	// The ExecutedQueryString can be viewed in QueryInspector in UI
-	for i, frame := range r.Frames {
-		if i == 0 {
-			frame.Meta = &data.FrameMeta{ExecutedQueryString: query.RawQuery, PreferredVisualization: util.GetVisType(query.ResultFormat)}
-		}
 	}
 
 	return r

--- a/pkg/tsdb/influxdb/influxql/testdata/all_values_are_null.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/all_values_are_null.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/all_values_are_null.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/all_values_are_null.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu.mean",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/cardinality.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/cardinality.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "SHOW TAG VALUES CARDINALITY with key = \"host\""
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 1 Fields by 1 Rows
 //  +-----------------+
@@ -130,14 +123,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "SHOW TAG VALUES CARDINALITY with key = \"host\""
-        },
         "fields": [
           {
             "name": "Value",

--- a/pkg/tsdb/influxdb/influxql/testdata/influx_select_all_from_cpu.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/influx_select_all_from_cpu.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 4 Fields by 4 Rows
 //  +-------------------------------+------------------------+-----------------------+-----------------------+
@@ -29,14 +22,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/influx_select_all_from_cpu.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/influx_select_all_from_cpu.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean_usage_guest
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+------------------+
@@ -61,14 +54,6 @@
     {
       "schema": {
         "name": "cpu.mean_usage_guest",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/invalid_value_format.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/invalid_value_format.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/invalid_value_format.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/invalid_value_format.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu.mean",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/many_columns.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/many_columns.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: series_name
 //  Dimensions: 18 Fields by 9 Rows
 //  +-----------------------------------+--------------------+------------------+--------------------+-----------------+--------------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+-----------------+------------------+------------------+
@@ -34,14 +27,6 @@
     {
       "schema": {
         "name": "series_name",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/many_columns.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/many_columns.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: series_name.col_1_name { series_tag_2: 3167640 }
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+------------------------------+
@@ -1885,14 +1878,6 @@
     {
       "schema": {
         "name": "series_name.col_1_name { series_tag_2: 3167640 }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/metric_find_queries.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/metric_find_queries.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: measurements
 //  Dimensions: 1 Fields by 10 Rows
 //  +-----------------+
@@ -35,14 +28,6 @@
     {
       "schema": {
         "name": "measurements",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "name",

--- a/pkg/tsdb/influxdb/influxql/testdata/metric_find_queries.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/metric_find_queries.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: measurements
 //  Dimensions: 1 Fields by 10 Rows
 //  +-----------------+
@@ -35,14 +28,6 @@
     {
       "schema": {
         "name": "measurements",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Value",

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_measurements.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_measurements.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.upc
 //  Dimensions: 3 Fields by 2 Rows
 //  +-----------------------------------+------------------+------------------+
@@ -27,14 +20,6 @@
     {
       "schema": {
         "name": "cpu.upc",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_measurements.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_measurements.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.upc.mean { datacenter: America }
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+----------------------------+
@@ -39,14 +32,6 @@
     {
       "schema": {
         "name": "cpu.upc.mean { datacenter: America }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 3 Fields by 20 Rows
 //  +-------------------------------+-----------------+-------------------+
@@ -35,14 +28,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean { cpu: cpu-total }
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+-----------------------+
@@ -93,14 +86,6 @@
     {
       "schema": {
         "name": "cpu.mean { cpu: cpu-total }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags_and_multiple_columns.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags_and_multiple_columns.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 7 Fields by 11 Rows
 //  +-------------------------------+-----------------+-------------------+-------------------+-------------------+-------------------+-------------------+
@@ -35,14 +28,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags_and_multiple_columns.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/multiple_series_with_tags_and_multiple_columns.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean { cpu: cpu-total }
 //  Dimensions: 2 Fields by 1 Rows
 //  +-------------------------------+-----------------------+
@@ -728,14 +721,6 @@
     {
       "schema": {
         "name": "cpu.mean { cpu: cpu-total }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/one_measurement_with_two_columns.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/one_measurement_with_two_columns.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+-------------------+
@@ -29,14 +22,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/one_measurement_with_two_columns.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/one_measurement_with_two_columns.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean
 //  Dimensions: 2 Fields by 4 Rows
 //  +-------------------------------+-------------------+
@@ -29,14 +22,6 @@
     {
       "schema": {
         "name": "cpu.mean",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/response_with_nil_bools_and_nil_strings.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/response_with_nil_bools_and_nil_strings.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 5 Fields by 3 Rows
 //  +-----------------------------------+------------------+------------------+-----------------+----------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/response_with_nil_bools_and_nil_strings.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/response_with_nil_bools_and_nil_strings.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean { datacenter: America }
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+----------------------------+
@@ -58,14 +51,6 @@
     {
       "schema": {
         "name": "cpu.mean { datacenter: America }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/response_with_weird_tag.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/response_with_weird_tag.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.upc
 //  Dimensions: 4 Fields by 1 Rows
 //  +-----------------------------------+----------------------+------------------+------------------+
@@ -26,14 +19,6 @@
     {
       "schema": {
         "name": "cpu.upc",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/response_with_weird_tag.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/response_with_weird_tag.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.upc.mean { @cluster@name@: Cluster@ }
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+---------------------------------+
@@ -39,14 +32,6 @@
     {
       "schema": {
         "name": "cpu.upc.mean { @cluster@name@: Cluster@ }",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/retention_policy.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/retention_policy.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 5 Fields by 5 Rows
 //  +-----------------+-----------------+--------------------------+------------------+---------------+
@@ -29,14 +22,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "name",

--- a/pkg/tsdb/influxdb/influxql/testdata/retention_policy.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/retention_policy.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: 
 //  Dimensions: 1 Fields by 5 Rows
 //  +-----------------+
@@ -29,14 +22,6 @@
   "frames": [
     {
       "schema": {
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Value",

--- a/pkg/tsdb/influxdb/influxql/testdata/show_tag_values_response.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/show_tag_values_response.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 2 Fields by 11 Rows
 //  +-----------------+-----------------+
@@ -35,14 +28,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "key",

--- a/pkg/tsdb/influxdb/influxql/testdata/show_tag_values_response.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/show_tag_values_response.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 1 Fields by 11 Rows
 //  +-----------------+
@@ -35,14 +28,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Value",

--- a/pkg/tsdb/influxdb/influxql/testdata/simple_response.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/simple_response.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 3 Fields by 5 Rows
 //  +-------------------------------+-------------------+----------------------+
@@ -30,14 +23,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/simple_response.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/simple_response.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.usage_idle
 //  Dimensions: 2 Fields by 5 Rows
 //  +-------------------------------+-------------------+
@@ -47,14 +40,6 @@
     {
       "schema": {
         "name": "cpu.usage_idle",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/simple_response_with_diverse_data_types.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/simple_response_with_diverse_data_types.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: Annotation
 //  Dimensions: 5 Fields by 2 Rows
 //  +-----------------------------------+-----------------+-----------------+------------------+-----------------------------------------------------------+
@@ -27,14 +20,6 @@
     {
       "schema": {
         "name": "Annotation",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/simple_response_with_diverse_data_types.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/simple_response_with_diverse_data_types.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: Annotation.domain
 //  Dimensions: 2 Fields by 2 Rows
 //  +-----------------------------------+-----------------+
@@ -69,14 +62,6 @@
     {
       "schema": {
         "name": "Annotation.domain",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/some_values_are_null.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/some_values_are_null.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/some_values_are_null.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/some_values_are_null.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: cpu.mean
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "cpu.mean",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: series_name
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "series_name",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: series_name.col_1_name
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+-----------------+
@@ -52,14 +45,6 @@
     {
       "schema": {
         "name": "series_name.col_1_name",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value2.table.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value2.table.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "table",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: series_name
 //  Dimensions: 2 Fields by 3 Rows
 //  +-----------------------------------+------------------+
@@ -28,14 +21,6 @@
     {
       "schema": {
         "name": "series_name",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "table",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",

--- a/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value2.time_series.golden.jsonc
+++ b/pkg/tsdb/influxdb/influxql/testdata/string_column_with_null_value2.time_series.golden.jsonc
@@ -1,13 +1,6 @@
 //  🌟 This was machine generated.  Do not edit. 🌟
 //  
-//  Frame[0] {
-//      "typeVersion": [
-//          0,
-//          0
-//      ],
-//      "preferredVisualisationType": "graph",
-//      "executedQueryString": "Test raw query"
-//  }
+//  Frame[0] 
 //  Name: series_name.col_1_name
 //  Dimensions: 2 Fields by 1 Rows
 //  +-----------------------------------+------------------+
@@ -52,14 +45,6 @@
     {
       "schema": {
         "name": "series_name.col_1_name",
-        "meta": {
-          "typeVersion": [
-            0,
-            0
-          ],
-          "preferredVisualisationType": "graph",
-          "executedQueryString": "Test raw query"
-        },
         "fields": [
           {
             "name": "Time",


### PR DESCRIPTION
**What is this feature?**

To have a dynamic disconnect threshold without hard-coding one into panel options that only works for a specific zoom level / data resolution. With this PR we set the query interval value as field interval configuration.

related issue: https://github.com/grafana/grafana/issues/83031

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
