### PR TITLE
Optimize memory allocations in permissions cache

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -175,10 +175,8 @@ func (sc *scenarioContext) exec() {
 	sc.m.ServeHTTP(sc.resp, sc.req)
 }
 
-type (
-	scenarioFunc func(c *scenarioContext)
-	handlerFunc  func(c *contextmodel.ReqContext) response.Response
-)
+type scenarioFunc func(c *scenarioContext)
+type handlerFunc func(c *contextmodel.ReqContext) response.Response
 
 func getContextHandler(t *testing.T, cfg *setting.Cfg) *contexthandler.ContextHandler {
 	t.Helper()
@@ -219,7 +217,7 @@ func setupScenarioContext(t *testing.T, url string) *scenarioContext {
 
 func setupScenarioContextSamlLogout(t *testing.T, url string) *scenarioContext {
 	cfg := setting.NewCfg()
-	// seed sections and keys
+	//seed sections and keys
 	cfg.Raw.DeleteSection("DEFAULT")
 	saml, err := cfg.Raw.NewSection("auth.saml")
 	assert.NoError(t, err)
@@ -276,6 +274,7 @@ func setupSimpleHTTPServer(features featuremgmt.FeatureToggles) *HTTPServer {
 		authInfoService: &authinfotest.FakeService{
 			ExpectedLabels: map[int64]string{int64(1): login.GetAuthProviderLabel(login.LDAPAuthModule)},
 		},
+		tracer: tracing.InitializeTracerForTest(),
 	}
 }
 

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -175,8 +175,10 @@ func (sc *scenarioContext) exec() {
 	sc.m.ServeHTTP(sc.resp, sc.req)
 }
 
-type scenarioFunc func(c *scenarioContext)
-type handlerFunc func(c *contextmodel.ReqContext) response.Response
+type (
+	scenarioFunc func(c *scenarioContext)
+	handlerFunc  func(c *contextmodel.ReqContext) response.Response
+)
 
 func getContextHandler(t *testing.T, cfg *setting.Cfg) *contexthandler.ContextHandler {
 	t.Helper()
@@ -217,7 +219,7 @@ func setupScenarioContext(t *testing.T, url string) *scenarioContext {
 
 func setupScenarioContextSamlLogout(t *testing.T, url string) *scenarioContext {
 	cfg := setting.NewCfg()
-	//seed sections and keys
+	// seed sections and keys
 	cfg.Raw.DeleteSection("DEFAULT")
 	saml, err := cfg.Raw.NewSection("auth.saml")
 	assert.NoError(t, err)
@@ -299,6 +301,7 @@ func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Serv
 		Features:           featuremgmt.WithFeatures(),
 		QuotaService:       quotatest.New(false, nil),
 		searchUsersService: &searchusers.OSSService{},
+		tracer:             tracing.InitializeTracerForTest(),
 	}
 
 	for _, opt := range opts {

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -82,7 +82,6 @@ func dashboardGuardianResponse(err error) response.Response {
 // 404: notFoundError
 // 500: internalServerError
 func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response {
-	// START span here
 	ctx, span := hs.tracer.Start(c.Req.Context(), "httpserver.GetDashboard")
 	defer span.End()
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -81,6 +81,7 @@ func TestGetHomeDashboard(t *testing.T) {
 		preferenceService:       prefService,
 		dashboardVersionService: dashboardVersionService,
 		log:                     log.New("test-logger"),
+		tracer:                  tracing.InitializeTracerForTest(),
 	}
 
 	tests := []struct {
@@ -585,7 +586,8 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				DashboardID: 2,
 				Version:     1,
 				Data:        fakeDash.Data,
-			}}
+			},
+		}
 		mockSQLStore := dbtest.NewFakeDB()
 		origNewGuardian := guardian.New
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true})
@@ -622,7 +624,8 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				DashboardID: 2,
 				Version:     1,
 				Data:        fakeDash.Data,
-			}}
+			},
+		}
 
 		cmd := dtos.RestoreDashboardVersionCommand{
 			Version: 1,
@@ -680,6 +683,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				DashboardService:             dashboardService,
 				Features:                     featuremgmt.WithFeatures(),
 				starService:                  startest.NewStarServiceFake(),
+				tracer:                       tracing.InitializeTracerForTest(),
 			}
 			hs.callGetDashboard(sc)
 
@@ -718,6 +722,7 @@ func TestDashboardVersionsAPIEndpoint(t *testing.T) {
 			userService:             userSvc,
 			CacheService:            localcache.New(5*time.Minute, 10*time.Minute),
 			log:                     log.New(),
+			tracer:                  tracing.InitializeTracerForTest(),
 		}
 	}
 
@@ -855,6 +860,7 @@ func getDashboardShouldReturn200WithConfig(t *testing.T, sc *scenarioContext, pr
 		DashboardService:             dashboardService,
 		Features:                     featuremgmt.WithFeatures(),
 		starService:                  startest.NewStarServiceFake(),
+		tracer:                       tracing.InitializeTracerForTest(),
 	}
 
 	hs.callGetDashboard(sc)
@@ -908,6 +914,7 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 			Features:              featuremgmt.WithFeatures(),
 			accesscontrolService:  actest.FakeService{},
 			log:                   log.New("test-logger"),
+			tracer:                tracing.InitializeTracerForTest(),
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -927,7 +934,8 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 }
 
 func postDiffScenario(t *testing.T, desc string, url string, routePattern string, cmd dtos.CalculateDiffOptions,
-	role org.RoleType, fn scenarioFunc, sqlmock db.DB, fakeDashboardVersionService *dashvertest.FakeDashboardVersionService) {
+	role org.RoleType, fn scenarioFunc, sqlmock db.DB, fakeDashboardVersionService *dashvertest.FakeDashboardVersionService,
+) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		cfg := setting.NewCfg()
 
@@ -943,6 +951,7 @@ func postDiffScenario(t *testing.T, desc string, url string, routePattern string
 			dashboardVersionService: fakeDashboardVersionService,
 			Features:                featuremgmt.WithFeatures(),
 			DashboardService:        dashSvc,
+			tracer:                  tracing.InitializeTracerForTest(),
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -967,7 +976,8 @@ func postDiffScenario(t *testing.T, desc string, url string, routePattern string
 
 func restoreDashboardVersionScenario(t *testing.T, desc string, url string, routePattern string,
 	mock *dashboards.FakeDashboardService, fakeDashboardVersionService *dashvertest.FakeDashboardVersionService,
-	cmd dtos.RestoreDashboardVersionCommand, fn scenarioFunc, sqlStore db.DB) {
+	cmd dtos.RestoreDashboardVersionCommand, fn scenarioFunc, sqlStore db.DB,
+) {
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		cfg := setting.NewCfg()
 		folderSvc := foldertest.NewFakeService()
@@ -986,6 +996,7 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 			dashboardVersionService: fakeDashboardVersionService,
 			accesscontrolService:    actest.FakeService{},
 			folderService:           folderSvc,
+			tracer:                  tracing.InitializeTracerForTest(),
 		}
 
 		sc := setupScenarioContext(t, url)
@@ -1022,12 +1033,12 @@ type mockDashboardProvisioningService struct {
 }
 
 func (s mockDashboardProvisioningService) GetProvisionedDashboardDataByDashboardID(ctx context.Context, dashboardID int64) (
-	*dashboards.DashboardProvisioning, error) {
+	*dashboards.DashboardProvisioning, error,
+) {
 	return nil, nil
 }
 
-type mockLibraryPanelService struct {
-}
+type mockLibraryPanelService struct{}
 
 var _ librarypanels.Service = (*mockLibraryPanelService)(nil)
 
@@ -1039,8 +1050,7 @@ func (m *mockLibraryPanelService) ImportLibraryPanelsForDashboard(c context.Cont
 	return nil
 }
 
-type mockLibraryElementService struct {
-}
+type mockLibraryElementService struct{}
 
 func (l *mockLibraryElementService) CreateElement(c context.Context, signedInUser identity.Requester, cmd model.CreateLibraryElementCommand) (model.LibraryElementDTO, error) {
 	return model.LibraryElementDTO{}, nil

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -43,29 +43,11 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 	Scope:  dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
 }
 
-var OSSRolesPrefixes = []string{
-	accesscontrol.ManagedRolePrefix,
-	accesscontrol.ExternalServiceRolePrefix,
-}
+var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
 
-func ProvideService(
-	cfg *setting.Cfg,
-	db db.DB,
-	routeRegister routing.RouteRegister,
-	cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl,
-	actionResolver accesscontrol.ActionResolver,
-	features featuremgmt.FeatureToggles,
-	tracer tracing.Tracer,
-) (*Service, error) {
-	service := ProvideOSSService(
-		cfg,
-		database.ProvideService(db),
-		actionResolver,
-		cache,
-		features,
-		tracer,
-	)
+func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
+	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
+	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
@@ -83,14 +65,7 @@ func ProvideService(
 	return service, nil
 }
 
-func ProvideOSSService(
-	cfg *setting.Cfg,
-	store accesscontrol.Store,
-	actionResolver accesscontrol.ActionResolver,
-	cache *localcache.CacheService,
-	features featuremgmt.FeatureToggles,
-	tracer tracing.Tracer,
-) *Service {
+func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver, cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	s := &Service{
 		actionResolver: actionResolver,
 		cache:          cache,
@@ -125,11 +100,7 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]any {
 }
 
 // GetUserPermissions returns user permissions based on built-in roles
-func (s *Service) GetUserPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.GetUserPermissionsOSS")
 	defer span.End()
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
@@ -142,11 +113,7 @@ func (s *Service) GetUserPermissions(
 	return s.getCachedUserPermissions(ctx, user, options)
 }
 
-func (s *Service) getUserPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	permissions := make([]accesscontrol.Permission, 0)
 	for _, builtin := range accesscontrol.GetOrgRoles(user) {
 		if basicRole, ok := s.roles[builtin]; ok {
@@ -180,11 +147,7 @@ func (s *Service) getUserPermissions(
 	return append(permissions, dbPermissions...), nil
 }
 
-func (s *Service) getBasicRolePermissions(
-	ctx context.Context,
-	role string,
-	orgID int64,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgID int64) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getBasicRolePermissions")
 	defer span.End()
 
@@ -194,14 +157,11 @@ func (s *Service) getBasicRolePermissions(
 	}
 
 	// Fetch managed role permissions assigned to basic roles
-	dbPermissions, err := s.store.GetBasicRolesPermissions(
-		ctx,
-		accesscontrol.GetUserPermissionsQuery{
-			Roles:        []string{role},
-			OrgID:        orgID,
-			RolePrefixes: OSSRolesPrefixes,
-		},
-	)
+	dbPermissions, err := s.store.GetBasicRolesPermissions(ctx, accesscontrol.GetUserPermissionsQuery{
+		Roles:        []string{role},
+		OrgID:        orgID,
+		RolePrefixes: OSSRolesPrefixes,
+	})
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
 		dbPermissions = s.actionResolver.ExpandActionSets(dbPermissions)
 	}
@@ -209,11 +169,7 @@ func (s *Service) getBasicRolePermissions(
 	return append(permissions, dbPermissions...), err
 }
 
-func (s *Service) getTeamsPermissions(
-	ctx context.Context,
-	teamIDs []int64,
-	orgID int64,
-) (map[int64][]accesscontrol.Permission, error) {
+func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgID int64) (map[int64][]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getTeamsPermissions")
 	defer span.End()
 
@@ -233,10 +189,7 @@ func (s *Service) getTeamsPermissions(
 }
 
 // Returns only permissions directly assigned to user, without basic role and team permissions
-func (s *Service) getUserDirectPermissions(
-	ctx context.Context,
-	user identity.Requester,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Requester) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getUserDirectPermissions")
 	defer span.End()
 
@@ -256,6 +209,7 @@ func (s *Service) getUserDirectPermissions(
 		UserID:       userID,
 		RolePrefixes: OSSRolesPrefixes,
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -270,11 +224,7 @@ func (s *Service) getUserDirectPermissions(
 	return permissions, nil
 }
 
-func (s *Service) getCachedUserPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserPermissions")
 	defer span.End()
 
@@ -295,15 +245,11 @@ func (s *Service) getCachedUserPermissions(
 	}
 
 	permissions = append(permissions, userPermissions...)
+
 	return permissions, nil
 }
 
-func (s *Service) getCachedBasicRolesPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-	perms []accesscontrol.Permission,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options, basicRolesPermissions []accesscontrol.Permission) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedBasicRolesPermissions")
 	defer span.End()
 
@@ -313,17 +259,12 @@ func (s *Service) getCachedBasicRolesPermissions(
 		if err != nil {
 			return nil, err
 		}
-		perms = append(perms, permissions...)
+		basicRolesPermissions = append(basicRolesPermissions, permissions...)
 	}
-	return perms, nil
+	return basicRolesPermissions, nil
 }
 
-func (s *Service) getCachedBasicRolePermissions(
-	ctx context.Context,
-	role string,
-	orgID int64,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string, orgID int64, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	key := accesscontrol.GetBasicRolePermissionCacheKey(role, orgID)
 	getPermissionsFn := func() ([]accesscontrol.Permission, error) {
 		return s.getBasicRolePermissions(ctx, role, orgID)
@@ -331,11 +272,7 @@ func (s *Service) getCachedBasicRolePermissions(
 	return s.getCachedPermissions(ctx, key, getPermissionsFn, options)
 }
 
-func (s *Service) getCachedUserDirectPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserDirectPermissions")
 	defer span.End()
 
@@ -349,12 +286,7 @@ func (s *Service) getCachedUserDirectPermissions(
 type GetPermissionsFn = func() ([]accesscontrol.Permission, error)
 
 // Generic method for getting various permissions from cache
-func (s *Service) getCachedPermissions(
-	ctx context.Context,
-	key string,
-	getPermissionsFn GetPermissionsFn,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermissionsFn GetPermissionsFn, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	_, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
@@ -377,12 +309,7 @@ func (s *Service) getCachedPermissions(
 	return permissions, nil
 }
 
-func (s *Service) getCachedTeamsPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-	perms []accesscontrol.Permission,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options, permissions []accesscontrol.Permission) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
@@ -397,7 +324,7 @@ func (s *Service) getCachedTeamsPermissions(
 			teamPermissions, ok := s.cache.Get(key)
 			if ok {
 				metrics.MAccessPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheHit).Inc()
-				perms = append(perms, teamPermissions.([]accesscontrol.Permission)...)
+				permissions = append(permissions, teamPermissions.([]accesscontrol.Permission)...)
 			} else {
 				miss = append(miss, teamID)
 			}
@@ -415,11 +342,11 @@ func (s *Service) getCachedTeamsPermissions(
 		for teamID, teamPermissions := range teamsPermissions {
 			key := accesscontrol.GetTeamPermissionCacheKey(teamID, orgID)
 			s.cache.Set(key, teamPermissions, cacheTTL)
-			perms = append(perms, teamPermissions...)
+			permissions = append(permissions, teamPermissions...)
 		}
 	}
 
-	return perms, nil
+	return permissions, nil
 }
 
 func (s *Service) ClearUserPermissionCache(user identity.Requester) {
@@ -460,9 +387,7 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 	s.registrations.Range(func(registration accesscontrol.RoleRegistration) bool {
 		for br := range accesscontrol.BuiltInRolesWithParents(registration.Grants) {
 			if basicRole, ok := s.roles[br]; ok {
-				basicRole.Permissions = append(
-					basicRole.Permissions,
-					registration.Role.Permissions...)
+				basicRole.Permissions = append(basicRole.Permissions, registration.Role.Permissions...)
 			} else {
 				s.log.Error("Unknown builtin role", "builtInRole", br)
 			}
@@ -474,11 +399,7 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 
 // DeclarePluginRoles allow the caller to declare, to the service, plugin roles and their assignments
 // to organization roles ("Viewer", "Editor", "Admin") or "Grafana Admin"
-func (s *Service) DeclarePluginRoles(
-	ctx context.Context,
-	ID, name string,
-	regs []plugins.RoleRegistration,
-) error {
+func (s *Service) DeclarePluginRoles(ctx context.Context, ID, name string, regs []plugins.RoleRegistration) error {
 	// Protect behind feature toggle
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagAccessControlOnCall) {
 		return nil
@@ -513,8 +434,7 @@ func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bo
 
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
 func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester,
-	options accesscontrol.SearchOptions,
-) (map[int64][]accesscontrol.Permission, error) {
+	options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.NamespacedID != "" {
@@ -625,11 +545,7 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Reque
 	return res, nil
 }
 
-func (s *Service) SearchUserPermissions(
-	ctx context.Context,
-	orgID int64,
-	searchOptions accesscontrol.SearchOptions,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) SearchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
@@ -643,11 +559,7 @@ func (s *Service) SearchUserPermissions(
 	return s.searchUserPermissions(ctx, orgID, searchOptions)
 }
 
-func (s *Service) searchUserPermissions(
-	ctx context.Context,
-	orgID int64,
-	searchOptions accesscontrol.SearchOptions,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, err
@@ -687,27 +599,17 @@ func (s *Service) searchUserPermissions(
 	}
 	permissions = append(permissions, dbPermissions[userID]...)
 
-	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) &&
-		len(searchOptions.ActionSets) != 0 {
-		permissions = s.actionResolver.ExpandActionSetsWithFilter(
-			permissions,
-			GetActionFilter(searchOptions),
-		)
+	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) && len(searchOptions.ActionSets) != 0 {
+		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, GetActionFilter(searchOptions))
 	}
 
-	key := accesscontrol.GetSearchPermissionCacheKey(
-		&user.SignedInUser{UserID: userID, OrgID: orgID},
-		searchOptions,
-	)
+	key := accesscontrol.GetSearchPermissionCacheKey(&user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
 	s.cache.Set(key, permissions, cacheTTL)
 
 	return permissions, nil
 }
 
-func (s *Service) searchUserPermissionsFromCache(
-	orgID int64,
-	searchOptions accesscontrol.SearchOptions,
-) ([]accesscontrol.Permission, bool) {
+func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, bool) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, false
@@ -722,8 +624,7 @@ func (s *Service) searchUserPermissionsFromCache(
 	key := accesscontrol.GetSearchPermissionCacheKey(tempUser, searchOptions)
 	permissions, ok := s.cache.Get((key))
 	if !ok {
-		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).
-			Inc()
+		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
 		return nil, false
 	}
 
@@ -733,10 +634,7 @@ func (s *Service) searchUserPermissionsFromCache(
 	return permissions.([]accesscontrol.Permission), true
 }
 
-func PermissionMatchesSearchOptions(
-	permission accesscontrol.Permission,
-	searchOptions *accesscontrol.SearchOptions,
-) bool {
+func PermissionMatchesSearchOptions(permission accesscontrol.Permission, searchOptions *accesscontrol.SearchOptions) bool {
 	if searchOptions.Scope != "" {
 		// Permissions including the scope should also match
 		scopes := append(searchOptions.Wildcards(), searchOptions.Scope)
@@ -750,14 +648,9 @@ func PermissionMatchesSearchOptions(
 	return strings.HasPrefix(permission.Action, searchOptions.ActionPrefix)
 }
 
-func (s *Service) SaveExternalServiceRole(
-	ctx context.Context,
-	cmd accesscontrol.SaveExternalServiceRoleCommand,
-) error {
+func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug(
-			"Registering an external service role is behind a feature flag, enable it to use this feature.",
-		)
+		s.log.Debug("Registering an external service role is behind a feature flag, enable it to use this feature.")
 		return nil
 	}
 
@@ -770,9 +663,7 @@ func (s *Service) SaveExternalServiceRole(
 
 func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug(
-			"Deleting an external service role is behind a feature flag, enable it to use this feature.",
-		)
+		s.log.Debug("Deleting an external service role is behind a feature flag, enable it to use this feature.")
 		return nil
 	}
 
@@ -781,19 +672,11 @@ func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalService
 	return s.store.DeleteExternalServiceRole(ctx, slug)
 }
 
-func (*Service) SyncUserRoles(
-	ctx context.Context,
-	orgID int64,
-	cmd accesscontrol.SyncUserRolesCommand,
-) error {
+func (*Service) SyncUserRoles(ctx context.Context, orgID int64, cmd accesscontrol.SyncUserRolesCommand) error {
 	return nil
 }
 
-func (s *Service) GetRoleByName(
-	ctx context.Context,
-	orgID int64,
-	roleName string,
-) (*accesscontrol.RoleDTO, error) {
+func (s *Service) GetRoleByName(ctx context.Context, orgID int64, roleName string) (*accesscontrol.RoleDTO, error) {
 	err := accesscontrol.ErrRoleNotFound
 	if _, ok := s.roles[roleName]; ok {
 		return nil, err

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -46,7 +47,8 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
 
 func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
+	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
+) (*Service, error) {
 	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
@@ -151,9 +153,9 @@ func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgI
 	ctx, span := s.tracer.Start(ctx, "authz.getBasicRolePermissions")
 	defer span.End()
 
-	permissions := make([]accesscontrol.Permission, 0)
+	var permissions []accesscontrol.Permission
 	if basicRole, ok := s.roles[role]; ok {
-		permissions = append(permissions, basicRole.Permissions...)
+		permissions = basicRole.Permissions
 	}
 
 	// Fetch managed role permissions assigned to basic roles
@@ -209,7 +211,6 @@ func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Re
 		UserID:       userID,
 		RolePrefixes: OSSRolesPrefixes,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +246,7 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	}
 
 	permissions = append(permissions, userPermissions...)
-span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
+	span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
 
 	return permissions, nil
 }
@@ -266,8 +267,11 @@ func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user ident
 }
 
 func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string, orgID int64, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	ctx, span := s.tracer.Start(ctx, "authz.getCachedBasicRolePermissions")
+	defer span.End()
+
 	key := accesscontrol.GetBasicRolePermissionCacheKey(role, orgID)
-	getPermissionsFn := func() ([]accesscontrol.Permission, error) {
+	getPermissionsFn := func(ctx context.Context) ([]accesscontrol.Permission, error) {
 		return s.getBasicRolePermissions(ctx, role, orgID)
 	}
 	return s.getCachedPermissions(ctx, key, getPermissionsFn, options)
@@ -278,17 +282,17 @@ func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user ident
 	defer span.End()
 
 	key := accesscontrol.GetUserDirectPermissionCacheKey(user)
-	getUserPermissionsFn := func() ([]accesscontrol.Permission, error) {
+	getUserPermissionsFn := func(ctx context.Context) ([]accesscontrol.Permission, error) {
 		return s.getUserDirectPermissions(ctx, user)
 	}
 	return s.getCachedPermissions(ctx, key, getUserPermissionsFn, options)
 }
 
-type GetPermissionsFn = func() ([]accesscontrol.Permission, error)
+type getPermissionsFunc = func(ctx context.Context) ([]accesscontrol.Permission, error)
 
 // Generic method for getting various permissions from cache
-func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermissionsFn GetPermissionsFn, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
-	_, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
+func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermissionsFn getPermissionsFunc, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	_, span := s.tracer.Start(ctx, "authz.getCachedPermissions")
 	defer span.End()
 
 	if !options.ReloadCache {
@@ -301,7 +305,7 @@ func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermi
 
 	span.AddEvent("cache miss")
 	metrics.MAccessPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
-	permissions, err := getPermissionsFn()
+	permissions, err := getPermissionsFn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +439,8 @@ func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bo
 
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
 func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester,
-	options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
+	options accesscontrol.SearchOptions,
+) (map[int64][]accesscontrol.Permission, error) {
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.NamespacedID != "" {

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -46,9 +46,7 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 
 var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
 
-func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
-) (*Service, error) {
+func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService, accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
 	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -249,19 +249,19 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	return permissions, nil
 }
 
-func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options, basicRolesPermissions []accesscontrol.Permission) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options, permissions []accesscontrol.Permission) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedBasicRolesPermissions")
 	defer span.End()
 
 	basicRoles := accesscontrol.GetOrgRoles(user)
 	for _, role := range basicRoles {
-		permissions, err := s.getCachedBasicRolePermissions(ctx, role, user.GetOrgID(), options)
+		perms, err := s.getCachedBasicRolePermissions(ctx, role, user.GetOrgID(), options)
 		if err != nil {
 			return nil, err
 		}
-		basicRolesPermissions = append(basicRolesPermissions, permissions...)
+		permissions = append(permissions, perms...)
 	}
-	return basicRolesPermissions, nil
+	return permissions, nil
 }
 
 func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string, orgID int64, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
@@ -436,9 +436,7 @@ func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bo
 }
 
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
-func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester,
-	options accesscontrol.SearchOptions,
-) (map[int64][]accesscontrol.Permission, error) {
+func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester, options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.NamespacedID != "" {

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -245,6 +245,7 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	}
 
 	permissions = append(permissions, userPermissions...)
+span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
 
 	return permissions, nil
 }

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -43,11 +43,29 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 	Scope:  dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
 }
 
-var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
+var OSSRolesPrefixes = []string{
+	accesscontrol.ManagedRolePrefix,
+	accesscontrol.ExternalServiceRolePrefix,
+}
 
-func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
-	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
+func ProvideService(
+	cfg *setting.Cfg,
+	db db.DB,
+	routeRegister routing.RouteRegister,
+	cache *localcache.CacheService,
+	accessControl accesscontrol.AccessControl,
+	actionResolver accesscontrol.ActionResolver,
+	features featuremgmt.FeatureToggles,
+	tracer tracing.Tracer,
+) (*Service, error) {
+	service := ProvideOSSService(
+		cfg,
+		database.ProvideService(db),
+		actionResolver,
+		cache,
+		features,
+		tracer,
+	)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
@@ -65,7 +83,14 @@ func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegis
 	return service, nil
 }
 
-func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver, cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
+func ProvideOSSService(
+	cfg *setting.Cfg,
+	store accesscontrol.Store,
+	actionResolver accesscontrol.ActionResolver,
+	cache *localcache.CacheService,
+	features featuremgmt.FeatureToggles,
+	tracer tracing.Tracer,
+) *Service {
 	s := &Service{
 		actionResolver: actionResolver,
 		cache:          cache,
@@ -100,7 +125,11 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]any {
 }
 
 // GetUserPermissions returns user permissions based on built-in roles
-func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) GetUserPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.GetUserPermissionsOSS")
 	defer span.End()
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
@@ -113,7 +142,11 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 	return s.getCachedUserPermissions(ctx, user, options)
 }
 
-func (s *Service) getUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	permissions := make([]accesscontrol.Permission, 0)
 	for _, builtin := range accesscontrol.GetOrgRoles(user) {
 		if basicRole, ok := s.roles[builtin]; ok {
@@ -147,7 +180,11 @@ func (s *Service) getUserPermissions(ctx context.Context, user identity.Requeste
 	return append(permissions, dbPermissions...), nil
 }
 
-func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgID int64) ([]accesscontrol.Permission, error) {
+func (s *Service) getBasicRolePermissions(
+	ctx context.Context,
+	role string,
+	orgID int64,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getBasicRolePermissions")
 	defer span.End()
 
@@ -157,11 +194,14 @@ func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgI
 	}
 
 	// Fetch managed role permissions assigned to basic roles
-	dbPermissions, err := s.store.GetBasicRolesPermissions(ctx, accesscontrol.GetUserPermissionsQuery{
-		Roles:        []string{role},
-		OrgID:        orgID,
-		RolePrefixes: OSSRolesPrefixes,
-	})
+	dbPermissions, err := s.store.GetBasicRolesPermissions(
+		ctx,
+		accesscontrol.GetUserPermissionsQuery{
+			Roles:        []string{role},
+			OrgID:        orgID,
+			RolePrefixes: OSSRolesPrefixes,
+		},
+	)
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
 		dbPermissions = s.actionResolver.ExpandActionSets(dbPermissions)
 	}
@@ -169,7 +209,11 @@ func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgI
 	return append(permissions, dbPermissions...), err
 }
 
-func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgID int64) (map[int64][]accesscontrol.Permission, error) {
+func (s *Service) getTeamsPermissions(
+	ctx context.Context,
+	teamIDs []int64,
+	orgID int64,
+) (map[int64][]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getTeamsPermissions")
 	defer span.End()
 
@@ -189,7 +233,10 @@ func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgI
 }
 
 // Returns only permissions directly assigned to user, without basic role and team permissions
-func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Requester) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserDirectPermissions(
+	ctx context.Context,
+	user identity.Requester,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getUserDirectPermissions")
 	defer span.End()
 
@@ -209,7 +256,6 @@ func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Re
 		UserID:       userID,
 		RolePrefixes: OSSRolesPrefixes,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -224,46 +270,63 @@ func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Re
 	return permissions, nil
 }
 
-func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
-	basicRolesPermissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
+func (s *Service) getCachedUserPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
+	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserPermissions")
+	defer span.End()
+
+	permissions := []accesscontrol.Permission{}
+	permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	teamsPermissions, err := s.getCachedTeamsPermissions(ctx, user, options)
+	permissions, err = s.getCachedTeamsPermissions(ctx, user, options, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	userPermissions, err := s.getCachedUserDirectPermissions(ctx, user, options)
+	permissions, err = s.getCachedUserDirectPermissions(ctx, user, options, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	permissions := make([]accesscontrol.Permission, 0, len(basicRolesPermissions)+len(teamsPermissions)+len(userPermissions))
-	permissions = append(permissions, basicRolesPermissions...)
-	permissions = append(permissions, teamsPermissions...)
-	permissions = append(permissions, userPermissions...)
+	// permissions = append(permissions, basicRolesPermissions...)
+	// permissions = append(permissions, teamsPermissions...)
+	// permissions = append(permissions, userPermissions...)
 	return permissions, nil
 }
 
-func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolesPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+	perm []accesscontrol.Permission,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedBasicRolesPermissions")
 	defer span.End()
 
 	basicRoles := accesscontrol.GetOrgRoles(user)
-	basicRolesPermissions := make([]accesscontrol.Permission, 0)
+	// basicRolesPermissions := make([]accesscontrol.Permission, 0)
 	for _, role := range basicRoles {
 		permissions, err := s.getCachedBasicRolePermissions(ctx, role, user.GetOrgID(), options)
 		if err != nil {
 			return nil, err
 		}
-		basicRolesPermissions = append(basicRolesPermissions, permissions...)
+		perm = append(perm, permissions...)
 	}
-	return basicRolesPermissions, nil
+	return perm, nil
 }
 
-func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string, orgID int64, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolePermissions(
+	ctx context.Context,
+	role string,
+	orgID int64,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	key := accesscontrol.GetBasicRolePermissionCacheKey(role, orgID)
 	getPermissionsFn := func() ([]accesscontrol.Permission, error) {
 		return s.getBasicRolePermissions(ctx, role, orgID)
@@ -271,7 +334,12 @@ func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string
 	return s.getCachedPermissions(ctx, key, getPermissionsFn, options)
 }
 
-func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedUserDirectPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+	perm []accesscontrol.Permission,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserDirectPermissions")
 	defer span.End()
 
@@ -285,7 +353,12 @@ func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user ident
 type GetPermissionsFn = func() ([]accesscontrol.Permission, error)
 
 // Generic method for getting various permissions from cache
-func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermissionsFn GetPermissionsFn, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedPermissions(
+	ctx context.Context,
+	key string,
+	getPermissionsFn GetPermissionsFn,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	_, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
@@ -308,13 +381,18 @@ func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermi
 	return permissions, nil
 }
 
-func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedTeamsPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+	permissions []accesscontrol.Permission,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
 	teams := user.GetTeams()
 	orgID := user.GetOrgID()
-	permissions := make([]accesscontrol.Permission, 0)
+	// permissions := make([]accesscontrol.Permission, 0)
 	miss := teams
 
 	if !options.ReloadCache {
@@ -387,7 +465,9 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 	s.registrations.Range(func(registration accesscontrol.RoleRegistration) bool {
 		for br := range accesscontrol.BuiltInRolesWithParents(registration.Grants) {
 			if basicRole, ok := s.roles[br]; ok {
-				basicRole.Permissions = append(basicRole.Permissions, registration.Role.Permissions...)
+				basicRole.Permissions = append(
+					basicRole.Permissions,
+					registration.Role.Permissions...)
 			} else {
 				s.log.Error("Unknown builtin role", "builtInRole", br)
 			}
@@ -399,7 +479,11 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 
 // DeclarePluginRoles allow the caller to declare, to the service, plugin roles and their assignments
 // to organization roles ("Viewer", "Editor", "Admin") or "Grafana Admin"
-func (s *Service) DeclarePluginRoles(ctx context.Context, ID, name string, regs []plugins.RoleRegistration) error {
+func (s *Service) DeclarePluginRoles(
+	ctx context.Context,
+	ID, name string,
+	regs []plugins.RoleRegistration,
+) error {
 	// Protect behind feature toggle
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagAccessControlOnCall) {
 		return nil
@@ -434,7 +518,8 @@ func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bo
 
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
 func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester,
-	options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
+	options accesscontrol.SearchOptions,
+) (map[int64][]accesscontrol.Permission, error) {
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.NamespacedID != "" {
@@ -545,7 +630,11 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Reque
 	return res, nil
 }
 
-func (s *Service) SearchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
+func (s *Service) SearchUserPermissions(
+	ctx context.Context,
+	orgID int64,
+	searchOptions accesscontrol.SearchOptions,
+) ([]accesscontrol.Permission, error) {
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
@@ -559,7 +648,11 @@ func (s *Service) SearchUserPermissions(ctx context.Context, orgID int64, search
 	return s.searchUserPermissions(ctx, orgID, searchOptions)
 }
 
-func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
+func (s *Service) searchUserPermissions(
+	ctx context.Context,
+	orgID int64,
+	searchOptions accesscontrol.SearchOptions,
+) ([]accesscontrol.Permission, error) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, err
@@ -599,17 +692,27 @@ func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, search
 	}
 	permissions = append(permissions, dbPermissions[userID]...)
 
-	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) && len(searchOptions.ActionSets) != 0 {
-		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, GetActionFilter(searchOptions))
+	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) &&
+		len(searchOptions.ActionSets) != 0 {
+		permissions = s.actionResolver.ExpandActionSetsWithFilter(
+			permissions,
+			GetActionFilter(searchOptions),
+		)
 	}
 
-	key := accesscontrol.GetSearchPermissionCacheKey(&user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
+	key := accesscontrol.GetSearchPermissionCacheKey(
+		&user.SignedInUser{UserID: userID, OrgID: orgID},
+		searchOptions,
+	)
 	s.cache.Set(key, permissions, cacheTTL)
 
 	return permissions, nil
 }
 
-func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, bool) {
+func (s *Service) searchUserPermissionsFromCache(
+	orgID int64,
+	searchOptions accesscontrol.SearchOptions,
+) ([]accesscontrol.Permission, bool) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, false
@@ -624,7 +727,8 @@ func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions acce
 	key := accesscontrol.GetSearchPermissionCacheKey(tempUser, searchOptions)
 	permissions, ok := s.cache.Get((key))
 	if !ok {
-		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
+		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).
+			Inc()
 		return nil, false
 	}
 
@@ -634,7 +738,10 @@ func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions acce
 	return permissions.([]accesscontrol.Permission), true
 }
 
-func PermissionMatchesSearchOptions(permission accesscontrol.Permission, searchOptions *accesscontrol.SearchOptions) bool {
+func PermissionMatchesSearchOptions(
+	permission accesscontrol.Permission,
+	searchOptions *accesscontrol.SearchOptions,
+) bool {
 	if searchOptions.Scope != "" {
 		// Permissions including the scope should also match
 		scopes := append(searchOptions.Wildcards(), searchOptions.Scope)
@@ -648,9 +755,14 @@ func PermissionMatchesSearchOptions(permission accesscontrol.Permission, searchO
 	return strings.HasPrefix(permission.Action, searchOptions.ActionPrefix)
 }
 
-func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error {
+func (s *Service) SaveExternalServiceRole(
+	ctx context.Context,
+	cmd accesscontrol.SaveExternalServiceRoleCommand,
+) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug("Registering an external service role is behind a feature flag, enable it to use this feature.")
+		s.log.Debug(
+			"Registering an external service role is behind a feature flag, enable it to use this feature.",
+		)
 		return nil
 	}
 
@@ -663,7 +775,9 @@ func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol
 
 func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug("Deleting an external service role is behind a feature flag, enable it to use this feature.")
+		s.log.Debug(
+			"Deleting an external service role is behind a feature flag, enable it to use this feature.",
+		)
 		return nil
 	}
 
@@ -672,11 +786,19 @@ func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalService
 	return s.store.DeleteExternalServiceRole(ctx, slug)
 }
 
-func (*Service) SyncUserRoles(ctx context.Context, orgID int64, cmd accesscontrol.SyncUserRolesCommand) error {
+func (*Service) SyncUserRoles(
+	ctx context.Context,
+	orgID int64,
+	cmd accesscontrol.SyncUserRolesCommand,
+) error {
 	return nil
 }
 
-func (s *Service) GetRoleByName(ctx context.Context, orgID int64, roleName string) (*accesscontrol.RoleDTO, error) {
+func (s *Service) GetRoleByName(
+	ctx context.Context,
+	orgID int64,
+	roleName string,
+) (*accesscontrol.RoleDTO, error) {
 	err := accesscontrol.ErrRoleNotFound
 	if _, ok := s.roles[roleName]; ok {
 		return nil, err

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -43,29 +43,11 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 	Scope:  dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
 }
 
-var OSSRolesPrefixes = []string{
-	accesscontrol.ManagedRolePrefix,
-	accesscontrol.ExternalServiceRolePrefix,
-}
+var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
 
-func ProvideService(
-	cfg *setting.Cfg,
-	db db.DB,
-	routeRegister routing.RouteRegister,
-	cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl,
-	actionResolver accesscontrol.ActionResolver,
-	features featuremgmt.FeatureToggles,
-	tracer tracing.Tracer,
-) (*Service, error) {
-	service := ProvideOSSService(
-		cfg,
-		database.ProvideService(db),
-		actionResolver,
-		cache,
-		features,
-		tracer,
-	)
+func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
+	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
+	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
@@ -83,14 +65,7 @@ func ProvideService(
 	return service, nil
 }
 
-func ProvideOSSService(
-	cfg *setting.Cfg,
-	store accesscontrol.Store,
-	actionResolver accesscontrol.ActionResolver,
-	cache *localcache.CacheService,
-	features featuremgmt.FeatureToggles,
-	tracer tracing.Tracer,
-) *Service {
+func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver, cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	s := &Service{
 		actionResolver: actionResolver,
 		cache:          cache,
@@ -125,11 +100,7 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]any {
 }
 
 // GetUserPermissions returns user permissions based on built-in roles
-func (s *Service) GetUserPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.GetUserPermissionsOSS")
 	defer span.End()
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
@@ -142,11 +113,7 @@ func (s *Service) GetUserPermissions(
 	return s.getCachedUserPermissions(ctx, user, options)
 }
 
-func (s *Service) getUserPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	permissions := make([]accesscontrol.Permission, 0)
 	for _, builtin := range accesscontrol.GetOrgRoles(user) {
 		if basicRole, ok := s.roles[builtin]; ok {
@@ -180,11 +147,7 @@ func (s *Service) getUserPermissions(
 	return append(permissions, dbPermissions...), nil
 }
 
-func (s *Service) getBasicRolePermissions(
-	ctx context.Context,
-	role string,
-	orgID int64,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgID int64) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getBasicRolePermissions")
 	defer span.End()
 
@@ -194,14 +157,11 @@ func (s *Service) getBasicRolePermissions(
 	}
 
 	// Fetch managed role permissions assigned to basic roles
-	dbPermissions, err := s.store.GetBasicRolesPermissions(
-		ctx,
-		accesscontrol.GetUserPermissionsQuery{
-			Roles:        []string{role},
-			OrgID:        orgID,
-			RolePrefixes: OSSRolesPrefixes,
-		},
-	)
+	dbPermissions, err := s.store.GetBasicRolesPermissions(ctx, accesscontrol.GetUserPermissionsQuery{
+		Roles:        []string{role},
+		OrgID:        orgID,
+		RolePrefixes: OSSRolesPrefixes,
+	})
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
 		dbPermissions = s.actionResolver.ExpandActionSets(dbPermissions)
 	}
@@ -209,11 +169,7 @@ func (s *Service) getBasicRolePermissions(
 	return append(permissions, dbPermissions...), err
 }
 
-func (s *Service) getTeamsPermissions(
-	ctx context.Context,
-	teamIDs []int64,
-	orgID int64,
-) (map[int64][]accesscontrol.Permission, error) {
+func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgID int64) (map[int64][]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getTeamsPermissions")
 	defer span.End()
 
@@ -233,10 +189,7 @@ func (s *Service) getTeamsPermissions(
 }
 
 // Returns only permissions directly assigned to user, without basic role and team permissions
-func (s *Service) getUserDirectPermissions(
-	ctx context.Context,
-	user identity.Requester,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Requester) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getUserDirectPermissions")
 	defer span.End()
 
@@ -256,6 +209,7 @@ func (s *Service) getUserDirectPermissions(
 		UserID:       userID,
 		RolePrefixes: OSSRolesPrefixes,
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -270,63 +224,46 @@ func (s *Service) getUserDirectPermissions(
 	return permissions, nil
 }
 
-func (s *Service) getCachedUserPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
-	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserPermissions")
-	defer span.End()
-
-	permissions := []accesscontrol.Permission{}
-	permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options, permissions)
+func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+	basicRolesPermissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
 	if err != nil {
 		return nil, err
 	}
 
-	permissions, err = s.getCachedTeamsPermissions(ctx, user, options, permissions)
+	teamsPermissions, err := s.getCachedTeamsPermissions(ctx, user, options)
 	if err != nil {
 		return nil, err
 	}
 
-	permissions, err = s.getCachedUserDirectPermissions(ctx, user, options, permissions)
+	userPermissions, err := s.getCachedUserDirectPermissions(ctx, user, options)
 	if err != nil {
 		return nil, err
 	}
 
-	// permissions = append(permissions, basicRolesPermissions...)
-	// permissions = append(permissions, teamsPermissions...)
-	// permissions = append(permissions, userPermissions...)
+	permissions := make([]accesscontrol.Permission, 0, len(basicRolesPermissions)+len(teamsPermissions)+len(userPermissions))
+	permissions = append(permissions, basicRolesPermissions...)
+	permissions = append(permissions, teamsPermissions...)
+	permissions = append(permissions, userPermissions...)
 	return permissions, nil
 }
 
-func (s *Service) getCachedBasicRolesPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-	perm []accesscontrol.Permission,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedBasicRolesPermissions")
 	defer span.End()
 
 	basicRoles := accesscontrol.GetOrgRoles(user)
-	// basicRolesPermissions := make([]accesscontrol.Permission, 0)
+	basicRolesPermissions := make([]accesscontrol.Permission, 0)
 	for _, role := range basicRoles {
 		permissions, err := s.getCachedBasicRolePermissions(ctx, role, user.GetOrgID(), options)
 		if err != nil {
 			return nil, err
 		}
-		perm = append(perm, permissions...)
+		basicRolesPermissions = append(basicRolesPermissions, permissions...)
 	}
-	return perm, nil
+	return basicRolesPermissions, nil
 }
 
-func (s *Service) getCachedBasicRolePermissions(
-	ctx context.Context,
-	role string,
-	orgID int64,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string, orgID int64, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	key := accesscontrol.GetBasicRolePermissionCacheKey(role, orgID)
 	getPermissionsFn := func() ([]accesscontrol.Permission, error) {
 		return s.getBasicRolePermissions(ctx, role, orgID)
@@ -334,12 +271,7 @@ func (s *Service) getCachedBasicRolePermissions(
 	return s.getCachedPermissions(ctx, key, getPermissionsFn, options)
 }
 
-func (s *Service) getCachedUserDirectPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-	perm []accesscontrol.Permission,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserDirectPermissions")
 	defer span.End()
 
@@ -353,12 +285,7 @@ func (s *Service) getCachedUserDirectPermissions(
 type GetPermissionsFn = func() ([]accesscontrol.Permission, error)
 
 // Generic method for getting various permissions from cache
-func (s *Service) getCachedPermissions(
-	ctx context.Context,
-	key string,
-	getPermissionsFn GetPermissionsFn,
-	options accesscontrol.Options,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermissionsFn GetPermissionsFn, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	_, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
@@ -381,18 +308,13 @@ func (s *Service) getCachedPermissions(
 	return permissions, nil
 }
 
-func (s *Service) getCachedTeamsPermissions(
-	ctx context.Context,
-	user identity.Requester,
-	options accesscontrol.Options,
-	permissions []accesscontrol.Permission,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
 	teams := user.GetTeams()
 	orgID := user.GetOrgID()
-	// permissions := make([]accesscontrol.Permission, 0)
+	permissions := make([]accesscontrol.Permission, 0)
 	miss := teams
 
 	if !options.ReloadCache {
@@ -465,9 +387,7 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 	s.registrations.Range(func(registration accesscontrol.RoleRegistration) bool {
 		for br := range accesscontrol.BuiltInRolesWithParents(registration.Grants) {
 			if basicRole, ok := s.roles[br]; ok {
-				basicRole.Permissions = append(
-					basicRole.Permissions,
-					registration.Role.Permissions...)
+				basicRole.Permissions = append(basicRole.Permissions, registration.Role.Permissions...)
 			} else {
 				s.log.Error("Unknown builtin role", "builtInRole", br)
 			}
@@ -479,11 +399,7 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 
 // DeclarePluginRoles allow the caller to declare, to the service, plugin roles and their assignments
 // to organization roles ("Viewer", "Editor", "Admin") or "Grafana Admin"
-func (s *Service) DeclarePluginRoles(
-	ctx context.Context,
-	ID, name string,
-	regs []plugins.RoleRegistration,
-) error {
+func (s *Service) DeclarePluginRoles(ctx context.Context, ID, name string, regs []plugins.RoleRegistration) error {
 	// Protect behind feature toggle
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagAccessControlOnCall) {
 		return nil
@@ -518,8 +434,7 @@ func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bo
 
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
 func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester,
-	options accesscontrol.SearchOptions,
-) (map[int64][]accesscontrol.Permission, error) {
+	options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.NamespacedID != "" {
@@ -630,11 +545,7 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Reque
 	return res, nil
 }
 
-func (s *Service) SearchUserPermissions(
-	ctx context.Context,
-	orgID int64,
-	searchOptions accesscontrol.SearchOptions,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) SearchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
@@ -648,11 +559,7 @@ func (s *Service) SearchUserPermissions(
 	return s.searchUserPermissions(ctx, orgID, searchOptions)
 }
 
-func (s *Service) searchUserPermissions(
-	ctx context.Context,
-	orgID int64,
-	searchOptions accesscontrol.SearchOptions,
-) ([]accesscontrol.Permission, error) {
+func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, err
@@ -692,27 +599,17 @@ func (s *Service) searchUserPermissions(
 	}
 	permissions = append(permissions, dbPermissions[userID]...)
 
-	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) &&
-		len(searchOptions.ActionSets) != 0 {
-		permissions = s.actionResolver.ExpandActionSetsWithFilter(
-			permissions,
-			GetActionFilter(searchOptions),
-		)
+	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) && len(searchOptions.ActionSets) != 0 {
+		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, GetActionFilter(searchOptions))
 	}
 
-	key := accesscontrol.GetSearchPermissionCacheKey(
-		&user.SignedInUser{UserID: userID, OrgID: orgID},
-		searchOptions,
-	)
+	key := accesscontrol.GetSearchPermissionCacheKey(&user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
 	s.cache.Set(key, permissions, cacheTTL)
 
 	return permissions, nil
 }
 
-func (s *Service) searchUserPermissionsFromCache(
-	orgID int64,
-	searchOptions accesscontrol.SearchOptions,
-) ([]accesscontrol.Permission, bool) {
+func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, bool) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, false
@@ -727,8 +624,7 @@ func (s *Service) searchUserPermissionsFromCache(
 	key := accesscontrol.GetSearchPermissionCacheKey(tempUser, searchOptions)
 	permissions, ok := s.cache.Get((key))
 	if !ok {
-		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).
-			Inc()
+		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
 		return nil, false
 	}
 
@@ -738,10 +634,7 @@ func (s *Service) searchUserPermissionsFromCache(
 	return permissions.([]accesscontrol.Permission), true
 }
 
-func PermissionMatchesSearchOptions(
-	permission accesscontrol.Permission,
-	searchOptions *accesscontrol.SearchOptions,
-) bool {
+func PermissionMatchesSearchOptions(permission accesscontrol.Permission, searchOptions *accesscontrol.SearchOptions) bool {
 	if searchOptions.Scope != "" {
 		// Permissions including the scope should also match
 		scopes := append(searchOptions.Wildcards(), searchOptions.Scope)
@@ -755,14 +648,9 @@ func PermissionMatchesSearchOptions(
 	return strings.HasPrefix(permission.Action, searchOptions.ActionPrefix)
 }
 
-func (s *Service) SaveExternalServiceRole(
-	ctx context.Context,
-	cmd accesscontrol.SaveExternalServiceRoleCommand,
-) error {
+func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug(
-			"Registering an external service role is behind a feature flag, enable it to use this feature.",
-		)
+		s.log.Debug("Registering an external service role is behind a feature flag, enable it to use this feature.")
 		return nil
 	}
 
@@ -775,9 +663,7 @@ func (s *Service) SaveExternalServiceRole(
 
 func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug(
-			"Deleting an external service role is behind a feature flag, enable it to use this feature.",
-		)
+		s.log.Debug("Deleting an external service role is behind a feature flag, enable it to use this feature.")
 		return nil
 	}
 
@@ -786,19 +672,11 @@ func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalService
 	return s.store.DeleteExternalServiceRole(ctx, slug)
 }
 
-func (*Service) SyncUserRoles(
-	ctx context.Context,
-	orgID int64,
-	cmd accesscontrol.SyncUserRolesCommand,
-) error {
+func (*Service) SyncUserRoles(ctx context.Context, orgID int64, cmd accesscontrol.SyncUserRolesCommand) error {
 	return nil
 }
 
-func (s *Service) GetRoleByName(
-	ctx context.Context,
-	orgID int64,
-	roleName string,
-) (*accesscontrol.RoleDTO, error) {
+func (s *Service) GetRoleByName(ctx context.Context, orgID int64, roleName string) (*accesscontrol.RoleDTO, error) {
 	err := accesscontrol.ErrRoleNotFound
 	if _, ok := s.roles[roleName]; ok {
 		return nil, err

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -43,11 +43,29 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 	Scope:  dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.SharedWithMeFolderUID),
 }
 
-var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
+var OSSRolesPrefixes = []string{
+	accesscontrol.ManagedRolePrefix,
+	accesscontrol.ExternalServiceRolePrefix,
+}
 
-func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
-	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (*Service, error) {
-	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer)
+func ProvideService(
+	cfg *setting.Cfg,
+	db db.DB,
+	routeRegister routing.RouteRegister,
+	cache *localcache.CacheService,
+	accessControl accesscontrol.AccessControl,
+	actionResolver accesscontrol.ActionResolver,
+	features featuremgmt.FeatureToggles,
+	tracer tracing.Tracer,
+) (*Service, error) {
+	service := ProvideOSSService(
+		cfg,
+		database.ProvideService(db),
+		actionResolver,
+		cache,
+		features,
+		tracer,
+	)
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
@@ -65,7 +83,14 @@ func ProvideService(cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegis
 	return service, nil
 }
 
-func ProvideOSSService(cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver, cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
+func ProvideOSSService(
+	cfg *setting.Cfg,
+	store accesscontrol.Store,
+	actionResolver accesscontrol.ActionResolver,
+	cache *localcache.CacheService,
+	features featuremgmt.FeatureToggles,
+	tracer tracing.Tracer,
+) *Service {
 	s := &Service{
 		actionResolver: actionResolver,
 		cache:          cache,
@@ -100,7 +125,11 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]any {
 }
 
 // GetUserPermissions returns user permissions based on built-in roles
-func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) GetUserPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.GetUserPermissionsOSS")
 	defer span.End()
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
@@ -113,7 +142,11 @@ func (s *Service) GetUserPermissions(ctx context.Context, user identity.Requeste
 	return s.getCachedUserPermissions(ctx, user, options)
 }
 
-func (s *Service) getUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	permissions := make([]accesscontrol.Permission, 0)
 	for _, builtin := range accesscontrol.GetOrgRoles(user) {
 		if basicRole, ok := s.roles[builtin]; ok {
@@ -147,7 +180,11 @@ func (s *Service) getUserPermissions(ctx context.Context, user identity.Requeste
 	return append(permissions, dbPermissions...), nil
 }
 
-func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgID int64) ([]accesscontrol.Permission, error) {
+func (s *Service) getBasicRolePermissions(
+	ctx context.Context,
+	role string,
+	orgID int64,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getBasicRolePermissions")
 	defer span.End()
 
@@ -157,11 +194,14 @@ func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgI
 	}
 
 	// Fetch managed role permissions assigned to basic roles
-	dbPermissions, err := s.store.GetBasicRolesPermissions(ctx, accesscontrol.GetUserPermissionsQuery{
-		Roles:        []string{role},
-		OrgID:        orgID,
-		RolePrefixes: OSSRolesPrefixes,
-	})
+	dbPermissions, err := s.store.GetBasicRolesPermissions(
+		ctx,
+		accesscontrol.GetUserPermissionsQuery{
+			Roles:        []string{role},
+			OrgID:        orgID,
+			RolePrefixes: OSSRolesPrefixes,
+		},
+	)
 	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
 		dbPermissions = s.actionResolver.ExpandActionSets(dbPermissions)
 	}
@@ -169,7 +209,11 @@ func (s *Service) getBasicRolePermissions(ctx context.Context, role string, orgI
 	return append(permissions, dbPermissions...), err
 }
 
-func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgID int64) (map[int64][]accesscontrol.Permission, error) {
+func (s *Service) getTeamsPermissions(
+	ctx context.Context,
+	teamIDs []int64,
+	orgID int64,
+) (map[int64][]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getTeamsPermissions")
 	defer span.End()
 
@@ -189,7 +233,10 @@ func (s *Service) getTeamsPermissions(ctx context.Context, teamIDs []int64, orgI
 }
 
 // Returns only permissions directly assigned to user, without basic role and team permissions
-func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Requester) ([]accesscontrol.Permission, error) {
+func (s *Service) getUserDirectPermissions(
+	ctx context.Context,
+	user identity.Requester,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getUserDirectPermissions")
 	defer span.End()
 
@@ -209,7 +256,6 @@ func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Re
 		UserID:       userID,
 		RolePrefixes: OSSRolesPrefixes,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -224,13 +270,21 @@ func (s *Service) getUserDirectPermissions(ctx context.Context, user identity.Re
 	return permissions, nil
 }
 
-func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
-	basicRolesPermissions, err := s.getCachedBasicRolesPermissions(ctx, user, options)
+func (s *Service) getCachedUserPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
+	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserPermissions")
+	defer span.End()
+
+	permissions := []accesscontrol.Permission{}
+	permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options, permissions)
 	if err != nil {
 		return nil, err
 	}
 
-	teamsPermissions, err := s.getCachedTeamsPermissions(ctx, user, options)
+	permissions, err = s.getCachedTeamsPermissions(ctx, user, options, permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -240,30 +294,36 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 		return nil, err
 	}
 
-	permissions := make([]accesscontrol.Permission, 0, len(basicRolesPermissions)+len(teamsPermissions)+len(userPermissions))
-	permissions = append(permissions, basicRolesPermissions...)
-	permissions = append(permissions, teamsPermissions...)
 	permissions = append(permissions, userPermissions...)
 	return permissions, nil
 }
 
-func (s *Service) getCachedBasicRolesPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolesPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+	perms []accesscontrol.Permission,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedBasicRolesPermissions")
 	defer span.End()
 
 	basicRoles := accesscontrol.GetOrgRoles(user)
-	basicRolesPermissions := make([]accesscontrol.Permission, 0)
 	for _, role := range basicRoles {
 		permissions, err := s.getCachedBasicRolePermissions(ctx, role, user.GetOrgID(), options)
 		if err != nil {
 			return nil, err
 		}
-		basicRolesPermissions = append(basicRolesPermissions, permissions...)
+		perms = append(perms, permissions...)
 	}
-	return basicRolesPermissions, nil
+	return perms, nil
 }
 
-func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string, orgID int64, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedBasicRolePermissions(
+	ctx context.Context,
+	role string,
+	orgID int64,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	key := accesscontrol.GetBasicRolePermissionCacheKey(role, orgID)
 	getPermissionsFn := func() ([]accesscontrol.Permission, error) {
 		return s.getBasicRolePermissions(ctx, role, orgID)
@@ -271,7 +331,11 @@ func (s *Service) getCachedBasicRolePermissions(ctx context.Context, role string
 	return s.getCachedPermissions(ctx, key, getPermissionsFn, options)
 }
 
-func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedUserDirectPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedUserDirectPermissions")
 	defer span.End()
 
@@ -285,7 +349,12 @@ func (s *Service) getCachedUserDirectPermissions(ctx context.Context, user ident
 type GetPermissionsFn = func() ([]accesscontrol.Permission, error)
 
 // Generic method for getting various permissions from cache
-func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermissionsFn GetPermissionsFn, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedPermissions(
+	ctx context.Context,
+	key string,
+	getPermissionsFn GetPermissionsFn,
+	options accesscontrol.Options,
+) ([]accesscontrol.Permission, error) {
 	_, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
@@ -308,13 +377,17 @@ func (s *Service) getCachedPermissions(ctx context.Context, key string, getPermi
 	return permissions, nil
 }
 
-func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.Requester, options accesscontrol.Options) ([]accesscontrol.Permission, error) {
+func (s *Service) getCachedTeamsPermissions(
+	ctx context.Context,
+	user identity.Requester,
+	options accesscontrol.Options,
+	perms []accesscontrol.Permission,
+) ([]accesscontrol.Permission, error) {
 	ctx, span := s.tracer.Start(ctx, "authz.getCachedTeamsPermissions")
 	defer span.End()
 
 	teams := user.GetTeams()
 	orgID := user.GetOrgID()
-	permissions := make([]accesscontrol.Permission, 0)
 	miss := teams
 
 	if !options.ReloadCache {
@@ -324,7 +397,7 @@ func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.R
 			teamPermissions, ok := s.cache.Get(key)
 			if ok {
 				metrics.MAccessPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheHit).Inc()
-				permissions = append(permissions, teamPermissions.([]accesscontrol.Permission)...)
+				perms = append(perms, teamPermissions.([]accesscontrol.Permission)...)
 			} else {
 				miss = append(miss, teamID)
 			}
@@ -342,11 +415,11 @@ func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.R
 		for teamID, teamPermissions := range teamsPermissions {
 			key := accesscontrol.GetTeamPermissionCacheKey(teamID, orgID)
 			s.cache.Set(key, teamPermissions, cacheTTL)
-			permissions = append(permissions, teamPermissions...)
+			perms = append(perms, teamPermissions...)
 		}
 	}
 
-	return permissions, nil
+	return perms, nil
 }
 
 func (s *Service) ClearUserPermissionCache(user identity.Requester) {
@@ -387,7 +460,9 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 	s.registrations.Range(func(registration accesscontrol.RoleRegistration) bool {
 		for br := range accesscontrol.BuiltInRolesWithParents(registration.Grants) {
 			if basicRole, ok := s.roles[br]; ok {
-				basicRole.Permissions = append(basicRole.Permissions, registration.Role.Permissions...)
+				basicRole.Permissions = append(
+					basicRole.Permissions,
+					registration.Role.Permissions...)
 			} else {
 				s.log.Error("Unknown builtin role", "builtInRole", br)
 			}
@@ -399,7 +474,11 @@ func (s *Service) RegisterFixedRoles(ctx context.Context) error {
 
 // DeclarePluginRoles allow the caller to declare, to the service, plugin roles and their assignments
 // to organization roles ("Viewer", "Editor", "Admin") or "Grafana Admin"
-func (s *Service) DeclarePluginRoles(ctx context.Context, ID, name string, regs []plugins.RoleRegistration) error {
+func (s *Service) DeclarePluginRoles(
+	ctx context.Context,
+	ID, name string,
+	regs []plugins.RoleRegistration,
+) error {
 	// Protect behind feature toggle
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagAccessControlOnCall) {
 		return nil
@@ -434,7 +513,8 @@ func GetActionFilter(options accesscontrol.SearchOptions) func(action string) bo
 
 // SearchUsersPermissions returns all users' permissions filtered by action prefixes
 func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Requester,
-	options accesscontrol.SearchOptions) (map[int64][]accesscontrol.Permission, error) {
+	options accesscontrol.SearchOptions,
+) (map[int64][]accesscontrol.Permission, error) {
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.NamespacedID != "" {
@@ -545,7 +625,11 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Reque
 	return res, nil
 }
 
-func (s *Service) SearchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
+func (s *Service) SearchUserPermissions(
+	ctx context.Context,
+	orgID int64,
+	searchOptions accesscontrol.SearchOptions,
+) ([]accesscontrol.Permission, error) {
 	timer := prometheus.NewTimer(metrics.MAccessPermissionsSummary)
 	defer timer.ObserveDuration()
 
@@ -559,7 +643,11 @@ func (s *Service) SearchUserPermissions(ctx context.Context, orgID int64, search
 	return s.searchUserPermissions(ctx, orgID, searchOptions)
 }
 
-func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, error) {
+func (s *Service) searchUserPermissions(
+	ctx context.Context,
+	orgID int64,
+	searchOptions accesscontrol.SearchOptions,
+) ([]accesscontrol.Permission, error) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, err
@@ -599,17 +687,27 @@ func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, search
 	}
 	permissions = append(permissions, dbPermissions[userID]...)
 
-	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) && len(searchOptions.ActionSets) != 0 {
-		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, GetActionFilter(searchOptions))
+	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) &&
+		len(searchOptions.ActionSets) != 0 {
+		permissions = s.actionResolver.ExpandActionSetsWithFilter(
+			permissions,
+			GetActionFilter(searchOptions),
+		)
 	}
 
-	key := accesscontrol.GetSearchPermissionCacheKey(&user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
+	key := accesscontrol.GetSearchPermissionCacheKey(
+		&user.SignedInUser{UserID: userID, OrgID: orgID},
+		searchOptions,
+	)
 	s.cache.Set(key, permissions, cacheTTL)
 
 	return permissions, nil
 }
 
-func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions accesscontrol.SearchOptions) ([]accesscontrol.Permission, bool) {
+func (s *Service) searchUserPermissionsFromCache(
+	orgID int64,
+	searchOptions accesscontrol.SearchOptions,
+) ([]accesscontrol.Permission, bool) {
 	userID, err := searchOptions.ComputeUserID()
 	if err != nil {
 		return nil, false
@@ -624,7 +722,8 @@ func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions acce
 	key := accesscontrol.GetSearchPermissionCacheKey(tempUser, searchOptions)
 	permissions, ok := s.cache.Get((key))
 	if !ok {
-		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()
+		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).
+			Inc()
 		return nil, false
 	}
 
@@ -634,7 +733,10 @@ func (s *Service) searchUserPermissionsFromCache(orgID int64, searchOptions acce
 	return permissions.([]accesscontrol.Permission), true
 }
 
-func PermissionMatchesSearchOptions(permission accesscontrol.Permission, searchOptions *accesscontrol.SearchOptions) bool {
+func PermissionMatchesSearchOptions(
+	permission accesscontrol.Permission,
+	searchOptions *accesscontrol.SearchOptions,
+) bool {
 	if searchOptions.Scope != "" {
 		// Permissions including the scope should also match
 		scopes := append(searchOptions.Wildcards(), searchOptions.Scope)
@@ -648,9 +750,14 @@ func PermissionMatchesSearchOptions(permission accesscontrol.Permission, searchO
 	return strings.HasPrefix(permission.Action, searchOptions.ActionPrefix)
 }
 
-func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol.SaveExternalServiceRoleCommand) error {
+func (s *Service) SaveExternalServiceRole(
+	ctx context.Context,
+	cmd accesscontrol.SaveExternalServiceRoleCommand,
+) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug("Registering an external service role is behind a feature flag, enable it to use this feature.")
+		s.log.Debug(
+			"Registering an external service role is behind a feature flag, enable it to use this feature.",
+		)
 		return nil
 	}
 
@@ -663,7 +770,9 @@ func (s *Service) SaveExternalServiceRole(ctx context.Context, cmd accesscontrol
 
 func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagExternalServiceAccounts) {
-		s.log.Debug("Deleting an external service role is behind a feature flag, enable it to use this feature.")
+		s.log.Debug(
+			"Deleting an external service role is behind a feature flag, enable it to use this feature.",
+		)
 		return nil
 	}
 
@@ -672,11 +781,19 @@ func (s *Service) DeleteExternalServiceRole(ctx context.Context, externalService
 	return s.store.DeleteExternalServiceRole(ctx, slug)
 }
 
-func (*Service) SyncUserRoles(ctx context.Context, orgID int64, cmd accesscontrol.SyncUserRolesCommand) error {
+func (*Service) SyncUserRoles(
+	ctx context.Context,
+	orgID int64,
+	cmd accesscontrol.SyncUserRolesCommand,
+) error {
 	return nil
 }
 
-func (s *Service) GetRoleByName(ctx context.Context, orgID int64, roleName string) (*accesscontrol.RoleDTO, error) {
+func (s *Service) GetRoleByName(
+	ctx context.Context,
+	orgID int64,
+	roleName string,
+) (*accesscontrol.RoleDTO, error) {
 	err := accesscontrol.ErrRoleNotFound
 	if _, ok := s.roles[roleName]; ok {
 		return nil, err

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -44,10 +44,7 @@ func ProvideIdentitySynchronizer(s *Service) authn.IdentitySynchronizer {
 	return s
 }
 
-func ProvideService(
-	cfg *setting.Cfg, tracer tracing.Tracer,
-	sessionService auth.UserTokenService, usageStats usagestats.Service, registerer prometheus.Registerer,
-) *Service {
+func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, sessionService auth.UserTokenService, usageStats usagestats.Service, registerer prometheus.Registerer) *Service {
 	s := &Service{
 		log:                    log.New("authn.service"),
 		cfg:                    cfg,
@@ -373,7 +370,8 @@ func (s *Service) resolveIdenity(ctx context.Context, orgID int64, namespaceID a
 				AllowGlobalOrg:  true,
 				FetchSyncedUser: true,
 				SyncPermissions: true,
-			}}, nil
+			},
+		}, nil
 	}
 
 	if namespaceID.IsNamespace(authn.NamespaceServiceAccount) {
@@ -384,7 +382,8 @@ func (s *Service) resolveIdenity(ctx context.Context, orgID int64, namespaceID a
 				AllowGlobalOrg:  true,
 				FetchSyncedUser: true,
 				SyncPermissions: true,
-			}}, nil
+			},
+		}, nil
 	}
 
 	resolver, ok := s.idenityResolverClients[namespaceID.Namespace().String()]

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -44,7 +44,10 @@ func ProvideIdentitySynchronizer(s *Service) authn.IdentitySynchronizer {
 	return s
 }
 
-func ProvideService(cfg *setting.Cfg, tracer tracing.Tracer, sessionService auth.UserTokenService, usageStats usagestats.Service, registerer prometheus.Registerer) *Service {
+func ProvideService(
+	cfg *setting.Cfg, tracer tracing.Tracer,
+	sessionService auth.UserTokenService, usageStats usagestats.Service, registerer prometheus.Registerer,
+) *Service {
 	s := &Service{
 		log:                    log.New("authn.service"),
 		cfg:                    cfg,
@@ -370,8 +373,7 @@ func (s *Service) resolveIdenity(ctx context.Context, orgID int64, namespaceID a
 				AllowGlobalOrg:  true,
 				FetchSyncedUser: true,
 				SyncPermissions: true,
-			},
-		}, nil
+			}}, nil
 	}
 
 	if namespaceID.IsNamespace(authn.NamespaceServiceAccount) {
@@ -382,8 +384,7 @@ func (s *Service) resolveIdenity(ctx context.Context, orgID int64, namespaceID a
 				AllowGlobalOrg:  true,
 				FetchSyncedUser: true,
 				SyncPermissions: true,
-			},
-		}, nil
+			}}, nil
 	}
 
 	resolver, ok := s.idenityResolverClients[namespaceID.Namespace().String()]

--- a/pkg/services/authn/clients/basic.go
+++ b/pkg/services/authn/clients/basic.go
@@ -7,9 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/authn"
 )
 
-var (
-	errDecodingBasicAuthHeader = errutil.BadRequest("basic-auth.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
-)
+var errDecodingBasicAuthHeader = errutil.BadRequest("basic-auth.invalid-header", errutil.WithPublicMessage("Invalid Basic Auth Header"))
 
 var _ authn.ContextAwareClient = new(Basic)
 


### PR DESCRIPTION
**What is this feature?**
This PR reduces the number of allocations made while caching permissions from the database.

**Why do we need this feature?**
Existing code allocates 4 times resulting in 4x memory usage in large datasets.

**Who is this feature for?**
Everyone

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
