### PR TITLE
Chore: Stricter plugin-id org-name-slug format and allow an underscore in name

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -10,7 +10,7 @@
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin `id` has to follow the naming conventions.",
-      "pattern": "^[0-9a-z]+\\-([0-9a-z]+\\-)?(app|panel|datasource|secretsmanager)$"
+      "pattern": "^[0-9a-z]+\\-[0-9a-z_]+\\-(app|panel|datasource|secretsmanager)$"
     },
     "type": {
       "type": "string",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Alternative to https://github.com/grafana/grafana/pull/87399

All of our tooling is oriented towards a strict format `<orgName>-<pluginName>-<pluginType>` ([Docs](https://grafana.com/developers/plugin-tools/#step-2-open-the-generated-folder-structure)) and we see no reason to change this format even if there are already existing outliers in our plugin catalog.

This PR enforces this format while enabling `pluginName` / `slug` to contain `underscores` to have prettier plugin-ids -> e.g. `my-somewhat_longer_named-app`

Keep in mind that plugin id's and slugs should be treated as `id` and not something humanly readable. We have a special plugin.json -> `name` field for displaying of the plugin name.

**Why do we need this feature?**
Make plugin name's a bit more pretty

**Who is this feature for?**

Plugin Devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**What about plugins that are already published but do not fit this schema?**
We will keep them working as is, and maybe have a migration path in the future. Currently only 14 plugins are affected that are not owned by Grafana Labs.
