### PR TITLE
Chore: Remove gf-forms from alertmanager and graphite datasources

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -8024,11 +8024,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
-    "public/app/plugins/datasource/graphite/components/AnnotationsEditor.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
-    ],
     "public/app/plugins/datasource/influxdb/components/editor/annotation/AnnotationEditor.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -7991,12 +7991,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
-    "public/app/plugins/datasource/alertmanager/ConfigEditor.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
-    ],
     "public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -8029,9 +8029,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
-    "public/app/plugins/datasource/graphite/configuration/MappingsConfiguration.tsx:5381": [
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
-    ],
     "public/app/plugins/datasource/influxdb/components/editor/annotation/AnnotationEditor.tsx:5381": [
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],

--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -4,7 +4,16 @@ import { Link } from 'react-router-dom';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
-import { DataSourceHttpSettings, InlineField, InlineFormLabel, InlineSwitch, Select, Text } from '@grafana/ui';
+import {
+  Box,
+  DataSourceHttpSettings,
+  InlineField,
+  InlineFormLabel,
+  InlineSwitch,
+  Select,
+  Space,
+  Text,
+} from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from './types';
@@ -47,50 +56,45 @@ export const ConfigEditor = (props: Props) => {
   return (
     <>
       <h3 className="page-heading">Alertmanager</h3>
-      <div className="gf-form-group">
-        <div className="gf-form-inline">
-          <div className="gf-form">
-            <InlineFormLabel width={13}>Implementation</InlineFormLabel>
-            <Select
-              width={40}
-              options={IMPL_OPTIONS}
-              value={options.jsonData.implementation || AlertManagerImplementation.mimir}
-              onChange={(value) =>
-                onOptionsChange({
-                  ...options,
-                  jsonData: {
-                    ...options.jsonData,
-                    implementation: value.value,
-                  },
+      <Box marginBottom={5}>
+        <InlineField label="Implementation" labelWidth={26}>
+          <Select
+            width={40}
+            options={IMPL_OPTIONS}
+            value={options.jsonData.implementation || AlertManagerImplementation.mimir}
+            onChange={(value) =>
+              onOptionsChange({
+                ...options,
+                jsonData: {
+                  ...options.jsonData,
+                  implementation: value.value,
+                },
+              })
+            }
+          />
+        </InlineField>
+        <InlineField
+          label="Receive Grafana Alerts"
+          tooltip="When enabled, Grafana-managed alerts are sent to this Alertmanager."
+          labelWidth={26}
+        >
+          <InlineSwitch
+            value={options.jsonData.handleGrafanaManagedAlerts ?? false}
+            onChange={(e) => {
+              onOptionsChange(
+                produce(options, (draft) => {
+                  draft.jsonData.handleGrafanaManagedAlerts = e.currentTarget.checked;
                 })
-              }
-            />
-          </div>
-        </div>
-        <div className="gf-form-inline">
-          <InlineField
-            label="Receive Grafana Alerts"
-            tooltip="When enabled, Grafana-managed alerts are sent to this Alertmanager."
-            labelWidth={26}
-          >
-            <InlineSwitch
-              value={options.jsonData.handleGrafanaManagedAlerts ?? false}
-              onChange={(e) => {
-                onOptionsChange(
-                  produce(options, (draft) => {
-                    draft.jsonData.handleGrafanaManagedAlerts = e.currentTarget.checked;
-                  })
-                );
-              }}
-            />
-          </InlineField>
-        </div>
+              );
+            }}
+          />
+        </InlineField>
         {options.jsonData.handleGrafanaManagedAlerts && (
           <Text variant="bodySmall" color="secondary">
             Make sure to enable the alert forwarding on the <Link to="/alerting/admin">settings page</Link>.
           </Text>
         )}
-      </div>
+      </Box>
       <DataSourceHttpSettings
         defaultUrl={''}
         dataSourceConfig={options}

--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -4,16 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
-import {
-  Box,
-  DataSourceHttpSettings,
-  InlineField,
-  InlineFormLabel,
-  InlineSwitch,
-  Select,
-  Space,
-  Text,
-} from '@grafana/ui';
+import { Box, DataSourceHttpSettings, InlineField, InlineSwitch, Select, Text } from '@grafana/ui';
 import { config } from 'app/core/config';
 
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from './types';

--- a/public/app/plugins/datasource/graphite/components/AnnotationsEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/AnnotationsEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { QueryEditorProps } from '@grafana/data';
-import { InlineFormLabel, Input, TagsInput } from '@grafana/ui';
+import { Box, InlineField, Input, TagsInput } from '@grafana/ui';
 
 import { GraphiteDatasource } from '../datasource';
 import { GraphiteQuery, GraphiteOptions } from '../types';
@@ -34,23 +34,21 @@ export const AnnotationEditor = (props: QueryEditorProps<GraphiteDatasource, Gra
   };
 
   return (
-    <div className="gf-form-group">
-      <div className="gf-form">
-        <InlineFormLabel width={12}>Graphite Query</InlineFormLabel>
+    <Box marginBottom={5}>
+      <InlineField label="Graphite Query" labelWidth={24} grow>
         <Input
           value={target}
           onChange={(e) => setTarget(e.currentTarget.value || '')}
           onBlur={() => updateValue('target', target)}
           placeholder="Example: statsd.application.counters.*.count"
         />
-      </div>
+      </InlineField>
 
       <h5 className="section-heading">Or</h5>
 
-      <div className="gf-form">
-        <InlineFormLabel width={12}>Graphite events tags</InlineFormLabel>
+      <InlineField label="Graphite events tags" labelWidth={24}>
         <TagsInput id="tags-input" width={50} tags={tags} onChange={onTagsChange} placeholder="Example: event_tag" />
-      </div>
-    </div>
+      </InlineField>
+    </Box>
   );
 };

--- a/public/app/plugins/datasource/graphite/configuration/MappingsConfiguration.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/MappingsConfiguration.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useState } from 'react';
 
-import { Button, Icon, InlineField, InlineFieldRow, Input } from '@grafana/ui';
+import { Box, Button, Icon, InlineField, InlineFieldRow, Input } from '@grafana/ui';
 
 import MappingsHelp from './MappingsHelp';
 
@@ -27,7 +27,7 @@ export const MappingsConfiguration = (props: Props): JSX.Element => {
       )}
       {props.showHelp && <MappingsHelp onDismiss={props.onDismiss} />}
 
-      <div className="gf-form-group">
+      <Box marginBottom={5}>
         {mappings.map((mapping, i) => (
           <InlineFieldRow key={i}>
             <InlineField label={`Mapping (${i + 1})`}>
@@ -71,7 +71,7 @@ export const MappingsConfiguration = (props: Props): JSX.Element => {
         >
           Add label mapping
         </Button>
-      </div>
+      </Box>
     </div>
   );
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This removes use of gf-form classes from:

- Alertmanager configuration

| Before | After |
| --- | --- |
| <img width="579" alt="Screenshot 2024-06-07 at 17 06 32" src="https://github.com/grafana/grafana/assets/100691367/acf44119-28c6-434e-b7ff-3642c01064a7"> | <img width="584" alt="Screenshot 2024-06-07 at 17 03 13" src="https://github.com/grafana/grafana/assets/100691367/0c0994a9-8ede-401b-a6fd-c7ff98210f7b"> |

- Graphite annotations config

| Before | After |
| --- | --- |
| <img width="1072" alt="Screenshot 2024-06-07 at 17 06 45" src="https://github.com/grafana/grafana/assets/100691367/2da78c64-e9cf-4814-9e11-120f70ebd21d"> | <img width="1069" alt="Screenshot 2024-06-07 at 17 03 01" src="https://github.com/grafana/grafana/assets/100691367/fb712403-d43b-471a-af0d-556737827b22"> |

- Graphite label mappings config

| Before | After |
| --- | --- |
| <img width="1064" alt="Screenshot 2024-06-07 at 17 06 21" src="https://github.com/grafana/grafana/assets/100691367/64fcdfbc-b28d-4f4d-9ac8-e1997f8d2053"> | <img width="1076" alt="Screenshot 2024-06-07 at 17 04 32" src="https://github.com/grafana/grafana/assets/100691367/9e8750d6-7150-4a3e-83b7-b4fae964e98c"> |

**Why do we need this feature?**

To remove usage of Sass styles from Grafana

**Who is this feature for?**

everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes part of https://github.com/grafana/grafana/issues/65513

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
