### PR TITLE
LogRows: remove app restriction from popover menu

### DIFF
--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -254,7 +254,7 @@ describe('Popover menu', () => {
     setup({
       onClickFilterOutString: undefined,
       onClickFilterString: undefined,
-     });
+    });
     await userEvent.click(screen.getByText('log message 1'));
     expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
   });
@@ -264,7 +264,7 @@ describe('Popover menu', () => {
     setup({
       onClickFilterOutString,
       onClickFilterString,
-     });
+    });
     await userEvent.click(screen.getByText('log message 1'));
     expect(screen.getByText('Copy selection')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Add as line contains filter'));
@@ -272,7 +272,7 @@ describe('Popover menu', () => {
     await userEvent.click(screen.getByText('log message 1'));
     expect(screen.getByText('Copy selection')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Add as line does not contain filter'));
-    
+
     expect(onClickFilterOutString).toHaveBeenCalledTimes(1);
     expect(onClickFilterString).toHaveBeenCalledTimes(1);
   });

--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { range } from 'lodash';
 import React from 'react';
 
-import { CoreApp, LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
+import { LogRowModel, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
 
-import { LogRows, PREVIEW_LIMIT } from './LogRows';
+import { LogRows, PREVIEW_LIMIT, Props } from './LogRows';
 import { createLogRow } from './__mocks__/logRow';
 
 jest.mock('@grafana/runtime', () => ({
@@ -207,7 +207,7 @@ describe('LogRows', () => {
 });
 
 describe('Popover menu', () => {
-  function setup(app = CoreApp.Explore) {
+  function setup(overrides: Partial<Props> = {}) {
     const rows: LogRowModel[] = [createLogRow({ uid: '1' })];
     return render(
       <LogRows
@@ -223,7 +223,7 @@ describe('Popover menu', () => {
         displayedFields={[]}
         onClickFilterOutString={() => {}}
         onClickFilterString={() => {}}
-        app={app}
+        {...overrides}
       />
     );
   }
@@ -232,6 +232,8 @@ describe('Popover menu', () => {
     orgGetSelection = document.getSelection;
     jest.spyOn(document, 'getSelection').mockReturnValue({
       toString: () => 'selected log line',
+      removeAllRanges: () => {},
+      addRange: (range: Range) => {},
     } as Selection);
   });
   afterAll(() => {
@@ -248,9 +250,30 @@ describe('Popover menu', () => {
     expect(screen.getByText('Add as line contains filter')).toBeInTheDocument();
     expect(screen.getByText('Add as line does not contain filter')).toBeInTheDocument();
   });
-  it('Does not appear outside Explore', async () => {
-    setup(CoreApp.Unknown);
+  it('Does not appear when the props are not defined', async () => {
+    setup({
+      onClickFilterOutString: undefined,
+      onClickFilterString: undefined,
+     });
     await userEvent.click(screen.getByText('log message 1'));
     expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+  });
+  it('Appears after selecting test', async () => {
+    const onClickFilterOutString = jest.fn();
+    const onClickFilterString = jest.fn();
+    setup({
+      onClickFilterOutString,
+      onClickFilterString,
+     });
+    await userEvent.click(screen.getByText('log message 1'));
+    expect(screen.getByText('Copy selection')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Add as line contains filter'));
+
+    await userEvent.click(screen.getByText('log message 1'));
+    expect(screen.getByText('Copy selection')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Add as line does not contain filter'));
+    
+    expect(onClickFilterOutString).toHaveBeenCalledTimes(1);
+    expect(onClickFilterString).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -105,7 +105,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   };
 
   popoverMenuSupported() {
-    if (!config.featureToggles.logRowsPopoverMenu || this.props.app !== CoreApp.Explore) {
+    if (!config.featureToggles.logRowsPopoverMenu) {
       return false;
     }
     return Boolean(this.props.onClickFilterOutString || this.props.onClickFilterString);


### PR DESCRIPTION
This PR removes the app restriction from the popover menu. It was added as an extra check to prevent the popover menu from appearing outside of Explore.

Analog to the magnifier glass filters from `LogDetails`, what controls the feature appearing or not is the definition of the underlying callbacks: https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/LogRows.tsx#L111

After https://github.com/grafana/grafana/pull/88980 we enable app developers to make use of this filtering API, so this check is no longer valid.

Part of https://github.com/grafana/explore-logs/pull/460