### PR TITLE
Gops: Fix data field in incidents query

### DIFF
--- a/public/app/features/alerting/unified/api/incidentsApi.ts
+++ b/public/app/features/alerting/unified/api/incidentsApi.ts
@@ -12,9 +12,9 @@ const getProxyApiUrl = (path: string) => `/api/plugins/${SupportedPlugin.Inciden
 export const incidentsApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
     getIncidentsPluginConfig: build.query<IncidentsPluginConfigDto, void>({
-      query: (integration) => ({
+      query: () => ({
         url: getProxyApiUrl('/api/ConfigurationTrackerService.GetConfigurationTracker'),
-        data: integration,
+        data: {},
         method: 'POST',
         showErrorAlert: false,
       }),


### PR DESCRIPTION
This PR fixes data field in the incidents query used in the configuration tracker. It seems that this field was included from the beginning wrongly.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
