### PR TITLE
MetaAnalytics: Force dashboard usage events emitter when the FF alwaysSendUsageInisghts is enabled

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -192,6 +192,7 @@ Experimental features might be changed or removed without prior notice.
 | `failWrongDSUID`                            | Throws an error if a datasource has an invalid UIDs                                                                                                                                                                                                                               |
 | `databaseReadReplica`                       | Use a read replica for some database queries.                                                                                                                                                                                                                                     |
 | `alertingApiServer`                         | Register Alerting APIs with the K8s API server                                                                                                                                                                                                                                    |
+| `alwaysSendUsageInisghts`                   | Forces sending usage insights data no matter what if config.analytics.enabled is enabled                                                                                                                                                                                          |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -192,7 +192,6 @@ Experimental features might be changed or removed without prior notice.
 | `failWrongDSUID`                            | Throws an error if a datasource has an invalid UIDs                                                                                                                                                                                                                               |
 | `databaseReadReplica`                       | Use a read replica for some database queries.                                                                                                                                                                                                                                     |
 | `alertingApiServer`                         | Register Alerting APIs with the K8s API server                                                                                                                                                                                                                                    |
-| `alwaysSendUsageInisghts`                   | Forces sending usage insights data no matter what if config.analytics.enabled is enabled                                                                                                                                                                                          |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -199,4 +199,5 @@ export interface FeatureToggles {
   zanzana?: boolean;
   passScopeToDashboardApi?: boolean;
   alertingApiServer?: boolean;
+  alwaysSendUsageInisghts?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1362,6 +1362,12 @@ var (
 			Owner:           grafanaAlertingSquad,
 			RequiresRestart: true,
 		},
+		{
+			Name:        "alwaysSendUsageInisghts",
+			Description: "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSharingSquad,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1363,14 +1363,14 @@ var (
 			RequiresRestart: true,
 		},
 		{
-			Name:        "alwaysSendUsageInisghts",
-			Description: "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
-			Stage:       FeatureStageExperimental,
+			Name:              "alwaysSendUsageInisghts",
+			Description:       "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
+			Stage:             FeatureStageExperimental,
 			FrontendOnly:      true,
 			AllowSelfServe:    false,
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
-			Owner:       grafanaSharingSquad,
+			Owner:             grafanaOperatorExperienceSquad,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1366,6 +1366,10 @@ var (
 			Name:        "alwaysSendUsageInisghts",
 			Description: "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
 			Stage:       FeatureStageExperimental,
+			FrontendOnly:      true,
+			AllowSelfServe:    false,
+			HideFromDocs:      true,
+			HideFromAdminPage: true,
 			Owner:       grafanaSharingSquad,
 		},
 	}

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -180,3 +180,4 @@ databaseReadReplica,experimental,@grafana/grafana-backend-services-squad,false,f
 zanzana,experimental,@grafana/identity-access-team,false,false,false
 passScopeToDashboardApi,experimental,@grafana/dashboards-squad,false,false,false
 alertingApiServer,experimental,@grafana/alerting-squad,false,true,false
+alwaysSendUsageInisghts,experimental,@grafana/sharing-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -180,4 +180,4 @@ databaseReadReplica,experimental,@grafana/grafana-backend-services-squad,false,f
 zanzana,experimental,@grafana/identity-access-team,false,false,false
 passScopeToDashboardApi,experimental,@grafana/dashboards-squad,false,false,false
 alertingApiServer,experimental,@grafana/alerting-squad,false,true,false
-alwaysSendUsageInisghts,experimental,@grafana/sharing-squad,false,false,true
+alwaysSendUsageInisghts,experimental,@grafana/grafana-operator-experience-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -180,4 +180,4 @@ databaseReadReplica,experimental,@grafana/grafana-backend-services-squad,false,f
 zanzana,experimental,@grafana/identity-access-team,false,false,false
 passScopeToDashboardApi,experimental,@grafana/dashboards-squad,false,false,false
 alertingApiServer,experimental,@grafana/alerting-squad,false,true,false
-alwaysSendUsageInisghts,experimental,@grafana/sharing-squad,false,false,false
+alwaysSendUsageInisghts,experimental,@grafana/sharing-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -730,4 +730,8 @@ const (
 	// FlagAlertingApiServer
 	// Register Alerting APIs with the K8s API server
 	FlagAlertingApiServer = "alertingApiServer"
+
+	// FlagAlwaysSendUsageInisghts
+	// Forces sending usage insights data no matter what if config.analytics.enabled is enabled
+	FlagAlwaysSendUsageInisghts = "alwaysSendUsageInisghts"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -270,16 +270,16 @@
     {
       "metadata": {
         "name": "alwaysSendUsageInisghts",
-        "resourceVersion": "1718969832408",
+        "resourceVersion": "1718969996875",
         "creationTimestamp": "2024-06-21T11:11:46Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2024-06-21 11:37:12.408705 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2024-06-21 11:39:56.875558 +0000 UTC"
         }
       },
       "spec": {
         "description": "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
         "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
         "frontend": true,
         "hideFromAdminPage": true,
         "hideFromDocs": true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -269,6 +269,18 @@
     },
     {
       "metadata": {
+        "name": "alwaysSendUsageInisghts",
+        "resourceVersion": "1718968306014",
+        "creationTimestamp": "2024-06-21T11:11:46Z"
+      },
+      "spec": {
+        "description": "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
+        "stage": "experimental",
+        "codeowner": "@grafana/sharing-squad"
+      }
+    },
+    {
+      "metadata": {
         "name": "angularDeprecationUI",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2023-08-29T14:05:47Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -270,13 +270,19 @@
     {
       "metadata": {
         "name": "alwaysSendUsageInisghts",
-        "resourceVersion": "1718968306014",
-        "creationTimestamp": "2024-06-21T11:11:46Z"
+        "resourceVersion": "1718969832408",
+        "creationTimestamp": "2024-06-21T11:11:46Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-06-21 11:37:12.408705 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Forces sending usage insights data no matter what if config.analytics.enabled is enabled",
         "stage": "experimental",
-        "codeowner": "@grafana/sharing-squad"
+        "codeowner": "@grafana/sharing-squad",
+        "frontend": true,
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
       }
     },
     {


### PR DESCRIPTION
Add a new FF to enable dashboard usage analytics to emit usage events ignoring `config.analytics.enabled` value