### PR TITLE
Alerting: Make all in api generator tooling now actually makes all

### DIFF
--- a/pkg/services/ngalert/api/tooling/Makefile
+++ b/pkg/services/ngalert/api/tooling/Makefile
@@ -60,7 +60,7 @@ fix:
 	sed $(SED_INPLACE) -e 's/apimodels\.\[\]PostableApiReceiver/apimodels.TestReceiversConfigParams/' $(GENERATED_GO_MATCHERS)
 	goimports -w -v $(GENERATED_GO_MATCHERS)
 
-clean:
+clean: clean-go
 	rm spec.json
 	rm spec-stable.json
 

--- a/pkg/services/ngalert/api/tooling/Makefile
+++ b/pkg/services/ngalert/api/tooling/Makefile
@@ -61,6 +61,10 @@ fix:
 	goimports -w -v $(GENERATED_GO_MATCHERS)
 
 clean:
+	rm spec.json
+	rm spec-stable.json
+
+clean-go:
 	rm -rf ./go
 
 serve: post.json
@@ -69,6 +73,6 @@ serve: post.json
 serve-stable: api.json
 	docker run --rm -p 80:8080 -v $$(pwd):/tmp -e SWAGGER_FILE=/tmp/$(<) swaggerapi/swagger-editor
 
-gen: swagger-codegen-api fix copy-files clean
+gen: swagger-codegen-api fix copy-files clean-go
 
-all: post.json api.json gen
+all: clean spec.json spec-stable.json post.json api.json gen


### PR DESCRIPTION
**What is this feature?**

`make all` is prone to caching problems, if the swagger docs already exist it does not regenerate them. It rarely makes "all" as the name suggests. There is also no command to clean the swagger docs themselves.

**Why do we need this feature?**

Changes clean to clean the swagger docs in addition to generated go files to avoid caching problems.
Make all cleans and rebuilds.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
