### PR TITLE
Navigation: One layer topnav poc 

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -240,7 +240,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     drawer: css({
       '.main-view &': {
-        top: 80,
+        top: 40,
       },
 
       '.main-view--search-bar-hidden &': {

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -14,7 +14,6 @@ import { KioskMode } from 'app/types';
 import { AppChromeMenu } from './AppChromeMenu';
 import { DOCKED_LOCAL_STORAGE_KEY, DOCKED_MENU_OPEN_LOCAL_STORAGE_KEY } from './AppChromeService';
 import { MegaMenu } from './MegaMenu/MegaMenu';
-import { NavToolbar } from './NavToolbar/NavToolbar';
 import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
 import { TopSearchBar } from './TopBar/TopSearchBar';
 import { TOP_BAR_LEVEL_HEIGHT } from './types';
@@ -87,8 +86,13 @@ export function AppChrome({ children }: Props) {
             Skip to main content
           </LinkButton>
           <header className={cx(styles.topNav)}>
-            {!searchBarHidden && <TopSearchBar />}
-            <NavToolbar
+            <TopSearchBar
+              sectionNav={state.sectionNav.node}
+              pageNav={state.pageNav}
+              onToggleMegaMenu={handleMegaMenu}
+              isMenuDocked={state.megaMenuDocked}
+            />
+            {/* <NavToolbar
               searchBarHidden={searchBarHidden}
               sectionNav={state.sectionNav.node}
               pageNav={state.pageNav}
@@ -96,7 +100,7 @@ export function AppChrome({ children }: Props) {
               onToggleSearchBar={chrome.onToggleSearchBar}
               onToggleMegaMenu={handleMegaMenu}
               onToggleKioskMode={chrome.onToggleKioskMode}
-            />
+            /> */}
           </header>
         </>
       )}
@@ -124,7 +128,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     content: css({
       display: 'flex',
       flexDirection: 'column',
-      paddingTop: TOP_BAR_LEVEL_HEIGHT * 2,
+      paddingTop: TOP_BAR_LEVEL_HEIGHT,
       flexGrow: 1,
       height: '100%',
     }),

--- a/public/app/core/components/AppChrome/AppChromeMenu.tsx
+++ b/public/app/core/components/AppChrome/AppChromeMenu.tsx
@@ -76,8 +76,6 @@ export function AppChromeMenu({}: Props) {
 }
 
 const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
-  const topPosition = searchBarHidden ? TOP_BAR_LEVEL_HEIGHT : TOP_BAR_LEVEL_HEIGHT * 2;
-
   return {
     backdrop: css({
       backdropFilter: 'blur(1px)',
@@ -90,7 +88,7 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
       zIndex: theme.zIndex.modalBackdrop,
 
       [theme.breakpoints.up('md')]: {
-        top: topPosition,
+        top: TOP_BAR_LEVEL_HEIGHT,
       },
     }),
     menu: css({
@@ -110,7 +108,7 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
       [theme.breakpoints.up('md')]: {
         right: 'unset',
         borderRight: `1px solid ${theme.colors.border.weak}`,
-        top: topPosition,
+        top: TOP_BAR_LEVEL_HEIGHT,
       },
     }),
     wrapper: css({

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -13,7 +13,7 @@ import { useSelector } from 'app/types';
 import { MegaMenuItem } from './MegaMenuItem';
 import { enrichWithInteractionTracking, getActiveItem } from './utils';
 
-export const MENU_WIDTH = '300px';
+export const MENU_WIDTH = 300;
 
 export interface Props extends DOMAttributes {
   onClose: () => void;
@@ -63,7 +63,7 @@ export const MegaMenu = React.memo(
             <ul className={styles.itemList} aria-label={t('navigation.megamenu.list-label', 'Navigation')}>
               {navItems.map((link, index) => (
                 <Stack key={link.text} direction={index === 0 ? 'row-reverse' : 'row'} alignItems="center">
-                  {index === 0 && (
+                  {index === 0 && !state.megaMenuDocked && (
                     <IconButton
                       id="dock-menu-button"
                       className={styles.dockMenuButton}
@@ -117,7 +117,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     listStyleType: 'none',
-    padding: theme.spacing(1, 1, 2, 1),
+    padding: theme.spacing(1, 1, 2, 1.5),
     [theme.breakpoints.up('md')]: {
       width: MENU_WIDTH,
     },

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -80,18 +80,6 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
       >
         {level !== 0 && <Indent level={level === MAX_DEPTH ? level - 1 : level} spacing={3} />}
         {level === MAX_DEPTH && <div className={styles.itemConnector} />}
-        <div className={styles.collapseButtonWrapper}>
-          {showExpandButton && (
-            <IconButton
-              aria-label={`${sectionExpanded ? 'Collapse' : 'Expand'} section ${link.text}`}
-              className={styles.collapseButton}
-              onClick={() => setSectionExpanded(!sectionExpanded)}
-              name={sectionExpanded ? 'angle-down' : 'angle-right'}
-              size="md"
-              variant="secondary"
-            />
-          )}
-        </div>
         <div className={styles.collapsibleSectionWrapper}>
           <MegaMenuItemText
             isActive={isActive}
@@ -112,6 +100,18 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick }: Props) {
               <Text truncate>{link.text}</Text>
             </div>
           </MegaMenuItemText>
+        </div>
+        <div className={styles.collapseButtonWrapper}>
+          {showExpandButton && (
+            <IconButton
+              aria-label={`${sectionExpanded ? 'Collapse' : 'Expand'} section ${link.text}`}
+              className={styles.collapseButton}
+              onClick={() => setSectionExpanded(!sectionExpanded)}
+              name={sectionExpanded ? 'angle-down' : 'angle-right'}
+              size="md"
+              variant="secondary"
+            />
+          )}
         </div>
       </div>
       {showExpandButton && sectionExpanded && (

--- a/public/app/core/components/AppChrome/NavToolbar/NavToolbar.tsx
+++ b/public/app/core/components/AppChrome/NavToolbar/NavToolbar.tsx
@@ -1,83 +1,46 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
-import { Icon, IconButton, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { Icon, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { t } from 'app/core/internationalization';
-import { HOME_NAV_ID } from 'app/core/reducers/navModel';
-import { useSelector } from 'app/types';
+import { KioskMode } from 'app/types';
 
-import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
-import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { TOP_BAR_LEVEL_HEIGHT } from '../types';
-
-import { NavToolbarSeparator } from './NavToolbarSeparator';
 
 export const TOGGLE_BUTTON_ID = 'mega-menu-toggle';
 
 export interface Props {
-  onToggleSearchBar(): void;
-  onToggleMegaMenu(): void;
-  onToggleKioskMode(): void;
-  searchBarHidden?: boolean;
-  sectionNav: NavModelItem;
-  pageNav?: NavModelItem;
-  actions: React.ReactNode;
+  children: React.ReactNode;
 }
 
-export function NavToolbar({
-  actions,
-  searchBarHidden,
-  sectionNav,
-  pageNav,
-  onToggleMegaMenu,
-  onToggleSearchBar,
-  onToggleKioskMode,
-}: Props) {
+export function NavToolbar({ children }: Props) {
+  const styles = useStyles2(getStyles);
   const { chrome } = useGrafana();
   const state = chrome.useState();
-  const homeNav = useSelector((state) => state.navIndex)[HOME_NAV_ID];
-  const styles = useStyles2(getStyles);
-  const breadcrumbs = buildBreadcrumbs(sectionNav, pageNav, homeNav);
+  const searchBarHidden = state.searchBarHidden || state.kioskMode === KioskMode.TV;
 
   return (
     <div data-testid={Components.NavToolbar.container} className={styles.pageToolbar}>
-      <div className={styles.menuButton}>
-        <IconButton
-          id={TOGGLE_BUTTON_ID}
-          name="bars"
-          tooltip={
-            state.megaMenuOpen
-              ? t('navigation.toolbar.close-menu', 'Close menu')
-              : t('navigation.toolbar.open-menu', 'Open menu')
-          }
-          tooltipPlacement="bottom"
-          size="xl"
-          onClick={onToggleMegaMenu}
-          data-testid={Components.NavBar.Toggle.button}
-        />
-      </div>
-      <Breadcrumbs breadcrumbs={breadcrumbs} className={styles.breadcrumbsWrapper} />
       <div className={styles.actions}>
-        {actions}
-        {searchBarHidden && (
+        {children}
+        {/* {searchBarHidden && (
           <ToolbarButton
-            onClick={onToggleKioskMode}
+            onClick={() => {}}
             narrow
             title={t('navigation.toolbar.enable-kiosk', 'Enable kiosk mode')}
             icon="monitor"
           />
         )}
-        {actions && <NavToolbarSeparator />}
         <ToolbarButton
-          onClick={onToggleSearchBar}
+          onClick={() => {}}
           narrow
           title={t('navigation.toolbar.toggle-search-bar', 'Toggle top search bar')}
         >
           <Icon name={searchBarHidden ? 'angle-down' : 'angle-up'} size="xl" />
-        </ToolbarButton>
+        </ToolbarButton> */}
       </div>
     </div>
   );
@@ -98,6 +61,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       padding: theme.spacing(0, 1, 0, 2),
       alignItems: 'center',
       borderBottom: `1px solid ${theme.colors.border.weak}`,
+      background: theme.colors.background.primary,
     }),
     menuButton: css({
       display: 'flex',

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBar.tsx
@@ -149,6 +149,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     border: 'none',
     color: theme.colors.text.secondary,
     alignItems: 'center',
+    paddingLeft: 0,
   }),
   dockedLogo: css({
     width: MENU_WIDTH - 16,

--- a/public/app/core/components/AppChrome/TopBar/TopSearchBarCommandPaletteTrigger.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopSearchBarCommandPaletteTrigger.tsx
@@ -69,7 +69,6 @@ function PretendTextInput({ onClick }: PretendTextInputProps) {
         </button>
 
         <div className={styles.suffix}>
-          <Icon name="keyboard" />
           <Text variant="bodySmall">{modKey}+k</Text>
         </div>
       </div>

--- a/public/app/core/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/public/app/core/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -10,13 +10,14 @@ import { Breadcrumb } from './types';
 export interface Props {
   breadcrumbs: Breadcrumb[];
   className?: string;
+  isMenuDocked?: boolean;
 }
 
-export function Breadcrumbs({ breadcrumbs, className }: Props) {
+export function Breadcrumbs({ breadcrumbs, className, isMenuDocked }: Props) {
   const styles = useStyles2(getStyles);
 
   return (
-    <nav aria-label="Breadcrumbs" className={className}>
+    <nav aria-label="Breadcrumbs" className={cx(className, isMenuDocked && styles.isDocked)}>
       <ol className={styles.breadcrumbs}>
         {breadcrumbs.map((breadcrumb, index) => (
           <BreadcrumbItem
@@ -51,6 +52,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       alignItems: 'center',
       flexWrap: 'nowrap',
       overflow: 'hidden',
+    }),
+    isDocked: css({
+      paddingLeft: theme.spacing(3),
     }),
   };
 };

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -16,7 +16,8 @@ import React, { useEffect, useMemo, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { EmptyState, Icon, LoadingBar, useStyles2 } from '@grafana/ui';
+import { EmptyState, Icon, LoadingBar, styleMixins, useStyles2 } from '@grafana/ui';
+import { getFocusStyles } from '@grafana/ui/src/themes/mixins';
 import { t } from 'app/core/internationalization';
 
 import { KBarResults } from './KBarResults';
@@ -151,7 +152,8 @@ const getSearchStyles = (theme: GrafanaTheme2) => {
     positioner: css({
       zIndex: theme.zIndex.portal,
       marginTop: '0px',
-      paddingTop: '4px !important',
+      justifyContent: 'flex-end !important',
+      padding: '0 187px 0 0 !important',
       '&::before': {
         content: '""',
         position: 'fixed',
@@ -164,7 +166,7 @@ const getSearchStyles = (theme: GrafanaTheme2) => {
       },
     }),
     animator: css({
-      maxWidth: theme.breakpoints.values.md,
+      maxWidth: theme.breakpoints.values.lg,
       width: '100%',
       background: theme.colors.background.primary,
       color: theme.colors.text.primary,
@@ -185,8 +187,11 @@ const getSearchStyles = (theme: GrafanaTheme2) => {
       borderBottom: `1px solid ${theme.colors.border.weak}`,
       display: 'flex',
       gap: theme.spacing(1),
-      padding: theme.spacing(1, 2),
+      padding: theme.spacing(0.5),
+      borderRadius: theme.shape.radius.default,
       position: 'relative',
+      margin: theme.spacing(1),
+      ...styleMixins.getFocusStyles(theme),
     }),
     search: css({
       fontSize: theme.typography.fontSize,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -6,7 +6,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import { SceneComponentProps } from '@grafana/scenes';
 import { Button, ToolbarButton, useStyles2 } from '@grafana/ui';
 
-import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { UnlinkModal } from '../scene/UnlinkModal';
 import { getDashboardSceneFor, getLibraryPanel } from '../utils/utils';
 
@@ -15,7 +14,6 @@ import { SaveLibraryVizPanelModal } from './SaveLibraryVizPanelModal';
 import { useSnappingSplitter } from './splitter/useSnappingSplitter';
 
 export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>) {
-  const dashboard = getDashboardSceneFor(model);
   const { optionsPane } = model.useState();
   const styles = useStyles2(getStyles);
 
@@ -32,7 +30,6 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
 
   return (
     <>
-      <NavToolbarActions dashboard={dashboard} />
       <div {...containerProps} data-testid={selectors.components.PanelEditor.General.content}>
         <div {...primaryProps} className={cx(primaryProps.className, styles.body)}>
           <VizAndDataPane model={model} />

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -12,7 +12,7 @@ import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 import { useSelector } from 'app/types';
 
 import { DashboardScene } from './DashboardScene';
-import { NavToolbarActions } from './NavToolbarActions';
+import { ToolbarActions } from './NavToolbarActions';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {
   const { controls, overlay, editview, editPanel, isEmpty, scopes, meta } = model.useState();
@@ -44,6 +44,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
+      <ToolbarActions dashboard={model} />
       {editPanel && <editPanel.Component model={editPanel} />}
       {!editPanel && (
         <div
@@ -55,7 +56,6 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
           )}
         >
           {scopes && <scopes.Component model={scopes} />}
-          <NavToolbarActions dashboard={model} />
           {!isHomePage && controls && (
             <div
               className={cx(styles.controlsWrapper, scopes && !isScopesExpanded && styles.controlsWrapperWithScopes)}

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -12,7 +12,7 @@ import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';
 import { useSelector } from 'app/types';
 
 import { DashboardScene } from './DashboardScene';
-import { ToolbarActions } from './NavToolbarActions';
+import { NavToolbarActions } from './NavToolbarActions';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {
   const { controls, overlay, editview, editPanel, isEmpty, scopes, meta } = model.useState();
@@ -44,7 +44,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Custom}>
-      <ToolbarActions dashboard={model} />
+      <NavToolbarActions dashboard={model} />
       {editPanel && <editPanel.Component model={editPanel} />}
       {!editPanel && (
         <div

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -39,7 +39,7 @@ interface Props {
 /**
  * This part is split into a separate component to help test this
  */
-export function ToolbarActions({ dashboard }: Props) {
+export function NavToolbarActions({ dashboard }: Props) {
   const {
     isEditing,
     viewPanelScene,

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -15,7 +15,7 @@ import {
   ToolbarButtonRow,
   useStyles2,
 } from '@grafana/ui';
-import { AppChromeUpdate } from 'app/core/components/AppChrome/AppChromeUpdate';
+import { NavToolbar } from 'app/core/components/AppChrome/NavToolbar/NavToolbar';
 import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
 import { contextSrv } from 'app/core/core';
 import { Trans, t } from 'app/core/internationalization';
@@ -35,13 +35,6 @@ import { LibraryVizPanel } from './LibraryVizPanel';
 interface Props {
   dashboard: DashboardScene;
 }
-
-export const NavToolbarActions = React.memo<Props>(({ dashboard }) => {
-  const actions = <ToolbarActions dashboard={dashboard} />;
-  return <AppChromeUpdate actions={actions} />;
-});
-
-NavToolbarActions.displayName = 'NavToolbarActions';
 
 /**
  * This part is split into a separate component to help test this
@@ -589,7 +582,11 @@ export function ToolbarActions({ dashboard }: Props) {
     lastGroup = action.group;
   }
 
-  return <ToolbarButtonRow alignment="right">{actionElements}</ToolbarButtonRow>;
+  return (
+    <NavToolbar>
+      <ToolbarButtonRow alignment="right">{actionElements}</ToolbarButtonRow>
+    </NavToolbar>
+  );
 }
 
 function addDynamicActions(


### PR DESCRIPTION
This is a quick (2h) nav poc implementing a design by @Ijin08 with a few tweaks 

* Unify the top search bar and breadcrumb bar into one
* Only pages that use the navbar actions render a navtoolbar (and it's not part of AppChrome now but rendered inside the Page)
* When mega menu is docked make breadcrumbs align with page AND SHOW Grafana wordmark 🎉 
* Adjust mega menu so that icons and text align by moving toggle to the right 

**TODO**
* [x] Dashboard nav toolbar works 
* [x] Panel edit nav toolbar works
* [ ] Dashboard settings
* [ ] Edit alert rule 

Video demo:

https://github.com/grafana/grafana/assets/10999/4317bef3-043d-4783-9591-0ab435fd4afe

Screenshots: 

![Screenshot 2024-06-13 at 16 10 13](https://github.com/grafana/grafana/assets/10999/980c467a-84f0-4400-b694-4f30dc034085)
![Screenshot 2024-06-13 at 16 12 09](https://github.com/grafana/grafana/assets/10999/8f68a067-bcb1-4086-9f27-2f5c81116ca9)


