### PR TITLE
feat: Create extension points for Signal attributes in explore traces and logs

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -128,6 +128,8 @@ export enum PluginExtensionPoints {
   DataSourceConfig = 'grafana/datasources/config',
   ExploreToolbarAction = 'grafana/explore/toolbar/action',
   UserProfileTab = 'grafana/user/profile/tab',
+  ExploreLogsLabelAction = 'grafana/explore/logs/label/action',
+  ExploreTracesAttributeAttributeAction = 'grafana/explore/traces/attribute/action',
 }
 
 export type PluginExtensionPanelContext = {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -20,6 +20,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
 
 import { autoColor } from '../../Theme';
+import AttributeActionExtensionPoint from "../../common/AttributeActionExtensionPoint";
 import CopyIcon from '../../common/CopyIcon';
 import { TraceKeyValuePair, TraceLink, TNil } from '../../types';
 
@@ -145,6 +146,7 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
                 </td>
                 <td>{valueMarkup}</td>
                 <td className={styles.copyColumn}>
+                  <AttributeActionExtensionPoint attribute={row} attributes={data}/>
                   <CopyIcon
                     className={copyIconClassName}
                     copyText={JSON.stringify(row, null, 2)}

--- a/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPoint.tsx
+++ b/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPoint.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, Suspense} from "react";
+import React, {ReactElement} from "react";
 
 import {PluginExtensionPoints} from "@grafana/data";
 import {usePluginComponents} from "@grafana/runtime";
@@ -17,7 +17,6 @@ export default function AttributeActionExtensionPoint(props: AttributeActionExte
 
   return (
     <>
-      <Suspense fallback={null}>
       {components.map((component) => {
         const Component = component as React.ComponentType<{
           attribute: TraceKeyValuePair | undefined;
@@ -26,7 +25,6 @@ export default function AttributeActionExtensionPoint(props: AttributeActionExte
 
         return <Component key={props.attribute?.key} attribute={props.attribute} attributes={props.attributes}/>;
       })}
-      </Suspense>
     </>
   );
 }

--- a/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPoint.tsx
+++ b/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPoint.tsx
@@ -1,0 +1,32 @@
+import React, {ReactElement, Suspense} from "react";
+
+import {PluginExtensionPoints} from "@grafana/data";
+import {usePluginComponents} from "@grafana/runtime";
+
+import {TraceKeyValuePair} from "../types";
+
+interface AttributeActionExtensionPointProps {
+  attribute?: TraceKeyValuePair,
+  attributes?: TraceKeyValuePair[]
+}
+
+export default function AttributeActionExtensionPoint(props: AttributeActionExtensionPointProps): ReactElement | null {
+  const {components} = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.ExploreTracesAttributeAttributeAction
+  });
+
+  return (
+    <>
+      <Suspense fallback={null}>
+      {components.map((component) => {
+        const Component = component as React.ComponentType<{
+          attribute: TraceKeyValuePair | undefined;
+          attributes: TraceKeyValuePair[] | undefined;
+        }>;
+
+        return <Component key={props.attribute?.key} attribute={props.attribute} attributes={props.attributes}/>;
+      })}
+      </Suspense>
+    </>
+  );
+}

--- a/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPointTest.tsx
+++ b/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPointTest.tsx
@@ -7,16 +7,6 @@ describe('<AttributeActionExtensionPoint />', () => {
   const attribute = ({ key: 'key', value: 'value' });
   const attributes = [{ key: 'key', value: 'value' }];
 
-  let copySpy: jest.SpyInstance;
-
-  beforeAll(() => {
-    copySpy = jest.spyOn(navigator.clipboard, 'writeText');
-  });
-
-  beforeEach(() => {
-    copySpy.mockReset();
-  });
-
   it('renders as expected', () => {
     expect(() => render(<AttributeActionExtensionPoint attribute={attribute} attributes={attributes} />)).not.toThrow();
   });

--- a/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPointTest.tsx
+++ b/public/app/features/explore/TraceView/components/common/AttributeActionExtensionPointTest.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import AttributeActionExtensionPoint from "./AttributeActionExtensionPoint";
+
+describe('<AttributeActionExtensionPoint />', () => {
+  const attribute = ({ key: 'key', value: 'value' });
+  const attributes = [{ key: 'key', value: 'value' }];
+
+  let copySpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    copySpy = jest.spyOn(navigator.clipboard, 'writeText');
+  });
+
+  beforeEach(() => {
+    copySpy.mockReset();
+  });
+
+  it('renders as expected', () => {
+    expect(() => render(<AttributeActionExtensionPoint attribute={attribute} attributes={attributes} />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
**What is this feature?**



This changes introduces an app extension to allow Grafana Apps to contribute react components to the explore signal views.

**Why do we need this feature?**

In Logs and traces, labels and attributes respectively have a special meaning.

Grafana Apps should be able to decide how they want to handle these attributes and where.

**Who is this feature for?**

3rd act products and their users.
