### PR TITLE
RestoreDashboards: Clear cached parent folders after restoring a dashboard

### DIFF
--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -381,11 +381,6 @@ export const browseDashboardsAPI = createApi({
         url: `/dashboards/uid/${dashboardUID}/trash`,
         method: 'PATCH',
       }),
-      onQueryStarted: ({ dashboardUID }, { queryFulfilled, dispatch }) => {
-        queryFulfilled.then(() => {
-          dispatch(refreshParents([dashboardUID]));
-        });
-      },
     }),
   }),
 });

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -3,15 +3,13 @@ import React, { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data/';
 import { Button, useStyles2 } from '@grafana/ui';
-import { PAGE_SIZE } from 'app/features/browse-dashboards/api/services';
 
 import appEvents from '../../../core/app_events';
 import { Trans } from '../../../core/internationalization';
 import { useDispatch } from '../../../types';
 import { ShowModalReactEvent } from '../../../types/events';
 import { useRestoreDashboardMutation } from '../../browse-dashboards/api/browseDashboardsAPI';
-import { refetchChildren, setAllSelection, useActionSelectionState } from '../../browse-dashboards/state';
-import { useRecentlyDeletedStateManager } from '../api/useRecentlyDeletedStateManager';
+import { clearFolders, setAllSelection, useActionSelectionState } from '../../browse-dashboards/state';
 import { RestoreModal } from '../components/RestoreModal';
 
 export function RecentlyDeletedActions() {
@@ -47,17 +45,10 @@ export function RecentlyDeletedActions() {
 
     await Promise.all(promises);
 
-    const parentUIDs = selectedDashboards.map((uid) => resultsView.find((v) => v.uid === uid)?.location);
-    const refreshedParents = new Set<string | undefined>();
-
-    for (const parentUID of parentUIDs) {
-      if (refreshedParents.has(parentUID)) {
-        continue;
-      }
-
-      refreshedParents.add(parentUID);
-      dispatch(refetchChildren({ parentUID, pageSize: PAGE_SIZE }));
-    }
+    const parentUIDs = selectedDashboards
+      .map((uid) => resultsView.find((v) => v.uid === uid)?.location)
+      .filter((uid, index, self) => self.indexOf(uid) === index);
+    dispatch(clearFolders(parentUIDs));
 
     onActionComplete();
   };

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -206,8 +206,6 @@ type UIDLike = string | undefined;
 export function clearFolders(state: BrowseDashboardsState, action: PayloadAction<UIDLike | UIDLike[]>) {
   const folderUIDs = Array.isArray(action.payload) ? action.payload : [action.payload];
 
-  console.log('clearing folder', folderUIDs);
-
   for (const folderUID of folderUIDs) {
     if (!folderUID || folderUID === GENERAL_FOLDER_UID) {
       state.rootItems = undefined;

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
+import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
 import { isSharedWithMe } from '../components/utils';
@@ -197,6 +198,24 @@ export function setAllSelection(
       for (const uid in selection) {
         selection[uid] = isSelected;
       }
+    }
+  }
+}
+
+type UIDLike = string | undefined;
+export function clearFolders(state: BrowseDashboardsState, action: PayloadAction<UIDLike | UIDLike[]>) {
+  const folderUIDs = Array.isArray(action.payload) ? action.payload : [action.payload];
+
+  console.log('clearing folder', folderUIDs);
+
+  for (const folderUID of folderUIDs) {
+    if (!folderUID || folderUID === GENERAL_FOLDER_UID) {
+      state.rootItems = undefined;
+    } else {
+      state.childrenByParentUID[folderUID] = undefined;
+
+      // close the folder to require it to be refetched next time its opened
+      state.openFolders[folderUID] = false;
     }
   }
 }

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -1,6 +1,5 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
-import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
 import { isSharedWithMe } from '../components/utils';
@@ -202,12 +201,11 @@ export function setAllSelection(
   }
 }
 
-type UIDLike = string | undefined;
-export function clearFolders(state: BrowseDashboardsState, action: PayloadAction<UIDLike | UIDLike[]>) {
+export function clearFolders(state: BrowseDashboardsState, action: PayloadAction<Array<string | undefined>>) {
   const folderUIDs = Array.isArray(action.payload) ? action.payload : [action.payload];
 
   for (const folderUID of folderUIDs) {
-    if (!folderUID || folderUID === GENERAL_FOLDER_UID) {
+    if (!folderUID) {
       state.rootItems = undefined;
     } else {
       state.childrenByParentUID[folderUID] = undefined;

--- a/public/app/features/browse-dashboards/state/slice.ts
+++ b/public/app/features/browse-dashboards/state/slice.ts
@@ -32,7 +32,8 @@ const browseDashboardsSlice = createSlice({
 
 export const browseDashboardsReducer = browseDashboardsSlice.reducer;
 
-export const { setFolderOpenState, setItemSelectionState, setAllSelection } = browseDashboardsSlice.actions;
+export const { setFolderOpenState, setItemSelectionState, setAllSelection, clearFolders } =
+  browseDashboardsSlice.actions;
 
 export default {
   browseDashboards: browseDashboardsReducer,


### PR DESCRIPTION
After restoring a dashboard, we now clear the request cache of any parent folders that dashboard might be in.

Initially this just automatically refreshed the parent folders, but I figured that's a wasteful request if the user doesn't navigate back to that page. So instead we just lazilly clear the cache, and next time they browse to browse dashboards, it'll request again.

Fixes https://github.com/grafana/grafana/issues/88806 