### PR TITLE
NavToolbarActions: Make sure ToolbarActions are renrendered when needed

### DIFF
--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -37,7 +37,9 @@ interface Props {
 }
 
 export const NavToolbarActions = React.memo<Props>(({ dashboard }) => {
-  const actions = <ToolbarActions dashboard={dashboard} />;
+  const id = useId();
+
+  const actions = <ToolbarActions dashboard={dashboard} key={id} />;
   return <AppChromeUpdate actions={actions} />;
 });
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-org/issues/135

Makes sure that `ToolbarActions` will unmount alongside `NavToolbarActions` - currently it's being rendered as part of the app chrome, so `DashboardScene` unmount will not unmount it.