### PR TITLE
[v11.1.x] InfluxDB: Fix sending range info on variable editor

### DIFF
--- a/public/app/plugins/datasource/influxdb/variables.ts
+++ b/public/app/plugins/datasource/influxdb/variables.ts
@@ -40,7 +40,7 @@ export class InfluxVariableSupport extends CustomVariableSupport<InfluxDatasourc
           query: interpolated,
           maxDataPoints: request.targets[0].maxDataPoints ?? 1000,
         },
-        request.range
+        { range: request.range }
       )
     );
     return metricFindStream.pipe(map((results) => ({ data: results })));


### PR DESCRIPTION
Backport e5a50a7db80a55d22af4f0a97acdaa1aa03adc18 from #89347

---

**What is this feature?**

In PR https://github.com/grafana/grafana/pull/87903 we introduced a new custom variable editor support. But with this PR we introduced a bug. Range information should be passed with the `range` keyword. That was missing in [the PR](https://github.com/grafana/grafana/pull/87903) and we are fixing it in this PR

**Who is this feature for?**

InfluxDB users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/88983
Fixes https://github.com/grafana/support-escalations/issues/10974 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
