### PR TITLE
Docs: Add line about installing corepack in developer guide

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -19,6 +19,7 @@ We recommend using [Homebrew](https://brew.sh/) for installing any missing depen
 brew install git
 brew install go
 brew install node@20
+brew install corepack
 corepack enable
 ```
 


### PR DESCRIPTION
I recently got a new computer and noticed I had to install corepack before I enabled it, I imagine others might as well.