### PR TITLE
Alerting: Move rule evaluation status logic out of prometheus API and into scheduler

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -63,6 +63,7 @@ type API struct {
 	DataProxy            *datasourceproxy.DataSourceProxyService
 	MultiOrgAlertmanager *notifier.MultiOrgAlertmanager
 	StateManager         *state.Manager
+	Scheduler            SchedulerReader
 	AccessControl        ac.AccessControl
 	Policies             *provisioning.NotificationPolicyService
 	ReceiverService      *notifier.ReceiverService
@@ -115,7 +116,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterPrometheusApiEndpoints(NewForkingProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
-		&PrometheusSrv{log: logger, manager: api.StateManager, store: api.RuleStore, authz: ruleAuthzService},
+		&PrometheusSrv{log: logger, manager: api.StateManager, sch: api.Scheduler, store: api.RuleStore, authz: ruleAuthzService},
 	), m)
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkingRuler(

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -63,7 +63,7 @@ type API struct {
 	DataProxy            *datasourceproxy.DataSourceProxyService
 	MultiOrgAlertmanager *notifier.MultiOrgAlertmanager
 	StateManager         *state.Manager
-	Scheduler            SchedulerReader
+	Scheduler            StatusReader
 	AccessControl        ac.AccessControl
 	Policies             *provisioning.NotificationPolicyService
 	ReceiverService      *notifier.ReceiverService
@@ -116,7 +116,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterPrometheusApiEndpoints(NewForkingProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
-		&PrometheusSrv{log: logger, manager: api.StateManager, sch: api.Scheduler, store: api.RuleStore, authz: ruleAuthzService},
+		&PrometheusSrv{log: logger, manager: api.StateManager, status: api.Scheduler, store: api.RuleStore, authz: ruleAuthzService},
 	), m)
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkingRuler(

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -447,7 +447,14 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 
 	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	for _, rule := range rules {
-		status, _ := sch.Status(rule.GetKey())
+		status, ok := sch.Status(rule.GetKey())
+		// Grafana by design return "ok" health and default other fields for unscheduled rules.
+		// This differs from Prometheus.
+		if !ok {
+			status = ngmodels.RuleStatus{
+				Health: "ok",
+			}
+		}
 
 		alertingRule := apimodels.AlertingRule{
 			State:       "inactive",

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/prometheus/alertmanager/pkg/labels"
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -448,6 +447,8 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 
 	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	for _, rule := range rules {
+		health, _ := sch.Health(rule.GetKey())
+
 		alertingRule := apimodels.AlertingRule{
 			State:       "inactive",
 			Name:        rule.Title,
@@ -459,9 +460,11 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 		newRule := apimodels.Rule{
 			Name:           rule.Title,
 			Labels:         apimodels.LabelsFromMap(rule.GetLabels(labelOptions...)),
-			Health:         "ok",
+			Health:         health.Health,
+			LastError:      errorOrEmpty(health.LastError),
 			Type:           rule.Type().String(),
-			LastEvaluation: time.Time{},
+			LastEvaluation: health.EvaluatedAt,
+			EvaluationTime: health.EvaluatedDuration.Seconds(),
 		}
 
 		states := manager.GetStatesForRuleUID(rule.OrgID, rule.UID)
@@ -490,12 +493,6 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 				Value:    valString,
 			}
 
-			if alertState.LastEvaluationTime.After(newRule.LastEvaluation) {
-				newRule.LastEvaluation = alertState.LastEvaluationTime
-			}
-
-			newRule.EvaluationTime = alertState.EvaluationDuration.Seconds()
-
 			switch alertState.State {
 			case eval.Normal:
 			case eval.Pending:
@@ -508,14 +505,7 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 				}
 				alertingRule.State = "firing"
 			case eval.Error:
-				newRule.Health = "error"
 			case eval.NoData:
-				newRule.Health = "nodata"
-			}
-
-			if alertState.Error != nil {
-				newRule.LastError = alertState.Error.Error()
-				newRule.Health = "error"
 			}
 
 			if len(withStates) > 0 {
@@ -608,4 +598,11 @@ func encodedQueriesOrError(rules []ngmodels.AlertQuery) string {
 	}
 
 	return err.Error()
+}
+
+func errorOrEmpty(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -470,8 +470,8 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sr StatusRe
 			Health:         status.Health,
 			LastError:      errorOrEmpty(status.LastError),
 			Type:           rule.Type().String(),
-			LastEvaluation: status.EvaluatedAt,
-			EvaluationTime: status.EvaluatedDuration.Seconds(),
+			LastEvaluation: status.EvaluationTimestamp,
+			EvaluationTime: status.EvaluationDuration.Seconds(),
 		}
 
 		states := manager.GetStatesForRuleUID(rule.OrgID, rule.UID)

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -239,14 +239,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 	return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 }
 
-<<<<<<< HEAD
 func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager, status StatusReader, store ListAlertRulesStore, opts RuleGroupStatusesOptions) apimodels.RuleResponse {
-=======
-// TODO: Refactor this function to reduce the cylomatic complexity
-//
-//nolint:gocyclo
-func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager, status StatusReader, store ListAlertRulesStore, opts RuleGroupStatusesOptions) apimodels.RuleResponse {
->>>>>>> 8e7bedd172b (rename to StatusReader)
 	ruleResponse := apimodels.RuleResponse{
 		DiscoveryBase: apimodels.DiscoveryBase{
 			Status: "success",

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -24,7 +24,7 @@ import (
 )
 
 type SchedulerReader interface {
-	Health(key ngmodels.AlertRuleKey) (ngmodels.Health, bool)
+	Status(key ngmodels.AlertRuleKey) (ngmodels.RuleStatus, bool)
 }
 
 type PrometheusSrv struct {
@@ -447,7 +447,7 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 
 	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	for _, rule := range rules {
-		health, _ := sch.Health(rule.GetKey())
+		status, _ := sch.Status(rule.GetKey())
 
 		alertingRule := apimodels.AlertingRule{
 			State:       "inactive",
@@ -460,11 +460,11 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, sch Schedul
 		newRule := apimodels.Rule{
 			Name:           rule.Title,
 			Labels:         apimodels.LabelsFromMap(rule.GetLabels(labelOptions...)),
-			Health:         health.Health,
-			LastError:      errorOrEmpty(health.LastError),
+			Health:         status.Health,
+			LastError:      errorOrEmpty(status.LastError),
 			Type:           rule.Type().String(),
-			LastEvaluation: health.EvaluatedAt,
-			EvaluationTime: health.EvaluatedDuration.Seconds(),
+			LastEvaluation: status.EvaluatedAt,
+			EvaluationTime: status.EvaluatedDuration.Seconds(),
 		}
 
 		states := manager.GetStatesForRuleUID(rule.OrgID, rule.UID)

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -498,7 +498,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			api := PrometheusSrv{
 				log:     log.NewNopLogger(),
 				manager: fakeAIM,
-				sch:     fakeSch,
+				status:  fakeSch,
 				store:   ruleStore,
 				authz:   &fakeRuleAccessControlService{},
 			}
@@ -560,7 +560,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		api := PrometheusSrv{
 			log:     log.NewNopLogger(),
 			manager: fakeAIM,
-			sch:     newFakeSchedulerReader(t).setupStates(fakeAIM),
+			status:  newFakeSchedulerReader(t).setupStates(fakeAIM),
 			store:   ruleStore,
 			authz:   accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())),
 		}
@@ -676,7 +676,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			api := PrometheusSrv{
 				log:     log.NewNopLogger(),
 				manager: fakeAIM,
-				sch:     newFakeSchedulerReader(t).setupStates(fakeAIM),
+				status:  newFakeSchedulerReader(t).setupStates(fakeAIM),
 				store:   ruleStore,
 				authz:   accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())),
 			}
@@ -1399,7 +1399,7 @@ func setupAPI(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, Promet
 	api := PrometheusSrv{
 		log:     log.NewNopLogger(),
 		manager: fakeAIM,
-		sch:     fakeSch,
+		status:  fakeSch,
 		store:   fakeStore,
 		authz:   fakeAuthz,
 	}

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -489,6 +489,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		t.Run("should return sorted", func(t *testing.T) {
 			ruleStore := fakes.NewRuleStore(t)
 			fakeAIM := NewFakeAlertInstanceManager(t)
+			fakeSch := newFakeSchedulerReader(t).setupStates(fakeAIM)
 			groupKey := ngmodels.GenerateGroupKey(orgID)
 			gen := ngmodels.RuleGen
 			rules := gen.With(gen.WithGroupKey(groupKey), gen.WithUniqueGroupIndex()).GenerateManyRef(5, 10)
@@ -497,6 +498,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			api := PrometheusSrv{
 				log:     log.NewNopLogger(),
 				manager: fakeAIM,
+				sch:     fakeSch,
 				store:   ruleStore,
 				authz:   &fakeRuleAccessControlService{},
 			}
@@ -558,6 +560,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 		api := PrometheusSrv{
 			log:     log.NewNopLogger(),
 			manager: fakeAIM,
+			sch:     newFakeSchedulerReader(t).setupStates(fakeAIM),
 			store:   ruleStore,
 			authz:   accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())),
 		}
@@ -673,6 +676,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			api := PrometheusSrv{
 				log:     log.NewNopLogger(),
 				manager: fakeAIM,
+				sch:     newFakeSchedulerReader(t).setupStates(fakeAIM),
 				store:   ruleStore,
 				authz:   accesscontrol.NewRuleService(acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())),
 			}
@@ -1389,11 +1393,13 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 func setupAPI(t *testing.T) (*fakes.RuleStore, *fakeAlertInstanceManager, PrometheusSrv) {
 	fakeStore := fakes.NewRuleStore(t)
 	fakeAIM := NewFakeAlertInstanceManager(t)
+	fakeSch := newFakeSchedulerReader(t).setupStates(fakeAIM)
 	fakeAuthz := &fakeRuleAccessControlService{}
 
 	api := PrometheusSrv{
 		log:     log.NewNopLogger(),
 		manager: fakeAIM,
+		sch:     fakeSch,
 		store:   fakeStore,
 		authz:   fakeAuthz,
 	}

--- a/pkg/services/ngalert/api/testing.go
+++ b/pkg/services/ngalert/api/testing.go
@@ -191,5 +191,5 @@ func (f *fakeSchedulerReader) Status(key models.AlertRuleKey) (models.RuleStatus
 	if f.states == nil {
 		return models.RuleStatus{}, false
 	}
-	return schedule.StatesToHealth(f.states.GetStatesForRuleUID(key.OrgID, key.UID)), true
+	return schedule.StatesToRuleStatus(f.states.GetStatesForRuleUID(key.OrgID, key.UID)), true
 }

--- a/pkg/services/ngalert/api/testing.go
+++ b/pkg/services/ngalert/api/testing.go
@@ -13,7 +13,6 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -191,5 +190,5 @@ func (f *fakeSchedulerReader) Status(key models.AlertRuleKey) (models.RuleStatus
 	if f.states == nil {
 		return models.RuleStatus{}, false
 	}
-	return schedule.StatesToRuleStatus(f.states.GetStatesForRuleUID(key.OrgID, key.UID)), true
+	return state.StatesToRuleStatus(f.states.GetStatesForRuleUID(key.OrgID, key.UID)), true
 }

--- a/pkg/services/ngalert/api/testing.go
+++ b/pkg/services/ngalert/api/testing.go
@@ -187,9 +187,9 @@ func (f *fakeSchedulerReader) setupStates(reader statesReader) *fakeSchedulerRea
 	return f
 }
 
-func (f *fakeSchedulerReader) Health(key models.AlertRuleKey) (models.Health, bool) {
+func (f *fakeSchedulerReader) Status(key models.AlertRuleKey) (models.RuleStatus, bool) {
 	if f.states == nil {
-		return models.Health{}, false
+		return models.RuleStatus{}, false
 	}
 	return schedule.StatesToHealth(f.states.GetStatesForRuleUID(key.OrgID, key.UID)), true
 }

--- a/pkg/services/ngalert/api/testing.go
+++ b/pkg/services/ngalert/api/testing.go
@@ -13,6 +13,7 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -165,4 +166,30 @@ func (f fakeRuleAccessControlService) AuthorizeDatasourceAccessForRule(ctx conte
 
 func (f fakeRuleAccessControlService) AuthorizeDatasourceAccessForRuleGroup(ctx context.Context, user identity.Requester, rules models.RulesGroup) error {
 	return nil
+}
+
+type statesReader interface {
+	GetStatesForRuleUID(orgID int64, alertRuleUID string) []*state.State
+}
+
+type fakeSchedulerReader struct {
+	states statesReader
+}
+
+func newFakeSchedulerReader(t *testing.T) *fakeSchedulerReader {
+	return &fakeSchedulerReader{}
+}
+
+// setupStates allows the fake scheduler to return data consistent with states defined elsewhere.
+// This can be combined with fakeAlertInstanceManager, for instance.
+func (f *fakeSchedulerReader) setupStates(reader statesReader) *fakeSchedulerReader {
+	f.states = reader
+	return f
+}
+
+func (f *fakeSchedulerReader) Health(key models.AlertRuleKey) (models.Health, bool) {
+	if f.states == nil {
+		return models.Health{}, false
+	}
+	return schedule.StatesToHealth(f.states.GetStatesForRuleUID(key.OrgID, key.UID)), true
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -887,8 +887,8 @@ func hasAnyCondition(rule *AlertRuleWithOptionals) bool {
 	return rule.Condition != "" || (rule.Record != nil && rule.Record.From != "")
 }
 
-// Health contains health-tracking info about a rule's current evaluation state.
-type Health struct {
+// RuleStatus contains info about a rule's current evaluation state.
+type RuleStatus struct {
 	Health            string
 	LastError         error
 	EvaluatedAt       time.Time

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -886,3 +886,11 @@ func (r *Record) Fingerprint() data.Fingerprint {
 func hasAnyCondition(rule *AlertRuleWithOptionals) bool {
 	return rule.Condition != "" || (rule.Record != nil && rule.Record.From != "")
 }
+
+// Health contains health-tracking info about a rule's current evaluation state.
+type Health struct {
+	Health            string
+	LastError         error
+	EvaluatedAt       time.Time
+	EvaluatedDuration time.Duration
+}

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -889,8 +889,8 @@ func hasAnyCondition(rule *AlertRuleWithOptionals) bool {
 
 // RuleStatus contains info about a rule's current evaluation state.
 type RuleStatus struct {
-	Health            string
-	LastError         error
-	EvaluatedAt       time.Time
-	EvaluatedDuration time.Duration
+	Health              string
+	LastError           error
+	EvaluationTimestamp time.Time
+	EvaluationDuration  time.Duration
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -478,6 +478,7 @@ func (ng *AlertNG) init() error {
 		ProvenanceStore:      ng.store,
 		MultiOrgAlertmanager: ng.MultiOrgAlertmanager,
 		StateManager:         ng.stateManager,
+		Scheduler:            scheduler,
 		AccessControl:        ng.accesscontrol,
 		Policies:             policyService,
 		ReceiverService:      receiverService,

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -184,34 +184,7 @@ func (a *alertRule) Type() ngmodels.RuleType {
 
 func (a *alertRule) Health() ngmodels.Health {
 	states := a.stateManager.GetStatesForRuleUID(a.key.OrgID, a.key.UID)
-	health := ngmodels.Health{
-		Health:      "ok",
-		LastError:   nil,
-		EvaluatedAt: time.Time{},
-	}
-	for _, state := range states {
-		if state.LastEvaluationTime.After(health.EvaluatedAt) {
-			health.EvaluatedAt = state.LastEvaluationTime
-		}
-
-		health.EvaluatedDuration = state.EvaluationDuration
-
-		switch state.State {
-		case eval.Normal:
-		case eval.Pending:
-		case eval.Alerting:
-		case eval.Error:
-			health.Health = "error"
-		case eval.NoData:
-			health.Health = "nodata"
-		}
-
-		if state.Error != nil {
-			health.LastError = state.Error
-			health.Health = "error"
-		}
-	}
-	return health
+	return StatesToHealth(states)
 }
 
 // eval signals the rule evaluation routine to perform the evaluation of the rule. Does nothing if the loop is stopped.
@@ -554,4 +527,35 @@ func SchedulerUserFor(orgID int64) *user.SignedInUser {
 			},
 		},
 	}
+}
+
+func StatesToHealth(states []*state.State) ngmodels.Health {
+	health := ngmodels.Health{
+		Health:      "ok",
+		LastError:   nil,
+		EvaluatedAt: time.Time{},
+	}
+	for _, state := range states {
+		if state.LastEvaluationTime.After(health.EvaluatedAt) {
+			health.EvaluatedAt = state.LastEvaluationTime
+		}
+
+		health.EvaluatedDuration = state.EvaluationDuration
+
+		switch state.State {
+		case eval.Normal:
+		case eval.Pending:
+		case eval.Alerting:
+		case eval.Error:
+			health.Health = "error"
+		case eval.NoData:
+			health.Health = "nodata"
+		}
+
+		if state.Error != nil {
+			health.LastError = state.Error
+			health.Health = "error"
+		}
+	}
+	return health
 }

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -40,6 +40,8 @@ type Rule interface {
 	Update(lastVersion RuleVersionAndPauseStatus) bool
 	// Type gives the type of the rule.
 	Type() ngmodels.RuleType
+	// Health indicates the health of the evaluating rule.
+	Health() string
 }
 
 type ruleFactoryFunc func(context.Context, *ngmodels.AlertRule) Rule
@@ -178,6 +180,10 @@ func newAlertRule(
 
 func (a *alertRule) Type() ngmodels.RuleType {
 	return ngmodels.RuleTypeAlerting
+}
+
+func (a *alertRule) Health() string {
+	return "ok"
 }
 
 // eval signals the rule evaluation routine to perform the evaluation of the rule. Does nothing if the loop is stopped.

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -183,8 +183,7 @@ func (a *alertRule) Type() ngmodels.RuleType {
 }
 
 func (a *alertRule) Status() ngmodels.RuleStatus {
-	states := a.stateManager.GetStatesForRuleUID(a.key.OrgID, a.key.UID)
-	return StatesToRuleStatus(states)
+	return a.stateManager.GetStatusForRuleUID(a.key.OrgID, a.key.UID)
 }
 
 // eval signals the rule evaluation routine to perform the evaluation of the rule. Does nothing if the loop is stopped.
@@ -527,35 +526,4 @@ func SchedulerUserFor(orgID int64) *user.SignedInUser {
 			},
 		},
 	}
-}
-
-func StatesToRuleStatus(states []*state.State) ngmodels.RuleStatus {
-	status := ngmodels.RuleStatus{
-		Health:      "ok",
-		LastError:   nil,
-		EvaluatedAt: time.Time{},
-	}
-	for _, state := range states {
-		if state.LastEvaluationTime.After(status.EvaluatedAt) {
-			status.EvaluatedAt = state.LastEvaluationTime
-		}
-
-		status.EvaluatedDuration = state.EvaluationDuration
-
-		switch state.State {
-		case eval.Normal:
-		case eval.Pending:
-		case eval.Alerting:
-		case eval.Error:
-			status.Health = "error"
-		case eval.NoData:
-			status.Health = "nodata"
-		}
-
-		if state.Error != nil {
-			status.LastError = state.Error
-			status.Health = "error"
-		}
-	}
-	return status
 }

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -376,8 +376,8 @@ func TestRuleRoutine(t *testing.T) {
 				status := ruleInfo.Status()
 				require.Equal(t, "ok", status.Health)
 				require.Nil(t, status.LastError)
-				require.Equal(t, states[0].LastEvaluationTime, status.EvaluatedAt)
-				require.Equal(t, states[0].EvaluationDuration, status.EvaluatedDuration)
+				require.Equal(t, states[0].LastEvaluationTime, status.EvaluationTimestamp)
+				require.Equal(t, states[0].EvaluationDuration, status.EvaluationDuration)
 			})
 
 			t.Run("it reports metrics", func(t *testing.T) {
@@ -717,8 +717,8 @@ func TestRuleRoutine(t *testing.T) {
 			require.Equal(t, "error", status.Health)
 			require.NotNil(t, status.LastError, "expected status to carry the latest evaluation error")
 			require.Contains(t, status.LastError.Error(), "cannot reference itself")
-			require.Equal(t, int64(0), status.EvaluatedAt.UTC().Unix())
-			require.Equal(t, time.Duration(0), status.EvaluatedDuration)
+			require.Equal(t, int64(0), status.EvaluationTimestamp.UTC().Unix())
+			require.Equal(t, time.Duration(0), status.EvaluationDuration)
 		})
 	})
 

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -369,6 +369,17 @@ func TestRuleRoutine(t *testing.T) {
 				require.Equal(t, s.Labels, data.Labels(cmd.Labels))
 			})
 
+			t.Run("status should accurately reflect latest evaluation", func(t *testing.T) {
+				states := sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
+				require.NotEmpty(t, states)
+
+				status := ruleInfo.Status()
+				require.Equal(t, "ok", status.Health)
+				require.Nil(t, status.LastError)
+				require.Equal(t, states[0].LastEvaluationTime, status.EvaluatedAt)
+				require.Equal(t, states[0].EvaluationDuration, status.EvaluatedDuration)
+			})
+
 			t.Run("it reports metrics", func(t *testing.T) {
 				// duration metric has 0 values because of mocked clock that do not advance
 				expectedMetric := fmt.Sprintf(
@@ -699,6 +710,15 @@ func TestRuleRoutine(t *testing.T) {
 			require.Truef(t, ok, fmt.Sprintf("expected argument of function was supposed to be 'definitions.PostableAlerts' but got %T", sender.Calls()[0].Arguments[2]))
 			assert.Len(t, args.PostableAlerts, 1)
 			assert.Equal(t, state.ErrorAlertName, args.PostableAlerts[0].Labels[prometheusModel.AlertNameLabel])
+		})
+
+		t.Run("status should reflect unhealthy rule", func(t *testing.T) {
+			status := ruleInfo.Status()
+			require.Equal(t, "error", status.Health)
+			require.NotNil(t, status.LastError, "expected status to carry the latest evaluation error")
+			require.Contains(t, status.LastError.Error(), "cannot reference itself")
+			require.Equal(t, int64(0), status.EvaluatedAt.UTC().Unix())
+			require.Equal(t, time.Duration(0), status.EvaluatedDuration)
 		})
 	})
 

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -84,18 +84,12 @@ func (r *recordingRule) Type() ngmodels.RuleType {
 	return ngmodels.RuleTypeRecording
 }
 
-func (r *recordingRule) Status() RuleStatus {
-	return RuleStatus{
-		Health:              r.health.Load(),
-		LastError:           r.lastError.Load(),
-		EvaluationTimestamp: r.evaluationTimestamp.Load(),
-		EvaluationDuration:  r.evaluationDuration.Load(),
-	}
-}
-
-func (r *recordingRule) Health() ngmodels.Health {
-	return ngmodels.Health{
-		Health: "ok",
+func (r *recordingRule) Status() ngmodels.RuleStatus {
+	return ngmodels.RuleStatus{
+		Health:            r.health.Load(),
+		LastError:         r.lastError.Load(),
+		EvaluatedAt:       r.evaluationTimestamp.Load(),
+		EvaluatedDuration: r.evaluationDuration.Load(),
 	}
 }
 

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -86,10 +86,10 @@ func (r *recordingRule) Type() ngmodels.RuleType {
 
 func (r *recordingRule) Status() ngmodels.RuleStatus {
 	return ngmodels.RuleStatus{
-		Health:            r.health.Load(),
-		LastError:         r.lastError.Load(),
-		EvaluatedAt:       r.evaluationTimestamp.Load(),
-		EvaluatedDuration: r.evaluationDuration.Load(),
+		Health:              r.health.Load(),
+		LastError:           r.lastError.Load(),
+		EvaluationTimestamp: r.evaluationTimestamp.Load(),
+		EvaluationDuration:  r.evaluationDuration.Load(),
 	}
 }
 

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -93,6 +93,10 @@ func (r *recordingRule) Status() RuleStatus {
 	}
 }
 
+func (r *recordingRule) Health() string {
+	return "ok"
+}
+
 func (r *recordingRule) Eval(eval *Evaluation) (bool, *Evaluation) {
 	// read the channel in unblocking manner to make sure that there is no concurrent send operation.
 	var droppedMsg *Evaluation

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -93,8 +93,10 @@ func (r *recordingRule) Status() RuleStatus {
 	}
 }
 
-func (r *recordingRule) Health() string {
-	return "ok"
+func (r *recordingRule) Health() ngmodels.Health {
+	return ngmodels.Health{
+		Health: "ok",
+	}
 }
 
 func (r *recordingRule) Eval(eval *Evaluation) (bool, *Evaluation) {

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -192,8 +192,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 
 			require.Equal(t, "unknown", status.Health)
 			require.Nil(t, status.LastError)
-			require.Zero(t, status.EvaluationTimestamp)
-			require.Zero(t, status.EvaluationDuration)
+			require.Zero(t, status.EvaluatedAt)
+			require.Zero(t, status.EvaluatedDuration)
 		})
 
 		process.Eval(&Evaluation{
@@ -331,8 +331,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 
 			require.Equal(t, "unknown", status.Health)
 			require.Nil(t, status.LastError)
-			require.Zero(t, status.EvaluationTimestamp)
-			require.Zero(t, status.EvaluationDuration)
+			require.Zero(t, status.EvaluatedAt)
+			require.Zero(t, status.EvaluatedDuration)
 		})
 
 		process.Eval(&Evaluation{
@@ -469,8 +469,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 
 			require.Equal(t, "unknown", status.Health)
 			require.Nil(t, status.LastError)
-			require.Zero(t, status.EvaluationTimestamp)
-			require.Zero(t, status.EvaluationDuration)
+			require.Zero(t, status.EvaluatedAt)
+			require.Zero(t, status.EvaluatedDuration)
 		})
 
 		process.Eval(&Evaluation{

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -192,8 +192,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 
 			require.Equal(t, "unknown", status.Health)
 			require.Nil(t, status.LastError)
-			require.Zero(t, status.EvaluatedAt)
-			require.Zero(t, status.EvaluatedDuration)
+			require.Zero(t, status.EvaluationTimestamp)
+			require.Zero(t, status.EvaluationDuration)
 		})
 
 		process.Eval(&Evaluation{
@@ -331,8 +331,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 
 			require.Equal(t, "unknown", status.Health)
 			require.Nil(t, status.LastError)
-			require.Zero(t, status.EvaluatedAt)
-			require.Zero(t, status.EvaluatedDuration)
+			require.Zero(t, status.EvaluationTimestamp)
+			require.Zero(t, status.EvaluationDuration)
 		})
 
 		process.Eval(&Evaluation{
@@ -469,8 +469,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 
 			require.Equal(t, "unknown", status.Health)
 			require.Nil(t, status.LastError)
-			require.Zero(t, status.EvaluatedAt)
-			require.Zero(t, status.EvaluatedDuration)
+			require.Zero(t, status.EvaluationTimestamp)
+			require.Zero(t, status.EvaluationDuration)
 		})
 
 		process.Eval(&Evaluation{

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -56,6 +56,14 @@ func (r *ruleRegistry) exists(key models.AlertRuleKey) bool {
 	return ok
 }
 
+// get fetches a rule from the registry by key. It returns (rule, ok) where ok is false if the rule did not exist.
+func (r *ruleRegistry) get(key models.AlertRuleKey) (Rule, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ru, ok := r.rules[key]
+	return ru, ok
+}
+
 // del removes pair that has specific key from the registry.
 // Returns 2-tuple where the first element is value of the removed pair
 // and the second element indicates whether element with the specified key existed.

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -172,11 +172,11 @@ func (sch *schedule) RuleDefs() ([]*ngmodels.AlertRule, map[ngmodels.FolderKey]s
 }
 
 // Rule fetches the health of a given scheduled rule, by key.
-func (sch *schedule) Health(key ngmodels.AlertRuleKey) (string, bool) {
+func (sch *schedule) Health(key ngmodels.AlertRuleKey) (ngmodels.Health, bool) {
 	if rule, ok := sch.registry.get(key); ok {
 		return rule.Health(), true
 	}
-	return "", false
+	return ngmodels.Health{}, false
 }
 
 // deleteAlertRule stops evaluation of the rule, deletes it from active rules, and cleans up state cache.

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -171,12 +171,12 @@ func (sch *schedule) RuleDefs() ([]*ngmodels.AlertRule, map[ngmodels.FolderKey]s
 	return sch.schedulableAlertRules.all()
 }
 
-// Rule fetches the health of a given scheduled rule, by key.
-func (sch *schedule) Health(key ngmodels.AlertRuleKey) (ngmodels.Health, bool) {
+// Status fetches the health of a given scheduled rule, by key.
+func (sch *schedule) Status(key ngmodels.AlertRuleKey) (ngmodels.RuleStatus, bool) {
 	if rule, ok := sch.registry.get(key); ok {
-		return rule.Health(), true
+		return rule.Status(), true
 	}
-	return ngmodels.Health{}, false
+	return ngmodels.RuleStatus{}, false
 }
 
 // deleteAlertRule stops evaluation of the rule, deletes it from active rules, and cleans up state cache.

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -167,7 +167,7 @@ func (sch *schedule) Run(ctx context.Context) error {
 // Rules fetches the entire set of rules considered for evaluation by the scheduler on the next tick.
 // Such rules are not guaranteed to have been evaluated by the scheduler.
 // Rules returns all supplementary metadata for the rules that is stored by the scheduler - namely, the set of folder titles.
-func (sch *schedule) RuleDefs() ([]*ngmodels.AlertRule, map[ngmodels.FolderKey]string) {
+func (sch *schedule) Rules() ([]*ngmodels.AlertRule, map[ngmodels.FolderKey]string) {
 	return sch.schedulableAlertRules.all()
 }
 

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -167,8 +167,16 @@ func (sch *schedule) Run(ctx context.Context) error {
 // Rules fetches the entire set of rules considered for evaluation by the scheduler on the next tick.
 // Such rules are not guaranteed to have been evaluated by the scheduler.
 // Rules returns all supplementary metadata for the rules that is stored by the scheduler - namely, the set of folder titles.
-func (sch *schedule) Rules() ([]*ngmodels.AlertRule, map[ngmodels.FolderKey]string) {
+func (sch *schedule) RuleDefs() ([]*ngmodels.AlertRule, map[ngmodels.FolderKey]string) {
 	return sch.schedulableAlertRules.all()
+}
+
+// Rule fetches the health of a given scheduled rule, by key.
+func (sch *schedule) Health(key ngmodels.AlertRuleKey) (string, bool) {
+	if rule, ok := sch.registry.get(key); ok {
+		return rule.Health(), true
+	}
+	return "", false
 }
 
 // deleteAlertRule stops evaluation of the rule, deletes it from active rules, and cleans up state cache.

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -556,6 +556,11 @@ func (st *Manager) GetStatesForRuleUID(orgID int64, alertRuleUID string) []*Stat
 	return st.cache.getStatesForRuleUID(orgID, alertRuleUID, st.doNotSaveNormalState)
 }
 
+func (st *Manager) GetStatusForRuleUID(orgID int64, alertRuleUID string) ngModels.RuleStatus {
+	states := st.GetStatesForRuleUID(orgID, alertRuleUID)
+	return StatesToRuleStatus(states)
+}
+
 func (st *Manager) Put(states []*State) {
 	for _, s := range states {
 		st.cache.set(s)
@@ -622,4 +627,35 @@ func (st *Manager) deleteStaleStatesFromCache(ctx context.Context, logger log.Lo
 
 func stateIsStale(evaluatedAt time.Time, lastEval time.Time, intervalSeconds int64) bool {
 	return !lastEval.Add(2 * time.Duration(intervalSeconds) * time.Second).After(evaluatedAt)
+}
+
+func StatesToRuleStatus(states []*State) ngModels.RuleStatus {
+	status := ngModels.RuleStatus{
+		Health:      "ok",
+		LastError:   nil,
+		EvaluatedAt: time.Time{},
+	}
+	for _, state := range states {
+		if state.LastEvaluationTime.After(status.EvaluatedAt) {
+			status.EvaluatedAt = state.LastEvaluationTime
+		}
+
+		status.EvaluatedDuration = state.EvaluationDuration
+
+		switch state.State {
+		case eval.Normal:
+		case eval.Pending:
+		case eval.Alerting:
+		case eval.Error:
+			status.Health = "error"
+		case eval.NoData:
+			status.Health = "nodata"
+		}
+
+		if state.Error != nil {
+			status.LastError = state.Error
+			status.Health = "error"
+		}
+	}
+	return status
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -631,16 +631,16 @@ func stateIsStale(evaluatedAt time.Time, lastEval time.Time, intervalSeconds int
 
 func StatesToRuleStatus(states []*State) ngModels.RuleStatus {
 	status := ngModels.RuleStatus{
-		Health:      "ok",
-		LastError:   nil,
-		EvaluatedAt: time.Time{},
+		Health:              "ok",
+		LastError:           nil,
+		EvaluationTimestamp: time.Time{},
 	}
 	for _, state := range states {
-		if state.LastEvaluationTime.After(status.EvaluatedAt) {
-			status.EvaluatedAt = state.LastEvaluationTime
+		if state.LastEvaluationTime.After(status.EvaluationTimestamp) {
+			status.EvaluationTimestamp = state.LastEvaluationTime
 		}
 
-		status.EvaluatedDuration = state.EvaluationDuration
+		status.EvaluationDuration = state.EvaluationDuration
 
 		switch state.State {
 		case eval.Normal:


### PR DESCRIPTION
**What is this feature?**

Part of the status API's job is to determine the current status of a scheduled rule. (Rule health, last evaluated time, etc)
Right now it calculates this based on alert rule states, inside the API layer.

This is domain logic and not API logic, so this PR pushes this logic out of the API and into the scheduler. Now the API asks the scheduler about rule status rather than calculating it directly from states.

This allows for alternate implementations of status. For example, recording rules, which do not produce states at all, still have a status, that's calculated in a completely different way.

**What does this feature do?**

Adds a method `Status()` to the scheduler and rules that fetches status information in a way that's appropriate for that rule type. Moves some calculation logic out of the API layer and into the alert rule implementation.

For now, we only handle fields that are agnostic to rule type. In the future, we could consider moving all the status calculation in a similar way (instance totals, etc) if we like this.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
