### PR TITLE
Docs: Add Installation YouTube Videos to documentation pages. (#88465)

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/view-provisioned-resources/index.md
@@ -22,7 +22,7 @@ weight: 300
 
 Verify that your alerting resources were created in Grafana, as well as edit or export your provisioned alerting resources.
 
-## View provisioned alerting resoureces
+## View provisioned alerting resources
 
 To view your provisioned resources in Grafana, complete the following steps.
 

--- a/docs/sources/release-notes/release-notes-8-2-0.md
+++ b/docs/sources/release-notes/release-notes-8-2-0.md
@@ -34,7 +34,7 @@ title: Release notes for Grafana 8.2.0
 
 #### Potential failure to start in Ubuntu 18.04 / Debian 9 / CentOS
 
-- In Grafana v8.2.0, this change can prevent the `grafana-server` service from starting on older versions of systemd, present on Ubuntu 18.04 and slightly older versions of Debian. If running one of those versions, please wait until v8.2.1 is released before upgrading. If you still want to upgrade or have already ugpraded, a simple fix is available here: https://github.com/grafana/grafana/issues/40162#issuecomment-938060240 Issue [#38109](https://github.com/grafana/grafana/issues/38109)
+- In Grafana v8.2.0, this change can prevent the `grafana-server` service from starting on older versions of systemd, present on Ubuntu 18.04 and slightly older versions of Debian. If running one of those versions, please wait until v8.2.1 is released before upgrading. If you still want to upgrade or have already upgraded, a simple fix is available here: https://github.com/grafana/grafana/issues/40162#issuecomment-938060240 Issue [#38109](https://github.com/grafana/grafana/issues/38109)
 
 ### Plugin development fixes & changes
 

--- a/docs/sources/release-notes/release-notes-9-0-4.md
+++ b/docs/sources/release-notes/release-notes-9-0-4.md
@@ -18,7 +18,7 @@ title: Release notes for Grafana 9.0.4
 - **Browse/Search:** Make browser back work properly when visiting Browse or search. [#52271](https://github.com/grafana/grafana/pull/52271), [@torkelo](https://github.com/torkelo)
 - **Logs:** Improve getLogRowContext API. [#52130](https://github.com/grafana/grafana/pull/52130), [@gabor](https://github.com/gabor)
 - **Loki:** Improve handling of empty responses. [#52397](https://github.com/grafana/grafana/pull/52397), [@gabor](https://github.com/gabor)
-- **Plugins:** Always validate root URL if specified in signature manfiest. [#52332](https://github.com/grafana/grafana/pull/52332), [@wbrowne](https://github.com/wbrowne)
+- **Plugins:** Always validate root URL if specified in signature manifest. [#52332](https://github.com/grafana/grafana/pull/52332), [@wbrowne](https://github.com/wbrowne)
 - **Preferences:** Get home dashboard from teams. [#52225](https://github.com/grafana/grafana/pull/52225), [@sakjur](https://github.com/sakjur)
 - **SQLStore:** Support Upserting multiple rows. [#52228](https://github.com/grafana/grafana/pull/52228), [@joeblubaugh](https://github.com/joeblubaugh)
 - **Traces:** Add more template variables in Tempo & Zipkin. [#52306](https://github.com/grafana/grafana/pull/52306), [@joey-grafana](https://github.com/joey-grafana)

--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -21,6 +21,10 @@ This page lists the minimum hardware and software requirements to install Grafan
 
 To run Grafana, you must have a supported operating system, hardware that meets or exceeds minimum requirements, a supported database, and a supported browser.
 
+The following video guides you through the steps and common commands for installing Grafana on various operating systems as described in this document.
+
+{{< youtube id="f-x_p2lvz8s" >}}
+
 Grafana relies on other open source software to operate. For a list of open source software that Grafana uses, refer to [package.json](https://github.com/grafana/grafana/blob/main/package.json).
 
 ## Supported operating systems

--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -22,6 +22,10 @@ There are multiple ways to install Grafana: using the Grafana Labs APT repositor
 If you install via the `.deb` package or `.tar.gz` file, then you must manually update Grafana for each new version.
 {{% /admonition %}}
 
+The following video demonstrates how to install Grafana on Debian and Ubuntu as outlined in this document:
+
+{{< youtube id="_Zk_XQSjF_Q" >}}
+
 ## Install from APT repository
 
 If you install from the APT repository, Grafana automatically updates when you run `apt-get update`.

--- a/docs/sources/setup-grafana/installation/mac/index.md
+++ b/docs/sources/setup-grafana/installation/mac/index.md
@@ -15,6 +15,10 @@ weight: 600
 
 This page explains how to install Grafana on macOS.
 
+The following video demonstrates how to install Grafana on macOS as outlined in this document:
+
+{{< youtube id="1zdm8SxOLYQ" >}}
+
 ## Install Grafana on macOS using Homebrew
 
 To install Grafana on macOS using Homebrew, complete the following steps:

--- a/docs/sources/setup-grafana/installation/redhat-rhel-fedora/index.md
+++ b/docs/sources/setup-grafana/installation/redhat-rhel-fedora/index.md
@@ -17,6 +17,10 @@ You can install Grafana from the RPM repository, from standalone RPM, or with th
 
 If you install via RPM or the `.tar.gz` file, then you must manually update Grafana for each new version.
 
+The following video demonstrates how to install Grafana on RHEL or Fedora as outlined in this document:
+
+{{< youtube id="4khbLlyoqzE" >}}
+
 ## Install Grafana from the RPM repository
 
 If you install from the RPM repository, then Grafana is automatically updated every time you update your applications.

--- a/docs/sources/setup-grafana/installation/suse-opensuse/index.md
+++ b/docs/sources/setup-grafana/installation/suse-opensuse/index.md
@@ -17,6 +17,10 @@ You can install Grafana using the RPM repository, or by downloading a binary `.t
 
 If you install via RPM or the `.tar.gz` file, then you must manually update Grafana for each new version.
 
+The following video demonstrates how to install Grafana on SUSE or openSUSE as outlined in this document:
+
+{{< youtube id="2MWsu0xy5Xc" >}}
+
 ## Install Grafana from the RPM repository
 
 If you install from the RPM repository, then Grafana is automatically updated every time you run `sudo zypper update`.

--- a/docs/sources/setup-grafana/installation/windows/index.md
+++ b/docs/sources/setup-grafana/installation/windows/index.md
@@ -13,6 +13,10 @@ weight: 700
 
 # Install Grafana on Windows
 
+The following video demonstrates how to install Grafana using the Windows standalone installer as outlined in this document:
+
+{{< youtube id="js2bZijbhJM" >}}
+
 You install Grafana using the Windows installer or using the standalone Windows binary file.
 
 1. Navigate to the [Grafana download page](/grafana/download).


### PR DESCRIPTION
Fixed Backport issues.

**What is this feature?**

Added youtube videos but pull request failed due to backports

**Why do we need this feature?**

Trying to merge to all backports

**Who is this feature for?**

N/A

**Which issue(s) does this PR fix?**:

N/A

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
