### PR TITLE
Logs panel: do not pass default handlers if context is not defined

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7124,6 +7124,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "6"],
       [0, 0, 0, "Styles should be written using objects.", "7"]
     ],
+    "public/app/plugins/panel/logs/LogsPanel.test.tsx:5381": [
+      [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
+    ],
     "public/app/plugins/panel/logs/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
     ],

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -249,7 +249,7 @@ export const LogsPanel = ({
     [scrollElement]
   );
 
-  const defaultOnClickFilterLabel = useCallback(
+  const handleOnClickFilterLabel = useCallback(
     (key: string, value: string) => {
       onAddAdHocFilter?.({
         key,
@@ -260,7 +260,7 @@ export const LogsPanel = ({
     [onAddAdHocFilter]
   );
 
-  const defaultOnClickFilterOutLabel = useCallback(
+  const handleOnClickFilterOutLabel = useCallback(
     (key: string, value: string) => {
       onAddAdHocFilter?.({
         key,
@@ -284,6 +284,10 @@ export const LogsPanel = ({
       />
     </div>
   );
+
+  // Passing callbacks control the display of the filtering buttons. We want to pass it only if onAddAdHocFilter is defined.
+  const defaultOnClickFilterLabel = onAddAdHocFilter ? handleOnClickFilterLabel : undefined;
+  const defaultOnClickFilterOutLabel = onAddAdHocFilter ? handleOnClickFilterOutLabel : undefined;
 
   return (
     <>


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/88980

Making sure we don't pass default handlers when the context doesn't meet the required criteria.