### PR TITLE
Alerting: Fix display of falsy alert values in state history

### DIFF
--- a/public/app/features/alerting/unified/components/Label.tsx
+++ b/public/app/features/alerting/unified/components/Label.tsx
@@ -33,11 +33,9 @@ const Label = ({ label, value, icon, color, size = 'md' }: Props) => {
             )}
           </Stack>
         </div>
-        {value && (
-          <div className={styles.value} title={value.toString()}>
-            {value}
-          </div>
-        )}
+        <div className={styles.value} title={value?.toString()}>
+          {value ?? '-'}
+        </div>
       </Stack>
     </div>
   );


### PR DESCRIPTION

**What is this feature?**

Fix for small inconsistency when displaying falsy values in alert state history:

Before, could potentially show like this:
![image](https://github.com/grafana/grafana/assets/4377076/7d86d3a6-6648-4a7c-b373-18a84c9fd43a)

After:
![image](https://github.com/grafana/grafana/assets/4377076/b73307c9-eb7e-4e23-a075-1585aff5fd7b)


**Why do we need this feature?**

🐛  🧹 

**Who is this feature for?**

Alerting UI users