### PR TITLE
[v11.1.x] DashboardScene: Make Grafana usable when custom home dashboard is invalid

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -18,7 +18,9 @@ export interface Props extends GrafanaRouteComponentProps<DashboardPageRoutePara
 
 export function DashboardScenePage({ match, route, queryParams, history }: Props) {
   const stateManager = getDashboardScenePageStateManager();
+
   const { dashboard, isLoading, loadError } = stateManager.useState();
+
   // After scene migration is complete and we get rid of old dashboard we should refactor dashboardWatcher so this route reload is not need
   const routeReloadCounter = (history.location.state as any)?.routeReloadCounter;
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -36,21 +36,9 @@ describe('DashboardScenePageStateManager', () => {
       const loader = new DashboardScenePageStateManager({});
       await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
 
-      expect(loader.state.dashboard).toBeUndefined();
+      expect(loader.state.dashboard).toBeDefined();
       expect(loader.state.isLoading).toBe(false);
-      expect(loader.state.loadError).toBe('Error: Dashboard not found');
-    });
-
-    it('should handle home dashboard redirect', async () => {
-      setBackendSrv({
-        get: () => Promise.resolve({ redirectUri: '/d/asd' }),
-      } as unknown as BackendSrv);
-
-      const loader = new DashboardScenePageStateManager({});
-      await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
-
-      expect(loader.state.dashboard).toBeUndefined();
-      expect(loader.state.loadError).toBeUndefined();
+      expect(loader.state.loadError).toBe('Dashboard not found');
     });
 
     it('shoud fetch dashboard from local storage and remove it after if it exists', async () => {
@@ -128,6 +116,36 @@ describe('DashboardScenePageStateManager', () => {
 
       expect(dash!.state.$timeRange?.state.from).toEqual('now-6h');
     });
+
+    describe('Home dashboard', () => {
+      it('should handle home dashboard redirect', async () => {
+        setBackendSrv({
+          get: () => Promise.resolve({ redirectUri: '/d/asd' }),
+        } as unknown as BackendSrv);
+
+        const loader = new DashboardScenePageStateManager({});
+        await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
+
+        expect(loader.state.dashboard).toBeUndefined();
+        expect(loader.state.loadError).toBeUndefined();
+      });
+
+      it('should handle invalid home dashboard request', async () => {
+        setBackendSrv({
+          get: () =>
+            Promise.reject({
+              status: 500,
+              data: { message: 'Failed to load home dashboard' },
+            }),
+        } as unknown as BackendSrv);
+
+        const loader = new DashboardScenePageStateManager({});
+        await loader.loadDashboard({ uid: '', route: DashboardRoutes.Home });
+
+        expect(loader.state.dashboard).toBeDefined();
+        expect(loader.state.dashboard?.state.title).toEqual('Failed to load home dashboard');
+        expect(loader.state.loadError).toEqual('Failed to load home dashboard');
+      });
 
     describe('New dashboards', () => {
       it('Should have new empty model with meta.isNew and should not be cached', async () => {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -146,6 +146,7 @@ describe('DashboardScenePageStateManager', () => {
         expect(loader.state.dashboard?.state.title).toEqual('Failed to load home dashboard');
         expect(loader.state.loadError).toEqual('Failed to load home dashboard');
       });
+    });
 
     describe('New dashboards', () => {
       it('Should have new empty model with meta.isNew and should not be cached', async () => {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,10 +1,13 @@
 import { locationUtil } from '@grafana/data';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
+import { defaultDashboard } from '@grafana/schema';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { default as localStorageStore } from 'app/core/store';
+import { getMessageFromError } from 'app/core/utils/errors';
 import { startMeasure, stopMeasure } from 'app/core/utils/metrics';
 import { dashboardLoaderSrv } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { DashboardModel } from 'app/features/dashboard/state';
 import { emitDashboardViewEvent } from 'app/features/dashboard/state/analyticsProcessor';
 import {
   DASHBOARD_FROM_LS_KEY,
@@ -16,7 +19,10 @@ import { DashboardDTO, DashboardRoutes } from 'app/types';
 import { PanelEditor } from '../panel-edit/PanelEditor';
 import { DashboardScene } from '../scene/DashboardScene';
 import { buildNewDashboardSaveModel } from '../serialization/buildNewDashboardSaveModel';
-import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+import {
+  createDashboardSceneFromDashboardModel,
+  transformSaveModelToScene,
+} from '../serialization/transformSaveModelToScene';
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
 import { updateNavModel } from './utils';
@@ -143,7 +149,6 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
         return null;
       }
 
-      console.error(e);
       throw e;
     }
 
@@ -200,7 +205,12 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
         });
       }
     } catch (err) {
-      this.setState({ isLoading: false, loadError: String(err) });
+      const msg = getMessageFromError(err);
+      this.setState({
+        isLoading: false,
+        loadError: msg,
+        dashboard: getErrorScene(msg),
+      });
     }
   }
 
@@ -285,4 +295,43 @@ export function getDashboardScenePageStateManager(): DashboardScenePageStateMana
   }
 
   return stateManager;
+}
+
+function getErrorScene(msg: string) {
+  return createDashboardSceneFromDashboardModel(
+    new DashboardModel(
+      {
+        ...defaultDashboard,
+        title: msg,
+        panels: [
+          {
+            fieldConfig: {
+              defaults: {},
+              overrides: [],
+            },
+            gridPos: {
+              h: 6,
+              w: 12,
+              x: 7,
+              y: 0,
+            },
+            id: 1,
+            options: {
+              code: {
+                language: 'plaintext',
+                showLineNumbers: false,
+                showMiniMap: false,
+              },
+              content: `<br/><br/><center><h1>${msg}</h1></center>`,
+              mode: 'html',
+            },
+            title: '',
+            transparent: true,
+            type: 'text',
+          },
+        ],
+      },
+      { canSave: false, canEdit: false }
+    )
+  );
 }


### PR DESCRIPTION
Backport ae04580e5f16335b5867252a18bc33c3ccbb95f4 from #89305

---

This makes sure grafana is usable when provided custom home dashboard is invalid.

Fixes https://github.com/grafana/grafana/issues/89112


View in the old arch:

<img width="1682" alt="image" src="https://github.com/grafana/grafana/assets/2376619/0b8fbf4f-8169-462f-ae3c-e9e2d214a0d3">


View in the new arch:

<img width="1679" alt="image" src="https://github.com/grafana/grafana/assets/2376619/72dc0560-1d4c-42e3-a40b-dc25e9540e7f">
