### PR TITLE
Devenv: Allow configuring alertmanager config for prometheus docker block

### DIFF
--- a/devenv/docker/blocks/prometheus/alertmanager.yml
+++ b/devenv/docker/blocks/prometheus/alertmanager.yml
@@ -1,0 +1,16 @@
+route:
+  group_by: ['alertname']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  receiver: 'web.hook'
+receivers:
+  - name: 'web.hook'
+    webhook_configs:
+      - url: 'http://127.0.0.1:5001/'
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'dev', 'instance']

--- a/devenv/docker/blocks/prometheus/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus/docker-compose.yaml
@@ -25,7 +25,11 @@
       FD_DATASOURCE: prom
 
   alertmanager:
-    image: quay.io/prometheus/alertmanager
+    image: prom/alertmanager 
+    volumes:
+    - ${PWD}/docker/blocks/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml
+    command: >
+      --config.file=/etc/alertmanager/alertmanager.yml
     ports:
       - "9093:9093"
 


### PR DESCRIPTION
**What is this feature?**

This PR allows configuration of the Alertmanager in the Prometheus docker block.

The default config is taken from the [ha example](https://github.com/prometheus/alertmanager/blob/main/Dockerfile#L10) as per the default Alertmanager image.