### PR TITLE
Scopes: Remove disabled flag on nodes search input

### DIFF
--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -1,5 +1,6 @@
 import { isEqual } from 'lodash';
 import React from 'react';
+import { from, Subscription } from 'rxjs';
 
 import { Scope } from '@grafana/data';
 import {
@@ -33,6 +34,8 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
 
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['scopes'] });
 
+  private nodesFetchingSub: Subscription | undefined;
+
   get scopesParent(): ScopesScene {
     return sceneGraph.getAncestor(this, ScopesScene);
   }
@@ -61,6 +64,10 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
 
     this.addActivationHandler(() => {
       this.fetchBaseNodes();
+
+      return () => {
+        this.nodesFetchingSub?.unsubscribe();
+      };
     });
   }
 
@@ -80,6 +87,8 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
   }
 
   public async updateNode(path: string[], isExpanded: boolean, query: string) {
+    this.nodesFetchingSub?.unsubscribe();
+
     let nodes = { ...this.state.nodes };
     let currentLevel: NodesMap = nodes;
 
@@ -93,7 +102,15 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
     if (isExpanded || currentNode.query !== query) {
       this.setState({ loadingNodeName: name });
 
-      currentNode.nodes = await fetchNodes(name, query);
+      this.nodesFetchingSub = from(fetchNodes(name, query)).subscribe((childNodes) => {
+        currentNode.nodes = childNodes;
+        currentNode.isExpanded = isExpanded;
+        currentNode.query = query;
+
+        this.setState({ nodes, loadingNodeName: undefined });
+
+        this.nodesFetchingSub?.unsubscribe();
+      });
     }
 
     currentNode.isExpanded = isExpanded;

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -99,24 +99,24 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
     const name = path[path.length - 1];
     const currentNode = currentLevel[name];
 
-    if (isExpanded || currentNode.query !== query) {
+    const isDifferentQuery = currentNode.query !== query;
+
+    currentNode.isExpanded = isExpanded;
+    currentNode.query = query;
+
+    this.setState({ nodes, loadingNodeName: undefined });
+
+    if (isExpanded || isDifferentQuery) {
       this.setState({ loadingNodeName: name });
 
       this.nodesFetchingSub = from(fetchNodes(name, query)).subscribe((childNodes) => {
         currentNode.nodes = childNodes;
-        currentNode.isExpanded = isExpanded;
-        currentNode.query = query;
 
         this.setState({ nodes, loadingNodeName: undefined });
 
         this.nodesFetchingSub?.unsubscribe();
       });
     }
-
-    currentNode.isExpanded = isExpanded;
-    currentNode.query = query;
-
-    this.setState({ nodes, loadingNodeName: undefined });
   }
 
   public toggleNodeSelect(path: string[]) {

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash';
 import React from 'react';
-import { from, Subscription } from 'rxjs';
+import { finalize, from, Subscription } from 'rxjs';
 
 import { Scope } from '@grafana/data';
 import {
@@ -109,13 +109,19 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
     if (isExpanded || isDifferentQuery) {
       this.setState({ loadingNodeName: name });
 
-      this.nodesFetchingSub = from(fetchNodes(name, query)).subscribe((childNodes) => {
-        currentNode.nodes = childNodes;
+      this.nodesFetchingSub = from(fetchNodes(name, query))
+        .pipe(
+          finalize(() => {
+            this.setState({ loadingNodeName: undefined });
+          })
+        )
+        .subscribe((childNodes) => {
+          currentNode.nodes = childNodes;
 
-        this.setState({ nodes, loadingNodeName: undefined });
+          this.setState({ nodes });
 
-        this.nodesFetchingSub?.unsubscribe();
-      });
+          this.nodesFetchingSub?.unsubscribe();
+        });
     }
   }
 

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Checkbox, Icon, IconButton, Input, useStyles2 } from '@grafana/ui';
@@ -37,19 +37,18 @@ export function ScopesTreeLevel({
   const anyChildExpanded = childNodesArr.some(({ isExpanded }) => isExpanded);
   const anyChildSelected = childNodesArr.some(({ linkId }) => linkId && scopeNames.includes(linkId!));
 
+  const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
+
   return (
     <>
       {showQuery && !anyChildExpanded && (
         <Input
           prefix={<Icon name="filter" />}
           className={styles.searchInput}
-          disabled={!!loadingNodeName}
           placeholder={t('scopes.tree.search', 'Filter')}
           defaultValue={node.query}
           data-testid={`scopes-tree-${nodeId}-search`}
-          onChange={debounce((evt) => {
-            onNodeUpdate(nodePath, true, evt.target.value);
-          }, 500)}
+          onInput={(evt) => onQueryUpdate(nodePath, true, evt.currentTarget.value)}
         />
       )}
 

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -3,7 +3,7 @@ import { debounce } from 'lodash';
 import React, { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, Icon, IconButton, Input, useStyles2 } from '@grafana/ui';
+import { Checkbox, Icon, IconButton, Input, Spinner, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { NodesMap } from './types';
@@ -33,6 +33,7 @@ export function ScopesTreeLevel({
   const node = nodes[nodeId];
   const childNodes = node.nodes;
   const childNodesArr = Object.values(childNodes);
+  const isNodeLoading = loadingNodeName === nodeId;
 
   const anyChildExpanded = childNodesArr.some(({ isExpanded }) => isExpanded);
   const anyChildSelected = childNodesArr.some(({ linkId }) => linkId && scopeNames.includes(linkId!));
@@ -53,68 +54,65 @@ export function ScopesTreeLevel({
       )}
 
       <div role="tree">
-        {childNodesArr.map((childNode) => {
-          const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
+        {isNodeLoading && <Spinner className={styles.loader} />}
 
-          if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
-            return null;
-          }
+        {!isNodeLoading &&
+          childNodesArr.map((childNode) => {
+            const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
 
-          const childNodePath = [...nodePath, childNode.name];
+            if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
+              return null;
+            }
 
-          return (
-            <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
-              <div className={styles.itemTitle}>
-                {childNode.isSelectable && !childNode.isExpanded ? (
-                  <Checkbox
-                    checked={isSelected}
-                    disabled={!!loadingNodeName || (anyChildSelected && !isSelected && node.disableMultiSelect)}
-                    data-testid={`scopes-tree-${childNode.name}-checkbox`}
-                    onChange={() => {
-                      onNodeSelectToggle(childNodePath);
-                    }}
-                  />
-                ) : null}
+            const childNodePath = [...nodePath, childNode.name];
 
-                {childNode.isExpandable && (
-                  <IconButton
-                    disabled={(anyChildSelected && !childNode.isExpanded) || !!loadingNodeName}
-                    name={
-                      !childNode.isExpanded
-                        ? 'angle-right'
-                        : loadingNodeName === childNode.name
-                          ? 'spinner'
-                          : 'angle-down'
-                    }
-                    aria-label={
-                      childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
-                    }
-                    data-testid={`scopes-tree-${childNode.name}-expand`}
-                    onClick={() => {
-                      onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
-                    }}
-                  />
-                )}
+            return (
+              <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
+                <div className={styles.itemTitle}>
+                  {childNode.isSelectable && !childNode.isExpanded ? (
+                    <Checkbox
+                      checked={isSelected}
+                      disabled={anyChildSelected && !isSelected && node.disableMultiSelect}
+                      data-testid={`scopes-tree-${childNode.name}-checkbox`}
+                      onChange={() => {
+                        onNodeSelectToggle(childNodePath);
+                      }}
+                    />
+                  ) : null}
 
-                <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+                  {childNode.isExpandable && (
+                    <IconButton
+                      disabled={anyChildSelected && !childNode.isExpanded}
+                      name={!childNode.isExpanded ? 'angle-right' : 'angle-down'}
+                      aria-label={
+                        childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
+                      }
+                      data-testid={`scopes-tree-${childNode.name}-expand`}
+                      onClick={() => {
+                        onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
+                      }}
+                    />
+                  )}
+
+                  <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+                </div>
+
+                <div className={styles.itemChildren}>
+                  {childNode.isExpanded && (
+                    <ScopesTreeLevel
+                      showQuery={showQuery}
+                      nodes={node.nodes}
+                      nodePath={childNodePath}
+                      loadingNodeName={loadingNodeName}
+                      scopeNames={scopeNames}
+                      onNodeUpdate={onNodeUpdate}
+                      onNodeSelectToggle={onNodeSelectToggle}
+                    />
+                  )}
+                </div>
               </div>
-
-              <div className={styles.itemChildren}>
-                {childNode.isExpanded && (
-                  <ScopesTreeLevel
-                    showQuery={showQuery}
-                    nodes={node.nodes}
-                    nodePath={childNodePath}
-                    loadingNodeName={loadingNodeName}
-                    scopeNames={scopeNames}
-                    onNodeUpdate={onNodeUpdate}
-                    onNodeSelectToggle={onNodeSelectToggle}
-                  />
-                )}
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
       </div>
     </>
   );
@@ -124,6 +122,9 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     searchInput: css({
       margin: theme.spacing(1, 0),
+    }),
+    loader: css({
+      padding: theme.spacing(1, 0),
     }),
     itemTitle: css({
       alignItems: 'center',

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import React, { useMemo } from 'react';
+import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, Icon, IconButton, Input, Spinner, useStyles2 } from '@grafana/ui';
+import { Checkbox, Icon, IconButton, Input, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { NodesMap } from './types';
@@ -54,7 +55,7 @@ export function ScopesTreeLevel({
       )}
 
       <div role="tree">
-        {isNodeLoading && <Spinner className={styles.loader} />}
+        {isNodeLoading && <Skeleton count={5} className={styles.loader} />}
 
         {!isNodeLoading &&
           childNodesArr.map((childNode) => {
@@ -124,7 +125,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       margin: theme.spacing(1, 0),
     }),
     loader: css({
-      padding: theme.spacing(1, 0),
+      margin: theme.spacing(0.5, 0),
     }),
     itemTitle: css({
       alignItems: 'center',


### PR DESCRIPTION
**What is this feature?**

Remove the disabled flag from the scopes node search input. Move to a reactive approach instead.

**Why do we need this feature?**

Because some users are typing more slowly and for cases where search takes more time this could create an annoying behavior.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
