### PR TITLE
[v11.1.x] Home: Remove extra padding for dashboard home

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -15,7 +15,7 @@ import { DashboardScene } from './DashboardScene';
 import { NavToolbarActions } from './NavToolbarActions';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {
-  const { controls, overlay, editview, editPanel, isEmpty, scopes, meta } = model.useState();
+  const { controls, overlay, editview, editPanel, isEmpty, scopes } = model.useState();
   const { isExpanded: isScopesExpanded } = scopes?.useState() ?? {};
   const styles = useStyles2(getStyles);
   const location = useLocation();
@@ -23,7 +23,6 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   const pageNav = model.getPageNav(location, navIndex);
   const bodyToRender = model.getBodyToRender();
   const navModel = getNavModel(navIndex, 'dashboards/browse');
-  const isHomePage = !meta.url && !meta.slug && !meta.isNew && !meta.isSnapshot;
   const hasControls = controls?.hasControls();
 
   if (editview) {
@@ -71,7 +70,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
             className={styles.scrollbarContainer}
             testId={selectors.pages.Dashboard.DashNav.scrollContainer}
           >
-            <div className={cx(styles.canvasContent, isHomePage && styles.homePagePadding)}>
+            <div className={cx(styles.canvasContent)}>
               <>{isEmpty && emptyState}</>
               {withPanels}
             </div>
@@ -126,9 +125,6 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     controlsWrapperWithScopes: css({
       padding: theme.spacing(2, 2, 2, 0),
-    }),
-    homePagePadding: css({
-      padding: theme.spacing(2, 2),
     }),
     canvasContent: css({
       label: 'canvas-content',


### PR DESCRIPTION
Backport aea894191b91ea18644f5eb37f96e4a3af8d1022 from #89432

---

Remove extra padding for dashboards when they are set as the home page.

This padding is not needed anymore since PR #88920 where margins were standardized.

This is how it looks now in the different scenarios:
|Home page|Custom home page with controls|Custom home page without controls|
|-|-|-|
<img width="1728" alt="Captura de pantalla 2024-06-19 a las 17 48 57" src="https://github.com/grafana/grafana/assets/5699976/2ce9a162-6779-4004-ad41-a01552d845fa">|<img width="1728" alt="Captura de pantalla 2024-06-19 a las 17 49 36" src="https://github.com/grafana/grafana/assets/5699976/dfd5ae1c-5a9c-49d5-8c86-6132012d1607">|<img width="1728" alt="Captura de pantalla 2024-06-19 a las 17 50 05" src="https://github.com/grafana/grafana/assets/5699976/9d434163-944e-4271-bb7f-6637e51bb229">
