### PR TITLE
Alerting: Skip setting up clustering in remote primary/only modes

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -177,6 +177,7 @@ func (ng *AlertNG) init() error {
 			ng.Log.Debug("Starting Grafana with remote only mode enabled")
 			m := ng.Metrics.GetRemoteAlertmanagerMetrics()
 			m.Info.WithLabelValues(metrics.ModeRemoteOnly).Set(1)
+			ng.Cfg.UnifiedAlerting.SkipClustering = true
 
 			// This function will be used by the MOA to create new Alertmanagers.
 			override := notifier.WithAlertmanagerOverride(func(_ notifier.OrgAlertmanagerFactory) notifier.OrgAlertmanagerFactory {
@@ -203,6 +204,7 @@ func (ng *AlertNG) init() error {
 
 		case remotePrimary:
 			ng.Log.Warn("Only remote secondary mode is supported at the moment, falling back to remote secondary")
+			// TODO: Skip setting up clustering with ng.Cfg.UnifiedAlerting.SkipClustering = true
 			fallthrough
 
 		case remoteSecondary:

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -142,8 +142,12 @@ func NewMultiOrgAlertmanager(
 		peer:           &NilPeer{},
 	}
 
-	if err := moa.setupClustering(cfg); err != nil {
-		return nil, err
+	if cfg.UnifiedAlerting.SkipClustering {
+		l.Debug("Skipping setting up clustering for MOA")
+	} else {
+		if err := moa.setupClustering(cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	// Set up the default per tenant Alertmanager factory.

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -143,7 +143,7 @@ func NewMultiOrgAlertmanager(
 	}
 
 	if cfg.UnifiedAlerting.SkipClustering {
-		l.Debug("Skipping setting up clustering for MOA")
+		l.Info("Skipping setting up clustering for MOA")
 	} else {
 		if err := moa.setupClustering(cfg); err != nil {
 			return nil, err

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -98,6 +98,7 @@ type UnifiedAlertingSettings struct {
 	DefaultRuleEvaluationInterval time.Duration
 	Screenshots                   UnifiedAlertingScreenshotSettings
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
+	SkipClustering                bool
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	RemoteAlertmanager            RemoteAlertmanagerSettings
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.


### PR DESCRIPTION
This PR adds a way to skip setting up clustering. This will be used both in _remote primary_ and _remote only_ modes.