### PR TITLE
Backend: Add CoreApp to query header

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -84,6 +84,7 @@ enum PluginRequestHeaders {
   QueryGroupID = 'X-Query-Group-Id', // mainly useful to find related queries with query splitting
   FromExpression = 'X-Grafana-From-Expr', // used by datasources to identify expression queries
   SkipQueryCache = 'X-Cache-Skip', // used by datasources to skip the query cache
+  OriginApp = 'X-Origin-App', // what application run the query
 }
 
 /**
@@ -243,6 +244,9 @@ class DataSourceWithBackend<
     }
     if (request.skipQueryCache) {
       headers[PluginRequestHeaders.SkipQueryCache] = 'true';
+    }
+    if (request.app) {
+      headers[PluginRequestHeaders.OriginApp] = `${request.app}`;
     }
     return getBackendSrv()
       .fetch<BackendDataSourceResponse>({

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -84,7 +84,7 @@ enum PluginRequestHeaders {
   QueryGroupID = 'X-Query-Group-Id', // mainly useful to find related queries with query splitting
   FromExpression = 'X-Grafana-From-Expr', // used by datasources to identify expression queries
   SkipQueryCache = 'X-Cache-Skip', // used by datasources to skip the query cache
-  OriginApp = 'X-Origin-App', // what application run the query
+  RequestOrigin = 'X-Request-Origin', // what application run the query
 }
 
 /**
@@ -246,7 +246,7 @@ class DataSourceWithBackend<
       headers[PluginRequestHeaders.SkipQueryCache] = 'true';
     }
     if (request.app) {
-      headers[PluginRequestHeaders.OriginApp] = `${request.app}`;
+      headers[PluginRequestHeaders.RequestOrigin] = `${request.app}`;
     }
     return getBackendSrv()
       .fetch<BackendDataSourceResponse>({

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -36,7 +36,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		return
 	}
 
-	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId}
+	var headersList = []string{query.HeaderQueryGroupID, query.HeaderPanelID, query.HeaderDashboardUID, query.HeaderDatasourceUID, query.HeaderFromExpression, `X-Grafana-Org-Id`, query.HeaderPanelPluginId, query.HeaderRequestOrigin}
 
 	for _, headerName := range headersList {
 		gotVal := reqCtx.Req.Header.Get(headerName)

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -35,6 +35,7 @@ const (
 	HeaderPanelPluginId  = "X-Panel-Plugin-Id"
 	HeaderQueryGroupID   = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
 	HeaderFromExpression = "X-Grafana-From-Expr" // used by datasources to identify expression queries
+	HeaderRequestOrigin  = "X-Request-Origin" // used for debugging source of slow queries 
 )
 
 func ProvideService(

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -35,7 +35,7 @@ const (
 	HeaderPanelPluginId  = "X-Panel-Plugin-Id"
 	HeaderQueryGroupID   = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
 	HeaderFromExpression = "X-Grafana-From-Expr" // used by datasources to identify expression queries
-	HeaderRequestOrigin  = "X-Request-Origin" // used for debugging source of slow queries 
+	HeaderRequestOrigin  = "X-Request-Origin"    // used for debugging source of slow queries
 )
 
 func ProvideService(


### PR DESCRIPTION
**What is this feature?**
When a query is ran, certain logging features would benefit from knowing the source of the query being ran in Grafana. This attaches the Grafana `CoreApp` label to a header when the query is ran. 

Available CoreApps are listed here https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/app.ts#L17 

Fixes #89317

**Special notes for your reviewer:**

This code was written by @ifrost https://github.com/grafana/grafana/issues/89317#issuecomment-2175468889

Tested that queries from the dashboard, panel-edit, and Explore have the available header. 

I could not see this being done with Alerting rules, so some more work may be required to be sure the CoreApp is being attached to those requests, if they are being sent in a different way.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
