### PR TITLE
User: add second migration for lowercasing login/email of users

### DIFF
--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -161,6 +161,8 @@ func addUserMigrations(mg *Migrator) {
 
 	// Users login and email should be in lower case
 	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail, &usermig.UsersLowerCaseLoginAndEmail{})
+	// Users login and email should be in lower case - 2, fix for creating users not lowering login and email
+	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail+"2", &usermig.UsersLowerCaseLoginAndEmail{})
 }
 
 const migSQLITEisServiceAccountNullable = `ALTER TABLE user ADD COLUMN tmp_service_account BOOLEAN DEFAULT 0;


### PR DESCRIPTION
**why**
`CaseInsensitiveLogin` is semi broken in v11.0.x for external auth. Using `auth_proxy`

We need to add this migration to main, to be able to backport this change into v11.0.x. In the backport we include the lower case change on insert.

**what**
Adds a second migration of lower casing users `email` and `login`.