### PR TITLE
chore(ci): Lint only pkg/ code, and lint all Go modules

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -26,7 +26,8 @@ jobs:
         uses: golangci/golangci-lint-action@v5
         with:
           version: v1.59.0
-          args: --config .golangci.toml --max-same-issues=0 --max-issues-per-linter=0 --verbose
+          args: |
+            --config .golangci.toml --max-same-issues=0 --max-issues-per-linter=0 --verbose ./pkg/... ./pkg/apimachinery/... ./pkg/apiserver/... ./pkg/build/wire/... ./pkg/promlib/... ./pkg/util/xorm/...
           only-new-issues: true
           skip-cache: true
           install-mode: binary


### PR DESCRIPTION
**What is this feature?**

Before #88916 we linted only code under `pkg/`, but that PR broke that behaviour. This restores it.

**Why do we need this feature?**

CI regression fix

**Who is this feature for?**

Maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
