### PR TITLE
Alerting: Send external URL to the remote Alertmanager

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -199,7 +199,7 @@ func (ng *AlertNG) init() error {
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
 						PromoteConfig:     true,
 						SyncInterval:      ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
-						AppURL:            ng.Cfg.AppURL,
+						ExternalURL:       ng.Cfg.AppURL,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
 					if err != nil {
@@ -234,7 +234,7 @@ func (ng *AlertNG) init() error {
 						PromoteConfig:     true,
 						TenantID:          ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
-						AppURL:            ng.Cfg.AppURL,
+						ExternalURL:       ng.Cfg.AppURL,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
 					if err != nil {
@@ -271,7 +271,7 @@ func (ng *AlertNG) init() error {
 						TenantID:          ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
 						SyncInterval:      ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
-						AppURL:            ng.Cfg.AppURL,
+						ExternalURL:       ng.Cfg.AppURL,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
 					if err != nil {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -199,6 +199,7 @@ func (ng *AlertNG) init() error {
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
 						PromoteConfig:     true,
 						SyncInterval:      ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
+						AppURL:            ng.Cfg.AppURL,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
 					if err != nil {
@@ -233,6 +234,7 @@ func (ng *AlertNG) init() error {
 						PromoteConfig:     true,
 						TenantID:          ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
+						AppURL:            ng.Cfg.AppURL,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
 					if err != nil {
@@ -269,6 +271,7 @@ func (ng *AlertNG) init() error {
 						TenantID:          ng.Cfg.UnifiedAlerting.RemoteAlertmanager.TenantID,
 						URL:               ng.Cfg.UnifiedAlerting.RemoteAlertmanager.URL,
 						SyncInterval:      ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
+						AppURL:            ng.Cfg.AppURL,
 					}
 					remoteAM, err := createRemoteAlertmanager(cfg, ng.KVStore, ng.SecretsService.Decrypt, autogenFn, m, ng.tracer)
 					if err != nil {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -78,8 +78,8 @@ type AlertmanagerConfig struct {
 
 	DefaultConfig string
 
-	// AppURL is used in notifications sent by the remote Alertmanager.
-	AppURL string
+	// ExternalURL is used in notifications sent by the remote Alertmanager.
+	ExternalURL string
 	// PromoteConfig is a flag that determines whether the configuration should be used in the remote Alertmanager.
 	// The same flag is used for promoting state.
 	PromoteConfig bool
@@ -119,7 +119,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, store stateStore, decryptFn Decrypt
 		TenantID:      cfg.TenantID,
 		URL:           u,
 		PromoteConfig: cfg.PromoteConfig,
-		ExternalURL:   cfg.AppURL,
+		ExternalURL:   cfg.ExternalURL,
 	}
 	mc, err := remoteClient.New(mcCfg, metrics, tracer)
 	if err != nil {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -77,10 +77,12 @@ type AlertmanagerConfig struct {
 	BasicAuthPassword string
 
 	DefaultConfig string
+
+	// AppURL is used in notifications sent by the remote Alertmanager.
+	AppURL string
 	// PromoteConfig is a flag that determines whether the configuration should be used in the remote Alertmanager.
 	// The same flag is used for promoting state.
 	PromoteConfig bool
-
 	// SyncInterval determines how often we should attempt to synchronize configuration.
 	SyncInterval time.Duration
 }
@@ -117,6 +119,7 @@ func NewAlertmanager(cfg AlertmanagerConfig, store stateStore, decryptFn Decrypt
 		TenantID:      cfg.TenantID,
 		URL:           u,
 		PromoteConfig: cfg.PromoteConfig,
+		ExternalURL:   cfg.AppURL,
 	}
 	mc, err := remoteClient.New(mcCfg, metrics, tracer)
 	if err != nil {

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -168,7 +168,7 @@ func TestApplyConfig(t *testing.T) {
 		DefaultConfig: defaultGrafanaConfig,
 		PromoteConfig: true,
 		SyncInterval:  1 * time.Hour,
-		AppURL:        "https://test.grafana.com",
+		ExternalURL:   "https://test.grafana.com",
 	}
 
 	ctx := context.Background()
@@ -200,7 +200,7 @@ func TestApplyConfig(t *testing.T) {
 	require.True(t, configSent.Promoted)
 
 	// Grafana's URL should be sent alongside the configuration.
-	require.Equal(t, cfg.AppURL, configSent.ExternalURL)
+	require.Equal(t, cfg.ExternalURL, configSent.ExternalURL)
 
 	// If we already got a 200 status code response and the sync interval hasn't elapsed,
 	// we shouldn't send the state/configuration again.

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -168,6 +168,7 @@ func TestApplyConfig(t *testing.T) {
 		DefaultConfig: defaultGrafanaConfig,
 		PromoteConfig: true,
 		SyncInterval:  1 * time.Hour,
+		AppURL:        "https://test.grafana.com",
 	}
 
 	ctx := context.Background()
@@ -197,6 +198,9 @@ func TestApplyConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, testGrafanaConfigWithSecret, string(amCfg))
 	require.True(t, configSent.Promoted)
+
+	// Grafana's URL should be sent alongside the configuration.
+	require.Equal(t, cfg.AppURL, configSent.ExternalURL)
 
 	// If we already got a 200 status code response and the sync interval hasn't elapsed,
 	// we shouldn't send the state/configuration again.

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -21,6 +21,7 @@ type UserGrafanaConfig struct {
 	CreatedAt                 int64                         `json:"created"`
 	Default                   bool                          `json:"default"`
 	Promoted                  bool                          `json:"promoted"`
+	ExternalURL               string                        `json:"external_url"`
 }
 
 func (mc *Mimir) ShouldPromoteConfig() bool {
@@ -53,6 +54,7 @@ func (mc *Mimir) CreateGrafanaAlertmanagerConfig(ctx context.Context, cfg *apimo
 		CreatedAt:                 createdAt,
 		Default:                   isDefault,
 		Promoted:                  mc.promoteConfig,
+		ExternalURL:               mc.externalURL,
 	})
 	if err != nil {
 		return err

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -40,6 +40,7 @@ type Mimir struct {
 	logger        log.Logger
 	metrics       *metrics.RemoteAlertmanager
 	promoteConfig bool
+	externalURL   string
 }
 
 type Config struct {
@@ -49,6 +50,7 @@ type Config struct {
 
 	Logger        log.Logger
 	PromoteConfig bool
+	ExternalURL   string
 }
 
 // successResponse represents a successful response from the Mimir API.
@@ -91,6 +93,7 @@ func New(cfg *Config, metrics *metrics.RemoteAlertmanager, tracer tracing.Tracer
 		logger:        cfg.Logger,
 		metrics:       metrics,
 		promoteConfig: cfg.PromoteConfig,
+		externalURL:   cfg.ExternalURL,
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds the Grafana instance's URL to the payload we send to the remote Alertmanager when sending the configuration. This URL will be used by the remote Alertmanager as the `ExternalURL` in notification templates.