### PR TITLE
AzureMonitor: Fix out of bounds error when accessing `metricNamespaceArray` and `resourceNameArray` in `buildResourceURI`

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -39,12 +39,19 @@ func (params *urlBuilder) buildResourceURI() (*string, error) {
 	}
 
 	metricNamespaceArray := strings.Split(*metricNamespace, "/")
+
+	provider := ""
+	if len(metricNamespaceArray) > 1 {
+		provider = metricNamespaceArray[0]
+		metricNamespaceArray = metricNamespaceArray[1:]
+	} else {
+		return nil, fmt.Errorf("metricNamespace is not in the correct format")
+	}
+
 	var resourceNameArray []string
 	if params.ResourceName != nil && *params.ResourceName != "" {
 		resourceNameArray = strings.Split(*params.ResourceName, "/")
 	}
-	provider := metricNamespaceArray[0]
-	metricNamespaceArray = metricNamespaceArray[1:]
 
 	if strings.HasPrefix(strings.ToLower(*metricNamespace), "microsoft.storage/storageaccounts/") &&
 		params.ResourceName != nil &&
@@ -66,7 +73,11 @@ func (params *urlBuilder) buildResourceURI() (*string, error) {
 	}
 
 	for i, namespace := range metricNamespaceArray {
-		urlArray = append(urlArray, namespace, resourceNameArray[i])
+		if i < len(resourceNameArray) {
+			urlArray = append(urlArray, namespace, resourceNameArray[i])
+		} else {
+			return nil, fmt.Errorf("resourceNameArray does not have enough elements")
+		}
 	}
 
 	resourceURI := strings.Join(urlArray, "/")


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/10994 (but does not fix that issue), this PR adds code to better handle cases when `metricNamespaceArray` is empty or does not contain a provider, which currently throws a more cryptic error when the namespace field in the "Advanced" box when adding a resource is invalid.