### PR TITLE
Tempo: Remove kind=server from metrics summary

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/GroupByField.tsx
@@ -71,10 +71,7 @@ export const GroupByField = (props: Props) => {
   const scopeOptions = Object.values(TraceqlSearchScope).map((t) => ({ label: t, value: t }));
 
   return (
-    <InlineSearchField
-      label="Aggregate by"
-      tooltip="Select one or more tags to see the metrics summary. Note: the metrics summary API only considers spans of kind = server."
-    >
+    <InlineSearchField label="Aggregate by" tooltip="Select one or more tags to see the metrics summary.">
       <>
         {query.groupBy?.map((f, i) => {
           const tags = getTags(f)

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -536,9 +536,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         if (!response.data.summaries) {
           return {
             error: {
-              message: getErrorMessage(
-                `No summary data for '${groupBy}'. Note: the metrics summary API only considers spans of kind = server. You can check if the attributes exist by running a TraceQL query like { attr_key = attr_value && kind = server }`
-              ),
+              message: getErrorMessage(`No summary data for '${groupBy}'.`),
             },
             data: emptyResponse,
           };

--- a/public/app/plugins/datasource/tempo/metricsSummary.test.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.test.ts
@@ -58,7 +58,7 @@ describe('MetricsSummary', () => {
                         "datasourceName": "tempo",
                         "datasourceUid": "gdev-tempo",
                         "query": {
-                          "query": "{name="HTTP POST - post" && span.http.status_code=\${__data.fields["span.http.status_code"]} && temperature=\${__data.fields["temperature"]} && kind=server} | by(resource.service.name)",
+                          "query": "{name="HTTP POST - post" && span.http.status_code=\${__data.fields["span.http.status_code"]} && temperature=\${__data.fields["temperature"]}} | by(resource.service.name)",
                           "queryType": "traceql",
                         },
                       },
@@ -83,7 +83,7 @@ describe('MetricsSummary', () => {
                         "datasourceName": "tempo",
                         "datasourceUid": "gdev-tempo",
                         "query": {
-                          "query": "{name="HTTP POST - post" && span.http.status_code=\${__data.fields["span.http.status_code"]} && temperature=\${__data.fields["temperature"]} && kind=server} | by(resource.service.name)",
+                          "query": "{name="HTTP POST - post" && span.http.status_code=\${__data.fields["span.http.status_code"]} && temperature=\${__data.fields["temperature"]}} | by(resource.service.name)",
                           "queryType": "traceql",
                         },
                       },
@@ -97,19 +97,6 @@ describe('MetricsSummary', () => {
                 "type": "string",
                 "values": [
                   38.1,
-                ],
-              },
-              {
-                "config": {
-                  "custom": {
-                    "width": 150,
-                  },
-                  "displayNameFromDS": "Kind",
-                },
-                "name": "kind",
-                "type": "string",
-                "values": [
-                  "server",
                 ],
               },
               {
@@ -222,7 +209,6 @@ describe('MetricsSummary', () => {
         {
           "contains_sink": "true",
           "errorPercentage": 10,
-          "kind": "server",
           "p50": 1,
           "p90": 2,
           "p95": 3,
@@ -241,21 +227,21 @@ describe('MetricsSummary', () => {
     it('getConfigQuery should return correctly for empty target query', () => {
       const result = getConfigQuery(series, '{}');
       expect(result).toEqual(
-        '{span.http.status_code=${__data.fields["span.http.status_code"]} && temperature=${__data.fields["temperature"]} && room="${__data.fields["room"]}" && contains_sink="${__data.fields["contains_sink"]}" && window_open="${__data.fields["window_open"]}" && spanStatus=${__data.fields["spanStatus"]} && spanKind=${__data.fields["spanKind"]} && kind=server}'
+        '{span.http.status_code=${__data.fields["span.http.status_code"]} && temperature=${__data.fields["temperature"]} && room="${__data.fields["room"]}" && contains_sink="${__data.fields["contains_sink"]}" && window_open="${__data.fields["window_open"]}" && spanStatus=${__data.fields["spanStatus"]} && spanKind=${__data.fields["spanKind"]}}'
       );
     });
 
     it('getConfigQuery should return correctly for target query', () => {
       const result = getConfigQuery(series, '{name="HTTP POST - post"} | by(resource.service.name)');
       expect(result).toEqual(
-        '{name="HTTP POST - post" && span.http.status_code=${__data.fields["span.http.status_code"]} && temperature=${__data.fields["temperature"]} && room="${__data.fields["room"]}" && contains_sink="${__data.fields["contains_sink"]}" && window_open="${__data.fields["window_open"]}" && spanStatus=${__data.fields["spanStatus"]} && spanKind=${__data.fields["spanKind"]} && kind=server} | by(resource.service.name)'
+        '{name="HTTP POST - post" && span.http.status_code=${__data.fields["span.http.status_code"]} && temperature=${__data.fields["temperature"]} && room="${__data.fields["room"]}" && contains_sink="${__data.fields["contains_sink"]}" && window_open="${__data.fields["window_open"]}" && spanStatus=${__data.fields["spanStatus"]} && spanKind=${__data.fields["spanKind"]}} | by(resource.service.name)'
       );
     });
 
     it('getConfigQuery should return correctly for target query without brackets', () => {
       const result = getConfigQuery(series, 'by(resource.service.name)');
       expect(result).toEqual(
-        '{span.http.status_code=${__data.fields["span.http.status_code"]} && temperature=${__data.fields["temperature"]} && room="${__data.fields["room"]}" && contains_sink="${__data.fields["contains_sink"]}" && window_open="${__data.fields["window_open"]}" && spanStatus=${__data.fields["spanStatus"]} && spanKind=${__data.fields["spanKind"]} && kind=server} | by(resource.service.name)'
+        '{span.http.status_code=${__data.fields["span.http.status_code"]} && temperature=${__data.fields["temperature"]} && room="${__data.fields["room"]}" && contains_sink="${__data.fields["contains_sink"]}" && window_open="${__data.fields["window_open"]}" && spanStatus=${__data.fields["spanStatus"]} && spanKind=${__data.fields["spanKind"]}} | by(resource.service.name)'
       );
     });
   });

--- a/public/app/plugins/datasource/tempo/metricsSummary.ts
+++ b/public/app/plugins/datasource/tempo/metricsSummary.ts
@@ -71,11 +71,6 @@ export function createTableFrameFromMetricsSummaryQuery(
     fields: [
       ...Object.values(dynamicMetrics).sort((a, b) => a.name.localeCompare(b.name)),
       {
-        name: 'kind',
-        type: FieldType.string,
-        config: { displayNameFromDS: 'Kind', custom: { width: 150 } },
-      },
-      {
         name: 'spanCount',
         type: FieldType.number,
         config: { displayNameFromDS: 'Span count', custom: { width: 150 } },
@@ -113,7 +108,6 @@ export const transformToMetricsData = (data: MetricsSummary) => {
     : '0%';
 
   const metricsData: MetricsData = {
-    kind: 'server', // so the user knows all results are of kind = server
     spanCount: getNumberForMetric(data.spanCount),
     errorPercentage,
     p50: getNumberForMetric(data.p50),
@@ -145,12 +139,12 @@ export const getConfigQuery = (series: Series[], targetQuery: string) => {
     configQuery = targetQuery.substring(0, closingBracketIndex);
     if (queryParts.length > 0) {
       configQuery += targetQuery.replace(/\s/g, '').includes('{}') ? '' : ' && ';
-      configQuery += `${queryParts.join(' && ')} && kind=server`;
+      configQuery += `${queryParts.join(' && ')}`;
       configQuery += `}`;
     }
     configQuery += `${queryAfterClosingBracket}`;
   } else {
-    configQuery = `{${queryParts.join(' && ')} && kind=server} | ${targetQuery}`;
+    configQuery = `{${queryParts.join(' && ')}} | ${targetQuery}`;
   }
 
   return configQuery;


### PR DESCRIPTION
**What is this feature?**

Removes kind=server from the metrics summary.

**Why do we need this feature?**

kind = server was needed when the metrics summary was first released but now this is no longer a requirement.

**Who is this feature for?**

Tempo users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/88635
