### PR TITLE
fix: sql instrumentation dual registration error

### DIFF
--- a/pkg/services/sqlstore/replstore.go
+++ b/pkg/services/sqlstore/replstore.go
@@ -118,7 +118,7 @@ func (ss *SQLStore) initReadOnlyEngine(engine *xorm.Engine) error {
 	ss.dbCfg = dbCfg
 
 	if ss.cfg.DatabaseInstrumentQueries {
-		ss.dbCfg.Type = WrapDatabaseDriverWithHooks(ss.dbCfg.Type, ss.tracer)
+		ss.dbCfg.Type = WrapDatabaseReplDriverWithHooks(ss.dbCfg.Type, ss.tracer)
 	}
 
 	if engine == nil {


### PR DESCRIPTION
This fixes the following error by adding "Replica" to the driver name:
`level=error msg="Critical error" reason="sql: Register called twice for driver mysqlWithHooks"`

I think this is good enough for right now, but I'll make the method a bit nicer (and with less duplicated code) when implementing multiple database replicas and need an instrumentation driver for each. I'm also open to suggestions.