### PR TITLE
Dashboard scenes: Allow undefined filter prop in adhoc variable when comparing two adhoc variables.

### DIFF
--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
@@ -59,21 +59,12 @@ describe('adHocVariableFiltersEqual', () => {
   });
 
   describe('when filter property is undefined', () => {
-    const warnSpy = jest.spyOn(console, 'warn');
-
-    afterEach(() => {
-      warnSpy.mockClear();
-    });
-
-    beforeEach(() => {
-      warnSpy.mockImplementation(() => {});
-    });
-
     afterAll(() => {
-      warnSpy.mockRestore();
+      jest.clearAllMocks();
     });
 
     it('should compare two adhoc variables where both are missing the filter property and return true', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
       expect(
         adHocVariableFiltersEqual({} as unknown as AdHocVariableModel, {} as unknown as AdHocVariableModel)
       ).toBeTruthy();
@@ -82,6 +73,7 @@ describe('adHocVariableFiltersEqual', () => {
     });
 
     it('should compare two adhoc variables where one has no filter property and return false', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
       expect(
         adHocVariableFiltersEqual(
           {} as unknown as AdHocVariableModel,

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
@@ -57,6 +57,39 @@ describe('adHocVariableFiltersEqual', () => {
       )
     ).toBeFalsy();
   });
+
+  describe('when filter property is undefined', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    afterEach(() => {
+      warnSpy.mockClear();
+    });
+
+    afterAll(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should compare two adhoc variables where both are missing the filter property and return true', () => {
+      expect(
+        adHocVariableFiltersEqual({} as unknown as AdHocVariableModel, {} as unknown as AdHocVariableModel)
+      ).toBeTruthy();
+
+      expect(warnSpy).toHaveBeenCalledWith('Adhoc variable filter property is undefined');
+    });
+
+    it('should compare two adhoc variables where one has no filter property and return false', () => {
+      expect(
+        adHocVariableFiltersEqual(
+          {} as unknown as AdHocVariableModel,
+          {
+            filters: [{ value: 'asdio', key: 'qwe', operator: 'wer' }],
+          } as unknown as AdHocVariableModel
+        )
+      ).toBeFalsy();
+
+      expect(warnSpy).toHaveBeenCalledWith('Adhoc variable filter property is undefined');
+    });
+  });
 });
 
 describe('getDashboardChanges', () => {
@@ -85,6 +118,7 @@ describe('getDashboardChanges', () => {
       ],
     },
   };
+
   it('should return the correct result when no changes', () => {
     const changed = { ...initial };
 

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
@@ -59,10 +59,14 @@ describe('adHocVariableFiltersEqual', () => {
   });
 
   describe('when filter property is undefined', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn');
 
     afterEach(() => {
       warnSpy.mockClear();
+    });
+
+    beforeEach(() => {
+      warnSpy.mockImplementation(() => {});
     });
 
     afterAll(() => {

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -72,8 +72,14 @@ export function getHasTimeChanged(saveModel: Dashboard, originalSaveModel: Dashb
 }
 
 export function adHocVariableFiltersEqual(a: AdHocVariableModel, b: AdHocVariableModel) {
-  if (a.filters === undefined || b.filters === undefined) {
-    throw new Error('AdHoc variable missing filter property');
+  if (a.filters === undefined && b.filters === undefined) {
+    console.warn('Adhoc variable filter property is undefined');
+    return true;
+  }
+
+  if ((a.filters === undefined && b.filters !== undefined) || (b.filters === undefined && a.filters !== undefined)) {
+    console.warn('Adhoc variable filter property is undefined');
+    return false;
   }
 
   if (a.filters.length !== b.filters.length) {


### PR DESCRIPTION
**What is this feature?**

Because we can end up with adhoc variable models that are undefined when they are loaded from the db we must allow this when comparing, even if the interface says they can never be undefined.

Closes https://github.com/grafana/hyperion-planning/issues/64