### PR TITLE
Chore: Remove deprecated Layout components

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -447,9 +447,6 @@ exports[`better eslint`] = {
     "packages/grafana-prometheus/src/components/PromQueryField.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "packages/grafana-prometheus/src/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
@@ -6430,8 +6427,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
     "public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "Styles should be written using objects.", "1"]
+      [0, 0, 0, "Styles should be written using objects.", "0"]
     ],
     "public/app/plugins/datasource/graphite/components/GraphiteQueryEditor.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
@@ -6570,9 +6566,6 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"],
       [0, 0, 0, "Styles should be written using objects.", "1"]
-    ],
-    "public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx:5381": [
       [0, 0, 0, "Styles should be written using objects.", "0"]

--- a/packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
+++ b/packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
@@ -8,7 +8,8 @@ import { selectors } from '@grafana/e2e-selectors';
 import {
   BrowserLabel as PromLabel,
   Button,
-  HorizontalGroup,
+  // HorizontalGroup,
+  Stack,
   Input,
   Label,
   LoadingPlaceholder,
@@ -488,7 +489,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
 
     return (
       <div className={styles.wrapper}>
-        <HorizontalGroup align="flex-start" spacing="lg">
+        <Stack gap={3}>
           <div>
             <div className={styles.section}>
               <Label description="Once a metric is selected only possible labels are shown.">1. Select a metric</Label>
@@ -631,7 +632,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
               </div>
             </div>
           </div>
-        </HorizontalGroup>
+        </Stack>
 
         <div className={styles.section}>
           <Label>4. Resulting selector</Label>
@@ -639,7 +640,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
             {selector}
           </div>
           {validationStatus && <div className={styles.validationStatus}>{validationStatus}</div>}
-          <HorizontalGroup>
+          <Stack>
             <Button
               data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.useQuery}
               aria-label="Use selector for query button"
@@ -677,7 +678,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
             <div className={cx(styles.status, (status || error) && styles.statusShowing)}>
               <span className={error ? styles.error : ''}>{error || status}</span>
             </div>
-          </HorizontalGroup>
+          </Stack>
         </div>
       </div>
     );

--- a/packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
+++ b/packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
@@ -409,7 +409,8 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       this.updateLabelState(name, { values, loading: false });
     } catch (error) {
       console.error(error);
-    }Stack
+    }
+  }
 
   async fetchSeries(selector: string, lastFacetted?: string) {
     const { languageProvider } = this.props;

--- a/packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
+++ b/packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
@@ -8,7 +8,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import {
   BrowserLabel as PromLabel,
   Button,
-  // HorizontalGroup,
   Stack,
   Input,
   Label,
@@ -410,8 +409,7 @@ export class UnthemedPrometheusMetricsBrowser extends React.Component<BrowserPro
       this.updateLabelState(name, { values, loading: false });
     } catch (error) {
       console.error(error);
-    }
-  }
+    }Stack
 
   async fetchSeries(selector: string, lastFacetted?: string) {
     const { languageProvider } = this.props;

--- a/public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import React, { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { HorizontalGroup, InlineLabel, useStyles2 } from '@grafana/ui';
+import { Stack, InlineLabel, useStyles2 } from '@grafana/ui';
 
 import { FuncInstance } from '../gfunc';
 import { actions } from '../state/actions';
@@ -42,7 +42,7 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
       onMouseOver={() => setIsMouseOver(true)}
       onMouseOut={() => setIsMouseOver(false)}
     >
-      <HorizontalGroup spacing="none">
+      <Stack gap={0} alignItems={"baseline"}>
         <FunctionEditor
           func={func}
           onMoveLeft={() => {
@@ -55,7 +55,7 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
             dispatch(actions.removeFunction({ func }));
           }}
         />
-        <InlineLabel className={styles.label}>(</InlineLabel>
+        <InlineLabel className={styles.label} width={"auto"}>(</InlineLabel>
         {params.map((editableParam: EditableParam, index: number) => {
           return (
             <React.Fragment key={index}>
@@ -75,8 +75,8 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
             </React.Fragment>
           );
         })}
-        <InlineLabel className={styles.label}>)</InlineLabel>
-      </HorizontalGroup>
+        <InlineLabel className={styles.label} width={"auto"}>)</InlineLabel>
+      </Stack>
     </div>
   );
 }

--- a/public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
@@ -42,7 +42,7 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
       onMouseOver={() => setIsMouseOver(true)}
       onMouseOut={() => setIsMouseOver(false)}
     >
-      <Stack gap={0} alignItems={"baseline"}>
+      <Stack gap={0} alignItems={'baseline'}>
         <FunctionEditor
           func={func}
           onMoveLeft={() => {
@@ -55,7 +55,9 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
             dispatch(actions.removeFunction({ func }));
           }}
         />
-        <InlineLabel className={styles.label} width={"auto"}>(</InlineLabel>
+        <InlineLabel className={styles.label} width={'auto'}>
+          (
+        </InlineLabel>
         {params.map((editableParam: EditableParam, index: number) => {
           return (
             <React.Fragment key={index}>
@@ -75,7 +77,9 @@ export function GraphiteFunctionEditor({ func }: FunctionEditorProps) {
             </React.Fragment>
           );
         })}
-        <InlineLabel className={styles.label} width={"auto"}>)</InlineLabel>
+        <InlineLabel className={styles.label} width={'auto'}>
+          )
+        </InlineLabel>
       </Stack>
     </div>
   );

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -34,7 +34,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
   };
 
   return (
-    <Stack direction={"column"}>
+    <Stack direction={'column'}>
       <TextArea
         aria-label="query"
         rows={3}

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useId } from 'react';
 
-import { HorizontalGroup, InlineFormLabel, Input, Select, TextArea } from '@grafana/ui';
+import { Stack, InlineFormLabel, Input, Select, TextArea } from '@grafana/ui';
 
 import { InfluxQuery } from '../../../../../types';
 import { DEFAULT_RESULT_FORMAT, RESULT_FORMATS } from '../../../constants';
@@ -46,7 +46,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
         }}
         value={currentQuery ?? ''}
       />
-      <HorizontalGroup>
+      <Stack>
         <InlineFormLabel htmlFor={selectElementId}>Format as</InlineFormLabel>
         <Select
           inputId={selectElementId}
@@ -69,7 +69,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
           }}
           value={currentAlias ?? ''}
         />
-      </HorizontalGroup>
+      </Stack>
     </div>
   );
 };

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -34,7 +34,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
   };
 
   return (
-    <div>
+    <Stack direction={"column"}>
       <TextArea
         aria-label="query"
         rows={3}
@@ -72,6 +72,6 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
           />
         </InlineField>
       </Stack>
-    </div>
+    </Stack>
   );
 };

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -47,7 +47,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
         value={currentQuery ?? ''}
       />
       <Stack>
-        <InlineField htmlFor={selectElementId} label="Format as">
+        <InlineField htmlFor={aliasElementId} label="Format as">
           <Select
             inputId={selectElementId}
             onChange={(v) => {
@@ -58,7 +58,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
             options={RESULT_FORMATS}
           />
         </InlineField>
-        <InlineField htmlFor={selectElementId} label="Alias by">
+        <InlineField htmlFor={aliasElementId} label="Alias by">
           <Input
             id={aliasElementId}
             type="text"

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -47,7 +47,7 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
         value={currentQuery ?? ''}
       />
       <Stack>
-        <InlineField htmlFor={aliasElementId} label="Format as">
+        <InlineField htmlFor={selectElementId} label="Format as">
           <Select
             inputId={selectElementId}
             onChange={(v) => {

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useId } from 'react';
 
-import { Stack, InlineFormLabel, Input, Select, TextArea } from '@grafana/ui';
+import { Stack, InlineField, Input, Select, TextArea } from '@grafana/ui';
 
 import { InfluxQuery } from '../../../../../types';
 import { DEFAULT_RESULT_FORMAT, RESULT_FORMATS } from '../../../constants';
@@ -47,28 +47,30 @@ export const RawInfluxQLEditor = ({ query, onChange, onRunQuery }: Props): JSX.E
         value={currentQuery ?? ''}
       />
       <Stack>
-        <InlineFormLabel htmlFor={selectElementId}>Format as</InlineFormLabel>
-        <Select
-          inputId={selectElementId}
-          onChange={(v) => {
-            onChange({ ...query, resultFormat: v.value });
-            onRunQuery();
-          }}
-          value={resultFormat}
-          options={RESULT_FORMATS}
-        />
-        <InlineFormLabel htmlFor={aliasElementId}>Alias by</InlineFormLabel>
-        <Input
-          id={aliasElementId}
-          type="text"
-          spellCheck={false}
-          placeholder="Naming pattern"
-          onBlur={applyDelayedChangesAndRunQuery}
-          onChange={(e) => {
-            setCurrentAlias(e.currentTarget.value);
-          }}
-          value={currentAlias ?? ''}
-        />
+        <InlineField htmlFor={selectElementId} label="Format as">
+          <Select
+            inputId={selectElementId}
+            onChange={(v) => {
+              onChange({ ...query, resultFormat: v.value });
+              onRunQuery();
+            }}
+            value={resultFormat}
+            options={RESULT_FORMATS}
+          />
+        </InlineField>
+        <InlineField htmlFor={selectElementId} label="Alias by">
+          <Input
+            id={aliasElementId}
+            type="text"
+            spellCheck={false}
+            placeholder="Naming pattern"
+            onBlur={applyDelayedChangesAndRunQuery}
+            onChange={(e) => {
+              setCurrentAlias(e.currentTarget.value);
+            }}
+            value={currentAlias ?? ''}
+          />
+        </InlineField>
       </Stack>
     </div>
   );


### PR DESCRIPTION
**What is this feature?**

This change removes usage of deprecated components `HorizontalGroup` and `VericalGroup` in `Layout.tsx` and instead use `Stack`

**Why do we need this feature?**

To remove the usage of deprecated components

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

Fixes #86872

**Changes done**: 

Made the change in:
- [x]  packages/grafana-prometheus/src/components/PrometheusMetricsBrowser.tsx
  - Before the change 
  ![image](https://github.com/grafana/grafana/assets/36930204/4eb9bd18-f392-4fb8-b96d-703f9ca4b74a)
  - After the change
  ![image](https://github.com/grafana/grafana/assets/36930204/dc66bb38-19b5-4b60-b5d2-b60368c03106)
- [x] public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
  - Before the change
  ![image](https://github.com/grafana/grafana/assets/36930204/05a531f8-7265-4018-bbb7-6c24e97fb39c)
  - After the change  
  ![image](https://github.com/grafana/grafana/assets/36930204/53fdc5ce-fd97-4bac-9c4c-9a68ed87c4da)
- [ ] public/app/plugins/datasource/graphite/components/GraphiteFunctionEditor.tsx
  - Before the change
   ![image](https://github.com/grafana/grafana/assets/36930204/c80c55ff-9158-4653-b2a9-c6ba9a9ac983)
  - After the change
   ![image](https://github.com/grafana/grafana/assets/36930204/f366e784-da9d-4259-9e21-e5ef14c02b26)



**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
