### PR TITLE
Chore: Bump ws

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -30966,8 +30966,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.16.0, ws@npm:^8.2.3, ws@npm:^8.9.0":
-  version: 8.16.0
-  resolution: "ws@npm:8.16.0"
+  version: 8.17.1
+  resolution: "ws@npm:8.17.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -30976,7 +30976,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/7c511c59e979bd37b63c3aea4a8e4d4163204f00bd5633c053b05ed67835481995f61a523b0ad2b603566f9a89b34cb4965cb9fab9649fbfebd8f740cea57f17
+  checksum: 10/4264ae92c0b3e59c7e309001e93079b26937aab181835fb7af79f906b22cd33b6196d96556dafb4e985742dd401e99139572242e9847661fdbc96556b9e6902d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps to resolve https://github.com/grafana/grafana/security/dependabot/233

This is non-exploitable as we don't use `ws` in production code.

```
$ yarn why ws
├─ @storybook/core-server@npm:8.1.6
│  └─ ws@npm:8.16.0 [13e34] (via npm:^8.2.3 [13e34])
│
├─ chrome-remote-interface@npm:0.33.0
│  └─ ws@npm:7.5.10 [b7689] (via npm:^7.2.0 [b7689])
│
├─ jsdom@npm:20.0.2
│  └─ ws@npm:8.16.0 (via npm:^8.9.0)
│
├─ jsdom@npm:20.0.2 [28905]
│  └─ ws@npm:8.16.0 [13e34] (via npm:^8.2.3 [13e34])
│
├─ webpack-bundle-analyzer@npm:4.10.2
│  └─ ws@npm:7.5.10 [b7689] (via npm:^7.2.0 [b7689])
│
├─ webpack-dev-server@npm:5.0.4
│  └─ ws@npm:8.16.0 (via npm:^8.16.0)
│
└─ webpack-dev-server@npm:5.0.4 [655a6]
   └─ ws@npm:8.16.0 [13e34] (via npm:^8.2.3 [13e34])
```