### PR TITLE
Add info tooltips to logs that have been sampled by adaptive logs

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4702,8 +4702,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "31"],
       [0, 0, 0, "Styles should be written using objects.", "32"],
       [0, 0, 0, "Styles should be written using objects.", "33"],
-      [0, 0, 0, "Styles should be written using objects.", "34"],
-      [0, 0, 0, "Styles should be written using objects.", "35"]
+      [0, 0, 0, "Styles should be written using objects.", "34"]
     ],
     "public/app/features/logs/components/log-context/LogContextButtons.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -256,7 +256,11 @@ class UnThemedLogRow extends PureComponent<Props, State> {
             </td>
           )}
           <td
-            className={hasError || isSampled ? styles.logsRowWithError : `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}`}
+            className={
+              hasError || isSampled
+                ? styles.logsRowWithError
+                : `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}`
+            }
           >
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -17,7 +17,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { DataQuery, TimeZone } from '@grafana/schema';
 import { withTheme2, Themeable2, Icon, Tooltip, PopoverContent } from '@grafana/ui';
 
-import { checkLogsError, escapeUnescapedString } from '../utils';
+import { checkLogsError, escapeUnescapedString, checkLogsSampled } from '../utils';
 
 import { LogDetails } from './LogDetails';
 import { LogLabels } from './LogLabels';
@@ -222,6 +222,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
     const { showDetails, showingContext, permalinked } = this.state;
     const levelStyles = getLogLevelStyles(theme, row.logLevel);
     const { errorMessage, hasError } = checkLogsError(row);
+    const { sampleMessage, isSampled } = checkLogsSampled(row);
     const logRowBackground = cx(styles.logsRow, {
       [styles.errorLogRow]: hasError,
       [styles.highlightBackground]: showingContext || permalinked,
@@ -255,11 +256,16 @@ class UnThemedLogRow extends PureComponent<Props, State> {
             </td>
           )}
           <td
-            className={hasError ? styles.logsRowWithError : `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}`}
+            className={hasError || isSampled ? styles.logsRowWithError : `${levelStyles.logsRowLevelColor} ${styles.logsRowLevel}`}
           >
             {hasError && (
               <Tooltip content={`Error: ${errorMessage}`} placement="right" theme="error">
                 <Icon className={styles.logIconError} name="exclamation-triangle" size="xs" />
+              </Tooltip>
+            )}
+            {isSampled && (
+              <Tooltip content={`${sampleMessage}`} placement="right" theme="info">
+                <Icon className={styles.logIconInfo} name="info-circle" size="xs" />
               </Tooltip>
             )}
           </td>

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -120,9 +120,11 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
     logIconError: css`
       color: ${theme.colors.warning.main};
     `,
-    logIconInfo: css`
-      color: ${theme.colors.info.main};
-    `,
+    logIconInfo: css({
+      color: theme.colors.info.main,
+      position: 'relative',
+      top: '-2px',
+    }),
     logsRowToggleDetails: css`
       label: logs-row-toggle-details__level;
       font-size: 9px;

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -117,9 +117,11 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
       width: 4em;
       cursor: default;
     `,
-    logIconError: css`
-      color: ${theme.colors.warning.main};
-    `,
+    logIconError: css({
+      color: theme.colors.warning.main,
+      position: 'relative',
+      top: '-2px',
+    }),
     logIconInfo: css({
       color: theme.colors.info.main,
       position: 'relative',

--- a/public/app/features/logs/components/getLogRowStyles.ts
+++ b/public/app/features/logs/components/getLogRowStyles.ts
@@ -120,6 +120,9 @@ export const getLogRowStyles = memoizeOne((theme: GrafanaTheme2) => {
     logIconError: css`
       color: ${theme.colors.warning.main};
     `,
+    logIconInfo: css`
+      color: ${theme.colors.info.main};
+    `,
     logsRowToggleDetails: css`
       label: logs-row-toggle-details__level;
       font-size: 9px;

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -156,7 +156,10 @@ export const checkLogsError = (logRow: LogRowModel): { hasError: boolean; errorM
 
 export const checkLogsSampled = (logRow: LogRowModel): { isSampled: boolean; sampleMessage?: string } => {
   if (logRow.labels.__adaptive_logs_sampled__) {
-    let msg = logRow.labels.__adaptive_logs_sampled__ === 'true' ? 'Logs like this one have been dropped by Adaptive Logs' :  `${logRow.labels.__adaptive_logs_sampled__}% of logs like this one have been dropped by Adaptive Logs`;
+    let msg =
+      logRow.labels.__adaptive_logs_sampled__ === 'true'
+        ? 'Logs like this one have been dropped by Adaptive Logs'
+        : `${logRow.labels.__adaptive_logs_sampled__}% of logs like this one have been dropped by Adaptive Logs`;
     return {
       isSampled: true,
       sampleMessage: msg,

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -154,6 +154,19 @@ export const checkLogsError = (logRow: LogRowModel): { hasError: boolean; errorM
   };
 };
 
+export const checkLogsSampled = (logRow: LogRowModel): { isSampled: boolean; sampleMessage?: string } => {
+  if (logRow.labels.__adaptive_logs_sampled__) {
+    let msg = logRow.labels.__adaptive_logs_sampled__ === 'true' ? 'Logs like this one have been dropped by Adaptive Logs' :  `${logRow.labels.__adaptive_logs_sampled__}% of logs like this one have been dropped by Adaptive Logs`;
+    return {
+      isSampled: true,
+      sampleMessage: msg,
+    };
+  }
+  return {
+    isSampled: false,
+  };
+};
+
 export const escapeUnescapedString = (string: string) =>
   string.replace(/\\r\\n|\\n|\\t|\\r/g, (match: string) => (match.slice(1) === 't' ? '\t' : '\n'));
 


### PR DESCRIPTION
This PR adds additional context to log lines that have been sampled by Adaptive Logs. This is necessary to help users understand why they may be seeing gaps in their log