### PR TITLE
Transformations: Fix filter by value error on interpolation

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -56,14 +56,12 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
       interpolatedFilters.push(
         ...filters.map((filter) => {
           if (filter.config.id === ValueMatcherID.between) {
-            const interpolatedFrom =
-              typeof filter.config.options.from !== 'string'
-                ? filter.config.options.from
-                : ctx.interpolate(filter.config.options.from);
-            const interpolatedTo =
-              typeof filter.config.options.to !== 'string'
-                ? filter.config.options.to
-                : ctx.interpolate(filter.config.options.to);
+            if (typeof filter.config.options.from === 'string') {
+              filter.config.options.from = ctx.interpolate(filter.config.options.from);
+            }
+            if (typeof filter.config.options.to === 'string') {
+              filter.config.options.to = ctx.interpolate(filter.config.options.to);
+            }
 
             const newFilter = {
               ...filter,
@@ -71,8 +69,8 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
                 ...filter.config,
                 options: {
                   ...filter.config.options,
-                  to: interpolatedTo,
-                  from: interpolatedFrom,
+                  to: filter.config.options.to,
+                  from: filter.config.options.from,
                 },
               },
             };
@@ -82,15 +80,14 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
             // Due to colliding syntaxes, interpolating regex filters will cause issues.
             return filter;
           } else if (filter.config.options.value) {
-            const interpolatedValue =
-              typeof filter.config.options.value !== 'string'
-                ? filter.config.options.value
-                : ctx.interpolate(filter.config.options.value);
+            if (typeof filter.config.options.value === 'string') {
+              filter.config.options.value = ctx.interpolate(filter.config.options.value);
+            }
+
             const newFilter = {
               ...filter,
-              config: { ...filter.config, options: { ...filter.config.options, value: interpolatedValue } },
+              config: { ...filter.config, options: { ...filter.config.options, value: filter.config.options.value } },
             };
-            newFilter.config.options.value! = interpolatedValue;
             return newFilter;
           }
 

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -56,8 +56,14 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
       interpolatedFilters.push(
         ...filters.map((filter) => {
           if (filter.config.id === ValueMatcherID.between) {
-            const interpolatedFrom = ctx.interpolate(filter.config.options.from);
-            const interpolatedTo = ctx.interpolate(filter.config.options.to);
+            const interpolatedFrom =
+              typeof filter.config.options.from !== 'string'
+                ? filter.config.options.from
+                : ctx.interpolate(filter.config.options.from);
+            const interpolatedTo =
+              typeof filter.config.options.to !== 'string'
+                ? filter.config.options.to
+                : ctx.interpolate(filter.config.options.to);
 
             const newFilter = {
               ...filter,
@@ -76,7 +82,10 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
             // Due to colliding syntaxes, interpolating regex filters will cause issues.
             return filter;
           } else if (filter.config.options.value) {
-            const interpolatedValue = ctx.interpolate(filter.config.options.value);
+            const interpolatedValue =
+              typeof filter.config.options.value !== 'string'
+                ? filter.config.options.value
+                : ctx.interpolate(filter.config.options.value);
             const newFilter = {
               ...filter,
               config: { ...filter.config, options: { ...filter.config.options, value: interpolatedValue } },


### PR DESCRIPTION
Fixes an error where the `filterByValue` transformation would try to interpolate a value that is not a string and would not apply the filter, ending in a crash in the panel using the new scenes architecture. This also throws a warning in the old arch.

The bug can be seen in [this](https://bi.grafana-ops.net/d/edp2w3b9po8w0f/account-happiness-report-copy?var-csm_name=Sam%20Harris&var-csm_name=Rachel%20Zalkind&var-csm_name=Cassidy%20Kinsella&var-csm_name=Matt%20Talarczyk&var-csm_name=Jessica%20Hamburg&var-csm_name=Jessi%20Young%20Sorenson&var-csm_name=Gabriel%20Cortes&var-csm_name=Eshwar%20Dandapani&var-csm_name=Trevor%20Gordon&var-ae_name=$__all&var-success_motion=G30&var-success_motion=Core&var-region=$__all&var-rsd_region=$__all&var-rvp_region=$__all&var-segment=$__all&tab=transformations) dashboard.

An extra guard was added in scenes to also mitigate this, in this [PR](https://github.com/grafana/scenes/pull/796), but ultimately should be fixed in the transformation.

Fixes https://github.com/grafana/support-escalations/issues/11102