### PR TITLE
Echo: Suppress errors from frontend-metrics API call failing

### DIFF
--- a/public/app/core/services/echo/backends/PerformanceBackend.ts
+++ b/public/app/core/services/echo/backends/PerformanceBackend.ts
@@ -32,9 +32,17 @@ export class PerformanceBackend implements EchoBackend<PerformanceEvent, Perform
       return;
     }
 
-    backendSrv.post('/api/frontend-metrics', {
-      events: this.buffer,
-    });
+    backendSrv
+      .post(
+        '/api/frontend-metrics',
+        {
+          events: this.buffer,
+        },
+        { showErrorAlert: false }
+      )
+      .catch(() => {
+        // Just swallow this error - it's non-critical
+      });
 
     this.buffer = [];
   };


### PR DESCRIPTION
Suppresses the error toast from PerformanceBackend flushing, as this API is non-critical (it just sends web vitals).

Another reason why I don't think errors should automatically toast.

Fixes https://github.com/grafana/grafana/issues/89378