### PR TITLE
FeatureFlags: Update creation timestamps

### DIFF
--- a/pkg/services/featuremgmt/toggles-gitlog.csv
+++ b/pkg/services/featuremgmt/toggles-gitlog.csv
@@ -1,0 +1,332 @@
+#name,created,deleted,hash,author
+newNavigation,2022-01-26T17:44:20Z,2022-06-16T09:48:38Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+trimDefaults,2022-01-26T17:44:20Z,2023-11-02T15:35:14Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+dashboardPreviews,2022-01-26T17:44:20Z,2023-04-13T17:42:24Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+live-config,2022-01-26T17:44:20Z,2023-02-03T21:21:48Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+accesscontrol,2022-01-26T17:44:20Z,2022-05-16T10:45:41Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+tempoServiceGraph,2022-01-26T17:44:20Z,2022-07-19T07:00:58Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+httpclientprovider_azure_auth,2022-01-26T17:44:20Z,2022-05-30T15:43:32Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+tempoBackendSearch,2022-01-26T17:44:20Z,2022-06-01T17:32:10Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+showFeatureFlagsInUI,2022-01-26T17:44:20Z,2023-02-09T00:01:34Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+queryOverLive,2022-01-26T17:44:20Z,,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+validatedQueries,2022-01-26T17:44:20Z,2022-05-16T21:17:05Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+fullRangeLogsVolume,2022-01-26T17:44:20Z,2022-02-15T08:05:03Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+prometheus_azure_auth,2022-01-26T17:44:20Z,2022-08-11T14:12:57Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+live-service-web-worker,2022-01-26T17:44:20Z,,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+envelopeEncryption,2022-01-26T17:44:20Z,2022-05-24T08:34:47Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+database_metrics,2022-01-26T17:44:20Z,2023-04-28T13:19:06Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+live-pipeline,2022-01-26T17:44:20Z,2023-03-22T18:09:44Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+service-accounts,2022-01-26T17:44:20Z,2022-04-21T09:41:37Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+tempoSearch,2022-01-26T17:44:20Z,2022-06-01T17:32:10Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+disable_http_request_histogram,2022-01-26T17:44:20Z,2022-06-01T12:33:59Z,5d66194ec5d8a7c174a075b6023dcbf58d17b861,Ryan McKinley
+featureHighlights,2022-02-03T11:53:23Z,,a79c048344bddff7a868b040d9a08953917480f9,Alex Khomenko
+lokiBackendMode,2022-02-07T07:43:48Z,2022-06-08T06:14:34Z,560c77390550e12e8c0be507c00f27cde0aa31e5,Gábor Farkas
+swaggerUi,2022-02-08T12:38:43Z,2023-03-01T14:36:37Z,35fe58de374003bb4b077a878cc47ffc0a9d27b5,Sofia Papagiannaki
+influxdbBackendMigration,2022-02-09T18:26:16Z,2023-01-17T14:11:26Z,10232c78577520ce7b3fc6bba86d2e48ee5bab88,Joey Tawadrous
+dashboardPreviewsScheduler,2022-02-10T18:45:00Z,2022-04-24T21:55:10Z,0276b029fc656e61763f6ae045ad7826380a43fc,Artur Wierzbicki
+migrationLocking,2022-02-15T16:54:27Z,2024-03-22T19:22:29Z,d718ee191834b3084b2e8c8c6cac473bd9b97681,Sofia Papagiannaki
+panelTitleSearch,2022-02-15T18:26:03Z,,d665306ad1c2abe515c7ba48350904f749eafc18,Ryan McKinley
+dashboardPreviewsAdmin,2022-02-17T08:34:07Z,2023-02-03T21:45:10Z,3e53a08090ad8ac61d7d316b97a93a7a5ea63a57,Artur Wierzbicki
+annotationComments,2022-02-22T07:47:42Z,2023-03-11T12:28:12Z,28c30a34adbe94d0f08acdba3c1605143dce6c6c,Alexander Emelin
+dashboardComments,2022-02-22T07:47:42Z,2023-03-11T12:28:12Z,28c30a34adbe94d0f08acdba3c1605143dce6c6c,Alexander Emelin
+lokiLive,2022-03-01T22:46:52Z,2023-06-19T10:03:51Z,796bc27f75d52148d5b15cc8c4901276c344df2d,Ryan McKinley
+fileStoreApi,2022-03-03T06:53:26Z,2022-03-11T18:08:19Z,a8b90d9a2524765c49923c48a7fcf0025c85b733,Artur Wierzbicki
+azureMonitorResourcePickerForMetrics,2022-03-14T19:07:45Z,2023-01-30T16:19:03Z,275f33cf37bb4221ef120310a87c17d2e0ff5f35,Sarah Zinger
+storageLocalUpload,2022-03-17T17:19:23Z,2022-07-18T17:44:42Z,1cfb9a4a1916d3eac473e5ccd0cb77ce281f044f,Ryan McKinley
+storage,2022-03-17T17:19:23Z,,1cfb9a4a1916d3eac473e5ccd0cb77ce281f044f,Ryan McKinley
+saveDashboardDrawer,2022-03-30T17:07:41Z,2022-05-02T16:29:22Z,edf384c730a448a5e90b21bbbce49bc0e70e8197,Ryan McKinley
+accesscontrol-builtins,2022-03-31T09:40:57Z,2022-05-19T07:29:36Z,0d87de153a2b8406d03efe0cf43b5a926ce7acab,Gabriel MABILLE
+alertProvisioning,2022-04-01T06:32:00Z,2022-06-05T05:45:36Z,b8e277ee4c070b64ba4cf024b18c460626d1a2d3,Alexander Weaver
+explore2Dashboard,2022-04-07T08:26:01Z,2022-11-07T16:06:40Z,ca286a238d1e9ce1e5357fde8148476a9d618cee,Giordano Ricci
+publicDashboards,2022-04-07T18:30:19Z,,4a4d87dbdcaf4dca753bcf29205ac036b6c59862,Jeff Levin
+persistNotifications,2022-04-20T09:42:32Z,2022-05-26T11:03:04Z,c48d8d1d488e0ce5870c54eb5828660081743108,kay delaney
+serviceAccounts,2022-04-21T09:41:37Z,2022-06-27T08:22:49Z,8677552dda7b63f5d44df6fe51ca8a28726c5a5c,Eric Leijonmarck
+commandPalette,2022-04-21T21:50:34Z,2023-02-02T14:44:21Z,3e7db088acd1da32ea489b0756cdf4e15ec2da69,Kristina
+export,2022-04-25T23:59:18Z,2023-03-01T17:42:53Z,e0aeb83786731769e870d79c0d8a21ef2c33b073,Ryan McKinley
+savedItems,2022-04-26T10:27:01Z,2022-06-27T14:41:00Z,e420252d45cd48fdcf5cc68ad84f89e36d5c936c,Ashley Harrison
+tracing,2022-04-26T13:31:27Z,2023-03-21T09:35:21Z,3b4d237ade03e67a971ca8899e8e0371e1d83f2a,kay delaney
+cloudWatchDynamicLabels,2022-04-29T09:43:04Z,2023-05-02T08:48:17Z,7bb4f5cd9baff81b354e4bb65fd4b6141e3488f6,Shirley
+datasourceQueryMultiStatus,2022-05-03T16:02:20Z,,4ecd57f49c75d72927be62aba23a15dca02f8eb6,Will Browne
+azureMonitorExperimentalUI,2022-05-04T13:54:09Z,2022-07-14T13:07:31Z,b2644de6c8a08181cbe0a9f545393bd42753477c,Adam Simpson
+traceToMetrics,2022-05-05T20:46:18Z,2024-02-22T13:30:41Z,c1b5ea3e54169c7a4bbd58bd8be2c4c192a093c0,Connor Lindsey
+prometheusStreamingJSONParser,2022-05-13T18:28:54Z,2022-11-11T16:53:12Z,87e8521591534bcfd8a7c78fbd39b226c13a99b2,Todd Treece
+validateDashboardsOnSave,2022-05-22T00:44:12Z,2023-09-06T15:25:44Z,a3402641d6cac01208179126dcbd2256ad500cd8,sam boyer
+disableEnvelopeEncryption,2022-05-24T08:34:47Z,,3e4b4dba46e5310015c7de5c3de1f3fae5332cb8,Joan López de la Franca Beltran
+prometheusWideSeries,2022-05-24T20:17:11Z,2023-08-24T14:47:19Z,94b9c524a81df2085ad769229ca09cfd1923a8e9,Todd Treece
+prometheusAzureOverrideAudience,2022-05-30T15:43:32Z,2023-07-16T21:30:14Z,2b83cf46186f745e356a24e4c78a1fbc24b3051e,Sergey Kostrukov
+canvasPanelNesting,2022-05-31T19:03:34Z,,e18e8002c4dda17e95cb4f04977a6aefcc5984a4,Adela Almasan
+cloudMonitoringExperimentalUI,2022-06-09T13:56:32Z,2022-09-15T14:12:26Z,615132002044e56074be63c5b597b9982e0a2a21,Kevin Yu
+tempoApmTable,2022-06-09T16:56:15Z,2023-02-01T15:56:34Z,4ed7ff2ed13f2b5ec79f0946670c945edc902d7b,Joey Tawadrous
+logRequestsInstrumentedAsUnknown,2022-06-10T08:56:55Z,,2d6e69226be20a7f001c7792bda8df68d90287c6,Carl Bergquist
+dataConnectionsConsole,2022-06-10T10:13:31Z,2024-02-29T09:29:41Z,9a85a2e4410266270a1cd59db1937c7ba248966e,Levente Balogh
+internationalization,2022-06-10T11:02:52Z,2023-06-02T08:24:40Z,9a62849dc39e960640b5762cc5eace1baf29c0ee,Josh Hunt
+autoMigrateGraphPanels,2022-06-11T00:12:56Z,2023-03-23T04:02:36Z,ae8dd737704bb6232c52e19090e593d9165f5e77,Ryan McKinley
+lokiDataframeApi,2022-06-13T06:33:46Z,2023-04-13T13:22:09Z,8fd9cb48548313cf43ebcf5dcfa0daad0bfdfe0c,Gábor Farkas
+topnav,2022-06-20T14:25:43Z,,3c3293df78344a782fb65e5f977fd148daa597ce,Torkel Ödegaard
+customBranding,2022-06-22T15:05:52Z,2022-10-05T12:07:35Z,405df77e3e6abcf5264ba192abe33630bd64da20,Tania
+useLegacyHeatmapPanel,2022-06-23T18:48:28Z,2022-11-23T18:46:21Z,dd5a3b77472884035de13ddd441f41d0dd007e4b,Ryan McKinley
+scenes,2022-07-07T06:53:02Z,,935334cbdabef8b0516bfe6c8ed45dd063cce7e9,Torkel Ödegaard
+disableSecretsCompatibility,2022-07-12T20:27:37Z,,2d8a91a8461098f83aa512c867aff5af17b7893e,Guilherme Caulada
+dashboardsFromStorage,2022-07-14T22:36:17Z,2023-03-20T16:36:49Z,da1701ce576ab26506d6256567b73a597043623a,Ryan McKinley
+exploreMixedDatasource,2022-07-27T14:40:59Z,2022-07-27T15:17:31Z,e2258120e742b31ecde50e8de93544220a0762a3,Kristina
+prometheusStreamingJSONParserTest,2022-07-28T12:26:51Z,2022-11-07T18:20:00Z,d0e548c3e53ffdbc29f35e055d52aa63cca310db,Andrej Ocenas
+fullstoryUserTracking,2022-08-16T08:32:00Z,2022-08-16T10:45:14Z,961479b1115d39f3918b60c49a48841916939f03,Ivan Ortega Alba
+traceqlEditor,2022-08-24T16:57:59Z,2022-12-13T13:27:45Z,c8f2148f7504b393b8f9b32fe19e7f519fa66793,Andre Pereira
+athenaAsyncQueryDataSupport,2022-09-05T15:39:45Z,2024-03-20T14:14:21Z,34fe7a1119c0f649d3e9df866353438ff2177fdc,Kevin Yu
+redshiftAsyncQueryDataSupport,2022-09-05T15:39:45Z,2024-03-20T14:14:21Z,34fe7a1119c0f649d3e9df866353438ff2177fdc,Kevin Yu
+increaseInMemDatabaseQueryCache,2022-09-12T07:50:54Z,2023-02-06T21:01:04Z,72ae4a5aa368d18793f778683e92ae4a3ac7a1db,Carl Bergquist
+correlations,2022-09-16T13:14:27Z,,9b4cdfe6526a290e5708a8c0760d50efda607d5c,Piotr Jamróz
+grpcServer,2022-09-26T20:25:34Z,,55aae797441d2beadc911e390f14c04bb3f101da,Alexander Emelin
+alertingBigTransactions,2022-10-06T06:22:58Z,2023-04-06T16:06:25Z,b476ae62fba9b94dd272409c521812108750bf50,Joe Blubaugh
+lokiMonacoEditor,2022-10-06T14:35:30Z,2023-02-06T10:18:01Z,729ce8bb72a5db53fbeb1b5856557652bb175c7a,Matias Chomicki
+objectStore,2022-10-06T19:48:53Z,2022-11-30T22:52:15Z,609abf00d1c6bd065f163e06882aa2f09dc0fcb5,Ryan McKinley
+flameGraph,2022-10-07T10:39:14Z,2023-03-01T11:32:39Z,74c809f54459d235f4d3e9b1c117f291cbf16339,Joey Tawadrous
+queryLibrary,2022-10-07T18:31:45Z,2023-03-20T16:00:14Z,bf264d2f76a1efb902b41791e110077d5c3a5557,Artur Wierzbicki
+newPanelChromeUI,2022-10-10T15:03:16Z,2023-09-12T08:54:41Z,129a5a29e78853bb1427c8dc7473125ba2a35981,Polina Boneva
+mysqlAnsiQuotes,2022-10-12T11:43:35Z,,80ede174dd6e343722cc708ebc4c5f21fb9e90af,ying-jeanne
+showDashboardValidationWarnings,2022-10-14T13:51:05Z,,2e16d5499e1cf29e67db5031feda09407f69550c,Josh Hunt
+interFont,2022-10-15T14:22:33Z,2022-12-01T11:59:37Z,9f5e691994c9db15f5984b196ab55fd7213b7f72,Torkel Ödegaard
+accessControlOnCall,2022-10-19T16:10:09Z,,717bd4a6c051d1447c9e35385a4ba176dd391c65,Gabriel MABILLE
+newDBLibrary,2022-10-26T01:20:41Z,2023-11-14T14:51:35Z,a3acfb1a48126119fd4913efbb572de162264e92,Ryan McKinley
+nestedFolders,2022-10-26T14:15:14Z,,b346ae03105af606521bbefec16722d590378646,Kristin Laemmert
+datasourceLogger,2022-11-02T13:51:51Z,2023-02-07T11:49:16Z,06705a49e236dc3ab3b35db51b7bad8625e4866f,Carl Bergquist
+promQueryBuilder,2022-11-03T17:34:01Z,2022-12-19T13:52:06Z,857e545c5ac71722c8b2d3d27621dfb453dbb8ff,Ryan McKinley
+elasticsearchBackendMigration,2022-11-10T15:35:15Z,2023-04-12T12:20:43Z,261d620f1c46eb43282cc444ffb4633b77af4283,Ivana Huckova
+prometheusBufferedClient,2022-11-11T16:53:12Z,2022-12-12T17:05:55Z,1c5039085bdf9252d0aa1666675f5313589c1703,ismail simsek
+accessTokenExpirationCheck,2022-11-14T15:47:46Z,2023-12-15T12:20:17Z,4915d21c25891dae2ee7a4eec4fe0dd2659d614d,Misi
+cloudWatchCrossAccountQuerying,2022-11-28T11:39:12Z,,254577ba568d8010dcc96446e788866d618c96c8,Erik Sundell
+authnService,2022-11-29T09:57:47Z,2023-06-07T06:57:41Z,17ec4089dc75da0e54edf60a754a0fc9291275e3,Karl Persson
+secureSocksDatasourceProxy,2022-11-30T05:50:59Z,2023-04-18T17:11:23Z,6805c951e94c626401770ed468c6afb462093c0d,Stephanie Hingtgen
+entityStore,2022-11-30T22:52:15Z,2023-12-06T20:21:21Z,14a080ec122f8ff3f656f44a46683f5161c15e14,Ryan McKinley
+sessionRemoteCache,2022-12-07T09:55:48Z,2023-02-06T12:51:12Z,df4f0343e587695f37fa7a6de04cc884af4df284,Jo
+returnUnameHeader,2022-12-07T12:14:53Z,2023-02-07T09:04:20Z,1b676d0d49460572352af4639274a4e7fe03fc9b,Carl Bergquist
+datasourceOnboarding,2022-12-07T23:29:38Z,2023-05-17T12:22:40Z,955bf55c6a6a710a2fd7ebdbdac2d9a826858eaf,kay delaney
+k8s,2022-12-13T15:41:16Z,2023-04-26T13:52:13Z,cf055ab4ecda9db9427ae09560aa26553433a5c0,Ryan McKinley
+alertingBacktesting,2022-12-14T14:44:14Z,,ad09feed837737c188e37fc6adfead7b8a45715e,Yuri Tseretyan
+disablePrometheusExemplarSampling,2022-12-19T15:00:15Z,2024-01-30T16:00:04Z,f67b8fe0dc2a2d860e71887a4d2e6e25da80bd8f,Ludovic Viaud
+supportBundles,2022-12-20T10:13:37Z,2023-02-10T09:12:04Z,2c7410c87d81b8a644e738fee2bb6f34355111c6,Jo
+publicDashboardsEmailSharing,2023-01-03T19:45:15Z,,f0ee3ac80ae2af695c56e709af435c155a2fb33d,owensmallwood
+alertingNoNormalState,2023-01-13T23:29:29Z,,9d57b1c72eb817c5fe1b43ad7bc9706a264b2da0,Yuri Tseretyan
+azureMultipleResourcePicker,2023-01-20T15:29:23Z,2023-01-30T16:19:03Z,b1efd911c1f7bfabe1b8231b059470c72dce4712,Andres Martinez Gotor
+editPanelCSVDragAndDrop,2023-01-24T09:43:44Z,,4167214e3535f41c85004c6aca86fcb9ae8956dd,Zoltán Bedi
+topNavCommandPalette,2023-01-24T12:41:09Z,2023-02-24T12:14:53Z,88347caf5fcc99c21c8a07367b9e846947367636,Josh Hunt
+k8sDashboards,2023-01-25T19:10:16Z,2023-02-09T17:54:00Z,4965cf2edae6eae8e341e6c93c3a1aa56417efb3,Ryan McKinley
+logsContextDatasourceUi,2023-01-27T14:12:01Z,,7c02d9bb8a864aab35c676f1a44c6c5be9eb6c09,Sven Grossmann
+logsSampleInExplore,2023-01-27T16:30:25Z,2023-07-24T12:24:43Z,d5294eb8fa71ba62546d00ebce7b9376ab6f2b1a,Ivana Huckova
+apiserver,2023-02-01T20:28:19Z,2023-02-09T17:54:00Z,d4f4a83574dd03a5419fa890b916d09d03cb9acd,Ryan McKinley
+lokiQuerySplitting,2023-02-09T17:27:02Z,,94241f6676cf36824a180c11c2824ad41c81a470,Matias Chomicki
+individualCookiePreferences,2023-02-21T10:19:07Z,,0caacb3333152015bf0369f54315a26ff6f60f88,Emil Tullstedt
+newTraceView,2023-02-28T15:41:40Z,2023-04-21T10:31:24Z,82bcfb492867138bcc4744f88d36eb081c1b6811,Joey
+drawerDataSourcePicker,2023-03-01T10:26:19Z,2023-04-14T11:01:10Z,dc1600ff14acc3deecc5de02f6584dcf20d3c8b1,Oscar Kilhed
+traceqlSearch,2023-03-06T16:31:08Z,2023-07-24T15:26:10Z,fd37ff29b57520036fdc02f8a93a7d74770fd153,Andre Pereira
+prometheusMetricEncyclopedia,2023-03-07T18:41:05Z,,9b6e531549e145d1a1a0ede870a6163c69b0bfd5,Brendan O'Handley
+timeSeriesTable,2023-03-10T12:41:06Z,2023-10-13T08:00:42Z,548a5054ad8fa5c199bd01e20a02fbbe558d52fe,Domas
+lokiQuerySplittingConfig,2023-03-20T15:51:36Z,,68551ac9ca5b92621e6ab895c759822797bbf418,Sven Grossmann
+onlyExternalOrgRoleSync,2023-03-22T17:41:59Z,2023-07-25T09:51:47Z,3cd952b8bad8d23daee10fcc303a6d19c8b6d0a0,Eric Leijonmarck
+autoMigrateOldPanels,2023-03-23T04:02:36Z,,baf5a1d1411ee7e5f297aba099e735ebeee3ab83,Ryan McKinley
+clientTokenRotation,2023-03-23T13:39:04Z,2024-02-16T14:03:37Z,382b24742ab8b124af072533f74027a1a103b037,Karl Persson
+disableAngular,2023-03-23T15:43:45Z,,58704390269c8eeedd32c571245d5ef08f0ffb82,Ryan McKinley
+disableElasticsearchBackendExploreQuery,2023-03-27T13:52:27Z,2023-04-12T12:20:43Z,f3da91f53fa32a8e870124e9514a010b97359529,Ivana Huckova
+emptyDashboardPage,2023-03-28T09:42:23Z,2024-01-25T14:04:29Z,221c5efedc593fb42d87c849b3d0827e325fc6cd,Polina Boneva
+prometheusDataplane,2023-03-29T15:26:32Z,,674144c8e84cb4aca3bfc448f08b88bb516d3b77,Kyle Brandt
+alertStateHistoryLokiOnly,2023-03-30T18:53:21Z,,b2abb6328677a90e3f3bc8b706d22734696d02e3,Alexander Weaver
+alertStateHistoryLokiPrimary,2023-03-30T18:53:21Z,,b2abb6328677a90e3f3bc8b706d22734696d02e3,Alexander Weaver
+alertStateHistoryLokiSecondary,2023-03-30T18:53:21Z,,b2abb6328677a90e3f3bc8b706d22734696d02e3,Alexander Weaver
+unifiedRequestLog,2023-03-31T13:38:09Z,,be9361cb9ec2f1ad0bc0cda139c56e3cd46deb16,Emil Tullstedt
+prometheusResourceBrowserCache,2023-04-03T14:07:17Z,2023-10-11T13:18:56Z,96e9e807396b600c3325f4d3580eeef0710f6050,Galen Kistler
+renderAuthJWT,2023-04-03T16:53:38Z,,87a0c95164074dce6a877ea3faa3c7ac0e705ad3,Joan López de la Franca Beltran
+showTraceId,2023-04-05T07:13:24Z,2023-07-20T05:59:38Z,4ded937c79a38087576b3224bf6f2ba59345571e,Gábor Farkas
+pyroscopeFlameGraph,2023-04-05T12:57:24Z,2023-08-02T15:01:12Z,37eaf5019751aa76568574757830d63b764bbb1f,Andrej Ocenas
+dataplaneFrontendFallback,2023-04-07T21:13:19Z,,af31c77331c89c6a1f8e00747c44c3f39bb737bb,Ryan McKinley
+externalServiceAuth,2023-04-11T13:21:19Z,2024-02-26T10:29:09Z,5df9e64986e8c0324b4da96de5b55e533c3990ed,Gabriel MABILLE
+disableElasticsearchBackendQuerying,2023-04-12T12:20:43Z,2023-04-14T09:24:35Z,303777e682758076d6a8e1df6b82f97b3b2393a7,Ivana Huckova
+disableSSEDataplane,2023-04-12T16:24:34Z,,e78be44e1a38b7afb85909b807b6a2e9e5a98830,Kyle Brandt
+useCachingService,2023-04-12T16:30:33Z,2024-01-17T21:53:25Z,5626461b3c358f5c5c5c690b82977c09744d09b4,Michael Mandrus
+lokiMetricDataplane,2023-04-13T13:07:08Z,,531caec60263738ed6b31878b1ec093de635e4e2,Gábor Farkas
+authenticationConfigUI,2023-04-13T14:07:43Z,2023-06-14T16:58:15Z,7476219b0c2876f60bc9c6e28b22190f239e1426,Alexander Zobnin
+enableElasticsearchBackendQuerying,2023-04-14T09:24:35Z,2024-06-05T15:03:29Z,f48c858ca22b3f246d1033670f14605adb13cdf3,Ivana Huckova
+advancedDataSourcePicker,2023-04-14T11:01:10Z,2024-02-06T09:20:07Z,7bc31ab04b5c87f06bdb383c7f4a6195e70d53d1,Ivan Ortega Alba
+opensearchDetectVersion,2023-04-14T17:59:31Z,2023-05-16T14:22:23Z,1b0cee491a06fa135936b883406a6b11e6221322,Isabella Siu
+pluginsAPIManifestKey,2023-04-18T14:12:05Z,2023-06-16T09:20:30Z,98c695c68fb3f0d276da0d98b1e78186e459db50,Andres Martinez Gotor
+newTraceViewHeader,2023-04-21T10:31:24Z,2023-07-19T13:31:58Z,6522bb377e1bc4b64fe0aebd7e34ec2111859e11,Joey
+enableDatagridEditing,2023-04-24T14:46:31Z,,efd0e9cbea4a6c4c51337f14004f2df2f876fdb1,Victor Marin
+faroDatasourceSelector,2023-05-05T00:35:10Z,,e7cbe0276e3a6f41c31dd8e1ac16ccaa90b184f3,Elliot Kirk
+extraThemes,2023-05-10T13:37:04Z,,f8cf67347f069310b8cc6a2d9ff83345a81e3247,Torkel Ödegaard
+dataSourcePageHeader,2023-05-23T13:18:00Z,2023-11-06T20:21:15Z,7f84e83ffee53446b4c458c29f7c1385dac09ce3,Taewoo K
+alertingNotificationsPoliciesMatchingInstances,2023-05-30T13:15:22Z,2023-11-09T17:35:03Z,2f0728ac677c26b291947354058253d2e8a50bb7,Konrad Lalik
+lokiPredefinedOperations,2023-06-02T10:52:36Z,,06003c98c855fcb7c1c718c3f0e5f190b644656a,Ivana Huckova
+pluginsFrontendSandbox,2023-06-05T08:51:36Z,,1ed4c0382b3812eecf9722596d8a3ac922f3543d,Esteban Beltran
+refactorVariablesTimeRange,2023-06-06T13:12:09Z,,07dd90b5a8866273813c6b4a5e7087cea529f908,Alexa V
+sqlDatasourceDatabaseSelection,2023-06-06T16:28:52Z,,c0a1fc2cbdc1ceab4fdcb43270fd3720efe4494a,Jev Forsberg
+cloudWatchLogsMonacoEditor,2023-06-12T13:49:52Z,2024-03-18T12:56:57Z,5a831d877ac3305e7dfdb54057069b41b36b40fa,Isabella Siu
+recordedQueriesMulti,2023-06-14T12:34:22Z,,db75f20e53e717503fe3bf27217fedc40f4a12e1,Kyle Brandt
+exploreScrollableLogsContainer,2023-06-15T11:25:34Z,2024-03-12T14:53:13Z,cda10fae525d5cf784368791e1aaa1de2ce88f4b,Gareth Dawson
+alertingLokiRangeToInstant,2023-06-16T17:55:49Z,2023-09-13T11:52:40Z,934ba1aaa1fa4c1b9f1dcc0d6753c67a23c4f466,Jean-Philippe Quéméner
+lokiExperimentalStreaming,2023-06-19T10:03:51Z,,271cdb4baa6d5b021e013b463350f227173c4e95,Gábor Farkas
+flameGraphV2,2023-06-19T14:34:06Z,2023-07-11T12:58:43Z,5ca03a82f042808efabae84b46991106c23de514,Andrej Ocenas
+pluginsDynamicAngularDetectionPatterns,2023-06-26T13:33:21Z,2024-04-15T08:37:28Z,cca9d897339ae2de087bc5b7177849a730d4b38d,Giuseppe Guerra
+elasticToggleableFilters,2023-06-27T08:38:20Z,2023-07-28T12:49:02Z,c1ce24c90f75daa133e2cb59288ecc14195e5194,Matias Chomicki
+vizAndWidgetSplit,2023-06-27T10:22:13Z,,2785ed80d999b9ee1770e1209284d4fccd985401,Alexa V
+nestedFolderPicker,2023-06-28T09:40:29Z,2024-06-04T09:16:12Z,f18a7f7d9696a6e80606dc49d5ac0064384f111d,Josh Hunt
+frontendSandboxMonitorOnly,2023-07-05T11:48:25Z,,72f6793344fb3a63f5a8a86570b786b518264366,Esteban Beltran
+prometheusIncrementalQueryInstrumentation,2023-07-05T19:39:49Z,,daf9f9cd199e0bbc110222a3f005dc05dab1681a,Galen Kistler
+dashboardEmbed,2023-07-06T14:43:20Z,2024-04-19T10:48:08Z,420b19e0e4bbdb97ae707cc1360bef7f79839d02,Alex Khomenko
+awsDatasourcesTempCredentials,2023-07-06T15:06:11Z,,d33508453f6f1f7aab262b54c36ef471ed3eab87,Ida Štambuk
+logsExploreTableVisualisation,2023-07-12T13:52:42Z,,7e4e743a42052183f549f7fa88cd0cc362844ad1,Sven Grossmann
+transformationsRedesign,2023-07-12T16:35:49Z,,5099e882276227f4b4c8e695f35156b7873d81b3,Ludovic Viaud
+lokiLogsDataplane,2023-07-13T07:58:00Z,,e045860fbf449feb101d187730a46bb1cdab787a,Gábor Farkas
+mlExpressions,2023-07-13T17:37:50Z,,541bfe636daa55705a130df4004aa417c99adc09,Yuri Tseretyan
+disableTraceQLStreaming,2023-07-14T14:10:46Z,2023-07-26T13:33:16Z,c1709c93013a3fa5797898e81c046a2a53ae7ed4,Andre Pereira
+grafanaAPIServer,2023-07-14T19:22:10Z,2024-01-23T16:27:28Z,52121b7165b6ffcdf10dd7a62fdf04043ef0c00a,Todd Treece
+featureToggleAdminPage,2023-07-18T20:43:32Z,,600f623610b00547400e00fd0b2ee7dc4bab5849,Ibrahim
+lokiFormatQuery,2023-07-21T12:03:56Z,2024-06-05T09:46:28Z,4e42f9b6198d39ffca82c3c3d32a16d54c66090b,Gareth Dawson
+splitScopes,2023-07-21T14:23:01Z,2024-02-23T15:53:37Z,cfa1a2c55feea58bd7f82e4e03df2ea712ef34a7,Ieva
+awsAsyncQueryCaching,2023-07-21T15:34:07Z,,56913fbd9578c4666599b2ab46423361d6c9261f,Isabella Siu
+toggleLabelsInLogsUI,2023-07-24T08:22:47Z,2023-10-27T11:00:49Z,84f94cdc24c3b911ae4f8eabfe875b3e4a9c1f1b,Matias Chomicki
+azureMonitorDataplane,2023-07-24T13:50:49Z,2023-11-08T15:02:46Z,ee60d8c82dbcc8496d52d673bfc000901d72f232,Kyle Brandt
+gcomOnlyExternalOrgRoleSync,2023-07-25T12:27:02Z,2023-11-13T09:56:02Z,f7c6491f7317f3fbaf4f21b8beec967d76778a87,Ieva
+traceQLStreaming,2023-07-26T13:33:16Z,,89092a1e697788428f76fead65371b7c904cd13f,Andre Pereira
+prometheusConfigOverhaulAuth,2023-07-26T16:09:53Z,,98cb3ce3b63ee4d1b82e6b04d11f8a6a065de7b4,Brendan O'Handley
+configurableSchedulerTick,2023-07-26T16:44:12Z,,c7598cc6fb492cb7cc34eec90fbd2a08d859cffd,Yuri Tseretyan
+permissionsFilterRemoveSubquery,2023-08-02T07:39:25Z,,2c26a02b82238e0f89ca08844914cff22a84255a,Sofia Papagiannaki
+influxdbSqlSupport,2023-08-02T16:27:43Z,2024-04-18T14:29:27Z,77e7ae2a1b253276ceae4ef5cda1dffc0e674b4d,ismail simsek
+noBasicRole,2023-08-04T09:08:14Z,2023-10-12T11:00:26Z,64ed77ddce79009ce05f43801cc578c135f05b6b,linoman
+alertingNoDataErrorExecution,2023-08-15T14:27:15Z,,0717ec11d6042bbc5b4cb8d908a396ecec78cdd5,Yuri Tseretyan
+metricsSummary,2023-08-28T14:02:12Z,,59e4c257bba00968741ffc235e2dbe9d4c5b90ac,Joey
+angularDeprecationUI,2023-08-29T14:05:47Z,,bf4d025012af42ce023b1166e95626f86e819855,Giuseppe Guerra
+dashgpt,2023-08-30T20:22:05Z,,2f4fbf89cac96b74c2375b9ec9710a2c890dcf8f,Nathan Marrs
+reportingRetries,2023-08-31T07:47:47Z,,f919c55bbb417f3b1023d72bbfce6617acfd1ab9,Agnès Toulet
+newBrowseDashboards,2023-09-07T10:41:00Z,2023-11-22T15:22:00Z,ebe13a53f729c265c1f161be4e6f2c29ba074127,Ashley Harrison
+sseGroupByDatasource,2023-09-07T20:02:07Z,,5cc737bb24f80514d35b1f02c7113e106a277dc6,Kyle Brandt
+requestInstrumentationStatusSource,2023-09-11T10:13:13Z,2024-02-06T08:29:41Z,8ee43f37051e6b6a016e1c38c3d585cc0df47419,Marcus Efraimsson
+wargamesTesting,2023-09-13T18:32:01Z,,2d8f5c1488142288d73a4db892e2108b7c7db03b,Carl Bergquist
+alertingInsights,2023-09-14T12:58:04Z,,5d88b8a4f58abeafc11553865f99df69b760fcd3,Virginia Cepeda
+dockedMegaMenu,2023-09-18T10:57:11Z,2024-02-06T13:43:11Z,0ceeb18269765b40eb5cf7bf2536894152d5e5e8,Laura Fernández
+lokiRunQueriesInParallel,2023-09-19T09:34:01Z,,98aa7db64ab4c4d0f3699a9bcbde9894429daa62,Travis Patterson
+pluginsAPIMetrics,2023-09-21T11:36:32Z,,8e8bd2760b8c05df9015900ebdf865c1629881de,Esteban Beltran
+externalCorePlugins,2023-09-22T08:50:13Z,,61cdfba87a36bd4b8e1bb227a14c5d88fc943aff,Andres Martinez Gotor
+httpSLOLevels,2023-09-22T08:52:28Z,2024-02-06T08:29:41Z,e5fbc4a4cd587e4b342afd0ab0136754cf8ebf76,Carl Bergquist
+idForwarding,2023-09-25T15:21:28Z,,d15661c726b582212e1329f0ebe938664445e44a,Karl Persson
+cloudwatchNewRegionsHandler,2023-09-25T18:19:12Z,2024-01-30T12:11:52Z,ef441f02d09730449f3f7bbdcf3b31dc00ed797a,Sarah Zinger
+cloudWatchWildCardDimensionValues,2023-09-27T14:41:48Z,2024-03-15T13:49:53Z,06a35f55ac56ca5699031b2af9202ac7a26918fc,Isabella Siu
+externalServiceAccounts,2023-09-28T07:26:37Z,,4563fc48afe81ff1af54b6a5bf6d65355f961155,Gabriel MABILLE
+alertingModifiedExport,2023-09-28T14:07:45Z,2023-10-12T17:17:32Z,169c5262a5e7d04234119a3733b00bb787b8bf90,Sonia Aguilar
+enableNativeHTTPHistogram,2023-10-03T18:23:55Z,,0fc403d116b9cbd0b93e497cff0ddded55f9fe60,Carl Bergquist
+transformationsVariableSupport,2023-10-04T14:28:46Z,,40cdb3033697e8d8e43d0ee0342f0d16fac7d633,Oscar Kilhed
+kubernetesPlaylists,2023-10-05T19:00:36Z,,664ebf771e2a1d2f94bc14d3dababb634c4ac40f,Todd Treece
+grafanaAPIServerWithExperimentalAPIs,2023-10-06T18:55:22Z,,717a9dd6160e352ff7c184bfcddf2410eed9d908,Ryan McKinley
+panelMonitoring,2023-10-09T05:19:08Z,,ef82767dabea7d19cd8efac0c36ed590d4d767f4,Victor Marin
+navAdminSubsections,2023-10-10T10:50:44Z,2023-11-17T10:04:34Z,f56cc6fdc01dbf2efb802f22650cb2bef0c40179,Ashley Harrison
+recoveryThreshold,2023-10-10T14:51:50Z,,810fbc3327841da6d21f945e75cad9daf040e625,Yuri Tseretyan
+libraryPanelRBAC,2023-10-11T23:30:50Z,,a12cb8cbf3a9b33841b2f2cb1522be11de78c86a,kay delaney
+awsDatasourcesNewFormStyling,2023-10-12T08:59:10Z,,2771fb940342aa152377b26b9554eb15082f90ac,Ida Štambuk
+cachingOptimizeSerializationMemoryUsage,2023-10-12T16:56:49Z,,94ce87571ddfcede0fb7a229a65502b385d5bca3,Michael Mandrus
+panelTitleSearchInV1,2023-10-13T12:04:24Z,,bf2f2540da7a4e4b8d80e1fa4ae3d05868cf7b69,Arati R
+exploreContentOutline,2023-10-13T16:57:13Z,,4ec54bc2c39ba43843c693fdb2a4529b6a4703f2,Haris Rozajac
+formatString,2023-10-13T18:17:12Z,,889576ac1d9278b1c6e3e278e8195968646a2db0,Sol
+pluginsInstrumentationStatusSource,2023-10-17T08:27:45Z,2024-02-21T11:57:40Z,f5076d1868caa14ce44a70e812315541b4199d9f,Giuseppe Guerra
+teamHttpHeaders,2023-10-17T10:23:54Z,,be5ba6813209b5b24e955e0f761032cb5826b578,Eric Leijonmarck
+costManagementUi,2023-10-17T16:15:51Z,2024-01-08T14:25:11Z,de1ed216f4bbf6f341aa22b144fa66d583a63981,Adam Bannach
+managedPluginsInstall,2023-10-18T13:17:03Z,,43add83d1a84fe0945860a9cc700df92c7e8341f,Hugo Kiyodi Oshiro
+prometheusPromQAIL,2023-10-19T15:45:32Z,,5580d061019bee46ea2e69c94041f3da14585ceb,Brendan O'Handley
+cloudWatchBatchQueries,2023-10-20T19:09:41Z,,ecbc52f51529e1f35e26895db1a10f8a1c2f4244,Isabella Siu
+alertingContactPointsV2,2023-10-25T13:57:53Z,2023-11-30T12:37:14Z,e12e40fc2493160338237b0b94e72fa530a78ef4,Gilles De Mey
+alertmanagerRemoteOnly,2023-10-30T16:27:08Z,,363830883cb1f5de30f7015df5cba419df47468e,Santiago
+alertmanagerRemoteSecondary,2023-10-30T16:27:08Z,,363830883cb1f5de30f7015df5cba419df47468e,Santiago
+alertmanagerRemotePrimary,2023-10-30T16:27:08Z,,363830883cb1f5de30f7015df5cba419df47468e,Santiago
+annotationPermissionUpdate,2023-10-31T13:30:13Z,,c51c51458e4dd103aa0c099aa48b0d41f9375f86,Ieva
+kubernetesPlaylistsAPI,2023-10-31T17:26:39Z,2023-11-08T19:14:05Z,dd773e74f120ba908cafd596a6875c2d7fa199bf,Ryan McKinley
+traceToProfiles,2023-11-01T10:14:24Z,2024-01-22T14:21:14Z,c39e9a8f527b79881b95f64fd1c413b4bff42983,Joey
+extractFieldsNameDeduplication,2023-11-02T15:47:42Z,,0eda368d32dbd7f57635cabd6b7d6870ca7b58ee,Oscar Kilhed
+dashboardSceneForViewers,2023-11-02T19:02:25Z,,6e80a3d59b14d9af235431d6acdce95835e2a792,Dominik Prokop
+panelFilterVariable,2023-11-03T12:15:54Z,,6bf4d0cbc6756ec8e8fb64b3a9d7b76f4c4194f5,Jacob Zelek
+addFieldFromCalculationStatFunctions,2023-11-03T14:39:58Z,,61d63d3034d7eed4837c63e1f5cb2f6b7114758d,Victor Marin
+pdfTables,2023-11-06T13:39:22Z,,95b48339f89c7d267bce7d894404d26ccd75d0e3,Agnès Toulet
+newVizTooltips,2023-11-06T16:35:59Z,2024-04-03T00:32:01Z,6b4b7127544865b78f712d907e6f1719595f4232,Adela Almasan
+ssoSettingsApi,2023-11-08T09:50:01Z,,5285e9503be5702680acb2b52a6bda0632f4603d,Misi
+logsInfiniteScrolling,2023-11-09T10:54:03Z,,174c2ab45a2af912519153c5c3e671f04396d7d7,Matias Chomicki
+flameGraphItemCollapsing,2023-11-09T14:31:07Z,,494a07b522df4e3ff9512b47767745a94c15f080,Andrej Ocenas
+alertingDetailsViewV2,2023-11-09T17:35:03Z,2024-03-14T14:18:01Z,323ee7c38ceb18b8e71c780d797fabac7041a673,Gilles De Mey
+alertingSimplifiedRouting,2023-11-10T13:14:39Z,,68e37c3925080cf64a5e7570eabb042f19ca2dbf,Sonia Aguilar
+dashboardScene,2023-11-13T08:51:21Z,,4bc322ca1d6ed63d7e79eecb1ed09f3043f9aedb,Torkel Ödegaard
+datatrails,2023-11-15T11:28:29Z,2024-04-09T18:15:18Z,1f1d348e1700735683dc9b80fce106b8a5bc4cee,Torkel Ödegaard
+pluginsSkipHostEnvVars,2023-11-15T17:09:14Z,,cb0a88a02770eaee2561fd434d8339cab268f02e,Giuseppe Guerra
+logRowsPopoverMenu,2023-11-16T09:48:10Z,,9cb303c3f701169e8651267744a4b5fe1695a066,Matias Chomicki
+lokiStructuredMetadata,2023-11-16T16:06:14Z,,a01f8c5b42bb7937139b8d52e9723cc37e5f7ae6,Sven Grossmann
+tracesEmbeddedFlameGraph,2023-11-23T13:36:53Z,2024-01-22T14:21:14Z,4f46fb412ca4e96b0b0ef3f462aead3fc146389e,Joey
+regressionTransformation,2023-11-24T14:49:16Z,,ab982e7bd36b86c94093bddcc31008f5dc49660e,Oscar Kilhed
+displayAnonymousStats,2023-11-29T16:58:41Z,2024-02-23T15:53:37Z,59bdff0280d52ca5d8918157d7697b9279b25501,Eric Leijonmarck
+influxqlStreamingParser,2023-11-29T17:29:35Z,,5845f140758473ab5ffe789bec4077032fd22839,ismail simsek
+kubernetesSnapshots,2023-12-05T22:31:49Z,,439edebcd605a1b63bf3a9b0ab5c2b83341cd5cd,Ryan McKinley
+grafanaAPIServerEnsureKubectlAccess,2023-12-06T20:21:21Z,,c4c9bfaf2e7fa12a8e453df0f089c8b4f914a3d3,Dan Cech
+unifiedStorage,2023-12-06T20:21:21Z,,c4c9bfaf2e7fa12a8e453df0f089c8b4f914a3d3,Dan Cech
+alertStateHistoryAnnotationsFromLoki,2023-12-11T19:17:01Z,2024-01-25T17:56:09Z,4c1bf86ae11696277025296b86e8514386b4bb31,William Wernert
+tableSharedCrosshair,2023-12-13T09:33:14Z,,5aff3389f4633d6970eb2b3629ac015e564c626c,Victor Marin
+lokiQueryHints,2023-12-18T20:43:16Z,,2165c9b3f000f59c9fbda80d2bfe3bc74cd6d9dc,Sven Grossmann
+canvasPanelPanZoom,2024-01-02T19:52:21Z,,2502fe4d19faa993da8fd4d21b9802d59f4b02af,Drew Slobodnjak
+alertingPreviewUpgrade,2024-01-05T18:31:05Z,2024-03-14T14:36:35Z,49891d6a72537c869628a13ab75c8d616fbac590,Matthew Jacobson
+enablePluginsTracingByDefault,2024-01-10T11:25:54Z,2024-04-11T16:40:47Z,b40d3e748717961ef68457442d71c1284189c577,Giuseppe Guerra
+cloudRBACRoles,2024-01-10T13:19:01Z,,5b3cd9f55b292f0b693f3bb5171da7b69dac4a95,Karl Persson
+alertingQueryOptimization,2024-01-10T20:52:58Z,,afa33f12b2cf50d2c7e438f498d27b0684797778,Matthew Jacobson
+newFolderPicker,2024-01-15T11:43:19Z,,ec53487c995777b314f566f5a1054e3f8e29ec05,Ashley Harrison
+kubernetesFeatureToggles,2024-01-18T05:32:44Z,,41e523bde7db5706f339d418c68d019039a8062e,Ryan McKinley
+returnToPrevious,2024-01-18T17:12:14Z,2024-05-27T15:47:57Z,5800e40fba2accf96d81328f000e35bbb7c7acf1,Laura Fernández
+jitterAlertRulesWithinGroups,2024-01-18T18:48:11Z,,00a260effab802edc8f72df50bfb6447aac343f0,Alexander Weaver
+jitterAlertRules,2024-01-18T18:48:11Z,2024-02-09T21:53:58Z,00a260effab802edc8f72df50bfb6447aac343f0,Alexander Weaver
+onPremToCloudMigrations,2024-01-22T16:09:08Z,,cf13cb9f70c2230f17450667ce59440304fb023c,Michael Mandrus
+alertingSaveStatePeriodic,2024-01-23T16:03:30Z,,aa25776f813926cb4f1947d4ae5a014f4e7728ff,Jean-Philippe Quéméner
+promQLScope,2024-01-29T20:22:17Z,,43d0664340f3e3af219d7b5c747f486a073f5ce3,Kyle Brandt
+slateAutocomplete,2024-01-31T10:01:20Z,2024-02-01T13:03:11Z,39057552dc2ddfe8ee770c67a71cf55159aca741,Ashley Harrison
+nodeGraphDotLayout,2024-01-31T16:26:12Z,,cb945aa5df3453ab2a851ef7ec8bee244e3eeac4,Andrej Ocenas
+kubernetesQueryServiceRewrite,2024-01-31T18:36:51Z,2024-04-19T09:26:21Z,e013cd427cb0457177e11f19ebd30bc523b36c76,Ryan McKinley
+influxdbRunQueriesInParallel,2024-02-01T10:58:24Z,,536153c3362782ae7f79e06755e8c7e0cd3b3acd,ismail simsek
+groupToNestedTableTransformation,2024-02-07T14:28:26Z,,756cd3c28b0648f55a6c0158f5faf63b632ebe70,Kyle Cunningham
+newPDFRendering,2024-02-08T12:09:34Z,,28e66b4ad82ecebb551374325f0be4332412341c,Agnès Toulet
+autoMigrateGraphPanel,2024-02-08T22:00:48Z,,829672759c12b27f849c92c3a2aee4a6b0037920,Nathan Marrs
+dashboardSceneSolo,2024-02-11T08:08:47Z,,fe6d1460b09b403fc74fd20e95f61513eede2555,Torkel Ödegaard
+kubernetesAggregator,2024-02-12T20:59:35Z,,d6e6298103d5d6a4efd1c21a3d74f429b506f3a7,Todd Treece
+autoMigrateStatPanel,2024-02-14T16:06:25Z,,ce750e06187599da6b9c0a91ef95c7a62fe0d069,Nathan Marrs
+autoMigrateWorldmapPanel,2024-02-14T16:06:25Z,,ce750e06187599da6b9c0a91ef95c7a62fe0d069,Nathan Marrs
+autoMigratePiechartPanel,2024-02-14T16:06:25Z,,ce750e06187599da6b9c0a91ef95c7a62fe0d069,Nathan Marrs
+autoMigrateTablePanel,2024-02-14T16:06:25Z,,ce750e06187599da6b9c0a91ef95c7a62fe0d069,Nathan Marrs
+groupByVariable,2024-02-14T17:18:04Z,,f016f95298fe490a865612864520f3622f8e804a,Dominik Prokop
+alertingUpgradeDryrunOnStart,2024-02-16T16:29:54Z,2024-03-14T14:36:35Z,dfaf6d1e2e13b2bd11dc8f0cd4432bfcad819aa9,Matthew Jacobson
+expressionParser,2024-02-17T00:59:11Z,,f23f50f58d7ab5cb1fd88b42b6c58ec09c1a159d,Ryan McKinley
+sqlExpressions,2024-02-27T21:16:00Z,,70009201d44c2d0ab39cc77081808a69a6c4fd63,Scott Lepper
+aiGeneratedDashboardChanges,2024-03-05T12:01:31Z,,a7c06d26f14b2a9fa8faa929a6c9a0c355018429,Ivan Ortega Alba
+scopeFilters,2024-03-05T15:41:19Z,,b3efb4217e48656f24aacdffd5737595d7361afe,Carl Bergquist
+betterPageScrolling,2024-03-06T15:06:47Z,,6a4e0c692ab26f4d4cb99ae615013e0b6e23f90b,Josh Hunt
+emailVerificationEnforcement,2024-03-11T14:09:44Z,2024-03-22T13:30:58Z,0b55d72fb5698e1ea2cf73eaceae166cd5619daa,Karl Persson
+ssoSettingsSAML,2024-03-14T11:04:45Z,,831ee9ee1696c0aa7a6e4ca022ddfc0ab28b86dc,linoman
+publicDashboardsScene,2024-03-22T14:48:21Z,,8d4ca72f2a0e66c446d58d8bf13fadbc988fce11,Juan Cabanas
+autoMigrateXYChartPanel,2024-03-22T15:44:37Z,,d7fa99e2df8269425eefb6373a665d8ec0b219d9,Leon Sorokin
+usePrometheusFrontendPackage,2024-03-23T00:47:53Z,2024-04-15T21:45:23Z,d0845952117152e7707f964cc343790497220990,Brendan O'Handley
+oauthRequireSubClaim,2024-03-25T13:22:24Z,,2f3a01f79fda7f6c465dd64adf5cf5c7227f9d19,Karl Persson
+authAPIAccessTokenAuth,2024-04-02T15:45:15Z,,5340a6e548b1e5fcd3af66695ca34d7e943fd068,Jo
+newDashboardWithFiltersAndGroupBy,2024-04-04T11:25:21Z,,32b6ef9d153dc7def2c17b81b02cfb1c412eb315,Dominik Prokop
+prometheusCodeModeMetricNamesSearch,2024-04-04T20:38:23Z,,559fab9dc6a6c882e7d9621ba013c3a53347176a,Nick Richmond
+cloudWatchNewLabelParsing,2024-04-05T15:57:56Z,,58f32150c262605d188874b88f44a7dece4b9388,Isabella Siu
+exploreMetrics,2024-04-09T18:15:18Z,,66c0fd4dcc3202e11f41b302d27894dc162fb288,Darren Janeczek
+accessActionSets,2024-04-12T16:19:25Z,,56f4664875047d6861ea3facbc94cd921e263950,Ieva
+disableNumericMetricsSortingInExpressions,2024-04-16T14:52:47Z,,d3fee607e2818747ad02daf6b8c58cc801075076,Nick Richmond
+queryServiceRewrite,2024-04-19T09:26:21Z,,5a8384a2455bbd3c0ba5ec67e5f5e3cc4a836904,Ryan McKinley
+queryServiceFromUI,2024-04-19T09:26:21Z,,5a8384a2455bbd3c0ba5ec67e5f5e3cc4a836904,Ryan McKinley
+queryService,2024-04-19T09:26:21Z,,5a8384a2455bbd3c0ba5ec67e5f5e3cc4a836904,Ryan McKinley
+grafanaManagedRecordingRules,2024-04-22T17:53:16Z,,c32953e52cf9fd46a462711bc23fde15a5c3b6bf,Alexander Weaver
+logsExploreTableDefaultVisualization,2024-05-02T15:28:15Z,,840aeddbd1957117d9b62074c155e87bb4afd4b4,Galen Kistler
+autofixDSUID,2024-05-03T11:32:07Z,,b6f899d953a0924760dc5fd5a3d40669c86d475d,Andres Martinez Gotor
+newDashboardSharingComponent,2024-05-03T15:02:18Z,,d1434fad3a68bc1d2b49725be31e45526e6ad349,Juan Cabanas
+tlsMemcached,2024-05-09T19:12:08Z,,b009536329d110afd807ef2f27f2b7dcc7d310ba,lean.dev
+notificationBanner,2024-05-13T09:32:34Z,,f3953b4955c218cc4678e842faa3d3380fd0f8f7,Alex Khomenko
+dualWritePlaylistsMode3,2024-05-14T12:11:56Z,2024-05-31T18:18:09Z,6836bfe1ea1bf62f4eb66dc1328a456183874f81,Arati R
+dualWritePlaylistsMode2,2024-05-14T12:11:56Z,2024-05-31T18:18:09Z,6836bfe1ea1bf62f4eb66dc1328a456183874f81,Arati R
+dashboardRestore,2024-05-16T17:36:26Z,,42d75ac737d7ac001a6d53376e25512408a01db5,Ezequiel Victorero
+datasourceProxyDisableRBAC,2024-05-21T13:05:16Z,,0072e4a92d896df343d9586522d6f7533773da78,Aaron Godin
+alertingDisableSendAlertsExternal,2024-05-23T12:29:19Z,,8421919cb552b9e8dbd4ebba20bcc67bbc5e6b4f,Steve Simpson
+datasourceQueryTypes,2024-05-23T16:46:28Z,,42b0f802de31f3d42ece68544c193a69ea381bc0,Ryan McKinley
+alertingListViewV2,2024-05-24T14:40:49Z,,99b5259cc1efa3f5c9dbb9b0153be14437818f38,Gilles De Mey
+preserveDashboardStateWhenNavigating,2024-05-27T12:28:06Z,,6e9543e0addab825f6755d4d02c5a15a1598a483,Dominik Prokop
+alertingCentralAlertHistory,2024-05-29T15:01:38Z,,289ce6185574df99acea37b86c2e0866ea5940fd,Sonia Aguilar
+pluginProxyPreserveTrailingSlash,2024-06-05T11:36:14Z,,fe3e5917f1bc83ab29b6a57578316e054718aa4a,Marcus Efraimsson
+kubernetesDashboards,2024-06-05T14:34:23Z,,41e0430f83bf7db50c4caaa1472afa3bf3d5c2dc,Ryan McKinley
+azureMonitorPrometheusExemplars,2024-06-06T16:53:17Z,,c9778c3332aa93e5dd8bc3b894264e1955f0d593,Andreas Christou

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5,109 +5,9 @@
   "items": [
     {
       "metadata": {
-        "name": "notificationBanner",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the notification banner UI and API",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "datasourceProxyDisableRBAC",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Disables applying a plugin route's ReqAction field to authorization",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "recordedQueriesMulti",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables writing multiple items from a single query within Recorded Queries",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "traceQLStreaming",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sseGroupByDatasource",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "newPDFRendering",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "New implementation for the dashboard-to-PDF rendering",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateOldPanels",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "datasourceQueryTypes",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Show query type endpoints in datasource API servers (currently hardcoded for testdata, expressions, and prometheus)",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
         "name": "accessActionSets",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-04-12T16:19:25Z"
       },
       "spec": {
         "description": "Introduces action sets for resource permissions",
@@ -117,742 +17,9 @@
     },
     {
       "metadata": {
-        "name": "metricsSummary",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables metrics summary queries in the Tempo data source",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "configurableSchedulerTick",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "wargamesTesting",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Placeholder feature flag for internal testing",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSaveStatePeriodic",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "live-service-web-worker",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "This will use a webworker thread to processes events rather than the main thread",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiExperimentalStreaming",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreContentOutline",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Content outline sidebar",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiLogsDataplane",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "newDashboardWithFiltersAndGroupBy",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "transformationsRedesign",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the transformations redesign",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigratePiechartPanel",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneForViewers",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using Scenes for viewer roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelFilterVariable",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudRBACRoles",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enabled grafana cloud specific RBAC roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "promQLScope",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow injection of labels into prometheus queries.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesAggregator",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable grafana aggregator",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "extraThemes",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables extra themes",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "permissionsFilterRemoveSubquery",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-group"
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalCorePlugins",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Allow core plugins to be loaded as external",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertmanagerRemoteOnly",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Disable the internal Alertmanager and only use the external one defined.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "scopeFilters",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the use of scope filters in Grafana",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryLibrary",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables Query Library feature in Explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/explore-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingCentralAlertHistory",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the new central alert history.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiPredefinedOperations",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Adds predefined query operations to Loki query editor",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesPlaylists",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryServiceRewrite",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Rewrite requests targeting /ds/query to the query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "tlsMemcached",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Use TLS-enabled memcached in the enterprise caching feature",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "annotationPermissionUpdate",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Change the way annotation permissions work by scoping them to folders and dashboards.",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "onPremToCloudMigrations",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingListViewV2",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the new alert list view design",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardRestore",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables deleted dashboard restore feature",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedRequestLog",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Writes error logs to the request logger",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-group"
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsExploreTableVisualisation",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "A table visualisation for logs in Explore",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiRunQueriesInParallel",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables running Loki queries in parallel",
-        "stage": "privatePreview",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusPromQAIL",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Prometheus and AI/ML to assist users in creating a query",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingSimplifiedRouting",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "cloudWatchNewLabelParsing",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Updates CloudWatch label parsing to be more accurate",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboardsScene",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables public dashboard rendering using scenes",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "editPanelCSVDragAndDrop",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables drag and drop for CSV and Excel files",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "individualCookiePreferences",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Support overriding cookie preferences per user",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-group"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiSecondary",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "correlations",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Correlations page",
-        "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesTempCredentials",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
-        "stage": "experimental",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "angularDeprecationUI",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Display Angular warnings in dashboards and panels",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "ssoSettingsApi",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
-        "stage": "GA",
-        "codeowner": "@grafana/identity-access-team",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "jitterAlertRulesWithinGroups",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaManagedRecordingRules",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables Grafana-managed recording rules.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryOverLive",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Use Grafana Live WebSocket to execute backend queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateStatPanel",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerEnsureKubectlAccess",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Start an additional https handler and write kubectl options",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardScene",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables dashboard rendering using scenes for all roles",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "managedPluginsInstall",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Install managed plugins directly from plugins catalog",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "nodeGraphDotLayout",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Changed the layout algorithm for the node graph",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "expressionParser",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable new expression parser",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsExploreTableDefaultVisualization",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Sets the logs table as default visualisation in logs explore",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateXYChartPanel",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Migrate old XYChart panel to new XYChart2 model",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelNesting",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Allow elements nesting",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
         "name": "accessControlOnCall",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2022-10-19T16:10:09Z"
       },
       "spec": {
         "description": "Access control primitives for OnCall",
@@ -863,129 +30,25 @@
     },
     {
       "metadata": {
-        "name": "sqlDatasourceDatabaseSelection",
+        "name": "addFieldFromCalculationStatFunctions",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-11-03T14:39:58Z"
       },
       "spec": {
-        "description": "Enables previous SQL data source dataset dropdown behavior",
+        "description": "Add cumulative and window functions to the add field from calculation transformation",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "newDashboardSharingComponent",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the new sharing drawer design",
-        "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "cloudWatchBatchQueries",
+        "name": "aiGeneratedDashboardChanges",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-03-05T12:01:31Z"
       },
       "spec": {
-        "description": "Runs CloudWatch metrics queries as separate batches",
-        "stage": "preview",
-        "codeowner": "@grafana/aws-datasources"
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsDatasourcesNewFormStyling",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Applies new form styling for configuration and query editors in AWS plugins",
-        "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logRowsPopoverMenu",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable filtering menu displayed when text of a log line is selected",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQueryHints",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables query hints for Loki",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "publicDashboards",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
-        "stage": "GA",
-        "codeowner": "@grafana/sharing-squad",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "nestedFolders",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable folder nesting",
-        "stage": "GA",
-        "codeowner": "@grafana/search-and-storage"
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusMetricEncyclopedia",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "vizAndWidgetSplit",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Split panels between visualizations and widgets",
+        "description": "Enable AI powered features for dashboards to auto-summary changes when saving",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
         "frontend": true
@@ -993,176 +56,70 @@
     },
     {
       "metadata": {
-        "name": "ssoSettingsSAML",
+        "name": "alertStateHistoryLokiOnly",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-03-30T18:53:21Z"
       },
       "spec": {
-        "description": "Use the new SSO Settings API to configure the SAML connector",
-        "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "allowSelfServe": true
+        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
       }
     },
     {
       "metadata": {
-        "name": "pluginsFrontendSandbox",
+        "name": "alertStateHistoryLokiPrimary",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-03-30T18:53:21Z"
       },
       "spec": {
-        "description": "Enables the plugins frontend sandbox",
+        "description": "Enable a remote Loki instance as the primary source for state history reads.",
         "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertStateHistoryLokiSecondary",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-03-30T18:53:21Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to write alert state history to an external Loki instance in addition to Grafana annotations.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingBacktesting",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-12-14T14:44:14Z"
+      },
+      "spec": {
+        "description": "Rule backtesting API for alerting",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingCentralAlertHistory",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-29T15:01:38Z"
+      },
+      "spec": {
+        "description": "Enables the new central alert history.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
         "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusIncrementalQueryInstrumentation",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Adds RudderStack events to incremental queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiMetricDataplane",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesSnapshots",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Routes snapshot requests from /api to the /apis endpoint",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "sqlExpressions",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables using SQL and DuckDB functions as Expressions.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusConfigOverhaulAuth",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Update the Prometheus configuration page with the new auth component",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "formatString",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable format string transformer",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryServiceFromUI",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Routes requests to the new query service",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "tableSharedCrosshair",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables shared crosshair in table panel",
-        "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "dataplaneFrontendFallback",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsAPIMetrics",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Sends metrics of public grafana packages usage by plugins",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "cachingOptimizeSerializationMemoryUsage",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad"
       }
     },
     {
       "metadata": {
         "name": "alertingDisableSendAlertsExternal",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-05-23T12:29:19Z"
       },
       "spec": {
         "description": "Disables the ability to send alerts to an external Alertmanager datasource.",
@@ -1174,268 +131,9 @@
     },
     {
       "metadata": {
-        "name": "publicDashboardsEmailSharing",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables public dashboard sharing to be restricted to only allowed emails",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSSEDataplane",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Disables dataplane specific processing in server side expressions.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "dashboardSceneSolo",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables rendering dashboards using scenes for solo panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "reportingRetries",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables rendering retries for the reporting feature",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "canvasPanelPanZoom",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Allow pan and zoom in canvas panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "oauthRequireSubClaim",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Require that sub claims is present in oauth tokens.",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "datasourceQueryMultiStatus",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoNormalState",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Stop maintaining state of alerts that are not firing",
-        "stage": "preview",
-        "codeowner": "@grafana/alerting-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "mlExpressions",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable support for Machine Learning in server-side expressions",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafanaAPIServerWithExperimentalAPIs",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Register experimental APIs with the k8s API server",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresDevMode": true,
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "betterPageScrolling",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "authAPIAccessTokenAuth",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the use of Auth API access tokens for authentication",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "influxqlStreamingParser",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertStateHistoryLokiPrimary",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable a remote Loki instance as the primary source for state history reads.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "frontendSandboxMonitorOnly",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingNoDataErrorExecution",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Changes how Alerting state manager handles execution of NoData/Error",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "flameGraphItemCollapsing",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Allow collapsing of flame graph items",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-traces-and-profiling",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "kubernetesFeatureToggles",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Use the kubernetes API for feature toggle management in the frontend",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-operator-experience-squad",
-        "frontend": true,
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autofixDSUID",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Automatically migrates invalid datasource UIDs",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
-      }
-    },
-    {
-      "metadata": {
-        "name": "enableDatagridEditing",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the edit functionality in the datagrid panel",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
         "name": "alertingInsights",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-09-14T12:58:04Z"
       },
       "spec": {
         "description": "Show the new alerting insights landing page",
@@ -1447,254 +145,159 @@
     },
     {
       "metadata": {
-        "name": "enableNativeHTTPHistogram",
+        "name": "alertingListViewV2",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-05-24T14:40:49Z"
       },
       "spec": {
-        "description": "Enables native HTTP Histograms",
+        "description": "Enables the new alert list view design",
         "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "addFieldFromCalculationStatFunctions",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Add cumulative and window functions to the add field from calculation transformation",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
+        "codeowner": "@grafana/alerting-squad",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "renderAuthJWT",
+        "name": "alertingNoDataErrorExecution",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-08-15T14:27:15Z"
       },
       "spec": {
-        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "description": "Changes how Alerting state manager handles execution of NoData/Error",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNoNormalState",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-01-13T23:29:29Z"
+      },
+      "spec": {
+        "description": "Stop maintaining state of alerts that are not firing",
         "stage": "preview",
-        "codeowner": "@grafana/grafana-as-code",
+        "codeowner": "@grafana/alerting-squad",
         "hideFromAdminPage": true
       }
     },
     {
       "metadata": {
-        "name": "refactorVariablesTimeRange",
+        "name": "alertingQueryOptimization",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-01-10T20:52:58Z"
       },
       "spec": {
-        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
-        "stage": "preview",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "awsAsyncQueryCaching",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
+        "description": "Optimizes eligible queries in order to reduce load on datasources",
         "stage": "GA",
-        "codeowner": "@grafana/aws-datasources"
+        "codeowner": "@grafana/alerting-squad"
       }
     },
     {
       "metadata": {
-        "name": "aiGeneratedDashboardChanges",
+        "name": "alertingSaveStatePeriodic",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-01-23T16:03:30Z"
       },
       "spec": {
-        "description": "Enable AI powered features for dashboards to auto-summary changes when saving",
+        "description": "Writes the state periodically to the database, asynchronous to rule evaluation",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingSimplifiedRouting",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-10T13:14:39Z"
+      },
+      "spec": {
+        "description": "Enables users to easily configure alert notifications by specifying a contact point directly when editing or creating an alert rule",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteOnly",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-30T16:27:08Z"
+      },
+      "spec": {
+        "description": "Disable the internal Alertmanager and only use the external one defined.",
         "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemotePrimary",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-30T16:27:08Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanagerRemoteSecondary",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-30T16:27:08Z"
+      },
+      "spec": {
+        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "angularDeprecationUI",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-08-29T14:05:47Z"
+      },
+      "spec": {
+        "description": "Display Angular warnings in dashboards and panels",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "cloudWatchCrossAccountQuerying",
+        "name": "annotationPermissionUpdate",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-10-31T13:30:13Z"
       },
       "spec": {
-        "description": "Enables cross-account querying in CloudWatch datasources",
+        "description": "Change the way annotation permissions work by scoping them to folders and dashboards.",
         "stage": "GA",
-        "codeowner": "@grafana/aws-datasources",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "mysqlAnsiQuotes",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Use double quotes to escape keyword in a MySQL query",
-        "stage": "experimental",
-        "codeowner": "@grafana/search-and-storage"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQuerySplitting",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Split large interval queries into subqueries with smaller time intervals",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusDataplane",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-metrics",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelMonitoring",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables panel monitoring through logs and measurements",
-        "stage": "GA",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "teamHttpHeaders",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
-        "stage": "preview",
         "codeowner": "@grafana/identity-access-team"
       }
     },
     {
       "metadata": {
-        "name": "extractFieldsNameDeduplication",
+        "name": "authAPIAccessTokenAuth",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-04-02T15:45:15Z"
       },
       "spec": {
-        "description": "Make sure extracted field names are unique in the dataframe",
+        "description": "Enables the use of Auth API access tokens for authentication",
         "stage": "experimental",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "newFolderPicker",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the nested folder picker without having nested folders enabled",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-frontend-platform",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "preserveDashboardStateWhenNavigating",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables possibility to preserve dashboard variables and time range when navigating between dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
+        "codeowner": "@grafana/identity-access-team",
         "hideFromAdminPage": true,
         "hideFromDocs": true
       }
     },
     {
       "metadata": {
-        "name": "disableEnvelopeEncryption",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Disable envelope encryption (emergency only)",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "unifiedStorage",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "SQL-based k8s storage",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsInfiniteScrolling",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableNumericMetricsSortingInExpressions",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "In server-side expressions, disable the sorting of numeric-kind metrics by their metric name or labels.",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
         "name": "autoMigrateGraphPanel",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-02-08T22:00:48Z"
       },
       "spec": {
         "description": "Migrate old graph panel to supported time series panel - broken out from autoMigrateOldPanels to enable granular tracking",
@@ -1705,25 +308,12 @@
     },
     {
       "metadata": {
-        "name": "dashgpt",
+        "name": "autoMigrateOldPanels",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-03-23T04:02:36Z"
       },
       "spec": {
-        "description": "Enable AI powered features in dashboards",
-        "stage": "GA",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "groupToNestedTableTransformation",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the group to nested table transformation",
+        "description": "Migrate old angular panels to supported versions (graph, table-old, worldmap, etc)",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true
@@ -1731,40 +321,27 @@
     },
     {
       "metadata": {
-        "name": "groupByVariable",
+        "name": "autoMigratePiechartPanel",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-02-14T16:06:25Z"
       },
       "spec": {
-        "description": "Enable groupBy variable support in scenes dashboards",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "hideFromAdminPage": true,
-        "hideFromDocs": true
+        "description": "Migrate old piechart panel to supported piechart panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "alertmanagerRemotePrimary",
+        "name": "autoMigrateStatPanel",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-02-14T16:06:25Z"
       },
       "spec": {
-        "description": "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "exploreMetrics",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables the new Explore Metrics core app",
-        "stage": "GA",
-        "codeowner": "@grafana/dashboards-squad",
+        "description": "Migrate old stat panel to supported stat panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
         "frontend": true
       }
     },
@@ -1772,7 +349,7 @@
       "metadata": {
         "name": "autoMigrateTablePanel",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-02-14T16:06:25Z"
       },
       "spec": {
         "description": "Migrate old table panel to supported table panel - broken out from autoMigrateOldPanels to enable granular tracking",
@@ -1783,9 +360,343 @@
     },
     {
       "metadata": {
+        "name": "autoMigrateWorldmapPanel",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-14T16:06:25Z"
+      },
+      "spec": {
+        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autoMigrateXYChartPanel",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-03-22T15:44:37Z"
+      },
+      "spec": {
+        "description": "Migrate old XYChart panel to new XYChart2 model",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "autofixDSUID",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-03T11:32:07Z"
+      },
+      "spec": {
+        "description": "Automatically migrates invalid datasource UIDs",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsAsyncQueryCaching",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-21T15:34:07Z"
+      },
+      "spec": {
+        "description": "Enable caching for async queries for Redshift and Athena. Requires that the datasource has caching and async query support enabled",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesNewFormStyling",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-12T08:59:10Z"
+      },
+      "spec": {
+        "description": "Applies new form styling for configuration and query editors in AWS plugins",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "awsDatasourcesTempCredentials",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-06T15:06:11Z"
+      },
+      "spec": {
+        "description": "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
+        "stage": "experimental",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "azureMonitorPrometheusExemplars",
+        "resourceVersion": "1717667267324",
+        "creationTimestamp": "2024-06-06T16:53:17Z"
+      },
+      "spec": {
+        "description": "Allows configuration of Azure Monitor as a data source that can provide Prometheus exemplars",
+        "stage": "experimental",
+        "codeowner": "@grafana/partner-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "betterPageScrolling",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-03-06T15:06:47Z"
+      },
+      "spec": {
+        "description": "Removes CustomScrollbar from the UI, relying on native browser scrollbars",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cachingOptimizeSerializationMemoryUsage",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-12T16:56:49Z"
+      },
+      "spec": {
+        "description": "If enabled, the caching backend gradually serializes query responses for the cache, comparing against the configured `[caching]max_value_mb` value as it goes. This can can help prevent Grafana from running out of memory while attempting to cache very large query responses.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelNesting",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-05-31T19:03:34Z"
+      },
+      "spec": {
+        "description": "Allow elements nesting",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "canvasPanelPanZoom",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-02T19:52:21Z"
+      },
+      "spec": {
+        "description": "Allow pan and zoom in canvas panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudRBACRoles",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-10T13:19:01Z"
+      },
+      "spec": {
+        "description": "Enabled grafana cloud specific RBAC roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchBatchQueries",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-20T19:09:41Z"
+      },
+      "spec": {
+        "description": "Runs CloudWatch metrics queries as separate batches",
+        "stage": "preview",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchCrossAccountQuerying",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-11-28T11:39:12Z"
+      },
+      "spec": {
+        "description": "Enables cross-account querying in CloudWatch datasources",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudWatchNewLabelParsing",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-05T15:57:56Z"
+      },
+      "spec": {
+        "description": "Updates CloudWatch label parsing to be more accurate",
+        "stage": "GA",
+        "codeowner": "@grafana/aws-datasources"
+      }
+    },
+    {
+      "metadata": {
+        "name": "configurableSchedulerTick",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-26T16:44:12Z"
+      },
+      "spec": {
+        "description": "Enable changing the scheduler base interval via configuration option unified_alerting.scheduler_tick_interval",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "correlations",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-09-16T13:14:27Z"
+      },
+      "spec": {
+        "description": "Correlations page",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardRestore",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-16T17:36:26Z"
+      },
+      "spec": {
+        "description": "Enables deleted dashboard restore feature",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardScene",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-13T08:51:21Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using scenes for all roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneForViewers",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-02T19:02:25Z"
+      },
+      "spec": {
+        "description": "Enables dashboard rendering using Scenes for viewer roles",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashboardSceneSolo",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-11T08:08:47Z"
+      },
+      "spec": {
+        "description": "Enables rendering dashboards using scenes for solo panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dashgpt",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-08-30T20:22:05Z"
+      },
+      "spec": {
+        "description": "Enable AI powered features in dashboards",
+        "stage": "GA",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "dataplaneFrontendFallback",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-04-07T21:13:19Z"
+      },
+      "spec": {
+        "description": "Support dataplane contract field name change for transformations and field name matchers where the name is different",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourceProxyDisableRBAC",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-21T13:05:16Z"
+      },
+      "spec": {
+        "description": "Disables applying a plugin route's ReqAction field to authorization",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourceQueryMultiStatus",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-05-03T16:02:20Z"
+      },
+      "spec": {
+        "description": "Introduce HTTP 207 Multi Status for api/ds/query",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "datasourceQueryTypes",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-23T16:46:28Z"
+      },
+      "spec": {
+        "description": "Show query type endpoints in datasource API servers (currently hardcoded for testdata, expressions, and prometheus)",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
         "name": "disableAngular",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-03-23T15:43:45Z"
       },
       "spec": {
         "description": "Dynamic flag to disable angular at runtime. The preferred method is to set `angular_support_enabled` to `false` in the [security] settings, which allows you to change the state at runtime.",
@@ -1797,9 +708,229 @@
     },
     {
       "metadata": {
+        "name": "disableEnvelopeEncryption",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-05-24T08:34:47Z"
+      },
+      "spec": {
+        "description": "Disable envelope encryption (emergency only)",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableNumericMetricsSortingInExpressions",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-16T14:52:47Z"
+      },
+      "spec": {
+        "description": "In server-side expressions, disable the sorting of numeric-kind metrics by their metric name or labels.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableSSEDataplane",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-04-12T16:24:34Z"
+      },
+      "spec": {
+        "description": "Disables dataplane specific processing in server side expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "disableSecretsCompatibility",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-07-12T20:27:37Z"
+      },
+      "spec": {
+        "description": "Disable duplicated secret storage in legacy tables",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "editPanelCSVDragAndDrop",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-01-24T09:43:44Z"
+      },
+      "spec": {
+        "description": "Enables drag and drop for CSV and Excel files",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableDatagridEditing",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-04-24T14:46:31Z"
+      },
+      "spec": {
+        "description": "Enables the edit functionality in the datagrid panel",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableElasticsearchBackendQuerying",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-04-14T09:24:35Z",
+        "deletionTimestamp": "2024-06-05T15:03:29Z"
+      },
+      "spec": {
+        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "enableNativeHTTPHistogram",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-03T18:23:55Z"
+      },
+      "spec": {
+        "description": "Enables native HTTP Histograms",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreContentOutline",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-13T16:57:13Z"
+      },
+      "spec": {
+        "description": "Content outline sidebar",
+        "stage": "GA",
+        "codeowner": "@grafana/explore-squad",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "exploreMetrics",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-09T18:15:18Z"
+      },
+      "spec": {
+        "description": "Enables the new Explore Metrics core app",
+        "stage": "GA",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "expressionParser",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-17T00:59:11Z"
+      },
+      "spec": {
+        "description": "Enable new expression parser",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalCorePlugins",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-09-22T08:50:13Z"
+      },
+      "spec": {
+        "description": "Allow core plugins to be loaded as external",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "externalServiceAccounts",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-09-28T07:26:37Z"
+      },
+      "spec": {
+        "description": "Automatic service account and token setup for plugins",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "extraThemes",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-05-10T13:37:04Z"
+      },
+      "spec": {
+        "description": "Enables extra themes",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "extractFieldsNameDeduplication",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-02T15:47:42Z"
+      },
+      "spec": {
+        "description": "Make sure extracted field names are unique in the dataframe",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "faroDatasourceSelector",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-05-05T00:35:10Z"
+      },
+      "spec": {
+        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
+        "stage": "preview",
+        "codeowner": "@grafana/app-o11y",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "featureHighlights",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-02-03T11:53:23Z"
+      },
+      "spec": {
+        "description": "Highlight Grafana Enterprise features",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-as-code",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
         "name": "featureToggleAdminPage",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-07-18T20:43:32Z"
       },
       "spec": {
         "description": "Enable admin page for managing feature toggles from the Grafana front-end. Grafana Cloud only.",
@@ -1811,139 +942,25 @@
     },
     {
       "metadata": {
-        "name": "idForwarding",
+        "name": "flameGraphItemCollapsing",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-11-09T14:31:07Z"
       },
       "spec": {
-        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
+        "description": "Allow collapsing of flame graph items",
         "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team"
-      }
-    },
-    {
-      "metadata": {
-        "name": "lokiQuerySplittingConfig",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Give users the option to configure split durations for Loki queries",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-logs",
+        "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "alertingQueryOptimization",
+        "name": "formatString",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-10-13T18:17:12Z"
       },
       "spec": {
-        "description": "Optimizes eligible queries in order to reduce load on datasources",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearch",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Search for dashboards using panel title",
-        "stage": "preview",
-        "codeowner": "@grafana/grafana-app-platform-squad",
-        "hideFromAdminPage": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "storage",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Configurable storage for dashboards, datasources, and resources",
-        "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "disableSecretsCompatibility",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Disable duplicated secret storage in legacy tables",
-        "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "logsContextDatasourceUi",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Allow datasource to provide custom UI for context view",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "frontend": true,
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "showDashboardValidationWarnings",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Show warnings when dashboards do not validate against the schema",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "recoveryThreshold",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
-        "stage": "GA",
-        "codeowner": "@grafana/alerting-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "prometheusCodeModeMetricNamesSearch",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables search for metric names in Code Mode, to improve performance when working with an enormous number of metric names",
-        "stage": "experimental",
-        "codeowner": "@grafana/observability-metrics",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "regressionTransformation",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables regression analysis transformation",
+        "description": "Enable format string transformer",
         "stage": "preview",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true
@@ -1951,107 +968,91 @@
     },
     {
       "metadata": {
-        "name": "logRequestsInstrumentedAsUnknown",
+        "name": "frontendSandboxMonitorOnly",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-07-05T11:48:25Z"
       },
       "spec": {
-        "description": "Logs the path for requests that are instrumented as unknown",
+        "description": "Enables monitor only in the plugin frontend sandbox (if enabled)",
         "stage": "experimental",
-        "codeowner": "@grafana/hosted-grafana-team"
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
       }
     },
     {
       "metadata": {
-        "name": "alertStateHistoryLokiOnly",
+        "name": "grafanaAPIServerEnsureKubectlAccess",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-12-06T20:21:21Z"
       },
       "spec": {
-        "description": "Disable Grafana alerts from emitting annotations when a remote Loki instance is available.",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "libraryPanelRBAC",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables RBAC support for library panels",
-        "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "requiresRestart": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pdfTables",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables generating table data as PDF in reporting",
-        "stage": "preview",
-        "codeowner": "@grafana/sharing-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "topnav",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
-        "stage": "deprecated",
-        "codeowner": "@grafana/grafana-frontend-platform"
-      }
-    },
-    {
-      "metadata": {
-        "name": "alertingBacktesting",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Rule backtesting API for alerting",
-        "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
-      }
-    },
-    {
-      "metadata": {
-        "name": "queryService",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Register /apis/query.grafana.app/ -- will eventually replace /api/ds/query",
+        "description": "Start an additional https handler and write kubectl options",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
         "requiresRestart": true
       }
     },
     {
       "metadata": {
-        "name": "alertmanagerRemoteSecondary",
+        "name": "grafanaAPIServerWithExperimentalAPIs",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-10-06T18:55:22Z"
       },
       "spec": {
-        "description": "Enable Grafana to sync configuration and state with a remote Alertmanager.",
+        "description": "Register experimental APIs with the k8s API server",
         "stage": "experimental",
-        "codeowner": "@grafana/alerting-squad"
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "grafanaManagedRecordingRules",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-22T17:53:16Z"
+      },
+      "spec": {
+        "description": "Enables Grafana-managed recording rules.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupByVariable",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-14T17:18:04Z"
+      },
+      "spec": {
+        "description": "Enable groupBy variable support in scenes dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "groupToNestedTableTransformation",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-07T14:28:26Z"
+      },
+      "spec": {
+        "description": "Enables the group to nested table transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
       }
     },
     {
       "metadata": {
         "name": "grpcServer",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2022-09-26T20:25:34Z"
       },
       "spec": {
         "description": "Run the GRPC server",
@@ -2062,86 +1063,34 @@
     },
     {
       "metadata": {
-        "name": "faroDatasourceSelector",
+        "name": "idForwarding",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-09-25T15:21:28Z"
       },
       "spec": {
-        "description": "Enable the data source selector within the Frontend Apps section of the Frontend Observability",
-        "stage": "preview",
-        "codeowner": "@grafana/app-o11y",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginsSkipHostEnvVars",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Disables passing host environment variable to plugin processes",
+        "description": "Generate signed id token for identity that can be forwarded to plugins and external services",
         "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend"
+        "codeowner": "@grafana/identity-access-team"
       }
     },
     {
       "metadata": {
-        "name": "transformationsVariableSupport",
+        "name": "individualCookiePreferences",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-02-21T10:19:07Z"
       },
       "spec": {
-        "description": "Allows using variables in transformations",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "panelTitleSearchInV1",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Enable searching for dashboards using panel title in search v1",
+        "description": "Support overriding cookie preferences per user",
         "stage": "experimental",
-        "codeowner": "@grafana/search-and-storage",
-        "requiresDevMode": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "featureHighlights",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Highlight Grafana Enterprise features",
-        "stage": "GA",
-        "codeowner": "@grafana/grafana-as-code",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "autoMigrateWorldmapPanel",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Migrate old worldmap panel to supported geomap panel - broken out from autoMigrateOldPanels to enable granular tracking",
-        "stage": "preview",
-        "codeowner": "@grafana/dataviz-squad",
-        "frontend": true
+        "codeowner": "@grafana/grafana-backend-group"
       }
     },
     {
       "metadata": {
         "name": "influxdbBackendMigration",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2022-02-09T18:26:16Z",
+        "deletionTimestamp": "2023-01-17T14:11:26Z"
       },
       "spec": {
         "description": "Query InfluxDB InfluxQL without the proxy",
@@ -2154,7 +1103,7 @@
       "metadata": {
         "name": "influxdbRunQueriesInParallel",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-02-01T10:58:24Z"
       },
       "spec": {
         "description": "Enables running InfluxDB Influxql queries in parallel",
@@ -2164,73 +1113,48 @@
     },
     {
       "metadata": {
-        "name": "scenes",
+        "name": "influxqlStreamingParser",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2023-11-29T17:29:35Z"
       },
       "spec": {
-        "description": "Experimental framework to build interactive dashboards",
+        "description": "Enable streaming JSON parser for InfluxDB datasource InfluxQL query language",
         "stage": "experimental",
-        "codeowner": "@grafana/dashboards-squad",
-        "frontend": true
+        "codeowner": "@grafana/observability-metrics"
       }
     },
     {
       "metadata": {
-        "name": "enableElasticsearchBackendQuerying",
+        "name": "jitterAlertRulesWithinGroups",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z",
-        "deletionTimestamp": "2024-06-05T14:07:54Z"
+        "creationTimestamp": "2024-01-18T18:48:11Z"
       },
       "spec": {
-        "description": "Enable the processing of queries and responses in the Elasticsearch data source through backend",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs",
-        "allowSelfServe": true
-      }
-    },
-    {
-      "metadata": {
-        "name": "externalServiceAccounts",
-        "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
-      },
-      "spec": {
-        "description": "Automatic service account and token setup for plugins",
+        "description": "Distributes alert rule evaluations more evenly over time, including spreading out rules within the same group",
         "stage": "preview",
-        "codeowner": "@grafana/identity-access-team",
-        "hideFromAdminPage": true
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
       }
     },
     {
       "metadata": {
-        "name": "lokiStructuredMetadata",
+        "name": "kubernetesAggregator",
         "resourceVersion": "1717578796182",
-        "creationTimestamp": "2024-06-05T09:13:16Z"
+        "creationTimestamp": "2024-02-12T20:59:35Z"
       },
       "spec": {
-        "description": "Enables the loki data source to request structured metadata from the Loki server",
-        "stage": "GA",
-        "codeowner": "@grafana/observability-logs"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginProxyPreserveTrailingSlash",
-        "resourceVersion": "1717581171624",
-        "creationTimestamp": "2024-06-05T09:52:51Z"
-      },
-      "spec": {
-        "description": "Preserve plugin proxy trailing slash.",
-        "stage": "GA",
-        "codeowner": "@grafana/plugins-platform-backend"
+        "description": "Enable grafana aggregator",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
       }
     },
     {
       "metadata": {
         "name": "kubernetesDashboards",
         "resourceVersion": "1717593661635",
-        "creationTimestamp": "2024-06-05T13:21:01Z"
+        "creationTimestamp": "2024-06-05T14:34:23Z"
       },
       "spec": {
         "description": "Use the kubernetes API in the frontend for dashboards",
@@ -2241,14 +1165,1092 @@
     },
     {
       "metadata": {
-        "name": "azureMonitorPrometheusExemplars",
-        "resourceVersion": "1717667267324",
-        "creationTimestamp": "2024-06-06T09:47:47Z"
+        "name": "kubernetesFeatureToggles",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-18T05:32:44Z"
       },
       "spec": {
-        "description": "Allows configuration of Azure Monitor as a data source that can provide Prometheus exemplars",
+        "description": "Use the kubernetes API for feature toggle management in the frontend",
         "stage": "experimental",
-        "codeowner": "@grafana/partner-datasources"
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesPlaylists",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-05T19:00:36Z"
+      },
+      "spec": {
+        "description": "Use the kubernetes API in the frontend for playlists, and route /api/playlist requests to k8s",
+        "stage": "GA",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesSnapshots",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-12-05T22:31:49Z"
+      },
+      "spec": {
+        "description": "Routes snapshot requests from /api to the /apis endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "libraryPanelRBAC",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-11T23:30:50Z"
+      },
+      "spec": {
+        "description": "Enables RBAC support for library panels",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "live-service-web-worker",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-01-26T17:44:20Z"
+      },
+      "spec": {
+        "description": "This will use a webworker thread to processes events rather than the main thread",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRequestsInstrumentedAsUnknown",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-06-10T08:56:55Z"
+      },
+      "spec": {
+        "description": "Logs the path for requests that are instrumented as unknown",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "logRowsPopoverMenu",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-16T09:48:10Z"
+      },
+      "spec": {
+        "description": "Enable filtering menu displayed when text of a log line is selected",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsContextDatasourceUi",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-01-27T14:12:01Z"
+      },
+      "spec": {
+        "description": "Allow datasource to provide custom UI for context view",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableDefaultVisualization",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-02T15:28:15Z"
+      },
+      "spec": {
+        "description": "Sets the logs table as default visualisation in logs explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsExploreTableVisualisation",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-12T13:52:42Z"
+      },
+      "spec": {
+        "description": "A table visualisation for logs in Explore",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "logsInfiniteScrolling",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-09T10:54:03Z"
+      },
+      "spec": {
+        "description": "Enables infinite scrolling for the Logs panel in Explore and Dashboards",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiExperimentalStreaming",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-19T10:03:51Z"
+      },
+      "spec": {
+        "description": "Support new streaming approach for loki (prototype, needs special loki build)",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiLogsDataplane",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-13T07:58:00Z"
+      },
+      "spec": {
+        "description": "Changes logs responses from Loki to be compliant with the dataplane specification.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiMetricDataplane",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-04-13T13:07:08Z"
+      },
+      "spec": {
+        "description": "Changes metric responses from Loki to be compliant with the dataplane specification.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiPredefinedOperations",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-02T10:52:36Z"
+      },
+      "spec": {
+        "description": "Adds predefined query operations to Loki query editor",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQueryHints",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-12-18T20:43:16Z"
+      },
+      "spec": {
+        "description": "Enables query hints for Loki",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQuerySplitting",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-02-09T17:27:02Z"
+      },
+      "spec": {
+        "description": "Split large interval queries into subqueries with smaller time intervals",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiQuerySplittingConfig",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-03-20T15:51:36Z"
+      },
+      "spec": {
+        "description": "Give users the option to configure split durations for Loki queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiRunQueriesInParallel",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-09-19T09:34:01Z"
+      },
+      "spec": {
+        "description": "Enables running Loki queries in parallel",
+        "stage": "privatePreview",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "lokiStructuredMetadata",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-16T16:06:14Z"
+      },
+      "spec": {
+        "description": "Enables the loki data source to request structured metadata from the Loki server",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs"
+      }
+    },
+    {
+      "metadata": {
+        "name": "managedPluginsInstall",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-18T13:17:03Z"
+      },
+      "spec": {
+        "description": "Install managed plugins directly from plugins catalog",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "metricsSummary",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-08-28T14:02:12Z"
+      },
+      "spec": {
+        "description": "Enables metrics summary queries in the Tempo data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "mlExpressions",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-13T17:37:50Z"
+      },
+      "spec": {
+        "description": "Enable support for Machine Learning in server-side expressions",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "mysqlAnsiQuotes",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-10-12T11:43:35Z"
+      },
+      "spec": {
+        "description": "Use double quotes to escape keyword in a MySQL query",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "nestedFolders",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-10-26T14:15:14Z"
+      },
+      "spec": {
+        "description": "Enable folder nesting",
+        "stage": "GA",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "newDashboardSharingComponent",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-03T15:02:18Z"
+      },
+      "spec": {
+        "description": "Enables the new sharing drawer design",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "newDashboardWithFiltersAndGroupBy",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-04T11:25:21Z"
+      },
+      "spec": {
+        "description": "Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "newFolderPicker",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-15T11:43:19Z"
+      },
+      "spec": {
+        "description": "Enables the nested folder picker without having nested folders enabled",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "newPDFRendering",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-08T12:09:34Z"
+      },
+      "spec": {
+        "description": "New implementation for the dashboard-to-PDF rendering",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "nodeGraphDotLayout",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-31T16:26:12Z"
+      },
+      "spec": {
+        "description": "Changed the layout algorithm for the node graph",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "notificationBanner",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-13T09:32:34Z"
+      },
+      "spec": {
+        "description": "Enables the notification banner UI and API",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauthRequireSubClaim",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-03-25T13:22:24Z"
+      },
+      "spec": {
+        "description": "Require that sub claims is present in oauth tokens.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "onPremToCloudMigrations",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-22T16:09:08Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow users to easily migrate their on-prem Grafana instances to Grafana Cloud.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelFilterVariable",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-03T12:15:54Z"
+      },
+      "spec": {
+        "description": "Enables use of the `systemPanelFilterVar` variable to filter panels in a dashboard",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelMonitoring",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-09T05:19:08Z"
+      },
+      "spec": {
+        "description": "Enables panel monitoring through logs and measurements",
+        "stage": "GA",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearch",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-02-15T18:26:03Z"
+      },
+      "spec": {
+        "description": "Search for dashboards using panel title",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "panelTitleSearchInV1",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-13T12:04:24Z"
+      },
+      "spec": {
+        "description": "Enable searching for dashboards using panel title in search v1",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "requiresDevMode": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pdfTables",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-06T13:39:22Z"
+      },
+      "spec": {
+        "description": "Enables generating table data as PDF in reporting",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "permissionsFilterRemoveSubquery",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-08-02T07:39:25Z"
+      },
+      "spec": {
+        "description": "Alternative permission filter implementation that does not use subqueries for fetching the dashboard folder",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-group"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginProxyPreserveTrailingSlash",
+        "resourceVersion": "1717581171624",
+        "creationTimestamp": "2024-06-05T11:36:14Z"
+      },
+      "spec": {
+        "description": "Preserve plugin proxy trailing slash.",
+        "stage": "GA",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsAPIMetrics",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-09-21T11:36:32Z"
+      },
+      "spec": {
+        "description": "Sends metrics of public grafana packages usage by plugins",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsFrontendSandbox",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-05T08:51:36Z"
+      },
+      "spec": {
+        "description": "Enables the plugins frontend sandbox",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "pluginsSkipHostEnvVars",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-15T17:09:14Z"
+      },
+      "spec": {
+        "description": "Disables passing host environment variable to plugin processes",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend"
+      }
+    },
+    {
+      "metadata": {
+        "name": "preserveDashboardStateWhenNavigating",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-27T12:28:06Z"
+      },
+      "spec": {
+        "description": "Enables possibility to preserve dashboard variables and time range when navigating between dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "promQLScope",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-01-29T20:22:17Z"
+      },
+      "spec": {
+        "description": "In-development feature that will allow injection of labels into prometheus queries.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusCodeModeMetricNamesSearch",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-04T20:38:23Z"
+      },
+      "spec": {
+        "description": "Enables search for metric names in Code Mode, to improve performance when working with an enormous number of metric names",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusConfigOverhaulAuth",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-26T16:09:53Z"
+      },
+      "spec": {
+        "description": "Update the Prometheus configuration page with the new auth component",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusDataplane",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-03-29T15:26:32Z"
+      },
+      "spec": {
+        "description": "Changes responses to from Prometheus to be compliant with the dataplane specification. In particular, when this feature toggle is active, the numeric `Field.Name` is set from 'Value' to the value of the `__name__` label.",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusIncrementalQueryInstrumentation",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-05T19:39:49Z"
+      },
+      "spec": {
+        "description": "Adds RudderStack events to incremental queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusMetricEncyclopedia",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-03-07T18:41:05Z"
+      },
+      "spec": {
+        "description": "Adds the metrics explorer component to the Prometheus query builder as an option in metric select",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheusPromQAIL",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-19T15:45:32Z"
+      },
+      "spec": {
+        "description": "Prometheus and AI/ML to assist users in creating a query",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboards",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-04-07T18:30:19Z"
+      },
+      "spec": {
+        "description": "[Deprecated] Public dashboards are now enabled by default; to disable them, use the configuration setting. This feature toggle will be removed in the next major version.",
+        "stage": "GA",
+        "codeowner": "@grafana/sharing-squad",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboardsEmailSharing",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-01-03T19:45:15Z"
+      },
+      "spec": {
+        "description": "Enables public dashboard sharing to be restricted to only allowed emails",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "publicDashboardsScene",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-03-22T14:48:21Z"
+      },
+      "spec": {
+        "description": "Enables public dashboard rendering using scenes",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryLibrary",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-10-07T18:31:45Z",
+        "deletionTimestamp": "2023-03-20T16:00:14Z"
+      },
+      "spec": {
+        "description": "Enables Query Library feature in Explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/explore-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryOverLive",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-01-26T17:44:20Z"
+      },
+      "spec": {
+        "description": "Use Grafana Live WebSocket to execute backend queries",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryService",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-19T09:26:21Z"
+      },
+      "spec": {
+        "description": "Register /apis/query.grafana.app/ -- will eventually replace /api/ds/query",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryServiceFromUI",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-19T09:26:21Z"
+      },
+      "spec": {
+        "description": "Routes requests to the new query service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "queryServiceRewrite",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-04-19T09:26:21Z"
+      },
+      "spec": {
+        "description": "Rewrite requests targeting /ds/query to the query service",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "recordedQueriesMulti",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-14T12:34:22Z"
+      },
+      "spec": {
+        "description": "Enables writing multiple items from a single query within Recorded Queries",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "recoveryThreshold",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-10T14:51:50Z"
+      },
+      "spec": {
+        "description": "Enables feature recovery threshold (aka hysteresis) for threshold server-side expression",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "refactorVariablesTimeRange",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-06T13:12:09Z"
+      },
+      "spec": {
+        "description": "Refactor time range variables flow to reduce number of API calls made when query variables are chained",
+        "stage": "preview",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "regressionTransformation",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-24T14:49:16Z"
+      },
+      "spec": {
+        "description": "Enables regression analysis transformation",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "renderAuthJWT",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-04-03T16:53:38Z"
+      },
+      "spec": {
+        "description": "Uses JWT-based auth for rendering instead of relying on remote cache",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-as-code",
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "reportingRetries",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-08-31T07:47:47Z"
+      },
+      "spec": {
+        "description": "Enables rendering retries for the reporting feature",
+        "stage": "preview",
+        "codeowner": "@grafana/sharing-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "scenes",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-07-07T06:53:02Z"
+      },
+      "spec": {
+        "description": "Experimental framework to build interactive dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "scopeFilters",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-03-05T15:41:19Z"
+      },
+      "spec": {
+        "description": "Enables the use of scope filters in Grafana",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "showDashboardValidationWarnings",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-10-14T13:51:05Z"
+      },
+      "spec": {
+        "description": "Show warnings when dashboards do not validate against the schema",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlDatasourceDatabaseSelection",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-06T16:28:52Z"
+      },
+      "spec": {
+        "description": "Enables previous SQL data source dataset dropdown behavior",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "hideFromAdminPage": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "sqlExpressions",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-02-27T21:16:00Z"
+      },
+      "spec": {
+        "description": "Enables using SQL and DuckDB functions as Expressions.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "sseGroupByDatasource",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-09-07T20:02:07Z"
+      },
+      "spec": {
+        "description": "Send query to the same datasource in a single request when using server side expressions. The `cloudWatchBatchQueries` feature toggle should be enabled if this used with CloudWatch.",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-metrics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsApi",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-11-08T09:50:01Z"
+      },
+      "spec": {
+        "description": "Enables the SSO settings API and the OAuth configuration UIs in Grafana",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "ssoSettingsSAML",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-03-14T11:04:45Z"
+      },
+      "spec": {
+        "description": "Use the new SSO Settings API to configure the SAML connector",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team",
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "storage",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-03-17T17:19:23Z"
+      },
+      "spec": {
+        "description": "Configurable storage for dashboards, datasources, and resources",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad"
+      }
+    },
+    {
+      "metadata": {
+        "name": "tableSharedCrosshair",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-12-13T09:33:14Z"
+      },
+      "spec": {
+        "description": "Enables shared crosshair in table panel",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "teamHttpHeaders",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-17T10:23:54Z"
+      },
+      "spec": {
+        "description": "Enables Team LBAC for datasources to apply team headers to the client requests",
+        "stage": "preview",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
+        "name": "tlsMemcached",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2024-05-09T19:12:08Z"
+      },
+      "spec": {
+        "description": "Use TLS-enabled memcached in the enterprise caching feature",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "topnav",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2022-06-20T14:25:43Z"
+      },
+      "spec": {
+        "description": "Enables topnav support in external plugins. The new Grafana navigation cannot be disabled.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/grafana-frontend-platform"
+      }
+    },
+    {
+      "metadata": {
+        "name": "traceQLStreaming",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-26T13:33:16Z"
+      },
+      "spec": {
+        "description": "Enables response streaming of TraceQL queries of the Tempo data source",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-traces-and-profiling",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsRedesign",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-07-12T16:35:49Z"
+      },
+      "spec": {
+        "description": "Enables the transformations redesign",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-metrics",
+        "frontend": true,
+        "allowSelfServe": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "transformationsVariableSupport",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-10-04T14:28:46Z"
+      },
+      "spec": {
+        "description": "Allows using variables in transformations",
+        "stage": "preview",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedRequestLog",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-03-31T13:38:09Z"
+      },
+      "spec": {
+        "description": "Writes error logs to the request logger",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-group"
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedStorage",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-12-06T20:21:21Z"
+      },
+      "spec": {
+        "description": "SQL-based k8s storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "vizAndWidgetSplit",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-06-27T10:22:13Z"
+      },
+      "spec": {
+        "description": "Split panels between visualizations and widgets",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
+        "name": "wargamesTesting",
+        "resourceVersion": "1717578796182",
+        "creationTimestamp": "2023-09-13T18:32:01Z"
+      },
+      "spec": {
+        "description": "Placeholder feature flag for internal testing",
+        "stage": "experimental",
+        "codeowner": "@grafana/hosted-grafana-team"
       }
     }
   ]

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -107,6 +108,25 @@ func TestFeatureToggleFiles(t *testing.T) {
 				})
 			}
 
+			// Set the dates from git history
+			dates := readFlagDateInfo(t)
+			for idx, item := range current.Items {
+				found, ok := dates[item.Name]
+				if ok {
+					// current.Items[idx].ResourceVersion = fmt.Sprintf("%d", found.created.UnixMilli()+int64(idx))
+					current.Items[idx].CreationTimestamp = v1.NewTime(found.created)
+					if found.deleted != nil {
+						tmp := v1.NewTime(*found.deleted)
+						current.Items[idx].DeletionTimestamp = &tmp
+					}
+				}
+			}
+
+			// Sort by name -- will avoid more git conflicts
+			sort.Slice(current.Items, func(i, j int) bool {
+				return current.Items[i].Name < current.Items[j].Name
+			})
+
 			out, err := json.MarshalIndent(current, "", "  ")
 			require.NoError(t, err)
 
@@ -187,6 +207,36 @@ func verifyFlagsConfiguration(t *testing.T) {
 	// Make sure the names are valid
 	require.Empty(t, invalidNames, "%s feature names should be camel cased", invalidNames)
 	// acronyms can be configured as needed via `ConfigureAcronym` function from `./strcase/camel.go`
+}
+
+type flagDateInfo struct {
+	created time.Time
+	deleted *time.Time
+}
+
+// Load a cached copy of the feature toggle dates
+func readFlagDateInfo(t *testing.T) map[string]flagDateInfo {
+	info := make(map[string]flagDateInfo, 300)
+	body, err := os.ReadFile("toggles-gitlog.csv")
+	require.NoError(t, err)
+	reader := csv.NewReader(bytes.NewBuffer(body))
+	rows, err := reader.ReadAll()
+	require.NoError(t, err)
+	for _, row := range rows {
+		if strings.HasPrefix(row[0], "#") {
+			continue
+		}
+		d := flagDateInfo{}
+		d.created, err = time.Parse(time.RFC3339, row[1])
+		require.NoError(t, err)
+		if row[2] != "" {
+			tmp, err := time.Parse(time.RFC3339, row[2])
+			require.NoError(t, err)
+			d.deleted = &tmp
+		}
+		info[row[0]] = d
+	}
+	return info
 }
 
 func verifyAndGenerateFile(t *testing.T, fpath string, gen string) {

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -217,6 +217,8 @@ type flagDateInfo struct {
 // Load a cached copy of the feature toggle dates
 func readFlagDateInfo(t *testing.T) map[string]flagDateInfo {
 	info := make(map[string]flagDateInfo, 300)
+	// This file is created by running the script in:
+	// https://github.com/grafana/grafana-enterprise/blob/ff-git-log-history/scripts/sidecar/main.go#L9
 	body, err := os.ReadFile("toggles-gitlog.csv")
 	require.NoError(t, err)
 	reader := csv.NewReader(bytes.NewBuffer(body))


### PR DESCRIPTION
This is a follow up from https://github.com/grafana/grafana/pull/88654.  In that PR, we updated the timestamps from a script and then crossed our fingers they would not get changed.  But in a few commits, [they all got wiped out ](https://github.com/grafana/grafana/pull/87493/files#diff-33f79832890bdb4973989dd844fdbd980ee20a266ececffc8632a939cbb055ae) again.  So...  this PR tries to to make that less likely.

In this PR:
1. save a copy of the git log output and read when generating the file
2. sort the flags by name -- this will avoid conflicts with open PRs that always add the last line!

Note, the gitlog is generated once, and can be updated using:
https://github.com/grafana/grafana-enterprise/blob/ff-git-log-history/scripts/sidecar/main.go#L9
This is not the easiest thing to re-create, but also not too bad -- if this continues to be a problem, we will find a way to make it easier to recreate.
