### PR TITLE
VizTooltip: Fix heatmap histogram display

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -210,6 +210,7 @@ export const HeatmapPanel = ({
                       panelData={data}
                       annotate={enableAnnotationCreation ? annotate : undefined}
                       maxHeight={options.tooltip.maxHeight}
+                      maxWidth={options.tooltip.maxWidth}
                     />
                   );
                 }}

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -59,8 +59,8 @@ export const HeatmapTooltip = (props: HeatmapTooltipProps) => {
   return <HeatmapHoverCell {...props} />;
 };
 
-const canvasWidth = 264;
-const canvasHeight = 64;
+const defaultHistogramWidth = 264;
+const defaultHistogramHeight = 64;
 
 const HeatmapHoverCell = ({
   dataIdxs,
@@ -310,8 +310,8 @@ const HeatmapHoverCell = ({
   const theme = useTheme2();
   const themeSpacing = parseInt(theme.spacing(1), 10);
 
-  let histCssWidth = Math.min(canvasWidth, maxWidth ? maxWidth - themeSpacing * 2 : canvasWidth);
-  let histCssHeight = canvasHeight;
+  let histCssWidth = Math.min(defaultHistogramWidth, maxWidth ? maxWidth - themeSpacing * 2 : defaultHistogramWidth);
+  let histCssHeight = defaultHistogramHeight;
   let histCanWidth = Math.round(histCssWidth * uPlot.pxRatio);
   let histCanHeight = Math.round(histCssHeight * uPlot.pxRatio);
 

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -41,6 +41,7 @@ interface HeatmapTooltipProps {
   panelData: PanelData;
   annotate?: () => void;
   maxHeight?: number;
+  maxWidth?: number;
 }
 
 export const HeatmapTooltip = (props: HeatmapTooltipProps) => {
@@ -67,6 +68,7 @@ const HeatmapHoverCell = ({
   mode,
   annotate,
   maxHeight,
+  maxWidth,
 }: HeatmapTooltipProps) => {
   const index = dataIdxs[1]!;
   const data = dataRef.current;
@@ -302,7 +304,7 @@ const HeatmapHoverCell = ({
 
   let can = useRef<HTMLCanvasElement>(null);
 
-  let histCssWidth = 264;
+  let histCssWidth = Math.min(264, maxWidth ? maxWidth - 20 : 264);
   let histCssHeight = 64;
   let histCanWidth = Math.round(histCssWidth * uPlot.pxRatio);
   let histCanHeight = Math.round(histCssHeight * uPlot.pxRatio);

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -59,6 +59,9 @@ export const HeatmapTooltip = (props: HeatmapTooltipProps) => {
   return <HeatmapHoverCell {...props} />;
 };
 
+const canvasWidth = 264;
+const canvasHeight = 64;
+
 const HeatmapHoverCell = ({
   dataIdxs,
   dataRef,
@@ -304,8 +307,11 @@ const HeatmapHoverCell = ({
 
   let can = useRef<HTMLCanvasElement>(null);
 
-  let histCssWidth = Math.min(264, maxWidth ? maxWidth - 20 : 264);
-  let histCssHeight = 64;
+  const theme = useTheme2();
+  const themeSpacing = parseInt(theme.spacing(1), 10);
+
+  let histCssWidth = Math.min(canvasWidth, maxWidth ? maxWidth - themeSpacing * 2 : canvasWidth);
+  let histCssHeight = canvasHeight;
   let histCanWidth = Math.round(histCssWidth * uPlot.pxRatio);
   let histCanHeight = Math.round(histCssHeight * uPlot.pxRatio);
 
@@ -354,7 +360,6 @@ const HeatmapHoverCell = ({
   }
 
   const styles = useStyles2(getStyles);
-  const theme = useTheme2();
 
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
This PR updates the heatmap tooltip histogram width to accommodate the `maxWidth` option being set.

Before
![histogram_before](https://github.com/grafana/grafana/assets/88068998/3f02a42e-9d13-4d97-8d98-fc1f3accc5df)

After
![histogram_after](https://github.com/grafana/grafana/assets/88068998/8e60596d-9f9e-4121-8d3b-e616dcda98d5)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
