### PR TITLE
RecentlyDeleted: Update Search table for deleted items

### DIFF
--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -371,7 +371,7 @@ function makeDeletedRemainingColumn(
       const isDeletingSoon = duration.days === 0 && duration.hours === 0 && duration.minutes === 0;
       const formatted = isDeletingSoon
         ? t('search.results-table.deleted-less-than-1-min', '< 1 min')
-        : formatDuration(duration);
+        : formatDuration(duration, { style: 'long' });
 
       return (
         <div {...p.cellProps} className={cx(styles.cell, styles.typeCell)}>
@@ -510,7 +510,7 @@ const HOURS_IN_DAY = 24;
  *  - 35 seconds - returns { days: 0, hours: 0, minutes: 0 }
  */
 function calcCourseDuration(start: Date, end: Date) {
-  let minutes = (end.getTime() - start.getTime()) / MILLISECONDS_IN_MINUTE;
+  let minutes = Math.floor((end.getTime() - start.getTime()) / MILLISECONDS_IN_MINUTE);
 
   let hours = minutes > MINUTES_IN_HOUR ? Math.floor(minutes / MINUTES_IN_HOUR) : 0;
   if (hours > 0) {

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -368,7 +368,7 @@ function makeDeletedRemainingColumn(
       }
 
       const duration = calcCourseDuration(new Date(), deletedDate);
-      const isDeletingSoon = duration.days === 0 && duration.hours === 0 && duration.minutes === 0;
+      const isDeletingSoon = !Object.values(duration).some((v) => v > 0);
       const formatted = isDeletingSoon
         ? t('search.results-table.deleted-less-than-1-min', '< 1 min')
         : formatDuration(duration, { style: 'long' });
@@ -499,32 +499,32 @@ function getDisplayValue({
   return formattedValueToString(getDisplay(value));
 }
 
-const MILLISECONDS_IN_MINUTE = 60 * 1000;
-const MINUTES_IN_HOUR = 60;
-const HOURS_IN_DAY = 24;
-
 /**
- * Calculates the rough duration with between two dates, with varying precision depending on
- * how far apart the dates are. e.g:
+ * Calculates the rough duration between two dates, keeping only the most significant unit e.g:
  *  - 20 days, 13 hours, 43 minutes apart, 35 seconds - returns { days: 20, hours: 0, minutes: 0 }
  *  - 13 hours, 43 minutes apart, 35 seconds - returns { days: 0, hours: 13, minutes: 0 }
  *  - 43 minutes apart, 35 seconds - returns { days: 0, hours: 0, minutes: 43 }
  *  - 35 seconds - returns { days: 0, hours: 0, minutes: 0 }
  */
 function calcCourseDuration(start: Date, end: Date) {
-  let minutes = Math.floor((end.getTime() - start.getTime()) / MILLISECONDS_IN_MINUTE);
+  let { years = 0, months = 0, days = 0, hours = 0, minutes = 0 } = intervalToDuration({ start, end });
 
-  let hours = minutes > MINUTES_IN_HOUR ? Math.floor(minutes / MINUTES_IN_HOUR) : 0;
-  if (hours > 0) {
+  if (years > 0) {
+    months = 0;
+    days = 0;
+    hours = 0;
+    minutes = 0;
+  } else if (months > 0) {
+    days = 0;
+    hours = 0;
+    minutes = 0;
+  } else if (hours > 0) {
     minutes = 0;
   }
 
-  let days = hours > HOURS_IN_DAY ? Math.floor(hours / HOURS_IN_DAY) : 0;
-  if (days > 0) {
-    hours = 0;
-  }
-
   return {
+    years,
+    months,
     days,
     hours,
     minutes,

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -12,7 +12,7 @@ import {
   getFieldDisplayName,
 } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
-import { Checkbox, Icon, IconName, TagList, Text } from '@grafana/ui';
+import { Checkbox, Icon, IconName, TagList, Text, Tooltip } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { t } from 'app/core/internationalization';
 import { formatDate, formatDuration } from 'app/core/internationalization/dates';
@@ -375,7 +375,9 @@ function makeDeletedRemainingColumn(
 
       return (
         <div {...p.cellProps} className={cx(styles.cell, styles.typeCell)}>
-          {formatted}
+          <Tooltip content={formatDate(deletedDate, { dateStyle: 'medium', timeStyle: 'short' })}>
+            <span>{formatted}</span>
+          </Tooltip>
         </div>
       );
     },

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -518,6 +518,9 @@ function calcCourseDuration(start: Date, end: Date) {
     days = 0;
     hours = 0;
     minutes = 0;
+  } else if (days > 0) {
+    hours = 0;
+    minutes = 0;
   } else if (hours > 0) {
     minutes = 0;
   }

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -354,6 +354,7 @@ function makeDeletedRemainingColumn(
   return {
     id: 'column-delete-age',
     field: deletedField,
+    width,
     Header: t('search.results-table.deleted-remaining-header', 'Time remaining'),
     Cell: (p) => {
       const i = p.row.index;
@@ -367,7 +368,7 @@ function makeDeletedRemainingColumn(
         );
       }
 
-      const duration = calcCourseDuration(new Date(), deletedDate);
+      const duration = calcCoarseDuration(new Date(), deletedDate);
       const isDeletingSoon = !Object.values(duration).some((v) => v > 0);
       const formatted = isDeletingSoon
         ? t('search.results-table.deleted-less-than-1-min', '< 1 min')
@@ -500,36 +501,20 @@ function getDisplayValue({
 }
 
 /**
- * Calculates the rough duration between two dates, keeping only the most significant unit e.g:
- *  - 20 days, 13 hours, 43 minutes apart, 35 seconds - returns { days: 20, hours: 0, minutes: 0 }
- *  - 13 hours, 43 minutes apart, 35 seconds - returns { days: 0, hours: 13, minutes: 0 }
- *  - 43 minutes apart, 35 seconds - returns { days: 0, hours: 0, minutes: 43 }
- *  - 35 seconds - returns { days: 0, hours: 0, minutes: 0 }
+ * Calculates the rough duration between two dates, keeping only the most significant unit
  */
-function calcCourseDuration(start: Date, end: Date) {
+function calcCoarseDuration(start: Date, end: Date) {
   let { years = 0, months = 0, days = 0, hours = 0, minutes = 0 } = intervalToDuration({ start, end });
 
   if (years > 0) {
-    months = 0;
-    days = 0;
-    hours = 0;
-    minutes = 0;
+    return { years };
   } else if (months > 0) {
-    days = 0;
-    hours = 0;
-    minutes = 0;
+    return { months };
   } else if (days > 0) {
-    hours = 0;
-    minutes = 0;
+    return { days };
   } else if (hours > 0) {
-    minutes = 0;
+    return { hours };
   }
 
-  return {
-    years,
-    months,
-    days,
-    hours,
-    minutes,
-  };
+  return { minutes };
 }

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -158,6 +158,8 @@ export class SQLSearcher implements GrafanaSearcher {
     const tags: string[][] = [];
     const location: string[] = [];
     const sortBy: number[] = [];
+    const isDeleted: boolean[] = [];
+    const permanentlyDeleteDate: Array<Date | undefined> = [];
     let sortMetaName: string | undefined;
 
     for (let hit of rsp) {
@@ -168,6 +170,8 @@ export class SQLSearcher implements GrafanaSearcher {
       url.push(hit.url);
       tags.push(hit.tags);
       sortBy.push(hit.sortMeta!);
+      isDeleted.push(hit.isDeleted ?? false);
+      permanentlyDeleteDate.push(hit.permanentlyDeleteDate ? new Date(hit.permanentlyDeleteDate) : undefined);
 
       let v = hit.folderUid;
       if (!v && k === 'dashboard') {
@@ -204,6 +208,8 @@ export class SQLSearcher implements GrafanaSearcher {
         { name: 'url', type: FieldType.string, config: {}, values: url },
         { name: 'tags', type: FieldType.other, config: {}, values: tags },
         { name: 'location', type: FieldType.string, config: {}, values: location },
+        { name: 'isDeleted', type: FieldType.boolean, config: {}, values: isDeleted },
+        { name: 'permanentlyDeleteDate', type: FieldType.time, config: {}, values: permanentlyDeleteDate },
       ],
       length: name.length,
       meta: {

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -39,6 +39,8 @@ export interface DashboardQueryResult {
   tags: string[];
   location: string; // url that can be split
   ds_uid: string[];
+  isDeleted?: boolean;
+  permanentlyDeleteDate?: Date;
 
   // debugging fields
   score: number;

--- a/public/app/features/search/types.ts
+++ b/public/app/features/search/types.ts
@@ -30,6 +30,8 @@ export interface DashboardSearchHit extends WithAccessControlMetadata {
   url: string;
   sortMeta?: number;
   sortMetaName?: string;
+  isDeleted?: boolean;
+  permanentlyDeleteDate?: string;
 }
 
 /**

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1654,6 +1654,7 @@
     },
     "results-table": {
       "datasource-header": "Data source",
+      "deleted-remaining-header": "Time remaining (todo)",
       "location-header": "Location",
       "name-header": "Name",
       "tags-header": "Tags",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1654,7 +1654,8 @@
     },
     "results-table": {
       "datasource-header": "Data source",
-      "deleted-remaining-header": "Time remaining (todo)",
+      "deleted-less-than-1-min": "< 1 min",
+      "deleted-remaining-header": "Time remaining",
       "location-header": "Location",
       "name-header": "Name",
       "tags-header": "Tags",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1654,6 +1654,7 @@
     },
     "results-table": {
       "datasource-header": "Đäŧä şőūřčę",
+      "deleted-remaining-header": "Ŧįmę řęmäįŉįŉģ (ŧőđő)",
       "location-header": "Ŀőčäŧįőŉ",
       "name-header": "Ńämę",
       "tags-header": "Ŧäģş",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1654,7 +1654,8 @@
     },
     "results-table": {
       "datasource-header": "Đäŧä şőūřčę",
-      "deleted-remaining-header": "Ŧįmę řęmäįŉįŉģ (ŧőđő)",
+      "deleted-less-than-1-min": "< 1 mįŉ",
+      "deleted-remaining-header": "Ŧįmę řęmäįŉįŉģ",
       "location-header": "Ŀőčäŧįőŉ",
       "name-header": "Ńämę",
       "tags-header": "Ŧäģş",


### PR DESCRIPTION
Updates the search results table for displaying deleted items:

 - Deleted dashboards no longer link to the dashboard (it's deleted!)
 - Shows the rough time remaining until hard deletion.
    - only shows day count if it's <1 day, only shows hours if <1 hour, only shows minutes if <1 minute
    - avoids showing seconds remaining because the count doesn't update per-second
 - Time remaining has a tooltip with the exact date

![image](https://github.com/grafana/grafana/assets/46142/76001d6c-5273-4a8e-b159-cb0d03d34259)


Fixes https://github.com/grafana/grafana/issues/88559 