### PR TITLE
Cloudwatch: Metrics Query Builder should clear old query

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
@@ -21,6 +21,7 @@ export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   period: '',
   metricQueryType: MetricQueryType.Search,
   metricEditorMode: MetricEditorMode.Builder,
+  sql: undefined,
   sqlExpression: '',
   matchExact: true,
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Pops up the confirm box when switching to the Metrics Query Builder and actually clears the query. The reason we were getting the bug is that the Metrics Query Builder uses an intermediate `sql` field to both populate the Namespace/Metrics/etc fields in the Metrics Query Builder and to construct the `sqlExpression`, which is what the backend actually runs. This lead to the two bugs:
- Metric Search Builder -> Metric Query Builder: The metric was changed in the `query.metric` field but not in the `query.sql` or `query.sqlExpression` fields, so it displayed the new metric but it actually ran the query with the old one (which I think interacts weirdly with the label parsing code)
- Metric Query Code -> Metric Query Builder: `query.sqlExpression` was changed in the Code editor, but when it switched back to the Builder it pulled the values for the display from `query.sql` while running `query.sqlExpression` instead.

While we could look into more smartly regenerating the `sql` and the `sqlExpression` query fields when changing query mode or type, there isn't a simple way to implement that, so fully clearing the query seemed like the best way to clear up the confusion about the displayed query in the query builder not matching the run query.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #87568 

**Special notes for your reviewer:**
I was having a hard time figuring out how to write a test for this, so I decided to put this up for review to confirm that this is what we want to do first.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
