### PR TITLE
Unified Storage: Fix data races in DualWriter

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode1_test.go
@@ -25,6 +25,8 @@ var exampleList = &example.PodList{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ListM
 var anotherList = &example.PodList{Items: []example.Pod{*anotherObj}}
 
 func newTestMode1(t *testing.T, ls LegacyStorage, us Storage) DualWriter {
+	t.Helper()
+
 	dw := NewDualWriter(Mode1, ls, us)
 	implem, ok := dw.(*DualWriterMode1)
 	require.True(t, ok)
@@ -45,7 +47,7 @@ func TestMode1_Create(t *testing.T) {
 		[]testCase{
 			{
 				name:  "creating an object only in the legacy store",
-				input: exampleObj,
+				input: prepareForCreate(t, exampleObj),
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
 					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(exampleObj, nil)
 				},
@@ -55,9 +57,9 @@ func TestMode1_Create(t *testing.T) {
 			},
 			{
 				name:  "error when creating object in the legacy store fails",
-				input: failingObj,
+				input: prepareForCreate(t, failingObj),
 				setupLegacyFn: func(m *mock.Mock, input runtime.Object) {
-					m.On("Create", mock.Anything, failingObj, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
+					m.On("Create", mock.Anything, input, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
 			},

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -60,7 +60,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, original runtime.Object, c
 	}
 
 	startStorage := time.Now()
-	rsp, err := d.Storage.Create(ctx, created, createValidation, options)
+	rsp, err := d.Storage.Create(ctx, createdLegacy, createValidation, options)
 	if err != nil {
 		log.WithValues("name").Error(err, "unable to create object in storage")
 		d.recordStorageDuration(true, mode2Str, options.Kind, method, startStorage)


### PR DESCRIPTION
**What is this feature?**

- Fix data races modifying the same object concurrently in tests
- Fix Mode2 returning an empty resource version in Create

TODO: Fix leaking goroutines in runtime code

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

Data Race 3 in #88882

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
