### PR TITLE
LibraryPanels: Use new folder picker when creating a library panel

### DIFF
--- a/public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/AddLibraryPanelModal/AddLibraryPanelModal.tsx
@@ -4,7 +4,7 @@ import { useAsync, useDebounce } from 'react-use';
 import { FetchError, isFetchError } from '@grafana/runtime';
 import { LibraryPanel } from '@grafana/schema/dist/esm/index.gen';
 import { Button, Field, Input, Modal } from '@grafana/ui';
-import { OldFolderPicker } from 'app/core/components/Select/OldFolderPicker';
+import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { t, Trans } from 'app/core/internationalization';
 
 import { PanelModel } from '../../../dashboard/state';
@@ -36,6 +36,7 @@ export const AddLibraryPanelContents = ({
 
   const onCreate = useCallback(() => {
     panel.libraryPanel = { uid: '', name: panelName };
+
     saveLibraryPanel(panel, folderUid!).then((res: LibraryPanel | FetchError) => {
       if (!isFetchError(res)) {
         onDismiss?.();
@@ -84,9 +85,9 @@ export const AddLibraryPanelContents = ({
           'Library panel permissions are derived from the folder permissions'
         )}
       >
-        <OldFolderPicker
-          onChange={({ uid }) => setFolderUid(uid)}
-          initialFolderUid={initialFolderUid}
+        <FolderPicker
+          onChange={(uid) => setFolderUid(uid)}
+          value={folderUid}
           inputId="share-panel-library-panel-folder-picker"
         />
       </Field>


### PR DESCRIPTION
**What is this feature?**

Uses the new Folder Picker that shows the nested folder structure when creating a library panel. Importantly, this makes it clearer that "Dashboards" represents the folderless root.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/43933