### PR TITLE
Fix: Portuguese Brazilian wasn't loading translations

### DIFF
--- a/public/app/core/internationalization/constants.ts
+++ b/public/app/core/internationalization/constants.ts
@@ -5,7 +5,7 @@ export const ENGLISH_US = 'en-US';
 export const FRENCH_FRANCE = 'fr-FR';
 export const SPANISH_SPAIN = 'es-ES';
 export const GERMAN_GERMANY = 'de-DE';
-export const BRAZILIAN_PORTUGUESE = 'pt-BR';
+export const BRAZILIAN_PORTUGUESE = 'pt-br';
 export const CHINESE_SIMPLIFIED = 'zh-Hans';
 export const PSEUDO_LOCALE = 'pseudo-LOCALE';
 
@@ -105,6 +105,15 @@ if (process.env.NODE_ENV !== 'test') {
   }
 }
 
-export const VALID_LANGUAGES = LANGUAGES.map((v) => v.code);
+export const VALID_LANGUAGES = LANGUAGES.flatMap((v) => {
+  let codes = [v.code];
+  const codeSplit = v.code.split('-');
+  // This makes sure that if the language was added with a lowercase country code,
+  // we also add the valid version (i.e. pt-br -> pt-BR)
+  if (codeSplit.length === 2 && codeSplit[1].toUpperCase() !== codeSplit[1]) {
+    codes.push(`${codeSplit[0]}-${codeSplit[1].toUpperCase()}`);
+  }
+  return codes;
+});
 
 export const NAMESPACES = uniq(LANGUAGES.flatMap((v) => Object.keys(v.loader)));

--- a/public/app/core/internationalization/constants.ts
+++ b/public/app/core/internationalization/constants.ts
@@ -5,7 +5,7 @@ export const ENGLISH_US = 'en-US';
 export const FRENCH_FRANCE = 'fr-FR';
 export const SPANISH_SPAIN = 'es-ES';
 export const GERMAN_GERMANY = 'de-DE';
-export const BRAZILIAN_PORTUGUESE = 'pt-br';
+export const BRAZILIAN_PORTUGUESE = 'pt-BR';
 export const CHINESE_SIMPLIFIED = 'zh-Hans';
 export const PSEUDO_LOCALE = 'pseudo-LOCALE';
 
@@ -105,15 +105,6 @@ if (process.env.NODE_ENV !== 'test') {
   }
 }
 
-export const VALID_LANGUAGES = LANGUAGES.flatMap((v) => {
-  let codes = [v.code];
-  const codeSplit = v.code.split('-');
-  // This makes sure that if the language was added with a lowercase country code,
-  // we also add the valid version (i.e. pt-br -> pt-BR)
-  if (codeSplit.length === 2 && codeSplit[1].toUpperCase() !== codeSplit[1]) {
-    codes.push(`${codeSplit[0]}-${codeSplit[1].toUpperCase()}`);
-  }
-  return codes;
-});
+export const VALID_LANGUAGES = LANGUAGES.map((v) => v.code);
 
 export const NAMESPACES = uniq(LANGUAGES.flatMap((v) => Object.keys(v.loader)));

--- a/public/app/core/internationalization/constants.ts
+++ b/public/app/core/internationalization/constants.ts
@@ -5,7 +5,7 @@ export const ENGLISH_US = 'en-US';
 export const FRENCH_FRANCE = 'fr-FR';
 export const SPANISH_SPAIN = 'es-ES';
 export const GERMAN_GERMANY = 'de-DE';
-export const BRAZILIAN_PORTUGUESE = 'pt-br';
+export const BRAZILIAN_PORTUGUESE = 'pt-BR';
 export const CHINESE_SIMPLIFIED = 'zh-Hans';
 export const PSEUDO_LOCALE = 'pseudo-LOCALE';
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When selecting "Portuguese Brazilian" from the languages dropdown it sets your language to "pt-br" but this is not loading correctly the translations (can try on ops), the language has to be "pt-BR".

**Why do we need this feature?**

So Grafana can be translated to Portuguese.

**Who is this feature for?**

Portuguese speaking users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I've set this to backport to 11.0.x and 11.1.x since we released [this](https://github.com/grafana/grafana/pull/84461) on 11.0.x and I think it's important to fix. Any agreements/disagreements to this?
Question: Do we need to do any sort of migration for users who have it set to "pt-br"? Since that will continue to be broken unless they select a different language and then go back to "Portuguese Brazilian"

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

# Release notice breaking change

If you had selected your language as "Português Brasileiro" previously, this will be reset. You have to select it again in your Preferences for the fix to be applied and the translations will then be shown.