### PR TITLE
OptionsPicker: skip needle when selecting all matches

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -115,9 +115,9 @@ const updateAllSelection = (state: OptionsPickerState): OptionsPickerState => {
 };
 
 // Utility function to select all options except 'ALL_VARIABLE_VALUE'
-const selectAllOptions = (options: VariableOption[]) =>
+const selectAllOptions = (options: VariableOption[], needleText: String) =>
   options
-    .filter((option) => option.value !== ALL_VARIABLE_VALUE)
+    .filter((option) => option.value !== ALL_VARIABLE_VALUE && option.text !== needleText)
     .map((option) => ({
       ...option,
       selected: true,
@@ -208,6 +208,7 @@ const optionsPickerSlice = createSlice({
       // Check if 'All' option is configured by the user and if it's selected in the dropdown
       const isAllSelected = state.selectedValues.find((option) => option.value === ALL_VARIABLE_VALUE);
       const allOptionConfigured = state.options.find((option) => option.value === ALL_VARIABLE_VALUE);
+      const needleText = '> ' + state.queryValue.trim();
 
       // If 'All' option is not selected from the dropdown, but some options are, clear all options and select 'All'
       if (state.selectedValues.length > 0 && !!allOptionConfigured && !isAllSelected) {
@@ -224,7 +225,7 @@ const optionsPickerSlice = createSlice({
 
       // If 'All' option is the only one selected in the dropdown, unselect "All" and select each one of the other options.
       if (isAllSelected && state.selectedValues.length === 1) {
-        state.selectedValues = selectAllOptions(state.options);
+        state.selectedValues = selectAllOptions(state.options, needleText);
         return applyStateChanges(state, updateOptions);
       }
 
@@ -236,7 +237,7 @@ const optionsPickerSlice = createSlice({
       }
 
       // If no options are selected and 'All' is not selected, select all options
-      state.selectedValues = selectAllOptions(state.options);
+      state.selectedValues = selectAllOptions(state.options, needleText);
       return applyStateChanges(state, updateOptions);
     },
 


### PR DESCRIPTION
Prior to #84790 on dashboards with multi-value variables one could:

1. Load the dashboard with the default values.
2. Select a variable and find the partial match.
3. Click on "Selected" once to unselect the default.
4. Click on "Selected" again to select the matches.

After #84790 this behaviour broke because the newly added needly was also selected, even though it isn't a necessarily valid option.

With this change we restore the previous behavior, while keeping the needle.

Here's an example.

1. Freshly loaded dashboard:

<img width="221" alt="image" src="https://github.com/grafana/grafana/assets/89186/f6f027d4-c03d-4dee-8c12-6884a678af61">

1. I'm actually interested in the thing `one`, so I type `on` and see the match:

<img width="231" alt="image" src="https://github.com/grafana/grafana/assets/89186/d7afae86-05c7-4859-8804-eb7cff449b05">

2. I click on "Selected" to remove the previous selection:

<img width="232" alt="image" src="https://github.com/grafana/grafana/assets/89186/dbff924f-baac-4d45-ab0d-81729899fe13">

3. I click on it again to apply the new selection, also selecting the needle for no reason:

<img width="228" alt="image" src="https://github.com/grafana/grafana/assets/89186/2c0c296c-1bad-4732-a3d6-de77eaca70ed">

This PR fixes the last step, skipping the needle:

<img width="231" alt="image" src="https://github.com/grafana/grafana/assets/89186/8c1624a4-d8d1-47e3-bcc5-53cd1a53e392">

Success! Just like it used to work!