### PR TITLE
RBAC: Allow folders actions in plugins roles

### DIFF
--- a/pkg/services/accesscontrol/pluginutils/utils.go
+++ b/pkg/services/accesscontrol/pluginutils/utils.go
@@ -30,7 +30,7 @@ func ValidatePluginPermissions(pluginID string, permissions []ac.Permission) err
 				return &ac.ErrorScopeTarget{Action: permissions[i].Action, Scope: permissions[i].Scope,
 					ExpectedScope: scopePrefix + pluginID}
 			}
-			// Prevent any unlickely injection
+			// Prevent any unlikely injection
 			permissions[i].Scope = scopePrefix + pluginID
 			continue
 		}

--- a/pkg/services/accesscontrol/pluginutils/utils.go
+++ b/pkg/services/accesscontrol/pluginutils/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	AllowedCoreActions = map[string]string{
+	allowedCoreActions = map[string]string{
 		"plugins.app:access":        "plugins:id:",
 		"folders:create":            "folders:uid:",
 		"folders:read":              "folders:uid:",
@@ -24,7 +24,7 @@ var (
 // ValidatePluginPermissions errors when a permission does not match expected pattern for plugins
 func ValidatePluginPermissions(pluginID string, permissions []ac.Permission) error {
 	for i := range permissions {
-		scopePrefix, isCore := AllowedCoreActions[permissions[i].Action]
+		scopePrefix, isCore := allowedCoreActions[permissions[i].Action]
 		if isCore {
 			if permissions[i].Scope != scopePrefix+pluginID {
 				return &ac.ErrorScopeTarget{Action: permissions[i].Action, Scope: permissions[i].Scope,

--- a/pkg/services/accesscontrol/pluginutils/utils_test.go
+++ b/pkg/services/accesscontrol/pluginutils/utils_test.go
@@ -167,7 +167,7 @@ func TestValidatePluginRole(t *testing.T) {
 				Name:        "plugins:test-app:reader",
 				DisplayName: "Plugin Folder Reader",
 				Permissions: []ac.Permission{
-					{Action: "folders:read", Scope: "plugins:id:other-app"},
+					{Action: "folders:read", Scope: "folders:uid:other-app"},
 				},
 			},
 			wantErr: &ac.ErrorInvalidRole{},

--- a/pkg/services/accesscontrol/pluginutils/utils_test.go
+++ b/pkg/services/accesscontrol/pluginutils/utils_test.go
@@ -149,6 +149,29 @@ func TestValidatePluginRole(t *testing.T) {
 			},
 			wantErr: &ac.ErrorInvalidRole{},
 		},
+		{
+			name:     "valid core permission targets plugin",
+			pluginID: "test-app",
+			role: ac.RoleDTO{
+				Name:        "plugins:test-app:reader",
+				DisplayName: "Plugin Folder Reader",
+				Permissions: []ac.Permission{
+					{Action: "folders:read", Scope: "folders:uid:test-app"},
+				},
+			},
+		},
+		{
+			name:     "invalid core permission targets other plugin",
+			pluginID: "test-app",
+			role: ac.RoleDTO{
+				Name:        "plugins:test-app:reader",
+				DisplayName: "Plugin Folder Reader",
+				Permissions: []ac.Permission{
+					{Action: "folders:read", Scope: "plugins:id:other-app"},
+				},
+			},
+			wantErr: &ac.ErrorInvalidRole{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature allows plugins to create roles with folders permissions as long as the target is `folders:uid:<pluginID>`

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
