### PR TITLE
Scopes: Implement message for when there are no dashboards found

### DIFF
--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesDashboardsScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesDashboardsScene.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, Scope, urlUtil } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { CustomScrollbar, FilterInput, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
-import { t } from 'app/core/internationalization';
+import { t, Trans } from 'app/core/internationalization';
 
 import { fetchSuggestedDashboards } from './api';
 import { SuggestedDashboard } from './types';
@@ -62,10 +62,18 @@ export class ScopesDashboardsScene extends SceneObjectBase<ScopesDashboardsScene
 }
 
 export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<ScopesDashboardsScene>) {
-  const { filteredDashboards, isLoading, searchQuery } = model.useState();
+  const { dashboards, filteredDashboards, isLoading, searchQuery } = model.useState();
   const styles = useStyles2(getStyles);
 
   const [queryParams] = useQueryParams();
+
+  if (!isLoading && dashboards.length === 0) {
+    return (
+      <p data-testid="scopes-dashboards-notFoundForScope">
+        <Trans i18nKey="scopes.suggestedDashboards.noResults">No dashboards found</Trans>
+      </p>
+    );
+  }
 
   return (
     <>
@@ -85,7 +93,7 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
           text={t('scopes.suggestedDashboards.loading', 'Loading dashboards')}
           data-testid="scopes-dashboards-loading"
         />
-      ) : (
+      ) : filteredDashboards.length > 0 ? (
         <CustomScrollbar>
           {filteredDashboards.map(({ dashboard, dashboardTitle }) => (
             <Link
@@ -98,6 +106,10 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
             </Link>
           ))}
         </CustomScrollbar>
+      ) : (
+        <p data-testid="scopes-dashboards-notFoundForFilter">
+          <Trans i18nKey="scopes.suggestedDashboards.noResults">No dashboards found</Trans>
+        </p>
       )}
     </>
   );

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -45,6 +45,10 @@ import {
   queryDashboardsContainer,
   queryDashboardsExpand,
   renderDashboard,
+  getNotFoundForScope,
+  queryDashboardsSearch,
+  getNotFoundForFilter,
+  getClustersSlothClusterEastSelect,
 } from './testUtils';
 
 jest.mock('@grafana/runtime', () => ({
@@ -297,6 +301,27 @@ describe('ScopesScene', () => {
         expect(queryAllDashboard('6')).toHaveLength(1);
         expect(queryAllDashboard('7')).toHaveLength(1);
         expect(queryAllDashboard('8')).toHaveLength(1);
+      });
+
+      it('Does not show the input when there are no dashboards found for scope', async () => {
+        await userEvents.click(getDashboardsExpand());
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getClustersExpand());
+        await userEvents.click(getClustersSlothClusterEastSelect());
+        await userEvents.click(getFiltersApply());
+        expect(getNotFoundForScope()).toBeInTheDocument();
+        expect(queryDashboardsSearch()).not.toBeInTheDocument();
+      });
+
+      it('Does show the input and a message when there are no dashboards found for filter', async () => {
+        await userEvents.click(getDashboardsExpand());
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getApplicationsExpand());
+        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getFiltersApply());
+        await userEvents.type(getDashboardsSearch(), 'unknown');
+        expect(queryDashboardsSearch()).toBeInTheDocument();
+        expect(getNotFoundForFilter()).toBeInTheDocument();
       });
     });
 

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -48,7 +48,7 @@ import {
   getNotFoundForScope,
   queryDashboardsSearch,
   getNotFoundForFilter,
-  getClustersSlothClusterEastSelect,
+  getClustersSlothClusterEastRadio,
 } from './testUtils';
 
 jest.mock('@grafana/runtime', () => ({
@@ -307,7 +307,7 @@ describe('ScopesScene', () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
         await userEvents.click(getClustersExpand());
-        await userEvents.click(getClustersSlothClusterEastSelect());
+        await userEvents.click(getClustersSlothClusterEastRadio());
         await userEvents.click(getFiltersApply());
         expect(getNotFoundForScope()).toBeInTheDocument();
         expect(queryDashboardsSearch()).not.toBeInTheDocument();

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -49,6 +49,8 @@ import {
   queryDashboardsSearch,
   getNotFoundForFilter,
   getClustersSlothClusterEastRadio,
+  getNotFoundForFilterClear,
+  getNotFoundNoScopes,
 } from './testUtils';
 
 jest.mock('@grafana/runtime', () => ({
@@ -303,6 +305,12 @@ describe('ScopesScene', () => {
         expect(queryAllDashboard('8')).toHaveLength(1);
       });
 
+      it('Does show a proper message when no scopes are selected', async () => {
+        await userEvents.click(getDashboardsExpand());
+        expect(getNotFoundNoScopes()).toBeInTheDocument();
+        expect(queryDashboardsSearch()).not.toBeInTheDocument();
+      });
+
       it('Does not show the input when there are no dashboards found for scope', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
@@ -322,6 +330,8 @@ describe('ScopesScene', () => {
         await userEvents.type(getDashboardsSearch(), 'unknown');
         expect(queryDashboardsSearch()).toBeInTheDocument();
         expect(getNotFoundForFilter()).toBeInTheDocument();
+        await userEvents.click(getNotFoundForFilterClear());
+        expect(getDashboardsSearch().value).toBe('');
       });
     });
 

--- a/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
@@ -50,6 +50,16 @@ export const mocksScopes: Scope[] = [
     },
   },
   {
+    metadata: { name: 'slothClusterEast' },
+    spec: {
+      title: 'slothClusterEast',
+      type: 'cluster',
+      description: 'slothClusterEast',
+      category: 'clusters',
+      filters: [{ key: 'cluster', value: 'slothClusterEast', operator: 'equals' }],
+    },
+  },
+  {
     metadata: { name: 'slothPictureFactory' },
     spec: {
       title: 'slothPictureFactory',
@@ -215,6 +225,17 @@ export const mocksNodes: Array<ScopeNode & { parent: string }> = [
   },
   {
     parent: 'clusters',
+    metadata: { name: 'clusters-slothClusterEast' },
+    spec: {
+      nodeType: 'leaf',
+      title: 'slothClusterEast',
+      description: 'slothClusterEast',
+      linkType: 'scope',
+      linkId: 'slothClusterEast',
+    },
+  },
+  {
+    parent: 'clusters',
     metadata: { name: 'clusters.applications' },
     spec: {
       nodeType: 'container',
@@ -312,6 +333,8 @@ const selectors = {
     search: 'scopes-dashboards-search',
     loading: 'scopes-dashboards-loading',
     dashboard: (uid: string) => `scopes-dashboards-${uid}`,
+    notFoundForScope: 'scopes-dashboards-notFoundForScope',
+    notFoundForFilter: 'scopes-dashboards-notFoundForFilter',
   },
 };
 
@@ -324,10 +347,13 @@ export const queryDashboardsExpand = () => screen.queryByTestId(selectors.dashbo
 export const getDashboardsExpand = () => screen.getByTestId(selectors.dashboards.expand);
 export const queryDashboardsContainer = () => screen.queryByTestId(selectors.dashboards.container);
 export const getDashboardsContainer = () => screen.getByTestId(selectors.dashboards.container);
+export const queryDashboardsSearch = () => screen.queryByTestId(selectors.dashboards.search);
 export const getDashboardsSearch = () => screen.getByTestId<HTMLInputElement>(selectors.dashboards.search);
 export const queryAllDashboard = (uid: string) => screen.queryAllByTestId(selectors.dashboards.dashboard(uid));
 export const queryDashboard = (uid: string) => screen.queryByTestId(selectors.dashboards.dashboard(uid));
 export const getDashboard = (uid: string) => screen.getByTestId(selectors.dashboards.dashboard(uid));
+export const getNotFoundForScope = () => screen.getByTestId(selectors.dashboards.notFoundForScope);
+export const getNotFoundForFilter = () => screen.getByTestId(selectors.dashboards.notFoundForFilter);
 
 export const getApplicationsExpand = () => screen.getByTestId(selectors.tree.expand('applications'));
 export const getApplicationsSearch = () => screen.getByTestId<HTMLInputElement>(selectors.tree.search('applications'));
@@ -357,6 +383,8 @@ export const getClustersSlothClusterNorthRadio = () =>
   screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterNorth'));
 export const getClustersSlothClusterSouthRadio = () =>
   screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterSouth'));
+export const getClustersSlothClusterEastRadio = () =>
+  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterEast'));
 
 export function buildTestScene(overrides: Partial<DashboardScene> = {}) {
   return new DashboardScene({

--- a/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
@@ -333,8 +333,10 @@ const selectors = {
     search: 'scopes-dashboards-search',
     loading: 'scopes-dashboards-loading',
     dashboard: (uid: string) => `scopes-dashboards-${uid}`,
+    notFoundNoScopes: 'scopes-dashboards-notFoundNoScopes',
     notFoundForScope: 'scopes-dashboards-notFoundForScope',
     notFoundForFilter: 'scopes-dashboards-notFoundForFilter',
+    notFoundForFilterClear: 'scopes-dashboards-notFoundForFilter-clear',
   },
 };
 
@@ -352,8 +354,10 @@ export const getDashboardsSearch = () => screen.getByTestId<HTMLInputElement>(se
 export const queryAllDashboard = (uid: string) => screen.queryAllByTestId(selectors.dashboards.dashboard(uid));
 export const queryDashboard = (uid: string) => screen.queryByTestId(selectors.dashboards.dashboard(uid));
 export const getDashboard = (uid: string) => screen.getByTestId(selectors.dashboards.dashboard(uid));
+export const getNotFoundNoScopes = () => screen.getByTestId(selectors.dashboards.notFoundNoScopes);
 export const getNotFoundForScope = () => screen.getByTestId(selectors.dashboards.notFoundForScope);
 export const getNotFoundForFilter = () => screen.getByTestId(selectors.dashboards.notFoundForFilter);
+export const getNotFoundForFilterClear = () => screen.getByTestId(selectors.dashboards.notFoundForFilterClear);
 
 export const getApplicationsExpand = () => screen.getByTestId(selectors.tree.expand('applications'));
 export const getApplicationsSearch = () => screen.getByTestId<HTMLInputElement>(selectors.tree.search('applications'));

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1657,6 +1657,7 @@
     },
     "suggestedDashboards": {
       "loading": "Loading dashboards",
+      "noResults": "No dashboards found",
       "search": "Search",
       "toggle": {
         "collapse": "Collapse scope filters",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1657,7 +1657,10 @@
     },
     "suggestedDashboards": {
       "loading": "Loading dashboards",
-      "noResults": "No dashboards found",
+      "noResultsForFilter": "No results found for your query",
+      "noResultsForFilterClear": "Clear search",
+      "noResultsForScopes": "No dashboards found for the selected scopes",
+      "noResultsNoScopes": "No scopes selected",
       "search": "Search",
       "toggle": {
         "collapse": "Collapse scope filters",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1657,7 +1657,10 @@
     },
     "suggestedDashboards": {
       "loading": "Ŀőäđįŉģ đäşĥþőäřđş",
-      "noResults": "Ńő đäşĥþőäřđş ƒőūŉđ",
+      "noResultsForFilter": "Ńő řęşūľŧş ƒőūŉđ ƒőř yőūř qūęřy",
+      "noResultsForFilterClear": "Cľęäř şęäřčĥ",
+      "noResultsForScopes": "Ńő đäşĥþőäřđş ƒőūŉđ ƒőř ŧĥę şęľęčŧęđ şčőpęş",
+      "noResultsNoScopes": "Ńő şčőpęş şęľęčŧęđ",
       "search": "Ŝęäřčĥ",
       "toggle": {
         "collapse": "Cőľľäpşę şčőpę ƒįľŧęřş",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1657,6 +1657,7 @@
     },
     "suggestedDashboards": {
       "loading": "Ŀőäđįŉģ đäşĥþőäřđş",
+      "noResults": "Ńő đäşĥþőäřđş ƒőūŉđ",
       "search": "Ŝęäřčĥ",
       "toggle": {
         "collapse": "Cőľľäpşę şčőpę ƒįľŧęřş",


### PR DESCRIPTION
**What is this feature?**

Show a message when there are no dashboards for the scope or for the search.

**Why do we need this feature?**

Inform the user that there are no dashboards found

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
