### PR TITLE
SSE: (Chore) Update log line with context (trace)

### DIFF
--- a/pkg/expr/converter.go
+++ b/pkg/expr/converter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/expr/mathexp"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -119,7 +120,7 @@ func (c *ResultConverter) Convert(ctx context.Context,
 	}, nil
 }
 
-func getResponseFrame(resp *backend.QueryDataResponse, refID string) (data.Frames, error) {
+func getResponseFrame(logger *log.ConcreteLogger, resp *backend.QueryDataResponse, refID string) (data.Frames, error) {
 	response, ok := resp.Responses[refID]
 	if !ok {
 		// This indicates that the RefID of the request was not included to the response, i.e. some problem in the data source plugin

--- a/pkg/expr/ml.go
+++ b/pkg/expr/ml.go
@@ -124,7 +124,7 @@ func (m *MLNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s *
 		data = &backend.QueryDataResponse{Responses: map[string]backend.DataResponse{}}
 	}
 
-	dataFrames, err := getResponseFrame(data, m.refID)
+	dataFrames, err := getResponseFrame(logger, data, m.refID)
 	if err != nil {
 		return mathexp.Results{}, MakeQueryError(m.refID, "ml", err)
 	}

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -325,7 +325,7 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 			}
 
 			for _, dn := range nodeGroup {
-				dataFrames, err := getResponseFrame(resp, dn.refID)
+				dataFrames, err := getResponseFrame(logger, resp, dn.refID)
 				if err != nil {
 					vars[dn.refID] = mathexp.Results{Error: MakeQueryError(dn.refID, dn.datasource.UID, err)}
 					instrument(err, "")
@@ -395,7 +395,7 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 		return mathexp.Results{}, MakeQueryError(dn.refID, dn.datasource.UID, err)
 	}
 
-	dataFrames, err := getResponseFrame(resp, dn.refID)
+	dataFrames, err := getResponseFrame(logger, resp, dn.refID)
 	if err != nil {
 		return mathexp.Results{}, MakeQueryError(dn.refID, dn.datasource.UID, err)
 	}


### PR DESCRIPTION
**What is this feature?**

Improves log line to help with debugging in Server Side Expressions. In particular, the traceId, datasourceType, and datasourceUid will now be included.

Before:

```
WARN [06-13|09:29:10] Can't find response by refID. Return nodata logger=expr responseRefIds=[]
```


After:
```
WARN [06-13|10:26:10] Can't find response by refID. Return nodata logger=expr traceID=aeccc69b70d363b25a9e12edfa253628 rule_uid=kZb7eVmVzz org_id=1 datasourceType=testdata queryRefId=A datasourceUid=PD8C576611E62080A datasourceVersion=1 responseRefIds=[]
```

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
