### PR TITLE
Docs: fixes overview text height

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -20,9 +20,9 @@ title: Grafana OSS and Enterprise documentation
 hero:
   title: Grafana OSS and Enterprise documentation
   level: 1
-  width: 110
+  width: 100
   image: /media/docs/grafana-cloud/infrastructure/grafanalogo.svg
-  height: 110
+  height: 100
   description: Query, visualize, alert on, and explore your metrics, logs, and traces wherever they are stored.
 cards:
   title_class: pt-0 lh-1

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -16,9 +16,9 @@ labels:
     - enterprise
     - oss
 menuTitle: Grafana documentation
-title: Grafana OSS and Enterprise documentation
+title: Grafana OSS and Enterprise
 hero:
-  title: Grafana OSS and Enterprise documentation
+  title: Grafana OSS and Enterprise
   level: 1
   width: 100
   image: /media/docs/grafana-cloud/infrastructure/grafanalogo.svg


### PR DESCRIPTION
corrects the width and height for better display of the overview text on the landing page