### PR TITLE
Alerting: Add option to use Redis in cluster mode for Alerting HA

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1178,6 +1178,9 @@ admin_config_poll_interval = 60s
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 alertmanager_config_poll_interval = 60s
 
+# Set to true when using redis in cluster mode.
+ha_redis_cluster_mode_enabled = false
+
 # The redis server address that should be connected to.
 ha_redis_address =
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1181,7 +1181,9 @@ alertmanager_config_poll_interval = 60s
 # Set to true when using redis in cluster mode.
 ha_redis_cluster_mode_enabled = false
 
-# The redis server address that should be connected to.
+# The redis server address(es) that should be connected to.
+# Can either be a single address, or if using redis in cluster mode,
+# the cluster configuration address or a comma-separated list of addresses.
 ha_redis_address =
 
 # The username that should be used to authenticate with the redis server.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1107,7 +1107,9 @@
 # Set to true when using redis in cluster mode.
 ;ha_redis_cluster_mode_enabled = false
 
-# The redis server address that should be connected to.
+# The redis server address(es) that should be connected to.
+# Can either be a single address, or if using redis in cluster mode,
+# the cluster configuration address or a comma-separated list of addresses.
 ;ha_redis_address =
 
 # The username that should be used to authenticate with the redis server.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1104,6 +1104,9 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;alertmanager_config_poll_interval = 60s
 
+# Set to true when using redis in cluster mode.
+;ha_redis_cluster_mode_enabled = false
+
 # The redis server address that should be connected to.
 ;ha_redis_address =
 

--- a/pkg/services/ngalert/notifier/redis_peer_test.go
+++ b/pkg/services/ngalert/notifier/redis_peer_test.go
@@ -16,6 +16,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewRedisPeerClusterMode(t *testing.T) {
+	// Write client and server certificates/keys to tempDir, both issued by the same CA
+	certPaths := createX509TestDir(t)
+
+	// Set up tls.Config and start miniredis with server-side TLS
+	x509Cert, err := tls.LoadX509KeyPair(certPaths.serverCert, certPaths.serverKey)
+	require.NoError(t, err)
+
+	mr, err := miniredis.RunTLS(&tls.Config{
+		Certificates: []tls.Certificate{x509Cert},
+		ClientAuth:   tls.NoClientCert,
+	})
+	require.NoError(t, err)
+	defer mr.Close()
+
+	redisPeer, err := newRedisPeer(redisConfig{
+		clusterMode: true,
+		addr:        mr.Addr(),
+		tlsEnabled:  true,
+		tls: dstls.ClientConfig{
+			CAPath:     certPaths.ca,
+			ServerName: "localhost",
+		}}, log.NewNopLogger(), prometheus.NewRegistry(), time.Second*60)
+	require.NoError(t, err)
+
+	ping := redisPeer.redis.Ping(context.Background())
+	require.NoError(t, ping.Err())
+}
+
 func TestNewRedisPeerWithTLS(t *testing.T) {
 	// Write client and server certificates/keys to tempDir, both issued by the same CA
 	certPaths := createX509TestDir(t)

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -73,6 +73,7 @@ type UnifiedAlertingSettings struct {
 	HAGossipInterval               time.Duration
 	HAPushPullInterval             time.Duration
 	HALabel                        string
+	HARedisClusterModeEnabled      bool
 	HARedisAddr                    string
 	HARedisPeerName                string
 	HARedisPrefix                  string
@@ -222,6 +223,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.HAListenAddr = ua.Key("ha_listen_address").MustString(alertmanagerDefaultClusterAddr)
 	uaCfg.HAAdvertiseAddr = ua.Key("ha_advertise_address").MustString("")
 	uaCfg.HALabel = ua.Key("ha_label").MustString("")
+	uaCfg.HARedisClusterModeEnabled = ua.Key("ha_redis_cluster_mode_enabled").MustBool(false)
 	uaCfg.HARedisAddr = ua.Key("ha_redis_address").MustString("")
 	uaCfg.HARedisPeerName = ua.Key("ha_redis_peer_name").MustString("")
 	uaCfg.HARedisPrefix = ua.Key("ha_redis_prefix").MustString("")


### PR DESCRIPTION
**What is this feature?**
Adds a new option `ha_redis_cluster_mode_enabled` which when `true` will use the `redis.ClusterClient` instead to connect to a clustered Redis setup. When true, also allows the ability to pass in a comma-separated list of addresses in `ha_redis_address`

**Why do we need this feature?**
Make it possible for users to connect to a clustered Redis.

**Which issue(s) does this PR fix?**:
https://github.com/grafana/grafana/issues/88464


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
