### PR TITLE
Plugins: Fix Explore button visibility for datasource plugins

### DIFF
--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -7,7 +7,6 @@ import { TestingStatus, config } from '@grafana/runtime';
 import { AlertVariant, Alert, useTheme2, Link } from '@grafana/ui';
 
 import { contextSrv } from '../../../core/core';
-import { AccessControlAction } from '../../../types';
 import { trackCreateDashboardClicked } from '../tracking';
 
 export type Props = {
@@ -43,7 +42,7 @@ const AlertSuccessMessage = ({ title, exploreUrl, dataSourceId, onDashboardLinkC
   const theme = useTheme2();
   const hasTitle = Boolean(title);
   const styles = getStyles(theme, hasTitle);
-  const canExploreDataSources = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
+  const canExploreDataSources = contextSrv.hasAccessToExplore();
 
   return (
     <div className={styles.content}>

--- a/public/app/features/datasources/components/DataSourcesList.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.tsx
@@ -22,7 +22,7 @@ export function DataSourcesList() {
   const dataSourcesCount = useSelector(({ dataSources }: StoreState) => getDataSourcesCount(dataSources));
   const hasCreateRights = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
   const hasWriteRights = contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
-  const hasExploreRights = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
+  const hasExploreRights = contextSrv.hasAccessToExplore();
 
   return (
     <DataSourcesListView

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { config } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
-import { AccessControlAction } from 'app/types';
 
 import { useDataSource } from '../state';
 import { trackCreateDashboardClicked, trackDsConfigClicked, trackExploreClicked } from '../tracking';
@@ -15,7 +14,7 @@ interface Props {
 
 export function EditDataSourceActions({ uid }: Props) {
   const dataSource = useDataSource(uid);
-  const hasExploreRights = contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
+  const hasExploreRights = contextSrv.hasAccessToExplore();
 
   return (
     <>


### PR DESCRIPTION
**What is this feature?**
This is a fix for checking Explore button visibility. Before it was checking only permission, but it should check also config value of explore enabled.

**Which issue(s) does this PR fix?**:
fixes #85697 
