### PR TITLE
LogRows: add missing call to close the popover

### DIFF
--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -147,6 +147,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
     if (document.getSelection()?.toString()) {
       return;
     }
+    this.closePopoverMenu();
   };
 
   closePopoverMenu = () => {


### PR DESCRIPTION
Found in https://github.com/grafana/explore-logs/pull/460#pullrequestreview-2125611884

If the click came from within the log rows container but there was no selection, then we needed to close the menu (missing call). This dates back to the original implementation ‼️ 

Before:

https://github.com/grafana/grafana/assets/1069378/11385cac-dd48-42be-84ed-025b79671819

After:

https://github.com/grafana/grafana/assets/1069378/b175f41d-8cff-45a3-964e-880c9bcc402a

Note: there's still a bug where, if you click the selected text, the menu will appear with empty content, which I haven't found a simple way to fix.