### PR TITLE
RBAC: List only the folders that the user has access to

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -347,10 +347,8 @@ func (s *Service) getRootFolders(ctx context.Context, q *folder.GetChildrenQuery
 	var folderPermissions []string
 	if q.Permission == dashboardaccess.PERMISSION_EDIT {
 		folderPermissions = permissions[dashboards.ActionFoldersWrite]
-		folderPermissions = append(folderPermissions, permissions[dashboards.ActionDashboardsWrite]...)
 	} else {
 		folderPermissions = permissions[dashboards.ActionFoldersRead]
-		folderPermissions = append(folderPermissions, permissions[dashboards.ActionDashboardsRead]...)
 	}
 
 	if len(folderPermissions) == 0 && !q.SignedInUser.GetIsGrafanaAdmin() {


### PR DESCRIPTION
**What is this feature?**

Fixing folder listing to only list folders that user has access to.

Without this change, if a user has access to any dashboards but no folders, we would list all the folders (user still can't access the content of the folder, only folder name and UID).

**Why do we need this feature?**

Returns correct results for folder listing.

**Who is this feature for?**

Anyone
