### PR TITLE
Plugin extensions: Add e2e tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,6 +13,8 @@ node_modules
 /public/lib/monaco
 /scripts/grafana-server/tmp
 vendor
+e2e/custom-plugins
+playwright-report
 
 # TS generate from cue by cuetsy
 **/*.gen.ts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -223,7 +223,7 @@
 /devenv/local-npm/ @grafana/frontend-ops
 /devenv/vscode/ @grafana/frontend-ops
 /devenv/setup.sh @grafana/grafana-backend-services-squad
-devenv/plugins.yaml @grafana/plugins-platform-frontend
+/devenv/plugins.yaml @grafana/plugins-platform-frontend
 
 # Emails
 /emails/ @grafana/alerting-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -223,6 +223,7 @@
 /devenv/local-npm/ @grafana/frontend-ops
 /devenv/vscode/ @grafana/frontend-ops
 /devenv/setup.sh @grafana/grafana-backend-services-squad
+devenv/plugins.yaml @grafana/plugins-platform-frontend
 
 # Emails
 /emails/ @grafana/alerting-frontend

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -235,7 +235,7 @@ yarn e2e:dev
 
 #### To run the Playwright tests:
 
-**Note:** If you're using VS Code as your development editor, it's recommended to install the [Playwright test extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright). It allows you to run, debug and generate Playwright tests from within the editor. For more information about the extension and how to install it, refer to the [Playwright documentation](https://playwright.dev/docs/getting-started-vscode).
+**Note:** If you're using VS Code as your development editor, it's recommended to install the [Playwright test extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright). It allows you to run, debug and generate Playwright tests from within the editor. For more information about the extension and how to use reports to analyze failing tests, refer to the [Playwright documentation](https://playwright.dev/docs/getting-started-vscode).
 
 Each version of Playwright needs specific versions of browser binaries to operate. You need to use the Playwright CLI to install these browsers.
 
@@ -243,22 +243,16 @@ Each version of Playwright needs specific versions of browser binaries to operat
 yarn playwright install chromium
 ```
 
-To run all tests in a headless Chromium browser and display results in the terminal:
+To run all tests in a headless Chromium browser and display results in the terminal. This assumes you have Grafana running on port 3000.
 
 ```
 yarn e2e:playwright
 ```
 
-For a better developer experience, open the Playwright UI where you can visually walk through each step of the test and see what was happening before, during, and after each step.
+The following script starts a Grafana [development server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) (same server that is being used when running e2e tests in Drone CI) on port 3001 and runs the Playwright tests. The development server is provisioned with the [devenv](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#add-data-sources) dashboards, data sources and apps.
 
 ```
-yarn e2e:playwright:ui
-```
-
-To open the HTML reporter for the last test run session:
-
-```
-yarn e2e:playwright:report
+yarn e2e:playwright:server
 ```
 
 ## Configure Grafana for development

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -33,3 +33,5 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
 The script above assumes you have Grafana running on `localhost:3000`. You may change this by providing environment variables.
 
 `HOST=127.0.0.1 PORT=3001 yarn e2e:playwright`
+
+- `yarn e2e:playwright:server` will start a Grafana [development server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) on port 3001 and run the Playwright tests. The development server is provisioned with the [devenv](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#add-data-sources) dashboards, data sources and apps.

--- a/devenv/dev-dashboards/extensions/link-onclick-extensions.json
+++ b/devenv/dev-dashboards/extensions/link-onclick-extensions.json
@@ -1,0 +1,342 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "title": "Link with one query",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "showRowNums": false
+      },
+      "pluginVersion": "10.1.0-55406pre",
+      "title": "No extensions",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 4
+        },
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "seriesCount": 1
+        }
+      ],
+      "title": "Link with new name",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "testdata"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "seriesCount": 1
+        },
+        {
+          "datasource": {
+            "type": "testdata"
+          },
+          "hide": false,
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "seriesCount": 1
+        }
+      ],
+      "title": "Link with defaults",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Link Extensions (onClick)",
+  "uid": "dbfb47c5-e5e5-4d28-8ac7-35f349b95946",
+  "version": 1,
+  "weekStart": ""
+}

--- a/devenv/dev-dashboards/extensions/link-path-extensions.json
+++ b/devenv/dev-dashboards/extensions/link-path-extensions.json
@@ -1,0 +1,237 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "testdata"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "id": 6,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "showRowNums": false
+        },
+        "pluginVersion": "9.5.0-53420pre",
+        "title": "No extensions",
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "testdata"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": []
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        },
+        "id": 4,
+        "options": {
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "testdata"
+            },
+            "refId": "A",
+            "scenarioId": "random_walk",
+            "seriesCount": 4
+          }
+        ],
+        "title": "Link with new name",
+        "type": "piechart"
+      },
+      {
+        "datasource": {
+          "type": "testdata"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 8
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "title": "Link with defaults",
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Link Extensions (path)",
+    "uid": "d1fbb077-cd44-4738-8c8a-d4e66748b719",
+    "version": 3,
+    "weekStart": ""
+  }

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -58,6 +58,8 @@
     "join-by-field": (import '../dev-dashboards/transforms/join-by-field.json'),
     "join-by-labels": (import '../dev-dashboards/transforms/join-by-labels.json'),
     "lazy_loading": (import '../dev-dashboards/panel-common/lazy_loading.json'),
+    "link-onclick-extensions": (import '../dev-dashboards/extensions/link-onclick-extensions.json'),
+    "link-path-extensions": (import '../dev-dashboards/extensions/link-path-extensions.json'),
     "linked-viz": (import '../dev-dashboards/panel-common/linked-viz.json'),
     "live-flakey": (import '../dev-dashboards/live/live-flakey.json'),
     "live-flakey-refresh": (import '../dev-dashboards/live/live-flakey-refresh.json'),

--- a/devenv/plugins.yaml
+++ b/devenv/plugins.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+apps:
+  - type: myorg-extensions-app
+    org_id: 1
+    org_name: Main Org.
+    disabled: false
+  - type: myorg-a-app
+    org_id: 1
+    org_name: Main Org.
+    disabled: false
+  - type: myorg-b-app
+    org_id: 1
+    org_name: Main Org.
+    disabled: false
+  - type: myorg-extensionpoint-app
+    org_id: 1
+    org_name: Main Org.
+    disabled: false

--- a/e2e/custom-plugins/README.md
+++ b/e2e/custom-plugins/README.md
@@ -1,0 +1,5 @@
+# Custom plugins
+
+Plugins in this directory will be installed when the e2e [test server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) is started. Optionally, you can provision the plugin by adding configuration to the [datasources.yaml](https://github.com/grafana/grafana/blob/extensions/add-e2e-tests/devenv/datasources.yaml) or to the [plugins.yaml](https://github.com/grafana/grafana/blob/extensions/add-e2e-tests/devenv/plugins.yaml).
+
+These plugins are not being built as part of CI. Plugins in this directory are being version controlled, so make sure the bundle size is small. Only use dependencies provided by the runtime (see list of runtime dependencies [here](https://github.com/grafana/plugin-tools/blob/08b67179bdbf8847788c54aadb22654aa1a7c060/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts#L36)).

--- a/e2e/custom-plugins/app-with-extension-point/README.md
+++ b/e2e/custom-plugins/app-with-extension-point/README.md
@@ -1,0 +1,12 @@
+# App with extension point
+
+This app was initially copied from the [app-with-extension-point](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-extension-point) example plugin. The plugin bundle is using AMD, but it's not minified and the plugin feature set is small so it should be possible to make changes in this file if necessary.
+
+To test this app:
+
+```sh
+# start e2e test instance (it will install this plugin)
+PORT=3000 ./scripts/grafana-server/start-server
+# run Playwright tests using Playwright VSCode extension or with the following script
+yarn e2e:playwright
+```

--- a/e2e/custom-plugins/app-with-extension-point/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/module.js
@@ -1,0 +1,197 @@
+define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], (e, t, n, a) =>
+  (() => {
+    'use strict';
+    let o = {
+        781: (t) => {
+          t.exports = e;
+        },
+        531: (e) => {
+          e.exports = a;
+        },
+        7: (e) => {
+          e.exports = n;
+        },
+        959: (e) => {
+          e.exports = t;
+        },
+      },
+      r = {};
+    function i(e) {
+      let t = r[e];
+      if (void 0 !== t) {
+        return t.exports;
+      }
+      let n = (r[e] = { exports: {} });
+      return o[e](n, n.exports, i), n.exports;
+    }
+    (i.n = (e) => {
+      let t = e && e.__esModule ? () => e.default : () => e;
+      return i.d(t, { a: t }), t;
+    }),
+      (i.d = (e, t) => {
+        for (let n in t) {
+          i.o(t, n) && !i.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
+        }
+      }),
+      (i.g = (function () {
+        if ('object' === typeof globalThis) {
+          return globalThis;
+        }
+        try {
+          return this || new Function('return this')();
+        } catch (e) {
+          if ('object' === typeof window) {
+            return window;
+          }
+        }
+      })()),
+      (i.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
+      (i.r = (e) => {
+        'undefined' !== typeof Symbol &&
+          Symbol.toStringTag &&
+          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
+          Object.defineProperty(e, '__esModule', { value: !0 });
+      });
+    let l = {};
+    return (
+      (() => {
+        i.r(l), i.d(l, { plugin: () => p });
+        let e = i(781),
+          t = i(959),
+          n = i.n(t),
+          a = i(7),
+          o = i(531);
+        const r = {
+          container: 'main-app-body',
+          actions: { button: 'action-button' },
+          modal: { container: 'container', open: 'open-link' },
+          appA: { container: 'a-app-body' },
+          appB: { modal: 'b-app-modal' },
+        };
+        function s(t) {
+          const { onDismiss: l, title: s, path: c } = t;
+          return n().createElement(
+            a.Modal,
+            { 'data-testid': r.modal.container, title: s, isOpen: !0, onDismiss: l },
+            n().createElement(
+              a.VerticalGroup,
+              { spacing: 'sm' },
+              n().createElement('p', null, 'Do you want to proceed in the current tab or open a new tab?')
+            ),
+            n().createElement(
+              a.Modal.ButtonRow,
+              null,
+              n().createElement(a.Button, { onClick: l, fill: 'outline', variant: 'secondary' }, 'Cancel'),
+              n().createElement(
+                a.Button,
+                {
+                  type: 'submit',
+                  variant: 'secondary',
+                  onClick: () => {
+                    i.g.open(e.locationUtil.assureBaseUrl(c), '_blank'), l();
+                  },
+                  icon: 'external-link-alt',
+                },
+                'Open in new tab'
+              ),
+              n().createElement(
+                a.Button,
+                {
+                  'data-testid': r.modal.open,
+                  type: 'submit',
+                  variant: 'primary',
+                  onClick: () => o.locationService.push(c),
+                  icon: 'apps',
+                },
+                'Open'
+              )
+            )
+          );
+        }
+        function c(e) {
+          const i =
+            ((l = e.extensions),
+            (0, t.useMemo)(
+              () =>
+                l.reduce(
+                  (e, t) => (
+                    (0, o.isPluginExtensionLink)(t) && e.push({ label: t.title, title: t.title, value: t }), e
+                  ),
+                  []
+                ),
+              [l]
+            ));
+          let l;
+          const [c, u] = (0, t.useState)();
+          return 0 === i.length
+            ? n().createElement(a.Button, null, 'Run default action')
+            : n().createElement(
+                n().Fragment,
+                null,
+                n().createElement(
+                  a.ButtonGroup,
+                  null,
+                  n().createElement(
+                    a.ToolbarButton,
+                    {
+                      key: 'default-action',
+                      variant: 'canvas',
+                      onClick: () => alert('You triggered the default action'),
+                    },
+                    'Run default action'
+                  ),
+                  n().createElement(a.ButtonSelect, {
+                    'data-testid': r.actions.button,
+                    key: 'select-extension',
+                    variant: 'canvas',
+                    options: i,
+                    onChange: (e) => {
+                      const t = e.value;
+                      if ((0, o.isPluginExtensionLink)(t)) {
+                        if (t.path) {
+                          return u(t);
+                        }
+                        if (t.onClick) {
+                          return t.onClick();
+                        }
+                      }
+                    },
+                  })
+                ),
+                c &&
+                  (null == c ? void 0 : c.path) &&
+                  n().createElement(s, { title: c.title, path: c.path, onDismiss: () => u(void 0) })
+              );
+        }
+        class u extends n().PureComponent {
+          render() {
+            const { extensions: e } = (0, o.getPluginExtensions)({
+              extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+              context: {},
+            });
+            return n().createElement(
+              'div',
+              { 'data-testid': r.container, style: { marginTop: '5%' } },
+              n().createElement(
+                a.HorizontalGroup,
+                { align: 'flex-start', justify: 'center' },
+                n().createElement(
+                  a.HorizontalGroup,
+                  null,
+                  n().createElement(
+                    'span',
+                    null,
+                    'Hello Grafana! These are the actions you can trigger from this plugin'
+                  ),
+                  n().createElement(c, { extensions: e })
+                )
+              )
+            );
+          }
+        }
+        const p = new e.AppPlugin().setRootPage(u);
+      })(),
+      l
+    );
+  })());
+//# sourceMappingURL=module.js.map

--- a/e2e/custom-plugins/app-with-extension-point/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/module.js
@@ -1,185 +1,141 @@
-define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], (e, t, n, a) =>
-  (() => {
-    'use strict';
-    var o = {
-        781: (t) => {
-          t.exports = e;
-        },
-        531: (e) => {
-          e.exports = a;
-        },
-        7: (e) => {
-          e.exports = n;
-        },
-        959: (e) => {
-          e.exports = t;
-        },
-      },
-      r = {};
-    function i(e) {
-      var t = r[e];
-      if (void 0 !== t) return t.exports;
-      var n = (r[e] = { exports: {} });
-      return o[e](n, n.exports, i), n.exports;
-    }
-    (i.n = (e) => {
-      var t = e && e.__esModule ? () => e.default : () => e;
-      return i.d(t, { a: t }), t;
-    }),
-      (i.d = (e, t) => {
-        for (var n in t) i.o(t, n) && !i.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
-      }),
-      (i.g = (function () {
-        if ('object' == typeof globalThis) return globalThis;
-        try {
-          return this || new Function('return this')();
-        } catch (e) {
-          if ('object' == typeof window) return window;
-        }
-      })()),
-      (i.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
-      (i.r = (e) => {
-        'undefined' != typeof Symbol &&
-          Symbol.toStringTag &&
-          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
-          Object.defineProperty(e, '__esModule', { value: !0 });
-      });
-    var l = {};
-    return (
-      (() => {
-        i.r(l), i.d(l, { plugin: () => p });
-        var e = i(781),
-          t = i(959),
-          n = i.n(t),
-          a = i(7),
-          o = i(531);
-        const r = {
-          container: 'main-app-body',
-          actions: { button: 'action-button' },
-          modal: { container: 'container', open: 'open-link' },
-          appA: { container: 'a-app-body' },
-          appB: { modal: 'b-app-modal' },
-        };
-        function s(t) {
-          const { onDismiss: l, title: s, path: c } = t;
-          return n().createElement(
-            a.Modal,
-            { 'data-testid': r.modal.container, title: s, isOpen: !0, onDismiss: l },
-            n().createElement(
-              a.VerticalGroup,
-              { spacing: 'sm' },
-              n().createElement('p', null, 'Do you want to proceed in the current tab or open a new tab?')
-            ),
-            n().createElement(
-              a.Modal.ButtonRow,
-              null,
-              n().createElement(a.Button, { onClick: l, fill: 'outline', variant: 'secondary' }, 'Cancel'),
-              n().createElement(
-                a.Button,
-                {
-                  type: 'submit',
-                  variant: 'secondary',
-                  onClick: () => {
-                    i.g.open(e.locationUtil.assureBaseUrl(c), '_blank'), l();
-                  },
-                  icon: 'external-link-alt',
-                },
-                'Open in new tab'
-              ),
-              n().createElement(
-                a.Button,
-                {
-                  'data-testid': r.modal.open,
-                  type: 'submit',
-                  variant: 'primary',
-                  onClick: () => o.locationService.push(c),
-                  icon: 'apps',
-                },
-                'Open'
-              )
-            )
-          );
-        }
-        function c(e) {
-          const i =
-            ((l = e.extensions),
-            (0, t.useMemo)(
-              () =>
-                l.reduce(
-                  (e, t) => (
-                    (0, o.isPluginExtensionLink)(t) && e.push({ label: t.title, title: t.title, value: t }), e
-                  ),
-                  []
-                ),
-              [l]
-            ));
-          var l;
-          const [c, u] = (0, t.useState)();
-          return 0 === i.length
-            ? n().createElement(a.Button, null, 'Run default action')
-            : n().createElement(
-                n().Fragment,
-                null,
-                n().createElement(
-                  a.ButtonGroup,
-                  null,
-                  n().createElement(
-                    a.ToolbarButton,
-                    {
-                      key: 'default-action',
-                      variant: 'canvas',
-                      onClick: () => alert('You triggered the default action'),
-                    },
-                    'Run default action'
-                  ),
-                  n().createElement(a.ButtonSelect, {
-                    'data-testid': r.actions.button,
-                    key: 'select-extension',
-                    variant: 'canvas',
-                    options: i,
-                    onChange: (e) => {
-                      const t = e.value;
-                      if ((0, o.isPluginExtensionLink)(t)) {
-                        if (t.path) return u(t);
-                        if (t.onClick) return t.onClick();
-                      }
-                    },
-                  })
-                ),
-                c &&
-                  (null == c ? void 0 : c.path) &&
-                  n().createElement(s, { title: c.title, path: c.path, onDismiss: () => u(void 0) })
-              );
-        }
-        class u extends n().PureComponent {
-          render() {
-            const { extensions: e } = (0, o.getPluginExtensions)({
-              extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
-              context: {},
-            });
-            return n().createElement(
-              'div',
-              { 'data-testid': r.container, style: { marginTop: '5%' } },
-              n().createElement(
-                a.HorizontalGroup,
-                { align: 'flex-start', justify: 'center' },
-                n().createElement(
-                  a.HorizontalGroup,
-                  null,
-                  n().createElement(
-                    'span',
-                    null,
-                    'Hello Grafana! These are the actions you can trigger from this plugin'
-                  ),
-                  n().createElement(c, { extensions: e })
-                )
-              )
-            );
-          }
-        }
-        const p = new e.AppPlugin().setRootPage(u);
-      })(),
-      l
+define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], function (data, React, UI, runtime) {
+  'use strict';
+
+  const styles = {
+    container: 'main-app-body',
+    actions: { button: 'action-button' },
+    modal: { container: 'container', open: 'open-link' },
+    appA: { container: 'a-app-body' },
+    appB: { modal: 'b-app-modal' },
+  };
+
+  function ModalComponent({ onDismiss, title, path }) {
+    return React.createElement(
+      UI.Modal,
+      { 'data-testid': styles.modal.container, title, isOpen: true, onDismiss },
+      React.createElement(
+        UI.VerticalGroup,
+        { spacing: 'sm' },
+        React.createElement('p', null, 'Do you want to proceed in the current tab or open a new tab?')
+      ),
+      React.createElement(
+        UI.Modal.ButtonRow,
+        null,
+        React.createElement(UI.Button, { onClick: onDismiss, fill: 'outline', variant: 'secondary' }, 'Cancel'),
+        React.createElement(
+          UI.Button,
+          {
+            type: 'submit',
+            variant: 'secondary',
+            onClick: function () {
+              window.open(data.locationUtil.assureBaseUrl(path), '_blank');
+              onDismiss();
+            },
+            icon: 'external-link-alt',
+          },
+          'Open in new tab'
+        ),
+        React.createElement(
+          UI.Button,
+          {
+            'data-testid': styles.modal.open,
+            type: 'submit',
+            variant: 'primary',
+            onClick: function () {
+              runtime.locationService.push(path);
+            },
+            icon: 'apps',
+          },
+          'Open'
+        )
+      )
     );
-  })());
-//# sourceMappingURL=module.js.map
+  }
+
+  function ActionComponent({ extensions }) {
+    const options = React.useMemo(
+      function () {
+        return extensions.reduce(function (acc, extension) {
+          if (runtime.isPluginExtensionLink(extension)) {
+            acc.push({ label: extension.title, title: extension.title, value: extension });
+          }
+          return acc;
+        }, []);
+      },
+      [extensions]
+    );
+
+    const [selected, setSelected] = React.useState();
+
+    return options.length === 0
+      ? React.createElement(UI.Button, null, 'Run default action')
+      : React.createElement(
+          React.Fragment,
+          null,
+          React.createElement(
+            UI.ButtonGroup,
+            null,
+            React.createElement(
+              UI.ToolbarButton,
+              {
+                key: 'default-action',
+                variant: 'canvas',
+                onClick: function () {
+                  alert('You triggered the default action');
+                },
+              },
+              'Run default action'
+            ),
+            React.createElement(UI.ButtonSelect, {
+              'data-testid': styles.actions.button,
+              key: 'select-extension',
+              variant: 'canvas',
+              options: options,
+              onChange: function (e) {
+                const extension = e.value;
+                if (runtime.isPluginExtensionLink(extension)) {
+                  if (extension.path) setSelected(extension);
+                  if (extension.onClick) extension.onClick();
+                }
+              },
+            })
+          ),
+          selected &&
+            selected.path &&
+            React.createElement(ModalComponent, {
+              title: selected.title,
+              path: selected.path,
+              onDismiss: function () {
+                setSelected(undefined);
+              },
+            })
+        );
+  }
+
+  class RootComponent extends React.PureComponent {
+    render() {
+      const { extensions } = runtime.getPluginExtensions({
+        extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+        context: {},
+      });
+
+      return React.createElement(
+        'div',
+        { 'data-testid': styles.container, style: { marginTop: '5%' } },
+        React.createElement(
+          UI.HorizontalGroup,
+          { align: 'flex-start', justify: 'center' },
+          React.createElement(
+            UI.HorizontalGroup,
+            null,
+            React.createElement('span', null, 'Hello Grafana! These are the actions you can trigger from this plugin'),
+            React.createElement(ActionComponent, { extensions: extensions })
+          )
+        )
+      );
+    }
+  }
+
+  const plugin = new data.AppPlugin().setRootPage(RootComponent);
+  return { plugin: plugin };
+});

--- a/e2e/custom-plugins/app-with-extension-point/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/module.js
@@ -1,7 +1,7 @@
 define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], (e, t, n, a) =>
   (() => {
     'use strict';
-    let o = {
+    var o = {
         781: (t) => {
           t.exports = e;
         },
@@ -17,46 +17,38 @@ define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], (e, t, n, 
       },
       r = {};
     function i(e) {
-      let t = r[e];
-      if (void 0 !== t) {
-        return t.exports;
-      }
-      let n = (r[e] = { exports: {} });
+      var t = r[e];
+      if (void 0 !== t) return t.exports;
+      var n = (r[e] = { exports: {} });
       return o[e](n, n.exports, i), n.exports;
     }
     (i.n = (e) => {
-      let t = e && e.__esModule ? () => e.default : () => e;
+      var t = e && e.__esModule ? () => e.default : () => e;
       return i.d(t, { a: t }), t;
     }),
       (i.d = (e, t) => {
-        for (let n in t) {
-          i.o(t, n) && !i.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
-        }
+        for (var n in t) i.o(t, n) && !i.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
       }),
       (i.g = (function () {
-        if ('object' === typeof globalThis) {
-          return globalThis;
-        }
+        if ('object' == typeof globalThis) return globalThis;
         try {
           return this || new Function('return this')();
         } catch (e) {
-          if ('object' === typeof window) {
-            return window;
-          }
+          if ('object' == typeof window) return window;
         }
       })()),
       (i.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
       (i.r = (e) => {
-        'undefined' !== typeof Symbol &&
+        'undefined' != typeof Symbol &&
           Symbol.toStringTag &&
           Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
           Object.defineProperty(e, '__esModule', { value: !0 });
       });
-    let l = {};
+    var l = {};
     return (
       (() => {
         i.r(l), i.d(l, { plugin: () => p });
-        let e = i(781),
+        var e = i(781),
           t = i(959),
           n = i.n(t),
           a = i(7),
@@ -121,7 +113,7 @@ define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], (e, t, n, 
                 ),
               [l]
             ));
-          let l;
+          var l;
           const [c, u] = (0, t.useState)();
           return 0 === i.length
             ? n().createElement(a.Button, null, 'Run default action')
@@ -148,12 +140,8 @@ define(['@grafana/data', 'react', '@grafana/ui', '@grafana/runtime'], (e, t, n, 
                     onChange: (e) => {
                       const t = e.value;
                       if ((0, o.isPluginExtensionLink)(t)) {
-                        if (t.path) {
-                          return u(t);
-                        }
-                        if (t.onClick) {
-                          return t.onClick();
-                        }
+                        if (t.path) return u(t);
+                        if (t.onClick) return t.onClick();
                       }
                     },
                   })

--- a/e2e/custom-plugins/app-with-extension-point/plugin.json
+++ b/e2e/custom-plugins/app-with-extension-point/plugin.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "type": "app",
+  "name": "Extension Point App",
+  "id": "myorg-extensionpoint-app",
+  "preload": true,
+  "info": {
+    "keywords": ["app"],
+    "description": "Show case how to add an extension point to your plugin",
+    "author": {
+      "name": "Myorg"
+    },
+    "logos": {
+      "small": "img/logo.svg",
+      "large": "img/logo.svg"
+    },
+    "screenshots": [],
+    "version": "1.0.0",
+    "updated": "2024-06-11"
+  },
+  "includes": [
+    {
+      "type": "page",
+      "name": "Default",
+      "path": "/a/myorg-extensionpoint-app",
+      "role": "Admin",
+      "addToNav": true,
+      "defaultNav": true
+    }
+  ],
+  "dependencies": {
+    "grafanaDependency": ">=10.3.3",
+    "plugins": []
+  },
+  "generated": {
+    "extensions": []
+  }
+}

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/module.js
@@ -1,0 +1,55 @@
+define(['@grafana/data', 'react'], (e, t) =>
+  (() => {
+    'use strict';
+    let o = {
+        781: (t) => {
+          t.exports = e;
+        },
+        959: (e) => {
+          e.exports = t;
+        },
+      },
+      r = {};
+    function n(e) {
+      let t = r[e];
+      if (void 0 !== t) {
+        return t.exports;
+      }
+      let a = (r[e] = { exports: {} });
+      return o[e](a, a.exports, n), a.exports;
+    }
+    (n.d = (e, t) => {
+      for (let o in t) {
+        n.o(t, o) && !n.o(e, o) && Object.defineProperty(e, o, { enumerable: !0, get: t[o] });
+      }
+    }),
+      (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
+      (n.r = (e) => {
+        'undefined' !== typeof Symbol &&
+          Symbol.toStringTag &&
+          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
+          Object.defineProperty(e, '__esModule', { value: !0 });
+      });
+    let a = {};
+    return (
+      (() => {
+        n.r(a), n.d(a, { plugin: () => i });
+        let e = n(781),
+          t = n(959);
+        const o = 'a-app-body';
+        class r extends t.PureComponent {
+          render() {
+            return t.createElement('div', { 'data-testid': o, className: 'page-container' }, 'Hello Grafana!');
+          }
+        }
+        const i = new e.AppPlugin().setRootPage(r).configureExtensionLink({
+          title: 'Go to A',
+          description: 'Navigating to pluging A',
+          extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+          path: '/a/myorg-a-app/',
+        });
+      })(),
+      a
+    );
+  })());
+//# sourceMappingURL=module.js.map

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/module.js
@@ -1,7 +1,7 @@
 define(['@grafana/data', 'react'], (e, t) =>
   (() => {
     'use strict';
-    let o = {
+    var o = {
         781: (t) => {
           t.exports = e;
         },
@@ -11,30 +11,26 @@ define(['@grafana/data', 'react'], (e, t) =>
       },
       r = {};
     function n(e) {
-      let t = r[e];
-      if (void 0 !== t) {
-        return t.exports;
-      }
-      let a = (r[e] = { exports: {} });
+      var t = r[e];
+      if (void 0 !== t) return t.exports;
+      var a = (r[e] = { exports: {} });
       return o[e](a, a.exports, n), a.exports;
     }
     (n.d = (e, t) => {
-      for (let o in t) {
-        n.o(t, o) && !n.o(e, o) && Object.defineProperty(e, o, { enumerable: !0, get: t[o] });
-      }
+      for (var o in t) n.o(t, o) && !n.o(e, o) && Object.defineProperty(e, o, { enumerable: !0, get: t[o] });
     }),
       (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
       (n.r = (e) => {
-        'undefined' !== typeof Symbol &&
+        'undefined' != typeof Symbol &&
           Symbol.toStringTag &&
           Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
           Object.defineProperty(e, '__esModule', { value: !0 });
       });
-    let a = {};
+    var a = {};
     return (
       (() => {
         n.r(a), n.d(a, { plugin: () => i });
-        let e = n(781),
+        var e = n(781),
           t = n(959);
         const o = 'a-app-body';
         class r extends t.PureComponent {
@@ -42,12 +38,14 @@ define(['@grafana/data', 'react'], (e, t) =>
             return t.createElement('div', { 'data-testid': o, className: 'page-container' }, 'Hello Grafana!');
           }
         }
-        const i = new e.AppPlugin().setRootPage(r).configureExtensionLink({
-          title: 'Go to A',
-          description: 'Navigating to pluging A',
-          extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
-          path: '/a/myorg-a-app/',
-        });
+        const i = new e.AppPlugin()
+          .setRootPage(r)
+          .configureExtensionLink({
+            title: 'Go to A',
+            description: 'Navigating to pluging A',
+            extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+            path: '/a/myorg-a-app/',
+          });
       })(),
       a
     );

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/module.js
@@ -1,53 +1,26 @@
-define(['@grafana/data', 'react'], (e, t) =>
-  (() => {
-    'use strict';
-    var o = {
-        781: (t) => {
-          t.exports = e;
-        },
-        959: (e) => {
-          e.exports = t;
-        },
-      },
-      r = {};
-    function n(e) {
-      var t = r[e];
-      if (void 0 !== t) return t.exports;
-      var a = (r[e] = { exports: {} });
-      return o[e](a, a.exports, n), a.exports;
+define(['@grafana/data', 'react'], function (data, React) {
+  'use strict';
+
+  const styles = {
+    container: 'a-app-body',
+  };
+
+  class RootComponent extends React.PureComponent {
+    render() {
+      return React.createElement(
+        'div',
+        { 'data-testid': styles.container, className: 'page-container' },
+        'Hello Grafana!'
+      );
     }
-    (n.d = (e, t) => {
-      for (var o in t) n.o(t, o) && !n.o(e, o) && Object.defineProperty(e, o, { enumerable: !0, get: t[o] });
-    }),
-      (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
-      (n.r = (e) => {
-        'undefined' != typeof Symbol &&
-          Symbol.toStringTag &&
-          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
-          Object.defineProperty(e, '__esModule', { value: !0 });
-      });
-    var a = {};
-    return (
-      (() => {
-        n.r(a), n.d(a, { plugin: () => i });
-        var e = n(781),
-          t = n(959);
-        const o = 'a-app-body';
-        class r extends t.PureComponent {
-          render() {
-            return t.createElement('div', { 'data-testid': o, className: 'page-container' }, 'Hello Grafana!');
-          }
-        }
-        const i = new e.AppPlugin()
-          .setRootPage(r)
-          .configureExtensionLink({
-            title: 'Go to A',
-            description: 'Navigating to pluging A',
-            extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
-            path: '/a/myorg-a-app/',
-          });
-      })(),
-      a
-    );
-  })());
-//# sourceMappingURL=module.js.map
+  }
+
+  const plugin = new data.AppPlugin().setRootPage(RootComponent).configureExtensionLink({
+    title: 'Go to A',
+    description: 'Navigating to plugin A',
+    extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+    path: '/a/myorg-a-app/',
+  });
+
+  return { plugin: plugin };
+});

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/plugin.json
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-a-app/plugin.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "type": "app",
+  "name": "A App",
+  "id": "myorg-a-app",
+  "preload": true,
+  "info": {
+    "keywords": ["app"],
+    "description": "Will extend root app with ui extensions",
+    "author": {
+      "name": "Myorg"
+    },
+    "logos": {
+      "small": "img/logo.svg",
+      "large": "img/logo.svg"
+    },
+    "screenshots": [],
+    "version": "%VERSION%",
+    "updated": "%TODAY%"
+  },
+  "includes": [
+    {
+      "type": "page",
+      "name": "Default",
+      "path": "/a/myorg-a-app",
+      "role": "Admin",
+      "addToNav": false,
+      "defaultNav": false
+    }
+  ],
+  "dependencies": {
+    "grafanaDependency": ">=10.3.3",
+    "plugins": []
+  },
+  "generated": {
+    "extensions": [
+      {
+        "extensionPointId": "plugins/myorg-extensionpoint-app/actions",
+        "title": "Go to A",
+        "description": "Navigating to pluging A",
+        "type": "link"
+      }
+    ]
+  }
+}

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/module.js
@@ -1,7 +1,7 @@
 define(['react', '@grafana/data'], (e, t) =>
   (() => {
     'use strict';
-    let r = {
+    var r = {
         781: (e) => {
           e.exports = t;
         },
@@ -11,34 +11,30 @@ define(['react', '@grafana/data'], (e, t) =>
       },
       o = {};
     function n(e) {
-      let t = o[e];
-      if (void 0 !== t) {
-        return t.exports;
-      }
-      let a = (o[e] = { exports: {} });
+      var t = o[e];
+      if (void 0 !== t) return t.exports;
+      var a = (o[e] = { exports: {} });
       return r[e](a, a.exports, n), a.exports;
     }
     (n.n = (e) => {
-      let t = e && e.__esModule ? () => e.default : () => e;
+      var t = e && e.__esModule ? () => e.default : () => e;
       return n.d(t, { a: t }), t;
     }),
       (n.d = (e, t) => {
-        for (let r in t) {
-          n.o(t, r) && !n.o(e, r) && Object.defineProperty(e, r, { enumerable: !0, get: t[r] });
-        }
+        for (var r in t) n.o(t, r) && !n.o(e, r) && Object.defineProperty(e, r, { enumerable: !0, get: t[r] });
       }),
       (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
       (n.r = (e) => {
-        'undefined' !== typeof Symbol &&
+        'undefined' != typeof Symbol &&
           Symbol.toStringTag &&
           Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
           Object.defineProperty(e, '__esModule', { value: !0 });
       });
-    let a = {};
+    var a = {};
     return (
       (() => {
         n.r(a), n.d(a, { plugin: () => p });
-        let e = n(959),
+        var e = n(959),
           t = n.n(e),
           r = n(781);
         class o extends e.PureComponent {

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/module.js
@@ -1,0 +1,65 @@
+define(['react', '@grafana/data'], (e, t) =>
+  (() => {
+    'use strict';
+    let r = {
+        781: (e) => {
+          e.exports = t;
+        },
+        959: (t) => {
+          t.exports = e;
+        },
+      },
+      o = {};
+    function n(e) {
+      let t = o[e];
+      if (void 0 !== t) {
+        return t.exports;
+      }
+      let a = (o[e] = { exports: {} });
+      return r[e](a, a.exports, n), a.exports;
+    }
+    (n.n = (e) => {
+      let t = e && e.__esModule ? () => e.default : () => e;
+      return n.d(t, { a: t }), t;
+    }),
+      (n.d = (e, t) => {
+        for (let r in t) {
+          n.o(t, r) && !n.o(e, r) && Object.defineProperty(e, r, { enumerable: !0, get: t[r] });
+        }
+      }),
+      (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
+      (n.r = (e) => {
+        'undefined' !== typeof Symbol &&
+          Symbol.toStringTag &&
+          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
+          Object.defineProperty(e, '__esModule', { value: !0 });
+      });
+    let a = {};
+    return (
+      (() => {
+        n.r(a), n.d(a, { plugin: () => p });
+        let e = n(959),
+          t = n.n(e),
+          r = n(781);
+        class o extends e.PureComponent {
+          render() {
+            return e.createElement('div', { className: 'page-container' }, 'Hello Grafana!');
+          }
+        }
+        const i = 'b-app-modal',
+          p = new r.AppPlugin().setRootPage(o).configureExtensionLink({
+            title: 'Open from B',
+            description: 'Open a modal from plugin B',
+            extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+            onClick: (e, { openModal: r }) => {
+              r({
+                title: 'Modal from app B',
+                body: () => t().createElement('div', { 'data-testid': i }, 'From plugin B'),
+              });
+            },
+          });
+      })(),
+      a
+    );
+  })());
+//# sourceMappingURL=module.js.map

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/module.js
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/module.js
@@ -1,61 +1,27 @@
-define(['react', '@grafana/data'], (e, t) =>
-  (() => {
-    'use strict';
-    var r = {
-        781: (e) => {
-          e.exports = t;
-        },
-        959: (t) => {
-          t.exports = e;
-        },
-      },
-      o = {};
-    function n(e) {
-      var t = o[e];
-      if (void 0 !== t) return t.exports;
-      var a = (o[e] = { exports: {} });
-      return r[e](a, a.exports, n), a.exports;
+define(['react', '@grafana/data'], function (React, data) {
+  'use strict';
+
+  class RootComponent extends React.PureComponent {
+    render() {
+      return React.createElement('div', { className: 'page-container' }, 'Hello Grafana!');
     }
-    (n.n = (e) => {
-      var t = e && e.__esModule ? () => e.default : () => e;
-      return n.d(t, { a: t }), t;
-    }),
-      (n.d = (e, t) => {
-        for (var r in t) n.o(t, r) && !n.o(e, r) && Object.defineProperty(e, r, { enumerable: !0, get: t[r] });
-      }),
-      (n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
-      (n.r = (e) => {
-        'undefined' != typeof Symbol &&
-          Symbol.toStringTag &&
-          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
-          Object.defineProperty(e, '__esModule', { value: !0 });
+  }
+
+  const modalId = 'b-app-modal';
+
+  const plugin = new data.AppPlugin().setRootPage(RootComponent).configureExtensionLink({
+    title: 'Open from B',
+    description: 'Open a modal from plugin B',
+    extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
+    onClick: function (e, { openModal }) {
+      openModal({
+        title: 'Modal from app B',
+        body: function () {
+          return React.createElement('div', { 'data-testid': modalId }, 'From plugin B');
+        },
       });
-    var a = {};
-    return (
-      (() => {
-        n.r(a), n.d(a, { plugin: () => p });
-        var e = n(959),
-          t = n.n(e),
-          r = n(781);
-        class o extends e.PureComponent {
-          render() {
-            return e.createElement('div', { className: 'page-container' }, 'Hello Grafana!');
-          }
-        }
-        const i = 'b-app-modal',
-          p = new r.AppPlugin().setRootPage(o).configureExtensionLink({
-            title: 'Open from B',
-            description: 'Open a modal from plugin B',
-            extensionPointId: 'plugins/myorg-extensionpoint-app/actions',
-            onClick: (e, { openModal: r }) => {
-              r({
-                title: 'Modal from app B',
-                body: () => t().createElement('div', { 'data-testid': i }, 'From plugin B'),
-              });
-            },
-          });
-      })(),
-      a
-    );
-  })());
-//# sourceMappingURL=module.js.map
+    },
+  });
+
+  return { plugin: plugin };
+});

--- a/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/plugin.json
+++ b/e2e/custom-plugins/app-with-extension-point/plugins/myorg-b-app/plugin.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "type": "app",
+  "name": "B App",
+  "id": "myorg-b-app",
+  "preload": true,
+  "info": {
+    "keywords": ["app"],
+    "description": "Will extend root app with ui extensions",
+    "author": {
+      "name": "Myorg"
+    },
+    "logos": {
+      "small": "img/logo.svg",
+      "large": "img/logo.svg"
+    },
+    "screenshots": [],
+    "version": "%VERSION%",
+    "updated": "%TODAY%"
+  },
+  "includes": [
+    {
+      "type": "page",
+      "name": "Default",
+      "path": "/a/myorg-b-app",
+      "role": "Admin",
+      "addToNav": false,
+      "defaultNav": false
+    }
+  ],
+  "dependencies": {
+    "grafanaDependency": ">=10.3.3",
+    "plugins": []
+  },
+  "generated": {
+    "extensions": [
+      {
+        "extensionPointId": "plugins/myorg-extensionpoint-app/actions",
+        "title": "Open from B",
+        "description": "Open a modal from plugin B",
+        "type": "link"
+      }
+    ]
+  }
+}

--- a/e2e/custom-plugins/app-with-extensions/README.md
+++ b/e2e/custom-plugins/app-with-extensions/README.md
@@ -1,0 +1,12 @@
+# App with extensions
+
+This app was initially copied from the [app-with-extensions](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-extensions) example plugin. The plugin bundle is using AMD, but it's not minified and the plugin feature set is small so it should be possible to make changes in this file if necessary.
+
+To test this app:
+
+```sh
+# start e2e test instance (it will install this plugin)
+PORT=3000 ./scripts/grafana-server/start-server
+# run Playwright tests using Playwright VSCode extension or with the following script
+yarn e2e:playwright
+```

--- a/e2e/custom-plugins/app-with-extensions/module.js
+++ b/e2e/custom-plugins/app-with-extensions/module.js
@@ -1,0 +1,326 @@
+define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/css', 'rxjs'], (e, t, n, r, o, i) =>
+  (() => {
+    'use strict';
+    let a = {
+        89: (e) => {
+          e.exports = o;
+        },
+        781: (e) => {
+          e.exports = t;
+        },
+        531: (e) => {
+          e.exports = r;
+        },
+        7: (e) => {
+          e.exports = n;
+        },
+        959: (t) => {
+          t.exports = e;
+        },
+        269: (e) => {
+          e.exports = i;
+        },
+      },
+      l = {};
+    function s(e) {
+      let t = l[e];
+      if (void 0 !== t) {
+        return t.exports;
+      }
+      let n = (l[e] = { exports: {} });
+      return a[e](n, n.exports, s), n.exports;
+    }
+    (s.n = (e) => {
+      let t = e && e.__esModule ? () => e.default : () => e;
+      return s.d(t, { a: t }), t;
+    }),
+      (s.d = (e, t) => {
+        for (let n in t) {
+          s.o(t, n) && !s.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
+        }
+      }),
+      (s.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
+      (s.r = (e) => {
+        'undefined' !== typeof Symbol &&
+          Symbol.toStringTag &&
+          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
+          Object.defineProperty(e, '__esModule', { value: !0 });
+      });
+    let c = {};
+    return (
+      (() => {
+        s.r(c), s.d(c, { plugin: () => E });
+        let e = s(959),
+          t = s.n(e),
+          n = s(781);
+        const r = 'ape-modal-body',
+          o = 'ape-main-page-container';
+        class i extends e.PureComponent {
+          render() {
+            return e.createElement('div', { 'data-testid': o, className: 'page-container' }, 'Hello Grafana!');
+          }
+        }
+        let a = s(7),
+          l = s(531),
+          u = s(89),
+          d = s(269);
+        function p(e, t, n, r, o, i, a) {
+          try {
+            var l = e[i](a),
+              s = l.value;
+          } catch (e) {
+            return void n(e);
+          }
+          l.done ? t(s) : Promise.resolve(s).then(r, o);
+        }
+        function f(e) {
+          return function () {
+            let t = this,
+              n = arguments;
+            return new Promise(function (r, o) {
+              let i = e.apply(t, n);
+              function a(e) {
+                p(i, r, o, a, l, 'next', e);
+              }
+              function l(e) {
+                p(i, r, o, a, l, 'throw', e);
+              }
+              a(void 0);
+            });
+          };
+        }
+        const m = (e) => ({
+            colorWeak: u.css`
+    color: ${e.colors.text.secondary};
+  `,
+            marginTop: u.css`
+    margin-top: ${e.spacing(3)};
+  `,
+          }),
+          g =
+            ((v = f(function* (e, t) {
+              try {
+                yield b(e, t), window.location.reload();
+              } catch (e) {
+                console.error('Error while updating the plugin', e);
+              }
+            })),
+            function (e, t) {
+              return v.apply(this, arguments);
+            });
+        let v;
+        const b = (function () {
+            let e = f(function* (e, t) {
+              const n = (0, l.getBackendSrv)().fetch({ url: `/api/plugins/${e}/settings`, method: 'POST', data: t });
+              return (0, d.lastValueFrom)(n);
+            });
+            return function (t, n) {
+              return e.apply(this, arguments);
+            };
+          })(),
+          y = JSON.parse('{"id":"myorg-extensions-app"}');
+        function h(e) {
+          alert(`You selected query "${e.refId}"`);
+        }
+        function O(n) {
+          const { targets: o = [], onDismiss: i } = n,
+            [l, s] = (0, e.useState)(o[0]);
+          return t().createElement(
+            'div',
+            { 'data-testid': r },
+            t().createElement(
+              'p',
+              null,
+              'Please select the query you would like to use to create "something" in the plugin.'
+            ),
+            t().createElement(
+              a.HorizontalGroup,
+              null,
+              o.map((e) =>
+                t().createElement(a.FilterPill, {
+                  key: e.refId,
+                  label: e.refId,
+                  selected: e.refId === (null == l ? void 0 : l.refId),
+                  onClick: () => s(e),
+                })
+              )
+            ),
+            t().createElement(
+              a.Modal.ButtonRow,
+              null,
+              t().createElement(a.Button, { variant: 'secondary', fill: 'outline', onClick: i }, 'Cancel'),
+              t().createElement(
+                a.Button,
+                {
+                  disabled: !Boolean(l),
+                  onClick: () => {
+                    null == i || i(), h(l);
+                  },
+                },
+                'OK'
+              )
+            )
+          );
+        }
+        function P(e, t, n) {
+          return (
+            t in e
+              ? Object.defineProperty(e, t, { value: n, enumerable: !0, configurable: !0, writable: !0 })
+              : (e[t] = n),
+            e
+          );
+        }
+        const E = new n.AppPlugin()
+          .setRootPage(i)
+          .addConfigPage({
+            title: 'Configuration',
+            icon: 'cog',
+            body: ({ plugin: e }) => {
+              const n = (0, a.useStyles2)(m),
+                { enabled: r, jsonData: o } = e.meta;
+              return t().createElement(
+                'div',
+                null,
+                t().createElement(a.Legend, null, 'Enable / Disable '),
+                !r &&
+                  t().createElement(
+                    t().Fragment,
+                    null,
+                    t().createElement('div', { className: n.colorWeak }, 'The plugin is currently not enabled.'),
+                    t().createElement(
+                      a.Button,
+                      {
+                        className: n.marginTop,
+                        variant: 'primary',
+                        onClick: () => g(e.meta.id, { enabled: !0, pinned: !0, jsonData: o }),
+                      },
+                      'Enable plugin'
+                    )
+                  ),
+                r &&
+                  t().createElement(
+                    t().Fragment,
+                    null,
+                    t().createElement('div', { className: n.colorWeak }, 'The plugin is currently enabled.'),
+                    t().createElement(
+                      a.Button,
+                      {
+                        className: n.marginTop,
+                        variant: 'destructive',
+                        onClick: () => g(e.meta.id, { enabled: !1, pinned: !1, jsonData: o }),
+                      },
+                      'Disable plugin'
+                    )
+                  )
+              );
+            },
+            id: 'configuration',
+          })
+          .configureExtensionLink({
+            title: 'Open from time series or pie charts (path)',
+            description: 'This link will only be visible on time series and pie charts',
+            extensionPointId: n.PluginExtensionPoints.DashboardPanelMenu,
+            path: `/a/${y.id}/`,
+            configure: (e) => {
+              let t;
+              if (
+                'Link Extensions (path)' ===
+                (null == e || null === (t = e.dashboard) || void 0 === t ? void 0 : t.title)
+              ) {
+                switch (null == e ? void 0 : e.pluginId) {
+                  case 'timeseries':
+                    return {};
+                  case 'piechart':
+                    return { title: `Open from ${e.pluginId}` };
+                  default:
+                    return;
+                }
+              }
+            },
+          })
+          .configureExtensionLink({
+            title: 'Open from time series or pie charts (onClick)',
+            description: 'This link will only be visible on time series and pie charts',
+            extensionPointId: n.PluginExtensionPoints.DashboardPanelMenu,
+            onClick: (e, { openModal: n, context: r }) => {
+              let o;
+              const i = null !== (o = null == r ? void 0 : r.targets) && void 0 !== o ? o : [],
+                a = null == r ? void 0 : r.title;
+              if (!x(r)) {
+                return;
+              }
+              if (i.length > 1) {
+                return n({
+                  title: `Select query from "${a}"`,
+                  body: (e) =>
+                    t().createElement(
+                      O,
+                      (function (e, t) {
+                        return (
+                          (t = null != t ? t : {}),
+                          Object.getOwnPropertyDescriptors
+                            ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t))
+                            : (function (e, t) {
+                                let n = Object.keys(e);
+                                if (Object.getOwnPropertySymbols) {
+                                  let r = Object.getOwnPropertySymbols(e);
+                                  n.push.apply(n, r);
+                                }
+                                return n;
+                              })(Object(t)).forEach(function (n) {
+                                Object.defineProperty(e, n, Object.getOwnPropertyDescriptor(t, n));
+                              }),
+                          e
+                        );
+                      })(
+                        (function (e) {
+                          for (let t = 1; t < arguments.length; t++) {
+                            var n = null != arguments[t] ? arguments[t] : {},
+                              r = Object.keys(n);
+                            'function' === typeof Object.getOwnPropertySymbols &&
+                              (r = r.concat(
+                                Object.getOwnPropertySymbols(n).filter(function (e) {
+                                  return Object.getOwnPropertyDescriptor(n, e).enumerable;
+                                })
+                              )),
+                              r.forEach(function (t) {
+                                P(e, t, n[t]);
+                              });
+                          }
+                          return e;
+                        })({}, e),
+                        { targets: i }
+                      )
+                    ),
+                });
+              }
+              const [l] = i;
+              h(l);
+            },
+            configure: (e) => {
+              let t;
+              if (
+                'Link Extensions (onClick)' ===
+                  (null == e || null === (t = e.dashboard) || void 0 === t ? void 0 : t.title) &&
+                x(e)
+              ) {
+                switch (null == e ? void 0 : e.pluginId) {
+                  case 'timeseries':
+                    return {};
+                  case 'piechart':
+                    return { title: `Open from ${e.pluginId}` };
+                  default:
+                    return;
+                }
+              }
+            },
+          });
+        function x(e) {
+          let t;
+          return (null !== (t = null == e ? void 0 : e.targets) && void 0 !== t ? t : []).length > 0;
+        }
+      })(),
+      c
+    );
+  })());
+//# sourceMappingURL=module.js.map

--- a/e2e/custom-plugins/app-with-extensions/module.js
+++ b/e2e/custom-plugins/app-with-extensions/module.js
@@ -1,7 +1,7 @@
 define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/css', 'rxjs'], (e, t, n, r, o, i) =>
   (() => {
     'use strict';
-    let a = {
+    var a = {
         89: (e) => {
           e.exports = o;
         },
@@ -23,34 +23,30 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
       },
       l = {};
     function s(e) {
-      let t = l[e];
-      if (void 0 !== t) {
-        return t.exports;
-      }
-      let n = (l[e] = { exports: {} });
+      var t = l[e];
+      if (void 0 !== t) return t.exports;
+      var n = (l[e] = { exports: {} });
       return a[e](n, n.exports, s), n.exports;
     }
     (s.n = (e) => {
-      let t = e && e.__esModule ? () => e.default : () => e;
+      var t = e && e.__esModule ? () => e.default : () => e;
       return s.d(t, { a: t }), t;
     }),
       (s.d = (e, t) => {
-        for (let n in t) {
-          s.o(t, n) && !s.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
-        }
+        for (var n in t) s.o(t, n) && !s.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
       }),
       (s.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
       (s.r = (e) => {
-        'undefined' !== typeof Symbol &&
+        'undefined' != typeof Symbol &&
           Symbol.toStringTag &&
           Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
           Object.defineProperty(e, '__esModule', { value: !0 });
       });
-    let c = {};
+    var c = {};
     return (
       (() => {
         s.r(c), s.d(c, { plugin: () => E });
-        let e = s(959),
+        var e = s(959),
           t = s.n(e),
           n = s(781);
         const r = 'ape-modal-body',
@@ -60,7 +56,7 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
             return e.createElement('div', { 'data-testid': o, className: 'page-container' }, 'Hello Grafana!');
           }
         }
-        let a = s(7),
+        var a = s(7),
           l = s(531),
           u = s(89),
           d = s(269);
@@ -75,10 +71,10 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
         }
         function f(e) {
           return function () {
-            let t = this,
+            var t = this,
               n = arguments;
             return new Promise(function (r, o) {
-              let i = e.apply(t, n);
+              var i = e.apply(t, n);
               function a(e) {
                 p(i, r, o, a, l, 'next', e);
               }
@@ -108,9 +104,9 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
             function (e, t) {
               return v.apply(this, arguments);
             });
-        let v;
+        var v;
         const b = (function () {
-            let e = f(function* (e, t) {
+            var e = f(function* (e, t) {
               const n = (0, l.getBackendSrv)().fetch({ url: `/api/plugins/${e}/settings`, method: 'POST', data: t });
               return (0, d.lastValueFrom)(n);
             });
@@ -222,11 +218,11 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
             extensionPointId: n.PluginExtensionPoints.DashboardPanelMenu,
             path: `/a/${y.id}/`,
             configure: (e) => {
-              let t;
+              var t;
               if (
                 'Link Extensions (path)' ===
                 (null == e || null === (t = e.dashboard) || void 0 === t ? void 0 : t.title)
-              ) {
+              )
                 switch (null == e ? void 0 : e.pluginId) {
                   case 'timeseries':
                     return {};
@@ -235,7 +231,6 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
                   default:
                     return;
                 }
-              }
             },
           })
           .configureExtensionLink({
@@ -243,13 +238,11 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
             description: 'This link will only be visible on time series and pie charts',
             extensionPointId: n.PluginExtensionPoints.DashboardPanelMenu,
             onClick: (e, { openModal: n, context: r }) => {
-              let o;
+              var o;
               const i = null !== (o = null == r ? void 0 : r.targets) && void 0 !== o ? o : [],
                 a = null == r ? void 0 : r.title;
-              if (!x(r)) {
-                return;
-              }
-              if (i.length > 1) {
+              if (!x(r)) return;
+              if (i.length > 1)
                 return n({
                   title: `Select query from "${a}"`,
                   body: (e) =>
@@ -261,9 +254,9 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
                           Object.getOwnPropertyDescriptors
                             ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t))
                             : (function (e, t) {
-                                let n = Object.keys(e);
+                                var n = Object.keys(e);
                                 if (Object.getOwnPropertySymbols) {
-                                  let r = Object.getOwnPropertySymbols(e);
+                                  var r = Object.getOwnPropertySymbols(e);
                                   n.push.apply(n, r);
                                 }
                                 return n;
@@ -274,10 +267,10 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
                         );
                       })(
                         (function (e) {
-                          for (let t = 1; t < arguments.length; t++) {
+                          for (var t = 1; t < arguments.length; t++) {
                             var n = null != arguments[t] ? arguments[t] : {},
                               r = Object.keys(n);
-                            'function' === typeof Object.getOwnPropertySymbols &&
+                            'function' == typeof Object.getOwnPropertySymbols &&
                               (r = r.concat(
                                 Object.getOwnPropertySymbols(n).filter(function (e) {
                                   return Object.getOwnPropertyDescriptor(n, e).enumerable;
@@ -293,17 +286,16 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
                       )
                     ),
                 });
-              }
               const [l] = i;
               h(l);
             },
             configure: (e) => {
-              let t;
+              var t;
               if (
                 'Link Extensions (onClick)' ===
                   (null == e || null === (t = e.dashboard) || void 0 === t ? void 0 : t.title) &&
                 x(e)
-              ) {
+              )
                 switch (null == e ? void 0 : e.pluginId) {
                   case 'timeseries':
                     return {};
@@ -312,11 +304,10 @@ define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/c
                   default:
                     return;
                 }
-              }
             },
           });
         function x(e) {
-          let t;
+          var t;
           return (null !== (t = null == e ? void 0 : e.targets) && void 0 !== t ? t : []).length > 0;
         }
       })(),

--- a/e2e/custom-plugins/app-with-extensions/module.js
+++ b/e2e/custom-plugins/app-with-extensions/module.js
@@ -1,317 +1,216 @@
-define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/css', 'rxjs'], (e, t, n, r, o, i) =>
-  (() => {
-    'use strict';
-    var a = {
-        89: (e) => {
-          e.exports = o;
-        },
-        781: (e) => {
-          e.exports = t;
-        },
-        531: (e) => {
-          e.exports = r;
-        },
-        7: (e) => {
-          e.exports = n;
-        },
-        959: (t) => {
-          t.exports = e;
-        },
-        269: (e) => {
-          e.exports = i;
-        },
-      },
-      l = {};
-    function s(e) {
-      var t = l[e];
-      if (void 0 !== t) return t.exports;
-      var n = (l[e] = { exports: {} });
-      return a[e](n, n.exports, s), n.exports;
+define(['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', '@emotion/css', 'rxjs'], function (
+  React,
+  data,
+  ui,
+  runtime,
+  css,
+  rxjs
+) {
+  'use strict';
+
+  const styles = {
+    modalBody: 'ape-modal-body',
+    mainPageContainer: 'ape-main-page-container',
+  };
+
+  class RootComponent extends React.PureComponent {
+    render() {
+      return React.createElement(
+        'div',
+        { 'data-testid': styles.mainPageContainer, className: 'page-container' },
+        'Hello Grafana!'
+      );
     }
-    (s.n = (e) => {
-      var t = e && e.__esModule ? () => e.default : () => e;
-      return s.d(t, { a: t }), t;
-    }),
-      (s.d = (e, t) => {
-        for (var n in t) s.o(t, n) && !s.o(e, n) && Object.defineProperty(e, n, { enumerable: !0, get: t[n] });
-      }),
-      (s.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
-      (s.r = (e) => {
-        'undefined' != typeof Symbol &&
-          Symbol.toStringTag &&
-          Object.defineProperty(e, Symbol.toStringTag, { value: 'Module' }),
-          Object.defineProperty(e, '__esModule', { value: !0 });
-      });
-    var c = {};
-    return (
-      (() => {
-        s.r(c), s.d(c, { plugin: () => E });
-        var e = s(959),
-          t = s.n(e),
-          n = s(781);
-        const r = 'ape-modal-body',
-          o = 'ape-main-page-container';
-        class i extends e.PureComponent {
-          render() {
-            return e.createElement('div', { 'data-testid': o, className: 'page-container' }, 'Hello Grafana!');
-          }
-        }
-        var a = s(7),
-          l = s(531),
-          u = s(89),
-          d = s(269);
-        function p(e, t, n, r, o, i, a) {
+  }
+
+  const asyncWrapper = (fn) => {
+    return function () {
+      const gen = fn.apply(this, arguments);
+      return new Promise((resolve, reject) => {
+        function step(key, arg) {
+          let info, value;
           try {
-            var l = e[i](a),
-              s = l.value;
-          } catch (e) {
-            return void n(e);
+            info = gen[key](arg);
+            value = info.value;
+          } catch (error) {
+            reject(error);
+            return;
           }
-          l.done ? t(s) : Promise.resolve(s).then(r, o);
+          if (info.done) {
+            resolve(value);
+          } else {
+            Promise.resolve(value).then(next, throw_);
+          }
         }
-        function f(e) {
-          return function () {
-            var t = this,
-              n = arguments;
-            return new Promise(function (r, o) {
-              var i = e.apply(t, n);
-              function a(e) {
-                p(i, r, o, a, l, 'next', e);
-              }
-              function l(e) {
-                p(i, r, o, a, l, 'throw', e);
-              }
-              a(void 0);
-            });
-          };
+        function next(value) {
+          step('next', value);
         }
-        const m = (e) => ({
-            colorWeak: u.css`
-    color: ${e.colors.text.secondary};
-  `,
-            marginTop: u.css`
-    margin-top: ${e.spacing(3)};
-  `,
-          }),
-          g =
-            ((v = f(function* (e, t) {
-              try {
-                yield b(e, t), window.location.reload();
-              } catch (e) {
-                console.error('Error while updating the plugin', e);
-              }
-            })),
-            function (e, t) {
-              return v.apply(this, arguments);
-            });
-        var v;
-        const b = (function () {
-            var e = f(function* (e, t) {
-              const n = (0, l.getBackendSrv)().fetch({ url: `/api/plugins/${e}/settings`, method: 'POST', data: t });
-              return (0, d.lastValueFrom)(n);
-            });
-            return function (t, n) {
-              return e.apply(this, arguments);
-            };
-          })(),
-          y = JSON.parse('{"id":"myorg-extensions-app"}');
-        function h(e) {
-          alert(`You selected query "${e.refId}"`);
+        function throw_(value) {
+          step('throw', value);
         }
-        function O(n) {
-          const { targets: o = [], onDismiss: i } = n,
-            [l, s] = (0, e.useState)(o[0]);
-          return t().createElement(
-            'div',
-            { 'data-testid': r },
-            t().createElement(
-              'p',
-              null,
-              'Please select the query you would like to use to create "something" in the plugin.'
-            ),
-            t().createElement(
-              a.HorizontalGroup,
-              null,
-              o.map((e) =>
-                t().createElement(a.FilterPill, {
-                  key: e.refId,
-                  label: e.refId,
-                  selected: e.refId === (null == l ? void 0 : l.refId),
-                  onClick: () => s(e),
-                })
-              )
-            ),
-            t().createElement(
-              a.Modal.ButtonRow,
-              null,
-              t().createElement(a.Button, { variant: 'secondary', fill: 'outline', onClick: i }, 'Cancel'),
-              t().createElement(
-                a.Button,
-                {
-                  disabled: !Boolean(l),
-                  onClick: () => {
-                    null == i || i(), h(l);
-                  },
-                },
-                'OK'
-              )
-            )
-          );
-        }
-        function P(e, t, n) {
-          return (
-            t in e
-              ? Object.defineProperty(e, t, { value: n, enumerable: !0, configurable: !0, writable: !0 })
-              : (e[t] = n),
-            e
-          );
-        }
-        const E = new n.AppPlugin()
-          .setRootPage(i)
-          .addConfigPage({
-            title: 'Configuration',
-            icon: 'cog',
-            body: ({ plugin: e }) => {
-              const n = (0, a.useStyles2)(m),
-                { enabled: r, jsonData: o } = e.meta;
-              return t().createElement(
-                'div',
-                null,
-                t().createElement(a.Legend, null, 'Enable / Disable '),
-                !r &&
-                  t().createElement(
-                    t().Fragment,
-                    null,
-                    t().createElement('div', { className: n.colorWeak }, 'The plugin is currently not enabled.'),
-                    t().createElement(
-                      a.Button,
-                      {
-                        className: n.marginTop,
-                        variant: 'primary',
-                        onClick: () => g(e.meta.id, { enabled: !0, pinned: !0, jsonData: o }),
-                      },
-                      'Enable plugin'
-                    )
-                  ),
-                r &&
-                  t().createElement(
-                    t().Fragment,
-                    null,
-                    t().createElement('div', { className: n.colorWeak }, 'The plugin is currently enabled.'),
-                    t().createElement(
-                      a.Button,
-                      {
-                        className: n.marginTop,
-                        variant: 'destructive',
-                        onClick: () => g(e.meta.id, { enabled: !1, pinned: !1, jsonData: o }),
-                      },
-                      'Disable plugin'
-                    )
-                  )
-              );
+        next();
+      });
+    };
+  };
+
+  const getStyles = (theme) => ({
+    colorWeak: css.css`color: ${theme.colors.text.secondary};`,
+    marginTop: css.css`margin-top: ${theme.spacing(3)};`,
+  });
+
+  const updatePlugin = asyncWrapper(function* (pluginId, settings) {
+    const response = runtime
+      .getBackendSrv()
+      .fetch({ url: `/api/plugins/${pluginId}/settings`, method: 'POST', data: settings });
+    return rxjs.lastValueFrom(response);
+  });
+
+  const handleUpdate = asyncWrapper(function* (pluginId, settings) {
+    try {
+      yield updatePlugin(pluginId, settings);
+      window.location.reload();
+    } catch (error) {
+      console.error('Error while updating the plugin', error);
+    }
+  });
+
+  const configPageBody = ({ plugin }) => {
+    const styles = getStyles(ui.useStyles2());
+    const { enabled, jsonData } = plugin.meta;
+    return React.createElement(
+      'div',
+      null,
+      React.createElement(ui.Legend, null, 'Enable / Disable '),
+      !enabled &&
+        React.createElement(
+          React.Fragment,
+          null,
+          React.createElement('div', { className: styles.colorWeak }, 'The plugin is currently not enabled.'),
+          React.createElement(
+            ui.Button,
+            {
+              className: styles.marginTop,
+              variant: 'primary',
+              onClick: () => handleUpdate(plugin.meta.id, { enabled: true, pinned: true, jsonData: jsonData }),
             },
-            id: 'configuration',
-          })
-          .configureExtensionLink({
-            title: 'Open from time series or pie charts (path)',
-            description: 'This link will only be visible on time series and pie charts',
-            extensionPointId: n.PluginExtensionPoints.DashboardPanelMenu,
-            path: `/a/${y.id}/`,
-            configure: (e) => {
-              var t;
-              if (
-                'Link Extensions (path)' ===
-                (null == e || null === (t = e.dashboard) || void 0 === t ? void 0 : t.title)
-              )
-                switch (null == e ? void 0 : e.pluginId) {
-                  case 'timeseries':
-                    return {};
-                  case 'piechart':
-                    return { title: `Open from ${e.pluginId}` };
-                  default:
-                    return;
-                }
+            'Enable plugin'
+          )
+        ),
+      enabled &&
+        React.createElement(
+          React.Fragment,
+          null,
+          React.createElement('div', { className: styles.colorWeak }, 'The plugin is currently enabled.'),
+          React.createElement(
+            ui.Button,
+            {
+              className: styles.marginTop,
+              variant: 'destructive',
+              onClick: () => handleUpdate(plugin.meta.id, { enabled: false, pinned: false, jsonData: jsonData }),
             },
-          })
-          .configureExtensionLink({
-            title: 'Open from time series or pie charts (onClick)',
-            description: 'This link will only be visible on time series and pie charts',
-            extensionPointId: n.PluginExtensionPoints.DashboardPanelMenu,
-            onClick: (e, { openModal: n, context: r }) => {
-              var o;
-              const i = null !== (o = null == r ? void 0 : r.targets) && void 0 !== o ? o : [],
-                a = null == r ? void 0 : r.title;
-              if (!x(r)) return;
-              if (i.length > 1)
-                return n({
-                  title: `Select query from "${a}"`,
-                  body: (e) =>
-                    t().createElement(
-                      O,
-                      (function (e, t) {
-                        return (
-                          (t = null != t ? t : {}),
-                          Object.getOwnPropertyDescriptors
-                            ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t))
-                            : (function (e, t) {
-                                var n = Object.keys(e);
-                                if (Object.getOwnPropertySymbols) {
-                                  var r = Object.getOwnPropertySymbols(e);
-                                  n.push.apply(n, r);
-                                }
-                                return n;
-                              })(Object(t)).forEach(function (n) {
-                                Object.defineProperty(e, n, Object.getOwnPropertyDescriptor(t, n));
-                              }),
-                          e
-                        );
-                      })(
-                        (function (e) {
-                          for (var t = 1; t < arguments.length; t++) {
-                            var n = null != arguments[t] ? arguments[t] : {},
-                              r = Object.keys(n);
-                            'function' == typeof Object.getOwnPropertySymbols &&
-                              (r = r.concat(
-                                Object.getOwnPropertySymbols(n).filter(function (e) {
-                                  return Object.getOwnPropertyDescriptor(n, e).enumerable;
-                                })
-                              )),
-                              r.forEach(function (t) {
-                                P(e, t, n[t]);
-                              });
-                          }
-                          return e;
-                        })({}, e),
-                        { targets: i }
-                      )
-                    ),
-                });
-              const [l] = i;
-              h(l);
-            },
-            configure: (e) => {
-              var t;
-              if (
-                'Link Extensions (onClick)' ===
-                  (null == e || null === (t = e.dashboard) || void 0 === t ? void 0 : t.title) &&
-                x(e)
-              )
-                switch (null == e ? void 0 : e.pluginId) {
-                  case 'timeseries':
-                    return {};
-                  case 'piechart':
-                    return { title: `Open from ${e.pluginId}` };
-                  default:
-                    return;
-                }
-            },
-          });
-        function x(e) {
-          var t;
-          return (null !== (t = null == e ? void 0 : e.targets) && void 0 !== t ? t : []).length > 0;
-        }
-      })(),
-      c
+            'Disable plugin'
+          )
+        )
     );
-  })());
-//# sourceMappingURL=module.js.map
+  };
+
+  const selectQueryModal = ({ targets = [], onDismiss }) => {
+    const [selectedQuery, setSelectedQuery] = React.useState(targets[0]);
+    return React.createElement(
+      'div',
+      { 'data-testid': styles.modalBody },
+      React.createElement(
+        'p',
+        null,
+        'Please select the query you would like to use to create "something" in the plugin.'
+      ),
+      React.createElement(
+        ui.HorizontalGroup,
+        null,
+        targets.map((query) =>
+          React.createElement(ui.FilterPill, {
+            key: query.refId,
+            label: query.refId,
+            selected: query.refId === (selectedQuery ? selectedQuery.refId : null),
+            onClick: () => setSelectedQuery(query),
+          })
+        )
+      ),
+      React.createElement(
+        ui.Modal.ButtonRow,
+        null,
+        React.createElement(ui.Button, { variant: 'secondary', fill: 'outline', onClick: onDismiss }, 'Cancel'),
+        React.createElement(
+          ui.Button,
+          {
+            disabled: !Boolean(selectedQuery),
+            onClick: () => {
+              onDismiss && onDismiss();
+              alert(`You selected query "${selectedQuery.refId}"`);
+            },
+          },
+          'OK'
+        )
+      )
+    );
+  };
+
+  const plugin = new data.AppPlugin()
+    .setRootPage(RootComponent)
+    .addConfigPage({
+      title: 'Configuration',
+      icon: 'cog',
+      body: configPageBody,
+      id: 'configuration',
+    })
+    .configureExtensionLink({
+      title: 'Open from time series or pie charts (path)',
+      description: 'This link will only be visible on time series and pie charts',
+      extensionPointId: data.PluginExtensionPoints.DashboardPanelMenu,
+      path: `/a/myorg-extensions-app/`,
+      configure: (context) => {
+        if (context.dashboard?.title === 'Link Extensions (path)') {
+          switch (context.pluginId) {
+            case 'timeseries':
+              return {};
+            case 'piechart':
+              return { title: `Open from ${context.pluginId}` };
+            default:
+              return;
+          }
+        }
+      },
+    })
+    .configureExtensionLink({
+      title: 'Open from time series or pie charts (onClick)',
+      description: 'This link will only be visible on time series and pie charts',
+      extensionPointId: data.PluginExtensionPoints.DashboardPanelMenu,
+      onClick: (_, { context, openModal }) => {
+        const targets = context?.targets || [];
+        const title = context?.title;
+        if (!targets.length) return;
+        if (targets.length > 1) {
+          openModal({
+            title: `Select query from "${title}"`,
+            body: (props) => React.createElement(selectQueryModal, { ...props, targets: targets }),
+          });
+        } else {
+          alert(`You selected query "${targets[0].refId}"`);
+        }
+      },
+      configure: (context) => {
+        if (context.dashboard?.title === 'Link Extensions (onClick)') {
+          switch (context.pluginId) {
+            case 'timeseries':
+              return {};
+            case 'piechart':
+              return { title: `Open from ${context.pluginId}` };
+            default:
+              return;
+          }
+        }
+      },
+    });
+
+  return { plugin: plugin };
+});

--- a/e2e/custom-plugins/app-with-extensions/plugin.json
+++ b/e2e/custom-plugins/app-with-extensions/plugin.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "type": "app",
+  "name": "Extensions App",
+  "id": "myorg-extensions-app",
+  "preload": true,
+  "info": {
+    "keywords": ["app"],
+    "description": "Example on how to extend grafana ui from a plugin",
+    "author": {
+      "name": "Myorg"
+    },
+    "screenshots": [],
+    "version": "1.0.0",
+    "updated": "2024-06-11"
+  },
+  "includes": [
+    {
+      "type": "page",
+      "name": "Default",
+      "path": "/a/myorg-extensions-app",
+      "role": "Admin",
+      "addToNav": true,
+      "defaultNav": true
+    }
+  ],
+  "dependencies": {
+    "grafanaDependency": ">=10.3.3",
+    "plugins": []
+  },
+  "extensions": [
+    {
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "type": "link",
+      "title": "Open from time series or pie charts (path)",
+      "description": "This link will only be visible on time series and pie charts"
+    },
+    {
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "type": "link",
+      "title": "Open from time series or pie charts (onClick)",
+      "description": "This link will only be visible on time series and pie charts"
+    }
+  ]
+}

--- a/e2e/custom-plugins/app-with-extensions/plugin.json
+++ b/e2e/custom-plugins/app-with-extensions/plugin.json
@@ -10,6 +10,10 @@
     "author": {
       "name": "Myorg"
     },
+    "logos": {
+      "small": "img/logo.svg",
+      "large": "img/logo.svg"
+    },
     "screenshots": [],
     "version": "1.0.0",
     "updated": "2024-06-11"

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensionPoints.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensionPoints.spec.ts
@@ -17,8 +17,10 @@ const testIds = {
   },
 };
 
+const pluginId = 'myorg-extensionpoint-app';
+
 test('should extend the actions menu with a link to a-app plugin', async ({ page }) => {
-  await page.goto(`/a/myorg-extensionpoint-app/one`);
+  await page.goto(`/a/${pluginId}/one`);
   await page.getByTestId(testIds.actions.button).click();
   await page.getByTestId(testIds.container).getByText('Go to A').click();
   await page.getByTestId(testIds.modal.open).click();
@@ -26,7 +28,7 @@ test('should extend the actions menu with a link to a-app plugin', async ({ page
 });
 
 test('should extend the actions menu with a command triggered from b-app plugin', async ({ page }) => {
-  await page.goto(`/a/myorg-extensionpoint-app/one`);
+  await page.goto(`/a/${pluginId}//one`);
   await page.getByTestId(testIds.actions.button).click();
   await page.getByTestId(testIds.container).getByText('Open from B').click();
   await expect(page.getByTestId(testIds.appB.modal)).toBeVisible();

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensionPoints.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensionPoints.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const testIds = {
+  container: 'main-app-body',
+  actions: {
+    button: 'action-button',
+  },
+  modal: {
+    container: 'container',
+    open: 'open-link',
+  },
+  appA: {
+    container: 'a-app-body',
+  },
+  appB: {
+    modal: 'b-app-modal',
+  },
+};
+
+test('should extend the actions menu with a link to a-app plugin', async ({ page }) => {
+  await page.goto(`/a/myorg-extensionpoint-app/one`);
+  await page.getByTestId(testIds.actions.button).click();
+  await page.getByTestId(testIds.container).getByText('Go to A').click();
+  await page.getByTestId(testIds.modal.open).click();
+  await expect(page.getByTestId(testIds.appA.container)).toBeVisible();
+});
+
+test('should extend the actions menu with a command triggered from b-app plugin', async ({ page }) => {
+  await page.goto(`/a/myorg-extensionpoint-app/one`);
+  await page.getByTestId(testIds.actions.button).click();
+  await page.getByTestId(testIds.container).getByText('Open from B').click();
+  await expect(page.getByTestId(testIds.appB.modal)).toBeVisible();
+});

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensionPoints.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensionPoints.spec.ts
@@ -28,7 +28,7 @@ test('should extend the actions menu with a link to a-app plugin', async ({ page
 });
 
 test('should extend the actions menu with a command triggered from b-app plugin', async ({ page }) => {
-  await page.goto(`/a/${pluginId}//one`);
+  await page.goto(`/a/${pluginId}/one`);
   await page.getByTestId(testIds.actions.button).click();
   await page.getByTestId(testIds.container).getByText('Open from B').click();
   await expect(page.getByTestId(testIds.appB.modal)).toBeVisible();

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensions.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensions.spec.ts
@@ -11,39 +11,27 @@ const testIds = {
   },
 };
 
-test('should add link extension (path) with defaults to time series panel', async ({
-  gotoDashboardPage,
-  readProvisionedDashboard,
-  page,
-}) => {
-  // const dashboard = await readProvisionedDashboard({ fileName: 'link-path-extensions.json' });
-  const dashboardPage = await gotoDashboardPage({ uid: 'd1fbb077-cd44-4738-8c8a-d4e66748b719' });
+const linkOnClickDashboardUid = 'dbfb47c5-e5e5-4d28-8ac7-35f349b95946';
+const linkPathDashboardUid = 'd1fbb077-cd44-4738-8c8a-d4e66748b719';
+
+test('should add link extension (path) with defaults to time series panel', async ({ gotoDashboardPage, page }) => {
+  const dashboardPage = await gotoDashboardPage({ uid: linkPathDashboardUid });
   const panel = await dashboardPage.getPanelByTitle(panelTitle);
   await panel.clickOnMenuItem(extensionTitle, { parentItem: 'Extensions' });
   await expect(page.getByTestId(testIds.mainPage.container)).toBeVisible();
 });
 
-test('should add link extension (onclick) with defaults to time series panel', async ({
-  gotoDashboardPage,
-  readProvisionedDashboard,
-  page,
-}) => {
-  // const dashboard = await readProvisionedDashboard({ fileName: 'link-onclick-extensions.json' });
-  const dashboardPage = await gotoDashboardPage({ uid: 'dbfb47c5-e5e5-4d28-8ac7-35f349b95946' });
+test('should add link extension (onclick) with defaults to time series panel', async ({ gotoDashboardPage, page }) => {
+  const dashboardPage = await gotoDashboardPage({ uid: linkOnClickDashboardUid });
   const panel = await dashboardPage.getPanelByTitle(panelTitle);
   await panel.clickOnMenuItem(extensionTitle, { parentItem: 'Extensions' });
   await expect(page.getByRole('dialog')).toContainText('Select query from "Link with defaults"');
 });
 
-test('should add link extension (onclick) with new title to pie chart panel', async ({
-  gotoDashboardPage,
-  readProvisionedDashboard,
-  page,
-}) => {
+test('should add link extension (onclick) with new title to pie chart panel', async ({ gotoDashboardPage, page }) => {
   const panelTitle = 'Link with new name';
   const extensionTitle = 'Open from piechart';
-  // const dashboard = await readProvisionedDashboard({ fileName: 'link-onclick-extensions.json' });
-  const dashboardPage = await gotoDashboardPage({ uid: 'dbfb47c5-e5e5-4d28-8ac7-35f349b95946' });
+  const dashboardPage = await gotoDashboardPage({ uid: linkOnClickDashboardUid });
   const panel = await dashboardPage.getPanelByTitle(panelTitle);
   await panel.clickOnMenuItem(extensionTitle, { parentItem: 'Extensions' });
   await expect(page.getByRole('dialog')).toContainText('Select query from "Link with new name"');

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensions.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/extensions.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+const panelTitle = 'Link with defaults';
+const extensionTitle = 'Open from time series...';
+const testIds = {
+  modal: {
+    container: 'ape-modal-body',
+  },
+  mainPage: {
+    container: 'ape-main-page-container',
+  },
+};
+
+test('should add link extension (path) with defaults to time series panel', async ({
+  gotoDashboardPage,
+  readProvisionedDashboard,
+  page,
+}) => {
+  // const dashboard = await readProvisionedDashboard({ fileName: 'link-path-extensions.json' });
+  const dashboardPage = await gotoDashboardPage({ uid: 'd1fbb077-cd44-4738-8c8a-d4e66748b719' });
+  const panel = await dashboardPage.getPanelByTitle(panelTitle);
+  await panel.clickOnMenuItem(extensionTitle, { parentItem: 'Extensions' });
+  await expect(page.getByTestId(testIds.mainPage.container)).toBeVisible();
+});
+
+test('should add link extension (onclick) with defaults to time series panel', async ({
+  gotoDashboardPage,
+  readProvisionedDashboard,
+  page,
+}) => {
+  // const dashboard = await readProvisionedDashboard({ fileName: 'link-onclick-extensions.json' });
+  const dashboardPage = await gotoDashboardPage({ uid: 'dbfb47c5-e5e5-4d28-8ac7-35f349b95946' });
+  const panel = await dashboardPage.getPanelByTitle(panelTitle);
+  await panel.clickOnMenuItem(extensionTitle, { parentItem: 'Extensions' });
+  await expect(page.getByRole('dialog')).toContainText('Select query from "Link with defaults"');
+});
+
+test('should add link extension (onclick) with new title to pie chart panel', async ({
+  gotoDashboardPage,
+  readProvisionedDashboard,
+  page,
+}) => {
+  const panelTitle = 'Link with new name';
+  const extensionTitle = 'Open from piechart';
+  // const dashboard = await readProvisionedDashboard({ fileName: 'link-onclick-extensions.json' });
+  const dashboardPage = await gotoDashboardPage({ uid: 'dbfb47c5-e5e5-4d28-8ac7-35f349b95946' });
+  const panel = await dashboardPage.getPanelByTitle(panelTitle);
+  await panel.clickOnMenuItem(extensionTitle, { parentItem: 'Extensions' });
+  await expect(page.getByRole('dialog')).toContainText('Select query from "Link with new name"');
+});

--- a/e2e/plugin-e2e/start-and-run-suite
+++ b/e2e/plugin-e2e/start-and-run-suite
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. scripts/grafana-server/variables
+
+LICENSE_PATH=""
+
+if [ "$1" = "enterprise" ]; then
+    if [ "$2" != "dev" ] && [ "$2" != "debug" ]; then
+      LICENSE_PATH=$2/license.jwt
+    else
+      LICENSE_PATH=$3/license.jwt
+    fi
+fi
+
+if [ "$BASE_URL" != "" ]; then
+    echo -e "BASE_URL set, skipping starting server"
+else
+  # Start it in the background
+  ./scripts/grafana-server/start-server $LICENSE_PATH 2>&1 > scripts/grafana-server/server.log &
+  ./scripts/grafana-server/wait-for-grafana
+fi
+
+PORT=3001 HOST=localhost yarn playwright test

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "e2e:enterprise:debug": "./e2e/start-and-run-suite enterprise debug",
     "e2e:playwright": "yarn playwright test",
     "e2e:playwright:server": "./e2e/plugin-e2e/start-and-run-suite",
-    "e2e:playwright:ui": "yarn playwright test --ui",
-    "e2e:playwright:report": "yarn playwright show-report",
     "test": "jest --notify --watch",
     "test:coverage": "jest --coverage",
     "test:coverage:changes": "jest --coverage --changedSince=origin/main",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "e2e:enterprise:dev": "./e2e/start-and-run-suite enterprise dev",
     "e2e:enterprise:debug": "./e2e/start-and-run-suite enterprise debug",
     "e2e:playwright": "yarn playwright test",
+    "e2e:playwright:server": "./e2e/plugin-e2e/start-and-run-suite",
     "e2e:playwright:ui": "yarn playwright test --ui",
     "e2e:playwright:report": "yarn playwright show-report",
     "test": "jest --notify --watch",

--- a/scripts/grafana-server/start-server
+++ b/scripts/grafana-server/start-server
@@ -31,6 +31,7 @@ mkdir $PROV_DIR
 mkdir $PROV_DIR/datasources
 mkdir $PROV_DIR/dashboards
 mkdir $PROV_DIR/alerting
+mkdir $PROV_DIR/plugins
 
 cp ./scripts/grafana-server/custom.ini $RUNDIR/conf/custom.ini
 cp ./conf/defaults.ini $RUNDIR/conf/defaults.ini
@@ -51,6 +52,7 @@ echo -e "Copy provisioning setup from devenv"
 cp devenv/datasources.yaml $PROV_DIR/datasources
 cp devenv/dashboards.yaml $PROV_DIR/dashboards
 cp devenv/alert_rules.yaml $PROV_DIR/alerting
+cp devenv/plugins.yaml $PROV_DIR/plugins
 
 cp -r devenv $RUNDIR
 


### PR DESCRIPTION
**What is this feature?**

This PR adds Playwright e2e tests that verifies that app plugins can define extension points and configure link extensions (path and onclick) using the latest Grafana runtime. 

To be able to test this, there needs to be apps with extensions (and extension points) installed on the instance that is being targeted in the e2e tests. For now, I've just copied the bundles from [app-with-extension-point](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-extension-point) and [app-with-extensions ](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-extensions) to the plugins directory. This is not ideal as it would require us to manually update the bundles whenever the examples are updated. However, I think it will still be useful as these example plugins use the now deprecated extensions APIs (configure, configureExtensionLink, getPluginExtensions etc), and we need to support them for roughly one more year.  

The e2e tests and the test dashboards are copied from the examples repo. 

**Why do we need this feature?**

To verify that legacy plugin extensions APIs are still working as expected. 

**Who is this feature for?**

Plugin authors

**Which issue(s) does this PR fix?**:

Fixes #89024

**Special notes for your reviewer:**

This change makes running e2e tests locally slightly more complicated, as it requires you to have these app plugins installed and provisioned on your local instance. As the only purpose of these apps is e2e testing and not development, I don't want to create them with the devenv scripts. So to be able to get these tests to work locally, one need to start the grafana server the [same way](https://github.com/grafana/grafana/blob/extensions/add-e2e-tests/scripts/grafana-server/start-server) as in Drone. Otherwise, the apps won't be installed. I've added a new script, `e2e:playwright:server`, that starts up the server and runs the tests. 