### PR TITLE
Alerting: Add setting for maximum allowed rule evaluation results

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1168,6 +1168,11 @@ global_correlations = -1
 # This is not strictly enforced yet, but will be enforced over time.
 alerting_rule_group_rules = 100
 
+# Limit the number of alert rule evaluation results per rule.
+# If the alert rule produces more results than this limit,
+# the evaluation results in an error.
+alerting_rule_evaluation_results = -1
+
 #################################### Unified Alerting ####################
 [unified_alerting]
 # Enable the Alerting sub-system and interface.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1168,8 +1168,8 @@ global_correlations = -1
 # This is not strictly enforced yet, but will be enforced over time.
 alerting_rule_group_rules = 100
 
-# Limit the number of alert rule evaluation results per rule.
-# If the alert rule produces more results than this limit,
+# Limit the number of query evaluation results per alert rule.
+# If the condition query of an alert rule produces more results than this limit,
 # the evaluation results in an error.
 alerting_rule_evaluation_results = -1
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1154,8 +1154,8 @@
 # This is not strictly enforced yet, but will be enforced over time.
 ;alerting_rule_group_rules = 100
 
-# Limit the number of alert rule evaluation results per rule.
-# If the alert rule produces more results than this limit,
+# Limit the number of query evaluation results per alert rule.
+# If the condition query of an alert rule produces more results than this limit,
 # the evaluation results in an error.
 ;alerting_rule_evaluation_results = -1
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1154,6 +1154,11 @@
 # This is not strictly enforced yet, but will be enforced over time.
 ;alerting_rule_group_rules = 100
 
+# Limit the number of alert rule evaluation results per rule.
+# If the alert rule produces more results than this limit,
+# the evaluation results in an error.
+;alerting_rule_evaluation_results = -1
+
 #################################### Unified Alerting ####################
 [unified_alerting]
 #Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed.```

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1548,6 +1548,10 @@ Sets a global limit on number of alert rules that can be created. Default is -1 
 
 Sets a global limit on number of correlations that can be created. Default is -1 (unlimited).
 
+### alerting_rule_evaluation_results
+
+Limit the number of query evaluation results per alert rule. If the condition query of an alert rule produces more results than this limit, the evaluation results in an error. Default is -1 (unlimited).
+
 <hr>
 
 ## [unified_alerting]

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -75,7 +75,21 @@ func (r *conditionEvaluator) EvaluateRaw(ctx context.Context, now time.Time) (re
 		execCtx = timeoutCtx
 	}
 	logger.FromContext(ctx).Debug("Executing pipeline", "commands", strings.Join(r.pipeline.GetCommandTypes(), ","), "datasources", strings.Join(r.pipeline.GetDatasourceTypes(), ","))
-	return r.expressionService.ExecutePipeline(execCtx, now, r.pipeline)
+	result, err := r.expressionService.ExecutePipeline(execCtx, now, r.pipeline)
+
+	// Check if the result of the condition evaluation is too large
+	if err == nil && result != nil && r.evalResultLimit > 0 {
+		conditionResultLength := 0
+		if conditionResponse, ok := result.Responses[r.condition.Condition]; ok {
+			conditionResultLength = len(conditionResponse.Frames)
+		}
+		if conditionResultLength > r.evalResultLimit {
+			logger.FromContext(ctx).Error("Query evaluation returned too many results", "limit", r.evalResultLimit, "actual", conditionResultLength)
+			return nil, fmt.Errorf("query evaluation returned too many results: %d (limit: %d)", conditionResultLength, r.evalResultLimit)
+		}
+	}
+
+	return result, err
 }
 
 // Evaluate evaluates the condition and converts the response to Results
@@ -84,7 +98,7 @@ func (r *conditionEvaluator) Evaluate(ctx context.Context, now time.Time) (Resul
 	if err != nil {
 		return nil, err
 	}
-	return EvaluateAlert(response, r.condition, now, r.evalResultLimit), nil
+	return EvaluateAlert(response, r.condition, now), nil
 }
 
 type evaluatorImpl struct {
@@ -111,9 +125,9 @@ func NewEvaluatorFactory(
 }
 
 // EvaluateAlert takes the results of an executed query and evaluates it as an alert rule, returning alert states that the query produces.
-func EvaluateAlert(queryResponse *backend.QueryDataResponse, condition models.Condition, now time.Time, evalResultLimit int) Results {
+func EvaluateAlert(queryResponse *backend.QueryDataResponse, condition models.Condition, now time.Time) Results {
 	execResults := queryDataResponseToExecutionResults(condition, queryResponse)
-	return evaluateExecutionResult(execResults, now, evalResultLimit)
+	return evaluateExecutionResult(execResults, now)
 }
 
 // invalidEvalResultFormatError is an error for invalid format of the alert definition evaluation results.
@@ -635,7 +649,7 @@ func datasourceUIDsToRefIDs(refIDsToDatasourceUIDs map[string]string) map[string
 //   - Nonzero (e.g 1.2, NaN) results in Alerting.
 //   - nil results in noData.
 //   - unsupported Frame schemas results in Error.
-func evaluateExecutionResult(execResults ExecutionResults, ts time.Time, evalResultLimit int) Results {
+func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results {
 	evalResults := make([]Result, 0)
 
 	appendErrRes := func(e error) {
@@ -669,12 +683,6 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time, evalRes
 
 	if len(execResults.Condition) == 0 {
 		appendNoData(nil)
-		return evalResults
-	}
-
-	if evalResultLimit > 0 && len(execResults.Condition) > evalResultLimit {
-		logger.Error("Query evaluation returned too many results", "results", len(execResults.Condition), "limit", evalResultLimit)
-		appendErrRes(fmt.Errorf("query evaluation returned too many results: %d (limit: %d)", len(execResults.Condition), evalResultLimit))
 		return evalResults
 	}
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -89,6 +89,7 @@ type UnifiedAlertingSettings struct {
 	MaxAttempts                    int64
 	MinInterval                    time.Duration
 	EvaluationTimeout              time.Duration
+	EvaluationResultLimit          int
 	DisableJitter                  bool
 	ExecuteAlerts                  bool
 	DefaultConfiguration           string
@@ -349,6 +350,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 
 	quotas := iniFile.Section("quota")
 	uaCfg.RulesPerRuleGroupLimit = quotas.Key("alerting_rule_group_rules").MustInt64(100)
+	uaCfg.EvaluationResultLimit = quotas.Key("alerting_rule_evaluation_results").MustInt(-1)
 
 	remoteAlertmanager := iniFile.Section("remote.alertmanager")
 	uaCfgRemoteAM := RemoteAlertmanagerSettings{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Added a new configuration setting `quota.alerting_rule_evaluation_results` to set the maximum number of alert rule evaluation results per rule. If the limit is exceeded, the evaluation will result in an error.

<details>
  <summary>Alert rule editing page</summary>
<img width="1526" alt="image" src="https://github.com/grafana/grafana/assets/1875873/e7406a5f-04b9-40eb-a4ca-1dfda597cf49">
</details>

<details>
  <summary>Alert rule viewing page</summary>
<img width="881" alt="image" src="https://github.com/grafana/grafana/assets/1875873/c4e360bb-e262-4a14-b5c3-a34b6e45261c">

---

<img width="1463" alt="image" src="https://github.com/grafana/grafana/assets/1875873/ee1be7d2-677c-4341-ba63-b53549e6a2f1">

</details>

<details>
  <summary>Notification</summary>
<img width="636" alt="image" src="https://github.com/grafana/grafana/assets/1875873/a6f383d0-b0b9-4f37-90bc-3dc1f45e84d1">

</details>

**Why do we need this feature?**
This feature helps prevent the server from being overloaded by adding an ability to limit the number of query evaluation results per alert rule. When an alert rule’s condition query generates large results, it can consume significant server resources, potentially leading to performance degradation or outages. 

**Who is this feature for?**

Server administrators.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
