### PR TITLE
RBAC: Fix the check for whether an action set should be added

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -671,7 +671,7 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 	/*
 		Add ACTION SET of managed permissions to in-memory store
 	*/
-	if s.shouldStoreActionSet(permission) {
+	if s.shouldStoreActionSet(resource, permission) {
 		actionSetName := GetActionSetName(resource, permission)
 		p := managedPermission(actionSetName, resource, resourceID, resourceAttribute)
 		p.RoleID = roleID
@@ -683,13 +683,13 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 
 	// If there are no missing actions for the resource (in case of access level downgrade or resource removal), we don't need to insert any actions
 	// we still want to add the action set (when permission != "")
-	if len(missingActions) == 0 && !s.shouldStoreActionSet(permission) {
+	if len(missingActions) == 0 && !s.shouldStoreActionSet(resource, permission) {
 		return nil
 	}
 
 	// if we have actionset feature enabled and are only working with action sets
 	// skip adding the missing actions to the permissions table
-	if !(s.shouldStoreActionSet(permission) && s.cfg.OnlyStoreAccessActionSets) {
+	if !(s.shouldStoreActionSet(resource, permission) && s.cfg.OnlyStoreAccessActionSets) {
 		for action := range missingActions {
 			p := managedPermission(action, resource, resourceID, resourceAttribute)
 			p.RoleID = roleID
@@ -706,8 +706,12 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 	return nil
 }
 
-func (s *store) shouldStoreActionSet(permission string) bool {
-	return (s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) && permission != "" && isFolderOrDashboardAction(permission))
+func (s *store) shouldStoreActionSet(resource, permission string) bool {
+	if !(s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) && permission != "") {
+		return false
+	}
+	actionSetName := GetActionSetName(resource, permission)
+	return isFolderOrDashboardAction(actionSetName)
 }
 
 func deletePermissions(sess *db.Session, ids []int64) error {


### PR DESCRIPTION
**What is this feature?**

In https://github.com/grafana/grafana/pull/89053 I messed up the check for whether an action set should be added when a managed permission is stored in a data base. I wrongly assumed that `permission` is the whole action set name, while it's actually only the permission part of it (eg, `view`, `edit`, `admin`). So `isFolderOrDashboardAction` never passed, as it is checking the action set prefix. This PR fixes the check - now action sets are written for dashboards and folders again.
