### PR TITLE
VizTooltip: Format header value

### DIFF
--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { ReactNode } from 'react';
 
-import { DataFrame, Field, FieldType } from '@grafana/data';
+import { DataFrame, Field, FieldType, formattedValueToString } from '@grafana/data';
 import { SortOrder, TooltipDisplayMode } from '@grafana/schema/dist/esm/common/common.gen';
 import { useStyles2 } from '@grafana/ui';
 import { VizTooltipContent } from '@grafana/ui/src/components/VizTooltip/VizTooltipContent';
@@ -52,8 +52,7 @@ export const TimeSeriesTooltip = ({
   const styles = useStyles2(getStyles);
 
   const xField = series.fields[0];
-
-  const xVal = xField.display!(xField.values[dataIdxs[0]!]).text;
+  const xVal = formattedValueToString(xField.display!(xField.values[dataIdxs[0]!]));
 
   const contentItems = getContentItems(
     series.fields,


### PR DESCRIPTION

![trend](https://github.com/grafana/grafana/assets/88068998/16896502-df84-4e74-96b7-7cd205900211)

Fixes https://github.com/grafana/grafana/issues/69409


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
