### PR TITLE
[v10.4.x] InfluxDB: Use json-iterator package for json operations

### DIFF
--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser.go
@@ -1,7 +1,6 @@
 package buffered
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/influxql/util"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
@@ -50,8 +50,9 @@ func parse(buf io.Reader, statusCode int, query *models.Query) *backend.DataResp
 func parseJSON(buf io.Reader) (models.Response, error) {
 	var response models.Response
 
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	dec := json.NewDecoder(buf)
-	dec.UseNumber()
 
 	err := dec.Decode(&response)
 
@@ -154,6 +155,12 @@ func newValueFields(rows []models.Row, labels data.Labels, colIdxStart, colIdxEn
 				case "json.Number":
 					value := util.ParseNumber(valuePair[colIdx])
 					floatArray = append(floatArray, value)
+				case "float64":
+					if value, ok := valuePair[colIdx].(float64); ok {
+						floatArray = append(floatArray, &value)
+					} else {
+						floatArray = append(floatArray, nil)
+					}
 				case "bool":
 					value, ok := valuePair[colIdx].(bool)
 					if ok {
@@ -195,6 +202,8 @@ func newValueFields(rows []models.Row, labels data.Labels, colIdxStart, colIdxEn
 			case "string":
 				valueField = data.NewField(row.Columns[colIdx], labels, stringArray)
 			case "json.Number":
+				valueField = data.NewField(row.Columns[colIdx], labels, floatArray)
+			case "float64":
 				valueField = data.NewField(row.Columns[colIdx], labels, floatArray)
 			case "bool":
 				valueField = data.NewField(row.Columns[colIdx], labels, boolArray)
@@ -241,12 +250,6 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 
 		if !hasTimeCol {
 			newFrame := newFrameWithoutTimeField(row, query)
-			if len(frames) == 0 {
-				newFrame.Meta = &data.FrameMeta{
-					ExecutedQueryString:    query.RawQuery,
-					PreferredVisualization: util.GetVisType(query.ResultFormat),
-				}
-			}
 			frames = append(frames, newFrame)
 		} else {
 			for colIndex, column := range row.Columns {
@@ -254,14 +257,15 @@ func transformRowsForTimeSeries(rows []models.Row, query models.Query) data.Fram
 					continue
 				}
 				newFrame := newFrameWithTimeField(row, column, colIndex, query, frameName)
-				if len(frames) == 0 {
-					newFrame.Meta = &data.FrameMeta{
-						ExecutedQueryString:    query.RawQuery,
-						PreferredVisualization: util.GetVisType(query.ResultFormat),
-					}
-				}
 				frames = append(frames, newFrame)
 			}
+		}
+	}
+
+	if len(frames) > 0 {
+		frames[0].Meta = &data.FrameMeta{
+			ExecutedQueryString:    query.RawQuery,
+			PreferredVisualization: util.GetVisType(query.ResultFormat),
 		}
 	}
 
@@ -294,6 +298,12 @@ func newFrameWithTimeField(row models.Row, column string, colIndex int, query mo
 		case "json.Number":
 			value := util.ParseNumber(valuePair[colIndex])
 			floatArray = append(floatArray, value)
+		case "float64":
+			if value, ok := valuePair[colIndex].(float64); ok {
+				floatArray = append(floatArray, &value)
+			} else {
+				floatArray = append(floatArray, nil)
+			}
 		case "bool":
 			value, ok := valuePair[colIndex].(bool)
 			if ok {
@@ -314,6 +324,8 @@ func newFrameWithTimeField(row models.Row, column string, colIndex int, query mo
 	case "string":
 		valueField = data.NewField("Value", row.Tags, stringArray)
 	case "json.Number":
+		valueField = data.NewField("Value", row.Tags, floatArray)
+	case "float64":
 		valueField = data.NewField("Value", row.Tags, floatArray)
 	case "bool":
 		valueField = data.NewField("Value", row.Tags, boolArray)

--- a/pkg/tsdb/influxdb/influxql/buffered/response_parser_test.go
+++ b/pkg/tsdb/influxdb/influxql/buffered/response_parser_test.go
@@ -363,10 +363,11 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		}
 	})
 
-	t.Run("Influxdb response parser parseTimestamp valid JSON.number", func(t *testing.T) {
+	t.Run("Influxdb response parser parseTimestamp valid number", func(t *testing.T) {
 		// currently we use milliseconds-precision with influxdb, so the test works with that.
 		// if we change this to for example nanoseconds-precision, the tests will have to change.
-		timestamp, err := util.ParseTimestamp(json.Number("1609556645000"))
+		ts := float64(1609556645000)
+		timestamp, err := util.ParseTimestamp(ts)
 		require.NoError(t, err)
 		require.Equal(t, timestamp.Format(time.RFC3339), "2021-01-02T03:04:05Z")
 	})

--- a/pkg/tsdb/influxdb/influxql/util/util.go
+++ b/pkg/tsdb/influxdb/influxql/util/util.go
@@ -89,18 +89,14 @@ func BuildFrameNameFromQuery(rowName, column string, tags map[string]string, fra
 }
 
 func ParseTimestamp(value any) (time.Time, error) {
-	timestampNumber, ok := value.(json.Number)
+	timestampNumber, ok := value.(float64)
 	if !ok {
 		return time.Time{}, fmt.Errorf("timestamp-value has invalid type: %#v", value)
-	}
-	timestampInMilliseconds, err := timestampNumber.Int64()
-	if err != nil {
-		return time.Time{}, err
 	}
 
 	// currently in the code the influxdb-timestamps are requested with
 	// milliseconds-precision, meaning these values are milliseconds
-	t := time.UnixMilli(timestampInMilliseconds).UTC()
+	t := time.UnixMilli(int64(timestampNumber)).UTC()
 
 	return t, nil
 }


### PR DESCRIPTION
Backport 808cf75ff87fef1612d6c104dac9fb8250e1ebff from #88562

---

**What is this feature?**

Just switching to `json-iterator` package from built-in json package. 

Small response (9 values each value has 17 items) difference

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/tsdb/influxdb/influxql
             │ buffered.txt │            buffered3.txt            │
             │    sec/op    │   sec/op     vs base                │
ParseJson-10   119.97µ ± 0%   91.65µ ± 1%  -23.61% (p=0.000 n=10)

             │ buffered.txt │            buffered3.txt            │
             │     B/op     │     B/op      vs base               │
ParseJson-10   123.7Ki ± 0%   117.3Ki ± 0%  -5.17% (p=0.000 n=10)

             │ buffered.txt │           buffered3.txt            │
             │  allocs/op   │  allocs/op   vs base               │
ParseJson-10    2.527k ± 0%   2.510k ± 0%  -0.67% (p=0.000 n=10)

```

Big response (55318 values each value has 2 items) difference:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/tsdb/influxdb/influxql
             │ buffered.txt │            buffered3.txt            │
             │    sec/op    │   sec/op     vs base                │
ParseJson-10    23.25m ± 0%   10.96m ± 0%  -52.86% (p=0.000 n=10)

             │ buffered.txt │            buffered3.txt             │
             │     B/op     │     B/op      vs base                │
ParseJson-10   26.62Mi ± 0%   21.23Mi ± 0%  -20.24% (p=0.000 n=10)

             │ buffered.txt │            buffered3.txt            │
             │  allocs/op   │  allocs/op   vs base                │
ParseJson-10    386.9k ± 0%   278.0k ± 0%  -28.13% (p=0.000 n=10)

```

