### PR TITLE
Alerting: Forward user headers through loki/cortex proxied APIs

### DIFF
--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -114,6 +114,11 @@ func (p *AlertingProxy) withReq(
 	for h, v := range headers {
 		req.Header.Add(h, v)
 	}
+	for h, vs := range ctx.Req.Header {
+		for _, v := range vs {
+			req.Header.Add(h, v)
+		}
+	}
 	// this response will be populated by the response from the datasource
 	resp := response.CreateNormalResponse(make(http.Header), nil, 0)
 	proxyContext := p.createProxyContext(ctx, req, resp)

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -111,13 +111,13 @@ func (p *AlertingProxy) withReq(
 	if err != nil {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}
-	for h, v := range headers {
-		req.Header.Add(h, v)
-	}
 	for h, vs := range ctx.Req.Header {
 		for _, v := range vs {
 			req.Header.Add(h, v)
 		}
+	}
+	for h, v := range headers {
+		req.Header.Add(h, v)
 	}
 	// this response will be populated by the response from the datasource
 	resp := response.CreateNormalResponse(make(http.Header), nil, 0)


### PR DESCRIPTION
**What is this feature?**

In certain on-prem setups users might want to forward auth context to the loki/mimir/cortex behind grafana. Grafana does not forward request headers through the proxy API, making this impossible.

**Why do we need this feature?**

Enables certain on-prem setups with custom auth in front of an external ruler.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
