### PR TITLE
storage: Avoid panic when no previous versions in history

### DIFF
--- a/pkg/services/store/entity/sqlstash/sql_storage_server.go
+++ b/pkg/services/store/entity/sqlstash/sql_storage_server.go
@@ -1095,6 +1095,11 @@ func (s *sqlEntityServer) poll(since int64, out chan *entity.EntityWatchResponse
 						return err
 					}
 
+					if len(history.Versions) == 0 {
+						ctxLogger.Error("error reading previous entity", "guid", updated.Guid, "err", "no previous version found")
+						return errors.New("no previous version found")
+					}
+
 					result.Previous = history.Versions[0]
 				}
 


### PR DESCRIPTION
**What is this feature?**

Seeing a panic in dev, this should help, though I really have no idea if this is the right fix:

```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 206 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
	go.opentelemetry.io/otel/sdk@v1.26.0/trace/span.go:381 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc002162480, {0x0, 0x0, 0xc002116120?})
	go.opentelemetry.io/otel/sdk@v1.26.0/trace/span.go:419 +0xa82
panic({0x11fd6e0?, 0xc00214c0f0?})
	runtime/panic.go:770 +0x132
github.com/grafana/grafana/pkg/services/store/entity/sqlstash.(*sqlEntityServer).poll.func1(0xc00255c0c0, {0xc001d93508, 0x1d, 0x484d8575efb4?}, 0xc0025dbf20, {0x2677410, 0xc002151aa0}, 0xc0025dbe7e, 0xc001eb6820, {0x2695fd0, ...}, ...)
	github.com/grafana/grafana/pkg/services/store/entity/sqlstash/sql_storage_server.go:1098 +0xad8
github.com/grafana/grafana/pkg/services/store/entity/sqlstash.(*sqlEntityServer).poll(0xc00255c0c0, 0x1, 0xc002390c00)
	github.com/grafana/grafana/pkg/services/store/entity/sqlstash/sql_storage_server.go:1107 +0x22e
github.com/grafana/grafana/pkg/services/store/entity/sqlstash.(*sqlEntityServer).poller(0xc00255c0c0, 0xc002390c00)
	github.com/grafana/grafana/pkg/services/store/entity/sqlstash/sql_storage_server.go:1011 +0x111
created by github.com/grafana/grafana/pkg/services/store/entity/sqlstash.(*sqlEntityServer).init.func1 in goroutine 205
	github.com/grafana/grafana/pkg/services/store/entity/sqlstash/sql_storage_server.go:146 +0x8e
```
