### PR TITLE
Unified Storage: Always populate RV and UID on create

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -54,7 +54,7 @@ func (d *DualWriterMode1) Create(ctx context.Context, original runtime.Object, c
 		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage create timeout"))
 		defer cancel()
 
-		if err := enrichLegacyObject(original, createdCopy, true); err != nil {
+		if err := enrichLegacyObject(original, createdCopy); err != nil {
 			cancel()
 		}
 
@@ -201,7 +201,7 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 
 		// if the object is found, create a new updateWrapper with the object found
 		if foundObj != nil {
-			if err := enrichLegacyObject(foundObj, resCopy, false); err != nil {
+			if err := enrichLegacyObject(foundObj, resCopy); err != nil {
 				log.Error(err, "could not enrich object")
 				cancel()
 			}

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -50,7 +50,7 @@ func (d *DualWriterMode2) Create(ctx context.Context, original runtime.Object, c
 	}
 	d.recordLegacyDuration(false, mode2Str, options.Kind, method, startLegacy)
 
-	if err := enrichLegacyObject(original, created, true); err != nil {
+	if err := enrichLegacyObject(original, created); err != nil {
 		return created, err
 	}
 
@@ -261,7 +261,7 @@ func (d *DualWriterMode2) Update(ctx context.Context, name string, objInfo rest.
 
 	// if the object is found, create a new updateWrapper with the object found
 	if foundObj != nil {
-		err = enrichLegacyObject(foundObj, obj, false)
+		err = enrichLegacyObject(foundObj, obj)
 		if err != nil {
 			return obj, false, err
 		}
@@ -328,7 +328,7 @@ func parseList(legacyList []runtime.Object) (metainternalversion.ListOptions, ma
 	return options, indexMap, nil
 }
 
-func enrichLegacyObject(originalObj, returnedObj runtime.Object, created bool) error {
+func enrichLegacyObject(originalObj, returnedObj runtime.Object) error {
 	accessorReturned, err := meta.Accessor(returnedObj)
 	if err != nil {
 		return err
@@ -350,13 +350,6 @@ func enrichLegacyObject(originalObj, returnedObj runtime.Object, created bool) e
 	}
 	accessorReturned.SetAnnotations(ac)
 
-	// if the object is created, we need to reset the resource version and UID
-	// create method expects an empty resource version
-	if created {
-		accessorReturned.SetResourceVersion("")
-		accessorReturned.SetUID("")
-		return nil
-	}
 	// otherwise, we propagate the original RV and UID
 	accessorReturned.SetResourceVersion(accessorOriginal.GetResourceVersion())
 	accessorReturned.SetUID(accessorOriginal.GetUID())

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -493,83 +493,7 @@ func TestEnrichReturnedObject(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name: "create: original object does not have labels and annotations",
-			inputOriginal: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5")},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			inputReturned: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "2", UID: types.UID("6"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			isCreated: true,
-			expectedObject: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "", UID: types.UID("")},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-		},
-		{
-			name: "create: returned object does not have labels and annotations",
-			inputOriginal: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			inputReturned: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "2", UID: types.UID("6")},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			isCreated: true,
-			expectedObject: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "", UID: types.UID(""), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-		},
-		{
-			name: "create: both objects have labels and annotations",
-			inputOriginal: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			inputReturned: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "2", UID: types.UID("6"), Labels: map[string]string{"label2": "2"}, Annotations: map[string]string{"annotation2": "2"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			isCreated: true,
-			expectedObject: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "", UID: types.UID(""), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-		},
-		{
-			name: "create: both objects have labels and annotations with duplicated keys",
-			inputOriginal: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			inputReturned: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "2", UID: types.UID("6"), Labels: map[string]string{"label1": "11"}, Annotations: map[string]string{"annotation1": "11"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-			isCreated: true,
-			expectedObject: &example.Pod{
-				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "", UID: types.UID(""), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
-				Spec:       example.PodSpec{}, Status: example.PodStatus{},
-			},
-		},
-		{
-			name: "update: original object does not have labels and annotations",
+			name: "original object does not have labels and annotations",
 			inputOriginal: &example.Pod{
 				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5")},
@@ -587,7 +511,7 @@ func TestEnrichReturnedObject(t *testing.T) {
 			},
 		},
 		{
-			name: "update: returned object does not have labels and annotations",
+			name: "returned object does not have labels and annotations",
 			inputOriginal: &example.Pod{
 				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
@@ -605,7 +529,7 @@ func TestEnrichReturnedObject(t *testing.T) {
 			},
 		},
 		{
-			name: "update: both objects have labels and annotations",
+			name: "both objects have labels and annotations",
 			inputOriginal: &example.Pod{
 				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
@@ -623,7 +547,7 @@ func TestEnrichReturnedObject(t *testing.T) {
 			},
 		},
 		{
-			name: "update: both objects have labels and annotations with duplicated keys",
+			name: "both objects have labels and annotations with duplicated keys",
 			inputOriginal: &example.Pod{
 				TypeMeta:   metav1.TypeMeta{Kind: "foo"},
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1", UID: types.UID("5"), Labels: map[string]string{"label1": "1"}, Annotations: map[string]string{"annotation1": "1"}},
@@ -658,7 +582,7 @@ func TestEnrichReturnedObject(t *testing.T) {
 
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
-			err := enrichLegacyObject(tt.inputOriginal, tt.inputReturned, tt.isCreated)
+			err := enrichLegacyObject(tt.inputOriginal, tt.inputReturned)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/apiserver/rest/dualwriter_mode2_test.go
+++ b/pkg/apiserver/rest/dualwriter_mode2_test.go
@@ -79,7 +79,7 @@ func TestMode2_Create(t *testing.T) {
 			assert.Equal(t, exampleObj, obj)
 			accessor, err := meta.Accessor(obj)
 			assert.NoError(t, err)
-			assert.Equal(t, accessor.GetResourceVersion(), "")
+			assert.Equal(t, accessor.GetResourceVersion(), "1")
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Because of historical reasons, we were ignoring the resource_version and UID for create methods on unified storage. We should change this, as each returned object needs.
We are changing this logic to be the same as on `update`.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
