### PR TITLE
Plugin extensions: Return react components from `usePluginComponents()`

### DIFF
--- a/packages/grafana-runtime/src/services/pluginExtensions/usePluginExtensions.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/usePluginExtensions.ts
@@ -41,12 +41,14 @@ export function usePluginLinks(options: GetPluginExtensionsOptions): {
 
 export function usePluginComponents<Props = {}>(
   options: GetPluginExtensionsOptions
-): { components: Array<PluginExtensionComponent<Props>>; isLoading: boolean } {
+): { components: Array<React.ComponentType<Props>>; isLoading: boolean } {
   const { extensions, isLoading } = usePluginExtensions(options);
 
   return useMemo(
     () => ({
-      components: extensions.filter(isPluginExtensionComponent) as Array<PluginExtensionComponent<Props>>,
+      components: extensions
+        .filter(isPluginExtensionComponent)
+        .map(({ component }) => component as React.ComponentType<Props>),
       isLoading,
     }),
     [extensions, isLoading]


### PR DESCRIPTION
### What changed?

Updated the `usePluginComponents()` hook exposed by `@grafana/runtime` to return an array of react components instead of an array of `PluginExtensionComponent` object - the former is easier to work with.