### PR TITLE
LibraryPanels: Replace 'General' folder with 'Dashboards'

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4553,6 +4553,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
+    "public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx:5381": [
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
     "public/app/features/library-panels/components/LibraryPanelInfo/LibraryPanelInfo.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],

--- a/public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx
@@ -80,11 +80,12 @@ function FolderLink({ libraryPanel }: FolderLinkProps): ReactElement | null {
     return null;
   }
 
+  // LibraryPanels API returns folder-less library panels with an empty string folder UID
   if (!libraryPanel.meta.folderUid) {
     return (
       <span className={styles.metaContainer}>
         <Icon name={'folder'} size="sm" />
-        <span>{libraryPanel.meta.folderName}</span>
+        <span>Dashboards</span>
       </span>
     );
   }


### PR DESCRIPTION
One missed out on https://github.com/grafana/grafana/pull/89017 because this string actually comes from the backend.