### PR TITLE
Alerting: fix updating error in the alert rule state during error to error transitions and restarts

### DIFF
--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1244,6 +1244,7 @@ func TestProcessEvalResults(t *testing.T) {
 					EndsAt:             tn(6).Add(state.ResendDelay * 4),
 					LastEvaluationTime: tn(6),
 					LastSentAt:         util.Pointer(tn(6)), // After 30s resend delay, last sent at is t6.
+					Annotations:        map[string]string{"annotation": "test", "Error": "with_state_error"},
 				},
 			},
 		},


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue where transitioning from one error state to another in alert rules sometimes did not update `Error` in the state correctly. If the error was caused by an error returned from the expression service or a panicking routine, the initial error remained, causing inaccurate error reporting in the UI and loss of the error message after a Grafana restart. `Error` of the state isn't preserved in the database, so it was lost and never updated after a restart. This led to errors displayed in the UI as "No error message":
<details>
  <summary>screenshot</summary>
<img width="843" alt="image" src="https://github.com/grafana/grafana/assets/1875873/6f186196-c07d-45e6-8ffa-221176f42bf3">
</details>

This PR adds error annotations and the error to the alert state in these cases in the same way as it's added when the error is encountered for the first time.



**Why do we need this feature?**

Some alert evaluation error messages can be lost.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

The easiest way to reproduce the issue is to have a broken alerting rule or make it panic in [EvaluateRaw](https://github.com/grafana/grafana/blob/3c157817885385298fb45c72b5d3eac7295a01ae/pkg/services/ngalert/eval/eval.go#L57). After that, a restart of the Grafana instance erases the error message and it's displayed as "No error message".

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
