### PR TITLE
Chore: Add missing build elements to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,10 @@ COPY .bingo .bingo
 COPY pkg/util/xorm/go.* pkg/util/xorm/
 COPY pkg/apiserver/go.* pkg/apiserver/
 COPY pkg/apimachinery/go.* pkg/apimachinery/
+COPY pkg/build/go.*  pkg/build/
 COPY pkg/build/wire/go.* pkg/build/wire/
 COPY pkg/promlib/go.* pkg/promlib/
+COPY pkg/storage/unified/resource/go.* pkg/storage/unified/resource/
 
 RUN go mod download
 RUN if [[ "$BINGO" = "true" ]]; then \


### PR DESCRIPTION
**What is this feature?**

Several go.* files that are referenced in go.work were missing in Dockerfile.

**Why do we need this feature?**

Without correct Dockerfile e.g.  'make build-docker-full' cannot finish successfully.
