### PR TITLE
RBAC: Only store action sets for dashboards and folders

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -62,7 +62,6 @@ type DeleteResourcePermissionsCmd struct {
 	ResourceID        string
 }
 
-// TODO check this as well
 func (s *store) DeleteResourcePermissions(ctx context.Context, orgID int64, cmd *DeleteResourcePermissionsCmd) error {
 	scope := accesscontrol.Scope(cmd.Resource, cmd.ResourceAttribute, cmd.ResourceID)
 

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -62,6 +62,7 @@ type DeleteResourcePermissionsCmd struct {
 	ResourceID        string
 }
 
+// TODO check this as well
 func (s *store) DeleteResourcePermissions(ctx context.Context, orgID int64, cmd *DeleteResourcePermissionsCmd) error {
 	scope := accesscontrol.Scope(cmd.Resource, cmd.ResourceAttribute, cmd.ResourceID)
 
@@ -707,7 +708,7 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 }
 
 func (s *store) shouldStoreActionSet(permission string) bool {
-	return (s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) && permission != "")
+	return (s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) && permission != "" && isFolderOrDashboardAction(permission))
 }
 
 func deletePermissions(sess *db.Session, ids []int64) error {


### PR DESCRIPTION
**What is this feature?**

After testing action sets out for a bit, I think it's safer to only store them for dashboards and folders (mainly because data source `query` action overlaps with data source `query` action set name, and it's causing some issues with the UI etc).

**Why do we need this feature?**

This doesn't have any customer impact - I just think we should make this change before anyone external tests action sets.
