### PR TITLE
WebpackDev: Resolve react-router-dom from local node modules

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -51,6 +51,10 @@ module.exports = (env = {}) => {
         // the same singletons
         '@grafana/runtime': path.resolve(__dirname, '../../packages/grafana-runtime'),
         '@grafana/data': path.resolve(__dirname, '../../packages/grafana-data'),
+
+        // This is required to correctly resolve react-router-dom when linking with
+        //  local version of @grafana/scenes
+        'react-router-dom': path.resolve('./node_modules/react-router-dom'),
       },
     },
 


### PR DESCRIPTION
This PR fixes issue with linking of `@grafana/scenes` where we get errors associated with multiple `react-router-dom` packages.

Not sure if this is preferred solution or not, so could be temporary fix until we figure out linking in `@grafana/scenes`


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
