### PR TITLE
CI: Fix release-npm-packages action

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2632,7 +2632,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: golang:1.21.8-alpine
+  image: node:18.12.0-alpine
   name: release-npm-packages
 trigger:
   event:
@@ -4569,6 +4569,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: a313b2e050893b466c53262fb06eb54dcb1f09f9750187864ad82346a0621b3d
+hmac: 19be6e305925fee3f9f13572b6f86412defc50611f7402f987f7e248b95f593a
 
 ...

--- a/pkg/build/cmd/npm.go
+++ b/pkg/build/cmd/npm.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -72,12 +71,6 @@ func NpmReleaseAction(c *cli.Context) error {
 	tag := c.String("tag")
 	if tag == "" {
 		return fmt.Errorf("no tag version specified, exitting")
-	}
-
-	cmd := exec.Command("git", "checkout", ".")
-	if err := cmd.Run(); err != nil {
-		fmt.Println("command failed to run, err: ", err)
-		return err
 	}
 
 	err := npm.PublishNpmPackages(c.Context, tag)

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -62,7 +62,7 @@ def retrieve_npm_packages_step():
 def release_npm_packages_step():
     return {
         "name": "release-npm-packages",
-        "image": images["go"],
+        "image": images["node"],
         "depends_on": [
             "compile-build-cmd",
             "retrieve-npm-packages",


### PR DESCRIPTION
Fixes publishing NPM packages for 10.0.x patches by backporting https://github.com/grafana/grafana/pull/77127.

Fixes [#939](https://github.com/grafana/grafana-release/issues/939)
Related to  #77106