### PR TITLE
 Frontend: InteractiveTable fix - prevent styles from leaking into tables added in expanded rows

### DIFF
--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -34,24 +34,20 @@ const getStyles = (theme: GrafanaTheme2) => {
       width: '100%',
       overflowX: 'auto',
     }),
+    cell: css({
+      padding: theme.spacing(1),
+      minWidth: theme.spacing(3),
+    }),
     table: css({
       borderRadius: theme.shape.radius.default,
       width: '100%',
-
-      '> tbody, > thead': {
-        '> tr > td': {
-          padding: theme.spacing(1),
-        },
-        '> tr > td, > tr > th': {
-          minWidth: theme.spacing(3),
-        },
-      },
     }),
     disableGrow: css({
       width: 0,
     }),
     header: css({
       borderBottom: `1px solid ${theme.colors.border.weak}`,
+      minWidth: theme.spacing(3),
       '&, & > button': {
         position: 'relative',
         whiteSpace: 'nowrap',
@@ -86,24 +82,23 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'expanded-row-content',
       borderBottom: 'none',
     }),
+    expandedContentCell: css({
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      position: 'relative',
+      padding: theme.spacing(2, 2, 2, 5),
+
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        width: '1px',
+        top: 0,
+        left: '16px',
+        bottom: theme.spacing(2),
+        background: theme.colors.border.medium,
+      },
+    }),
     expandedContentRow: css({
       label: 'expanded-row-content',
-
-      '> td': {
-        borderBottom: `1px solid ${theme.colors.border.weak}`,
-        position: 'relative',
-        padding: theme.spacing(2, 2, 2, 5),
-
-        '&:before': {
-          content: '""',
-          position: 'absolute',
-          width: '1px',
-          top: 0,
-          left: '16px',
-          bottom: theme.spacing(2),
-          background: theme.colors.border.medium,
-        },
-      },
     }),
     sortableHeader: css({
       /* increases selector's specificity so that it always takes precedence over default styles  */
@@ -291,7 +286,7 @@ export function InteractiveTable<TableData extends object>({
                   {row.cells.map((cell) => {
                     const { key, ...otherCellProps } = cell.getCellProps();
                     return (
-                      <td key={key} {...otherCellProps}>
+                      <td className={styles.cell} key={key} {...otherCellProps}>
                         {cell.render('Cell', { __rowID: rowId })}
                       </td>
                     );
@@ -299,7 +294,9 @@ export function InteractiveTable<TableData extends object>({
                 </tr>
                 {isExpanded && renderExpandedRow && (
                   <tr {...otherRowProps} id={rowId} className={styles.expandedContentRow}>
-                    <td colSpan={row.cells.length}>{renderExpandedRow(row.original)}</td>
+                    <td className={styles.expandedContentCell} colSpan={row.cells.length}>
+                      {renderExpandedRow(row.original)}
+                    </td>
                   </tr>
                 )}
               </Fragment>

--- a/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
+++ b/packages/grafana-ui/src/components/InteractiveTable/InteractiveTable.tsx
@@ -38,12 +38,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       borderRadius: theme.shape.radius.default,
       width: '100%',
 
-      td: {
-        padding: theme.spacing(1),
-      },
-
-      'td, th': {
-        minWidth: theme.spacing(3),
+      '> tbody, > thead': {
+        '> tr > td': {
+          padding: theme.spacing(1),
+        },
+        '> tr > td, > tr > th': {
+          minWidth: theme.spacing(3),
+        },
       },
     }),
     disableGrow: css({
@@ -88,7 +89,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     expandedContentRow: css({
       label: 'expanded-row-content',
 
-      td: {
+      '> td': {
         borderBottom: `1px solid ${theme.colors.border.weak}`,
         position: 'relative',
         padding: theme.spacing(2, 2, 2, 5),


### PR DESCRIPTION
**What is this feature?**
Fixing bug when trying to include nested tables inside the InteractiveTable, like the logs panel.

**Why do we need this feature?**
Styles for interactive table should not impact dynamic content

**Who is this feature for?**
Developers using the interactive table

**Special notes for your reviewer:**
This shouldn't impact any existing styles, but should prevent unwanted style cascade into custom (table) content within expanded row.


Before:
<img width="1728" alt="image" src="https://github.com/grafana/grafana/assets/109082771/4c94377f-d803-4f34-bc53-784dfa43333b">
<img width="1725" alt="image" src="https://github.com/grafana/grafana/assets/109082771/461a92f0-d8e0-4369-8b75-e8bba41ed493">

After:
<img width="1728" alt="image" src="https://github.com/grafana/grafana/assets/109082771/7bc28876-634a-4ab5-8b6e-0f5dc7d113f5">
<img width="1722" alt="image" src="https://github.com/grafana/grafana/assets/109082771/5a6131dc-1368-490d-9fea-6992e6dbc9db">



Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
