### PR TITLE
Alerting: Allow remote Alertmanager integration tests to fail

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1137,8 +1137,8 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.22.4-alpine
   failure: ignore
+  image: golang:1.22.4-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -2643,8 +2643,8 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.22.4-alpine
   failure: ignore
+  image: golang:1.22.4-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   branch: main
@@ -4536,8 +4536,8 @@ steps:
   environment:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
-  image: golang:1.22.4-alpine
   failure: ignore
+  image: golang:1.22.4-alpine
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -5181,6 +5181,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: c4a656d676b1228248f6948ac0347aea1d67016429aa24351d0a5c3e2d7dc617
+hmac: e296b5401c0632dc2549a2c3d0594a58c459f5d185376e9f1728ce75c1d8ff3c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1138,6 +1138,7 @@ steps:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
   image: golang:1.22.4-alpine
+  failure: ignore
   name: remote-alertmanager-integration-tests
 trigger:
   event:
@@ -2643,6 +2644,7 @@ steps:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
   image: golang:1.22.4-alpine
+  failure: ignore
   name: remote-alertmanager-integration-tests
 trigger:
   branch: main
@@ -4535,6 +4537,7 @@ steps:
     AM_TENANT_ID: test
     AM_URL: http://mimir_backend:8080
   image: golang:1.22.4-alpine
+  failure: ignore
   name: remote-alertmanager-integration-tests
 trigger:
   event:

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -218,14 +218,19 @@ def validate_openapi_spec_step():
         ],
     }
 
-def dockerize_step(name, hostname, port):
-    return {
+def dockerize_step(name, hostname, port, canFail = False):
+    step = {
         "name": name,
         "image": images["dockerize"],
         "commands": [
             "dockerize -wait tcp://{}:{} -timeout 120s".format(hostname, port),
         ],
     }
+
+    if canFail:
+        step["failure"] = "ignore"
+
+    return step
 
 def build_storybook_step(ver_mode):
     return {

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -959,7 +959,7 @@ def publish_images_step(ver_mode, docker_repo, trigger = None):
 
     return step
 
-def integration_tests_steps(name, cmds, hostname = None, port = None, environment = None):
+def integration_tests_steps(name, cmds, hostname = None, port = None, environment = None, canFail = False):
     """Integration test steps
 
     Args:
@@ -968,6 +968,7 @@ def integration_tests_steps(name, cmds, hostname = None, port = None, environmen
       hostname: the hostname where the remote server is available.
       port: the port where the remote server is available.
       environment: Any extra environment variables needed to run the integration tests.
+      canFail: controls whether the step can fail.
 
     Returns:
       A list of drone steps. If a hostname / port were provided, then a step to wait for the remove server to be
@@ -987,6 +988,9 @@ def integration_tests_steps(name, cmds, hostname = None, port = None, environmen
             "apk add --update build-base",
         ] + cmds,
     }
+    
+    if canFail:
+        step["failure"] = "ignore"
 
     if environment:
         step["environment"] = environment
@@ -1064,7 +1068,7 @@ def remote_alertmanager_integration_tests_steps():
         "AM_URL": "http://mimir_backend:8080",
     }
 
-    return integration_tests_steps("remote-alertmanager", cmds, "mimir_backend", "8080", environment = environment)
+    return integration_tests_steps("remote-alertmanager", cmds, "mimir_backend", "8080", environment = environment, canFail = True)
 
 def memcached_integration_tests_steps():
     cmds = [

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -988,7 +988,7 @@ def integration_tests_steps(name, cmds, hostname = None, port = None, environmen
             "apk add --update build-base",
         ] + cmds,
     }
-    
+
     if canFail:
         step["failure"] = "ignore"
 


### PR DESCRIPTION
This PR makes remote Alertmanager integration tests non-blocking in our CI. This change enables external contributors without access to private images to not be blocked by our CI.