### PR TITLE
Chore: Regenerate OpenAPI specs to fix swagger

### DIFF
--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -19970,6 +19970,7 @@
       }
     },
     "State": {
+      "description": "+enum",
       "type": "string"
     },
     "Status": {
@@ -20729,6 +20730,7 @@
       }
     },
     "Type": {
+      "description": "+enum",
       "type": "string"
     },
     "TypeMeta": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -10349,6 +10349,7 @@
         "type": "object"
       },
       "State": {
+        "description": "+enum",
         "type": "string"
       },
       "Status": {
@@ -11108,6 +11109,7 @@
         "type": "array"
       },
       "Type": {
+        "description": "+enum",
         "type": "string"
       },
       "TypeMeta": {


### PR DESCRIPTION
Fix [main build Swagger](https://drone.grafana.net/grafana/grafana/183319/4/3) issue:
```
SWAGGER_GENERATE_EXTENSION=false /go/bin/swagger-db51e79a0e37c572d8b59ae0c58bf2bbbbe53285 generate spec -q -m -w pkg/server -o public/api-spec.json \
-x "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions" \
-x "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options" \
-x "github.com/prometheus/alertmanager" \
-i pkg/api/swagger_tags.json \
--exclude-tag=alpha \
--exclude-tag=enterprise
re-generating swagger for enterprise
rm -f public/api-enterprise-spec.json
SWAGGER_GENERATE_EXTENSION=false /go/bin/swagger-db51e79a0e37c572d8b59ae0c58bf2bbbbe53285 generate spec -q -m -w pkg/server -o public/api-enterprise-spec.json \
-x "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions" \
-x "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options" \
-x "github.com/prometheus/alertmanager" \
-i pkg/api/swagger_tags.json \
--exclude-tag=alpha \
--include-tag=enterprise
# known conflicts DsPermissionType, AddApiKeyCommand, Json, Duration (identical models referenced by both specs)
/go/bin/swagger-db51e79a0e37c572d8b59ae0c58bf2bbbbe53285 mixin -q public/api-spec.json public/api-enterprise-spec.json pkg/services/ngalert/api/tooling/api.json --ignore-conflicts -o public/api-merged.json
/go/bin/swagger-db51e79a0e37c572d8b59ae0c58bf2bbbbe53285 validate --skip-warnings public/api-merged.json
2024/06/18 09:03:11 
The swagger spec at "public/api-merged.json" is valid against swagger specification 2.0
2024/06/18 09:03:11 
The swagger spec at "public/api-merged.json" showed up some valid but possibly unwanted constructs.
go run  scripts/openapi3/openapi3conv.go public/api-merged.json public/openapi3.json
Reading swagger 2 file public/api-merged.json
OpenAPI specs generated in file public/openapi3.json
+ for f in public/api-merged.json public/openapi3.json; do git add $f; done
+ if [ -z "$(git diff --name-only --cached)" ]; then echo "Everything seems up to date!"; else git diff --cached && echo "Please ensure the branch is up-to-date, then regenerate the specification by running make swagger-clean && make openapi3-gen" && return 1; fi
diff --git a/public/api-merged.json b/public/api-merged.json
index a0d78eb6f2..26cf2ef201 100644
--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -19970,6 +19970,7 @@
       }
     },
     "State": {
+      "description": "+enum",
       "type": "string"
     },
     "Status": {
@@ -20729,6 +20730,7 @@
       }
     },
     "Type": {
+      "description": "+enum",
       "type": "string"
     },
     "TypeMeta": {
diff --git a/public/openapi3.json b/public/openapi3.json
index 9e9ccbc7ef..a00082e3de 100644
--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -10349,6 +10349,7 @@
         "type": "object"
       },
       "State": {
+        "description": "+enum",
         "type": "string"
       },
       "Status": {
@@ -11108,6 +11109,7 @@
         "type": "array"
       },
       "Type": {
+        "description": "+enum",
         "type": "string"
       },
       "TypeMeta": {
Please ensure the branch is up-to-date, then regenerate the specification by running make swagger-clean && make openapi3-gen
```