### PR TITLE
Cli: Fix bug where password is hashed twice

### DIFF
--- a/pkg/cmd/grafana-cli/commands/reset_password_command.go
+++ b/pkg/cmd/grafana-cli/commands/reset_password_command.go
@@ -47,7 +47,7 @@ func resetPasswordCommand(c utils.CommandLine, runner server.Runner) error {
 	return err
 }
 
-func resetPassword(adminId int64, newPassword user.Password, userSvc user.Service) error {
+func resetPassword(adminId int64, password user.Password, userSvc user.Service) error {
 	userQuery := user.GetUserByIDQuery{ID: adminId}
 	usr, err := userSvc.GetByID(context.Background(), &userQuery)
 	if err != nil {
@@ -55,11 +55,6 @@ func resetPassword(adminId int64, newPassword user.Password, userSvc user.Servic
 	}
 	if !usr.IsAdmin {
 		return ErrMustBeAdmin
-	}
-
-	password, err := newPassword.Hash(usr.Salt)
-	if err != nil {
-		return err
 	}
 
 	if err := userSvc.Update(context.Background(), &user.UpdateUserCommand{UserID: adminId, Password: &password}); err != nil {


### PR DESCRIPTION
**What is this feature?**
When using cli to reset admin password we hash the password twice making it impossible to sign in after a reset has been made.

Fixes #87158

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
