### PR TITLE
Ensure running server from VSCode enables dev mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
       "env": {},
       "cwd": "${workspaceFolder}",
-      "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
+      "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev", "cfg:app_mode=development"]
     },
     {
       "name": "Run API Server (testdata)",
@@ -44,7 +44,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
-      "env": {"GF_GRAFANA_APISERVER_STORAGE_TYPE": "unified-grpc"},
+      "env": { "GF_GRAFANA_APISERVER_STORAGE_TYPE": "unified-grpc" },
       "cwd": "${workspaceFolder}",
       "args": ["server", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
     },
@@ -54,7 +54,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/pkg/cmd/grafana/",
-      "env": {"GF_DEFAULT_TARGET": "storage-server","GF_SERVER_HTTP_PORT": "3001"},
+      "env": { "GF_DEFAULT_TARGET": "storage-server", "GF_SERVER_HTTP_PORT": "3001" },
       "cwd": "${workspaceFolder}",
       "args": ["server", "target", "--homepath", "${workspaceFolder}", "--packaging", "dev"]
     },


### PR DESCRIPTION
**What is this feature?**

When running the server in VSCode to enable breakpoints in the backend, it will run the server as a production server. This will automatically disable some features that are hidden for production, like the app platform.

Many people have this overridden in a custom.ini file, but if a grafana developer missed that somewhere, they might not see what is going on, as the normal flow for running Grafana from a terminal adds the command flag https://github.com/grafana/grafana/blob/main/.bra.toml#L5

This makes running Grafana from the terminal, and running Grafana from VSCode more equal.