### PR TITLE
Tempo: TraceQL metrics step option

### DIFF
--- a/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen.ts
@@ -59,6 +59,10 @@ export interface TempoQuery extends common.DataQuery {
    */
   spss?: number;
   /**
+   * For metric queries, the step size to use
+   */
+  step?: string;
+  /**
    * The type of the table that is used to display the search results
    */
   tableType?: SearchTableType;

--- a/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
+++ b/pkg/tsdb/tempo/kinds/dataquery/types_dataquery_gen.go
@@ -129,6 +129,9 @@ type TempoQuery struct {
 	// Defines the maximum number of spans per spanset that are returned from Tempo
 	Spss *int64 `json:"spss,omitempty"`
 
+	// For metric queries, the step size to use
+	Step *string `json:"step,omitempty"`
+
 	// The type of the table that is used to display the search results
 	TableType *SearchTableType `json:"tableType,omitempty"`
 }

--- a/public/app/plugins/datasource/tempo/dataquery.cue
+++ b/public/app/plugins/datasource/tempo/dataquery.cue
@@ -51,6 +51,8 @@ composableKinds: DataQuery: {
 					groupBy?: [...#TraceqlFilter]
 					// The type of the table that is used to display the search results
 					tableType?: #SearchTableType
+					// For metric queries, the step size to use
+					step?: string
 				} @cuetsy(kind="interface") @grafana(TSVeneer="type")
 
 				#TempoQueryType: "traceql" | "traceqlSearch" | "serviceMap" | "upload" | "nativeSearch" | "traceId" | "clear" @cuetsy(kind="type")

--- a/public/app/plugins/datasource/tempo/dataquery.gen.ts
+++ b/public/app/plugins/datasource/tempo/dataquery.gen.ts
@@ -57,6 +57,10 @@ export interface TempoQuery extends common.DataQuery {
    */
   spss?: number;
   /**
+   * For metric queries, the step size to use
+   */
+  step?: string;
+  /**
    * The type of the table that is used to display the search results
    */
   tableType?: SearchTableType;

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -438,7 +438,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   isTraceQlMetricsQuery(query: string): boolean {
     // Check whether this is a metrics query by checking if it contains a metrics function
     const metricsFnRegex =
-      /\|\s*(rate|count_over_time|avg_over_time|max_over_time|min_over_time|quantile_over_time|histogram_over_time)\s*\(/;
+      /\|\s*(rate|count_over_time|avg_over_time|max_over_time|min_over_time|quantile_over_time|histogram_over_time|compare)\s*\(/;
     return !!query.trim().match(metricsFnRegex);
   }
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -647,6 +647,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   ): Observable<DataQueryResponse> => {
     return this._request('/api/metrics/query_range', {
       query: queryValue,
+      step: options.targets[0].step,
       start: options.range.from.unix(),
       end: options.range.to.unix(),
     }).pipe(

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -645,12 +645,18 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     options: DataQueryRequest<TempoQuery>,
     queryValue: string
   ): Observable<DataQueryResponse> => {
-    return this._request('/api/metrics/query_range', {
+    const requestData = {
       query: queryValue,
-      step: options.targets[0].step,
       start: options.range.from.unix(),
       end: options.range.to.unix(),
-    }).pipe(
+      step: options.targets[0].step,
+    };
+
+    if (!requestData.step) {
+      delete requestData.step;
+    }
+
+    return this._request('/api/metrics/query_range', requestData).pipe(
       map((response) => {
         return {
           data: formatTraceQLMetrics(queryValue, response.data),

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -99,7 +99,6 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               className="width-4"
               placeholder="auto"
               type="string"
-              min={1}
               defaultValue={query.step}
               onCommitChange={onStepChange}
               value={query.step}

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -44,11 +44,15 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
   const onTableTypeChange = (val: SearchTableType) => {
     onChange({ ...query, tableType: val });
   };
+  const onStepChange = (e: React.FormEvent<HTMLInputElement>) => {
+    onChange({ ...query, step: e.currentTarget.value });
+  };
 
   const collapsedInfoList = [
     `Limit: ${query.limit || DEFAULT_LIMIT}`,
     `Spans Limit: ${query.spss || DEFAULT_SPSS}`,
     `Table Format: ${query.tableType === SearchTableType.Traces ? 'Traces' : 'Spans'}`,
+    `Step: ${query.step || 'auto'}`,
   ];
 
   return (
@@ -85,6 +89,20 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               ]}
               value={query.tableType}
               onChange={onTableTypeChange}
+            />
+          </EditorField>
+          <EditorField
+            label="Step"
+            tooltip="Defines the step for metric queries. Use duration notation, for example 30s or 1m"
+          >
+            <AutoSizeInput
+              className="width-4"
+              placeholder="auto"
+              type="string"
+              min={1}
+              defaultValue={query.step}
+              onCommitChange={onStepChange}
+              value={query.step}
             />
           </EditorField>
         </QueryOptionGroup>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR introduces an option to set the step for TraceQL metrics queries for the Search and TraceQL tabs.

**Why do we need this feature?**

Tempo sets a default step based on the time range but it can be useful to override the step for a query. This is also possible in Prometheus for example. 

**Who is this feature for?**

Users of the Tempo datasource. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
