### PR TITLE
Docs: Use bearer auth not basic auth in IAM doc examples

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
@@ -136,7 +136,7 @@ The following request creates a custom role that includes permissions to access 
 
 ```
 curl --location --request POST '<grafana_url>/api/access-control/roles/' \
---header 'Authorization: Basic YWRtaW46cGFzc3dvcmQ=' \
+--header 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "version": 1,
@@ -144,7 +144,7 @@ curl --location --request POST '<grafana_url>/api/access-control/roles/' \
     "displayName": "Read-only access to alerts in folder Test-Folder",
     "description": "Let user query DS1 and DS2, and read alerts in folder Test-Folders",
     "group":"Custom",
-    "global": true,
+    "global": false,
     "permissions": [
         {
             "action": "folders:read",

--- a/docs/sources/developers/http_api/team.md
+++ b/docs/sources/developers/http_api/team.md
@@ -53,7 +53,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 GET /api/teams/search?perpage=10&page=1&query=mytestteam HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:
@@ -119,7 +119,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 GET /api/teams/1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:
@@ -165,7 +165,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 POST /api/teams HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 
 {
   "name": "MyTestTeam",
@@ -210,7 +210,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 PUT /api/teams/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 
 {
   "name": "MyTestTeam",
@@ -253,7 +253,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 DELETE /api/teams/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:
@@ -290,7 +290,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 GET /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:
@@ -343,7 +343,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 POST /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 
 {
   "userId": 2
@@ -385,7 +385,7 @@ See note in the [introduction]({{< ref "#team-api" >}}) for an explanation.
 DELETE /api/teams/2/members/3 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:

--- a/docs/sources/developers/http_api/team_sync.md
+++ b/docs/sources/developers/http_api/team_sync.md
@@ -45,7 +45,7 @@ See note in the [introduction]({{< ref "#external-group-synchronization-api" >}}
 GET /api/teams/1/groups HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:
@@ -87,7 +87,7 @@ See note in the [introduction]({{< ref "#external-group-synchronization-api" >}}
 POST /api/teams/1/groups HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer YWRtaW46YWRtaW4=
 
 {
   "groupId": "cn=editors,ou=groups,dc=grafana,dc=org"
@@ -129,7 +129,7 @@ See note in the [introduction]({{< ref "#external-group-synchronization-api" >}}
 DELETE /api/teams/1/groups?groupId=cn%3Deditors%2Cou%3Dgroups%2Cdc%3Dgrafana%2Cdc%3Dorg HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Basic YWRtaW46YWRtaW4=
+Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 ```
 
 **Example Response**:


### PR DESCRIPTION
**What is this feature?**

Try to make docs a bit clearer and encourage the use of service account tokens by using `Bearer` auth and not `Basic` auth in docs.

**Why do we need this feature?**

We recently had a question about why an example from the docs isn't working, and it turns out that the asker was using a service account token with `Basic` auth (due to copy pasting). I think this is the most common use case with API commands, so it makes sense to update docs.
