### PR TITLE
CI: Run auto-milestone on pull_request_target for forks

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -1,12 +1,5 @@
 [
   {
-    "type": "check-milestone",
-    "title": "Milestone Check",
-    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#assign-a-milestone",
-    "success": "Milestone set",
-    "failure": "Milestone not set"
-  },
-  {
     "type": "check-changelog",
     "title": "Changelog Check",
     "labels": {

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+      # Note: Github will not trigger other actions from this because it uses
+      # the GITHUB_TOKEN token
       - name: Run auto-milestone
         uses: grafana/grafana-github-actions-go/auto-milestone@main
         with:

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,39 +1,24 @@
 name: Auto-milestone
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
       - closed
+      - ready_for_review
 
+permissions:
+  pull-requests: write
+
+# Note: this action runs with write permissions on GITHUB_TOKEN even from forks
+# so it must not run untrusted code (such as checking out the pull request)
 jobs:
-  config:
-    runs-on: "ubuntu-latest"
-    outputs:
-      has-secrets: ${{ steps.check.outputs.has-secrets }}
-    steps:
-      - name: "Check for secrets"
-        id: check
-        shell: bash
-        run: |
-          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' && secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '') || '' }}" ]; then
-            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
-          fi
-
   main:
-    needs: config
-    if: needs.config.outputs.has-secrets
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
-      - name: "Generate token"
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-
       - name: Run auto-milestone
         uses: grafana/grafana-github-actions-go/auto-milestone@main
         with:
           pr: ${{ github.event.pull_request.number }}
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the Auto Milestone github action to be triggered by `pull_request_target`, which runs with a GITHUB_TOKEN with write permissions. I think this allows PRs from forks to be milestoned.

 - [Permissions for the `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
 - [`pull_request_target` trigger docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

> For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork. ***Although the workflow runs in the context of the base of the pull request***, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch. To help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered. For more information, see "[Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)" on the GitHub Security Lab website.

Also, this removes the milestone check from pr_checks.json because it'll no longer trigger from changes from GITHUB_TOKEN.

Note... I've had trouble testing this, so I'm open for suggestions on how to be more sure about this! https://github.com/grafana/github-actions-testrepo/pull/123

As this is merged, we'll need an admin to remove the mandatory milestone status check from the repo settings.