### PR TITLE
[WIP]Table: Add pagination persistence

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import {
   useAbsoluteLayout,
   useExpanded,
@@ -59,6 +60,11 @@ export const Table = memo((props: Props) => {
     initialRowIndex = undefined,
     fieldConfig,
   } = props;
+
+  const history = useHistory();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const tablePage = params.get('tablePage');
 
   const listRef = useRef<VariableSizeList>(null);
   const tableDivRef = useRef<HTMLDivElement>(null);
@@ -258,12 +264,21 @@ export const Table = memo((props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
+  useEffect(() => {
+    if (tablePage) {
+      gotoPage(Number(tablePage) - 1);
+    }
+  }, [tablePage, gotoPage]);
+
   useResetVariableListSizeCache(extendedState, listRef, data, hasUniqueId);
   useFixScrollbarContainer(variableSizeListScrollbarRef, tableDivRef);
 
+  // Use gotoPage for URL read
   const onNavigate = useCallback(
     (toPage: number) => {
       gotoPage(toPage - 1);
+      params.set('tablePage', toPage.toString());
+      history.replace({ pathname: location.pathname, search: params.toString() });
     },
     [gotoPage]
   );

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -100,6 +100,7 @@ export interface Props {
   // The index of the field value that the table will initialize scrolled to
   initialRowIndex?: number;
   fieldConfig?: FieldConfigSource;
+  uid?: number;
 }
 
 /**

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -64,6 +64,7 @@ export function TablePanel(props: Props) {
       timeRange={timeRange}
       enableSharedCrosshair={config.featureToggles.tableSharedCrosshair && enableSharedCrosshair}
       fieldConfig={fieldConfig}
+      uid={id}
     />
   );
 


### PR DESCRIPTION
Add persistence to table pagination using URL query params.

- [x] Set pagination from url on load
- [x] Update url on navigation
- [x] Include panel ID in url to handle multiple tables
- [ ] ~~Bypass reset during page set (gotoPage(0) condition seems to have issues)~~ @codeincarnate to investigate
- [ ] How do we handle panel resize? (recalc based on range, include first row index)
- [ ] Feature flag

Closes #61259