### PR TITLE
VizTooltip: Keep visible while hovering during data updates

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -463,7 +463,10 @@ export const TooltipPlugin2 = ({
     config.addHook('setData', (u) => {
       yZoomed = false;
       yDrag = false;
-      dismiss();
+
+      if (_isPinned) {
+        dismiss();
+      }
     });
 
     // fires on series focus/proximity changes


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11157

was especially annoying for Live/streaming scenarios where a rapid data updates caused the tooltip to disappear.