### PR TITLE
Heatmap: Use dashboard timeRange for auto-sizing x buckets

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -59,11 +59,11 @@ export const HeatmapPanel = ({
 
   const info = useMemo(() => {
     try {
-      return prepareHeatmapData(data.series, data.annotations, options, palette, theme, replaceVariables);
+      return prepareHeatmapData(data.series, data.annotations, options, palette, theme, replaceVariables, timeRange);
     } catch (ex) {
       return { warning: `${ex}` };
     }
-  }, [data.series, data.annotations, options, palette, theme, replaceVariables]);
+  }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);
 
   const facets = useMemo(() => {
     let exemplarsXFacet: number[] | undefined = []; // "Time" field

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -59,7 +59,15 @@ export const HeatmapPanel = ({
 
   const info = useMemo(() => {
     try {
-      return prepareHeatmapData(data.series, data.annotations, options, palette, theme, replaceVariables, timeRange);
+      return prepareHeatmapData({
+        frames: data.series,
+        annotations: data.annotations,
+        options,
+        palette,
+        theme,
+        replaceVariables,
+        timeRange,
+      });
     } catch (ex) {
       return { warning: `${ex}` };
     }

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -66,15 +66,25 @@ export interface HeatmapData {
   warning?: string;
 }
 
-export function prepareHeatmapData(
-  frames: DataFrame[],
-  annotations: DataFrame[] | undefined,
-  options: Options,
-  palette: string[],
-  theme: GrafanaTheme2,
-  replaceVariables: InterpolateFunction = (v) => v,
-  timeRange?: TimeRange
-): HeatmapData {
+interface PrepareHeatmapDataOptions {
+  frames: DataFrame[];
+  annotations?: DataFrame[];
+  options: Options;
+  palette: string[];
+  theme: GrafanaTheme2;
+  replaceVariables?: InterpolateFunction;
+  timeRange?: TimeRange;
+}
+
+export function prepareHeatmapData({
+  frames,
+  annotations,
+  options,
+  palette,
+  theme,
+  replaceVariables = (v) => v,
+  timeRange,
+}: PrepareHeatmapDataOptions): HeatmapData {
   if (!frames?.length) {
     return {};
   }

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -10,6 +10,7 @@ import {
   GrafanaTheme2,
   InterpolateFunction,
   outerJoinDataFrames,
+  TimeRange,
   ValueFormatter,
 } from '@grafana/data';
 import { parseSampleValue, sortSeriesByLabel } from '@grafana/prometheus';
@@ -71,7 +72,8 @@ export function prepareHeatmapData(
   options: Options,
   palette: string[],
   theme: GrafanaTheme2,
-  replaceVariables: InterpolateFunction = (v) => v
+  replaceVariables: InterpolateFunction = (v) => v,
+  timeRange?: TimeRange
 ): HeatmapData {
   if (!frames?.length) {
     return {};
@@ -104,7 +106,7 @@ export function prepareHeatmapData(
       }
 
       return getDenseHeatmapData(
-        calculateHeatmapFromData(frames, optionsCopy.calculation ?? {}),
+        calculateHeatmapFromData(frames, { ...options.calculation, timeRange }),
         exemplars,
         optionsCopy,
         palette,
@@ -113,7 +115,7 @@ export function prepareHeatmapData(
     }
 
     return getDenseHeatmapData(
-      calculateHeatmapFromData(frames, options.calculation ?? {}),
+      calculateHeatmapFromData(frames, { ...options.calculation, timeRange }),
       exemplars,
       options,
       palette,

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -53,7 +53,12 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
         // NOTE: this feels like overkill/expensive just to assert if we have an ordinal y
         // can probably simplify without doing full dataprep
         const palette = quantizeScheme(opts.color, config.theme2);
-        const v = prepareHeatmapData(context.data, undefined, opts, palette, config.theme2);
+        const v = prepareHeatmapData({
+          frames: context.data,
+          options: opts,
+          palette,
+          theme: config.theme2,
+        });
         isOrdinalY = readHeatmapRowsCustomMeta(v.heatmap).yOrdinalDisplay != null;
       } catch {}
     }

--- a/public/app/plugins/panel/heatmap/suggestions.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.ts
@@ -20,7 +20,12 @@ export class HeatmapSuggestionsSupplier {
     }
 
     const palette = quantizeScheme(defaultOptions.color, config.theme2);
-    const info = prepareHeatmapData(builder.data.series, undefined, defaultOptions, palette, config.theme2);
+    const info = prepareHeatmapData({
+      frames: builder.data.series,
+      options: defaultOptions,
+      palette,
+      theme: config.theme2,
+    });
     if (!info || info.warning) {
       return;
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/89319

when heatmap calculation buckets are defined in quantity rather than bucket size, we now divide the dashboard timeRange into x buckets rather than dividing the time range of the returned data. this keeps the heatmap resolution consistent and independent of the data responses.

[debug-Memory _ CPU-2024-06-17 21_42_10.json.txt](https://github.com/user-attachments/files/15877603/debug-Memory._.CPU-2024-06-17.21_42_10.json.txt)

with 10 buckets configured...

before:

![image](https://github.com/grafana/grafana/assets/43234/2b30c07c-9155-4467-a6d1-a3314b6008fa)


after:

![image](https://github.com/grafana/grafana/assets/43234/276a1711-7dbe-42b0-a7d8-56ce6fcef101)

this behavior is only changed for the Heatmap panel itself, and not the [Create heatmap transformation](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/transform-data/#create-heatmap), even though internally the panel uses the same code. the reason for this is that our Transformations do not currently rely on dashboard time range. they only rely on options passed in from their respective editors, plus a context [1] that contains a function to interpolate template variables. maybe in the future it can also have the dashboard time range, but this is a bigger change. so after this PR, the x buckets in the transformation will continue subdividing based on data range, but the panel will use dashboard range.

[1] https://github.com/grafana/grafana/blob/7c69f3657b5db4f6168af3d2b6e6796b7bb568d7/packages/grafana-data/src/types/transformations.ts#L13-L18