### PR TITLE
Chore: Export SelectMenuOptions

### DIFF
--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -231,6 +231,7 @@ export { FieldArray } from './Forms/FieldArray';
 // Select
 export { default as resetSelectStyles } from './Select/resetSelectStyles';
 export * from './Select/Select';
+export { SelectMenuOptions } from './Select/SelectMenu';
 export { getSelectStyles } from './Select/getSelectStyles';
 export * from './Select/types';
 


### PR DESCRIPTION
**What is this feature?**

We need `SelectMenuOptions` component in `grafana-prometheus` package. For the decoupling process, we duplicated the code and moved forward in order to unblock ourselves. Prometheus query builder has been using `SelectmenuOptions`.

See: 
Old: https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx#L222
New: https://github.com/grafana/grafana/blob/b4e49e31145e67b4c222fbb09cdbe3953b0ccea4/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx#L223
