### PR TITLE
Alerting: Allow future relative time

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.test.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.test.ts
@@ -40,6 +40,17 @@ describe('utils', () => {
         display: 'now-100m to now-5m',
       });
     });
+
+    it('should be able to work with future values', () => {
+      const relativeTimeRange = { from: 600, to: -600 };
+      const timeOption = mapRelativeTimeRangeToOption(relativeTimeRange);
+
+      expect(timeOption).toEqual({
+        from: 'now-10m',
+        to: 'now+10m',
+        display: 'now-10m to now+10m',
+      });
+    });
   });
 
   describe('mapOptionToRelativeTimeRange', () => {
@@ -55,6 +66,13 @@ describe('utils', () => {
       const relativeTimeRange = mapOptionToRelativeTimeRange(timeOption);
 
       expect(relativeTimeRange).toEqual({ from: 86400, to: 43200 });
+    });
+
+    it('should map future dates', () => {
+      const timeOption = { from: 'now-10m', to: 'now+10m', display: 'asdfasdf' };
+      const relativeTimeRange = mapOptionToRelativeTimeRange(timeOption);
+
+      expect(relativeTimeRange).toEqual({ from: 600, to: -600 });
     });
   });
 
@@ -83,6 +101,10 @@ describe('utils', () => {
       expect(isRelativeFormat('now-53w')).toBe(true);
     });
 
+    it('should consider now+10m as a relative format', () => {
+      expect(isRelativeFormat('now+10m')).toBe(true);
+    });
+
     it('should consider 123123123 as a relative format', () => {
       expect(isRelativeFormat('123123123')).toBe(false);
     });
@@ -96,6 +118,11 @@ describe('utils', () => {
 
     it('should consider now-90d as a valid relative format', () => {
       const result = isRangeValid('now-90d');
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should consider now+10m as a valid relative format', () => {
+      const result = isRangeValid('now+10m');
       expect(result.isValid).toBe(true);
     });
 

--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.ts
@@ -1,6 +1,6 @@
 import { RelativeTimeRange, TimeOption } from '@grafana/data';
 
-const regex = /^now$|^now\-(\d{1,10})([wdhms])$/;
+const regex = /^now$|^now(\-|\+)(\d{1,10})([wdhms])$/;
 
 export const mapOptionToRelativeTimeRange = (option: TimeOption): RelativeTimeRange | undefined => {
   return {
@@ -48,18 +48,19 @@ export const isRelativeFormat = (format: string): boolean => {
 const relativeToSeconds = (relative: string): number => {
   const match = regex.exec(relative);
 
-  if (!match || match.length !== 3) {
+  if (!match || match.length !== 4) {
     return 0;
   }
 
-  const [, value, unit] = match;
+  const [, sign, value, unit] = match;
   const parsed = parseInt(value, 10);
 
   if (isNaN(parsed)) {
     return 0;
   }
 
-  return parsed * units[unit];
+  const seconds = parsed * units[unit];
+  return sign === '+' ? seconds * -1 : seconds;
 };
 
 const units: Record<string, number> = {
@@ -71,25 +72,48 @@ const units: Record<string, number> = {
 };
 
 const secondsToRelativeFormat = (seconds: number): string => {
-  if (seconds <= 0) {
+  if (seconds === 0) {
     return 'now';
   }
 
-  if (seconds >= units.w && seconds % units.w === 0) {
-    return `now-${seconds / units.w}w`;
+  if (seconds < 0) {
+    return `now+${formatPrometheusDuration(Math.abs(seconds))}`;
   }
 
-  if (seconds >= units.d && seconds % units.d === 0) {
-    return `now-${seconds / units.d}d`;
-  }
-
-  if (seconds >= units.h && seconds % units.h === 0) {
-    return `now-${seconds / units.h}h`;
-  }
-
-  if (seconds >= units.m && seconds % units.m === 0) {
-    return `now-${seconds / units.m}m`;
-  }
-
-  return `now-${seconds}s`;
+  return `now-${formatPrometheusDuration(Math.abs(seconds))}`;
 };
+
+/**
+ * Formats the given duration in milliseconds into a human-readable string representation.
+ *
+ * @param milliseconds - The duration in milliseconds.
+ * @returns The formatted duration string.
+ */
+export function formatPrometheusDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const weeks = Math.floor(days / 7);
+
+  // we'll make an exception here for 0, 0ms seems a bit weird
+  if (seconds === 0) {
+    return '0s';
+  }
+
+  const timeUnits: Array<[number, string]> = [
+    [weeks % 52, 'w'],
+    [(days % 365) - 7 * (weeks % 52), 'd'],
+    [hours % 24, 'h'],
+    [minutes % 60, 'm'],
+    [seconds % 60, 's'],
+  ];
+
+  return (
+    timeUnits
+      // remove all 0 values
+      .filter(([time]) => time > 0)
+      // join time and unit
+      .map(([time, unit]) => time + unit)
+      .join('')
+  );
+}

--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.ts
@@ -76,29 +76,25 @@ const secondsToRelativeFormat = (seconds: number): string => {
     return 'now';
   }
 
+  const absoluteSeconds = Math.abs(seconds);
   if (seconds < 0) {
-    return `now+${formatPrometheusDuration(Math.abs(seconds))}`;
+    return `now+${formatDuration(absoluteSeconds)}`;
   }
 
-  return `now-${formatPrometheusDuration(Math.abs(seconds))}`;
+  return `now-${formatDuration(absoluteSeconds)}`;
 };
 
 /**
- * Formats the given duration in milliseconds into a human-readable string representation.
+ * Formats the given duration in seconds into a human-readable string representation.
  *
- * @param milliseconds - The duration in milliseconds.
+ * @param seconds - The duration in seconds.
  * @returns The formatted duration string.
  */
-export function formatPrometheusDuration(seconds: number): string {
+export function formatDuration(seconds: number): string {
   const minutes = Math.floor(seconds / 60);
   const hours = Math.floor(minutes / 60);
   const days = Math.floor(hours / 24);
   const weeks = Math.floor(days / 7);
-
-  // we'll make an exception here for 0, 0ms seems a bit weird
-  if (seconds === 0) {
-    return '0s';
-  }
 
   const timeUnits: Array<[number, string]> = [
     [weeks % 52, 'w'],

--- a/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/utils.ts
@@ -90,26 +90,23 @@ const secondsToRelativeFormat = (seconds: number): string => {
  * @param seconds - The duration in seconds.
  * @returns The formatted duration string.
  */
-export function formatDuration(seconds: number): string {
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-  const weeks = Math.floor(days / 7);
-
-  const timeUnits: Array<[number, string]> = [
-    [weeks % 52, 'w'],
-    [(days % 365) - 7 * (weeks % 52), 'd'],
-    [hours % 24, 'h'],
-    [minutes % 60, 'm'],
-    [seconds % 60, 's'],
+function formatDuration(seconds: number): string {
+  const units = [
+    { unit: 'w', value: 7 * 24 * 60 * 60 },
+    { unit: 'd', value: 24 * 60 * 60 },
+    { unit: 'h', value: 60 * 60 },
+    { unit: 'm', value: 60 },
+    { unit: 's', value: 1 },
   ];
 
-  return (
-    timeUnits
-      // remove all 0 values
-      .filter(([time]) => time > 0)
-      // join time and unit
-      .map(([time, unit]) => time + unit)
-      .join('')
-  );
+  for (const { unit, value } of units) {
+    if (seconds % value === 0) {
+      const quotient = seconds / value;
+      return `${quotient}${unit}`;
+    }
+  }
+
+  // If no perfect division, use the least significant unit
+  const leastSignificant = units[units.length - 1];
+  return `${seconds}${leastSignificant.unit}`;
 }


### PR DESCRIPTION
**What is this feature?**

Some data sources allow specifying relative time in the future, InfluxDB being one of those. There's a good use-case here for predictive time series.

This PR adds the ability to validate and support those in the `RelativeTimeRangerPicker`.

Fixes #88046 

**Special notes for your reviewer:**

It seems like alerting is the only consumer of this component in our code-base.