### PR TITLE
Alerting: Improve performance of /api/prometheus for large numbers of alerts.

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -97,7 +97,7 @@ func PrepareAlertStatuses(manager state.AlertInstanceManager, opts AlertStatuses
 		}
 
 		alertResponse.Data.Alerts = append(alertResponse.Data.Alerts, &apimodels.Alert{
-			Labels:      alertState.GetLabels(labelOptions...),
+			Labels:      apimodels.LabelsFromMap(alertState.GetLabels(labelOptions...)),
 			Annotations: alertState.Annotations,
 
 			// TODO: or should we make this two fields? Using one field lets the
@@ -471,7 +471,7 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, groupKey ng
 				totals["error"] += 1
 			}
 			alert := apimodels.Alert{
-				Labels:      alertState.GetLabels(labelOptions...),
+				Labels:      apimodels.LabelsFromMap(alertState.GetLabels(labelOptions...)),
 				Annotations: alertState.Annotations,
 
 				// TODO: or should we make this two fields? Using one field lets the

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -98,7 +98,7 @@ func PrepareAlertStatuses(manager state.AlertInstanceManager, opts AlertStatuses
 
 		alertResponse.Data.Alerts = append(alertResponse.Data.Alerts, &apimodels.Alert{
 			Labels:      apimodels.LabelsFromMap(alertState.GetLabels(labelOptions...)),
-			Annotations: alertState.Annotations,
+			Annotations: apimodels.LabelsFromMap(alertState.Annotations),
 
 			// TODO: or should we make this two fields? Using one field lets the
 			// frontend use the same logic for parsing text on annotations and this.
@@ -444,12 +444,12 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, groupKey ng
 			Name:        rule.Title,
 			Query:       ruleToQuery(log, rule),
 			Duration:    rule.For.Seconds(),
-			Annotations: rule.Annotations,
+			Annotations: apimodels.LabelsFromMap(rule.Annotations),
 		}
 
 		newRule := apimodels.Rule{
 			Name:           rule.Title,
-			Labels:         rule.GetLabels(labelOptions...),
+			Labels:         apimodels.LabelsFromMap(rule.GetLabels(labelOptions...)),
 			Health:         "ok",
 			Type:           rule.Type().String(),
 			LastEvaluation: time.Time{},
@@ -472,7 +472,7 @@ func toRuleGroup(log log.Logger, manager state.AlertInstanceManager, groupKey ng
 			}
 			alert := apimodels.Alert{
 				Labels:      apimodels.LabelsFromMap(alertState.GetLabels(labelOptions...)),
-				Annotations: alertState.Annotations,
+				Annotations: apimodels.LabelsFromMap(alertState.Annotations),
 
 				// TODO: or should we make this two fields? Using one field lets the
 				// frontend use the same logic for parsing text on annotations and this.

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -152,7 +152,7 @@ type AlertingRule struct {
 	Query    string  `json:"query,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
 	// required: true
-	Annotations overrideLabels `json:"annotations,omitempty"`
+	Annotations promlabels.Labels `json:"annotations,omitempty"`
 	// required: true
 	ActiveAt       *time.Time       `json:"activeAt,omitempty"`
 	Alerts         []Alert          `json:"alerts,omitempty"`
@@ -167,8 +167,8 @@ type Rule struct {
 	// required: true
 	Name string `json:"name"`
 	// required: true
-	Query  string         `json:"query"`
-	Labels overrideLabels `json:"labels,omitempty"`
+	Query  string            `json:"query"`
+	Labels promlabels.Labels `json:"labels,omitempty"`
 	// required: true
 	Health    string `json:"health"`
 	LastError string `json:"lastError,omitempty"`
@@ -184,7 +184,7 @@ type Alert struct {
 	// required: true
 	Labels promlabels.Labels `json:"labels"`
 	// required: true
-	Annotations overrideLabels `json:"annotations"`
+	Annotations promlabels.Labels `json:"annotations"`
 	// required: true
 	State    string     `json:"state"`
 	ActiveAt *time.Time `json:"activeAt"`
@@ -336,10 +336,8 @@ func (s AlertsSorter) Len() int           { return len(s.alerts) }
 func (s AlertsSorter) Swap(i, j int)      { s.alerts[i], s.alerts[j] = s.alerts[j], s.alerts[i] }
 func (s AlertsSorter) Less(i, j int) bool { return s.by(&s.alerts[i], &s.alerts[j]) }
 
-// override the labels type with a map for generation.
-// The custom marshaling for labels.Labels ends up doing this anyways.
-type overrideLabels map[string]string
-
+// LabelsFromMap creates Labels from a map. Note the Labels type requires the
+// labels be sorted, so we make sure to do that.
 func LabelsFromMap(m map[string]string) promlabels.Labels {
 	sb := promlabels.NewScratchBuilder(len(m))
 	for k, v := range m {

--- a/pkg/services/ngalert/api/tooling/definitions/prom_bench_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom_bench_test.go
@@ -21,10 +21,11 @@ func makeAlerts(amount int) []Alert {
 	alerts := make([]Alert, amount)
 
 	for i := 0; i < len(alerts); i++ {
-		alerts[i].Labels = make(map[string]string)
+		lbls := make(map[string]string)
 		for label := 0; label < numLabels; label++ {
-			alerts[i].Labels[fmt.Sprintf("label_%d", label)] = fmt.Sprintf("label_%d_value_%d", label, i%100)
+			lbls[fmt.Sprintf("label_%d", label)] = fmt.Sprintf("label_%d_value_%d", label, i%100)
 		}
+		alerts[i].Labels = LabelsFromMap(lbls)
 
 		if i%100 < percentAlerting {
 			alerts[i].State = "alerting"

--- a/pkg/services/ngalert/api/tooling/definitions/prom_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom_test.go
@@ -69,32 +69,42 @@ func TestSortAlertsByImportance(t *testing.T) {
 	}, {
 		name: "inactive alerts with same importance are ordered by labels",
 		input: []Alert{
-			{State: "normal", Labels: map[string]string{"c": "d"}},
-			{State: "normal", Labels: map[string]string{"a": "b"}},
+			{State: "normal", Labels: LabelsFromMap(map[string]string{"c": "d"})},
+			{State: "normal", Labels: LabelsFromMap(map[string]string{"a": "b"})},
 		},
 		expected: []Alert{
-			{State: "normal", Labels: map[string]string{"a": "b"}},
-			{State: "normal", Labels: map[string]string{"c": "d"}},
+			{State: "normal", Labels: LabelsFromMap(map[string]string{"a": "b"})},
+			{State: "normal", Labels: LabelsFromMap(map[string]string{"c": "d"})},
 		},
 	}, {
-		name: "active alerts with same importance and active time are ordered fewest labels first",
+		name: "active alerts with same importance and active time are ordered by label names",
 		input: []Alert{
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b", "c": "d"}},
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"e": "f"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"c": "d", "e": "f"})},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"a": "b"})},
 		},
 		expected: []Alert{
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"e": "f"}},
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b", "c": "d"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"a": "b"})},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"c": "d", "e": "f"})},
 		},
 	}, {
 		name: "active alerts with same importance and active time are ordered by labels",
 		input: []Alert{
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"c": "d"}},
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"c": "d"})},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"a": "b"})},
 		},
 		expected: []Alert{
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"a": "b"}},
-			{State: "alerting", ActiveAt: &tm1, Labels: map[string]string{"c": "d"}},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"a": "b"})},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"c": "d"})},
+		},
+	}, {
+		name: "active alerts with same importance and active time are ordered by label values",
+		input: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"x": "b"})},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"x": "a"})},
+		},
+		expected: []Alert{
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"x": "a"})},
+			{State: "alerting", ActiveAt: &tm1, Labels: LabelsFromMap(map[string]string{"x": "b"})},
 		},
 	}}
 


### PR DESCRIPTION
The AlertsByImportance comparison function is a big cost in serving API requests, especially for large numbers of alert instances. This is because on every comparison, it makes a slice of strings and sorts them. This change uses the Prometheus Labels type, which is an already sorted slice of name/values pairs. This makes comparison much faster.

This should not change the content of the API response - the `Labels` type has a custom marshal function that acts the exact same way as marshaling `map[string]string`.

Benchmark before and after:

`go test -v -run=^# -bench BenchmarkSortAlertsByImportance -count 5 -topk sort`

```
name                                         old time/op  new time/op  delta
SortAlertsByImportance/n_1000_k_16-32        15.6ms ± 2%   0.6ms ± 1%  -96.06%  (p=0.008 n=5+5)
SortAlertsByImportance/n_1000_k_100-32       15.6ms ± 1%   0.6ms ± 2%  -96.03%  (p=0.008 n=5+5)
SortAlertsByImportance/n_1000_k_1000-32      15.8ms ± 2%   0.6ms ± 1%  -96.10%  (p=0.008 n=5+5)
SortAlertsByImportance/n_1000_k_100000-32    15.5ms ± 1%   0.6ms ± 1%  -96.03%  (p=0.008 n=5+5)
SortAlertsByImportance/n_10000_k_16-32        159ms ± 1%     8ms ± 2%  -95.11%  (p=0.008 n=5+5)
SortAlertsByImportance/n_10000_k_100-32       158ms ± 1%     8ms ± 3%  -95.00%  (p=0.008 n=5+5)
SortAlertsByImportance/n_10000_k_1000-32      159ms ± 1%     8ms ± 4%  -94.87%  (p=0.008 n=5+5)
SortAlertsByImportance/n_10000_k_100000-32    158ms ± 0%     8ms ± 4%  -94.93%  (p=0.016 n=4+5)
SortAlertsByImportance/n_100000_k_16-32       1.67s ± 1%   0.14s ± 2%  -91.80%  (p=0.008 n=5+5)
SortAlertsByImportance/n_100000_k_100-32      1.67s ± 1%   0.14s ± 6%  -91.64%  (p=0.008 n=5+5)
SortAlertsByImportance/n_100000_k_1000-32     1.66s ± 1%   0.14s ± 4%  -91.72%  (p=0.008 n=5+5)
SortAlertsByImportance/n_100000_k_100000-32   1.66s ± 1%   0.14s ± 2%  -91.79%  (p=0.008 n=5+5)
```
