### PR TITLE
Alerting UX: update descriptions for alerting notification fields

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2094,8 +2094,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2094,7 +2094,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],

--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -133,7 +133,7 @@ export const AmRootRouteForm = ({
           </Field>
           <Field
             label="Group interval"
-            description="The waiting time before sending a notification about changes in the alert group after the first notification has been sent. Default 5 minutes."
+            description="The wait time before sending a notification about changes in the alert group after the first notification has been sent. Default is 5 minutes."
             invalid={!!errors.groupIntervalValue}
             error={errors.groupIntervalValue?.message}
             data-testid="am-group-interval"

--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -147,7 +147,7 @@ export const AmRootRouteForm = ({
           </Field>
           <Field
             label="Repeat interval"
-            description="The waiting time before resending a notification that has already been sent successfully. Default 4 hours. Should be a multiple of Group interval."
+            description="The wait time before resending a notification that has already been sent successfully. Default is 4 hours. Should be a multiple of Group interval."
             invalid={!!errors.repeatIntervalValue}
             error={errors.repeatIntervalValue?.message}
             data-testid="am-repeat-interval"

--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -87,7 +87,7 @@ export const AmRootRouteForm = ({
       </Field>
       <Field
         label="Group by"
-        description="Group alerts when you receive a notification based on labels."
+        description="Combine multiple alerts into a single notification by grouping them by the same label values."
         data-testid="am-group-select"
       >
         <Controller
@@ -119,7 +119,7 @@ export const AmRootRouteForm = ({
         <div className={styles.timingFormContainer}>
           <Field
             label="Group wait"
-            description="The waiting time until the initial notification is sent for a new group created by an incoming alert. Default 30 seconds."
+            description="The waiting time before sending the first notification for a new group of alerts. Default 30 seconds."
             invalid={!!errors.groupWaitValue}
             error={errors.groupWaitValue?.message}
             data-testid="am-group-wait"
@@ -133,7 +133,7 @@ export const AmRootRouteForm = ({
           </Field>
           <Field
             label="Group interval"
-            description="The waiting time to send a batch of new alerts for that group after the first notification was sent. Default 5 minutes."
+            description="The waiting time before sending a notification about changes in the alert group after the first notification has been sent. Default 5 minutes."
             invalid={!!errors.groupIntervalValue}
             error={errors.groupIntervalValue?.message}
             data-testid="am-group-interval"
@@ -147,7 +147,7 @@ export const AmRootRouteForm = ({
           </Field>
           <Field
             label="Repeat interval"
-            description="The waiting time to resend an alert after they have successfully been sent. Default 4 hours. Should be a multiple of Group interval."
+            description="The waiting time before resending a notification that has already been sent successfully. Default 4 hours. Should be a multiple of Group interval."
             invalid={!!errors.repeatIntervalValue}
             error={errors.repeatIntervalValue?.message}
             data-testid="am-repeat-interval"

--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
@@ -191,7 +191,7 @@ export const AmRoutesExpandedForm = ({
       {watch().overrideGrouping && (
         <Field
           label="Group by"
-          description="Combine multiple alerts into a single notification by grouping them by the same label values. If empty it will be inherited from the parent policy."
+          description="Combine multiple alerts into a single notification by grouping them by the same label values. If empty, it is inherited from the parent policy."
         >
           <Controller
             rules={{

--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
@@ -191,7 +191,7 @@ export const AmRoutesExpandedForm = ({
       {watch().overrideGrouping && (
         <Field
           label="Group by"
-          description="Group alerts when you receive a notification based on labels. If empty it will be inherited from the parent policy."
+          description="Combine multiple alerts into a single notification by grouping them by the same label values. If empty it will be inherited from the parent policy."
         >
           <Controller
             rules={{

--- a/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
@@ -13,7 +13,7 @@ export const routeTimingsFields = {
   },
   repeatInterval: {
     label: 'Repeat interval',
-    description: 'The waiting time before resending a notification that has already been sent successfully.',
+    description: 'The wait time before resending a notification that has already been sent successfully.',
     ariaLabel: 'Repeat interval value',
   },
 };

--- a/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
@@ -2,7 +2,7 @@ export const routeTimingsFields = {
   groupWait: {
     label: 'Group wait',
     description:
-      'The waiting time before sending the first notification for a new group of alerts. If empty it will be inherited from the parent policy.',
+      'The wait time before sending the first notification for a new group of alerts. If empty, it is inherited from the parent policy.',
     ariaLabel: 'Group wait value',
   },
   groupInterval: {

--- a/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
@@ -8,7 +8,7 @@ export const routeTimingsFields = {
   groupInterval: {
     label: 'Group interval',
     description:
-      'The waiting time before sending a notification about changes in the alert group after the first notification has been sent. If empty it will be inherited from the parent policy.',
+      'The wait time before sending a notification about changes in the alert group after the first notification has been sent. If empty, it is inherited from the parent policy.',
     ariaLabel: 'Group interval value',
   },
   repeatInterval: {

--- a/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/routeTimingsFields.ts
@@ -2,18 +2,18 @@ export const routeTimingsFields = {
   groupWait: {
     label: 'Group wait',
     description:
-      'The waiting time until the initial notification is sent for a new group created by an incoming alert. If empty it will be inherited from the parent policy.',
+      'The waiting time before sending the first notification for a new group of alerts. If empty it will be inherited from the parent policy.',
     ariaLabel: 'Group wait value',
   },
   groupInterval: {
     label: 'Group interval',
     description:
-      'The waiting time to send a batch of new alerts for that group after the first notification was sent. If empty it will be inherited from the parent policy.',
+      'The waiting time before sending a notification about changes in the alert group after the first notification has been sent. If empty it will be inherited from the parent policy.',
     ariaLabel: 'Group interval value',
   },
   repeatInterval: {
     label: 'Repeat interval',
-    description: 'The waiting time to resend an alert after they have successfully been sent.',
+    description: 'The waiting time before resending a notification that has already been sent successfully.',
     ariaLabel: 'Repeat interval value',
   },
 };

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -209,7 +209,7 @@ function NeedHelpInfoForContactpoint() {
           <br />
           Notifications for firing alert instances are grouped based on folder and alert rule name.
           <br />
-          The waiting time before sending the first notification for a new group of alerts is 30 seconds.
+          The wait time before sending the first notification for a new group of alerts is 30 seconds.
           <br />
           The waiting time before sending a notification about changes in the alert group after the first notification
           has been sent is 5 minutes.

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -214,7 +214,7 @@ function NeedHelpInfoForContactpoint() {
           The waiting time before sending a notification about changes in the alert group after the first notification
           has been sent is 5 minutes.
           <br />
-          The waiting time before resending a notification that has already been sent successfully is 4 hours.
+          The wait time before resending a notification that has already been sent successfully is 4 hours.
           <br />
           Grouping and wait time values are defined in your default notification policy.
         </>

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -173,20 +173,9 @@ function NeedHelpInfoForNotificationPolicy() {
         <Stack gap={1} direction="column">
           <Stack direction="column" gap={0}>
             <>
-              Firing alert rule instances are routed to notification policies based on matching labels. All alert rules
-              and instances, irrespective of their labels, match the default notification policy. If there are no nested
-              policies, or no nested policies match the labels in the alert rule or alert instance, then the default
-              notification policy is the matching policy.
+              Firing alert instances are routed to notification policies based on matching labels. The default
+              notification policy matches all alert instances.
             </>
-            <a
-              href={`https://grafana.com/docs/grafana/latest/alerting/fundamentals/notification-policies/notifications/`}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <Text color="link">
-                Read about notification routing. <Icon name="external-link-alt" />
-              </Text>
-            </a>
           </Stack>
           <Stack direction="column" gap={0}>
             <>
@@ -194,12 +183,12 @@ function NeedHelpInfoForNotificationPolicy() {
               connect them to your notification policy by adding label matchers.
             </>
             <a
-              href={`https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/`}
+              href={`https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/notification-policies/`}
               target="_blank"
               rel="noreferrer"
             >
               <Text color="link">
-                Read about Labels and annotations. <Icon name="external-link-alt" />
+                Read about notification policies. <Icon name="external-link-alt" />
               </Text>
             </a>
           </Stack>
@@ -220,20 +209,18 @@ function NeedHelpInfoForContactpoint() {
           <br />
           Notifications for firing alert instances are grouped based on folder and alert rule name.
           <br />
-          The waiting time until the initial notification is sent for a new group created by an incoming alert is 30
-          seconds.
+          The waiting time before sending the first notification for a new group of alerts is 30 seconds.
           <br />
-          The waiting time to send a batch of new alerts for that group after the first notification was sent is 5
-          minutes.
+          The waiting time before sending a notification about changes in the alert group after the first notification
+          has been sent is 5 minutes.
           <br />
-          The waiting time to resend an alert after they have successfully been sent is 4 hours.
+          The waiting time before resending a notification that has already been sent successfully is 4 hours.
           <br />
           Grouping and wait time values are defined in your default notification policy.
         </>
       }
-      // todo: update the link with the new documentation about simplified routing
-      externalLink="`https://grafana.com/docs/grafana/latest/alerting/fundamentals/notification-policies/notifications/`"
-      linkText="Read more about notifiying contact points"
+      externalLink="https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/"
+      linkText="Read more about notifications"
       title="Notify contact points"
     />
   );

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
@@ -67,7 +67,7 @@ export const RoutingSettings = ({ alertManager }: RoutingSettingsProps) => {
       {overrideGrouping && (
         <Field
           label="Group by"
-          description="Combine multiple alerts into a single notification by grouping them by the same label values. If empty it will be inherited from the default notification policy."
+          description="Combine multiple alerts into a single notification by grouping them by the same label values. If empty, it is inherited from the default notification policy."
           {...register(`contactPoints.${alertManager}.groupBy`)}
           invalid={!!errors.contactPoints?.[alertManager]?.groupBy}
           className={styles.optionalContent}

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
@@ -67,7 +67,7 @@ export const RoutingSettings = ({ alertManager }: RoutingSettingsProps) => {
       {overrideGrouping && (
         <Field
           label="Group by"
-          description="Group alerts when you receive a notification based on labels. If empty it will be inherited from the default notification policy."
+          description="Combine multiple alerts into a single notification by grouping them by the same label values. If empty it will be inherited from the default notification policy."
           {...register(`contactPoints.${alertManager}.groupBy`)}
           invalid={!!errors.contactPoints?.[alertManager]?.groupBy}
           className={styles.optionalContent}


### PR DESCRIPTION


1 - This PR aligns the descriptions with the updated [Group notifications and Timing options docs](https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/group-alert-notifications/). 

2 - I wanted to include `NeedHelp?` that links to [Group alert notifications docs](https://grafana.com/docs/grafana/next/alerting/fundamentals/notifications/group-alert-notifications/) in the `Override grouping` and `Override timing` options, but was unsure how.  But we have recently discussed to change the UI for both options, so it may then be a better moment. 

![Screenshot 2024-06-13 at 19 45 11](https://github.com/grafana/grafana/assets/825430/ed660b2a-f71e-485e-b156-2b9fedbc8f9d)

