### PR TITLE
Alerting: Don't crash the page when trying to filter rules by regex

### DIFF
--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -256,4 +256,26 @@ describe('filterRules', function () {
     expect(filtered[0]?.groups[0]?.rules).toHaveLength(1);
     expect(filtered[0]?.groups[0]?.rules[0]?.name).toBe('CPU too high');
   });
+
+  it('does not crash when trying to filter with regex-like strings', () => {
+    const rules = [mockCombinedRule({ name: '[alongnameinthefirstgroup]' })];
+
+    const ns = mockCombinedRuleNamespace({
+      name: 'foo|bar',
+      groups: [
+        // Create group with regex-like name so we can test that searching for it doesn't crash,
+        // and so we can test further paths of the filtering
+        // (we need some a group to be matched so we can test filtering by rule name as well)
+        mockCombinedRuleGroup('some|group', rules),
+      ],
+    });
+
+    const ruleQuery = '[alongnameinthefirstgroup][thishas spaces][somethingelse]';
+    const namespaceQuery = 'foo|bar';
+    const groupQuery = 'some|group';
+
+    const performFilter = () =>
+      filterRules([ns], getFilter({ groupName: groupQuery, ruleName: ruleQuery, namespace: namespaceQuery }));
+    expect(performFilter).not.toThrow();
+  });
 });


### PR DESCRIPTION
**What is this feature?**

We're at risk of crashing the page if a regex is passed into the fuzzy library. This can happen either with [square brackets] in the name, or using regexes where we don't expect (group name etc.)

The easiest way around this is to escape regex characters in the query so that the uFuzzy library at least doesn't generate an invalid regex and crash the page

**Why do we need this feature?**

Reduce possibility of rules filtering crashing the page

**Who is this feature for?**

Alerting users
