### PR TITLE
Query Library: POC Create a custom saving strategy to add createdBy annotation

### DIFF
--- a/public/app/features/explore/QueryLibrary/QueryTemplatesList.tsx
+++ b/public/app/features/explore/QueryLibrary/QueryTemplatesList.tsx
@@ -44,6 +44,7 @@ export function QueryTemplatesList() {
       datasourceRef,
       datasourceType,
       createdAtTimestamp: queryTemplate?.createdAtTimestamp || 0,
+      createdBy: queryTemplate.createdBy || 'Unknown',
       query: queryTemplate.targets[0],
       description: queryTemplate.title,
     };

--- a/public/app/features/explore/QueryLibrary/QueryTemplatesTable/AddedByCell.tsx
+++ b/public/app/features/explore/QueryLibrary/QueryTemplatesTable/AddedByCell.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { CellProps } from 'react-table';
 
 import { Avatar } from '@grafana/ui';
 
 import { useQueryLibraryListStyles } from './styles';
+import { QueryTemplateRow } from './types';
 
-export function AddedByCell() {
+export function AddedByCell(props: CellProps<QueryTemplateRow>) {
   const styles = useQueryLibraryListStyles();
 
   return (
@@ -12,7 +14,7 @@ export function AddedByCell() {
       <span className={styles.logo}>
         <Avatar src="https://secure.gravatar.com/avatar" alt="unknown" />
       </span>
-      <span className={styles.otherText}>Unknown</span>
+      <span className={styles.otherText}>{props.row.original.createdBy}</span>
     </div>
   );
 }

--- a/public/app/features/explore/QueryLibrary/QueryTemplatesTable/types.ts
+++ b/public/app/features/explore/QueryLibrary/QueryTemplatesTable/types.ts
@@ -7,4 +7,5 @@ export type QueryTemplateRow = {
   datasourceRef?: DataSourceRef | null;
   datasourceType?: string;
   createdAtTimestamp?: number;
+  createdBy?: string;
 };

--- a/public/app/features/query-library/api/mappers.ts
+++ b/public/app/features/query-library/api/mappers.ts
@@ -10,6 +10,7 @@ export const convertDataQueryResponseToQueryTemplates = (result: DataQuerySpecRe
   return result.items.map((spec) => {
     return {
       uid: spec.metadata.name || '',
+      createdBy: spec.metadata.annotations?.['grafana.app/createdBy'] || 'Unknown',
       title: spec.spec.title,
       targets: spec.spec.targets.map((target: DataQueryTarget) => target.properties),
       createdAtTimestamp: new Date(spec.metadata.creationTimestamp || '').getTime(),

--- a/public/app/features/query-library/api/types.ts
+++ b/public/app/features/query-library/api/types.ts
@@ -5,6 +5,10 @@ export type DataQueryTarget = {
   properties: DataQuery;
 };
 
+type DataQueryAnnotationKey = 'grafana.app/createdBy';
+
+type DataQueryAnnotations = Record<DataQueryAnnotationKey, string>;
+
 export type DataQuerySpec = {
   apiVersion: string;
   kind: string;
@@ -12,6 +16,7 @@ export type DataQuerySpec = {
     generateName: string;
     name?: string;
     creationTimestamp?: string;
+    annotations?: DataQueryAnnotations;
   };
   spec: {
     title: string;

--- a/public/app/features/query-library/types.ts
+++ b/public/app/features/query-library/types.ts
@@ -5,6 +5,7 @@ export type QueryTemplate = {
   title: string;
   targets: DataQuery[];
   createdAtTimestamp: number;
+  createdBy: string;
 };
 
 export type AddQueryTemplateCommand = {


### PR DESCRIPTION
Not sure if it's the best approach. IIUC in long run resources will be automatically annotated with "grafana.app/createdBy". Until we get there we could add a custom modifier to newly created objects.

Fixes #86987

https://github.com/grafana/grafana/assets/745532/00ceddca-764b-4a3a-9109-3ef1a0a93368

