### PR TITLE
Users: remove unused store function

### DIFF
--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -290,10 +290,6 @@ func (f *FakeUserStore) GetByID(context.Context, int64) (*user.User, error) {
 	return f.ExpectedUser, f.ExpectedError
 }
 
-func (f *FakeUserStore) CaseInsensitiveLoginConflict(context.Context, string, string) error {
-	return f.ExpectedError
-}
-
 func (f *FakeUserStore) LoginConflict(context.Context, string, string) error {
 	return f.ExpectedError
 }


### PR DESCRIPTION
**What is this feature?**
While investigating another issue I noticed that `CaseInsensitiveLoginConflict` was unused so we can remove it.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
