### PR TITLE
Adds metric and compare function

### DIFF
--- a/pkg/registry/apis/query/metrics.go
+++ b/pkg/registry/apis/query/metrics.go
@@ -7,10 +7,18 @@ import (
 const (
 	metricsSubSystem = "queryservice"
 	metricsNamespace = "grafana"
+
+	compareResultError     = "error"
+	compareResultEqual     = "equal"
+	compareResultDifferent = "different"
+
+	compareLabelResult         = "result"
+	compareLabelDatasourceType = "datasource_type"
 )
 
 type metrics struct {
 	dsRequests *prometheus.CounterVec
+	dsCompare  *prometheus.CounterVec
 
 	// older metric
 	expressionsQuerySummary *prometheus.SummaryVec
@@ -24,7 +32,12 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			Name:      "ds_queries_total",
 			Help:      "Number of datasource queries made from the query service",
 		}, []string{"error", "dataplane", "datasource_type"}),
-
+		dsCompare: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubSystem,
+			Name:      "ds_compare_results_total",
+			Help:      "Results that got compared using passive mode for the query service",
+		}, []string{compareLabelResult, compareLabelDatasourceType}),
 		expressionsQuerySummary: prometheus.NewSummaryVec(
 			prometheus.SummaryOpts{
 				Namespace:  metricsNamespace,

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -244,7 +244,7 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 
 	if b.passiveModeClient != nil {
 		// Let's only run the passive mode for prometheus and loki.
-		if pluginID == datasources.DS_PROMETHEUS && pluginID == datasources.DS_LOKI {
+		if pluginID == datasources.DS_PROMETHEUS || pluginID == datasources.DS_LOKI {
 			b.log.Debug("running dry run comparison to multi-tenant")
 			go b.queryDataAndCompare(ctx, pluginID, pluginUID, req2, code, rsp)
 		}

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -41,19 +41,19 @@ type QueryAPIBuilder struct {
 	returnMultiStatus      bool // from feature toggle
 	features               featuremgmt.FeatureToggles
 
-	tracer       tracing.Tracer
-	metrics      *metrics
-	parser       *queryParser
-	client       DataSourceClientSupplier
-	dryRunClient *DataSourceClientSupplier
-	registry     query.DataSourceApiServerRegistry
-	converter    *expr.ResultConverter
-	queryTypes   *query.QueryTypeDefinitionList
+	tracer            tracing.Tracer
+	metrics           *metrics
+	parser            *queryParser
+	client            DataSourceClientSupplier
+	passiveModeClient *DataSourceClientSupplier
+	registry          query.DataSourceApiServerRegistry
+	converter         *expr.ResultConverter
+	queryTypes        *query.QueryTypeDefinitionList
 }
 
 func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
 	client DataSourceClientSupplier,
-	dryRunClient *DataSourceClientSupplier,
+	passiveModeClient *DataSourceClientSupplier,
 	registry query.DataSourceApiServerRegistry,
 	legacy service.LegacyDataSourceLookup,
 	registerer prometheus.Registerer,
@@ -81,7 +81,7 @@ func NewQueryAPIBuilder(features featuremgmt.FeatureToggles,
 		log:                  log.New("query_apiserver"),
 		returnMultiStatus:    features.IsEnabledGlobally(featuremgmt.FlagDatasourceQueryMultiStatus),
 		client:               client,
-		dryRunClient:         dryRunClient,
+		passiveModeClient:    passiveModeClient,
 		registry:             registry,
 		parser:               newQueryParser(reader, legacy, tracer),
 		metrics:              newMetrics(registerer),


### PR DESCRIPTION
This PR does a few things:

- Compares only on `prometheus` and `loki`
- Renames DryRun to PassiveMode, as this is something more commonly known, especially when talking to other teams.
- Adds a simple compare function, that compares the shape of the returned dataframes.
- Adds a metric to track the comparisons