### PR TITLE
[sql expressions] - add configurable limit

### DIFF
--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -31,6 +31,10 @@ func (vals Values) AsDataFrames(refID string) []*data.Frame {
 	return frames
 }
 
+func (vals Values) Length() int {
+	return len(vals)
+}
+
 // Value is the interface that holds different types such as a Scalar, Series, or Number.
 // all Value implementations should be a *data.Frame
 type Value interface {

--- a/pkg/expr/sql/engine.go
+++ b/pkg/expr/sql/engine.go
@@ -1,0 +1,10 @@
+package sql
+
+import "github.com/grafana/grafana-plugin-sdk-go/data"
+
+type Engine = interface {
+	RunCommands(commands []string) (string, error)
+	QueryFramesInto(name string, query string, frames []*data.Frame, f *data.Frame) error
+	QueryFrames(name string, query string, frames []*data.Frame) (string, error)
+	Destroy() error
+}

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/jeremywohl/flatten"
-	"github.com/scottlepp/go-duck/duck"
 )
 
 const (
@@ -20,11 +19,10 @@ const (
 var logger = log.New("sql_expr")
 
 // TablesList returns a list of tables for the sql statement
-func TablesList(rawSQL string) ([]string, error) {
-	duckDB := duck.NewInMemoryDB()
+func TablesList(rawSQL string, engine Engine) ([]string, error) {
 	rawSQL = strings.Replace(rawSQL, "'", "''", -1)
 	cmd := fmt.Sprintf("SELECT json_serialize_sql('%s')", rawSQL)
-	ret, err := duckDB.RunCommands([]string{cmd})
+	ret, err := engine.RunCommands([]string{cmd})
 	if err != nil {
 		logger.Error("error serializing sql", "error", err.Error(), "sql", rawSQL, "cmd", cmd)
 		return nil, fmt.Errorf("error serializing sql: %s", err.Error())

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -98,6 +98,10 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 			logger.Warn("no results found for", "ref", ref)
 			continue
 		}
+		if results.Values.Length() > int(gr.limit) {
+			logger.Error("SQL expression results exceeded limit", "limit", gr.limit, "results", results.Values.Length())
+			return mathexp.Results{}, fmt.Errorf("SQL expression results exceeded limit of %d", gr.limit)
+		}
 		frames := results.Values.AsDataFrames(ref)
 		exceeds, total := exceedsLimit(frames, gr.limit)
 		if exceeds {

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -137,14 +137,16 @@ func (gr *SQLCommand) Type() string {
 }
 
 func exceedsLimit(frames []*data.Frame, limit int64) bool {
+	total := 0
 	for _, frame := range frames {
 		if frame != nil {
 			if int64(frame.Rows()) > limit {
 				return true
 			}
+			total += frame.Rows()
 		}
 	}
-	return false
+	return int64(total) > limit
 }
 
 func DefaultEngine() sql.Engine {

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -104,8 +104,6 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 	truncated := truncateFrames(allFrames, gr.limit)
 
 	rsp := mathexp.Results{}
-
-	// duckDB := duck.NewInMemoryDB()
 	var frame = &data.Frame{}
 
 	logger.Debug("Executing query", "query", gr.query, "frames", len(allFrames))

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -47,6 +47,27 @@ func TestExecute(t *testing.T) {
 	}
 }
 
+func TestExecuteUnderLimit(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", &testEngine{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+	cmd.limit = 4
+
+	frame := data.NewFrame("a", data.NewField("a", nil, []string{"1", "2", "3"}))
+	vars := mathexp.Vars{}
+	vars["foo"] = mathexp.Results{
+		Values: mathexp.Values{mathexp.TableData{Frame: frame}},
+	}
+
+	_, err = cmd.Execute(context.Background(), time.Now(), vars, &testTracer{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+}
+
 func TestExecuteExceedsLimit(t *testing.T) {
 	cmd, err := NewSQLCommand("a", "select a from foo, bar", &testEngine{})
 	if err != nil {

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -1,13 +1,18 @@
 package expr
 
 import (
+	"context"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestNewCommand(t *testing.T) {
-	t.Skip()
-	cmd, err := NewSQLCommand("a", "select a from foo, bar")
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", &testEngine{})
 	if err != nil && strings.Contains(err.Error(), "feature is not enabled") {
 		return
 	}
@@ -24,4 +29,79 @@ func TestNewCommand(t *testing.T) {
 		t.Fail()
 		return
 	}
+}
+
+func TestExecute(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", &testEngine{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+
+	ctx := context.Background()
+	_, err = cmd.Execute(ctx, time.Now(), nil, &testTracer{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+}
+
+func TestExecuteShouldTruncate(t *testing.T) {
+	cmd, err := NewSQLCommand("a", "select a from foo, bar", &testEngine{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+
+	cmd.limit = 1
+
+	ctx := context.Background()
+	res, err := cmd.Execute(ctx, time.Now(), nil, &testTracer{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+
+	f := res.Values.AsDataFrames("a")
+	if len(f) != 1 {
+		t.Fail()
+		return
+	}
+}
+
+type testEngine struct{}
+
+func (e *testEngine) QueryFrames(name string, query string, frames []*data.Frame) (string, error) {
+	return "", nil
+}
+func (e *testEngine) QueryFramesInto(name string, query string, frames []*data.Frame, f *data.Frame) error {
+	frame := &data.Frame{}
+	fld := data.NewField("a", nil, []string{"1", "2", "3"})
+	frame.Fields = append(frame.Fields, fld)
+	f.Fields = frame.Fields
+	return nil
+}
+func (e *testEngine) RunCommands(cmds []string) (string, error) {
+	return `[{"table_name": "foo"}]`, nil
+}
+func (e *testEngine) Destroy() error {
+	return nil
+}
+
+type testTracer struct {
+	trace.Tracer
+}
+
+func (t *testTracer) Start(ctx context.Context, name string, s ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return ctx, &testSpan{}
+}
+func (t *testTracer) Inject(context.Context, http.Header, trace.Span) {
+
+}
+
+type testSpan struct {
+	trace.Span
+}
+
+func (ts *testSpan) End(opt ...trace.SpanEndOption) {
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -412,6 +412,9 @@ type Cfg struct {
 	// ExpressionsEnabled specifies whether expressions are enabled.
 	ExpressionsEnabled bool
 
+	// SQLExpressionRowLimit is the maximum number of rows that can be used in a SQL expression.
+	SQLExpressionRowLimit int64
+
 	ImageUploadProvider string
 
 	// LiveMaxConnections is a maximum number of WebSocket connections to
@@ -739,6 +742,7 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
+	cfg.SQLExpressionRowLimit = expressions.Key("sql_row_limit").MustInt64(100000)
 }
 
 type AnnotationCleanupSettings struct {


### PR DESCRIPTION
This adds a default limit for sql expression results, to provide a safety net for OOM issues.

* also some refactoring to allow testing without an actual duckdb
