### PR TITLE
RecentlyDeleted: Remove search box

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseFilters.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseFilters.tsx
@@ -11,11 +11,11 @@ export function BrowseFilters() {
     <div>
       <ActionRow
         showStarredFilter
+        showLayout
         state={searchState}
         getTagOptions={stateManager.getTagOptions}
         getSortOptions={getGrafanaSearcher().getSortOptions}
         sortPlaceholder={getGrafanaSearcher().sortPlaceholder}
-        includePanels={searchState.includePanels ?? false}
         onLayoutChange={stateManager.onLayoutChange}
         onStarredFilterChange={stateManager.onStarredFilterChange}
         onSortChange={stateManager.onSortChange}

--- a/public/app/features/manage-dashboards/RecentlyDeletedPage.tsx
+++ b/public/app/features/manage-dashboards/RecentlyDeletedPage.tsx
@@ -1,9 +1,7 @@
 import React, { memo, useEffect } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { FilterInput } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
-import { t } from 'app/core/internationalization';
 import { ActionRow } from 'app/features/search/page/components/ActionRow';
 import { getGrafanaSearcher } from 'app/features/search/service';
 
@@ -37,19 +35,11 @@ const RecentlyDeletedPage = memo(() => {
   return (
     <Page navId="dashboards/recentlyDeleted">
       <Page.Contents>
-        <FilterInput
-          placeholder={t('recentlyDeleted.filter.placeholder', 'Search for dashboards')}
-          value={searchState.query}
-          escapeRegex={false}
-          onChange={(e) => stateManager.onQueryChange(e)}
-        />
         <ActionRow
-          showStarredFilter={false}
           state={searchState}
           getTagOptions={stateManager.getTagOptions}
           getSortOptions={getGrafanaSearcher().getSortOptions}
           sortPlaceholder={getGrafanaSearcher().sortPlaceholder}
-          includePanels={false}
           onLayoutChange={stateManager.onLayoutChange}
           onSortChange={stateManager.onSortChange}
           onTagFilterChange={stateManager.onTagFilterChange}

--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -21,21 +21,21 @@ function getLayoutOptions() {
   ];
 }
 
-interface Props {
+interface ActionRowProps {
+  state: SearchState;
+  showStarredFilter?: boolean;
+  showLayout?: boolean;
+  sortPlaceholder?: string;
+
   onLayoutChange: (layout: SearchLayout) => void;
   onSortChange: (value?: string) => void;
   onStarredFilterChange?: (event: FormEvent<HTMLInputElement>) => void;
   onTagFilterChange: (tags: string[]) => void;
   getTagOptions: () => Promise<TermCount[]>;
   getSortOptions: () => Promise<SelectableValue[]>;
-  sortPlaceholder?: string;
   onDatasourceChange: (ds?: string) => void;
   onPanelTypeChange: (pt?: string) => void;
-  includePanels: boolean;
   onSetIncludePanels: (v: boolean) => void;
-  state: SearchState;
-  showStarredFilter?: boolean;
-  hideLayout?: boolean;
 }
 
 export function getValidQueryLayout(q: SearchState): SearchLayout {
@@ -52,20 +52,20 @@ export function getValidQueryLayout(q: SearchState): SearchLayout {
 }
 
 export const ActionRow = ({
+  state,
+  showStarredFilter,
+  showLayout,
+  sortPlaceholder,
   onLayoutChange,
   onSortChange,
   onStarredFilterChange = () => {},
   onTagFilterChange,
   getTagOptions,
   getSortOptions,
-  sortPlaceholder,
   onDatasourceChange,
   onPanelTypeChange,
   onSetIncludePanels,
-  state,
-  showStarredFilter,
-  hideLayout,
-}: Props) => {
+}: ActionRowProps) => {
   const styles = useStyles2(getStyles);
   const layout = getValidQueryLayout(state);
 
@@ -113,7 +113,7 @@ export const ActionRow = ({
       </Stack>
 
       <Stack gap={2}>
-        {!hideLayout && (
+        {showLayout && (
           <RadioButtonGroup
             options={getLayoutOptions()}
             disabledOptions={disabledOptions}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1479,11 +1479,6 @@
     },
     "query-editor-not-exported": "Data source plugin does not export any Query Editor component"
   },
-  "recentlyDeleted": {
-    "filter": {
-      "placeholder": "Search for dashboards"
-    }
-  },
   "refresh-picker": {
     "aria-label": {
       "choose-interval": "Auto refresh turned off. Choose refresh time interval",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1479,11 +1479,6 @@
     },
     "query-editor-not-exported": "Đäŧä şőūřčę pľūģįŉ đőęş ŉőŧ ęχpőřŧ äŉy Qūęřy Ēđįŧőř čőmpőŉęŉŧ"
   },
-  "recentlyDeleted": {
-    "filter": {
-      "placeholder": "Ŝęäřčĥ ƒőř đäşĥþőäřđş"
-    }
-  },
   "refresh-picker": {
     "aria-label": {
       "choose-interval": "Åūŧő řęƒřęşĥ ŧūřŉęđ őƒƒ. Cĥőőşę řęƒřęşĥ ŧįmę įŉŧęřväľ",


### PR DESCRIPTION
Removes the search field from Recently Deleted page so we can focus on getting the core flow in.

Later, we'll iterate on this and get search back.