### PR TITLE
Alerting: Do not check evaluation interval for external rulers

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -338,7 +338,8 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
               </Stack>
             </Field>
 
-            {checkEvaluationIntervalGlobalLimit(watch('groupInterval')).exceedsLimit && (
+            {/* if we're dealing with a Grafana-managed group, check if the evaluation interval is valid / permitted */}
+            {isGrafanaManagedGroup && checkEvaluationIntervalGlobalLimit(watch('groupInterval')).exceedsLimit && (
               <EvaluationIntervalLimitExceeded />
             )}
 

--- a/public/app/features/alerting/unified/components/rules/RuleConfigStatus.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleConfigStatus.tsx
@@ -7,6 +7,7 @@ import { Icon, Tooltip, useStyles2 } from '@grafana/ui/src';
 
 import { CombinedRule } from '../../../../../types/unified-alerting';
 import { checkEvaluationIntervalGlobalLimit } from '../../utils/config';
+import { isGrafanaRulerRule } from '../../utils/rules';
 
 interface RuleConfigStatusProps {
   rule: CombinedRule;
@@ -14,11 +15,11 @@ interface RuleConfigStatusProps {
 
 export function RuleConfigStatus({ rule }: RuleConfigStatusProps) {
   const styles = useStyles2(getStyles);
+  const isGrafanaManagedRule = isGrafanaRulerRule(rule.rulerRule);
 
-  const { exceedsLimit } = useMemo(
-    () => checkEvaluationIntervalGlobalLimit(rule.group.interval),
-    [rule.group.interval]
-  );
+  const exceedsLimit = useMemo(() => {
+    return isGrafanaManagedRule ? checkEvaluationIntervalGlobalLimit(rule.group.interval).exceedsLimit : false;
+  }, [rule.group.interval, isGrafanaManagedRule]);
 
   if (!exceedsLimit) {
     return null;


### PR DESCRIPTION
**What is this feature?**

This PR will skip the check for evaluation interval when editing a rule group managed by an external ruler.