### PR TITLE
Alerting: Update alerting state history API to authorize access using RBAC

### DIFF
--- a/pkg/services/annotations/annotationsimpl/loki/historian_store.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store.go
@@ -99,7 +99,7 @@ func (r *LokiHistorianStore) Get(ctx context.Context, query *annotations.ItemQue
 		}
 	}
 
-	logQL, err := historian.BuildLogQuery(buildHistoryQuery(query, accessResources.Dashboards, rule.UID), nil, r.client.MaxQuerySize())
+	logQL, _, err := historian.BuildLogQuery(buildHistoryQuery(query, accessResources.Dashboards, rule.UID), nil, r.client.MaxQuerySize())
 	if err != nil {
 		grafanaErr := errutil.Error{}
 		if errors.As(err, &grafanaErr) {

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store.go
@@ -99,7 +99,7 @@ func (r *LokiHistorianStore) Get(ctx context.Context, query *annotations.ItemQue
 		}
 	}
 
-	logQL, err := historian.BuildLogQuery(buildHistoryQuery(query, accessResources.Dashboards, rule.UID), r.client.MaxQuerySize())
+	logQL, err := historian.BuildLogQuery(buildHistoryQuery(query, accessResources.Dashboards, rule.UID), nil, r.client.MaxQuerySize())
 	if err != nil {
 		grafanaErr := errutil.Error{}
 		if errors.As(err, &grafanaErr) {

--- a/pkg/services/ngalert/accesscontrol/fakes/rules.go
+++ b/pkg/services/ngalert/accesscontrol/fakes/rules.go
@@ -24,6 +24,7 @@ type FakeRuleService struct {
 	HasAccessInFolderFunc                     func(context.Context, identity.Requester, models.Namespaced) (bool, error)
 	AuthorizeAccessInFolderFunc               func(context.Context, identity.Requester, models.Namespaced) error
 	AuthorizeRuleChangesFunc                  func(context.Context, identity.Requester, *store.GroupDelta) error
+	CanReadAllRulesFunc                       func(context.Context, identity.Requester) (bool, error)
 
 	Calls []Call
 }
@@ -98,4 +99,12 @@ func (s *FakeRuleService) AuthorizeRuleChanges(ctx context.Context, user identit
 		return s.AuthorizeRuleChangesFunc(ctx, user, change)
 	}
 	return nil
+}
+
+func (s *FakeRuleService) CanReadAllRules(ctx context.Context, user identity.Requester) (bool, error) {
+	s.Calls = append(s.Calls, Call{"CanReadAllRules", []interface{}{ctx, user}})
+	if s.CanReadAllRulesFunc != nil {
+		return s.CanReadAllRulesFunc(ctx, user)
+	}
+	return false, nil
 }

--- a/pkg/services/ngalert/accesscontrol/rules.go
+++ b/pkg/services/ngalert/accesscontrol/rules.go
@@ -76,6 +76,14 @@ func (r *RuleService) getRulesQueryEvaluator(rules ...*models.AlertRule) accessc
 	return accesscontrol.EvalAll(evals...)
 }
 
+// CanReadAllRules returns true when user has access to all folders and can read rules in them.
+func (r *RuleService) CanReadAllRules(ctx context.Context, user identity.Requester) (bool, error) {
+	return r.HasAccess(ctx, user, accesscontrol.EvalAll(
+		accesscontrol.EvalPermission(ruleRead, dashboards.ScopeFoldersProvider.GetResourceAllScope()),
+		accesscontrol.EvalPermission(dashboards.ActionFoldersRead, dashboards.ScopeFoldersProvider.GetResourceAllScope()),
+	))
+}
+
 // AuthorizeDatasourceAccessForRule checks that user has access to all data sources declared by the rule
 func (r *RuleService) AuthorizeDatasourceAccessForRule(ctx context.Context, user identity.Requester, rule *models.AlertRule) error {
 	ds := r.getRulesQueryEvaluator(rule)

--- a/pkg/services/ngalert/accesscontrol/rules_test.go
+++ b/pkg/services/ngalert/accesscontrol/rules_test.go
@@ -453,3 +453,54 @@ func Test_authorizeAccessToRuleGroup(t *testing.T) {
 		require.ErrorIs(t, result, ErrAuthorizationBase)
 	})
 }
+
+func TestCanReadAllRules(t *testing.T) {
+	ac := &recordingAccessControlFake{}
+	svc := RuleService{
+		genericService{ac: ac},
+	}
+
+	testCases := []struct {
+		permissions map[string][]string
+		expected    bool
+	}{
+		{
+			permissions: map[string][]string{
+				ruleRead:                     {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+			},
+			expected: true,
+		},
+		{
+			permissions: make(map[string][]string),
+		},
+		{
+			permissions: map[string][]string{
+				ruleRead:                     {dashboards.ScopeFoldersProvider.GetResourceScopeUID("test")},
+				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+			},
+		},
+		{
+			permissions: map[string][]string{
+				ruleRead:                     {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceScopeUID("test")},
+			},
+		},
+		{
+			permissions: map[string][]string{
+				ruleRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+			},
+		},
+		{
+			permissions: map[string][]string{
+				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceAllScope()},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := svc.CanReadAllRules(context.Background(), createUserWithPermissions(tc.permissions))
+		assert.NoError(t, err)
+		assert.Equalf(t, tc.expected, result, "permissions: %v", tc.permissions)
+	}
+}

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -20,6 +20,7 @@ import (
 
 	alertingModels "github.com/grafana/alerting/models"
 
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/cmputil"
@@ -272,6 +273,12 @@ type AlertRule struct {
 // Namespaced describes a class of resources that are stored in a specific namespace.
 type Namespaced interface {
 	GetNamespaceUID() string
+}
+
+type Namespace folder.Folder
+
+func (n Namespace) GetNamespaceUID() string {
+	return n.UID
 }
 
 // AlertRuleWithOptionals This is to avoid having to pass in additional arguments deep in the call stack. Alert rule

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -570,7 +570,7 @@ func configureHistorianBackend(ctx context.Context, cfg setting.UnifiedAlertingS
 		}
 		req := historian.NewRequester()
 		lokiBackendLogger := log.New("ngalert.state.historian", "backend", "loki")
-		backend := historian.NewRemoteLokiBackend(lokiBackendLogger, lcfg, req, met, tracer)
+		backend := historian.NewRemoteLokiBackend(lokiBackendLogger, lcfg, req, met, tracer, rs, ac)
 
 		testConnCtx, cancelFunc := context.WithTimeout(ctx, 10*time.Second)
 		defer cancelFunc()

--- a/pkg/services/ngalert/ngalert_test.go
+++ b/pkg/services/ngalert/ngalert_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/folder"
+	acfakes "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol/fakes"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
@@ -67,8 +68,9 @@ func TestConfigureHistorianBackend(t *testing.T) {
 			Enabled: true,
 			Backend: "invalid-backend",
 		}
+		ac := &acfakes.FakeRuleService{}
 
-		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer)
+		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer, ac)
 
 		require.ErrorContains(t, err, "unrecognized")
 	})
@@ -82,8 +84,9 @@ func TestConfigureHistorianBackend(t *testing.T) {
 			Backend:      "multiple",
 			MultiPrimary: "invalid-backend",
 		}
+		ac := &acfakes.FakeRuleService{}
 
-		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer)
+		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer, ac)
 
 		require.ErrorContains(t, err, "multi-backend target")
 		require.ErrorContains(t, err, "unrecognized")
@@ -99,8 +102,9 @@ func TestConfigureHistorianBackend(t *testing.T) {
 			MultiPrimary:     "annotations",
 			MultiSecondaries: []string{"annotations", "invalid-backend"},
 		}
+		ac := &acfakes.FakeRuleService{}
 
-		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer)
+		_, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer, ac)
 
 		require.ErrorContains(t, err, "multi-backend target")
 		require.ErrorContains(t, err, "unrecognized")
@@ -117,8 +121,9 @@ func TestConfigureHistorianBackend(t *testing.T) {
 			LokiReadURL:  "http://gone.invalid",
 			LokiWriteURL: "http://gone.invalid",
 		}
+		ac := &acfakes.FakeRuleService{}
 
-		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer)
+		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer, ac)
 
 		require.NotNil(t, h)
 		require.NoError(t, err)
@@ -133,8 +138,9 @@ func TestConfigureHistorianBackend(t *testing.T) {
 			Enabled: true,
 			Backend: "annotations",
 		}
+		ac := &acfakes.FakeRuleService{}
 
-		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer)
+		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer, ac)
 
 		require.NotNil(t, h)
 		require.NoError(t, err)
@@ -155,8 +161,9 @@ grafana_alerting_state_history_info{backend="annotations"} 1
 		cfg := setting.UnifiedAlertingStateHistorySettings{
 			Enabled: false,
 		}
+		ac := &acfakes.FakeRuleService{}
 
-		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer)
+		h, err := configureHistorianBackend(context.Background(), cfg, nil, nil, nil, met, logger, tracer, ac)
 
 		require.NotNil(t, h)
 		require.NoError(t, err)

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -25,7 +26,9 @@ import (
 )
 
 type AccessControl interface {
+	CanReadAllRules(ctx context.Context, user identity.Requester) (bool, error)
 	AuthorizeAccessInFolder(ctx context.Context, user identity.Requester, rule ngmodels.Namespaced) error
+	HasAccessInFolder(ctx context.Context, user identity.Requester, rule ngmodels.Namespaced) (bool, error)
 }
 
 // AnnotationBackend is an implementation of state.Historian that uses Grafana Annotations as the backing datastore.
@@ -40,6 +43,7 @@ type AnnotationBackend struct {
 
 type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) (*ngmodels.AlertRule, error)
+	GetUserVisibleNamespaces(ctx context.Context, orgID int64, user identity.Requester) (map[string]*folder.Folder, error)
 }
 
 type AnnotationStore interface {

--- a/pkg/services/ngalert/state/historian/annotation_test.go
+++ b/pkg/services/ngalert/state/historian/annotation_test.go
@@ -4,28 +4,33 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	acfakes "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol/fakes"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
+	"github.com/grafana/grafana/pkg/services/user"
 )
 
 func TestAnnotationHistorian(t *testing.T) {
@@ -46,6 +51,31 @@ func TestAnnotationHistorian(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			require.Equal(t, frame.Fields[i].Len(), 1)
 		}
+	})
+
+	t.Run("alert annotations are authorized", func(t *testing.T) {
+		anns := createTestAnnotationBackendSut(t)
+		ac := &acfakes.FakeRuleService{}
+		expectedErr := errors.New("test-error")
+		ac.AuthorizeAccessInFolderFunc = func(ctx context.Context, requester identity.Requester, namespaced models.Namespaced) error {
+			return expectedErr
+		}
+		anns.ac = ac
+
+		items := []annotations.Item{createAnnotation()}
+		require.NoError(t, anns.store.Save(context.Background(), nil, items, 1, log.NewNopLogger()))
+
+		q := models.HistoryQuery{
+			RuleUID:      "my-rule",
+			OrgID:        1,
+			SignedInUser: &user.SignedInUser{Name: "test-user", OrgID: 1},
+		}
+		_, err := anns.Query(context.Background(), q)
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Len(t, ac.Calls, 1)
+		assert.Equal(t, "AuthorizeAccessInFolder", ac.Calls[0].MethodName)
+		assert.Equal(t, q.SignedInUser, ac.Calls[0].Arguments[1])
 	})
 
 	t.Run("annotation queries send expected item query", func(t *testing.T) {
@@ -132,7 +162,8 @@ func createTestAnnotationSutWithStore(t *testing.T, annotations AnnotationStore)
 		models.RuleGen.With(models.RuleMuts.WithOrgID(1), withUID("my-rule")).GenerateRef(),
 	}
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
-	return NewAnnotationBackend(annotationBackendLogger, annotations, rules, met)
+	ac := &acfakes.FakeRuleService{}
+	return NewAnnotationBackend(annotationBackendLogger, annotations, rules, met, ac)
 }
 
 func createTestAnnotationBackendSutWithMetrics(t *testing.T, met *metrics.Historian) *AnnotationBackend {
@@ -146,7 +177,8 @@ func createTestAnnotationBackendSutWithMetrics(t *testing.T, met *metrics.Histor
 	dbs.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
 	store := NewAnnotationStore(fakeAnnoRepo, dbs, met)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
-	return NewAnnotationBackend(annotationBackendLogger, store, rules, met)
+	ac := &acfakes.FakeRuleService{}
+	return NewAnnotationBackend(annotationBackendLogger, store, rules, met, ac)
 }
 
 func createFailingAnnotationSut(t *testing.T, met *metrics.Historian) *AnnotationBackend {
@@ -159,7 +191,8 @@ func createFailingAnnotationSut(t *testing.T, met *metrics.Historian) *Annotatio
 	dbs.On("GetDashboard", mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
 	store := NewAnnotationStore(fakeAnnoRepo, dbs, met)
-	return NewAnnotationBackend(annotationBackendLogger, store, rules, met)
+	ac := &acfakes.FakeRuleService{}
+	return NewAnnotationBackend(annotationBackendLogger, store, rules, met, ac)
 }
 
 func createAnnotation() annotations.Item {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -151,7 +151,7 @@ func (h *RemoteLokiBackend) Query(ctx context.Context, query models.HistoryQuery
 	if err != nil {
 		return nil, err
 	}
-	return merge(res, query.RuleUID)
+	return merge(res)
 }
 
 func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
@@ -176,7 +176,7 @@ func buildSelectors(query models.HistoryQuery) ([]Selector, error) {
 }
 
 // merge will put all the results in one array sorted by timestamp.
-func merge(res QueryRes, ruleUID string) (*data.Frame, error) {
+func merge(res QueryRes) (*data.Frame, error) {
 	// Find the total number of elements in all arrays.
 	totalLen := 0
 	for _, arr := range res.Data.Result {

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -411,7 +411,7 @@ func selectorString(selectors []Selector, folderUIDs []string) string {
 		b := strings.Builder{}
 		b.Grow(len(folderUIDs)*40 + len(FolderUIDLabel)) // rough estimate of the length
 		b.WriteString(FolderUIDLabel)
-		b.WriteString("~=`")
+		b.WriteString("=~`")
 		b.WriteString(regexp.QuoteMeta(folderUIDs[0]))
 		for _, uid := range folderUIDs[1:] {
 			b.WriteString("|")

--- a/pkg/services/ngalert/state/historian/loki.go
+++ b/pkg/services/ngalert/state/historian/loki.go
@@ -75,15 +75,19 @@ type RemoteLokiBackend struct {
 	clock          clock.Clock
 	metrics        *metrics.Historian
 	log            log.Logger
+	ac             AccessControl
+	ruleStore      RuleStore
 }
 
-func NewRemoteLokiBackend(logger log.Logger, cfg LokiConfig, req client.Requester, metrics *metrics.Historian, tracer tracing.Tracer) *RemoteLokiBackend {
+func NewRemoteLokiBackend(logger log.Logger, cfg LokiConfig, req client.Requester, metrics *metrics.Historian, tracer tracing.Tracer, ruleStore RuleStore, ac AccessControl) *RemoteLokiBackend {
 	return &RemoteLokiBackend{
 		client:         NewLokiClient(cfg, req, metrics, logger, tracer),
 		externalLabels: cfg.ExternalLabels,
 		clock:          clock.New(),
 		metrics:        metrics,
 		log:            logger,
+		ac:             ac,
+		ruleStore:      ruleStore,
 	}
 }
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -412,7 +412,7 @@ func TestMerge(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, err := merge(tc.res, tc.ruleID)
+			m, err := merge(tc.res)
 			require.NoError(t, err)
 
 			var dfTimeColumn *data.Field

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -210,7 +210,7 @@ func TestRemoteLokiBackend(t *testing.T) {
 		require.Equal(t, expected, result)
 
 		selectors = []Selector{{"name", "=", "quoted\"string"}, {"age", "=~", "30"}}
-		expected = "{name=\"quoted\\\"string\",age=~\"30\",folderUID~=`some\\\\d\\.r\\$|normal_string`}"
+		expected = "{name=\"quoted\\\"string\",age=~\"30\",folderUID=~`some\\\\d\\.r\\$|normal_string`}"
 		result = selectorString(selectors, []string{`some\d.r$`, "normal_string"})
 		require.Equal(t, expected, result)
 
@@ -327,7 +327,7 @@ func TestBuildLogQuery(t *testing.T) {
 				OrgID: 123,
 			},
 			folderUIDs: []string{"folder-1", "folder\\d"},
-			exp:        `{orgID="123",from="state-history",folderUID~=` + "`folder-1|folder\\\\d`" + `}`,
+			exp:        `{orgID="123",from="state-history",folderUID=~` + "`folder-1|folder\\\\d`" + `}`,
 		},
 		{
 			name: "should drop folders if it's too long",

--- a/pkg/services/ngalert/state/manager_bench_test.go
+++ b/pkg/services/ngalert/state/manager_bench_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/ngalert/accesscontrol/fakes"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -25,7 +26,8 @@ func BenchmarkProcessEvalResults(b *testing.B) {
 	metrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 	store := historian.NewAnnotationStore(&as, nil, metrics)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
-	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, metrics)
+	ac := &fakes.FakeRuleService{}
+	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, metrics, ac)
 	cfg := state.ManagerCfg{
 		Historian: hist,
 		Tracer:    tracing.InitializeTracerForTest(),

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	acfakes "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol/fakes"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -236,7 +237,8 @@ func TestDashboardAnnotations(t *testing.T) {
 	historianMetrics := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 	store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, historianMetrics)
 	annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
-	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, historianMetrics)
+	ac := &acfakes.FakeRuleService{}
+	hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, historianMetrics, ac)
 	cfg := state.ManagerCfg{
 		Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
 		ExternalURL:   nil,
@@ -1387,7 +1389,8 @@ func TestProcessEvalResults(t *testing.T) {
 			m := metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem)
 			store := historian.NewAnnotationStore(fakeAnnoRepo, &dashboards.FakeDashboardService{}, m)
 			annotationBackendLogger := log.New("ngalert.state.historian", "backend", "annotations")
-			hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, m)
+			ac := &acfakes.FakeRuleService{}
+			hist := historian.NewAnnotationBackend(annotationBackendLogger, store, nil, m, ac)
 			clk := clock.NewMock()
 			cfg := state.ManagerCfg{
 				Metrics:       stateMetrics,


### PR DESCRIPTION
**What is this feature?**
This PR fixes alerting state history API to authorize access to the rule's history:
- if filter by rule UID is specified, annotation and Loki backend check that the user is authorized to read the rule. 
- if the filter by UID is not specified, Loki backend appends a list of folder UIDs user is authorized to read rules to the query.
   - If the list of folder UIDs is too long and exceeds the `max_query_length` then the component falls back to in-memory filter: it sends query to Loki without list of folders and then filters results. 

**Why do we need this feature?**
To prevent unauthorized access to rule history

**Special notes for your reviewer:**
When users filter by ruleUID, they will receive the history of rule execution in all folders the rule was before, regardless of whether the user has access to previous folders. However, in the case when the filter is not specified, the user will get history records for the same rule only in the folders the user has access to. This is an intentional trade-off because of the following reason:
- ruleUID path is more frequent (at least for now), 
- an operation of getting authorized folders is pretty expensive
- a long list of folder UIDs in the filter can impact Loki performance. 

1. The problem with the fallback solution is that it does not honor the user-defined limit on the returned results. In the follow-up PR, I plan to split filter by folder UID into batches and fetch more data than needed, which could be limited later.
2. This PR does not address permissions in annotation storage. This will be implemented in a follow up PR too.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
