### PR TITLE
Alerting: Fix rule storage to filter by group names using case-sensitive comparison

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -692,18 +692,6 @@ type ListNamespaceAlertRulesQuery struct {
 	NamespaceUID string
 }
 
-// ListOrgRuleGroupsQuery is the query for listing unique rule groups
-// for an organization
-type ListOrgRuleGroupsQuery struct {
-	OrgID         int64
-	NamespaceUIDs []string
-
-	// DashboardUID and PanelID are optional and allow filtering rules
-	// to return just those for a dashboard and panel.
-	DashboardUID string
-	PanelID      int64
-}
-
 type UpdateRule struct {
 	Existing *AlertRule
 	New      AlertRule

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -114,7 +114,7 @@ func (st DBstore) GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmode
 		if err != nil {
 			return err
 		}
-		// make sure we keep the case-sensitive comparison.
+		// MySQL by default compares strings without case-sensitivity, make sure we keep the case-sensitive comparison.
 		var groupKey ngmodels.AlertRuleGroupKey
 		// find the rule, which group we fetch
 		for _, rule := range rules {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -124,7 +124,8 @@ func (st DBstore) GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmode
 			}
 		}
 		result = make([]*ngmodels.AlertRule, 0, len(rules))
-		// now pick only groups that have the same group key (case-sensitive comparison)
+		// MySQL (and potentially other databases) can use case-insensitive comparison.
+		// This code makes sure we return groups that only exactly match the filter.
 		for _, rule := range rules {
 			if rule.GetGroupKey() == groupKey {
 				result = append(result, rule)
@@ -431,8 +432,10 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 					continue
 				}
 			}
+			// MySQL (and potentially other databases) can use case-insensitive comparison.
+			// This code makes sure we return groups that only exactly match the filter.
 			if groupsMap != nil {
-				if _, ok := groupsMap[rule.RuleGroup]; !ok { // compare groups using case-sensitive logic.
+				if _, ok := groupsMap[rule.RuleGroup]; !ok {
 					continue
 				}
 			}
@@ -578,6 +581,8 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 				st.Logger.Error("Invalid rule found in DB store, ignoring it", "func", "GetAlertRulesForScheduling", "error", err)
 				continue
 			}
+			// MySQL (and potentially other databases) uses case-insensitive comparison.
+			// This code makes sure we return groups that only exactly match the filter
 			if groupsMap != nil {
 				if _, ok := groupsMap[rule.RuleGroup]; !ok { // compare groups using case-sensitive logic.
 					continue

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -961,6 +962,114 @@ func TestIntegrationGetNamespacesByRuleUID(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestIntegrationRuleGroupsCaseSensitive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	sqlStore := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	cfg.UnifiedAlerting.BaseInterval = 1 * time.Second
+	store := &DBstore{
+		SQLStore:       sqlStore,
+		FolderService:  setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures()),
+		Logger:         log.New("test-dbstore"),
+		Cfg:            cfg.UnifiedAlerting,
+		FeatureToggles: featuremgmt.WithFeatures(),
+	}
+
+	gen := models.RuleGen.With(models.RuleMuts.WithOrgID(1))
+	misc := gen.GenerateMany(5, 10)
+	groupKey1 := models.GenerateGroupKey(1)
+	groupKey1.RuleGroup = strings.ToLower(groupKey1.RuleGroup)
+	groupKey2 := groupKey1
+	groupKey2.RuleGroup = strings.ToUpper(groupKey2.RuleGroup)
+	groupKey3 := groupKey1
+	groupKey3.OrgID = 2
+
+	group1 := gen.With(gen.WithGroupKey(groupKey1)).GenerateMany(3)
+	group2 := gen.With(gen.WithGroupKey(groupKey2)).GenerateMany(1, 3)
+	group3 := gen.With(gen.WithGroupKey(groupKey3)).GenerateMany(1, 3)
+
+	_, err := store.InsertAlertRules(context.Background(), append(append(append(misc, group1...), group2...), group3...))
+	require.NoError(t, err)
+
+	t.Run("GetAlertRulesGroupByRuleUID", func(t *testing.T) {
+		t.Run("should return rules that belong to only that group", func(t *testing.T) {
+			result, err := store.GetAlertRulesGroupByRuleUID(context.Background(), &models.GetAlertRulesGroupByRuleUIDQuery{
+				UID:   group1[rand.Intn(len(group1))].UID,
+				OrgID: groupKey1.OrgID,
+			})
+			require.NoError(t, err)
+			assert.Len(t, result, len(group1))
+			for _, rule := range result {
+				assert.Equal(t, groupKey1, rule.GetGroupKey())
+				assert.Truef(t, slices.ContainsFunc(group1, func(r models.AlertRule) bool {
+					return r.UID == rule.UID
+				}), "rule with group key [%v] should not be in group [%v]", rule.GetGroupKey(), group1)
+			}
+			if t.Failed() {
+				deref := make([]models.AlertRule, 0, len(result))
+				for _, rule := range result {
+					deref = append(deref, *rule)
+				}
+				t.Logf("expected rules in group %v: %v\ngot:%v", groupKey1, group1, deref)
+			}
+		})
+	})
+
+	t.Run("ListAlertRules", func(t *testing.T) {
+		t.Run("should find only group with exact case", func(t *testing.T) {
+			result, err := store.ListAlertRules(context.Background(), &models.ListAlertRulesQuery{
+				OrgID:      1,
+				RuleGroups: []string{groupKey1.RuleGroup},
+			})
+			require.NoError(t, err)
+			assert.Len(t, result, len(group1))
+			for _, rule := range result {
+				assert.Equal(t, groupKey1, rule.GetGroupKey())
+				assert.Truef(t, slices.ContainsFunc(group1, func(r models.AlertRule) bool {
+					return r.UID == rule.UID
+				}), "rule with group key [%v] should not be in group [%v]", rule.GetGroupKey(), group1)
+			}
+			if t.Failed() {
+				deref := make([]models.AlertRule, 0, len(result))
+				for _, rule := range result {
+					deref = append(deref, *rule)
+				}
+				t.Logf("expected rules in group %v: %v\ngot:%v", groupKey1, group1, deref)
+			}
+		})
+	})
+
+	t.Run("GetAlertRulesForScheduling", func(t *testing.T) {
+		t.Run("should find only group with exact case", func(t *testing.T) {
+			q := &models.GetAlertRulesForSchedulingQuery{
+				PopulateFolders: false,
+				RuleGroups:      []string{groupKey1.RuleGroup},
+			}
+			err := store.GetAlertRulesForScheduling(context.Background(), q)
+			require.NoError(t, err)
+			result := q.ResultRules
+			expected := append(group1, group3...)
+			assert.Len(t, result, len(expected)) // query fetches all orgs
+			for _, rule := range result {
+				assert.Equal(t, groupKey1.RuleGroup, rule.RuleGroup)
+				assert.Truef(t, slices.ContainsFunc(expected, func(r models.AlertRule) bool {
+					return r.UID == rule.UID
+				}), "rule with group key [%v] should not be in group [%v]", rule.GetGroupKey(), group1)
+			}
+			if t.Failed() {
+				deref := make([]models.AlertRule, 0, len(result))
+				for _, rule := range result {
+					deref = append(deref, *rule)
+				}
+				t.Logf("expected rules in group %v: %v\ngot:%v", groupKey1.RuleGroup, expected, deref)
+			}
+		})
+	})
 }
 
 // createAlertRule creates an alert rule in the database and returns it.

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -423,6 +423,11 @@ func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {
 			rules:      []string{rule1.Title},
 		},
 		{
+			name:       "with a rule group filter, should be case sensitive",
+			ruleGroups: []string{strings.ToUpper(rule1.RuleGroup)},
+			rules:      []string{},
+		},
+		{
 			name:         "with a filter on orgs, it returns rules that do not belong to that org",
 			rules:        []string{rule1.Title},
 			disabledOrgs: []int64{rule2.OrgID, rule3.OrgID},

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -2100,3 +2100,59 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 		}
 	})
 }
+
+func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
+	// Setup Grafana and its Database
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		DisableAnonymous:      true,
+		AppModeProduction:     true,
+	})
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+
+	// Create a user to make authenticated requests
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	client := newAlertingApiClient(grafanaListedAddr, "admin", "admin")
+
+	folderUID := util.GenerateShortUID()
+	client.CreateFolder(t, folderUID, "folder1")
+
+	t.Run("group renamed followed by delete for case-only changes should not delete both groups", func(t *testing.T) { // Regression test.
+		group := generateAlertRuleGroup(3, alertRuleGen())
+		groupName := group.Name
+
+		_, status, body := client.PostRulesGroupWithStatus(t, folderUID, &group)
+		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
+		getGroup := client.GetRulesGroup(t, folderUID, group.Name)
+		require.Lenf(t, getGroup.Rules, 3, "expected 3 rules in group")
+		require.Equal(t, groupName, getGroup.Rules[0].GrafanaManagedAlert.RuleGroup)
+
+		group = convertGettableRuleGroupToPostable(getGroup.GettableRuleGroupConfig)
+		newGroup := strings.ToUpper(group.Name)
+		group.Name = newGroup
+		_, status, body = client.PostRulesGroupWithStatus(t, folderUID, &group)
+		require.Equalf(t, http.StatusAccepted, status, "failed to post rule group. Response: %s", body)
+
+		getGroup = client.GetRulesGroup(t, folderUID, group.Name)
+		require.Lenf(t, getGroup.Rules, 3, "expected 3 rules in group")
+		require.Equal(t, newGroup, getGroup.Rules[0].GrafanaManagedAlert.RuleGroup)
+
+		status, body = client.DeleteRulesGroup(t, folderUID, groupName)
+		require.Equalf(t, http.StatusAccepted, status, "failed to post noop rule group. Response: %s", body)
+
+		// Old group is gone.
+		getGroup = client.GetRulesGroup(t, folderUID, groupName)
+		require.Lenf(t, getGroup.Rules, 0, "expected no rules")
+
+		// New group still exists.
+		getGroup = client.GetRulesGroup(t, folderUID, newGroup)
+		require.Lenf(t, getGroup.Rules, 3, "expected 3 rules in group")
+		require.Equal(t, newGroup, getGroup.Rules[0].GrafanaManagedAlert.RuleGroup)
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR fixes a bug that is caused by database collation settings (confirmed in MySQL) that consider equal groups with names in a different cases, e.g. `Default` and `default`. 

It updates methods of the storage layer that accepts filter by group 

**Why do we need this feature?**
Make filters by group case-sensitive. 

Fixes #
https://github.com/grafana/grafana/issues/88990


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
