### PR TITLE
BrowseDashboards: Prepend subpath to New Browse Dashboard actions

### DIFF
--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Dropdown, Icon, Menu, MenuItem } from '@grafana/ui';
 import {
   getNewDashboardPhrase,
@@ -50,11 +50,11 @@ export default function CreateNewButton({ parentFolder, canCreateDashboard, canC
           label={getNewDashboardPhrase()}
           onClick={() =>
             reportInteraction('grafana_menu_item_clicked', {
-              url: addFolderUidToUrl('/dashboard/new', parentFolder?.uid),
+              url: buildUrl('/dashboard/new', parentFolder?.uid),
               from: location.pathname,
             })
           }
-          url={addFolderUidToUrl('/dashboard/new', parentFolder?.uid)}
+          url={buildUrl('/dashboard/new', parentFolder?.uid)}
         />
       )}
       {canCreateFolder && <MenuItem onClick={() => setShowNewFolderDrawer(true)} label={getNewFolderPhrase()} />}
@@ -63,11 +63,11 @@ export default function CreateNewButton({ parentFolder, canCreateDashboard, canC
           label={getImportPhrase()}
           onClick={() =>
             reportInteraction('grafana_menu_item_clicked', {
-              url: addFolderUidToUrl('/dashboard/import', parentFolder?.uid),
+              url: buildUrl('/dashboard/import', parentFolder?.uid),
               from: location.pathname,
             })
           }
-          url={addFolderUidToUrl('/dashboard/import', parentFolder?.uid)}
+          url={buildUrl('/dashboard/import', parentFolder?.uid)}
         />
       )}
     </Menu>
@@ -101,6 +101,7 @@ export default function CreateNewButton({ parentFolder, canCreateDashboard, canC
  * @param folderUid  folder id
  * @returns url with paramter if folder is present
  */
-function addFolderUidToUrl(url: string, folderUid: string | undefined) {
-  return folderUid ? url + '?folderUid=' + folderUid : url;
+function buildUrl(url: string, folderUid: string | undefined) {
+  const baseUrl = folderUid ? url + '?folderUid=' + folderUid : url;
+  return config.appSubUrl ? config.appSubUrl + baseUrl : baseUrl;
 }


### PR DESCRIPTION
Fixes an issue where the New Dashboard and Import buttons on Browse Dashboards wouldn't link correctly if serving Grafana from the `/dashboards` subpath.

As I mentioned in https://github.com/grafana/grafana/pull/84992#pullrequestreview-1966147154, this is mainly only a problem when Grafana is served from a subpath which conflicts with a prefix of the application URL - e.g. `/dashboards`. Automatic subpath-ing/react-router breaks down in this scenario.

Fixes https://github.com/grafana/grafana/issues/80777 