### PR TITLE
Update folder service's GetFolders to be able to filter by additional permissions

### DIFF
--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -169,6 +169,8 @@ type GetFoldersQuery struct {
 	// otherwise better to keep it false since ordering can have a performance impact
 	OrderByTitle bool
 	SignedInUser identity.Requester `json:"-"`
+	// AdditionalAction is an additional action to filter folders. This action must have folder scopes.
+	AdditionalAction string
 }
 
 // GetParentsQuery captures the information required by the folder service to


### PR DESCRIPTION
**What is this feature?**
This PR updates the method GetFolders of the folder service. Currently, this method returns folders that the current user has access to. The PR proposes a new field `AdditionalAction`  in the query struct, if specified, which makes the service filter out folders for which the user does not have additional permission.

I acknowledge that this is a suboptimal design. I considered alternatives like:
- using an access control service. The problem here is that it independently [fetches the parents](https://github.com/grafana/grafana/blob/99d8025829e896b68f6cd5eb11d4ff448d6c3b30/pkg/services/accesscontrol/acimpl/accesscontrol.go#L51-L63) of every folder if it cannot find an exact match in permissions.  This will affect the performance of list APIs where this method is usually used.
- doing it in the code outside folders. The problem here is that it multiplies places where we hack around the access control. GetFolders already implements reverse permission checks. 



**Why do we need this feature?**
To be able to get folders to which the user has two permissions. Primarily, it will be used in alerting APIs.

**Who is this feature for?**
Developers
