### PR TITLE
ci: Only run vuln scanner when Go deps are updated

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,9 +1,14 @@
 name: Trivy Scan
 on:
   pull_request:
+    # only run on PRs where go.mod/go.sum/etc have been updated
+    paths:
+      - go.*
   push:
     branches:
       - main
+    paths:
+      - go.*
 
 jobs:
   trivy-scan:
@@ -25,6 +30,8 @@ jobs:
         vuln-type: 'os,library'
         severity: 'CRITICAL,HIGH'
         trivyignores: .trivyignore
+        # for the PR check, ignore JS-related issues
+        skip-files: 'yarn.lock,package.json'
     - name: Run Trivy vulnerability scanner (SARIF)
       uses: aquasecurity/trivy-action@0.22.0
       with:


### PR DESCRIPTION
**What is this feature?**

This check has introduced some unintended friction in PRs where dependency-related code hasn't been updated as part of the PR.

This changes the check to focus only (for now) on PRs that change Go dependencies, and ignores the JS dependencies (since there's especially low signal/noise ratio there).

We still have other scanning mechanisms that happen later downstream.

**Who is this feature for?**

Maintainers