### PR TITLE
Scopes: Allow node title to expand the container

### DIFF
--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, FilterInput, IconButton, RadioButtonDot, useStyles2 } from '@grafana/ui';
+import { Checkbox, FilterInput, Icon, RadioButtonDot, useStyles2 } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
 import { NodesMap, TreeScope } from './types';
@@ -105,20 +105,24 @@ export function ScopesTreeLevel({
                     )
                   ) : null}
 
-                  {childNode.isExpandable && (
-                    <IconButton
-                      name={!childNode.isExpanded ? 'angle-right' : 'angle-down'}
+                  {childNode.isExpandable ? (
+                    <button
+                      className={styles.itemExpand}
+                      data-testid={`scopes-tree-${childNode.name}-expand`}
                       aria-label={
                         childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
                       }
-                      data-testid={`scopes-tree-${childNode.name}-expand`}
                       onClick={() => {
                         onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
                       }}
-                    />
-                  )}
+                    >
+                      <Icon name={!childNode.isExpanded ? 'angle-right' : 'angle-down'} />
 
-                  <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+                      {childNode.title}
+                    </button>
+                  ) : (
+                    <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+                  )}
                 </div>
 
                 <div className={styles.itemChildren}>
@@ -164,6 +168,15 @@ const getStyles = (theme: GrafanaTheme2) => {
       '& > label': css({
         gap: 0,
       }),
+    }),
+    itemExpand: css({
+      alignItems: 'center',
+      background: 'none',
+      border: 0,
+      display: 'flex',
+      gap: theme.spacing(1),
+      margin: 0,
+      padding: 0,
     }),
     itemChildren: css({
       paddingLeft: theme.spacing(4),


### PR DESCRIPTION
**What is this feature?**

Allow a node title to expand itself on click.

**Why do we need this feature?**

-

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
