### PR TITLE
CI: Don't use slim image for bump-version

### DIFF
--- a/pkg/build/actions/bump-version/main.go
+++ b/pkg/build/actions/bump-version/main.go
@@ -63,7 +63,7 @@ func NodeVersion(d *dagger.Client, src *dagger.Directory) *dagger.Container {
 
 func WithUpdatedVersion(d *dagger.Client, src *dagger.Directory, nodeVersion, version string) *dagger.Directory {
 	nodeVersion = strings.TrimPrefix(strings.TrimSpace(nodeVersion), "v")
-	image := fmt.Sprintf("node:%s-slim", nodeVersion)
+	image := fmt.Sprintf("node:%s", nodeVersion)
 
 	return d.Container().From(image).
 		WithDirectory("/src", src).


### PR DESCRIPTION
It will have some missing system level dependencies which will fail a `yarn install`. Instead of using `slim` we should just use the non-slim image.