### PR TITLE
alerting: notes on label matchers

### DIFF
--- a/docs/sources/alerting/alerting-rules/templating-labels-annotations.md
+++ b/docs/sources/alerting/alerting-rules/templating-labels-annotations.md
@@ -32,6 +32,10 @@ All templates should be written in [text/template](https://pkg.go.dev/text/templ
 
 Each template is evaluated whenever the alert rule is evaluated, and is evaluated for every alert separately. For example, if your alert rule has a templated summary annotation, and the alert rule has 10 firing alerts, then the template will be executed 10 times, once for each alert. You should try to avoid doing expensive computations in your templates as much as possible.
 
+{{% admonition type="caution" %}}
+Extra whitespace in label templates can break the match with notification policies.
+{{% /admonition %}}
+
 ## Examples
 
 The following examples attempt to show the most common use-cases we have seen for templates. You can use these examples verbatim, or adapt them as necessary for your use case. For more information on how to write text/template refer see [the beginner's guide to alert notification templates in Grafana](https://grafana.com/blog/2023/04/05/grafana-alerting-a-beginners-guide-to-templating-alert-notifications/).

--- a/docs/sources/alerting/alerting-rules/templating-labels-annotations.md
+++ b/docs/sources/alerting/alerting-rules/templating-labels-annotations.md
@@ -33,7 +33,7 @@ All templates should be written in [text/template](https://pkg.go.dev/text/templ
 Each template is evaluated whenever the alert rule is evaluated, and is evaluated for every alert separately. For example, if your alert rule has a templated summary annotation, and the alert rule has 10 firing alerts, then the template will be executed 10 times, once for each alert. You should try to avoid doing expensive computations in your templates as much as possible.
 
 {{% admonition type="caution" %}}
-Extra whitespace in label templates can break the match with notification policies.
+Extra whitespace in label templates can break matches with notification policies.
 {{% /admonition %}}
 
 ## Examples

--- a/docs/sources/alerting/fundamentals/notifications/notification-policies.md
+++ b/docs/sources/alerting/fundamentals/notifications/notification-policies.md
@@ -72,6 +72,8 @@ By default, once a matching policy is found, the system does not continue to loo
 
 The default notification policy matches all alert instances. It always handles alert instances if there are no child policies or if none of the child policies match the alert instance's labels—this prevents any alerts from being missed.
 
+If alerts use multiple labels, these labels must also be present in a notification policy to match and route notifications to a specific contact point.
+
 {{% /admonition %}}
 
 {{< collapse title="Routing example" >}}

--- a/docs/sources/alerting/fundamentals/notifications/notification-policies.md
+++ b/docs/sources/alerting/fundamentals/notifications/notification-policies.md
@@ -86,6 +86,10 @@ The `team=security` policy is not a match and **Continue matching siblings** was
 
 **Disk Usage – 80%** has both a `team` and `severity` label, and matches a child policy of the operations team.
 
+{{% admonition type="note" %}}
+When an alert matches both a parent policy and a child policy (like it does in this case), the routing follows the child policy (`severity`) as it provides a more specific match.
+{{% /admonition %}}
+
 **Unauthorized log entry** has a `team` label but does not match the first policy (`team=operations`) since the values are not the same, so it will continue searching and match the `team=security` policy. It does not have any child policies, so the additional `severity=high` label is ignored.
 
 {{< /collapse >}}

--- a/docs/sources/alerting/fundamentals/notifications/templates.md
+++ b/docs/sources/alerting/fundamentals/notifications/templates.md
@@ -107,7 +107,7 @@ Here are some commonly used built-in [variables](ref:variables-label-annotation)
         CPU usage for instance1 has exceeded 80% for the last 5 minutes: 81.2345
 
 {{% admonition type="caution" %}}
-Extra whitespace in label templates can break the match with notification policies.
+Extra whitespace in label templates can break matches with notification policies.
 {{% /admonition %}}
 
 ### Template annotations

--- a/docs/sources/alerting/fundamentals/notifications/templates.md
+++ b/docs/sources/alerting/fundamentals/notifications/templates.md
@@ -106,6 +106,10 @@ Here are some commonly used built-in [variables](ref:variables-label-annotation)
 
         CPU usage for instance1 has exceeded 80% for the last 5 minutes: 81.2345
 
+{{% admonition type="caution" %}}
+Extra whitespace in label templates can break the match with notification policies.
+{{% /admonition %}}
+
 ### Template annotations
 
 Both labels and annotations have the same structure: a set of named values; however their intended uses are different. The purpose of annotations is to add additional information to existing alerts.

--- a/docs/sources/shared/alerts/how_label_matching_works.md
+++ b/docs/sources/shared/alerts/how_label_matching_works.md
@@ -25,7 +25,9 @@ A label matchers consists of 3 distinct parts, the **label**, the **value** and 
   | `=~`     | Select labels that regex-match the value.          |
   | `!~`     | Select labels that do not regex-match the value.   |
 
+{{% admonition type="note" %}}
 If you are using multiple label matchers, they are combined using the AND logical operator. This means that all matchers must match in order to link a rule to a policy.
+{{% /admonition %}}
 
 **Label matching example**
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- warns the user that extra space in templated labels can break the match with the policy
- highlights that all alert labels must match the policy labels
- clarifies how matching works when multiple labels are present 

**Reference**:

https://github.com/grafana/grafana/issues/89203

https://community.grafana.com/t/grafana-alert-does-not-route-to-1-notification-policy/124034/2