### PR TITLE
CloudWatch: Fix labels for raw metric search queries

### DIFF
--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -105,9 +105,11 @@ func parseLabels(cloudwatchLabel string, query *models.CloudWatchQuery) (string,
 
 	splitLabels := strings.Split(cloudwatchLabel, keySeparator)
 	// The first part is the name of the time series, followed by the labels
+	name := splitLabels[0]
 	labelsIndex := 1
 
-	labels := data.Labels{}
+	// set Series to the name of the time series as a fallback
+	labels := data.Labels{"Series": name}
 	for _, dim := range dims {
 		values := query.Dimensions[dim]
 		if isSingleValue(values) {
@@ -118,7 +120,7 @@ func parseLabels(cloudwatchLabel string, query *models.CloudWatchQuery) (string,
 		labels[dim] = splitLabels[labelsIndex]
 		labelsIndex++
 	}
-	return splitLabels[0], labels
+	return name, labels
 }
 
 func getLabels(cloudwatchLabel string, query *models.CloudWatchQuery, addSeriesLabelAsFallback bool) data.Labels {

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -207,11 +207,13 @@ func Test_buildDataFrames_parse_label_to_name_and_labels(t *testing.T) {
 
 		frame1 := frames[0]
 		assert.Equal(t, "lb1", frame1.Name)
+		assert.Equal(t, "lb1", frame1.Fields[1].Labels["Series"])
 		assert.Equal(t, "lb1", frame1.Fields[1].Labels["LoadBalancer"])
 		assert.Equal(t, "tg", frame1.Fields[1].Labels["TargetGroup"])
 
 		frame2 := frames[1]
 		assert.Equal(t, "lb2", frame2.Name)
+		assert.Equal(t, "lb2", frame2.Fields[1].Labels["Series"])
 		assert.Equal(t, "lb2", frame2.Fields[1].Labels["LoadBalancer"])
 		assert.Equal(t, "tg", frame2.Fields[1].Labels["TargetGroup"])
 	})
@@ -272,11 +274,13 @@ func Test_buildDataFrames_parse_label_to_name_and_labels(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "some label lb3", frames[0].Name)
+		assert.Equal(t, "some label lb3", frames[0].Fields[1].Labels["Series"])
 		assert.Equal(t, "balancer 1", frames[0].Fields[1].Labels["LoadBalancer"])
 		assert.Equal(t, "inst1", frames[0].Fields[1].Labels["InstanceType"])
 		assert.Equal(t, "tg", frames[0].Fields[1].Labels["TargetGroup"])
 
 		assert.Equal(t, "some label lb4", frames[1].Name)
+		assert.Equal(t, "some label lb4", frames[1].Fields[1].Labels["Series"])
 		assert.Equal(t, "balancer 2", frames[1].Fields[1].Labels["LoadBalancer"])
 		assert.Equal(t, "inst2", frames[1].Fields[1].Labels["InstanceType"])
 		assert.Equal(t, "tg", frames[1].Fields[1].Labels["TargetGroup"])
@@ -492,6 +496,42 @@ func Test_buildDataFrames_parse_label_to_name_and_labels(t *testing.T) {
 		assert.Equal(t, "lb1", frames[0].Fields[1].Labels["LoadBalancer"])
 		assert.Equal(t, "micro", frames[0].Fields[1].Labels["InstanceType"])
 		assert.Equal(t, "res", frames[0].Fields[1].Labels["Resource"])
+	})
+
+	t.Run("when code editor used for `MetricSearch` query add fallback label", func(t *testing.T) {
+		timestamp := time.Unix(0, 0)
+		response := &models.QueryRowResponse{
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
+					Id:    aws.String("lb3"),
+					Label: aws.String("some label"),
+					Timestamps: []*time.Time{
+						aws.Time(timestamp),
+					},
+					Values:     []*float64{aws.Float64(23)},
+					StatusCode: aws.String("Complete"),
+				},
+			},
+		}
+
+		query := &models.CloudWatchQuery{
+			RefId:            "refId1",
+			Region:           "us-east-1",
+			Namespace:        "",
+			MetricName:       "",
+			Expression:       "SEARCH('MetricName=\"ResourceCount\" AND (\"AWS/Usage\") AND Resource=TargetsPer NOT QueueName=TargetsPerNetworkLoadBalancer', 'Average')",
+			Dimensions:       map[string][]string{},
+			Statistic:        "Average",
+			Period:           60,
+			MetricQueryType:  models.MetricQueryTypeSearch,
+			MetricEditorMode: models.MetricEditorModeRaw,
+			Label:            "actual",
+		}
+		frames, err := buildDataFrames(contextWithFeaturesEnabled(features.FlagCloudWatchNewLabelParsing), startTime, endTime, *response, query)
+		require.NoError(t, err)
+
+		assert.Equal(t, "actual", frames[0].Name)
+		assert.Equal(t, "some label", frames[0].Fields[1].Labels["Series"])
 	})
 
 	t.Run("when `MetricQuery` query has no label set and `GROUP BY` clause has multiple fields", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes alerting on metric search queries written with the code editor. We were only adding labels when the query had dimensions, which is only true for builder queries, but this pr adds the cloudwatch label as "series" to it.

For reviewing: You can reproduce the bug using Kevin's reproduction in the original issue, the metric search query: `SEARCH('MetricName="ResourceCount" AND ("AWS/Usage") AND Resource=TargetsPer
  NOT QueueName=TargetsPerNetworkLoadBalancer', 'Average')` and if you can see that it doesn't have labels in the reduce step and errors when evaluated.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #86426 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
