### PR TITLE
RBAC: Resolve action sets when `GetPermissions` is called

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -146,7 +146,6 @@ func (s *Service) GetPermissions(ctx context.Context, user identity.Requester, r
 				if !slices.Contains(actions, actionSet) {
 					actions = append(actions, actionSet)
 				}
-
 			}
 		}
 	}

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"sort"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -172,7 +172,13 @@ func (s *Service) GetPermissions(ctx context.Context, user identity.Requester, r
 				if isFolderOrDashboardAction(action) {
 					actionSetActions := s.actionSetSvc.ResolveActionSet(action)
 					if len(actionSetActions) > 0 {
-						expandedActions = append(expandedActions, actionSetActions...)
+						for _, actionSetAction := range actionSetActions {
+							// This check is needed for resolving inherited permissions - we don't want to include
+							// actions that are not related to dashboards when expanding folder action sets
+							if slices.Contains(s.actions, actionSetAction) {
+								expandedActions = append(expandedActions, actionSetAction)
+							}
+						}
 						continue
 					}
 				}


### PR DESCRIPTION
**What is this feature?**

Resolve action sets when `GetPermissions` method is called for managed permissions.

If we have the following DB entry in the DB
```
id	role_id	action	scope	created	updated	kind	attribute	identifier
2,026	134	folders:edit	folders:uid:bdjlmv34oomiof	2024-06-11 12:36:42	2024-06-11 12:36:42	folders	uid	bdjlmv34oomiof
```
and no other permissions for folder with UID `edibxrlatnocgf` stored in the DB, we wouldn't be able to see this permission  in the UI.

To test:
* set `only_store_access_action_sets` in the config file under `[rbac]` section;
* add `accessActionSets` to feature toggles in the config file;
* navigate to any folder;
* add a permission to a new user/team;
* observe that the permission appears in the UI;
* retest without these changes - the permission won't be visible.


**Why do we need this feature?**

This is need to correctly display permissions in the UI when action sets are enabled. Otherwise if only action sets are stored in the DB, we were not including these permissions in the response.

Note that in the future when we completely switch to using only action sets, we can refactor the code to not translate between action sets and the underlying permissions, and simply return the action set (issue for this: https://github.com/grafana/identity-access-team/issues/725)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/724
