### PR TITLE
Chore: Update github addToProject commands for influxdb, graphite, opentsdb

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -112,7 +112,7 @@
     "name":"datasource/InfluxDB",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/112"
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
@@ -120,7 +120,7 @@
     "name":"datasource/Graphite",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/112"
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
@@ -128,7 +128,7 @@
     "name":"datasource/OpenTSDB",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/112"
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {


### PR DESCRIPTION
**What is this feature?**

Since the codeowners changed https://github.com/grafana/grafana/pull/89629 we should also update the github commands for those labels

- `datasource/InfluxDB`
- `datasource/Graphite`
- `datasource/OpenTSDB`