### PR TITLE
InfluxDB: Flight SQL test, add function to search for free port

### DIFF
--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -26,10 +26,7 @@ type FSQLTestSuite struct {
 }
 
 func (suite *FSQLTestSuite) SetupTest() {
-	addr := freeport()
-	if addr == "err" {
-		suite.T().Fatal()
-	}
+	addr := freeport(suite.T())
 
 	suite.addr = addr
 
@@ -119,10 +116,10 @@ func mustQueryJSON(t *testing.T, refID, sql string) []byte {
 	return b
 }
 
-func freeport() string {
+func freeport(t *testing.T) string {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
 	if err != nil {
-		return "err"
+		t.Fatal(err)
 	}
 	defer l.Close()
 	a := l.Addr().(*net.TCPAddr)

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -22,7 +22,7 @@ type FSQLTestSuite struct {
 	suite.Suite
 	db     *sql.DB
 	server flight.Server
-	port   string
+	addr   string
 }
 
 func (suite *FSQLTestSuite) SetupTest() {

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -119,13 +119,12 @@ func mustQueryJSON(t *testing.T, refID, sql string) []byte {
 	return b
 }
 
-func freeport() (port int, addr string) {
+func freeport() string {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
 	if err != nil {
-		return 0, "err"
+		return "err"
 	}
 	defer l.Close()
 	a := l.Addr().(*net.TCPAddr)
-	port = a.Port
-	return port, a.String()
+	return a.String()
 }

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -26,12 +26,12 @@ type FSQLTestSuite struct {
 }
 
 func (suite *FSQLTestSuite) SetupTest() {
-	_, addr := freeport()
+	addr := freeport()
 	if addr == "err" {
 		suite.T().Fatal()
 	}
 
-	suite.port = addr
+	suite.addr = addr
 
 	db, err := example.CreateDB()
 	require.NoError(suite.T(), err)
@@ -41,7 +41,7 @@ func (suite *FSQLTestSuite) SetupTest() {
 	sqliteServer.Alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
 	server := flight.NewServerWithMiddleware(nil)
 	server.RegisterFlightService(flightsql.NewFlightServer(sqliteServer))
-	err = server.Init(suite.port)
+	err = server.Init(suite.addr)
 	require.NoError(suite.T(), err)
 	go func() {
 		err := server.Serve()
@@ -68,7 +68,7 @@ func (suite *FSQLTestSuite) TestIntegration_QueryData() {
 			&models.DatasourceInfo{
 				HTTPClient:   nil,
 				Token:        "secret",
-				URL:          "http://" + suite.port,
+				URL:          "http://" + suite.addr,
 				DbName:       "influxdb",
 				Version:      "test",
 				HTTPMode:     "proxy",

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -26,7 +26,7 @@ type FSQLTestSuite struct {
 }
 
 func (suite *FSQLTestSuite) SetupTest() {
-	addr := freeport(suite.T())
+	addr, _ := freeport(suite.T())
 
 	suite.addr = addr
 
@@ -116,12 +116,14 @@ func mustQueryJSON(t *testing.T, refID, sql string) []byte {
 	return b
 }
 
-func freeport(t *testing.T) string {
+func freeport(t *testing.T) (addr string, err error) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer l.Close()
+	defer func() {
+		err = l.Close()
+	}()
 	a := l.Addr().(*net.TCPAddr)
-	return a.String()
+	return a.String(), nil
 }


### PR DESCRIPTION
This fix searches for a free port for the test for Flight SQL DB instead of hardcoding the port.

[See slack thread for more details](https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1718380646651179).

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
