### PR TITLE
CI: Fix release-npm-packages action

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2670,7 +2670,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: golang:1.21.10-alpine
+  image: node:18.12.0-alpine
   name: release-npm-packages
 trigger:
   event:
@@ -4607,6 +4607,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 006c79befa5fdfb008b79047e1b4174e4df631d9b77d55021d6195a5bc2ca7ef
+hmac: ca7643a4737afad897d5002fa877bf31a1f60c25e976b977af608624df745b88
 
 ...

--- a/pkg/build/cmd/npm.go
+++ b/pkg/build/cmd/npm.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -72,12 +71,6 @@ func NpmReleaseAction(c *cli.Context) error {
 	tag := c.String("tag")
 	if tag == "" {
 		return fmt.Errorf("no tag version specified, exitting")
-	}
-
-	cmd := exec.Command("git", "checkout", ".")
-	if err := cmd.Run(); err != nil {
-		fmt.Println("command failed to run, err: ", err)
-		return err
 	}
 
 	err := npm.PublishNpmPackages(c.Context, tag)

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -62,7 +62,7 @@ def retrieve_npm_packages_step():
 def release_npm_packages_step():
     return {
         "name": "release-npm-packages",
-        "image": images["go"],
+        "image": images["node"],
         "depends_on": [
             "compile-build-cmd",
             "retrieve-npm-packages",


### PR DESCRIPTION
Fixes publishing NPM packages for 10.1.x patches by backporting https://github.com/grafana/grafana/pull/77127.

Fixes [#939](https://github.com/grafana/grafana-release/issues/939)
Related to  #77106