### PR TITLE
Docs: Add `maxWidth` to tooltip docs

### DIFF
--- a/docs/sources/panels-visualizations/configure-tooltips/index.md
+++ b/docs/sources/panels-visualizations/configure-tooltips/index.md
@@ -128,6 +128,10 @@ Set the hover proximity (in pixels) to control how close the cursor must be to a
 
 ![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
 
+### Max width
+
+Set the maximum width of the tooltip box.
+
 ### Max height
 
 Set the maximum height of the tooltip box. The default is 600 pixels.

--- a/docs/sources/panels-visualizations/visualizations/xy-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/xy-chart/index.md
@@ -187,6 +187,10 @@ When you hover your cursor over the visualization, Grafana can display tooltips.
 
 Use an override to hide individual series from the tooltip.
 
+### Max width
+
+Set the maximum width of the tooltip box.
+
 ### Max height
 
 Set the maximum height of the tooltip box. The default is 600 pixels.

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -26,6 +26,10 @@ When you set the **Tooltip mode** to **All**, the **Values sort order** option i
 - **Ascending** - Values in the tooltip are listed from smallest to largest.
 - **Descending** - Values in the tooltip are listed from largest to smallest.
 
+### Max width
+
+Set the maximum width of the tooltip box.
+
 ### Max height
 
 Set the maximum height of the tooltip box. The default is 600 pixels.

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -32,6 +32,10 @@ Set the hover proximity (in pixels) to control how close the cursor must be to a
 
 ![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
 
+### Max width
+
+Set the maximum width of the tooltip box.
+
 ### Max height
 
 Set the maximum height of the tooltip box. The default is 600 pixels.


### PR DESCRIPTION
This PR updates tooltip docs with `maxWidth` option.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
