### PR TITLE
Alerting: Fix erroneous use of grafana-cli/logger.

### DIFF
--- a/pkg/services/ngalert/state/historian/model/rule.go
+++ b/pkg/services/ngalert/state/historian/model/rule.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
@@ -22,7 +21,7 @@ type RuleMeta struct {
 	Condition    string
 }
 
-func NewRuleMeta(r *models.AlertRule, log log.Logger) RuleMeta {
+func NewRuleMeta(r *models.AlertRule, logger log.Logger) RuleMeta {
 	dashUID, ok := r.Annotations[models.DashboardUIDAnnotation]
 	var panelID int64
 	if ok {


### PR DESCRIPTION
Can't see how this was intentional, likely just a typo.
