### PR TITLE
chore(ci): Run golangci-lint in GitHub Actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -434,15 +434,6 @@ steps:
   image: golang:1.22.4-alpine
   name: wire-install
 - commands:
-  - apk add --update make build-base
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.22.4-alpine
-  name: lint-backend
-- commands:
   - go run scripts/modowners/modowners.go check go.mod
   image: golang:1.22.4-alpine
   name: validate-modfile
@@ -1760,15 +1751,6 @@ steps:
   depends_on: []
   image: golang:1.22.4-alpine
   name: wire-install
-- commands:
-  - apk add --update make build-base
-  - make lint-go
-  depends_on:
-  - wire-install
-  environment:
-    CGO_ENABLED: "1"
-  image: golang:1.22.4-alpine
-  name: lint-backend
 - commands:
   - go run scripts/modowners/modowners.go check go.mod
   image: golang:1.22.4-alpine
@@ -4911,6 +4893,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 7d2348a3bc09c44b08dda2d737f91c7de3e5048aa47ba65eada4cdde1eea9fa6
+hmac: 08f38b820f97302de03a9fdfd39fb12c185bb36170704cf7591c16f33c3e4d31
 
 ...

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -700,6 +700,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/i18n-crowdin-download.yml @grafana/grafana-frontend-platform
 /.github/workflows/pr-go-workspace-check.yml @grafana/grafana-app-platform-squad
 /.github/workflows/run-scenes-e2e.yml @grafana/dashboards-squad
+/.github/workflows/go_lint.yml @grafana/grafana-backend-services-squad
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -1,0 +1,32 @@
+name: golangci-lint
+on:
+  push:
+    paths:
+      - pkg/**
+      - .github/workflows/go_lint.yml
+      - go.*
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+      - run: CODEGEN_VERIFY=1 make gen-cue
+      - run: make gen-go
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v5
+        with:
+          version: v1.59.0
+          args: --config .golangci.toml --max-same-issues=0 --max-issues-per-linter=0 --verbose
+          only-new-issues: true
+          skip-cache: true
+          install-mode: binary

--- a/scripts/drone/pipelines/lint_backend.star
+++ b/scripts/drone/pipelines/lint_backend.star
@@ -7,7 +7,6 @@ load(
     "compile_build_cmd",
     "enterprise_setup_step",
     "identify_runner_step",
-    "lint_backend_step",
     "lint_drone_step",
     "validate_modfile_step",
     "validate_openapi_spec_step",
@@ -45,7 +44,6 @@ def lint_backend_pipeline(trigger, ver_mode):
     init_steps.append(wire_step)
 
     test_steps = [
-        lint_backend_step(),
         validate_modfile_step(),
         validate_openapi_spec_step(),
     ]

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -199,24 +199,6 @@ def enterprise_downstream_step(ver_mode):
 
     return step
 
-def lint_backend_step():
-    return {
-        "name": "lint-backend",
-        "image": images["go"],
-        "environment": {
-            # We need CGO because of go-sqlite3
-            "CGO_ENABLED": "1",
-        },
-        "depends_on": [
-            "wire-install",
-        ],
-        "commands": [
-            "apk add --update make build-base",
-            # Don't use Make since it will re-download the linters
-            "make lint-go",
-        ],
-    }
-
 def validate_modfile_step():
     return {
         "name": "validate-modfile",


### PR DESCRIPTION
**What is this feature?**

Adds the golangci-lint GitHub Action. It's running in Drone currently, but it's much better in GHA since we get annotations, and contributors will be able to much more easily see the results.

**Why do we need this feature?**

Improve visibility of lint errors and potential bugs

**Who is this feature for?**

Contributors

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
