### PR TITLE
Prometheus: Don't use match[] parameter if there is no metric

### DIFF
--- a/packages/grafana-prometheus/src/language_provider.test.ts
+++ b/packages/grafana-prometheus/src/language_provider.test.ts
@@ -505,6 +505,20 @@ describe('Language completion provider', () => {
           )
         );
       });
+
+      it('should dont send match[] parameter if there is no metric', async () => {
+        const mockQueries: PromQuery[] = [
+          {
+            refId: 'A',
+            expr: '',
+          },
+        ];
+        const fetchLabel = languageProvider.fetchLabels;
+        const requestSpy = jest.spyOn(languageProvider, 'request');
+        await fetchLabel(tr, mockQueries);
+        expect(requestSpy).toHaveBeenCalled();
+        expect(requestSpy.mock.calls[0][0].indexOf('match[]')).toEqual(-1);
+      });
     });
   });
 

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -219,11 +219,13 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const searchParams = new URLSearchParams({ ...timeParams });
     queries?.forEach((q) => {
       const visualQuery = buildVisualQueryFromString(q.expr);
-      searchParams.append('match[]', visualQuery.query.metric);
-      if (visualQuery.query.binaryQueries) {
-        visualQuery.query.binaryQueries.forEach((bq) => {
-          searchParams.append('match[]', bq.query.metric);
-        });
+      if (visualQuery.query.metric !== '') {
+        searchParams.append('match[]', visualQuery.query.metric);
+        if (visualQuery.query.binaryQueries) {
+          visualQuery.query.binaryQueries.forEach((bq) => {
+            searchParams.append('match[]', bq.query.metric);
+          });
+        }
       }
     });
 


### PR DESCRIPTION
**What is this feature?**

With [the PR](https://github.com/grafana/grafana/pull/85674) we changed how we load the ad-hoc labels. With that PR we only load the labels that we can apply to the metric we have. But this also introduced a small bug. If there is no metric and we want to see the labels we got nothing back. In this PR we are fixing that. 

**Why do we need this feature?**

Better ad-hoc variable support

**Who is this feature for?**

Prometheus users

