### PR TITLE
InfluxDB: Fix custom variable support

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/variable/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/variable/VariableQueryEditor.tsx
@@ -13,20 +13,20 @@ type Props = QueryEditorProps<InfluxDatasource, InfluxQuery, InfluxOptions, Infl
 const refId = 'InfluxVariableQueryEditor-VariableQuery';
 
 export const InfluxVariableEditor = ({ onChange, datasource, query }: Props) => {
-    const getVariableQuery = (q: InfluxVariableQuery | string) => {
-      // in legacy variable support query can be only a string
-      // in new variable support query can be an object and hold more information
-      // to be able to support old version we check the query here
-      if (typeof q !== 'string') {
-        return q;
-      }
+  const getVariableQuery = (q: InfluxVariableQuery | string) => {
+    // in legacy variable support query can be only a string
+    // in new variable support query can be an object and hold more information
+    // to be able to support old version we check the query here
+    if (typeof q !== 'string') {
+      return q;
+    }
 
-      return {
-        refId,
-        query: q,
-        ...(datasource.version === InfluxVersion.Flux ? { maxDataPoints: 1000 } : {}),
-      };
+    return {
+      refId,
+      query: q,
+      ...(datasource.version === InfluxVersion.Flux ? { maxDataPoints: 1000 } : {}),
     };
+  };
 
   switch (datasource.version) {
     case InfluxVersion.Flux:

--- a/public/app/plugins/datasource/influxdb/components/editor/variable/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/variable/VariableQueryEditor.tsx
@@ -13,20 +13,20 @@ type Props = QueryEditorProps<InfluxDatasource, InfluxQuery, InfluxOptions, Infl
 const refId = 'InfluxVariableQueryEditor-VariableQuery';
 
 export const InfluxVariableEditor = ({ onChange, datasource, query }: Props) => {
-  const getFluxVariableQuery = (q: InfluxVariableQuery | string) => {
-    // in legacy variable support query can be only a string
-    // in new variable support query can be an object and hold more information
-    // to be able to support old version we check the query here
-    if (typeof q !== 'string') {
-      return q;
-    }
+    const getVariableQuery = (q: InfluxVariableQuery | string) => {
+      // in legacy variable support query can be only a string
+      // in new variable support query can be an object and hold more information
+      // to be able to support old version we check the query here
+      if (typeof q !== 'string') {
+        return q;
+      }
 
-    return {
-      refId,
-      query: q,
-      maxDataPoints: 1000,
+      return {
+        refId,
+        query: q,
+        ...(datasource.version === InfluxVersion.Flux ? { maxDataPoints: 1000 } : {}),
+      };
     };
-  };
 
   switch (datasource.version) {
     case InfluxVersion.Flux:
@@ -34,7 +34,7 @@ export const InfluxVariableEditor = ({ onChange, datasource, query }: Props) => 
         <>
           <FluxQueryEditor
             datasource={datasource}
-            query={getFluxVariableQuery(query)}
+            query={getVariableQuery(query)}
             onChange={(q) => {
               onChange({ ...query, query: q.query ?? '' });
             }}
@@ -72,11 +72,11 @@ export const InfluxVariableEditor = ({ onChange, datasource, query }: Props) => 
           <InlineField label="Query" labelWidth={20} required grow aria-labelledby="influx-variable-query">
             <TextArea
               aria-label="influx-variable-query"
-              defaultValue={query.query}
+              defaultValue={getVariableQuery(query).query}
               placeholder="metric name or tags query"
               rows={1}
               onBlur={(e) => {
-                onChange({ refId, query: query.query ?? '' });
+                onChange({ refId, query: e.currentTarget.value ?? '' });
               }}
             />
           </InlineField>

--- a/public/app/plugins/datasource/influxdb/variables.ts
+++ b/public/app/plugins/datasource/influxdb/variables.ts
@@ -30,7 +30,9 @@ export class InfluxVariableSupport extends CustomVariableSupport<InfluxDatasourc
       return of({ data: [] });
     }
 
-    const interpolated = this.templateSrv.replace(query, request.scopedVars, this.datasource.interpolateQueryExpr);
+    const q = this.templateSrv.replace(query, request.scopedVars, this.datasource.interpolateQueryExpr);
+    const timeFilter = this.datasource.getTimeFilter({ rangeRaw: request.range.raw, timezone: request.timezone });
+    const interpolated = q.replace('$timeFilter', timeFilter);
     const metricFindStream = from(
       this.datasource.metricFindQuery(
         {


### PR DESCRIPTION
**What is this feature?**

Fixing custom variable support (which was implemented with https://github.com/grafana/grafana/pull/87903) by interpolating `$timeFilter` variable. Also fixes a minor bug with the variable queries that was preventing saving/executing the query.

