### PR TITLE
SQL: change buttons aria-label to title

### DIFF
--- a/packages/grafana-sql/src/components/visual-query-builder/GroupByRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/GroupByRow.tsx
@@ -51,7 +51,7 @@ function makeRenderColumn({ options }: { options?: Array<SelectableValue<string>
           menuShouldPortal
           onChange={({ value }) => value && onChangeItem(setGroupByField(value))}
         />
-        <AccessoryButton aria-label="Remove group by column" icon="times" variant="secondary" onClick={onDeleteItem} />
+        <AccessoryButton title="Remove group by column" icon="times" variant="secondary" onClick={onDeleteItem} />
       </InputGroup>
     );
   };

--- a/packages/grafana-sql/src/components/visual-query-builder/SelectRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SelectRow.tsx
@@ -150,7 +150,7 @@ export function SelectRow({ sql, format, columns, onSqlChange, functions }: Sele
               />
             </EditorField>
             <Button
-              aria-label="Remove"
+              title="Remove column"
               type="button"
               icon="trash-alt"
               variant="secondary"
@@ -164,9 +164,9 @@ export function SelectRow({ sql, format, columns, onSqlChange, functions }: Sele
         type="button"
         onClick={addColumn}
         variant="secondary"
+        title="Add column"
         size="md"
         icon="plus"
-        aria-label="Add"
         className={styles.addButton}
       />
     </Stack>


### PR DESCRIPTION
**What is this feature?**

This PR changes the buttons in the visual query builder to use title instead of aria-label, this way when hovered over the browser shows the title.

<img width="1080" alt="Screenshot 2024-06-05 at 09 39 41" src="https://github.com/grafana/grafana/assets/13729989/7c64f569-33a6-47c0-ae8a-3b6a2dace1d3">


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
