### PR TITLE
Use global function to compare any entity to both stores

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -277,7 +277,6 @@ func sortUnstructuredSlice(sl []any) []any {
 		default:
 			ret[i] = v
 		}
-
 	}
 
 	return ret

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -225,7 +225,8 @@ func hashUnstructuredObjToCompare(obj runtime.Object) []byte {
 	}
 	// we don't want to compare meta fields
 	delete(unstObj, "meta")
-	ordered := sortedUnstructeredMap(unstObj)
+
+	ordered := sortUnstructeredMap(unstObj)
 	h := md5.New()
 	if err := json.NewEncoder(h).Encode(ordered); err != nil {
 		return nil
@@ -234,45 +235,45 @@ func hashUnstructuredObjToCompare(obj runtime.Object) []byte {
 }
 
 type kv struct {
-	Key   string
-	Value any
+	value any
+	key   string
 }
 
-func sortedUnstructeredMap(obj map[string]any) []kv {
+func sortUnstructeredMap(obj map[string]any) []kv {
 	ret := make([]kv, 0, len(obj))
 
 	for k, v := range obj {
 		item := kv{
-			Key: k,
+			key: k,
 		}
 
 		switch t := v.(type) {
 		case map[string]any:
-			item.Value = sortedUnstructeredMap(t)
+			item.value = sortUnstructeredMap(t)
 		case []any:
-			item.Value = sortedUnstructuredSlice(t)
+			item.value = sortUnstructuredSlice(t)
 		default:
-			item.Value = v
+			item.value = v
 		}
 
 		ret = append(ret, item)
 	}
 
 	sort.Slice(ret, func(i, j int) bool {
-		return ret[i].Key < ret[j].Key
+		return ret[i].key < ret[j].key
 	})
 
 	return ret
 }
 
-func sortedUnstructuredSlice(sl []any) []any {
+func sortUnstructuredSlice(sl []any) []any {
 	ret := make([]any, len(sl))
 	for i, v := range sl {
 		switch vv := v.(type) {
 		case map[string]any:
-			ret[i] = sortedUnstructeredMap(vv)
+			ret[i] = sortUnstructeredMap(vv)
 		case []any:
-			ret[i] = sortedUnstructuredSlice(vv)
+			ret[i] = sortUnstructuredSlice(vv)
 		default:
 			ret[i] = v
 		}

--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -239,7 +239,7 @@ type kv struct {
 	key   string
 }
 
-func sortUnstructeredMap(obj map[string]any) []kv {
+func sortUnstructuredMap(obj map[string]any) []kv {
 	ret := make([]kv, 0, len(obj))
 
 	for k, v := range obj {

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -243,7 +243,3 @@ func (d *DualWriterMode1) NewList() runtime.Object {
 func (d *DualWriterMode1) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return d.Legacy.ConvertToTable(ctx, object, tableOptions)
 }
-
-func (d *DualWriterMode1) Compare(storageObj, legacyObj runtime.Object) bool {
-	return Compare(storageObj, legacyObj)
-}

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -245,5 +245,5 @@ func (d *DualWriterMode1) ConvertToTable(ctx context.Context, object runtime.Obj
 }
 
 func (d *DualWriterMode1) Compare(storageObj, legacyObj runtime.Object) bool {
-	return d.Storage.Compare(storageObj, legacyObj)
+	return Compare(storageObj, legacyObj)
 }

--- a/pkg/apiserver/rest/dualwriter_mode1_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode1_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -15,10 +16,10 @@ import (
 	"k8s.io/apiserver/pkg/apis/example"
 )
 
-var exampleObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
-var exampleObjNoRV = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: ""}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var exampleObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", CreationTimestamp: metav1.Time{}}, Spec: example.PodSpec{}, Status: example.PodStatus{StartTime: &metav1.Time{Time: time.Now()}}}
+var exampleObjNoRV = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "", CreationTimestamp: metav1.Time{}}, Spec: example.PodSpec{}, Status: example.PodStatus{StartTime: &metav1.Time{Time: time.Now()}}}
 var exampleObjDifferentRV = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "3"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
-var anotherObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
+var anotherObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "bar", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{StartTime: &metav1.Time{Time: time.Now()}}}
 var failingObj = &example.Pod{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ObjectMeta: metav1.ObjectMeta{Name: "object-fail", ResourceVersion: "2"}, Spec: example.PodSpec{}, Status: example.PodStatus{}}
 var exampleList = &example.PodList{TypeMeta: metav1.TypeMeta{Kind: "foo"}, ListMeta: metav1.ListMeta{}, Items: []example.Pod{*exampleObj}}
 var anotherList = &example.PodList{Items: []example.Pod{*anotherObj}}

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -306,10 +306,6 @@ func (d *DualWriterMode2) ConvertToTable(ctx context.Context, object runtime.Obj
 	return d.Storage.ConvertToTable(ctx, object, tableOptions)
 }
 
-func (d *DualWriterMode2) Compare(storageObj, legacyObj runtime.Object) bool {
-	return Compare(storageObj, legacyObj)
-}
-
 func parseList(legacyList []runtime.Object) (metainternalversion.ListOptions, map[string]int, error) {
 	options := metainternalversion.ListOptions{}
 	originKeys := []string{}

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -307,7 +307,7 @@ func (d *DualWriterMode2) ConvertToTable(ctx context.Context, object runtime.Obj
 }
 
 func (d *DualWriterMode2) Compare(storageObj, legacyObj runtime.Object) bool {
-	return d.Storage.Compare(storageObj, legacyObj)
+	return Compare(storageObj, legacyObj)
 }
 
 func parseList(legacyList []runtime.Object) (metainternalversion.ListOptions, map[string]int, error) {

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -157,5 +157,5 @@ func (d *DualWriterMode3) ConvertToTable(ctx context.Context, object runtime.Obj
 }
 
 func (d *DualWriterMode3) Compare(storageObj, legacyObj runtime.Object) bool {
-	return d.Storage.Compare(storageObj, legacyObj)
+	return Compare(storageObj, legacyObj)
 }

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -155,7 +155,3 @@ func (d *DualWriterMode3) NewList() runtime.Object {
 func (d *DualWriterMode3) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return d.Storage.ConvertToTable(ctx, object, tableOptions)
 }
-
-func (d *DualWriterMode3) Compare(storageObj, legacyObj runtime.Object) bool {
-	return Compare(storageObj, legacyObj)
-}

--- a/pkg/apiserver/rest/dualwriter_mode4.go
+++ b/pkg/apiserver/rest/dualwriter_mode4.go
@@ -85,5 +85,5 @@ func (d *DualWriterMode4) ConvertToTable(ctx context.Context, object runtime.Obj
 }
 
 func (d *DualWriterMode4) Compare(storageObj, legacyObj runtime.Object) bool {
-	return d.Storage.Compare(storageObj, legacyObj)
+	return Compare(storageObj, legacyObj)
 }

--- a/pkg/apiserver/rest/dualwriter_mode4.go
+++ b/pkg/apiserver/rest/dualwriter_mode4.go
@@ -83,7 +83,3 @@ func (d *DualWriterMode4) NewList() runtime.Object {
 func (d *DualWriterMode4) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	return d.Storage.ConvertToTable(ctx, object, tableOptions)
 }
-
-func (d *DualWriterMode4) Compare(storageObj, legacyObj runtime.Object) bool {
-	return Compare(storageObj, legacyObj)
-}

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestSetDualWritingMode(t *testing.T) {
@@ -59,78 +60,25 @@ func TestSetDualWritingMode(t *testing.T) {
 	}
 }
 
-func TestSortUnstructeredMap(t *testing.T) {
+func TestCompare(t *testing.T) {
 	testCase := []struct {
 		name     string
-		input    map[string]any
-		expected []kv
+		input    runtime.Object
+		expected bool
 	}{
 		{
-			name: "sorts a map by key",
-			input: map[string]any{
-				"a": 1,
-				"g": []any{[]string{"a", "b"}, []int{1, 5}},
-				"c": map[string]any{"f": map[string]string{"e": "b"}},
-				"d": []string{"a", "b"},
-				"b": "b",
-			},
-			expected: []kv{
-				{value: 1, key: "a"},
-				{value: "b", key: "b"},
-				{value: []kv{{value: map[string]string{"e": "b"}, key: "f"}}, key: "c"},
-				{value: []string{"a", "b"}, key: "d"},
-				{value: []any{[]string{"a", "b"}, []int{1, 5}}, key: "g"},
-			},
+			name:     "should return true when both objects are the same",
+			input:    exampleObj,
+			expected: true,
 		},
 		{
-			name:     "handles empty cases",
-			input:    map[string]any{},
-			expected: []kv{},
+			name:  "should return false when objects are different",
+			input: anotherObj,
 		},
 	}
-
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := sortUnstructeredMap(tt.input)
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
-func TestUnstructuredSlices(t *testing.T) {
-	testCase := []struct {
-		name     string
-		input    []any
-		expected []any
-	}{
-		{
-			name: "sorts a slice of unstructured objects",
-			input: []any{
-				map[string]any{"f": map[string]string{"e": "b"}},
-				[]string{"a", "b"},
-				[]any{map[int]string{3: "b"}, []map[string]string{{"z": "a"}, {"d": "e"}}},
-				[]int{3, 7, 5, 3},
-				[]string{"b", "a", "t", "a"},
-			},
-			expected: []any{
-				[]kv{{value: map[string]string{"e": "b"}, key: "f"}},
-				[]string{"a", "b"}, []interface{}{map[int]string{3: "b"},
-					[]map[string]string{{"z": "a"}, {"d": "e"}}},
-				[]int{3, 7, 5, 3},
-				[]string{"b", "a", "t", "a"},
-			},
-		},
-		{
-			name:     "handles empty cases",
-			input:    []any{},
-			expected: []any{},
-		},
-	}
-
-	for _, tt := range testCase {
-		t.Run(tt.name, func(t *testing.T) {
-			actual := sortUnstructuredSlice(tt.input)
-			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.expected, Compare(tt.input, exampleObj))
 		})
 	}
 }

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -58,3 +58,79 @@ func TestSetDualWritingMode(t *testing.T) {
 		assert.Equal(t, val, fmt.Sprint(tt.expectedMode))
 	}
 }
+
+func TestSortUnstructeredMap(t *testing.T) {
+	testCase := []struct {
+		name     string
+		input    map[string]any
+		expected []kv
+	}{
+		{
+			name: "sorts a map by key",
+			input: map[string]any{
+				"a": 1,
+				"g": []any{[]string{"a", "b"}, []int{1, 5}},
+				"c": map[string]any{"f": map[string]string{"e": "b"}},
+				"d": []string{"a", "b"},
+				"b": "b",
+			},
+			expected: []kv{
+				{value: 1, key: "a"},
+				{value: "b", key: "b"},
+				{value: []kv{{value: map[string]string{"e": "b"}, key: "f"}}, key: "c"},
+				{value: []string{"a", "b"}, key: "d"},
+				{value: []any{[]string{"a", "b"}, []int{1, 5}}, key: "g"},
+			},
+		},
+		{
+			name:     "handles empty cases",
+			input:    map[string]any{},
+			expected: []kv{},
+		},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := sortUnstructeredMap(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestUnstructuredSlices(t *testing.T) {
+	testCase := []struct {
+		name     string
+		input    []any
+		expected []any
+	}{
+		{
+			name: "sorts a slice of unstructured objects",
+			input: []any{
+				map[string]any{"f": map[string]string{"e": "b"}},
+				[]string{"a", "b"},
+				[]any{map[int]string{3: "b"}, []map[string]string{{"z": "a"}, {"d": "e"}}},
+				[]int{3, 7, 5, 3},
+				[]string{"b", "a", "t", "a"},
+			},
+			expected: []any{
+				[]kv{{value: map[string]string{"e": "b"}, key: "f"}},
+				[]string{"a", "b"}, []interface{}{map[int]string{3: "b"},
+					[]map[string]string{{"z": "a"}, {"d": "e"}}},
+				[]int{3, 7, 5, 3},
+				[]string{"b", "a", "t", "a"},
+			},
+		},
+		{
+			name:     "handles empty cases",
+			input:    []any{},
+			expected: []any{},
+		},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := sortUnstructuredSlice(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/registry/apis/dashboard/storage.go
+++ b/pkg/registry/apis/dashboard/storage.go
@@ -66,9 +66,3 @@ func newStorage(scheme *runtime.Scheme) (*storage, error) {
 		})
 	return &storage{Store: store}, nil
 }
-
-// Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
-func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	//TODO: define the comparison logic between a dashboard returned by the storage and a dashboard returned by the legacy storage
-	return false
-}

--- a/pkg/registry/apis/folders/storage.go
+++ b/pkg/registry/apis/folders/storage.go
@@ -40,9 +40,3 @@ func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, le
 	}
 	return &storage{Store: store}, nil
 }
-
-// Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
-func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	//TODO: define the comparison logic between a folder returned by the storage and a folder returned by the legacy storage
-	return false
-}

--- a/pkg/registry/apis/peakq/storage.go
+++ b/pkg/registry/apis/peakq/storage.go
@@ -62,9 +62,3 @@ func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*
 	}
 	return &storage{Store: store}, nil
 }
-
-// Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
-func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	//TODO: define the comparison logic between a query template returned by the storage and a query template returned by the legacy storage
-	return false
-}

--- a/pkg/registry/apis/playlist/storage.go
+++ b/pkg/registry/apis/playlist/storage.go
@@ -1,7 +1,6 @@
 package playlist
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
@@ -40,18 +39,4 @@ func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter, le
 		return nil, err
 	}
 	return &storage{Store: store}, nil
-}
-
-// Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
-func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	accStr, err := meta.Accessor(storageObj)
-	if err != nil {
-		return false
-	}
-	accLegacy, err := meta.Accessor(legacyObj)
-	if err != nil {
-		return false
-	}
-
-	return accStr.GetName() == accLegacy.GetName()
 }

--- a/pkg/registry/apis/scope/storage.go
+++ b/pkg/registry/apis/scope/storage.go
@@ -207,9 +207,3 @@ func SelectableScopeNodeFields(obj *scope.ScopeNode) fields.Set {
 		"spec.parentName": parentName,
 	})
 }
-
-// Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
-func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	//TODO: define the comparison logic between a scope returned by the storage and a scope returned by the legacy storage
-	return false
-}

--- a/pkg/registry/apis/service/storage.go
+++ b/pkg/registry/apis/service/storage.go
@@ -62,9 +62,3 @@ func newStorage(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*
 	}
 	return &storage{Store: store}, nil
 }
-
-// Compare asserts on the equality of objects returned from both stores	(object storage and legacy storage)
-func (s *storage) Compare(storageObj, legacyObj runtime.Object) bool {
-	//TODO: define the comparison logic between a generic object returned by the storage and a generic object returned by the legacy storage
-	return false
-}


### PR DESCRIPTION
**What is this feature?**

Implement compare for any entity when writing to both stores.
This function is only used for observability purposes.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/44

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
