### PR TITLE
Alerting: Configure recording rule writer from config.ini

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1394,7 +1394,7 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
-[unified_alerting.recording_rules]
+[recording_rules]
 # Target URL (including write path) for recording rules.
 url =
 
@@ -1408,7 +1408,7 @@ basic_auth_password =
 timeout = 10s
 
 # Optional custom headers to include in recording rule write requests.
-[unified_alerting.recording_rules.custom_headers]
+[recording_rules.custom_headers]
 # exampleHeader = exampleValue
 
 # NOTE: this configuration options are not used yet.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1402,9 +1402,9 @@ basic_auth_username =
 # Optional assword for basic authentication on recording rule write requests. Can be left blank.
 basic_auth_password =
 
-[unified_alerting.recording_rules.writer.prometheus]
-# Optional tenant ID for Prometheus-compatible data sources that require it. Can be left blank.
-tenant_id =
+# Optional custom headers to include in recording rule write requests.
+[unified_alerting.recording_rules.writer.custom_headers]
+# exampleHeader = exampleValue
 
 # NOTE: this configuration options are not used yet.
 [remote.alertmanager]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1394,6 +1394,18 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
+[unified_alerting.recording_rules.writer]
+# Target URL (including write path) for recording rules.
+url =
+# Optional username for basic authentication on recording rule write requests. Can be left blank to disable basic auth
+basic_auth_username =
+# Optional assword for basic authentication on recording rule write requests. Can be left blank.
+basic_auth_password =
+
+[unified_alerting.recording_rules.writer.prometheus]
+# Optional tenant ID for Prometheus-compatible data sources that require it. Can be left blank.
+tenant_id =
+
 # NOTE: this configuration options are not used yet.
 [remote.alertmanager]
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1394,16 +1394,21 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
-[unified_alerting.recording_rules.writer]
+[unified_alerting.recording_rules]
 # Target URL (including write path) for recording rules.
 url =
+
 # Optional username for basic authentication on recording rule write requests. Can be left blank to disable basic auth
 basic_auth_username =
+
 # Optional assword for basic authentication on recording rule write requests. Can be left blank.
 basic_auth_password =
 
+# Request timeout for recording rule writes.
+timeout = 10s
+
 # Optional custom headers to include in recording rule write requests.
-[unified_alerting.recording_rules.writer.custom_headers]
+[unified_alerting.recording_rules.custom_headers]
 # exampleHeader = exampleValue
 
 # NOTE: this configuration options are not used yet.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1295,6 +1295,18 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
+[unified_alerting.recording_rules.writer]
+# Target URL (including write path) for recording rules.
+url =
+# Optional username for basic authentication on recording rule write requests. Can be left blank to disable basic auth
+basic_auth_username =
+# Optional assword for basic authentication on recording rule write requests. Can be left blank.
+basic_auth_password =
+
+# Optional custom headers to include in recording rule write requests.
+[unified_alerting.recording_rules.writer.custom_headers]
+# exampleHeader = exampleValue
+
 #################################### Annotations #########################
 [annotations]
 # Configures the batch size for the annotation clean-up job. This setting is used for dashboard, API, and alert annotations.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1295,16 +1295,21 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
-[unified_alerting.recording_rules.writer]
+[unified_alerting.recording_rules]
 # Target URL (including write path) for recording rules.
 url =
+
 # Optional username for basic authentication on recording rule write requests. Can be left blank to disable basic auth
 basic_auth_username =
+
 # Optional assword for basic authentication on recording rule write requests. Can be left blank.
 basic_auth_password =
 
+# Request timeout for recording rule writes.
+timeout = 30s
+
 # Optional custom headers to include in recording rule write requests.
-[unified_alerting.recording_rules.writer.custom_headers]
+[unified_alerting.recording_rules.custom_headers]
 # exampleHeader = exampleValue
 
 #################################### Annotations #########################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1295,7 +1295,8 @@ max_age =
 # Configures max number of alert annotations that Grafana stores. Default value is 0, which keeps all alert annotations.
 max_annotations_to_keep =
 
-[unified_alerting.recording_rules]
+#################################### Recording Rules #####################
+[recording_rules]
 # Target URL (including write path) for recording rules.
 url =
 
@@ -1309,7 +1310,7 @@ basic_auth_password =
 timeout = 30s
 
 # Optional custom headers to include in recording rule write requests.
-[unified_alerting.recording_rules.custom_headers]
+[recording_rules.custom_headers]
 # exampleHeader = exampleValue
 
 #################################### Annotations #########################

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -296,7 +296,7 @@ func (ng *AlertNG) init() error {
 			URL:               ng.Cfg.UnifiedAlerting.RecordingRules.URL,
 			BasicAuthUsername: ng.Cfg.UnifiedAlerting.RecordingRules.BasicAuthUsername,
 			BasicAuthPassword: ng.Cfg.UnifiedAlerting.RecordingRules.BasicAuthPassword,
-			TenantID:          ng.Cfg.UnifiedAlerting.RecordingRules.TenantID,
+			CustomHeaders:     ng.Cfg.UnifiedAlerting.RecordingRules.CustomHeaders,
 			Timeout:           10 * time.Second,
 		}
 		recordingWriter, err = writer.NewPrometheusWriter(promWriterCfg, log.New("ngalert.writer"))

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
-	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
@@ -57,7 +56,7 @@ func newRuleFactory(
 	met *metrics.Scheduler,
 	logger log.Logger,
 	tracer tracing.Tracer,
-	recordingWriter writer.Writer,
+	recordingWriter RecordingWriter,
 	evalAppliedHook evalAppliedFunc,
 	stopAppliedHook stopAppliedFunc,
 ) ruleFactoryFunc {

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/util"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -39,10 +38,10 @@ type recordingRule struct {
 	metrics *metrics.Scheduler
 	tracer  tracing.Tracer
 
-	writer writer.Writer
+	writer RecordingWriter
 }
 
-func newRecordingRule(parent context.Context, maxAttempts int64, clock clock.Clock, evalFactory eval.EvaluatorFactory, ft featuremgmt.FeatureToggles, logger log.Logger, metrics *metrics.Scheduler, tracer tracing.Tracer, writer writer.Writer) *recordingRule {
+func newRecordingRule(parent context.Context, maxAttempts int64, clock clock.Clock, evalFactory eval.EvaluatorFactory, ft featuremgmt.FeatureToggles, logger log.Logger, metrics *metrics.Scheduler, tracer tracing.Tracer, writer RecordingWriter) *recordingRule {
 	ctx, stop := util.WithCancelCause(parent)
 	return &recordingRule{
 		ctx:            ctx,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/benbjohnson/clock"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -19,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
-	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/util/ticker"
 )
 
@@ -45,6 +45,10 @@ type AlertsSender interface {
 type RulesStore interface {
 	GetAlertRulesKeysForScheduling(ctx context.Context) ([]ngmodels.AlertRuleKeyWithVersion, error)
 	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error
+}
+
+type RecordingWriter interface {
+	Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error
 }
 
 type schedule struct {
@@ -94,7 +98,7 @@ type schedule struct {
 
 	tracer tracing.Tracer
 
-	recordingWriter writer.Writer
+	recordingWriter RecordingWriter
 }
 
 // SchedulerCfg is the scheduler configuration.
@@ -113,7 +117,7 @@ type SchedulerCfg struct {
 	AlertSender          AlertsSender
 	Tracer               tracing.Tracer
 	Log                  log.Logger
-	RecordingWriter      writer.Writer
+	RecordingWriter      RecordingWriter
 }
 
 // NewScheduler returns a new scheduler.

--- a/pkg/services/ngalert/writer/noop.go
+++ b/pkg/services/ngalert/writer/noop.go
@@ -7,10 +7,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-type Writer interface {
-	Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error
-}
-
 type NoopWriter struct{}
 
 func (w NoopWriter) Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error {

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -74,7 +74,7 @@ type PrometheusWriterConfig struct {
 	URL               string
 	BasicAuthUsername string
 	BasicAuthPassword string
-	TenantID          string
+	CustomHeaders     map[string]string
 	Timeout           time.Duration
 }
 

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/dataplane/sdata/numeric"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
@@ -70,25 +71,15 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 	return points, nil
 }
 
-type PrometheusWriterConfig struct {
-	URL               string
-	BasicAuthUsername string
-	BasicAuthPassword string
-	CustomHeaders     map[string]string
-	Timeout           time.Duration
-}
-
 type PrometheusWriter struct {
-	cfg    PrometheusWriterConfig
 	logger log.Logger
 }
 
 func NewPrometheusWriter(
-	cfg PrometheusWriterConfig,
+	settings setting.RecordingRuleSettings,
 	l log.Logger,
 ) (*PrometheusWriter, error) {
 	return &PrometheusWriter{
-		cfg:    cfg,
 		logger: l,
 	}, nil
 }

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -11,10 +11,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-type PrometheusWriter struct {
-	logger log.Logger
-}
-
 // Metric represents a Prometheus time series metric.
 type Metric struct {
 	T int64
@@ -26,27 +22,6 @@ type Point struct {
 	Name   string
 	Labels map[string]string
 	Metric Metric
-}
-
-func NewPrometheusWriter(l log.Logger) *PrometheusWriter {
-	return &PrometheusWriter{
-		logger: l,
-	}
-}
-
-// Write writes the given frames to the Prometheus remote write endpoint.
-// TODO: stub implementation, does not make any remote write calls.
-func (w PrometheusWriter) Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error {
-	l := w.logger.FromContext(ctx)
-
-	points, err := PointsFromFrames(name, t, frames, extraLabels)
-	if err != nil {
-		return err
-	}
-
-	// TODO: placeholder for actual remote write call
-	l.Debug("writing points", "points", points)
-	return nil
 }
 
 func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels map[string]string) ([]Point, error) {
@@ -93,4 +68,42 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 	}
 
 	return points, nil
+}
+
+type PrometheusWriterConfig struct {
+	URL               string
+	BasicAuthUsername string
+	BasicAuthPassword string
+	TenantID          string
+	Timeout           time.Duration
+}
+
+type PrometheusWriter struct {
+	cfg    PrometheusWriterConfig
+	logger log.Logger
+}
+
+func NewPrometheusWriter(
+	cfg PrometheusWriterConfig,
+	l log.Logger,
+) (*PrometheusWriter, error) {
+	return &PrometheusWriter{
+		cfg:    cfg,
+		logger: l,
+	}, nil
+}
+
+// Write writes the given frames to the Prometheus remote write endpoint.
+// TODO: stub implementation, does not make any remote write calls.
+func (w PrometheusWriter) Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error {
+	l := w.logger.FromContext(ctx)
+
+	points, err := PointsFromFrames(name, t, frames, extraLabels)
+	if err != nil {
+		return err
+	}
+
+	// TODO: placeholder for actual remote write call
+	l.Debug("writing points", "points", points)
+	return nil
 }

--- a/pkg/services/ngalert/writer/writer.go
+++ b/pkg/services/ngalert/writer/writer.go
@@ -10,3 +10,9 @@ import (
 type Writer interface {
 	Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error
 }
+
+type NoopWriter struct{}
+
+func (w NoopWriter) Write(ctx context.Context, name string, t time.Time, frames data.Frames, extraLabels map[string]string) error {
+	return nil
+}

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -100,6 +100,8 @@ type UnifiedAlertingSettings struct {
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	RemoteAlertmanager            RemoteAlertmanagerSettings
+	RecordingRules                RecordingRuleSettings
+
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
 	MaxStateSaveConcurrency   int
 	StatePeriodicSaveInterval time.Duration
@@ -107,6 +109,13 @@ type UnifiedAlertingSettings struct {
 
 	// Retention period for Alertmanager notification log entries.
 	NotificationLogRetention time.Duration
+}
+
+type RecordingRuleSettings struct {
+	URL               string
+	BasicAuthUsername string
+	BasicAuthPassword string
+	TenantID          string
 }
 
 // RemoteAlertmanagerSettings contains the configuration needed
@@ -387,6 +396,16 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		ExternalLabels:        stateHistoryLabels.KeysHash(),
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
+
+	rrWriter := iniFile.Section("unified_alerting.recording_rules.writer")
+	rrWriterProm := iniFile.Section("unified_alerting.recording_rules.writer.prometheus")
+	uaCfgRecordingRules := RecordingRuleSettings{
+		URL:               rrWriter.Key("url").MustString(""),
+		BasicAuthUsername: rrWriter.Key("basic_auth_username").MustString(""),
+		BasicAuthPassword: rrWriter.Key("basic_auth_password").MustString(""),
+		TenantID:          rrWriterProm.Key("tenant_id").MustString(""),
+	}
+	uaCfg.RecordingRules = uaCfgRecordingRules
 
 	uaCfg.MaxStateSaveConcurrency = ua.Key("max_state_save_concurrency").MustInt(1)
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -399,7 +399,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	}
 	uaCfg.StateHistory = uaCfgStateHistory
 
-	rr := iniFile.Section("unified_alerting.recording_rules")
+	rr := iniFile.Section("recording_rules")
 	uaCfgRecordingRules := RecordingRuleSettings{
 		URL:               rr.Key("url").MustString(""),
 		BasicAuthUsername: rr.Key("basic_auth_username").MustString(""),
@@ -407,7 +407,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		Timeout:           rr.Key("timeout").MustDuration(defaultRecordingRequestTimeout),
 	}
 
-	rrHeaders := iniFile.Section("unified_alerting.recording_rules.custom_headers")
+	rrHeaders := iniFile.Section("recording_rules.custom_headers")
 	rrHeadersKeys := rrHeaders.Keys()
 	uaCfgRecordingRules.CustomHeaders = make(map[string]string, len(rrHeadersKeys))
 	for _, key := range rrHeadersKeys {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -115,7 +115,7 @@ type RecordingRuleSettings struct {
 	URL               string
 	BasicAuthUsername string
 	BasicAuthPassword string
-	TenantID          string
+	CustomHeaders     map[string]string
 }
 
 // RemoteAlertmanagerSettings contains the configuration needed
@@ -398,13 +398,19 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.StateHistory = uaCfgStateHistory
 
 	rrWriter := iniFile.Section("unified_alerting.recording_rules.writer")
-	rrWriterProm := iniFile.Section("unified_alerting.recording_rules.writer.prometheus")
 	uaCfgRecordingRules := RecordingRuleSettings{
 		URL:               rrWriter.Key("url").MustString(""),
 		BasicAuthUsername: rrWriter.Key("basic_auth_username").MustString(""),
 		BasicAuthPassword: rrWriter.Key("basic_auth_password").MustString(""),
-		TenantID:          rrWriterProm.Key("tenant_id").MustString(""),
 	}
+
+	rrWriterHeaders := iniFile.Section("unified_alerting.recording_rules.writer.custom_headers")
+	rrWriterHeadersKeys := rrWriterHeaders.Keys()
+	uaCfgRecordingRules.CustomHeaders = make(map[string]string, len(rrWriterHeadersKeys))
+	for _, key := range rrWriterHeadersKeys {
+		uaCfgRecordingRules.CustomHeaders[key.Name()] = key.Value()
+	}
+
 	uaCfg.RecordingRules = uaCfgRecordingRules
 
 	uaCfg.MaxStateSaveConcurrency = ua.Key("max_state_save_concurrency").MustInt(1)


### PR DESCRIPTION
**What is this feature?**

This introduces basic config options for the recording rules writer, specifically used by the Prometheus writer for now.

**Why do we need this feature?**

Allows users to configure the write URL and basic auth for recording rule writes.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
