### PR TITLE
CI: add release comms workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -673,6 +673,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/bump-version.yml @grafana/grafana-release-guild
 /.github/workflows/close-milestone.yml @grafana/grafana-release-guild
 /.github/workflows/release-pr.yml @grafana/grafana-release-guild
+/.github/workflows/release-comms.yml @grafana/grafana-release-guild
 /.github/workflows/codeowners-validator.yml @tolzhabayev
 /.github/workflows/codeql-analysis.yml @DanCech
 /.github/workflows/commands.yml @torkelo

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -1,0 +1,34 @@
+# This workflow runs whenever the release PR is merged. It includes post-release communication processes like
+# posting to slack, the website, community forums, etc.
+# Only things that happen after a release is completed and all of the necessary code changes (like the changelog) are made.
+name: Post-release
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        required: false
+        default: true
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'main'
+      - 'v*.*.*'
+jobs:
+  post_release:
+    name: Post-release comms
+    env:
+    steps:
+      - if: github.event.workflow_dispatch
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
+      - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+        run: |
+          echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
+          echo "DRY_RUN=false" >> $GITHUB_ENV
+      - run: "echo push-grafana-tag $VERSION (dry run: $DRY_RUN)"
+      - run: "echo post changelog to forums for $VERSION (dry run: $DRY_RUN)"
+      - run: "echo create github release"
+      - run: "echo publish docs for $VERSION (dry run: $DRY_RUN)"
+      - run: "announce on slack that $VERSION has been released (dry run: $DRY_RUN)"

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -8,6 +8,8 @@ on:
       dry_run:
         required: false
         default: true
+      version:
+        required: true
   pull_request:
     types:
       - closed


### PR DESCRIPTION
This workflow will run after the release PR has been merged (or manually for testing).

This workflow should only run processes that happen after release is completed, mostly centered around communicating release status.