### PR TITLE
Alerting: Limit instances on alert detail view unless in instances tab

### DIFF
--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -8,7 +8,7 @@ import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { AlertRuleProvider } from './components/rule-viewer/RuleContext';
-import DetailView from './components/rule-viewer/RuleViewer';
+import DetailView, { ActiveTab, useActiveTab } from './components/rule-viewer/RuleViewer';
 import { useCombinedRule } from './hooks/useCombinedRule';
 import { stringifyErrorLike } from './utils/misc';
 import { getRuleIdFromPathname, parse as parseRuleId } from './utils/rule-id';
@@ -21,6 +21,11 @@ type RuleViewerProps = GrafanaRouteComponentProps<{
 const RuleViewer = (props: RuleViewerProps): JSX.Element => {
   const id = getRuleIdFromPathname(props.match.params);
 
+  // we'll use this to fetch all instances only when on the "instances" tab
+  const [activeTab] = useActiveTab();
+  const instancesTab = activeTab === ActiveTab.Instances;
+  const limitAlerts = instancesTab ? undefined : 0;
+
   // we convert the stringified ID to a rule identifier object which contains additional
   // type and source information
   const identifier = React.useMemo(() => {
@@ -32,7 +37,7 @@ const RuleViewer = (props: RuleViewerProps): JSX.Element => {
   }, [id]);
 
   // we then fetch the rule from the correct API endpoint(s)
-  const { loading, error, result: rule } = useCombinedRule({ ruleIdentifier: identifier });
+  const { loading, error, result: rule } = useCombinedRule({ ruleIdentifier: identifier, limitAlerts });
 
   if (error) {
     return (

--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -21,10 +21,12 @@ type RuleViewerProps = GrafanaRouteComponentProps<{
 const RuleViewer = (props: RuleViewerProps): JSX.Element => {
   const id = getRuleIdFromPathname(props.match.params);
 
-  // we'll use this to fetch all instances only when on the "instances" tab
   const [activeTab] = useActiveTab();
   const instancesTab = activeTab === ActiveTab.Instances;
-  const limitAlerts = instancesTab ? undefined : 0;
+
+  // We will fetch no instances by default to speed up loading times and reduce memory footprint _unless_ we are visiting
+  // the "instances" tab. This optimization is only available for the Grafana-managed ruler.
+  const limitAlerts = instancesTab ? undefined : 0; // "0" means "do not include alert rule instances in the response"
 
   // we convert the stringified ID to a rule identifier object which contains additional
   // type and source information

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -171,10 +171,15 @@ interface RequestState<T> {
   error?: unknown;
 }
 
+interface Props {
+  ruleIdentifier: RuleIdentifier;
+  limitAlerts?: number;
+}
+
 // Many places still use the old way of fetching code so synchronizing cache expiration is difficult
 // Hence, this hook fetches a fresh version of a rule most of the time
 // Due to enabled filtering for Prometheus and Ruler rules it shouldn't be a problem
-export function useCombinedRule({ ruleIdentifier }: { ruleIdentifier: RuleIdentifier }): RequestState<CombinedRule> {
+export function useCombinedRule({ ruleIdentifier, limitAlerts }: Props): RequestState<CombinedRule> {
   const { ruleSourceName } = ruleIdentifier;
   const ruleSource = getRulesSourceFromIdentifier(ruleIdentifier);
 
@@ -195,6 +200,7 @@ export function useCombinedRule({ ruleIdentifier }: { ruleIdentifier: RuleIdenti
       namespace: ruleLocation?.namespace,
       groupName: ruleLocation?.group,
       ruleName: ruleLocation?.ruleName,
+      limitAlerts,
     },
     {
       skip: !ruleLocation || isLoadingRuleLocation,


### PR DESCRIPTION
**What is this feature?**

This PR will limit the number of instances we fetch on the alert detail view _unless_ we are viewing the "instances" tab.

**Why do we need this feature?**

This is mostly for users with 10.000+ instances across their alert rules.

**Which issue(s) does this PR fix?**:

Fixes #89040

**Special notes for your reviewer:**

I'm not too happy with how we're doing the data fetching in this component, ideally the fetching logic should be part of the `RuleContext` so child components can choose to refetch with different options without the parent having to track what tab is being displayed.