### PR TITLE
RestoreDashboards: add IsDeleted and PermanentlyDeleteDate to deleted search

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -741,7 +741,9 @@ func makeQueryResult(query *dashboards.FindPersistedDashboardsQuery, res []dashb
 			hit.Tags = append(hit.Tags, item.Term)
 		}
 		if item.Deleted != nil {
-			hit.RemainingTrashAtAge = util.RemainingDaysUntil((*item.Deleted).Add(daysInTrash))
+			deletedDate := (*item.Deleted).Add(daysInTrash)
+			hit.IsDeleted = true
+			hit.PermanentlyDeleteDate = &deletedDate
 		}
 	}
 	return hitList

--- a/pkg/services/search/model/model.go
+++ b/pkg/services/search/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"strings"
+	"time"
 )
 
 // FilterWhere limits the set of dashboard IDs to the dashboards for
@@ -62,22 +63,23 @@ const (
 )
 
 type Hit struct {
-	ID                  int64    `json:"id"`
-	UID                 string   `json:"uid"`
-	Title               string   `json:"title"`
-	URI                 string   `json:"uri"`
-	URL                 string   `json:"url"`
-	Slug                string   `json:"slug"`
-	Type                HitType  `json:"type"`
-	Tags                []string `json:"tags"`
-	IsStarred           bool     `json:"isStarred"`
-	FolderID            int64    `json:"folderId,omitempty"` // Deprecated: use FolderUID instead
-	FolderUID           string   `json:"folderUid,omitempty"`
-	FolderTitle         string   `json:"folderTitle,omitempty"`
-	FolderURL           string   `json:"folderUrl,omitempty"`
-	SortMeta            int64    `json:"sortMeta"`
-	SortMetaName        string   `json:"sortMetaName,omitempty"`
-	RemainingTrashAtAge string   `json:"remainingTrashAtAge,omitempty"`
+	ID                    int64      `json:"id"`
+	UID                   string     `json:"uid"`
+	Title                 string     `json:"title"`
+	URI                   string     `json:"uri"`
+	URL                   string     `json:"url"`
+	Slug                  string     `json:"slug"`
+	Type                  HitType    `json:"type"`
+	Tags                  []string   `json:"tags"`
+	IsStarred             bool       `json:"isStarred"`
+	FolderID              int64      `json:"folderId,omitempty"` // Deprecated: use FolderUID instead
+	FolderUID             string     `json:"folderUid,omitempty"`
+	FolderTitle           string     `json:"folderTitle,omitempty"`
+	FolderURL             string     `json:"folderUrl,omitempty"`
+	SortMeta              int64      `json:"sortMeta"`
+	SortMetaName          string     `json:"sortMetaName,omitempty"`
+	IsDeleted             bool       `json:"isDeleted"`
+	PermanentlyDeleteDate *time.Time `json:"permanentlyDeleteDate,omitempty"`
 }
 
 type HitList []*Hit

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4703,11 +4703,15 @@
           "type": "integer",
           "format": "int64"
         },
+        "isDeleted": {
+          "type": "boolean"
+        },
         "isStarred": {
           "type": "boolean"
         },
-        "remainingTrashAtAge": {
-          "type": "string"
+        "permanentlyDeleteDate": {
+          "type": "string",
+          "format": "date-time"
         },
         "slug": {
           "type": "string"
@@ -7049,6 +7053,7 @@
       }
     },
     "State": {
+      "description": "+enum",
       "type": "string"
     },
     "Status": {
@@ -7492,6 +7497,7 @@
       }
     },
     "Type": {
+      "description": "+enum",
       "type": "string"
     },
     "TypeMeta": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15815,11 +15815,15 @@
           "type": "integer",
           "format": "int64"
         },
+        "isDeleted": {
+          "type": "boolean"
+        },
         "isStarred": {
           "type": "boolean"
         },
-        "remainingTrashAtAge": {
-          "type": "string"
+        "permanentlyDeleteDate": {
+          "type": "string",
+          "format": "date-time"
         },
         "slug": {
           "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6194,10 +6194,14 @@
             "format": "int64",
             "type": "integer"
           },
+          "isDeleted": {
+            "type": "boolean"
+          },
           "isStarred": {
             "type": "boolean"
           },
-          "remainingTrashAtAge": {
+          "permanentlyDeleteDate": {
+            "format": "date-time",
             "type": "string"
           },
           "slug": {


### PR DESCRIPTION
Changes the response for deleted items from the Search API:

 - Adds `isDeleted` property to explicitly mark soft-deleted items
 - Instead of a formatted `remainingTrashAtAge` string, returns `permanentlyDeleteDate` timestamp for UIs to determine the best way to present this

Part of https://github.com/grafana/grafana/issues/83620