### PR TITLE
Alerting: Update search examples for notification policies

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.tsx
@@ -64,7 +64,7 @@ const NotificationPoliciesFilter = ({
                 content={
                   <div>
                     Filter notification policies by using a comma separated list of matchers, e.g.:
-                    <pre>severity=critical, instance=~cluster-us-.+</pre>
+                    <pre>severity=critical, region=EMEA</pre>
                   </div>
                 }
               >


### PR DESCRIPTION
**What is this feature?**

This PR removes the regular expression example from the notification policies search input. This confuses users who might interpret this as support for regular expression matching in the search input field. 