### PR TITLE
Canvas: Fix off center element item in editor list

### DIFF
--- a/public/app/plugins/panel/canvas/globalStyles.ts
+++ b/public/app/plugins/panel/canvas/globalStyles.ts
@@ -89,6 +89,7 @@ export function getGlobalStyles(theme: GrafanaTheme2) {
           },
         },
         span: {
+          height: '100%',
           '&.rc-tree-checkbox, &.rc-tree-iconEle': {
             display: 'inline-block',
             width: '16px',


### PR DESCRIPTION
Noticed that the element item in the editor list was not centered 🙃

Before
<img width="371" alt="before" src="https://github.com/grafana/grafana/assets/22381771/d8e5b9b5-a799-43b1-a8c6-42729f14dd1b">

After
<img width="376" alt="after" src="https://github.com/grafana/grafana/assets/22381771/82fed66d-fefb-48e6-8ecc-f4f63ed48e4e">
