### PR TITLE
Scopes: Add DashboardTitle to scopedashboardbinding

### DIFF
--- a/pkg/apis/scope/v0alpha1/types.go
+++ b/pkg/apis/scope/v0alpha1/types.go
@@ -19,9 +19,7 @@ type Scope struct {
 
 type ScopeSpec struct {
 	Title       string `json:"title"`
-	Type        string `json:"type"`
 	Description string `json:"description"`
-	Category    string `json:"category"`
 
 	// +listType=atomic
 	Filters []ScopeFilter `json:"filters"`
@@ -62,8 +60,10 @@ type ScopeDashboardBinding struct {
 }
 
 type ScopeDashboardBindingSpec struct {
-	Dashboard string `json:"dashboard"`
-	Scope     string `json:"scope"`
+	Dashboard      string `json:"dashboard"`
+	DashboardTitle string `json:"dashboardTitle"`
+
+	Scope string `json:"scope"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/scope/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/scope/v0alpha1/zz_generated.openapi.go
@@ -171,6 +171,13 @@ func schema_pkg_apis_scope_v0alpha1_ScopeDashboardBindingSpec(ref common.Referen
 							Format:  "",
 						},
 					},
+					"dashboardTitle": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"scope": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -179,7 +186,7 @@ func schema_pkg_apis_scope_v0alpha1_ScopeDashboardBindingSpec(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"dashboard", "scope"},
+				Required: []string{"dashboard", "dashboardTitle", "scope"},
 			},
 		},
 	}
@@ -424,21 +431,7 @@ func schema_pkg_apis_scope_v0alpha1_ScopeSpec(ref common.ReferenceCallback) comm
 							Format:  "",
 						},
 					},
-					"type": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
 					"description": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-					"category": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
 							Type:    []string{"string"},
@@ -464,7 +457,7 @@ func schema_pkg_apis_scope_v0alpha1_ScopeSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"title", "type", "description", "category", "filters"},
+				Required: []string{"title", "description", "filters"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/registry/apis/scope/storage.go
+++ b/pkg/registry/apis/scope/storage.go
@@ -162,8 +162,7 @@ func Matcher(label labels.Selector, field fields.Selector) apistore.SelectionPre
 
 func SelectableScopeFields(obj *scope.Scope) fields.Set {
 	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
-		"spec.type":     obj.Spec.Type,
-		"spec.category": obj.Spec.Category,
+		"spec.title": obj.Spec.Title,
 	})
 }
 

--- a/pkg/tests/apis/scopes/scopes_test.go
+++ b/pkg/tests/apis/scopes/scopes_test.go
@@ -141,7 +141,7 @@ func TestIntegrationScopes(t *testing.T) {
 
 		// Field Selector test
 		found, err := scopeClient.Resource.List(ctx, metav1.ListOptions{
-			FieldSelector: "spec.category=fun",
+			FieldSelector: "spec.title=foo-scope",
 		})
 		require.NoError(t, err)
 		require.Len(t, found.Items, 1)

--- a/pkg/tests/apis/scopes/testdata/example-scope.yaml
+++ b/pkg/tests/apis/scopes/testdata/example-scope.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
     title: Example scope
     description: Longer description for a scope
-    category: should this be an enum or an external reference?
-    type: should this be an enum or an external reference?
     filters: 
       - key: aaa
         operator: equals

--- a/pkg/tests/apis/scopes/testdata/example-scope.yaml
+++ b/pkg/tests/apis/scopes/testdata/example-scope.yaml
@@ -3,7 +3,7 @@ kind: Scope
 metadata:
   name: example
 spec:
-    title: Example scope
+    title: bar-scope
     description: Longer description for a scope
     filters: 
       - key: aaa

--- a/pkg/tests/apis/scopes/testdata/example-scope2.yaml
+++ b/pkg/tests/apis/scopes/testdata/example-scope2.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
     title: Example scope 2
     description: Longer description for a scope
-    category: fun
-    type: should this be an enum or an external reference?
     filters: 
       - key: aaa
         operator: equals

--- a/pkg/tests/apis/scopes/testdata/example-scope2.yaml
+++ b/pkg/tests/apis/scopes/testdata/example-scope2.yaml
@@ -3,7 +3,7 @@ kind: Scope
 metadata:
   name: example2
 spec:
-    title: Example scope 2
+    title: foo-scope
     description: Longer description for a scope
     filters: 
       - key: aaa

--- a/pkg/tests/apis/scopes/testdata/scopeNodesExample/scopes.json
+++ b/pkg/tests/apis/scopes/testdata/scopeNodesExample/scopes.json
@@ -8,7 +8,6 @@
         "name": "slothClusterNorth"
       },
       "spec": {
-        "category": "clusters",
         "description": "slothClusterNorth",
         "filters": [
           {
@@ -17,8 +16,7 @@
             "value": "slothClusterNorth"
           }
         ],
-        "title": "slothClusterNorth",
-        "type": "cluster"
+        "title": "slothClusterNorth"
       }
     },
     {
@@ -28,7 +26,6 @@
         "name": "slothClusterSouth"
       },
       "spec": {
-        "category": "clusters",
         "description": "slothClusterSouth",
         "filters": [
           {
@@ -37,8 +34,7 @@
             "value": "slothClusterSouth"
           }
         ],
-        "title": "slothClusterSouth",
-        "type": "cluster"
+        "title": "slothClusterSouth"
       }
     },
     {
@@ -48,7 +44,6 @@
         "name": "slothPictureFactory"
       },
       "spec": {
-        "category": "apps",
         "description": "slothPictureFactory",
         "filters": [
           {
@@ -57,8 +52,7 @@
             "value": "slothPictureFactory"
           }
         ],
-        "title": "slothPictureFactory",
-        "type": "app"
+        "title": "slothPictureFactory"
       }
     },
     {
@@ -68,7 +62,6 @@
         "name": "slothVoteTracker"
       },
       "spec": {
-        "category": "apps",
         "description": "slothVoteTracker",
         "filters": [
           {
@@ -77,8 +70,7 @@
             "value": "slothVoteTracker"
           }
         ],
-        "title": "slothVoteTracker",
-        "type": "app"
+        "title": "slothVoteTracker"
       }
     },
     {
@@ -88,7 +80,6 @@
         "name": "indexHelperCluster"
       },
       "spec": {
-        "category": "indexHelpers",
         "description": "redundant label filter but makes queries faster",
         "filters": [
           {
@@ -97,8 +88,7 @@
             "value": "cluster"
           }
         ],
-        "title": "Cluster Index Helper",
-        "type": "indexHelper"
+        "title": "Cluster Index Helper"
       }
     }
   ]


### PR DESCRIPTION
Right now the frontend have to call the dashboardlist once for every item to get the Dashboard title. 

By adding the DashboardTitle to the spec, it can be set at creation time and avoid doing that extra look up. 
This type will primarly be managed by batch job and background processes and those can be responsible for updating this field if the dashboard is renamed. 