### PR TITLE
DashboardScene: Fixes issue removing override rule

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptions.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptions.test.tsx
@@ -152,6 +152,14 @@ describe('PanelOptions', () => {
 
       expect(screen.queryByLabelText(overrideRuleTooltipDescription)).not.toBeInTheDocument();
     });
+
+    it('Can delete rule', async () => {
+      const {} = setup();
+
+      await userEvent.click(screen.getByLabelText('Remove override'));
+
+      expect(screen.queryByLabelText(overrideRuleTooltipDescription)).not.toBeInTheDocument();
+    });
   });
 
   it('gets library panel options when the editing a library panel', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptions.tsx
@@ -62,7 +62,7 @@ export const PanelOptions = React.memo<Props>(({ vizManager, searchQuery, listMo
         data?.series ?? [],
         searchQuery,
         (newConfig) => {
-          panel.onFieldConfigChange(newConfig);
+          panel.onFieldConfigChange(newConfig, true);
         }
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
The fieldConfig merging (which is done by default when replace? is not true), automatically restores any field overrides (a bit counter intuitive when passing in an empty overrides array).
https://github.com/grafana/scenes/blob/main/packages/scenes/src/components/VizPanel/VizPanel.tsx#L289 

Anyway this fixes the issue removing overrides caused by a recent bugfix PR https://github.com/grafana/grafana/pull/88796
