### PR TITLE
DashboardScene: Adjust a11y tests errors

### DIFF
--- a/public/app/core/components/AccessControl/PermissionListItem.tsx
+++ b/public/app/core/components/AccessControl/PermissionListItem.tsx
@@ -60,7 +60,7 @@ export const PermissionListItem = ({ item, permissionLevels, canSet, onRemove, o
           />
         ) : (
           <Tooltip content={item.isInherited ? 'Inherited Permission' : 'Provisioned Permission'}>
-            <Button size="sm" icon="lock" />
+            <Button size="sm" icon="lock" aria-label="Locked permission indicator" />
           </Tooltip>
         )}
       </td>

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -566,7 +566,12 @@ export function ToolbarActions({ dashboard }: Props) {
             Save dashboard
           </Button>
           <Dropdown overlay={menu}>
-            <Button icon="angle-down" variant={isDirty ? 'primary' : 'secondary'} size="sm" />
+            <Button
+              aria-label="More save options"
+              icon="angle-down"
+              variant={isDirty ? 'primary' : 'secondary'}
+              size="sm"
+            />
           </Dropdown>
         </ButtonGroup>
       );


### PR DESCRIPTION
This PR adjusts a11y errors in test-frontend-a11y drone step when `dashboardScene` feature toggle is enabled

