### PR TITLE
Loki: Fix editor history in wrong order

### DIFF
--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.test.ts
@@ -13,21 +13,28 @@ const history: Array<HistoryItem<LokiQuery>> = [
     ts: 12345678,
     query: {
       refId: 'test-1',
-      expr: '{test: unit}',
+      expr: '{test="unit"}',
     },
   },
   {
     ts: 87654321,
     query: {
       refId: 'test-1',
-      expr: '{unit: test}',
+      expr: '{unit="test"}',
     },
   },
   {
     ts: 87654321,
     query: {
       refId: 'test-1',
-      expr: '{unit: test}',
+      expr: '{unit="test"}',
+    },
+  },
+  {
+    ts: 87654325,
+    query: {
+      refId: 'test-2',
+      expr: '{unit="test"} ', // will be trimmed and removed
     },
   },
   {
@@ -82,11 +89,11 @@ describe('CompletionDataProvider', () => {
   });
 
   test('Returns the expected history entries', () => {
-    expect(completionProvider.getHistory()).toEqual(['{test: unit}', '{unit: test}']);
+    expect(completionProvider.getHistory()).toEqual(['{unit="test"}', '{test="unit"}']);
   });
 
   test('Processes updates to the current historyRef value', () => {
-    expect(completionProvider.getHistory()).toEqual(['{test: unit}', '{unit: test}']);
+    expect(completionProvider.getHistory()).toEqual(['{unit="test"}', '{test="unit"}']);
 
     historyRef.current = [
       {

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/monaco-completion-provider/CompletionDataProvider.ts
@@ -32,7 +32,8 @@ export class CompletionDataProvider {
 
   getHistory() {
     return chain(this.historyRef.current)
-      .map((history: HistoryItem<LokiQuery>) => history.query.expr)
+      .orderBy('ts', 'desc')
+      .map((history: HistoryItem<LokiQuery>) => history.query.expr.trim())
       .filter()
       .uniq()
       .value();


### PR DESCRIPTION
**What is this feature?**

Loki's code editor provides a history of past queries. However, the history is in wrong order, which is fixed in this PR. Furthermore, I added some trimming and fixed query expressions in the test.

**Special notes for your reviewer:**

Before:
![image](https://github.com/grafana/grafana/assets/8092184/2277e69d-445f-4322-8707-08487c450462)

Now:
![image](https://github.com/grafana/grafana/assets/8092184/da6805eb-020f-43a6-9fa7-7a2bc9b06a92)
