### PR TITLE
fix(grafana-apps): copy namespace from connect ctx

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -87,9 +87,9 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 	b := r.builder
 
 	return http.HandlerFunc(func(w http.ResponseWriter, httpreq *http.Request) {
-		ctx := request.WithNamespace(httpreq.Context(), request.NamespaceValue(connectCtx))
-		ctx, span := b.tracer.Start(ctx, "QueryService.Query")
+		ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
 		defer span.End()
+		ctx = request.WithNamespace(ctx, request.NamespaceValue(connectCtx))
 
 		responder := newResponderWrapper(incomingResponder,
 			func(statusCode int, obj runtime.Object) {


### PR DESCRIPTION
This pull request addresses the issue of a missing namespace within the HTTP request context. Previously, the namespace was exclusively provided by the Connect context, limiting its availability downstream. This update ensures the namespace is propagated into the HTTP request context, thereby making it accessible to subsequent functions and enhancing overall context propagation throughout the call chain.