### PR TITLE
Core: Fix title with empty page names

### DIFF
--- a/public/app/core/components/Page/usePageTitle.ts
+++ b/public/app/core/components/Page/usePageTitle.ts
@@ -18,6 +18,6 @@ export function usePageTitle(navModel?: NavModel, pageNav?: NavModelItem) {
     // Override `Home` with the custom brand title
     parts[parts.length - 1] = Branding.AppTitle;
 
-    document.title = parts.join(' - ');
+    document.title = parts.filter((p) => !!p).join(' - ');
   }, [homeNav, navModel, pageNav]);
 }


### PR DESCRIPTION
**What is this feature?**

Page titles might be empty. If so, this leads to ugly page titles like in the case of https://play.grafana.org/a/grafana-lokiexplore-app/explore?logId=&var-fields=&var-filters=service_name%7C%3D%7Cnginx&var-ds=ddhr3fttaw8aod&var-patterns=&var-lineFilter=&var-logsFormat=%20%7C%20logfmt&mode=service_details&actionView=patterns&var-labelBy=$__all&from=now-3h&to=now where the page title is: 
![image](https://github.com/grafana/grafana/assets/8092184/26997b70-db1c-4cd5-8df0-790e977f092d)

This PR filters out every empty part name to avoid concatenating multiple ` -`.

**Why do we need this feature?**

![image](https://github.com/grafana/grafana/assets/8092184/26997b70-db1c-4cd5-8df0-790e977f092d)

**Who is this feature for?**

Every Grafana user.