### PR TITLE
[v10.4.x] AzureMonitor: Fix bug detecting app insights queries

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -97,7 +97,7 @@ func getApiURL(resourceOrWorkspace string, isAppInsightsQuery bool) string {
 
 func (e *AzureLogAnalyticsDatasource) buildQueries(ctx context.Context, queries []backend.DataQuery, dsInfo types.DatasourceInfo) ([]*AzureLogAnalyticsQuery, error) {
 	azureLogAnalyticsQueries := []*AzureLogAnalyticsQuery{}
-	appInsightsRegExp, err := regexp.Compile("providers/Microsoft.Insights/components")
+	appInsightsRegExp, err := regexp.Compile("(?i)providers/microsoft.insights/components")
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile Application Insights regex")
 	}

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1446,6 +1446,82 @@ func TestBuildingAzureLogAnalyticsQueries(t *testing.T) {
 			},
 			Err: require.NoError,
 		},
+		{
+			name: "Detects App Insights resource queries",
+			queryModel: []backend.DataQuery{{
+				JSON: []byte(fmt.Sprintf(`{
+						"queryType": "Azure Log Analytics",
+						"azureLogAnalytics": {
+							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"],
+							"query":        "Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
+							"resultFormat": "%s",
+							"dashboardTime": false
+						}
+					}`, dataquery.ResultFormatTimeSeries)),
+				RefID:     "A",
+				TimeRange: timeRange,
+				QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+			}},
+			azureLogAnalyticsQueries: []*AzureLogAnalyticsQuery{{
+				RefID:        "A",
+				ResultFormat: dataquery.ResultFormatTimeSeries,
+				URL:          "v1/apps/AppInsightsTestDataWorkspace/query",
+				JSON: []byte(fmt.Sprintf(`{
+						"queryType": "Azure Log Analytics",
+						"azureLogAnalytics": {
+							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"],
+							"query":        "Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
+							"resultFormat": "%s",
+							"dashboardTime": false
+						}
+					}`, dataquery.ResultFormatTimeSeries)),
+				Query:            "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
+				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/Microsoft.Insights/components/AppInsightsTestDataWorkspace"},
+				TimeRange:        timeRange,
+				QueryType:        dataquery.AzureQueryTypeAzureLogAnalytics,
+				AppInsightsQuery: true,
+				DashboardTime:    false,
+			}},
+			Err: require.NoError,
+		},
+		{
+			name: "Detects App Insights resource queries (case insensitive)",
+			queryModel: []backend.DataQuery{{
+				JSON: []byte(fmt.Sprintf(`{
+						"queryType": "Azure Log Analytics",
+						"azureLogAnalytics": {
+							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"],
+							"query":        "Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
+							"resultFormat": "%s",
+							"dashboardTime": false
+						}
+					}`, dataquery.ResultFormatTimeSeries)),
+				RefID:     "A",
+				TimeRange: timeRange,
+				QueryType: string(dataquery.AzureQueryTypeAzureLogAnalytics),
+			}},
+			azureLogAnalyticsQueries: []*AzureLogAnalyticsQuery{{
+				RefID:        "A",
+				ResultFormat: dataquery.ResultFormatTimeSeries,
+				URL:          "v1/apps/AppInsightsTestDataWorkspace/query",
+				JSON: []byte(fmt.Sprintf(`{
+						"queryType": "Azure Log Analytics",
+						"azureLogAnalytics": {
+							"resources":     ["/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"],
+							"query":        "Perf | where $__timeFilter() | where $__contains(Computer, 'comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, $__interval), Computer",
+							"resultFormat": "%s",
+							"dashboardTime": false
+						}
+					}`, dataquery.ResultFormatTimeSeries)),
+				Query:            "Perf | where ['TimeGenerated'] >= datetime('2018-03-15T13:00:00Z') and ['TimeGenerated'] <= datetime('2018-03-15T13:34:00Z') | where ['Computer'] in ('comp1','comp2') | summarize avg(CounterValue) by bin(TimeGenerated, 34000ms), Computer",
+				Resources:        []string{"/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/cloud-datasources/providers/microsoft.insights/components/AppInsightsTestDataWorkspace"},
+				TimeRange:        timeRange,
+				QueryType:        dataquery.AzureQueryTypeAzureLogAnalytics,
+				AppInsightsQuery: true,
+				DashboardTime:    false,
+			}},
+			Err: require.NoError,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport f787418e4ba5725de1cd325575ae80fb15eff899 from #88572

---

The regular expression for detecting app insights resources wasn't case insensitive which could lead to failures. This updates the regular expression accordingly and adds tests.

Fixes grafana/support-escalations#10607
