### PR TITLE
Alerting: Fix saving telegram contact point to Cloud AM config

### DIFF
--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
+import { render, screen, waitFor, userEvent } from 'test/test-utils';
+
+import {
+  EXTERNAL_VANILLA_ALERTMANAGER_UID,
+  setupVanillaAlertmanagerServer,
+} from 'app/features/alerting/unified/components/settings/__mocks__/server';
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { grantUserPermissions, mockDataSource } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
+import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
+import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types';
+
+import ContactPoints from './Receivers';
+
+import 'core-js/stable/structured-clone';
+
+const server = setupMswServer();
+
+const mockDataSources = {
+  [EXTERNAL_VANILLA_ALERTMANAGER_UID]: mockDataSource<AlertManagerDataSourceJsonData>({
+    uid: EXTERNAL_VANILLA_ALERTMANAGER_UID,
+    name: EXTERNAL_VANILLA_ALERTMANAGER_UID,
+    type: DataSourceType.Alertmanager,
+    jsonData: {
+      implementation: AlertManagerImplementation.prometheus,
+    },
+  }),
+};
+
+beforeEach(() => {
+  grantUserPermissions([
+    AccessControlAction.AlertingNotificationsRead,
+    AccessControlAction.AlertingNotificationsWrite,
+    AccessControlAction.AlertingNotificationsExternalRead,
+    AccessControlAction.AlertingNotificationsExternalWrite,
+  ]);
+});
+
+it('can save a contact point with a select dropdown', async () => {
+  setupVanillaAlertmanagerServer(server);
+  setupDataSources(mockDataSources[EXTERNAL_VANILLA_ALERTMANAGER_UID]);
+
+  const user = userEvent.setup();
+
+  render(<ContactPoints />, {
+    historyOptions: {
+      initialEntries: [`/alerting/notifications/receivers/new?alertmanager=${EXTERNAL_VANILLA_ALERTMANAGER_UID}`],
+    },
+  });
+
+  // Fill out contact point name
+  const contactPointName = await screen.findByPlaceholderText(/name/i);
+  await user.type(contactPointName, 'contact point with select');
+
+  // Select Telegram option (this is we expect the form to contain a dropdown)
+  const integrationDropdown = screen.getByLabelText(/integration/i);
+  await selectOptionInTest(integrationDropdown, /telegram/i);
+
+  // Fill out basic fields necessary for contact point to be saved
+  const botToken = await screen.findByLabelText(/bot token/i);
+  const chatId = await screen.findByLabelText(/chat id/i);
+
+  await user.type(botToken, 'sometoken');
+  await user.type(chatId, '-123');
+
+  await user.click(await screen.findByRole('button', { name: /save contact point/i }));
+
+  // TODO: Have a better way to assert that the contact point was saved. This is instead asserting on some
+  // text that's present on the list page, as there's a lot of overlap in text between the form and the list page
+  await waitFor(() => expect(screen.getByText(/search by name or type/i)).toBeInTheDocument(), { timeout: 2000 });
+});

--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -3,7 +3,6 @@ import { Route, Switch } from 'react-router-dom';
 
 import { withErrorBoundary } from '@grafana/ui';
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
 import { AlertmanagerPageWrapper } from './components/AlertingPageWrapper';
 
@@ -12,7 +11,7 @@ const EditContactPoint = SafeDynamicImport(() => import('./components/contact-po
 const NewContactPoint = SafeDynamicImport(() => import('./components/contact-points/NewContactPoint'));
 const GlobalConfig = SafeDynamicImport(() => import('./components/contact-points/components/GlobalConfig'));
 
-const ContactPoints = (_props: GrafanaRouteComponentProps): JSX.Element => (
+const ContactPoints = (): JSX.Element => (
   <AlertmanagerPageWrapper navId="receivers" accessType="notification">
     <Switch>
       <Route exact={true} path="/alerting/notifications" component={ContactPointsV2} />

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -161,7 +161,7 @@ const OptionInput: FC<Props & { id: string; pathIndex?: string }> = ({
           )}
           control={control}
           name={name}
-          defaultValue={option.defaultValue}
+          defaultValue={option.defaultValue?.value}
           rules={{
             validate: {
               customValidator: (v) => (customValidator ? customValidator(v) : true),


### PR DESCRIPTION
**What is this feature?**

Fixes saving contact points when the user hadn't interacted with any present select dropdowns in the forms.
In this case, we hadn't mapped the `defaultValue` object to get its `value` property, and were sending an object to the API instead, e.g.

```ts
{
  //...
  parse_mode: {
    label: 'MarkdownV2',
    value: 'MarkdownV2',
  }
}
```

instead of 

```ts
{
  //...
  parse_mode: 'MarkdownV2',
}
```

We can map the default value to be the value property. The existing behaviour already handles mapping the selected option on change, hence why this would work if you changed the dropdown before saving

**Why do we need this feature?**

🐛 

**Who is this feature for?**

Alerting users creating/editing contact points - primarily Telegram/WeChat
