### PR TITLE
Keybinds: Allow move time range shortcuts  (t left / t right) to be chained

### DIFF
--- a/public/app/core/services/mousetrap/Mousetrap.ts
+++ b/public/app/core/services/mousetrap/Mousetrap.ts
@@ -695,6 +695,11 @@ export class Mousetrap {
     }
     const event: KeyboardEvent = rawEvent;
 
+    // Don't trigger shortcuts when a key is just held down
+    if (event.repeat) {
+      return;
+    }
+
     // normalize e.which for key events
     // @see http://stackoverflow.com/questions/4285627/javascript-keycode-vs-charcode-utter-confusion
     if (typeof event.which !== 'number') {


### PR DESCRIPTION
**What is this feature?**

Grafana has the `t left` and `t right` sequence shortcuts to adjust the selected time range of dashboards and Explore. This PR allows for the shortcuts to be more easily chained without having to repeat the common prefix e.g. `t left left left right` will shift the time range back three times and forwards once.

**Why do we need this feature?**

For easier navigating through Dashboards.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/86710


**Special notes for your reviewer:**

Note - this does not allow shortcuts to be chained in this way across multiple pages. This is because Grafana resets all keyboard shortcuts when navigating between pages. I've already spent probably too much time on this enhancement, where I think the main advantage is to more quickly do things on the same page.