### PR TITLE
Loki: Respect pre-selected filters in adhoc filter queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -19,6 +19,7 @@ import {
   ToggleFilterAction,
   DataQueryRequest,
   ScopedVars,
+  AdHocVariableFilter,
 } from '@grafana/data';
 import {
   BackendSrv,
@@ -1712,7 +1713,28 @@ describe('LokiDatasource', () => {
       const spy = jest.spyOn(ds.languageProvider, 'fetchLabels').mockResolvedValue([]);
 
       await ds.getTagKeys({ filters, timeRange: mockTimeRange });
-      expect(spy).toHaveBeenCalledWith({ streamSelector: '{foo="bar",foo2="bar2"}', timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith({ streamSelector: '{foo="bar", foo2="bar2"}', timeRange: mockTimeRange });
+    });
+
+    it('should pass regex filters', async () => {
+      const ds = createLokiDatasource();
+      const filters = [
+        { key: 'foo', operator: '=~', value: 'abc|def' },
+        { key: 'foo2', operator: '=', value: 'bar2' },
+      ];
+      const spy = jest.spyOn(ds.languageProvider, 'fetchLabels').mockResolvedValue([]);
+
+      await ds.getTagKeys({ filters, timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith({ streamSelector: '{foo=~"abc|def", foo2="bar2"}', timeRange: mockTimeRange });
+    });
+
+    it('should pass empty stream selector when no filters', async () => {
+      const ds = createLokiDatasource();
+      const filters: AdHocVariableFilter[] = [];
+      const spy = jest.spyOn(ds.languageProvider, 'fetchLabels').mockResolvedValue([]);
+
+      await ds.getTagKeys({ filters, timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith({ streamSelector: '{}', timeRange: mockTimeRange });
     });
   });
 
@@ -1727,9 +1749,18 @@ describe('LokiDatasource', () => {
 
       await ds.getTagValues({ key: 'label1', filters, timeRange: mockTimeRange });
       expect(spy).toHaveBeenCalledWith('label1', {
-        streamSelector: '{foo="bar",foo2="bar2"}',
+        streamSelector: '{foo="bar", foo2="bar2"}',
         timeRange: mockTimeRange,
       });
+    });
+
+    it('should pass empty stream selector when no filters', async () => {
+      const ds = createLokiDatasource();
+      const filters: AdHocVariableFilter[] = [];
+      const spy = jest.spyOn(ds.languageProvider, 'fetchLabelValues').mockResolvedValue([]);
+
+      await ds.getTagValues({ key: 'label1', filters, timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith('label1', { streamSelector: '{}', timeRange: mockTimeRange });
     });
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1705,22 +1705,31 @@ describe('LokiDatasource', () => {
   describe('getTagKeys', () => {
     it('should pass timeRange and filters to the request', async () => {
       const ds = createLokiDatasource();
-      const filters = [{ key: 'foo', operator: '=', value: 'bar' }];
+      const filters = [
+        { key: 'foo', operator: '=', value: 'bar' },
+        { key: 'foo2', operator: '=', value: 'bar2' },
+      ];
       const spy = jest.spyOn(ds.languageProvider, 'fetchLabels').mockResolvedValue([]);
 
       await ds.getTagKeys({ filters, timeRange: mockTimeRange });
-      expect(spy).toHaveBeenCalledWith({ streamSelector: '{foo=bar}', timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith({ streamSelector: '{foo="bar",foo2="bar2"}', timeRange: mockTimeRange });
     });
   });
 
   describe('getTagValues', () => {
     it('should pass timeRange and filters to the request', async () => {
       const ds = createLokiDatasource();
-      const filters = [{ key: 'foo', operator: '=', value: 'bar' }];
+      const filters = [
+        { key: 'foo', operator: '=', value: 'bar' },
+        { key: 'foo2', operator: '=', value: 'bar2' },
+      ];
       const spy = jest.spyOn(ds.languageProvider, 'fetchLabelValues').mockResolvedValue([]);
 
       await ds.getTagValues({ key: 'label1', filters, timeRange: mockTimeRange });
-      expect(spy).toHaveBeenCalledWith('label1', { streamSelector: '{foo=bar}', timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith('label1', {
+        streamSelector: '{foo="bar",foo2="bar2"}',
+        timeRange: mockTimeRange,
+      });
     });
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1701,6 +1701,28 @@ describe('LokiDatasource', () => {
       expect(ds.applyTemplateVariables).toHaveBeenCalledWith(expect.objectContaining(query), scopedVars, filters);
     });
   });
+
+  describe('getTagKeys', () => {
+    it('should pass timeRange and filters to the request', async () => {
+      const ds = createLokiDatasource();
+      const filters = [{ key: 'foo', operator: '=', value: 'bar' }];
+      const spy = jest.spyOn(ds.languageProvider, 'fetchLabels').mockResolvedValue([]);
+
+      await ds.getTagKeys({ filters, timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith({ streamSelector: '{foo=bar}', timeRange: mockTimeRange });
+    });
+  });
+
+  describe('getTagValues', () => {
+    it('should pass timeRange and filters to the request', async () => {
+      const ds = createLokiDatasource();
+      const filters = [{ key: 'foo', operator: '=', value: 'bar' }];
+      const spy = jest.spyOn(ds.languageProvider, 'fetchLabelValues').mockResolvedValue([]);
+
+      await ds.getTagValues({ key: 'label1', filters, timeRange: mockTimeRange });
+      expect(spy).toHaveBeenCalledWith('label1', { streamSelector: '{foo=bar}', timeRange: mockTimeRange });
+    });
+  });
 });
 
 describe('applyTemplateVariables', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -743,9 +743,9 @@ export class LokiDatasource
    * @returns A Promise that resolves to an array of label names represented as MetricFindValue objects.
    */
   async getTagKeys(options?: DataSourceGetTagKeysOptions<LokiQuery>): Promise<MetricFindValue[]> {
-    let streamSelector;
-    if (options?.filters) {
-      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}"${escapeLabelValueInSelector(filter.value, filter.operator)}"`).join(',')}}`;
+    let streamSelector = '{}';
+    for (const filter of options?.filters ?? []) {
+      streamSelector = addLabelToQuery(streamSelector, filter.key, filter.operator, filter.value);
     }
     const result = await this.languageProvider.fetchLabels({ timeRange: options?.timeRange, streamSelector });
     return result.map((value: string) => ({ text: value }));
@@ -756,9 +756,9 @@ export class LokiDatasource
    * @returns A Promise that resolves to an array of label values represented as MetricFindValue objects
    */
   async getTagValues(options: DataSourceGetTagValuesOptions<LokiQuery>): Promise<MetricFindValue[]> {
-    let streamSelector;
-    if (options?.filters) {
-      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}"${escapeLabelValueInSelector(filter.value, filter.operator)}"`).join(',')}}`;
+    let streamSelector = '{}';
+    for (const filter of options?.filters ?? []) {
+      streamSelector = addLabelToQuery(streamSelector, filter.key, filter.operator, filter.value);
     }
     const result = await this.languageProvider.fetchLabelValues(options.key, {
       timeRange: options.timeRange,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -745,7 +745,7 @@ export class LokiDatasource
   async getTagKeys(options?: DataSourceGetTagKeysOptions<LokiQuery>): Promise<MetricFindValue[]> {
     let streamSelector;
     if (options?.filters) {
-      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}${escapeLabelValueInSelector(filter.value, filter.operator)}`).join(',')}}`;
+      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}"${escapeLabelValueInSelector(filter.value, filter.operator)}"`).join(',')}}`;
     }
     const result = await this.languageProvider.fetchLabels({ timeRange: options?.timeRange, streamSelector });
     return result.map((value: string) => ({ text: value }));
@@ -758,7 +758,7 @@ export class LokiDatasource
   async getTagValues(options: DataSourceGetTagValuesOptions<LokiQuery>): Promise<MetricFindValue[]> {
     let streamSelector;
     if (options?.filters) {
-      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}${escapeLabelValueInSelector(filter.value, filter.operator)}`).join(',')}}`;
+      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}"${escapeLabelValueInSelector(filter.value, filter.operator)}"`).join(',')}}`;
     }
     const result = await this.languageProvider.fetchLabelValues(options.key, {
       timeRange: options.timeRange,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -743,7 +743,11 @@ export class LokiDatasource
    * @returns A Promise that resolves to an array of label names represented as MetricFindValue objects.
    */
   async getTagKeys(options?: DataSourceGetTagKeysOptions<LokiQuery>): Promise<MetricFindValue[]> {
-    const result = await this.languageProvider.fetchLabels({ timeRange: options?.timeRange });
+    let streamSelector;
+    if (options?.filters) {
+      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}${escapeLabelValueInSelector(filter.value, filter.operator)}`).join(',')}}`;
+    }
+    const result = await this.languageProvider.fetchLabels({ timeRange: options?.timeRange, streamSelector });
     return result.map((value: string) => ({ text: value }));
   }
 
@@ -752,7 +756,14 @@ export class LokiDatasource
    * @returns A Promise that resolves to an array of label values represented as MetricFindValue objects
    */
   async getTagValues(options: DataSourceGetTagValuesOptions<LokiQuery>): Promise<MetricFindValue[]> {
-    const result = await this.languageProvider.fetchLabelValues(options.key, { timeRange: options.timeRange });
+    let streamSelector;
+    if (options?.filters) {
+      streamSelector = `{${options.filters.map((filter) => `${filter.key}${filter.operator}${escapeLabelValueInSelector(filter.value, filter.operator)}`).join(',')}}`;
+    }
+    const result = await this.languageProvider.fetchLabelValues(options.key, {
+      timeRange: options.timeRange,
+      streamSelector,
+    });
     return result.map((value: string) => ({ text: value }));
   }
 


### PR DESCRIPTION
`getTagKeys` and `getTagValues` receive pre-selected filters as `filters` which are part of `DataSourceGetTagKeysOptions` . When doing queries to fetch label and values, we should provide them and that way we receive only labels and values which are available for pre-selected streams.

Just for comparison - Prometheus data source is also doing this: https://github.com/grafana/grafana/blob/main/packages/grafana-prometheus/src/datasource.ts#L607-L626

Related to https://github.com/grafana/explore-logs/pull/432
Will fix https://github.com/grafana/explore-logs/issues/416 after  https://github.com/grafana/explore-logs/pull/432 is merged and this Grafana is released. 


Fixed:

https://github.com/grafana/grafana/assets/30407135/bd468d02-8386-44dc-acbc-1f756f08b145

Broken: 


https://github.com/grafana/grafana/assets/30407135/661a4f5d-3e92-44e9-971c-b0c4251ff2fb


