### PR TITLE
feat(DashboardGrid.tsx): Joining two rows to merge them implemented

### DIFF
--- a/public/app/features/dashboard/dashgrid/MergeRowsMenu.test.tsx
+++ b/public/app/features/dashboard/dashgrid/MergeRowsMenu.test.tsx
@@ -1,0 +1,276 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MergeRowsMenu, MergeRowsMenuProps } from './MergeRowsMenu';
+
+import {DashboardModel, PanelModel} from "../state";
+
+describe('MergeRowsMenu ', () => {
+  let panel1: PanelModel, panel2: PanelModel, panel3: PanelModel, panel4: PanelModel;
+  let draggedRowPanel: PanelModel, otherRowPanel: PanelModel;
+  let mockPanelMap: {[p: string]: PanelModel};
+  let defaultProps: MergeRowsMenuProps;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    panel1 = new PanelModel({
+      id: 3,
+      title: 'Panel 1',
+    });
+    panel2 = new PanelModel({
+      id: 4,
+      title: 'Panel 2',
+    });
+    panel3 = new PanelModel({
+      id: 5,
+      title: 'Panel 3',
+    });
+    panel4 = new PanelModel({
+      id: 6,
+      title: 'Panel 4',
+    });
+
+    draggedRowPanel = new PanelModel({
+      id: 1,
+      title: 'DraggedTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 0, w: 3, h: 1 },
+      panels: [panel1, panel2],
+      collapsed: true,
+    });
+    otherRowPanel = new PanelModel({
+      id: 2,
+      title: 'OtherTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 1, w: 3, h: 1 },
+      panels: [panel3, panel4],
+      collapsed: true,
+    });
+
+    mockPanelMap = {
+      '1': draggedRowPanel,
+      '2': otherRowPanel,
+    };
+
+    let dashboardMock= {} as DashboardModel;
+    dashboardMock.removeRow = jest.fn();
+
+    defaultProps = {
+      panelMap: mockPanelMap,
+      draggedItem: { i: '1', x: 0, y: 0, w: 3, h: 1 },
+      otherItem: { i: '2', x: 0, y: 1, w: 3, h: 1 },
+      isMenuOpen: true,
+      onClose: jest.fn(),
+      dashboard: dashboardMock,
+    };
+  });
+
+  it('Should render the modal title when isMenuOpen is true', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    expect(screen.getByText('Merge Rows')).toBeInTheDocument();
+  });
+
+  it('Should not render the modal title when isMenuOpen is false', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={false} />);
+
+    expect(screen.queryByText('Merge Rows')).not.toBeInTheDocument();
+  });
+
+  it('Should render the panels from the dragged row', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    expect(screen.getByText('Panel 1')).toBeInTheDocument();
+    expect(screen.getByText('Panel 2')).toBeInTheDocument();
+
+    const draggedRowColumn = screen.getByTestId('MergeRowsMenu-dragged-row');
+    expect(draggedRowColumn).toHaveTextContent('Panel 1');
+    expect(draggedRowColumn).toHaveTextContent('Panel 2');
+  });
+
+  it('Should render the panels from the other row', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    expect(screen.getByText('Panel 3')).toBeInTheDocument();
+    expect(screen.getByText('Panel 4')).toBeInTheDocument();
+
+    const otherRowColumn = screen.getByTestId('MergeRowsMenu-other-row');
+    expect(otherRowColumn).toHaveTextContent('Panel 3');
+    expect(otherRowColumn).toHaveTextContent('Panel 4');
+  });
+
+  it('Should call onClose when the Merge button is clicked', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    fireEvent.click(screen.getByText('Merge'));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('Should handle panel selection correctly', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    fireEvent.click(screen.getByText('Panel 1'));
+    expect(screen.getByText('Panel 1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Panel 3'));
+    expect(screen.getByText('Panel 3')).toBeInTheDocument();
+
+    const draggedRowColumn = screen.getByTestId('MergeRowsMenu-dragged-row');
+    expect(draggedRowColumn).toHaveTextContent('Panel 2');
+    expect(draggedRowColumn).toHaveTextContent('Panel 3');
+    const otherRowColumn = screen.getByTestId('MergeRowsMenu-other-row');
+    expect(otherRowColumn).toHaveTextContent('Panel 4');
+    expect(otherRowColumn).toHaveTextContent('Panel 1');
+
+    fireEvent.click(screen.getByText('Merge'));
+
+    expect(draggedRowPanel.panels).toContain(panel2);
+    expect(draggedRowPanel.panels).toContain(panel3);
+    expect(otherRowPanel.panels).toContain(panel4);
+    expect(otherRowPanel.panels).toContain(panel1);
+  });
+
+  it('Should render a special case menu when the dragged row and the other row have no panels', () => {
+    let draggedRowPanelNoPanels = new PanelModel({
+      id: 1,
+      title: 'DraggedTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 0, w: 3, h: 1 },
+      panels: [],
+      collapsed: true,
+    });
+    let otherRowPanelNoPanels = new PanelModel({
+      id: 2,
+      title: 'OtherTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 1, w: 3, h: 1 },
+      panels: [],
+      collapsed: true,
+    });
+
+    const noPanelsMockMap = {
+      '1': draggedRowPanelNoPanels,
+      '2': otherRowPanelNoPanels,
+    };
+    const noPanelsProps = {
+      ...defaultProps,
+      panelMap: noPanelsMockMap,
+    };
+
+    render(<MergeRowsMenu {...noPanelsProps} isMenuOpen={true} />);
+
+    expect(screen.getByText('The rows have no panels to merge')).toBeInTheDocument();
+  });
+
+  it('Should render a special case menu when the other row is not collapsed', () => {
+    let draggedRowPanelNoPanels = new PanelModel({
+      id: 1,
+      title: 'DraggedTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 0, w: 3, h: 1 },
+      panels: [panel3, panel4],
+      collapsed: true,
+    });
+    let otherRowPanelNoPanels = new PanelModel({
+      id: 2,
+      title: 'OtherTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 1, w: 3, h: 1 },
+      collapsed: false,
+    });
+
+    const noPanelsMockMap = {
+      '1': draggedRowPanelNoPanels,
+      '2': otherRowPanelNoPanels,
+    };
+    const noPanelsProps = {
+      ...defaultProps,
+      panelMap: noPanelsMockMap,
+    };
+
+    render(<MergeRowsMenu {...noPanelsProps} isMenuOpen={true} />);
+
+    expect(screen.getByText('The item you have tried to drag into is not a collapse row')).toBeInTheDocument();
+  });
+
+  it('Should render a special case menu when the row is dragged into a panel that is not a row', () => {
+    let draggedRowPanelNoPanels = new PanelModel({
+      id: 1,
+      title: 'DraggedTitleRow',
+      type: 'row',
+      gridPos: { x: 0, y: 0, w: 3, h: 1 },
+      panels: [panel3, panel4],
+      collapsed: true,
+    });
+    let otherRowPanelNoPanels = new PanelModel({
+      id: 2,
+      title: 'OtherTitleRow',
+      gridPos: { x: 0, y: 1, w: 3, h: 2 },
+    });
+
+    const noPanelsMockMap = {
+      '1': draggedRowPanelNoPanels,
+      '2': otherRowPanelNoPanels,
+    };
+    const noPanelsProps = {
+      ...defaultProps,
+      panelMap: noPanelsMockMap,
+    };
+
+    render(<MergeRowsMenu {...noPanelsProps} isMenuOpen={true} />);
+
+    expect(screen.getByText('The item you have tried to drag into is not a collapse row')).toBeInTheDocument();
+  });
+
+  it('Should open the confirm row delete menu if the dragged row has no panels left', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    fireEvent.click(screen.getByText('Panel 1'));
+    fireEvent.click(screen.getByText('Panel 2'));
+
+    fireEvent.click(screen.getByText('Merge'));
+    expect(draggedRowPanel.panels).toHaveLength(0);
+
+    expect(screen.getByText('Confirm Row Delete')).toBeInTheDocument();
+  });
+
+  it('Should open the confirm row delete menu if the other row has no panels left', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    fireEvent.click(screen.getByText('Panel 3'));
+    fireEvent.click(screen.getByText('Panel 4'));
+
+    fireEvent.click(screen.getByText('Merge'));
+    expect(otherRowPanel.panels).toHaveLength(0);
+
+    expect(screen.getByText('Confirm Row Delete')).toBeInTheDocument();
+  });
+
+  it('Should close the confirm row delete menu and call removeRow if the delete button is clicked', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    fireEvent.click(screen.getByText('Panel 1'));
+    fireEvent.click(screen.getByText('Panel 2'));
+    fireEvent.click(screen.getByText('Merge'));
+
+    fireEvent.click(screen.getByText('Yes, delete it'));
+
+    expect(defaultProps.dashboard.removeRow).toHaveBeenCalledWith(draggedRowPanel, false);
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('Should close the confirm row delete menu without calling removeRow if the keep row button is clicked', () => {
+    render(<MergeRowsMenu {...defaultProps} isMenuOpen={true} />);
+
+    fireEvent.click(screen.getByText('Panel 1'));
+    fireEvent.click(screen.getByText('Panel 2'));
+    fireEvent.click(screen.getByText('Merge'));
+
+    fireEvent.click(screen.getByText('No, keep it'));
+
+    expect(defaultProps.dashboard.removeRow).not.toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+});

--- a/public/app/features/dashboard/dashgrid/MergeRowsMenu.tsx
+++ b/public/app/features/dashboard/dashgrid/MergeRowsMenu.tsx
@@ -1,0 +1,271 @@
+import {css} from '@emotion/css';
+import React, {ReactElement, useState} from 'react';
+
+import {Button, IconButton, Modal} from '@grafana/ui';
+
+import {DashboardModel, PanelModel} from '../state';
+
+export interface MergeRowsMenuProps {
+  panelMap: { [key: string]: PanelModel };
+  draggedItem: ReactGridLayout.Layout | null;
+  otherItem: ReactGridLayout.Layout | null;
+  isMenuOpen: boolean;
+  onClose: () => void;
+  dashboard: DashboardModel;
+}
+
+export function MergeRowsMenu({panelMap, draggedItem, otherItem, isMenuOpen, onClose, dashboard}:
+                                MergeRowsMenuProps): ReactElement | null {
+
+  const initialDraggedRowPanelsVis = draggedItem?.i && panelMap[draggedItem.i]?.panels?.map((panel, index) => {
+    const title = (panel.title === undefined ||
+      panelMap[draggedItem.i]!.panels!.filter(p => p.title === panel.title).length > 1)
+      ? (panel.title === undefined ? `(${index + 1})` : `${panel.title} (${index + 1})`)
+      : panel.title;
+
+    return {
+      id: panel.id,
+      title: title,
+      dragged: true,
+    };
+  }) || [];
+
+  const [draggedRowPanelsVis, setDraggedRowPanelsVis] = useState(initialDraggedRowPanelsVis);
+
+  const initialOtherRowPanelsVis = otherItem?.i && panelMap[otherItem.i]?.panels?.map((panel, index) => {
+    const title = (panel.title === undefined ||
+      panelMap[otherItem.i]!.panels!.filter(p => p.title === panel.title).length > 1)
+      ? (panel.title === undefined ? `(${index + 1})` : `${panel.title} (${index + 1})`)
+      : panel.title;
+
+    return {
+      id: panel.id,
+      title: title,
+      dragged: false,
+    };
+  }) || [];
+
+  const [otherRowPanelsVis, setOtherRowPanelsVis] = useState(initialOtherRowPanelsVis);
+
+  const handlePanelSelection = (panel: {
+    id: number,
+    title: string,
+    dragged: boolean
+  }, index: number, isDragOrigin: boolean) => {
+    if (isDragOrigin) {
+      setOtherRowPanelsVis([...otherRowPanelsVis, panel]);
+      setDraggedRowPanelsVis(draggedRowPanelsVis.filter((_, i) => i !== index));
+    } else {
+      setDraggedRowPanelsVis([...draggedRowPanelsVis, panel]);
+      setOtherRowPanelsVis(otherRowPanelsVis.filter((_, i) => i !== index));
+    }
+  };
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const onMerge = () => {
+    if (draggedItem && otherItem && panelMap[draggedItem.i] && panelMap[otherItem.i]) {
+      // Update panels in the dragged row
+      const draggedPanels = draggedRowPanelsVis.map(panel => {
+        const fromDraggedRow = panelMap[draggedItem.i].panels?.find(p => p.id === panel.id);
+        const fromOtherRow = panelMap[otherItem.i].panels?.find(p => p.id === panel.id);
+        return fromDraggedRow || fromOtherRow!;
+      });
+
+      // Calculate the new y positions for the panels in draggedPanels
+      let yRow = draggedItem.y;
+      draggedPanels.forEach(panel => {
+        panel.gridPos.y = yRow;
+        yRow += panel.gridPos.h;
+      });
+
+      // Update panels in the other row
+      const otherPanels = otherRowPanelsVis.map(panel => {
+        const fromDraggedRow = panelMap[draggedItem.i].panels?.find(p => p.id === panel.id);
+        const fromOtherRow = panelMap[otherItem.i].panels?.find(p => p.id === panel.id);
+        return fromDraggedRow! || fromOtherRow!;
+      });
+
+      // Calculate the new y positions for the panels in otherPanels
+      yRow = otherItem.y;
+      otherPanels.forEach(panel => {
+        panel.gridPos.y = yRow;
+        yRow += panel.gridPos.h;
+      });
+
+      // Update the panel maps with the new panel configurations
+      panelMap[draggedItem.i].panels = draggedPanels;
+      panelMap[otherItem.i].panels = otherPanels;
+
+      // If a row is empty, show the delete modal, otherwise simply close the merge menu
+      if (panelMap[draggedItem.i].panels?.length === 0 || panelMap[otherItem.i].panels?.length === 0) {
+        setShowDeleteModal(true);
+      } else {
+        onClose();
+      }
+    }
+  };
+
+  const transferAllPanels = (transferToDrag: boolean) =>{
+    if (!transferToDrag){
+      setOtherRowPanelsVis([...otherRowPanelsVis, ...draggedRowPanelsVis]);
+      setDraggedRowPanelsVis([]);
+    } else {
+      setDraggedRowPanelsVis([...draggedRowPanelsVis, ...otherRowPanelsVis]);
+      setOtherRowPanelsVis([]);
+    }
+  }
+
+  const handleDelete = () => {
+    if (draggedItem && panelMap[draggedItem.i].panels?.length === 0) {
+      dashboard.removeRow(panelMap[draggedItem.i], false);
+    } else if (otherItem && panelMap[otherItem.i].panels?.length === 0) {
+      dashboard.removeRow(panelMap[otherItem.i], false);
+    }
+
+    setShowDeleteModal(false);
+    onClose();
+  };
+
+  const buttonStyleDragged = {
+    backgroundColor: 'rgba(0, 0, 255, 0.15)', // Give to the dragged button background a colour
+    border: 'none',
+    padding: '5px 10px',
+    margin: '5px 0',
+    cursor: 'pointer',
+    borderRadius: '3px',
+  };
+
+  const buttonStyleOther = {
+    backgroundColor: 'rgba(255, 0, 0, 0.15)', // Give to the other button background a different colour
+    border: 'none',
+    padding: '5px 10px',
+    margin: '5px 0',
+    cursor: 'pointer',
+    borderRadius: '3px',
+  };
+
+  const listStyle = {
+    listStyleType: 'none',
+    padding: 0,
+    margin: 0,
+  };
+
+  // Detect special cases
+  let specialCaseString: string | null = null;
+  if (draggedItem === null || otherItem === null) {
+    specialCaseString = 'Failed preparing menu';
+  } else if (panelMap[draggedItem.i]!.type !== 'row' || !panelMap[draggedItem.i]!.collapsed) {
+    specialCaseString = 'The item you are dragging is not a collapse row'; // This should not happen
+  } else if ( panelMap[otherItem.i]!.type !== 'row' || !panelMap[otherItem.i]!.collapsed) {
+    specialCaseString = 'The item you have tried to drag into is not a collapse row';
+  } else if (panelMap[draggedItem.i]!.panels!.length === 0 && panelMap[otherItem.i]!.panels!.length === 0) {
+    specialCaseString = 'The rows have no panels to merge';
+  }
+
+  // Show special case modal if required
+  if (specialCaseString !== null) {
+    return (
+      <Modal title="Merge Rows" isOpen={isMenuOpen} onDismiss={onClose}>
+        <div style={{textAlign: 'center', marginTop: '8px'}}>
+          <h3 style={{textAlign: 'center'}}>{specialCaseString}</h3>
+          <div style={{textAlign: 'center', marginTop: '32px'}}>
+            <Button onClick={onClose}>Close</Button>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  let defaultMergeRowMenuStyles = {
+    specificModal: css({
+      width: '1250px',
+    }),
+  };
+
+  return (
+    <>
+      <Modal title="Merge Rows" isOpen={isMenuOpen} onDismiss={onClose}
+             className={defaultMergeRowMenuStyles.specificModal}>
+        <p style={{ fontSize: '10px', textAlign: 'left', position: 'absolute', bottom: '-10px', left: '10px', color: 'rgba(255, 255, 255, 0.5)' }}>
+          Click on panels to switch their rows
+        </p>
+        <div style={{display: 'flex', justifyContent: 'space-around'}}>
+          <div data-testid="MergeRowsMenu-dragged-row"
+               style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+            <h3 style={{textAlign: 'center'}}>{panelMap[draggedItem?.i!]?.title}</h3>
+            <div style={{display: 'flex', alignItems: 'center'}}>
+              <p style={{textAlign: 'center', fontSize: '12px', marginBottom: '6px'}}>(Dragged Row Panels)</p>
+            </div>
+            <IconButton
+              style={{marginTop: '0px', marginBottom: '10px'}}
+              tooltip="Transfer all"
+              size="xl"
+              tooltipPlacement="top"
+              name="angle-double-right"
+              onClick={() => transferAllPanels(false)}
+            />
+            <ul style={{...listStyle, display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+              {draggedRowPanelsVis.map((panel, index) => (
+                <li key={panel.id}>
+                  <button
+                    style={panel.dragged ? buttonStyleDragged : buttonStyleOther}
+                    onClick={() => handlePanelSelection(panel, index, true)}
+                  >
+                    {panel.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div data-testid="MergeRowsMenu-other-row"
+               style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+            <h3 style={{textAlign: 'center'}}>{panelMap[otherItem?.i!]?.title}</h3>
+            <p style={{textAlign: 'center', fontSize: '12px', marginBottom: '6px'}}>(Other Row Panels)</p>
+            <IconButton
+              style={{marginTop: '0px', marginBottom: '10px'}}
+              tooltip="Transfer all"
+              size="xl"
+              tooltipPlacement="top"
+              name="angle-double-left"
+              onClick={() => transferAllPanels(true)}
+            />
+            <ul style={{...listStyle, display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
+              {otherRowPanelsVis.map((panel, index) => (
+                <li key={panel.id}>
+                  <button
+                    style={panel.dragged ? buttonStyleDragged : buttonStyleOther}
+                    onClick={() => handlePanelSelection(panel, index, false)}
+                  >
+                    {panel.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div style={{textAlign: 'center', marginTop: '20px'}}>
+          <Button onClick={onMerge}>Merge</Button>
+        </div>
+      </Modal>
+      <Modal title="Confirm Row Delete" isOpen={showDeleteModal} onDismiss={() => setShowDeleteModal(false)}>
+        <div style={{textAlign: 'center', alignItems: 'center'}}>
+          <h3>One of the rows is empty. Do you want to delete it?</h3>
+          <p>This action is permanent</p>
+        </div>
+        <div style={{display: 'flex', justifyContent: 'space-between', marginTop: '32px'}}>
+          <Button
+            style={{textAlign: 'center', marginLeft: '100px'}}
+            onClick={() => {setShowDeleteModal(false); onClose();} }
+          >No, keep it
+          </Button>
+          <Button
+            style={{backgroundColor: 'red', textAlign: 'center', marginRight: '100px'}}
+            onClick={handleDelete}
+          >Yes, delete it
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
**What is this feature?**

This is the implementation of a new mechanism (that we are calling merge rows) in the dashboard grid that allows the user to exchange panels between two rows when you drag rows on top of each other.

**Why do we need this feature?**

This feature makes it easier to organize the panels in complex dashboards by alloying people to transfer panels between rows, helping the user save time.

**Who is this feature for?**

This addiction can be pretty useful to users that usually have lots of panels to deal with and must have rows to organize themselves.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

We have created a new file called MergeRowsMenu.tsx and a test file for it in the same folder of the dashboard logic in order to separate the menu implementation of the dashboard grid itself. The merge row mechanism only works when the grid only has row-typed panels due to problems with the react-layout-grid library.