### PR TITLE
Chore: Remove hardcoded wait in keybinds e2e test

### DIFF
--- a/e2e/various-suite/keybinds.spec.ts
+++ b/e2e/various-suite/keybinds.spec.ts
@@ -32,7 +32,6 @@ describe('Keyboard shortcuts', () => {
       to: '2024-06-05 10:06:00',
       zone: 'Browser',
     });
-    e2e.components.TimePicker.fromField().should('not.exist');
     e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
 
     cy.get('body').type('{ctrl}z');
@@ -51,7 +50,6 @@ describe('Keyboard shortcuts', () => {
       to: '2024-06-05 10:06:00',
       zone: 'Browser',
     });
-    e2e.components.TimePicker.fromField().should('not.exist');
     e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
 
     cy.log('Trying one shift-left');

--- a/e2e/various-suite/keybinds.spec.ts
+++ b/e2e/various-suite/keybinds.spec.ts
@@ -1,11 +1,7 @@
 import { e2e } from '../utils';
 import { fromBaseUrl } from '../utils/support/url';
 
-const options = {
-  defaultCommandTimeout: 5 * 1000,
-};
-
-describe('Keyboard shortcuts', options, () => {
+describe('Keyboard shortcuts', () => {
   beforeEach(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
 
@@ -26,7 +22,7 @@ describe('Keyboard shortcuts', options, () => {
     e2e.components.Panels.Panel.title('Latest from the blog').should('be.visible');
   });
 
-  it('ctrl+z should zoom out the time range', options, () => {
+  it('ctrl+z should zoom out the time range', () => {
     cy.get('body').type('ge');
     e2e.pages.Explore.General.container().should('be.visible');
 
@@ -37,14 +33,15 @@ describe('Keyboard shortcuts', options, () => {
       zone: 'Browser',
     });
     e2e.components.TimePicker.fromField().should('not.exist');
-    cy.wait(500); // waiting is anti-pattern, but it's inconsistent for me locally without this
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
 
     cy.get('body').type('{ctrl}z');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     let expectedRange = `Time range selected: 2024-06-05 10:03:30 to 2024-06-05 10:07:30`;
     e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
   });
 
-  it('multiple time range shortcuts should work', options, () => {
+  it('multiple time range shortcuts should work', () => {
     cy.get('body').type('ge');
     e2e.pages.Explore.General.container().should('be.visible');
 
@@ -55,23 +52,29 @@ describe('Keyboard shortcuts', options, () => {
       zone: 'Browser',
     });
     e2e.components.TimePicker.fromField().should('not.exist');
-    cy.wait(500); // waiting is anti-pattern, but it's inconsistent for me locally without this
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
 
     cy.log('Trying one shift-left');
     cy.get('body').type('t{leftarrow}');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     let expectedRange = `Time range selected: 2024-06-05 10:04:00 to 2024-06-05 10:05:00`; // 1 min back
     e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
 
     cy.log('Trying two shift-lefts');
     cy.get('body').type('t{leftarrow}');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     cy.get('body').type('t{leftarrow}');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     expectedRange = `Time range selected: 2024-06-05 10:02:00 to 2024-06-05 10:03:00`; // 2 mins back
     e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
 
     cy.log('Trying two shift-lefts and a shift-right');
     cy.get('body').type('t{leftarrow}');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     cy.get('body').type('t{leftarrow}');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     cy.get('body').type('t{rightarrow}');
+    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     expectedRange = `Time range selected: 2024-06-05 10:01:00 to 2024-06-05 10:02:00`; // 2 mins back, 1 min forward (1 min back total)
     e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- removes the hardcoded waits in favour of waiting on the query button resetting back to the `Run query` state

**Why do we need this feature?**

- hardcoded waits are baaaaaad

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
