### PR TITLE
Unified Alerting: Only fetch rules for selected data sources

### DIFF
--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -81,7 +81,7 @@ const RuleList = withErrorBoundary(
     // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
     const [_, fetchRules] = useAsyncFn(async () => {
       if (!loading) {
-        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
+        await dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }, filterState));
       }
     }, [loading, limitAlerts, dispatch]);
 
@@ -91,8 +91,8 @@ const RuleList = withErrorBoundary(
 
     // fetch rules, then poll every RULE_LIST_POLL_INTERVAL_MS
     useEffect(() => {
-      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }));
-    }, [dispatch, limitAlerts]);
+      dispatch(fetchAllPromAndRulerRulesAction(false, { limitAlerts }, filterState));
+    }, [dispatch, limitAlerts, filterState]);
     useInterval(fetchRules, RULE_LIST_POLL_INTERVAL_MS);
 
     // Show splash only when we loaded all of the data sources and none of them has alerts

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -69,6 +69,7 @@ import {
   setRulerRuleGroup,
 } from '../api/ruler';
 import { encodeGrafanaNamespace } from '../components/expressions/util';
+import { RulesFilter } from '../search/rulesSearchParser';
 import { RuleFormType, RuleFormValues } from '../types/rule-form';
 import { addDefaultsToAlertmanagerConfig, removeMuteTimingFromRoute } from '../utils/alertmanager';
 import {
@@ -308,7 +309,8 @@ interface FetchPromRulesRulesActionProps {
 
 export function fetchAllPromAndRulerRulesAction(
   force = false,
-  options: FetchPromRulesRulesActionProps = {}
+  options: FetchPromRulesRulesActionProps = {},
+  rulesFilter?: RulesFilter
 ): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     const allStartLoadingTs = performance.now();
@@ -319,8 +321,12 @@ export function fetchAllPromAndRulerRulesAction(
 
         const { promRules, rulerRules, dataSources } = getStore().unifiedAlerting;
         const dataSourceConfig = dataSources[rulesSourceName].result;
+        const shouldLoad =
+          rulesFilter?.dataSourceNames.length == 0 ||
+          rulesFilter?.dataSourceNames.includes(rulesSourceName) ||
+          rulesSourceName == GRAFANA_RULES_SOURCE_NAME;
 
-        if (!dataSourceConfig) {
+        if (!dataSourceConfig || !shouldLoad) {
           return;
         }
 


### PR DESCRIPTION
Solves #82542

**What is this feature?**

This modification filters which data sources are loaded on the Alerting > Alert Rules page, based on which data sources are selected by the user.

**Why do we need this feature?**

Avoid loading all the datasources every time.

**Who is this feature for?**

User of the Alerting > Alert Rules page.

**Which issue(s) does this PR fix?**:

Fixes #82542

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
