### PR TITLE
Add [auth.saml] link to main configure Grafana page

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1144,6 +1144,13 @@ Refer to [Auth proxy authentication]({{< relref "../configure-security/configure
 
 Refer to [LDAP authentication]({{< relref "../configure-security/configure-authentication/ldap" >}}) for detailed instructions.
 
+<hr />
+
+## [auth.saml]
+
+Refer to [SAML authentication]({{< relref "../configure-security/configure-authentication/saml" >}}) for detailed instructions.
+
+
 ## [aws]
 
 You can configure core and external AWS plugins.


### PR DESCRIPTION
[auth.saml] was missing from the valid auth block list.