### PR TITLE
CI: Add release-pr workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -658,6 +658,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/backport.yml @grafana/grafana-release-guild
 /.github/workflows/bump-version.yml @grafana/grafana-release-guild
 /.github/workflows/close-milestone.yml @grafana/grafana-release-guild
+/.github/workflows/release-pr.yml @grafana/grafana-release-guild
 /.github/workflows/codeowners-validator.yml @tolzhabayev
 /.github/workflows/codeql-analysis.yml @DanCech
 /.github/workflows/commands.yml @torkelo

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,62 @@
+# This workflow creates a new PR in Grafana which is triggered after a release is completed.
+# It should include all code changes that are needed after a release is done. This includes the changelog update and
+# version bumps, but could include more in the future.
+# Please refrain from including any processes that do not result in code changes in this workflow. Instead, they should
+# either be triggered in the release promotion process or in the release comms process (that is triggered by merging
+# this PR).
+name: Complete a Grafana release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: The version of Grafana that is being released
+      target:
+        required: true
+        type: string
+        description: The base branch that these changes are being merged into
+      backport:
+        required: false
+        type: string
+        description: Branch to backport these changes to
+      dry_run:
+        required: false
+        type: bool
+
+jobs:
+  create-prs:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    if: github.repository == 'grafana/grafana'
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - name: Checkout Grafana
+        uses: actions/checkout@v4
+      - name: Configure git user
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Create branch
+        run: git checkout -b "release/${{ github.run_id }}/${{ inputs.version }}"
+      - name: Generate changelog
+        run: git commit --allow-empty -m "Update changelog placeholder"
+      - name: Update package.json
+        run: git commit --allow-empty -m "Update version in package.json(s) (and yarn install) placeholder"
+      - name: Create PR without backports
+        if: "${{ github.event.inputs.backport == '' }}"
+        run: >
+          gh pr create --dry-run=${{ inputs.dry_run }} -H "release/${{ inputs.version }}" -B "${{ inputs.target }}" --title "Release: ${{ inputs.version }}" --body "These code changes must be merged after a release is complete"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      - name: Create PR with backports
+        if: "${{ github.event.inputs.backport != '' }}"
+        run: >
+          gh pr create -l "backport-${{ inputs.backport }}" --dry-run=${{ inputs.dry_run }} -H "release/${{ inputs.version }}" -B "${{ inputs.target }}" --title "Release: ${{ inputs.version }}" --body "These code changes must be merged after a release is complete"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This workflow will be ran after a release is completed and will include all changes that need to be made back into the repository.

I've included placeholder commits for those. Once this is merged, we can add the jobs in the workflows that replace the placeholders.