### PR TITLE
LogDetailsRow: customize filters tooltip according to the current app

### DIFF
--- a/public/app/features/logs/components/LogDetails.test.tsx
+++ b/public/app/features/logs/components/LogDetails.test.tsx
@@ -11,6 +11,7 @@ import {
   FieldType,
   createDataFrame,
   DataFrameType,
+  CoreApp,
 } from '@grafana/data';
 
 import { LogDetails, Props } from './LogDetails';
@@ -32,6 +33,7 @@ const setup = (propOverrides?: Partial<Props>, rowOverrides?: Partial<LogRowMode
     onClickHideField: () => {},
     theme,
     styles,
+    app: CoreApp.Explore,
     ...(propOverrides || {}),
   };
 

--- a/public/app/features/logs/components/LogDetailsRow.test.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { ComponentProps } from 'react';
 
+import { CoreApp } from '@grafana/data';
+
 import { LogDetailsRow } from './LogDetailsRow';
 import { createLogRow } from './__mocks__/logRow';
 
@@ -20,6 +22,7 @@ const setup = (propOverrides?: Partial<Props>) => {
     displayedFields: [],
     row: createLogRow(),
     disableActions: false,
+    app: CoreApp.Explore,
   };
 
   Object.assign(props, propOverrides);

--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -261,6 +261,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
       onClickFilterOutLabel,
       disableActions,
       row,
+      app,
     } = this.props;
     const { showFieldsStats, fieldStats, fieldCount } = this.state;
     const styles = getStyles(theme);
@@ -268,7 +269,7 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
     const singleKey = parsedKeys == null ? false : parsedKeys.length === 1;
     const singleVal = parsedValues == null ? false : parsedValues.length === 1;
     const hasFilteringFunctionality = !disableActions && onClickFilterLabel && onClickFilterOutLabel;
-    const refIdTooltip = row.dataFrame?.refId ? ` in query ${row.dataFrame?.refId}` : '';
+    const refIdTooltip = app === CoreApp.Explore && row.dataFrame?.refId ? ` in query ${row.dataFrame?.refId}` : '';
 
     const isMultiParsedValueWithNoContent =
       !singleVal && parsedValues != null && !parsedValues.every((val) => val === '');

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -399,8 +399,8 @@ describe('LogsPanel', () => {
 
         await userEvent.click(screen.getByText('logline text'));
 
-        expect(screen.queryByLabelText('Filter for value in query A')).not.toBeInTheDocument();
-        expect(screen.queryByLabelText('Filter out value in query A')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Filter for value')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Filter out value')).not.toBeInTheDocument();
       });
       it('shows the controls if onAddAdHocFilter is defined', async () => {
         jest.spyOn(grafanaUI, 'usePanelContext').mockReturnValue({
@@ -421,8 +421,8 @@ describe('LogsPanel', () => {
 
         expect(await screen.findByText('common_app')).toBeInTheDocument();
 
-        expect(screen.getByLabelText('Filter for value in query A')).toBeInTheDocument();
-        expect(screen.getByLabelText('Filter out value in query A')).toBeInTheDocument();
+        expect(screen.getByLabelText('Filter for value')).toBeInTheDocument();
+        expect(screen.getByLabelText('Filter out value')).toBeInTheDocument();
       });
     });
   });

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -374,9 +374,9 @@ describe('LogsPanel', () => {
       expect(await screen.findByRole('row')).toBeInTheDocument();
 
       await userEvent.click(screen.getByText('logline text'));
-      await userEvent.click(screen.getByLabelText('Filter for value in query A'));
+      await userEvent.click(screen.getByLabelText('Filter for value'));
       expect(filterForMock).toHaveBeenCalledTimes(1);
-      await userEvent.click(screen.getByLabelText('Filter out value in query A'));
+      await userEvent.click(screen.getByLabelText('Filter out value'));
       expect(filterOutMock).toHaveBeenCalledTimes(1);
 
       expect(isFilterLabelActiveMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/88980 changes.

These messages and behaviors were originally implemented for Explore, but now are available for Dashboards and Apps. For that, we need to show different messages depending on the context.

In Explore, filters are toggleable, and have the capacity to display active status.
In Dashboards, we can only add basic adhoc filters with no active status.
In Apps, it depends on the implementation of the Logs Panel API, so filters behaviors and active status depend on the developer.

![2024-06-13 19 15 01](https://github.com/grafana/grafana/assets/1069378/467e7766-a313-493b-8fe6-eae3a4a392fd)

