### PR TITLE
Tracing: Only enable traces to profiles for api servers for now

### DIFF
--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -272,7 +272,9 @@ func (ots *TracingService) initOpentelemetryTracer() error {
 		}
 	}
 
-	tp = NewProfilingTracerProvider(tp)
+	if ots.cfg.ProfilingIntegration {
+		tp = NewProfilingTracerProvider(tp)
+	}
 
 	// Register our TracerProvider as the global so any imported
 	// instrumentation in the future will default to using it

--- a/pkg/infra/tracing/tracing_config.go
+++ b/pkg/infra/tracing/tracing_config.go
@@ -21,6 +21,8 @@ type TracingConfig struct {
 
 	ServiceName    string
 	ServiceVersion string
+
+	ProfilingIntegration bool
 }
 
 func ProvideTracingConfig(cfg *setting.Cfg) (*TracingConfig, error) {

--- a/pkg/services/apiserver/standalone/options/tracing.go
+++ b/pkg/services/apiserver/standalone/options/tracing.go
@@ -109,6 +109,7 @@ func (o *TracingOptions) ApplyTo(config *genericapiserver.RecommendedConfig) err
 	tracingCfg.Sampler = o.SamplerType
 	tracingCfg.SamplerParam = o.SamplerParam
 	tracingCfg.SamplerRemoteURL = o.SamplingServiceURL
+	tracingCfg.ProfilingIntegration = true
 
 	ts, err := tracing.ProvideService(tracingCfg)
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

Follow up from https://github.com/grafana/grafana/pull/88896. This removes enable tracing to profiles enabled by default in Grafana and only enables it for api servers.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
