### PR TITLE
[v11.1.x] Fix dashboard crash on dashboard leave in panel edit

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -200,6 +200,20 @@ describe('DashboardScene', () => {
         expect(resoredLayout.state.children.map((c) => c.state.key)).toEqual(originalPanelOrder);
       });
 
+      it('Should exit edit mode and discard panel changes if leaving the dashboard while in panel edit', () => {
+        const panel = findVizPanelByKey(scene, 'panel-1');
+        const editPanel = buildPanelEditScene(panel!);
+        scene.setState({
+          editPanel,
+        });
+
+        expect(scene.state.editPanel!['_discardChanges']).toBe(false);
+
+        scene.exitEditMode({ skipConfirm: true });
+
+        expect(scene.state.editPanel!['_discardChanges']).toBe(true);
+      });
+
       it.each`
         prop             | value
         ${'title'}       | ${'new title'}

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -325,6 +325,14 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     }
     // and start url sync again
     this.startUrlSync();
+
+    // if we are in edit panel, we need to onDiscard()
+    // so the useEffect cleanup comes later and
+    // doesn't try to commit the changes
+    if (this.state.editPanel) {
+      this.state.editPanel.onDiscard();
+    }
+
     // Disable grid dragging
     this.propagateEditModeChange();
   }


### PR DESCRIPTION
Backport 51c858f32e5e8308b4d2af8abf79d24bbb8f11c2 from #89353

---

Fixes a bug where the dashboard would crash when leaving it from panel edit (either by clicking on the grafana logo, or by navigating to Home/Dashboards through breadcrumbs).

To avoid crashing, we make sure that the panel editor gets cleanup properly.

Closes https://github.com/grafana/grafana-org/issues/132
