### PR TITLE
Fix X-Ds-Authorization header forwarding

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -224,12 +224,6 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 			password))
 	}
 
-	dsAuth := req.Header.Get("X-DS-Authorization")
-	if len(dsAuth) > 0 {
-		req.Header.Del("X-DS-Authorization")
-		req.Header.Set("Authorization", dsAuth)
-	}
-
 	proxyutil.ApplyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
 
 	proxyutil.ClearCookieHeader(req, proxy.ds.AllowedCookies(), []string{proxy.cfg.LoginCookieName})

--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -173,3 +173,11 @@ func (ctx *ReqContext) QueryBoolWithDefault(field string, d bool) bool {
 
 	return ctx.QueryBool(field)
 }
+
+const (
+	dsAuthorizationHeaderName = "X-Ds-Authorization"
+)
+
+func (ctx *ReqContext) GetDsAuthorization() (string, string) {
+	return dsAuthorizationHeaderName, ctx.Req.Header.Get(dsAuthorizationHeaderName)
+}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -114,6 +114,11 @@ func (p *AlertingProxy) withReq(
 	for h, v := range headers {
 		req.Header.Add(h, v)
 	}
+	dsAuthHeader, dsAuthHeaderValue := ctx.GetDsAuthorization()
+	if dsAuthHeaderValue != "" {
+		req.Header.Add(dsAuthHeader, dsAuthHeaderValue)
+	}
+
 	// this response will be populated by the response from the datasource
 	resp := response.CreateNormalResponse(make(http.Header), nil, 0)
 	proxyContext := p.createProxyContext(ctx, req, resp)

--- a/pkg/services/pluginsintegration/clientmiddleware/datasource_authorization_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/datasource_authorization_middleware.go
@@ -1,0 +1,66 @@
+package clientmiddleware
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
+)
+
+// NewDatasourceAuthorizationMiddleware creates a new plugins.ClientMiddleware that will
+// forward incoming datasource authorization HTTP request header to outgoing plugins.Client requests
+func NewDatasourceAuthorizationMiddleware() plugins.ClientMiddleware {
+	return plugins.ClientMiddlewareFunc(func(next plugins.Client) plugins.Client {
+		return &DatasourceAuthorizationMiddleware{
+			baseMiddleware: baseMiddleware{
+				next: next,
+			},
+		}
+	})
+}
+
+type DatasourceAuthorizationMiddleware struct {
+	baseMiddleware
+}
+
+func (m *DatasourceAuthorizationMiddleware) applyAuthorizationHeader(ctx context.Context, req backend.ForwardHTTPHeaders) {
+	reqCtx := contexthandler.FromContext(ctx)
+	// If no HTTP request context then skip middleware.
+	if req == nil || reqCtx == nil || reqCtx.Req == nil {
+		return
+	}
+
+	dsAuthHeader, dsAuthHeaderValue := reqCtx.GetDsAuthorization()
+	if dsAuthHeaderValue != "" {
+		req.SetHTTPHeader(dsAuthHeader, dsAuthHeaderValue)
+	}
+	return
+}
+
+func (m *DatasourceAuthorizationMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	if req == nil {
+		return m.next.QueryData(ctx, req)
+	}
+
+	m.applyAuthorizationHeader(ctx, req)
+	return m.next.QueryData(ctx, req)
+}
+
+func (m *DatasourceAuthorizationMiddleware) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	if req == nil {
+		return m.next.CallResource(ctx, req, sender)
+	}
+
+	m.applyAuthorizationHeader(ctx, req)
+	return m.next.CallResource(ctx, req, sender)
+}
+
+func (m *DatasourceAuthorizationMiddleware) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	if req == nil {
+		return m.next.CheckHealth(ctx, req)
+	}
+
+	m.applyAuthorizationHeader(ctx, req)
+	return m.next.CheckHealth(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/datasource_authorization_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/datasource_authorization_middleware_test.go
@@ -1,0 +1,108 @@
+package clientmiddleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/plugins/manager/client/clienttest"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+func TestDatasourceAuthorizationMiddleware(t *testing.T) {
+
+	req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("X-Ds-Authorization", "Bearer Token")
+
+	t.Run("Requests are for a datasource", func(t *testing.T) {
+		cdt := clienttest.NewClientDecoratorTest(t,
+			clienttest.WithReqContext(req, &user.SignedInUser{}),
+			clienttest.WithMiddlewares(
+				NewClearAuthHeadersMiddleware(),
+				NewDatasourceAuthorizationMiddleware(),
+			),
+		)
+
+		pluginCtx := backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+		}
+
+		t.Run("Should contain datasource authorization header when calling QueryData", func(t *testing.T) {
+			_, err = cdt.Decorator.QueryData(req.Context(), &backend.QueryDataRequest{
+				PluginContext: pluginCtx,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.QueryDataReq)
+			require.Len(t, cdt.QueryDataReq.Headers, 1)
+			require.Equal(t, "Bearer Token", cdt.QueryDataReq.GetHTTPHeader("X-Ds-Authorization"))
+		})
+
+		t.Run("Should contain datasource authorization header when calling CallResource", func(t *testing.T) {
+			err = cdt.Decorator.CallResource(req.Context(), &backend.CallResourceRequest{
+				PluginContext: pluginCtx,
+			}, nopCallResourceSender)
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CallResourceReq)
+			require.Len(t, cdt.CallResourceReq.Headers, 1)
+			require.Equal(t, "Bearer Token", cdt.QueryDataReq.GetHTTPHeader("X-Ds-Authorization"))
+		})
+
+		t.Run("Should contain datasource authorization header when calling CheckHealth", func(t *testing.T) {
+			_, err = cdt.Decorator.CheckHealth(req.Context(), &backend.CheckHealthRequest{
+				PluginContext: pluginCtx,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CheckHealthReq)
+			require.Len(t, cdt.CheckHealthReq.Headers, 1)
+			require.Equal(t, "Bearer Token", cdt.QueryDataReq.GetHTTPHeader("X-Ds-Authorization"))
+		})
+	})
+
+	t.Run("Requests are for an app", func(t *testing.T) {
+		cdt := clienttest.NewClientDecoratorTest(t,
+			clienttest.WithReqContext(req, &user.SignedInUser{}),
+			clienttest.WithMiddlewares(
+				NewClearAuthHeadersMiddleware(),
+				NewDatasourceAuthorizationMiddleware(),
+			),
+		)
+
+		pluginCtx := backend.PluginContext{
+			AppInstanceSettings: &backend.AppInstanceSettings{},
+		}
+
+		t.Run("Should contain datasource authorization header when calling QueryData", func(t *testing.T) {
+			_, err = cdt.Decorator.QueryData(req.Context(), &backend.QueryDataRequest{
+				PluginContext: pluginCtx,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.QueryDataReq)
+			require.Len(t, cdt.QueryDataReq.Headers, 1)
+			require.Equal(t, "Bearer Token", cdt.QueryDataReq.GetHTTPHeader("X-Ds-Authorization"))
+		})
+
+		t.Run("Should contain datasource authorization header when calling CallResource", func(t *testing.T) {
+			err = cdt.Decorator.CallResource(req.Context(), &backend.CallResourceRequest{
+				PluginContext: pluginCtx,
+			}, nopCallResourceSender)
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CallResourceReq)
+			require.Len(t, cdt.CallResourceReq.Headers, 1)
+			require.Equal(t, "Bearer Token", cdt.QueryDataReq.GetHTTPHeader("X-Ds-Authorization"))
+		})
+
+		t.Run("Should contain datasource authorization header when calling CheckHealth", func(t *testing.T) {
+			_, err = cdt.Decorator.CheckHealth(req.Context(), &backend.CheckHealthRequest{
+				PluginContext: pluginCtx,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CheckHealthReq)
+			require.Len(t, cdt.CheckHealthReq.Headers, 1)
+			require.Equal(t, "Bearer Token", cdt.QueryDataReq.GetHTTPHeader("X-Ds-Authorization"))
+		})
+	})
+}

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -180,6 +180,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		clientmiddleware.NewClearAuthHeadersMiddleware(),
 		clientmiddleware.NewOAuthTokenMiddleware(oAuthTokenService),
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
+		clientmiddleware.NewDatasourceAuthorizationMiddleware(),
 		clientmiddleware.NewResourceResponseMiddleware(),
 		clientmiddleware.NewCachingMiddlewareWithFeatureManager(cachingService, features),
 	)


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

It seems that datasource authorization header forwarding feature has unpredictable behavior since v8.2.7
Steps required to reproduce the issue:

## Prometheus

1. Create a simple proxy server for Prometheus that will also lookup for `X-Ds-Authorization` header value:

```go
package main

import (
	"log"
	"net/http"
	"net/http/httputil"
	"net/url"
)

func main() {
	remote, err := url.Parse("http://prometheus:9090")
	if err != nil {
		log.Fatal(err)
	}

	handler := func(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
		return func(w http.ResponseWriter, r *http.Request) {
			r.Host = remote.Host

			authHeaderValue := r.Header.Get("X-Ds-Authorization")
			if authHeaderValue == "" {
				authHeaderValue = "n/a"
			}
			log.Printf("[%s] X-Ds-Authorization: %s", r.URL, authHeaderValue)

			p.ServeHTTP(w, r)
		}
	}

	proxy := httputil.NewSingleHostReverseProxy(remote)
	http.HandleFunc("/", handler(proxy))
	err = http.ListenAndServe(":9090", nil)
	if err != nil {
		log.Fatal(err)
	}
}
```

2. Create nginx configuration so nginx could inject `X-Ds-Authorization` header into every request:

```
server {
    listen  0.0.0.0:8080 default;
    location / {
        proxy_pass                 http://grafana:3000;
        proxy_set_header           X-Ds-Authorization "OK";
        proxy_set_header           Host $http_host;
        proxy_pass_request_headers on;
    }
}
```

3. Create docker compose configuration file with latest docker images:

```yaml
version: "3"

networks:
  grafana:
    driver: bridge

services:
  nginx:
    image: nginx:1.27.0-alpine
    networks:
      - grafana
    ports:
      - "8080:8080"
    volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf
  grafana:
    image: grafana/grafana-oss:11.0.0-ubuntu
    networks:
      - grafana
    ports:
      - "3000:3000"
  prometheus-proxy:
    image: golang:1.21-alpine
    command: ["go", "run", "/go/src/proxy/main.go"]
    volumes:
      - ./proxy.go:/go/src/proxy/main.go
    networks:
      - grafana
    ports:
      - "9091:9090"
  prometheus:
    image: prom/prometheus:v2.52.0
    networks:
      - grafana
    ports:
      - "9090:9090"
```

4. Run `docker compose up`, login to Grafana using nginx ('http://localhost:8080') and add `http://prometheus-proxy:9090` as Prometheus datasource
5. Try `Save and Test`, `Expore data` and other basic operations with datasource
6. Run `docker logs grafana-prometheus-proxy-1` to see the output of prometheus-proxy and find what requests that contain the `X-Ds-Authorization` header:

```
2024/06/14 15:18:47 [/api/v1/query] X-Ds-Authorization: n/a
2024/06/14 15:18:47 [/api/v1/status/buildinfo] X-Ds-Authorization: n/a
2024/06/14 15:18:51 [/api/v1/query_exemplars] X-Ds-Authorization: OK
2024/06/14 15:18:51 [/api/v1/rules] X-Ds-Authorization: OK
2024/06/14 15:18:51 [/api/v1/label/__name__/values?start=1718356680&end=1718378340] X-Ds-Authorization: OK
2024/06/14 15:18:51 [/api/v1/label/__name__/values?start=1718374680&end=1718378340] X-Ds-Authorization: OK
2024/06/14 15:18:51 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:18:51 [/api/v1/metadata] X-Ds-Authorization: OK
2024/06/14 15:18:51 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:18:55 [/api/v1/query_range] X-Ds-Authorization: n/a
2024/06/14 15:18:55 [/api/v1/query] X-Ds-Authorization: n/a
2024/06/14 15:18:55 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:18:56 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:18:58 [/api/v1/label/job/values?start=1718374680&end=1718378340&match%5B%5D=%7B__name__%3D%22go_gc_duration_seconds%22%7D] X-Ds-Authorization: OK
2024/06/14 15:19:00 [/api/v1/query_range] X-Ds-Authorization: n/a
2024/06/14 15:19:00 [/api/v1/query] X-Ds-Authorization: n/a
2024/06/14 15:19:00 [/api/v1/label/__name__/values?start=1718374740&end=1718378400] X-Ds-Authorization: OK
2024/06/14 15:19:00 [/api/v1/labels] X-Ds-Authorization: OK
```

**The solution**:

1. Build Grafana with these changes:

```shell
docker build --platform linux/amd64 --build-arg BINGO=false --build-arg WIRE_TAGS="oss" --build-arg COMMIT_SHA="dsauth" --tag grafana:dsauth .
```

2. Replace Grafana image inside `docker-compose.yml` and repeat the previous steps:

```
2024/06/14 15:30:40 [/api/v1/query] X-Ds-Authorization: OK
2024/06/14 15:30:40 [/api/v1/status/buildinfo] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/query_exemplars] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/rules] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/label/__name__/values?start=1718357400&end=1718379060] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/label/__name__/values?start=1718375400&end=1718379060] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/metadata] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:30:42 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:30:45 [/api/v1/query_range] X-Ds-Authorization: OK
2024/06/14 15:30:45 [/api/v1/query] X-Ds-Authorization: OK
2024/06/14 15:30:46 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:30:46 [/api/v1/labels] X-Ds-Authorization: OK
2024/06/14 15:30:48 [/api/v1/label/job/values?start=1718375400&end=1718379060&match%5B%5D=%7B__name__%3D%22go_gc_duration_seconds%22%7D] X-Ds-Authorization: OK
2024/06/14 15:30:50 [/api/v1/query_range] X-Ds-Authorization: OK
2024/06/14 15:30:50 [/api/v1/query] X-Ds-Authorization: OK
2024/06/14 15:30:50 [/api/v1/labels] X-Ds-Authorization: OK
```

## Alertmanager

1. Same proxy, but for Alertmanager:

```go
package main

import (
	"log"
	"net/http"
	"net/http/httputil"
	"net/url"
)

func main() {
	remote, err := url.Parse("http://alertmanager:9093")
	if err != nil {
		log.Fatal(err)
	}

	handler := func(p *httputil.ReverseProxy) func(http.ResponseWriter, *http.Request) {
		return func(w http.ResponseWriter, r *http.Request) {
			r.Host = remote.Host

			authHeaderValue := r.Header.Get("X-Ds-Authorization")
			if authHeaderValue == "" {
				authHeaderValue = "n/a"
			}
			log.Printf("[%s] X-Ds-Authorization: %s", r.URL, authHeaderValue)

			p.ServeHTTP(w, r)
		}
	}

	proxy := httputil.NewSingleHostReverseProxy(remote)
	http.HandleFunc("/", handler(proxy))
	err = http.ListenAndServe(":9093", nil)
	if err != nil {
		log.Fatal(err)
	}
}
```

2. Same nginx config as it was with Prometheus

3. Docker compose file:

```yaml
version: "3"

networks:
  grafana:
    driver: bridge

services:
  nginx:
    image: nginx:1.27.0-alpine
    networks:
      - grafana
    ports:
      - "8080:8080"
    volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf
  grafana:
    image: grafana/grafana-oss:11.0.0-ubuntu
    networks:
      - grafana
    ports:
      - "3000:3000"
  alertmanager-proxy:
    image: golang:1.21-alpine
    command: ["go", "run", "/go/src/proxy/main.go"]
    volumes:
      - ./proxy.go:/go/src/proxy/main.go
    networks:
      - grafana
    ports:
      - "9094:9093"
  alertmanager:
    image: prom/alertmanager:v0.27.0
    networks:
      - grafana
    ports:
      - "9093:9093"
```

4 - 6. `docker logs grafana-alertmanager-proxy-1`:

Output with latest Grafana:

```
2024/06/14 15:45:07 [/api/v1/status/buildinfo] X-Ds-Authorization: n/a
2024/06/14 15:45:07 [/api/v2/status] X-Ds-Authorization: n/a
2024/06/14 15:45:16 [/api/v1/status/buildinfo] X-Ds-Authorization: n/a
2024/06/14 15:45:16 [/alertmanager/api/v2/status] X-Ds-Authorization: n/a
2024/06/14 15:45:16 [/api/v2/status] X-Ds-Authorization: n/a
2024/06/14 15:45:37 [/api/v2/status] X-Ds-Authorization: n/a
2024/06/14 15:45:39 [/api/v2/alerts/groups] X-Ds-Authorization: n/a
2024/06/14 15:45:40 [/api/v1/status/buildinfo] X-Ds-Authorization: n/a
2024/06/14 15:45:40 [/api/v2/silences] X-Ds-Authorization: n/a
2024/06/14 15:45:40 [/api/v2/alerts?silenced&active&inhibited] X-Ds-Authorization: n/a
2024/06/14 15:45:42 [/api/v2/alerts/groups] X-Ds-Authorization: n/a
2024/06/14 15:45:43 [/api/v2/silences] X-Ds-Authorization: n/a
2024/06/14 15:45:43 [/api/v2/alerts?silenced&active&inhibited] X-Ds-Authorization: n/a
2024/06/14 15:45:44 [/api/v2/silences] X-Ds-Authorization: n/a
2024/06/14 15:45:44 [/api/v2/alerts?silenced&active&inhibited] X-Ds-Authorization: n/a
2024/06/14 15:45:53 [/api/v2/silences] X-Ds-Authorization: n/a
2024/06/14 15:45:53 [/api/v2/silences] X-Ds-Authorization: n/a
2024/06/14 15:45:53 [/api/v2/alerts?silenced&active&inhibited] X-Ds-Authorization: n/a
```

Output with custom build:

```
2024/06/14 15:47:07 [/api/v1/status/buildinfo] X-Ds-Authorization: OK
2024/06/14 15:47:07 [/alertmanager/api/v2/status] X-Ds-Authorization: OK
2024/06/14 15:47:07 [/api/v2/status] X-Ds-Authorization: OK
2024/06/14 15:47:15 [/api/v2/status] X-Ds-Authorization: OK
2024/06/14 15:47:19 [/api/v2/status] X-Ds-Authorization: OK
2024/06/14 15:47:19 [/api/v2/alerts/groups] X-Ds-Authorization: OK
2024/06/14 15:47:21 [/api/v2/alerts?silenced=true&active=true&inhibited=true] X-Ds-Authorization: OK
2024/06/14 15:47:21 [/api/v2/silences?ruleMetadata=true&accesscontrol=true] X-Ds-Authorization: OK
2024/06/14 15:47:21 [/api/v1/status/buildinfo] X-Ds-Authorization: OK
2024/06/14 15:47:28 [/api/v2/alerts?filter=label%3D%22value%22] X-Ds-Authorization: OK
2024/06/14 15:47:29 [/api/v2/silences] X-Ds-Authorization: OK
2024/06/14 15:47:29 [/api/v2/alerts?filter=label%3D%22value%22] X-Ds-Authorization: OK
2024/06/14 15:47:29 [/api/v2/alerts?silenced=true&active=true&inhibited=true] X-Ds-Authorization: OK
2024/06/14 15:47:29 [/api/v2/silences?ruleMetadata=true&accesscontrol=true] X-Ds-Authorization: OK
2024/06/14 15:47:30 [/api/v2/alerts/groups] X-Ds-Authorization: OK
2024/06/14 15:47:33 [/api/v2/alerts/groups] X-Ds-Authorization: OK
```

Fixes #47734
May be interesting in context of:  #62891, #44250, #9509, #60510, #87386, #87364, #82688, #80698

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
