### PR TITLE
Alerting: Optimize rule status API when there is no limit specified

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/prom_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom_test.go
@@ -96,6 +96,46 @@ func TestSortAlertsByImportance(t *testing.T) {
 			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b"}},
 			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"c": "d"}},
 		},
+	}, {
+		name: "active alerts with same importance and active time are ordered by labels (same keys, different values)",
+		input: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "a"}},
+		},
+		expected: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "a"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b"}},
+		},
+	}, {
+		name: "active alerts with same importance and active time are ordered by labels (more keys with different values)",
+		input: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "a", "b": "c"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "a", "b": "b"}},
+		},
+		expected: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "a", "b": "b"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "a", "b": "c"}},
+		},
+	}, {
+		name: "active alerts with same importance and active time are ordered by labels (same labels, unordered)",
+		input: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"label_b": "2", "label_a": "1"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"label_b": "1", "label_a": "2"}},
+		},
+		expected: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"label_a": "1", "label_b": "2"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"label_a": "2", "label_b": "1"}},
+		},
+	}, {
+		name: "active alerts with same importance and active time, the one without labels is ordered first",
+		input: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"label_a": "1"}},
+		},
+		expected: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{}},
+			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"label_a": "1"}},
+		},
 	}}
 
 	for _, tt := range tc {


### PR DESCRIPTION
**What is this feature?**

Optimizes the `AlertByImportance` sorting by directly comparing the label maps instead of concatenating the keys and values of the labels and then comparing the resulting arrays of strings.

---
<details>
  <summary><b>benchstat (sort)</b></summary>

```
$ go test -v -run=^# -benchmem -bench BenchmarkSortAlertsByImportance -count 10 -topk sort

...

$ benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions
                                           │ before.txt  │              after.txt              │
                                           │   sec/op    │   sec/op     vs base                │
SortAlertsByImportance/n_1000_k_16-8         7.333m ± 0%   4.696m ± 0%  -35.96% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_100-8        7.337m ± 0%   4.709m ± 0%  -35.82% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_1000-8       7.345m ± 0%   4.698m ± 0%  -36.04% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_100000-8     7.354m ± 0%   4.703m ± 0%  -36.04% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_16-8        73.39m ± 0%   47.00m ± 0%  -35.96% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_100-8       73.66m ± 1%   47.06m ± 0%  -36.11% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_1000-8      73.71m ± 1%   47.15m ± 2%  -36.04% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_100000-8    73.81m ± 0%   47.14m ± 1%  -36.14% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_16-8       813.4m ± 1%   529.0m ± 0%  -34.97% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_100-8      815.3m ± 1%   528.4m ± 1%  -35.18% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_1000-8     811.6m ± 0%   529.1m ± 0%  -34.80% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_100000-8   814.7m ± 0%   527.3m ± 1%  -35.28% (p=0.000 n=10)
geomean                                      76.06m        48.91m       -35.70%

                                           │  before.txt  │              after.txt               │
                                           │     B/op     │     B/op      vs base                │
SortAlertsByImportance/n_1000_k_16-8         6.262Mi ± 0%   2.505Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_100-8        6.262Mi ± 0%   2.505Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_1000-8       6.262Mi ± 0%   2.505Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_100000-8     6.262Mi ± 0%   2.505Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_16-8        62.14Mi ± 0%   24.85Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_100-8       62.14Mi ± 0%   24.85Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_1000-8      62.14Mi ± 0%   24.85Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_100000-8    62.14Mi ± 0%   24.85Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_16-8       608.2Mi ± 0%   243.3Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_100-8      608.2Mi ± 0%   243.3Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_1000-8     608.2Mi ± 0%   243.3Mi ± 0%  -60.00% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_100000-8   608.2Mi ± 0%   243.3Mi ± 0%  -60.00% (p=0.000 n=10)
geomean                                      61.86Mi        24.74Mi       -60.00%

                                           │  before.txt  │              after.txt              │
                                           │  allocs/op   │  allocs/op   vs base                │
SortAlertsByImportance/n_1000_k_16-8         180.58k ± 0%   16.42k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_100-8        180.58k ± 0%   16.42k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_1000-8       180.58k ± 0%   16.42k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_1000_k_100000-8     180.58k ± 0%   16.42k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_16-8        1791.8k ± 0%   162.9k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_100-8       1791.8k ± 0%   162.9k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_1000-8      1791.8k ± 0%   162.9k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_10000_k_100000-8    1791.8k ± 0%   162.9k ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_16-8       17.538M ± 0%   1.594M ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_100-8      17.538M ± 0%   1.594M ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_1000-8     17.538M ± 0%   1.594M ± 0%  -90.91% (p=0.000 n=10)
SortAlertsByImportance/n_100000_k_100000-8   17.538M ± 0%   1.594M ± 0%  -90.91% (p=0.000 n=10)
geomean                                       1.784M        162.2k       -90.91%
```
</details>

<details>
  <summary><b>benchstat (heap)</b></summary>

```
$ go test -v -run=^# -benchmem -bench BenchmarkSortAlertsByImportance -count 6 -topk heap

...

$ benchstat before_heap.txt after_heap.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions
                                           │ before_heap.txt │           after_heap.txt           │
                                           │     sec/op      │   sec/op     vs base               │
SortAlertsByImportance/n_1000_k_16-8            1225.2µ ± 1%   772.2µ ± 1%  -36.97% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_100-8            3.650m ± 1%   2.267m ± 0%  -37.88% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_1000-8           9.588m ± 0%   6.034m ± 2%  -37.07% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_100000-8         9.831m ± 0%   6.318m ± 0%  -35.73% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_16-8            2.434m ± 1%   1.701m ± 4%  -30.14% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_100-8          13.214m ± 2%   8.536m ± 1%  -35.40% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_1000-8          48.54m ± 2%   31.01m ± 1%  -36.12% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_100000-8        96.31m ± 1%   61.39m ± 2%  -36.26% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_16-8           6.727m ± 2%   6.132m ± 3%   -8.84% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_100-8          21.67m ± 3%   15.62m ± 2%  -27.91% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_1000-8         173.3m ± 2%   114.8m ± 2%  -33.78% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_100000-8      1069.1m ± 1%   727.9m ± 2%  -31.92% (p=0.002 n=6)
geomean                                          18.60m        12.51m       -32.71%

                                           │ before_heap.txt │           after_heap.txt            │
                                           │      B/op       │     B/op      vs base               │
SortAlertsByImportance/n_1000_k_16-8           1140.3Ki ± 0%   494.9Ki ± 0%  -56.60% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_100-8           3.158Mi ± 0%   1.307Mi ± 0%  -58.61% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_1000-8          8.368Mi ± 0%   3.453Mi ± 0%  -58.73% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_100000-8       13.657Mi ± 0%   8.742Mi ± 0%  -35.99% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_16-8           2.211Mi ± 0%   1.252Mi ± 0%  -43.39% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_100-8         11.104Mi ± 0%   4.815Mi ± 0%  -56.64% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_1000-8         40.72Mi ± 0%   16.72Mi ± 0%  -58.93% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_100000-8       86.94Mi ± 0%   38.72Mi ± 0%  -55.47% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_16-8          8.089Mi ± 0%   6.899Mi ± 0%  -14.71% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_100-8         17.74Mi ± 0%   10.76Mi ± 0%  -39.31% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_1000-8       128.37Mi ± 0%   55.08Mi ± 0%  -57.09% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_100000-8      804.8Mi ± 0%   332.4Mi ± 0%  -58.69% (p=0.002 n=6)
geomean                                         16.83Mi        8.262Mi       -50.92%

                                           │ before_heap.txt │           after_heap.txt           │
                                           │    allocs/op    │  allocs/op   vs base               │
SortAlertsByImportance/n_1000_k_16-8            31.314k ± 0%   3.774k ± 0%  -87.95% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_100-8           90.050k ± 0%   9.190k ± 0%  -89.79% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_1000-8          238.20k ± 0%   23.48k ± 0%  -90.14% (p=0.002 n=6)
SortAlertsByImportance/n_1000_k_100000-8        238.20k ± 0%   23.48k ± 0%  -90.14% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_16-8            56.13k ± 0%   14.21k ± 0%  -74.68% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_100-8          312.36k ± 0%   37.58k ± 0%  -87.97% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_1000-8         1164.2k ± 0%   115.8k ± 0%  -90.05% (p=0.002 n=6)
SortAlertsByImportance/n_10000_k_100000-8       2337.7k ± 0%   230.7k ± 0%  -90.13% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_16-8           157.2k ± 0%   105.2k ± 0%  -33.07% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_100-8          435.2k ± 0%   130.6k ± 0%  -70.00% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_1000-8        3623.3k ± 0%   421.2k ± 0%  -88.37% (p=0.002 n=6)
SortAlertsByImportance/n_100000_k_100000-8      22.900M ± 0%   2.264M ± 0%  -90.12% (p=0.002 n=6)
geomean                                          432.9k        62.53k       -85.56%

```
</details>

---

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
