### PR TITLE
Elasticsearch: Fix stripping of trailing slashes in datasource URLs

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch_test.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch_test.go
@@ -211,13 +211,17 @@ func TestCreateElasticsearchURL(t *testing.T) {
 		{name: "with /abc/_mapping path and valid url", settings: es.DatasourceInfo{URL: "http://localhost:9200/"}, req: backend.CallResourceRequest{Path: "abc/_mapping"}, expected: "http://localhost:9200/abc/_mapping"},
 		// This is to support mappings to cross cluster search that includes ":"
 		{name: "with path including :", settings: es.DatasourceInfo{URL: "http://localhost:9200/"}, req: backend.CallResourceRequest{Path: "ab:c/_mapping"}, expected: "http://localhost:9200/ab:c/_mapping"},
+		{name: "with \"\" path and valid url and /", settings: es.DatasourceInfo{URL: "http://localhost:9200/"}, req: backend.CallResourceRequest{Path: ""}, expected: "http://localhost:9200/"},
+		{name: "with \"\" path and valid url", settings: es.DatasourceInfo{URL: "http://localhost:9200"}, req: backend.CallResourceRequest{Path: ""}, expected: "http://localhost:9200/"},
+		{name: "with \"\" path and valid url with path", settings: es.DatasourceInfo{URL: "http://elastic:9200/lb"}, req: backend.CallResourceRequest{Path: ""}, expected: "http://elastic:9200/lb/"},
+		{name: "with \"\" path and valid url with path and /", settings: es.DatasourceInfo{URL: "http://elastic:9200/lb/"}, req: backend.CallResourceRequest{Path: ""}, expected: "http://elastic:9200/lb/"},
 	}
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			url, err := createElasticsearchURL(&test.req, &test.settings)
 			require.NoError(t, err)
-			require.Equal(t, test.expected, url.String())
+			require.Equal(t, test.expected, url)
 		})
 	}
 }


### PR DESCRIPTION
This PR:

- Ensures root URLs are consistent and end with a slash.
- Enhances compatibility with load balancers expecting URLs to end with a slash.

It  ensures that if the request path is empty and the URL does not end with a slash, a slash is added to the URL. This helps maintain compatibility with load balancers that expect URLs to match the pattern `/.*`.

Related to https://github.com/grafana/support-escalations/issues/10533