### PR TITLE
Azure Monitor: Add validation for namespace field in AdvancedResourcePicker when entering a forward slash

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.test.tsx
@@ -106,9 +106,10 @@ describe('AdvancedResourcePicker', () => {
     const onChange = jest.fn();
 
     render(
-      <AdvancedResourcePicker onChange={onChange} resources={[
-        { metricNamespace: 'Microsoft.OperationalInsights/workspaces/' }
-      ]} />
+      <AdvancedResourcePicker
+        onChange={onChange}
+        resources={[{ metricNamespace: 'Microsoft.OperationalInsights/workspaces/' }]}
+      />
     );
 
     expect(screen.getByText('Namespace cannot end with a "/"')).toBeInTheDocument();

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -100,5 +100,17 @@ describe('AdvancedResourcePicker', () => {
     expect(screen.getByDisplayValue('res1')).toBeInTheDocument();
     expect(screen.getByDisplayValue('rg2')).toBeInTheDocument();
     expect(screen.getByDisplayValue('res2')).toBeInTheDocument();
+  });
+
+  it('should display an error when the namespace field ends in a /', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <AdvancedResourcePicker onChange={onChange} resources={[
+        { metricNamespace: 'Microsoft.OperationalInsights/workspaces/' }
+      ]} />
+    );
+
+    expect(screen.getByText('Namespace cannot end with a "/"')).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MetricsQueryEditor/AdvancedResourcePicker.tsx
@@ -81,6 +81,8 @@ const AdvancedResourcePicker = ({ resources, onChange }: ResourcePickerProps<Azu
         htmlFor={`input-advanced-resource-picker-metricNamespace`}
         labelWidth={15}
         data-testid={selectors.components.queryEditor.resourcePicker.advanced.namespace.input}
+        invalid={resources[0]?.metricNamespace?.endsWith('/')}
+        error={'Namespace cannot end with a "/"'}
       >
         <Input
           id={`input-advanced-resource-picker-metricNamespace`}


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/10994.