### PR TITLE
Select: Only restore input value if it's custom

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -285,23 +285,26 @@ export function SelectBase<T, Rest = {}>({
 
     // code needed to allow editing a custom value once entered
     // we only want to do this for single selects, not multi
-    if (!isMulti) {
+    // and only if the inputValue is uncontrolled
+    if (!isMulti && inputValue === undefined) {
       creatableProps.inputValue = internalInputValue;
       creatableProps.onMenuOpen = () => {
         // make sure we call the base onMenuOpen if it exists
         commonSelectProps.onMenuOpen?.();
 
-        // restore the input state to the selected value
-        setInternalInputValue(selectedValue?.[0]?.label ?? '');
+        // restore the input state to the selected value if it's custom
+        if (!options.find((o) => o.value === selectedValue?.[0]?.value)) {
+          setInternalInputValue(selectedValue?.[0]?.label ?? '');
+        }
       };
       creatableProps.onInputChange = (val, actionMeta) => {
-        // make sure we call the base onInputChange
-        commonSelectProps.onInputChange(val, actionMeta);
-
         // update the input value state on change since we're explicitly controlling it
         if (actionMeta.action === 'input-change') {
           setInternalInputValue(val);
         }
+
+        // make sure we call and return the base onInputChange
+        return commonSelectProps.onInputChange(val, actionMeta);
       };
       creatableProps.onMenuClose = () => {
         // make sure we call the base onMenuClose if it exists

--- a/public/app/plugins/datasource/elasticsearch/components/hooks/useCreatableSelectPersistedBehaviour.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/hooks/useCreatableSelectPersistedBehaviour.test.tsx
@@ -111,8 +111,7 @@ describe('useCreatableSelectPersistedBehaviour', () => {
     // we open the menu
     await userEvent.click(input);
 
-    // we expect 2 elemnts having "Option 2": the input itself and the option.
-    expect(screen.getByText('Option 2')).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toHaveValue('Option 2');
+    // we expect 2 elements having "Option 2": the input itself and the option.
+    expect(screen.getAllByText('Option 2')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- this does 3 separate things:
  - ensures the wrapped `onInputChange` returns the value from the base `onInputChange`
  - only applies the input editing logic if `inputValue` is not provided. if it is, it's up to the consumer to provide this logic
  - only restores the input state if the selected value is a custom value (i.e. not in the list of provided options)
    - this doesn't work in storybook as creating an option there mutates the options passed to `Select`
    - but this *does* work properly in the product itself
- follow up to https://github.com/grafana/grafana/pull/87843
- see https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1717172872797859

**Why do we need this feature?**

- better UX

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
