### PR TITLE
Add note for streaming TraceQL results for GET and/or Tempo setups using intermediary proxies

### DIFF
--- a/docs/sources/shared/datasources/tempo-editor-traceql.md
+++ b/docs/sources/shared/datasources/tempo-editor-traceql.md
@@ -33,7 +33,9 @@ This feature is automatically available in Grafana 10 (and newer) and Grafana Cl
 
 To use the TraceQL query editor in self-hosted Grafana 9.3.2 and older, you need to [enable the `traceqlEditor` feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
 
-To enable streaming on Grafana Cloud using an on-prem Grafana Enterprise Traces instance, the gateway (nginx) should allow gRPC connections.
+If trying to query a self-managed Grafana Tempo or Grafana Enterprise Traces database with a gateway (e.g., nginx) in front of it from your hosted Grafana, that gateway (e.g., nginx) must allow gRPC connections. If it does not, streaming will not work and queries will fail to return results. 
+
+If you cannot configure your gateway to allow gRPC, open a support escalation to request streaming query results be disabled in your hosted Grafana. 
 
 ## Write TraceQL queries using the query editor
 

--- a/docs/sources/shared/datasources/tempo-editor-traceql.md
+++ b/docs/sources/shared/datasources/tempo-editor-traceql.md
@@ -33,9 +33,9 @@ This feature is automatically available in Grafana 10 (and newer) and Grafana Cl
 
 To use the TraceQL query editor in self-hosted Grafana 9.3.2 and older, you need to [enable the `traceqlEditor` feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
 
-If trying to query a self-managed Grafana Tempo or Grafana Enterprise Traces database with a gateway (e.g., nginx) in front of it from your hosted Grafana, that gateway (e.g., nginx) must allow gRPC connections. If it does not, streaming will not work and queries will fail to return results. 
+If trying to query a self-managed Grafana Tempo or Grafana Enterprise Traces database with a gateway (e.g., nginx) in front of it from your hosted Grafana, that gateway (e.g., nginx) must allow gRPC connections. If it does not, streaming will not work and queries will fail to return results.
 
-If you cannot configure your gateway to allow gRPC, open a support escalation to request streaming query results be disabled in your hosted Grafana. 
+If you cannot configure your gateway to allow gRPC, open a support escalation to request streaming query results be disabled in your hosted Grafana.
 
 ## Write TraceQL queries using the query editor
 

--- a/docs/sources/shared/datasources/tempo-editor-traceql.md
+++ b/docs/sources/shared/datasources/tempo-editor-traceql.md
@@ -33,6 +33,8 @@ This feature is automatically available in Grafana 10 (and newer) and Grafana Cl
 
 To use the TraceQL query editor in self-hosted Grafana 9.3.2 and older, you need to [enable the `traceqlEditor` feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
 
+To enable streaming on Grafana Cloud using an on-prem Grafana Enterprise Traces instance, the gateway (ngnix) should allow gRPC connections.
+
 ## Write TraceQL queries using the query editor
 
 The Tempo data source’s TraceQL query editor helps you query and display traces from Tempo in **Explore**.

--- a/docs/sources/shared/datasources/tempo-editor-traceql.md
+++ b/docs/sources/shared/datasources/tempo-editor-traceql.md
@@ -33,7 +33,7 @@ This feature is automatically available in Grafana 10 (and newer) and Grafana Cl
 
 To use the TraceQL query editor in self-hosted Grafana 9.3.2 and older, you need to [enable the `traceqlEditor` feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/).
 
-To enable streaming on Grafana Cloud using an on-prem Grafana Enterprise Traces instance, the gateway (ngnix) should allow gRPC connections.
+To enable streaming on Grafana Cloud using an on-prem Grafana Enterprise Traces instance, the gateway (nginx) should allow gRPC connections.
 
 ## Write TraceQL queries using the query editor
 


### PR DESCRIPTION
Addresses a support escalation by adding a statement about nginx support and grpc streaming. 

Fixes https://github.com/grafana/support-escalations/issues/11000

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
