### PR TITLE
Codeowners: Remove `@mikkancso` from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -407,12 +407,12 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/features/geo/ @grafana/dataviz-squad
 /public/app/features/visualization/data-hover/ @grafana/dataviz-squad
 /public/app/features/commandPalette/ @grafana/grafana-frontend-platform
-/public/app/features/connections/ @grafana/plugins-platform-frontend @mikkancso
+/public/app/features/connections/ @grafana/plugins-platform-frontend
 /public/app/features/correlations/ @grafana/explore-squad
 /public/app/features/dashboard/ @grafana/dashboards-squad
 /public/app/features/dashboard/components/TransformationsEditor/ @grafana/dataviz-squad
 /public/app/features/dashboard-scene/ @grafana/dashboards-squad
-/public/app/features/datasources/ @grafana/plugins-platform-frontend @mikkancso
+/public/app/features/datasources/ @grafana/plugins-platform-frontend
 /public/app/features/dimensions/ @grafana/dataviz-squad
 /public/app/features/dataframe-import/ @grafana/dataviz-squad
 /public/app/features/explore/ @grafana/explore-squad


### PR DESCRIPTION
I originally added myself as codeowner to be informed about changes in the `connections` and `datasources` folder. Now that we're handing off these responsibilities to the plugins-platform team, I don't need this anymore.