### PR TITLE
InfluxDB: Don't interpolate bucket keyword in flux language if it is part of a join query

### DIFF
--- a/pkg/tsdb/influxdb/flux/macros.go
+++ b/pkg/tsdb/influxdb/flux/macros.go
@@ -25,27 +25,40 @@ func interpolateInterval(flux string, interval time.Duration) string {
 var fluxVariableFilterExp = regexp.MustCompile(`(?m)([a-zA-Z]+)\.([a-zA-Z]+)`)
 
 func interpolateFluxSpecificVariables(query queryModel) string {
+	rawQuery := query.RawQuery
 	flux := query.RawQuery
 
-	matches := fluxVariableFilterExp.FindAllStringSubmatch(flux, -1)
+	matches := fluxVariableFilterExp.FindAllStringSubmatchIndex(rawQuery, -1)
 	if matches != nil {
 		timeRange := query.TimeRange
 		from := timeRange.From.UTC().Format(time.RFC3339Nano)
 		to := timeRange.To.UTC().Format(time.RFC3339Nano)
 		for _, match := range matches {
-			switch match[2] {
+			// For query "range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+			// rawQuery[match[0]:match[1]] will be v.timeRangeStart
+			// rawQuery[match[2]:match[3]] will be v
+			// rawQuery[match[4]:match[5]] will be timeRangeStart
+			fullMatch := rawQuery[match[0]:match[1]]
+			key := rawQuery[match[4]:match[5]]
+
+			switch key {
 			case "timeRangeStart":
-				flux = strings.ReplaceAll(flux, match[0], from)
+				flux = strings.ReplaceAll(flux, fullMatch, from)
 			case "timeRangeStop":
-				flux = strings.ReplaceAll(flux, match[0], to)
+				flux = strings.ReplaceAll(flux, fullMatch, to)
 			case "windowPeriod":
-				flux = strings.ReplaceAll(flux, match[0], query.Interval.String())
+				flux = strings.ReplaceAll(flux, fullMatch, query.Interval.String())
 			case "bucket":
-				flux = strings.ReplaceAll(flux, match[0], "\""+query.Options.Bucket+"\"")
+				// Check if 'bucket' is part of a join query
+				beforeMatch := rawQuery[:match[0]]
+				if strings.Contains(beforeMatch, "join.") {
+					continue
+				}
+				flux = strings.ReplaceAll(flux, fullMatch, "\""+query.Options.Bucket+"\"")
 			case "defaultBucket":
-				flux = strings.ReplaceAll(flux, match[0], "\""+query.Options.DefaultBucket+"\"")
+				flux = strings.ReplaceAll(flux, fullMatch, "\""+query.Options.DefaultBucket+"\"")
 			case "organization":
-				flux = strings.ReplaceAll(flux, match[0], "\""+query.Options.Organization+"\"")
+				flux = strings.ReplaceAll(flux, fullMatch, "\""+query.Options.Organization+"\"")
 			}
 		}
 	}

--- a/pkg/tsdb/influxdb/flux/macros_test.go
+++ b/pkg/tsdb/influxdb/flux/macros_test.go
@@ -31,6 +31,11 @@ func TestInterpolate(t *testing.T) {
 			before: `v.timeRangeStart, something.timeRangeStop, XYZ.bucket, uuUUu.defaultBucket, aBcDefG.organization, window.windowPeriod, a91{}.bucket, $__interval, $__interval_ms`,
 			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1m1.258s, a91{}.bucket, 1m, 61258`,
 		},
+		{
+			name:   "don't interpolate bucket variable in join query",
+			before: `range(start: v.timeRangeStart, stop: v.timeRangeStop) join.left(left: left |> group(), right: right,on:((l,r) => l.bucket == r.id), as: ((l, r) => ({l with name: r.name})))`,
+			after:  `range(start: 2021-09-22T10:12:51.310985041Z, stop: 2021-09-22T11:12:51.310985042Z) join.left(left: left |> group(), right: right,on:((l,r) => l.bucket == r.id), as: ((l, r) => ({l with name: r.name})))`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

We interpolate some keywords already in the queries. See here https://github.com/grafana/grafana/blob/v11.1.x/pkg/tsdb/influxdb/flux/macros.go#L27-L53 
But for the `join` queries we should not interpolate the `bucket` keyword. 
It was causing issues with the queries. 

**Why do we need this feature?**

Better querying with Flux language.

**Who is this feature for?**

InfluxDB Flux language users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/78429

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
