### PR TITLE
Chore: Suppress error toast when `frontend-metrics` call fails

### DIFF
--- a/public/app/core/services/echo/backends/PerformanceBackend.ts
+++ b/public/app/core/services/echo/backends/PerformanceBackend.ts
@@ -32,9 +32,13 @@ export class PerformanceBackend implements EchoBackend<PerformanceEvent, Perform
       return;
     }
 
-    backendSrv.post('/api/frontend-metrics', {
-      events: this.buffer,
-    });
+    backendSrv.post(
+      '/api/frontend-metrics',
+      {
+        events: this.buffer,
+      },
+      { showErrorAlert: false }
+    );
 
     this.buffer = [];
   };


### PR DESCRIPTION
**What is this feature?**

`/api/frontend-metrics` can end up being blocked by Adblockers, and this would show a frequent error message on the screen when this happens. We should suppress the error message for this endpoint, as its non-critical

**Why do we need this feature?**

More refined experience for users with adblockers

**Who is this feature for?**

Grafana users with adblockers installed (specifically right now, uBlock)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/89378
