### PR TITLE
Notifications: Do not log email address in error message

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -70,7 +70,7 @@ func (sc *SmtpClient) Send(ctx context.Context, messages ...*Message) (int, erro
 				emailsSentFailed.Inc()
 			}
 
-			err = fmt.Errorf("failed to send notification to email addresses: %s: %w", strings.Join(msg.To, ";"), innerError)
+			err = fmt.Errorf("failed to send email: %w", innerError)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 


### PR DESCRIPTION
**What is this feature?**

This PR removes the email address(es) from the error message logged by the notifications service.

**Why do we need this feature?**

This info is PII and should not be logged by default.

**Who is this feature for?**

Users of alerting, and any other downstream service within Grafana that relies on email notifications.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
