### PR TITLE
[v11.0.x] Auth: Removal of conflicting users check upon creation

### DIFF
--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -1,8 +1,6 @@
 package user
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/auth/identity"
@@ -231,33 +229,12 @@ type CompleteEmailVerifyCommand struct {
 	Code string
 }
 
-type ErrCaseInsensitiveLoginConflict struct {
-	Users []User
-}
-
 type UserDisplayDTO struct {
 	ID        int64  `json:"id,omitempty"`
 	UID       string `json:"uid,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Login     string `json:"login,omitempty"`
 	AvatarURL string `json:"avatarUrl"`
-}
-
-func (e *ErrCaseInsensitiveLoginConflict) Unwrap() error {
-	return ErrCaseInsensitive
-}
-
-func (e *ErrCaseInsensitiveLoginConflict) Error() string {
-	n := len(e.Users)
-
-	userStrings := make([]string, 0, n)
-	for _, v := range e.Users {
-		userStrings = append(userStrings, fmt.Sprintf("%s (email:%s, id:%d)", v.Login, v.Email, v.ID))
-	}
-
-	return fmt.Sprintf(
-		"Found a conflict in user login information. %d users already exist with either the same login or email: [%s].",
-		n, strings.Join(userStrings, ", "))
 }
 
 type Filter interface {


### PR DESCRIPTION
Backport c85d10d6c3befb1c0403b3d2571e205d4acbe80b from #89045

---

**why**
During investigation we have seen that we limit the number of case insensitive login/emails to two users previously.

We should only allow for one and one only login/email for a users email now that we have caseinsensitivelogin checks at default. (meaning only one login/email lowercased for a user)

**what**
this lowercases the conflict check and removes the unncessary checks from the conflict check.


