### PR TITLE
Alerting: Improve performance of tupleLablesToLabels function

### DIFF
--- a/pkg/services/ngalert/models/instance_labels.go
+++ b/pkg/services/ngalert/models/instance_labels.go
@@ -105,7 +105,7 @@ func tupleLablesToLabels(tuples tupleLabels) (InstanceLabels, error) {
 	for _, tuple := range tuples {
 		key, value := tuple[0], tuple[1]
 		if _, ok := labels[key]; ok {
-			return nil, fmt.Errorf("duplicate key '%v' in labels: %v", key, tuples)
+			return nil, fmt.Errorf("duplicate key '%s' in labels: %v", key, tuples)
 		}
 
 		labels[key] = value

--- a/pkg/services/ngalert/models/instance_labels.go
+++ b/pkg/services/ngalert/models/instance_labels.go
@@ -100,12 +100,16 @@ func tupleLablesToLabels(tuples tupleLabels) (InstanceLabels, error) {
 	if tuples == nil {
 		return InstanceLabels{}, nil
 	}
-	labels := make(map[string]string)
+
+	labels := make(map[string]string, len(tuples))
 	for _, tuple := range tuples {
-		if key, ok := labels[tuple[0]]; ok {
-			return nil, fmt.Errorf("duplicate key '%v' in lables: %v", key, tuples)
+		key, value := tuple[0], tuple[1]
+		if _, ok := labels[key]; ok {
+			return nil, fmt.Errorf("duplicate key '%v' in labels: %v", key, tuples)
 		}
-		labels[tuple[0]] = tuple[1]
+
+		labels[key] = value
 	}
+
 	return labels, nil
 }

--- a/pkg/services/ngalert/models/instance_labels_test.go
+++ b/pkg/services/ngalert/models/instance_labels_test.go
@@ -1,0 +1,114 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTupleLabelsToLabels(t *testing.T) {
+	t.Run("converts tupleLabels to InstanceLabels", func(t *testing.T) {
+		in := tupleLabels{
+			{"foo", "bar"},
+			{"baz", "qux"},
+		}
+
+		labels, err := tupleLablesToLabels(in)
+		require.NoError(t, err)
+		require.Equal(t, InstanceLabels{
+			"foo": "bar",
+			"baz": "qux",
+		}, labels)
+	})
+
+	t.Run("nil input gives empty output", func(t *testing.T) {
+		labels, err := tupleLablesToLabels(nil)
+		require.NoError(t, err)
+		require.Empty(t, labels)
+	})
+
+	t.Run("duplicate keys are not allowed", func(t *testing.T) {
+		in := tupleLabels{
+			{"foo", "bar"},
+			{"foo", "qux"},
+		}
+
+		_, err := tupleLablesToLabels(in)
+		require.Error(t, err)
+	})
+}
+
+func BenchmarkTupleLabelsToLabels(b *testing.B) {
+	b.Run("10 labels", func(b *testing.B) {
+		in := make(tupleLabels, 0, 10)
+		for i := 0; i < 10; i++ {
+			key := fmt.Sprintf("key%d", i)
+			value := fmt.Sprintf("value%d", i)
+			in = append(in, tupleLabel{key, value})
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := tupleLablesToLabels(in)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("100 labels", func(b *testing.B) {
+		in := make(tupleLabels, 0, 100)
+		for i := 0; i < 100; i++ {
+			key := fmt.Sprintf("key%d", i)
+			value := fmt.Sprintf("value%d", i)
+			in = append(in, tupleLabel{key, value})
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := tupleLablesToLabels(in)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("10_000 labels", func(b *testing.B) {
+		in := make(tupleLabels, 0, 10_000)
+		for i := 0; i < 10_000; i++ {
+			key := fmt.Sprintf("key%d", i)
+			value := fmt.Sprintf("value%d", i)
+			in = append(in, tupleLabel{key, value})
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := tupleLablesToLabels(in)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("1_000_000 labels", func(b *testing.B) {
+		in := make(tupleLabels, 0, 1_000_000)
+		for i := 0; i < 1_000_000; i++ {
+			key := fmt.Sprintf("key%d", i)
+			value := fmt.Sprintf("value%d", i)
+			in = append(in, tupleLabel{key, value})
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := tupleLablesToLabels(in)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a performance issue in `tupleLabelsToLabels`.

I also fixed a typo in the error message, and a bug where the error message would print out the label's value rather than key.

**Why do we need this feature?**

In some cases where alert rules return very large numbers of dimensions, we're seeing excessive memory use and even OOMs.

In one recent example, the `tupleLabelsToLabels` function was responsible for 50% of the entire process's memory use.

I've added a micro-benchmark for this function, and discovered that the use of `make` without pre-allocating capacity causes a large number of allocations and increased CPU & memory usage. I've also fixed the code to perform more effectively.

Here's the output of `benchstat` for the benchmark run before and after the fix:

```console
$ benchstat before.txt after.txt 
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/models
                                        │  before.txt   │             after.txt              │
                                        │    sec/op     │   sec/op     vs base               │
TupleLabelsToLabels/10_labels-12           443.1n ±  4%   327.1n ± 7%  -26.18% (p=0.001 n=7)
TupleLabelsToLabels/100_labels-12          6.553µ ±  4%   4.263µ ± 1%  -34.95% (p=0.001 n=7)
TupleLabelsToLabels/10_000_labels-12       757.5µ ± 12%   429.6µ ± 1%  -43.29% (p=0.001 n=7)
TupleLabelsToLabels/1_000_000_labels-12   162.58m ±  1%   86.02m ± 1%  -47.09% (p=0.001 n=7)
geomean                                    137.5µ         84.73µ       -38.39%

                                        │  before.txt   │              after.txt              │
                                        │     B/op      │     B/op      vs base               │
TupleLabelsToLabels/10_labels-12             918.0 ± 0%     630.0 ± 0%  -31.37% (p=0.001 n=7)
TupleLabelsToLabels/100_labels-12         10.260Ki ± 0%   5.321Ki ± 0%  -48.13% (p=0.001 n=7)
TupleLabelsToLabels/10_000_labels-12      1245.2Ki ± 0%   584.1Ki ± 0%  -53.10% (p=0.001 n=7)
TupleLabelsToLabels/1_000_000_labels-12   155.03Mi ± 0%   72.25Mi ± 0%  -53.40% (p=0.001 n=7)
geomean                                    206.5Ki        109.1Ki       -47.19%

                                        │   before.txt   │             after.txt             │
                                        │   allocs/op    │ allocs/op   vs base               │
TupleLabelsToLabels/10_labels-12              3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.001 n=7)
TupleLabelsToLabels/100_labels-12            11.000 ± 0%   4.000 ± 0%  -63.64% (p=0.001 n=7)
TupleLabelsToLabels/10_000_labels-12        214.000 ± 0%   3.000 ± 0%  -98.60% (p=0.001 n=7)
TupleLabelsToLabels/1_000_000_labels-12   38237.000 ± 0%   3.000 ± 0%  -99.99% (p=0.001 n=7)
geomean                                       128.2        2.913       -97.73%
```

That's roughly a ~50% improvement in memory use, a ~98% improvement in allocations, and a ~40% improvement in CPU usage.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
