### PR TITLE
For now, only compare if names are the same in playlists

### DIFF
--- a/pkg/registry/apis/playlist/storage.go
+++ b/pkg/registry/apis/playlist/storage.go
@@ -1,6 +1,7 @@
 package playlist
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -41,6 +42,14 @@ func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, le
 
 // Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
 func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	//TODO: define the comparison logic between a playlist returned by the storage and a playlist returned by the legacy storage
-	return false
+	accStr, err := meta.Accessor(storageObj)
+	if err != nil {
+		return false
+	}
+	accLegacy, err := meta.Accessor(legacyObj)
+	if err != nil {
+		return false
+	}
+
+	return accStr.GetName() == accLegacy.GetName()
 }


### PR DESCRIPTION
**What is this feature?**

Implement compare method for playlists. The result of this is to be used by a metric to assess differences between writes to object storage and legacy storage.
For now we are only comparing the name. Comparing other fields, namely the ones in spec will require some more work as conversion fns from runtimeObject / unstructured into models are still not existing.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/search-and-storage-team/issues/44

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
