### PR TITLE
Alerting docs: fix `Alertmanagers` title

### DIFF
--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -18,7 +18,7 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Add an external Alertmanager
+title: Configure Alertmanagers
 weight: 200
 refs:
   notifications:
@@ -28,7 +28,7 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/
 ---
 
-## Configure Alertmanagers
+# Configure Alertmanagers
 
 Grafana Alerting is based on the architecture of the Prometheus alerting system. Grafana sends firing and resolved alerts to an Alertmanager, which is responsible for [handling notifications](ref:notifications).
 


### PR DESCRIPTION
Fix doc page title.

Requested by https://github.com/grafana/grafana/pull/88567#discussion_r1624272167