### PR TITLE
RestoreDashboards: Fix counting bug

### DIFF
--- a/public/app/features/manage-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/manage-dashboards/components/RestoreModal.tsx
@@ -3,22 +3,23 @@ import React from 'react';
 import { ConfirmModal, Text } from '@grafana/ui';
 
 import { Trans, t } from '../../../core/internationalization';
-import { DashboardTreeSelection } from '../../browse-dashboards/types';
 
 interface Props {
   isOpen: boolean;
   onConfirm: () => Promise<void>;
   onDismiss: () => void;
-  selectedItems: DashboardTreeSelection;
+  selectedDashboards: string[];
   isLoading: boolean;
 }
 
-export const RestoreModal = ({ onConfirm, onDismiss, selectedItems, isLoading, ...props }: Props) => {
-  const numberOfDashboards = selectedItems ? Object.keys(selectedItems.dashboard).length : 0;
+export const RestoreModal = ({ onConfirm, onDismiss, selectedDashboards, isLoading, ...props }: Props) => {
+  const numberOfDashboards = selectedDashboards.length;
+
   const onRestore = async () => {
     await onConfirm();
     onDismiss();
   };
+
   return (
     <ConfirmModal
       body={


### PR DESCRIPTION
**What is this fix?**
While clicking through different options for restoring dashboards we found an error. When a dashboard got selected and unselected the number of dashboards for retrieval would stay at 1. 

Related to #83620

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
