### PR TITLE
Alerting docs: update Introduction page

### DIFF
--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -61,7 +61,9 @@ Whether you’re just starting out or you're a more experienced user of Grafana 
 
 The following diagram gives you an overview of Grafana Alerting and introduces you to some of the fundamental features that are the principles of how Grafana Alerting works.
 
-{{< figure src="/media/docs/alerting/alerting-configure-notifications.svg" max-width="750px" alt="How Alerting works" caption="How Alerting works" >}}
+<br/>
+
+{{< figure src="/media/docs/alerting/alerting-configure-notifications-v2.png" max-width="750px" alt="How Alerting works" caption="How Alerting works" >}}
 
 ## How it works at a glance
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -111,7 +111,7 @@ Notification policies routes alerts to contact points via label matching. Each n
 
 {{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" alt="A diagram displaying how the notification policy tree routes alerts" caption="Notification policy routing" >}}
 
-Each notification policy is responsible for deciding the contact point and when to send the notification. Additionally, it can [group multiple firing alert instances into a single notification](ref:group-alert-notifications) to reduce alert noise.
+Each notification policy decides where to send the alert (contact point) and when to send the notification (timing options). Additionally, it can [group multiple firing alert instances into a single notification](ref:group-alert-notifications) to reduce alert noise.
 
 {{< figure src="/media/docs/alerting/alerting-notification-policy-diagram-v5.png" max-width="750px" alt="A diagram of the notification policy component" >}}
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -63,7 +63,7 @@ The following diagram gives you an overview of Grafana Alerting and introduces y
 
 <br/>
 
-{{< figure src="/media/docs/alerting/alerting-configure-notifications-v2.png" max-width="750px" alt="How Alerting works" caption="How Alerting works" >}}
+{{< figure src="/media/docs/alerting/alerting-configure-notifications-v2.png" max-width="750px" alt="How Grafana Alerting works" >}}
 
 ## How it works at a glance
 
@@ -109,7 +109,9 @@ In the alert rule, you can configure the contact point to receive the alert noti
 
 Notification policies routes alerts to contact points via label matching. Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined in a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alert instances are handled.
 
-{{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" alt="A diagram displaying how the notification policy tree routes alerts" caption="Notification policy routing" >}}
+{{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" alt="A diagram displaying how the notification policy tree routes alerts" caption="Routing firing alert instances through notification policies" >}}
+
+<br/>
 
 Each notification policy decides where to send the alert (contact point) and when to send the notification (timing options). Additionally, it can [group multiple firing alert instances into a single notification](ref:group-alert-notifications) to reduce alert noise.
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -126,7 +126,7 @@ Grafana Alerting is built on the Prometheus model of designing alerting systems.
 - An alert generator that evaluates alert rules and sends firing and resolved alerts to the alert receiver.
 - An alert receiver (also known as Alertmanager) that receives the alerts and is responsible for handling them and sending their notifications.
 
-Grafana Alerting doesn’t use Prometheus as its default alert generator because it needs to work with many other data sources, not just Prometheus.
+Grafana Alerting doesn’t use Prometheus as its default alert generator because it works with many other data sources; not just Prometheus.
 
 However, Grafana can also use Prometheus as an alert generator (refer to [alert rule types](ref:alert-rules)), as well as external Alertmanagers.
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -48,6 +48,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/rule-evaluation/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/rule-evaluation/
+  group-alert-notifications:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/group-alert-notifications/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/notifications/group-alert-notifications/
 ---
 
 # Introduction to Alerting
@@ -56,14 +61,13 @@ Whether you’re just starting out or you're a more experienced user of Grafana 
 
 The following diagram gives you an overview of Grafana Alerting and introduces you to some of the fundamental features that are the principles of how Grafana Alerting works.
 
-{{< figure src="/media/docs/alerting/how-alerting-works.png" max-width="750px" caption="How Alerting works" >}}
+{{< figure src="/media/docs/alerting/alerting-configure-notifications.svg" max-width="750px" alt="How Alerting works" caption="How Alerting works" >}}
 
 ## How it works at a glance
 
-- Grafana alerting periodically queries data sources and evaluates the condition defined in the alert rule
+- Grafana Alerting periodically queries data sources and evaluates the condition defined in the alert rule
 - If the condition is breached, an alert instance fires
-- Firing and resolved alert instances are routed to notification policies based on matching labels
-- Notifications are sent out to the contact points specified in the notification policy
+- Firing (and resolved) alert instances are sent for notifications, either directly to a contact point or through notification policies for more flexibility
 
 ## Fundamentals
 
@@ -73,9 +77,7 @@ The following concepts are key to your understanding of how Grafana Alerting wor
 
 An [alert rule](ref:alert-rules) consists of one or more queries and expressions that select the data you want to measure. It also contains a condition, which is the threshold that an alert rule must meet or exceed to fire.
 
-Add labels to uniquely identify your alert rule and configure alert routing. Labels link alert rules to notification policies, so you can easily manage which policy should handle which alerts and who gets notified.
-
-After alert rules are created, they go through various states and transitions.
+In the alert rule, choose the contact point or notification policies to determine how to receive the alert notifications.
 
 ### Alert instances
 
@@ -91,23 +93,25 @@ A rule using the PromQL expression above creates as many alert instances as the 
 
 {{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="Multiple alert instances from a single alert rule" >}}
 
-[Alert rules are frequently evaluated](ref:alert-rule-evaluation) and the state of their alert instances is updated accordingly. Only alert instances that are in a firing or resolved state are routed to notification policies to be handled.
-
-### Notification policies
-
-[Notification policies](ref:notification-policies) group alerts and then route them to contact points. They determine when notifications are sent, and how often notifications should be repeated.
-
-Alert instances are matched to notification policies using label matchers. This provides a flexible way to organize and route alerts to different receivers.
-
-Each policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined as a tree structure where the root of the notification policy tree is called the **Default notification policy**. Each policy can have child policies.
-
-{{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" caption="Notification policy routing" >}}
+[Alert rules are frequently evaluated](ref:alert-rule-evaluation) and the state of their alert instances is updated accordingly. Only alert instances that are in a firing or resolved state are sent for notifications.
 
 ### Contact points
 
-[Contact points](ref:contact-points) determine where notifications are sent. For example, you might have a contact point that sends notifications to an email address, to Slack, to an incident management system (IRM) such as Grafana OnCall or Pagerduty, or to a webhook.
+[Contact points](ref:contact-points) determine the notification message and where notifications are sent. For example, you might have a contact point that sends notifications to an email address, to Slack, to an incident management system (IRM) such as Grafana OnCall or Pagerduty, or to a webhook.
 
-Notifications sent from contact points are customizable with notification templates, which can be shared between contact points.
+In the alert rule, you can configure the contact point to receive the alert notifications or use notification policies instead.
+
+### Notification policies
+
+[Notification policies](ref:notification-policies) provide a flexible method to handle alert notifications by routing alerts to contact points via label matching.
+
+Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined as a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alerts are handled.
+
+{{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" caption="Notification policy routing" >}}
+
+Each notification policy is responsible for deciding the contact point and when to send the notification. Additionally, it can [group multiple firing alert instances into a single notification](ref:group-alert-notifications) to reduce alert noise.
+
+{{< figure src="/media/docs/alerting/alerting-notification-policy-diagram-v5.png" max-width="750px" alt="A diagram of the notification policy component" >}}
 
 ### Silences and mute timings
 
@@ -115,16 +119,14 @@ Notifications sent from contact points are customizable with notification templa
 
 ### Architecture
 
-Grafana Alerting is built on the Prometheus model of designing alerting systems.
-
-Prometheus-based alerting systems have two main components:
+Grafana Alerting is built on the Prometheus model of designing alerting systems. Prometheus-based alerting systems have two main components:
 
 - An alert generator that evaluates alert rules and sends firing and resolved alerts to the alert receiver.
 - An alert receiver (also known as Alertmanager) that receives the alerts and is responsible for handling them and sending their notifications.
 
-Grafana doesn’t use Prometheus as its default alert generator because Grafana Alerting needs to work with many other data sources in addition to Prometheus.
+Grafana Alerting doesn’t use Prometheus as its default alert generator because it needs to work with many other data sources, not just Prometheus.
 
-However, Grafana can also use Prometheus as an alert generator as well as external Alertmanagers. For more information about how to use distinct alerting systems, refer to the [Grafana alert rule types](ref:alert-rules).
+However, Grafana can also use Prometheus as an alert generator (refer to [alert rule types](ref:alert-rules)), as well as external Alertmanagers.
 
 ## Design your Alerting system
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -107,7 +107,7 @@ In the alert rule, you can configure the contact point to receive the alert noti
 
 [Notification policies](ref:notification-policies) provide a flexible method to handle alert notifications by routing alerts to contact points via label matching.
 
-Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined as a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alerts are handled.
+Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined in a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alert instances are handled.
 
 {{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" caption="Notification policy routing" >}}
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -95,7 +95,7 @@ A rule using the PromQL expression above creates as many alert instances as the 
 
 {{< figure src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" caption="Multiple alert instances from a single alert rule" >}}
 
-[Alert rules are frequently evaluated](ref:alert-rule-evaluation) and the state of their alert instances is updated accordingly. Only alert instances that are in a firing or resolved state are sent for notifications.
+[Alert rules are frequently evaluated](ref:alert-rule-evaluation) and the state of their alert instances is updated accordingly. Only alert instances that are in a firing or resolved state are sent in notifications.
 
 ### Contact points
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -101,7 +101,7 @@ A rule using the PromQL expression above creates as many alert instances as the 
 
 [Contact points](ref:contact-points) determine the notification message and where notifications are sent. For example, you might have a contact point that sends notifications to an email address, to Slack, to an incident management system (IRM) such as Grafana OnCall or Pagerduty, or to a webhook.
 
-In the alert rule, you can configure the contact point to receive the alert notifications or use notification policies instead.
+In the alert rule, you can choose a contact point to receive the alert notifications or use notification policies instead.
 
 ### Notification policies
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -105,9 +105,9 @@ In the alert rule, you can configure the contact point to receive the alert noti
 
 ### Notification policies
 
-[Notification policies](ref:notification-policies) provide a flexible method to handle alert notifications by routing alerts to contact points via label matching.
+[Notification policies](ref:notification-policies) provide a flexible method to handle alert notifications for larger systems.
 
-Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined in a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alert instances are handled.
+Notification policies routes alerts to contact points via label matching. Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined in a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alert instances are handled.
 
 {{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" alt="A diagram displaying how the notification policy tree routes alerts" caption="Notification policy routing" >}}
 

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -109,7 +109,7 @@ In the alert rule, you can configure the contact point to receive the alert noti
 
 Each notification policy consists of a set of label matchers (0 or more) that specify which alert instances (identified by their labels) they handle. Notification policies are defined in a tree structure, where the root of the notification policy tree is the **Default notification policy**, which ensures all alert instances are handled.
 
-{{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" caption="Notification policy routing" >}}
+{{< figure src="/media/docs/alerting/notification-routing.png" max-width="750px" alt="A diagram displaying how the notification policy tree routes alerts" caption="Notification policy routing" >}}
 
 Each notification policy is responsible for deciding the contact point and when to send the notification. Additionally, it can [group multiple firing alert instances into a single notification](ref:group-alert-notifications) to reduce alert noise.
 

--- a/docs/sources/alerting/fundamentals/notifications/_index.md
+++ b/docs/sources/alerting/fundamentals/notifications/_index.md
@@ -68,7 +68,9 @@ Choosing how, when, and where to send your alert notifications is an important p
 
 Start defining your [contact points](ref:contact-points) to specify how to receive your alert notifications. Then, configure your alert rules to send their alerts to either a contact point or use the [Notification Policy Tree](#notification-policies) to flexibly route alerts to contact points.
 
-{{< figure src="/media/docs/alerting/alerting-configure-notifications.svg" max-width="750px" alt="Configure alerts to send notifications to a contact point or via notification policies" caption="Configure alerts to send notifications to a contact point or via notification policies" >}}
+<br/>
+
+{{< figure src="/media/docs/alerting/alerting-configure-notifications-v2.svg" max-width="750px" alt="Configure alerts to send notifications to a contact point or via notification policies" caption="Configure alerts to send notifications to a contact point or via notification policies" >}}
 
 ## How it works at a glance
 

--- a/docs/sources/alerting/fundamentals/notifications/_index.md
+++ b/docs/sources/alerting/fundamentals/notifications/_index.md
@@ -70,7 +70,7 @@ Start defining your [contact points](ref:contact-points) to specify how to recei
 
 <br/>
 
-{{< figure src="/media/docs/alerting/alerting-configure-notifications-v2.svg" max-width="750px" alt="Configure alerts to send notifications to a contact point or via notification policies" caption="Configure alerts to send notifications to a contact point or via notification policies" >}}
+{{< figure src="/media/docs/alerting/alerting-configure-notifications-v2.png" max-width="750px" alt="Configure alert rules to forward firing alerts directly to a contact point or through notification policies" caption="Configure alert rules to forward firing alerts directly to a contact point or through notification policies" >}}
 
 ## How it works at a glance
 


### PR DESCRIPTION
Changes to [Introduction to Alerting docs](https://grafana.com/docs/grafana/next/alerting/fundamentals/):

- Cover the two notification flows: Simplified Routing & Notification Policies.
- Introduce Notification grouping to reduce the number of notifications.
- Additional minor changes.


Ready for review.
