### PR TITLE
Scenes: Unset _changesWorker when change tracker is terminated

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2838,6 +2838,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
+    "public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.test.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
     "public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.test.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.test.ts
@@ -1,0 +1,23 @@
+import * as createDetectChangesWorker from 'app/features/dashboard-scene/saving/createDetectChangesWorker';
+
+import { DashboardSceneChangeTracker } from './DashboardSceneChangeTracker';
+
+describe('DashboardSceneChangeTracker', () => {
+  it('should set _changesWorker to undefined when terminate is called', () => {
+    const terminate = jest.fn();
+    jest.spyOn(createDetectChangesWorker, 'createWorker').mockImplementation(
+      () =>
+        ({
+          terminate,
+        }) as any
+    );
+    const changeTracker = new DashboardSceneChangeTracker({
+      subscribeToEvent: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    } as any);
+    changeTracker.startTrackingChanges();
+
+    expect(changeTracker['_changesWorker']).not.toBeUndefined();
+    changeTracker.terminate();
+    expect(changeTracker['_changesWorker']).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -188,5 +188,6 @@ export class DashboardSceneChangeTracker {
   public terminate() {
     this.stopTrackingChanges();
     this._changesWorker?.terminate();
+    this._changesWorker = undefined;
   }
 }


### PR DESCRIPTION
Fixes an issue where `_changesWorker` was not unset when the change tracker was terminated, causing buggy behavior when navigating between dashboards without reloading.

Closes #89458