### PR TITLE
CI: Fix release-npm-packages action

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2630,7 +2630,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: golang:1.21.10-alpine
+  image: node:18.12.0-alpine
   name: release-npm-packages
 trigger:
   event:
@@ -4567,6 +4567,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: d875e64304bb3bfe8ffc56c41bdba91ece736db87c406d2652bdc6041f0c29cc
+hmac: 9475f9e7f31f19f020f8f2438ed3be14cc7f613886077d8a9e7eb7110d8efdf1
 
 ...

--- a/pkg/build/cmd/npm.go
+++ b/pkg/build/cmd/npm.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -72,12 +71,6 @@ func NpmReleaseAction(c *cli.Context) error {
 	tag := c.String("tag")
 	if tag == "" {
 		return fmt.Errorf("no tag version specified, exitting")
-	}
-
-	cmd := exec.Command("git", "checkout", ".")
-	if err := cmd.Run(); err != nil {
-		fmt.Println("command failed to run, err: ", err)
-		return err
 	}
 
 	err := npm.PublishNpmPackages(c.Context, tag)

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -62,7 +62,7 @@ def retrieve_npm_packages_step():
 def release_npm_packages_step():
     return {
         "name": "release-npm-packages",
-        "image": images["go"],
+        "image": images["node"],
         "depends_on": [
             "compile-build-cmd",
             "retrieve-npm-packages",


### PR DESCRIPTION
Fixes publishing NPM packages for 9.5.x patches by backporting https://github.com/grafana/grafana/pull/77127.

Fixes [#939](https://github.com/grafana/grafana-release/issues/939)
Related to  #77106