### PR TITLE
Trace View: Add Session for this span button

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -114,6 +114,11 @@ const getStyles = (theme: GrafanaTheme2) => {
     LinkIcon: css`
       font-size: 1.5em;
     `,
+    linkList: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: '10px',
+    }),
   };
 };
 
@@ -303,6 +308,7 @@ export default function SpanDetail(props: SpanDetailProps) {
 
   let logLinkButton: JSX.Element | null = null;
   let profileLinkButton: JSX.Element | null = null;
+  let sessionLinkButton: JSX.Element | null = null;
   if (createSpanLink) {
     const links = createSpanLink(span);
     const logsLink = links?.filter((link) => link.type === SpanLinkType.Logs);
@@ -315,6 +321,15 @@ export default function SpanDetail(props: SpanDetailProps) {
     if (links && profilesLink && profilesLink.length > 0) {
       profileLinkButton = createLinkButton(profilesLink[0], SpanLinkType.Profiles, 'Profiles for this span', 'link');
     }
+    const sessionLink = links?.filter((link) => link.type === SpanLinkType.Session);
+    if (links && sessionLink && sessionLink.length > 0) {
+      sessionLinkButton = createLinkButton(
+        sessionLink[0],
+        SpanLinkType.Session,
+        'Session for this span',
+        'frontend-observability'
+      );
+    }
   }
 
   const focusSpanLink = createFocusSpanLink(traceID, spanID);
@@ -326,8 +341,11 @@ export default function SpanDetail(props: SpanDetailProps) {
           <LabeledList className={styles.list} divider={true} items={overviewItems} />
         </div>
       </div>
-      <span style={{ marginRight: '10px' }}>{logLinkButton}</span>
-      {profileLinkButton}
+      <div className={styles.linkList}>
+        {logLinkButton}
+        {profileLinkButton}
+        {sessionLinkButton}
+      </div>
       <Divider spacing={1} />
       <div>
         <div>

--- a/public/app/features/explore/TraceView/components/types/links.ts
+++ b/public/app/features/explore/TraceView/components/types/links.ts
@@ -9,6 +9,7 @@ export enum SpanLinkType {
   Traces = 'trace',
   Metrics = 'metric',
   Profiles = 'profile',
+  Session = 'session',
   Unknown = 'unknown',
 }
 

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -1266,6 +1266,38 @@ describe('createSpanLinkFactory', () => {
     });
   });
 
+  describe('should return session link', () => {
+    beforeAll(() => {
+      setLinkSrv(new LinkSrv());
+      setTemplateSrv(new TemplateSrv());
+    });
+
+    it('does not add link when no ids are present', () => {
+      const createLink = setupSpanLinkFactory();
+      expect(createLink).toBeDefined();
+      const links = createLink!(createTraceSpan());
+      const sessionLink = links?.find((link) => link.type === SpanLinkType.Session);
+      expect(sessionLink).toBe(undefined);
+    });
+
+    it('adds link when fe o11y ids are present', () => {
+      const createLink = setupSpanLinkFactory();
+      expect(createLink).toBeDefined();
+      const links = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'feo11y-service',
+            tags: [{ key: 'gf.feo11y.app.id', value: 'appId' }],
+          },
+          tags: [{ key: 'session_id', value: 'the-session-id' }],
+        })
+      );
+      const sessionLink = links?.find((link) => link.type === SpanLinkType.Session);
+      expect(sessionLink).toBeDefined();
+      expect(sessionLink!.href).toBe('/a/grafana-kowalski-app/apps/appId/sessions/the-session-id');
+    });
+  });
+
   describe('should return pyroscope link', () => {
     beforeAll(() => {
       setDataSourceSrv({

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -1292,9 +1292,28 @@ describe('createSpanLinkFactory', () => {
           tags: [{ key: 'session_id', value: 'the-session-id' }],
         })
       );
+      expect(links).toHaveLength(1);
       const sessionLink = links?.find((link) => link.type === SpanLinkType.Session);
       expect(sessionLink).toBeDefined();
       expect(sessionLink!.href).toBe('/a/grafana-kowalski-app/apps/appId/sessions/the-session-id');
+    });
+
+    it('adds link when session id is defined following otel semantic convention', () => {
+      const createLink = setupSpanLinkFactory();
+      expect(createLink).toBeDefined();
+      const links = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'feo11y-service',
+            tags: [{ key: 'gf.feo11y.app.id', value: 'appId' }],
+          },
+          tags: [{ key: 'session.id', value: 'the-otel-session-id' }],
+        })
+      );
+      expect(links).toHaveLength(1);
+      const sessionLink = links?.find((link) => link.type === SpanLinkType.Session);
+      expect(sessionLink).toBeDefined();
+      expect(sessionLink!.href).toBe('/a/grafana-kowalski-app/apps/appId/sessions/the-otel-session-id');
     });
   });
 

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -399,7 +399,7 @@ function getQueryForLoki(
 
 function getLinkForFeO11y(span: TraceSpan): string | undefined {
   const feO11yAppId = span.process.tags.find((tag) => tag.key === feO11yTagKey)?.value;
-  const feO11ySessionId = span.tags.find((tag) => tag.key === 'session_id')?.value;
+  const feO11ySessionId = span.tags.find((tag) => tag.key === 'session_id' || tag.key === 'session.id')?.value;
 
   return feO11yAppId && feO11ySessionId
     ? `/a/grafana-kowalski-app/apps/${feO11yAppId}/sessions/${feO11ySessionId}`

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -139,6 +139,7 @@ const formatDefaultKeys = (keys: string[]) => {
 const defaultKeys = formatDefaultKeys(['cluster', 'hostname', 'namespace', 'pod', 'service.name', 'service.namespace']);
 export const defaultProfilingKeys = formatDefaultKeys(['service.name', 'service.namespace']);
 export const pyroscopeProfileIdTagKey = 'pyroscope.profile.id';
+export const feO11yTagKey = 'gf.feo11y.app.id';
 
 function legacyCreateSpanLinkFactory(
   splitOpenFn: SplitOpen,
@@ -350,6 +351,18 @@ function legacyCreateSpanLinkFactory(
       }
     }
 
+    // Get session links
+    const feO11yLink = getLinkForFeO11y(span);
+    if (feO11yLink) {
+      links.push({
+        title: 'Session for this span',
+        href: feO11yLink,
+        content: <Icon name="frontend-observability" title="Session for this span" />,
+        field,
+        type: SpanLinkType.Session,
+      });
+    }
+
     return links;
   };
 }
@@ -382,6 +395,15 @@ function getQueryForLoki(
     expr: expr,
     refId: '',
   };
+}
+
+function getLinkForFeO11y(span: TraceSpan): string | undefined {
+  const feO11yAppId = span.process.tags.find((tag) => tag.key === feO11yTagKey)?.value;
+  const feO11ySessionId = span.tags.find((tag) => tag.key === 'session_id')?.value;
+
+  return feO11yAppId && feO11ySessionId
+    ? `/a/grafana-kowalski-app/apps/${feO11yAppId}/sessions/${feO11ySessionId}`
+    : undefined;
 }
 
 // we do not have access to the dataquery type for opensearch,


### PR DESCRIPTION
**What is this feature?**

This PR adds a `Session for this span` button whenever `gf.feo11y.app.id` and `session_id` attributes are present in the span.

The `gf.feo11y.app.id` attribute gets added by the faro backend, so we know the user is using frontend observability if they have this attribute available.

<img width="2416" alt="Screenshot 2024-06-25 at 10 47 08" src="https://github.com/grafana/grafana/assets/7382419/d12e9427-dc69-4e9c-bb57-d0acbac625b4">


**Why do we need this feature?**

This feature will allow two things:

- Improve navigation to frontend observability from the explore panel
- Improve navigation to frontend observability from within the app observability app

**Who is this feature for?**

This feature is for users that are using frontend observability, and are currently sending traces.

**Which issue(s) does this PR fix?**:

Fixes [#1083](https://github.com/grafana/app-observability-plugin/issues/1083)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
