### PR TITLE
CI: auto-milestone needs repo write access

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 # Note: this action runs with write permissions on GITHUB_TOKEN even from forks
 # so it must not run untrusted code (such as checking out the pull request)


### PR DESCRIPTION
https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue

> The number of the milestone to associate this issue with or use null to remove the current milestone. Only users with push access can set the milestone for issues. Without push access to the repository, milestone changes are silently dropped.