### PR TITLE
Alerting: Update CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -169,13 +169,13 @@
 /devenv/bulk-dashboards/ @grafana/dashboards-squad
 /devenv/bulk-folders/ @grafana/grafana-frontend-platform
 /devenv/create_docker_compose.sh @grafana/grafana-backend-services-squad
-/devenv/alert_rules.yaml @grafana/alerting-backend-product
+/devenv/alert_rules.yaml @grafana/alerting-backend
 /devenv/dashboards.yaml @grafana/dashboards-squad
 /devenv/datasources.yaml @grafana/grafana-backend-group
 /devenv/datasources_docker.yaml @grafana/grafana-backend-group
 /devenv/dev-dashboards-without-uid/ @grafana/dashboards-squad
 /devenv/dev-dashboards/ @grafana/dashboards-squad
-/devenv/docker/blocks/alert_webhook_listener/ @grafana/alerting-backend-product
+/devenv/docker/blocks/alert_webhook_listener/ @grafana/alerting-backend
 /devenv/docker/blocks/clickhouse/ @grafana/partner-datasources
 /devenv/docker/blocks/collectd/ @grafana/observability-metrics
 /devenv/docker/blocks/etcd @grafana/grafana-app-platform-squad
@@ -189,7 +189,7 @@
 /devenv/docker/blocks/maildev/ @grafana/alerting-frontend
 /devenv/docker/blocks/mariadb/ @grafana/oss-big-tent
 /devenv/docker/blocks/memcached/ @grafana/grafana-backend-group
-/devenv/docker/blocks/mimir_backend/ @grafana/alerting-backend-product
+/devenv/docker/blocks/mimir_backend/ @grafana/alerting-backend
 /devenv/docker/blocks/mssql/ @grafana/partner-datasources
 /devenv/docker/blocks/mssql_arm64/ @grafana/partner-datasources
 /devenv/docker/blocks/mssql_tests/ @grafana/partner-datasources
@@ -211,11 +211,11 @@
 /devenv/docker/blocks/tempo/ @grafana/observability-traces-and-profiling
 /devenv/docker/blocks/traefik/ @mckn
 /devenv/docker/blocks/zipkin/ @grafana/observability-traces-and-profiling
-/devenv/docker/blocks/webdav/ @grafana/alerting-backend-product
+/devenv/docker/blocks/webdav/ @grafana/alerting-backend
 /devenv/docker/buildcontainer/ @bergquist
 /devenv/docker/compose_header.yml @grafana/grafana-backend-services-squad
 /devenv/docker/debtest/ @bergquist
-/devenv/docker/ha-test-unified-alerting/ @grafana/alerting-backend-product
+/devenv/docker/ha-test-unified-alerting/ @grafana/alerting-backend
 /devenv/docker/ha_test/ @grafana/grafana-backend-services-squad
 /devenv/docker/loadtest/ @grafana/grafana-backend-services-squad
 /devenv/docker/rpmtest/ @grafana/grafana-backend-services-squad
@@ -278,9 +278,9 @@
 /pkg/generated @grafana/grafana-app-platform-squad
 
 # Alerting
-/pkg/services/ngalert/ @grafana/alerting-backend-product
-/pkg/services/sqlstore/migrations/ualert/ @grafana/alerting-backend-product
-/pkg/tests/api/alerting/ @grafana/alerting-backend-product
+/pkg/services/ngalert/ @grafana/alerting-backend
+/pkg/services/sqlstore/migrations/ualert/ @grafana/alerting-backend
+/pkg/tests/api/alerting/ @grafana/alerting-backend
 /public/app/features/alerting/ @grafana/alerting-frontend
 /public/app/features/gops/ @grafana/alerting-frontend
 
@@ -653,7 +653,7 @@ embed.go @grafana/grafana-as-code
 /.github/pr-commands.json @marefr
 /.github/renovate.json5 @grafana/frontend-ops
 /.github/teams.yml @armandgrillet
-/.github/workflows/alerting-swagger-gen.yml @grafana/alerting-backend-product
+/.github/workflows/alerting-swagger-gen.yml @grafana/alerting-backend
 /.github/workflows/auto-milestone.yml @grafana/grafana-release-guild
 /.github/workflows/backport.yml @grafana/grafana-release-guild
 /.github/workflows/bump-version.yml @grafana/grafana-release-guild
@@ -714,7 +714,7 @@ embed.go @grafana/grafana-as-code
 /conf/ldap.toml @grafana/identity-access-team
 /conf/ldap_multiple.toml @grafana/identity-access-team
 /conf/provisioning/access-control/ @grafana/identity-access-team
-/conf/provisioning/alerting/ @grafana/alerting-backend-product
+/conf/provisioning/alerting/ @grafana/alerting-backend
 /conf/provisioning/dashboards/ @grafana/dashboards-squad
 /conf/provisioning/datasources/ @grafana/plugins-platform-backend
 /conf/provisioning/plugins/ @grafana/plugins-platform-backend

--- a/.github/workflows/alerting-swagger-gen.yml
+++ b/.github/workflows/alerting-swagger-gen.yml
@@ -32,6 +32,6 @@ jobs:
           branch: update-alerting-swagger-spec
           delete-branch: true
           labels: 'area/alerting,type/docs,no-changelog'
-          team-reviewers: 'grafana/alerting-backend-product'
+          team-reviewers: 'grafana/alerting-backend'
           draft: false
 


### PR DESCRIPTION
Assigns ownership of Alerting backend components to grafana/alerting-backend, due
to deprecation of the existing grafana/alerting-backend-product team.
