### PR TITLE
Added Grafana Play Links to Panel visualization docs

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -34,7 +34,7 @@ Alert lists allow you to display a list of important alerts that you want to tra
 
 On each dashboard load, this visualization queries the alert list, always providing the most up-to-date results.
 
-{{< docs/play title="Grafana Alert List Visualization" url="https://play.grafana.org/d/bdodlcyou483ke/" >}}
+{{< docs/play title="Alert List" url="https://play.grafana.org/d/bdodlcyou483ke/" >}}
 
 ## Configure an alert list
 

--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -34,7 +34,7 @@ Alert lists allow you to display a list of important alerts that you want to tra
 
 On each dashboard load, this visualization queries the alert list, always providing the most up-to-date results.
 
-{{< docs/play title="Grafana Gauge Visualization" url="https://play.grafana.org/d/bdodlcyou483ke/" >}}
+{{< docs/play title="Grafana Alert List Visualization" url="https://play.grafana.org/d/bdodlcyou483ke/" >}}
 
 ## Configure an alert list
 

--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -34,6 +34,8 @@ Alert lists allow you to display a list of important alerts that you want to tra
 
 On each dashboard load, this visualization queries the alert list, always providing the most up-to-date results.
 
+{{< docs/play title="Grafana Gauge Visualization" url="https://play.grafana.org/d/bdodlcyou483ke/" >}}
+
 ## Configure an alert list
 
 Once you’ve created a [dashboard](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-dashboard/), the following video shows you how to configure an alert list visualization:

--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -28,7 +28,7 @@ refs:
 
 # Alert list
 
-Alert lists allow you to display a list of important alerts that you want to track. You can configure the alert list to show the current state of your alert, such as firing, pending, or normal. Learn more about alerts in [Grafana Alerting overview][].
+Alert lists allow you to display a list of important alerts that you want to track. You can configure the alert list to show the current state of your alert, such as firing, pending, or normal. Learn more about alerts in [Grafana Alerting overview](https://grafana.com/docs/grafana/latest/alerting/).
 
 {{< figure src="/static/img/docs/alert-list-panel/alert-list-panel.png" max-width="850px" alt="An alert list visualization" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -28,7 +28,7 @@ refs:
 
 # Alert list
 
-Alert lists allow you to display a list of important alerts that you want to track. You can configure the alert list to show the current state of your alert, such as firing, pending, or normal. Learn more about alerts in [Grafana Alerting overview](https://grafana.com/docs/grafana/latest/alerting/).
+Alert lists allow you to display a list of important alerts that you want to track. You can configure the alert list to show the current state of your alert, such as firing, pending, or normal. Learn more about alerts in [Grafana Alerting overview](ref:grafana-alerting-overview).
 
 {{< figure src="/static/img/docs/alert-list-panel/alert-list-panel.png" max-width="850px" alt="An alert list visualization" >}}
 

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -30,7 +30,7 @@ In version 8.5, we discontinued the "Use Proxy" option for Grafana news visualiz
 
 You can use the news visualization to provide regular news and updates to your users.
 
-{{< docs/play title="Grafana News Visualization" url="https://play.grafana.org/d/cdodkwspaaa68b/" >}}
+{{< docs/play title="News Panel" url="https://play.grafana.org/d/cdodkwspaaa68b/" >}}
 
 ## Configure a news visualization
 

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -30,6 +30,8 @@ In version 8.5, we discontinued the "Use Proxy" option for Grafana news visualiz
 
 You can use the news visualization to provide regular news and updates to your users.
 
+{{< docs/play title="Grafana News Visualization" url="https://play.grafana.org/d/cdodkwspaaa68b/" >}}
+
 ## Configure a news visualization
 
 Once you’ve created a [dashboard](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-dashboard/), enter the URL of an RSS in the [URL](#url) field in the **News** section. This visualization type doesn't accept any other queries, and you shouldn't expect to be able to filter or query the RSS feed data in any way using this visualization.

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -29,7 +29,7 @@ The following video provides beginner steps for creating node panel visualizatio
 
 {{< youtube id="VrvsMkRwoKw" >}}
 
-{{< docs/play title="Node Panel Visualizations in Grafana" url="https://play.grafana.org/d/bdodfbi3d57uoe/" >}}
+{{< docs/play title="Node graph panel" url="https://play.grafana.org/d/bdodfbi3d57uoe/" >}}
 
 ## Data requirements
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -30,7 +30,7 @@ The following video provides beginner steps for creating node panel visualizatio
 
 {{< youtube id="VrvsMkRwoKw" >}}
 
-{{< docs/play title="Node Panel Visualizations in Grafana" url="https://play.grafana.org/d/bdodfbi3d57uoe" >}}
+{{< docs/play title="Node Panel Visualizations in Grafana" url="https://play.grafana.org/d/bdodfbi3d57uoe/" >}}
 
 ## Data requirements
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -25,7 +25,6 @@ Node graphs can visualize directed graphs or networks. They use a directed force
 
 ![Node graph visualization](/static/img/docs/node-graph/node-graph-8-0.png 'Node graph')
 
-
 The following video provides beginner steps for creating node panel visualizations. You'll learn the data requirements and caveats, special customizations, and much more:
 
 {{< youtube id="VrvsMkRwoKw" >}}

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -25,6 +25,8 @@ Node graphs can visualize directed graphs or networks. They use a directed force
 
 ![Node graph visualization](/static/img/docs/node-graph/node-graph-8-0.png 'Node graph')
 
+{{< docs/play title="Node Panel Visualizations in Grafana" url="https://play.grafana.org/d/bdodfbi3d57uoe" >}}
+
 ## Data requirements
 
 A node graph requires a specific shape of the data to be able to display its nodes and edges. This means not every data source or query can be visualized with this graph. If you want to use this as a data source developer see the section about data API.

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -65,6 +65,8 @@ For more information about traces and how to use them, refer to the following do
 
 {{< figure src="/static/img/docs/explore/trace-view-9-4.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view" >}}
 
+{{< docs/play title="Grafana Traces Visualization" url="https://play.grafana.org/d/edodkfmj0tce8f/" >}}
+
 ## Add a panel with tracing visualizations
 
 Once you have tracing data available in your Grafana stack, you can add tracing panels to your Grafana dashboards.

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -65,7 +65,7 @@ For more information about traces and how to use them, refer to the following do
 
 {{< figure src="/static/img/docs/explore/trace-view-9-4.png" class="docs-image--no-shadow" max-width= "900px" caption="Screenshot of the trace view" >}}
 
-{{< docs/play title="Grafana Traces Visualization" url="https://play.grafana.org/d/edodkfmj0tce8f/" >}}
+{{< docs/play title="Traces Panel" url="https://play.grafana.org/d/edodkfmj0tce8f/" >}}
 
 ## Add a panel with tracing visualizations
 


### PR DESCRIPTION
**What is this feature?**

Added Grafana Play links and messages to panel visualizations docs (Alert, News, Node, Traces) that did not have them yet.

**Why do we need this feature?**

Users can now check examples about the documentation they are reading.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
