### PR TITLE
[v10.3.x] Document Unix ms format for time type parsing

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -298,6 +298,9 @@ This transformation has the following options:
   - **Numeric** - attempts to make the values numbers
   - **String** - will make the values strings
   - **Time** - attempts to parse the values as time
+    - The input will be parsed according to the [Moment.js parsing format](https://momentjs.com/docs/#/parsing/)
+    - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
+      You must multiply your input by 1000 if it's in seconds.
     - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
   - **Boolean** - will make the values booleans
   - **Enum** - will make the values enums

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -192,18 +192,18 @@ export const transformationDocsContent: TransformationDocsContentType = {
   This transformation has the following options:
 
   - **Field** - Select from available fields
-- **as** - Select the FieldType to convert to
-  - **Numeric** - attempts to make the values numbers
-  - **String** - will make the values strings
-  - **Time** - attempts to parse the values as time
-    - The input will be parsed according to the [Moment.js parsing format](https://momentjs.com/docs/#/parsing/)
-    - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
-      You must multiply your input by 1000 if it's in seconds.
-    - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
-  - **Boolean** - will make the values booleans
-  - **Enum** - will make the values enums
-    - Will show a table to manage the enums
-  - **Other** - attempts to parse the values as JSON
+  - **as** - Select the FieldType to convert to
+    - **Numeric** - attempts to make the values numbers
+    - **String** - will make the values strings
+    - **Time** - attempts to parse the values as time
+      - The input will be parsed according to the [Moment.js parsing format](https://momentjs.com/docs/#/parsing/)
+      - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
+        You must multiply your input by 1000 if it's in seconds.
+      - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
+    - **Boolean** - will make the values booleans
+    - **Enum** - will make the values enums
+      - Will show a table to manage the enums
+    - **Other** - attempts to parse the values as JSON
 
   For example, consider the following query that could be modified by selecting the time field as Time and specifying Date Format as YYYY.
 

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -192,15 +192,18 @@ export const transformationDocsContent: TransformationDocsContentType = {
   This transformation has the following options:
 
   - **Field** - Select from available fields
-  - **as** - Select the FieldType to convert to
-    - **Numeric** - attempts to make the values numbers
-    - **String** - will make the values strings
-    - **Time** - attempts to parse the values as time
-      - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
-    - **Boolean** - will make the values booleans
-    - **Enum** - will make the values enums
-      - Will show a table to manage the enums
-    - **Other** - attempts to parse the values as JSON
+- **as** - Select the FieldType to convert to
+  - **Numeric** - attempts to make the values numbers
+  - **String** - will make the values strings
+  - **Time** - attempts to parse the values as time
+    - The input will be parsed according to the [Moment.js parsing format](https://momentjs.com/docs/#/parsing/)
+    - It will parse the numeric input as a Unix epoch timestamp in milliseconds.
+      You must multiply your input by 1000 if it's in seconds.
+    - Will show an option to specify a DateFormat as input by a string like yyyy-mm-dd or DD MM YYYY hh:mm:ss
+  - **Boolean** - will make the values booleans
+  - **Enum** - will make the values enums
+    - Will show a table to manage the enums
+  - **Other** - attempts to parse the values as JSON
 
   For example, consider the following query that could be modified by selecting the time field as Time and specifying Date Format as YYYY.
 


### PR DESCRIPTION
Backport ef921fee3db878862a7725dd3b790f1e768f91f9 from #89147

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Docs update.

**Why do we need this feature?**

I spent a while yesterday trying to figure out how to parse a Unix timestamp and convert the field type to "Time".

Turns out it expects a Unix timestamp in milliseconds. Since Unix timestamp is defined in seconds, I think it's worth a special mention in the docs.

**Who is this feature for?**

Any user.

**Which issue(s) does this PR fix?**:

No Github issue, although I saw the question in our Community: https://community.grafana.com/t/convert-unix-time/83140

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
