### PR TITLE
CI: fix release comms workflow

### DIFF
--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -21,7 +21,7 @@ jobs:
     name: Post-release comms
     runs-on: ubuntu-latest
     steps:
-      - if: github.event.workflow_dispatch
+      - if: github.event_name == 'workflow_dispatch'
         run: |
           echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
           echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   post_release:
     name: Post-release comms
+    runs-on: ubuntu-latest
     env:
     steps:
       - if: github.event.workflow_dispatch

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -23,14 +23,19 @@ jobs:
     steps:
       - if: github.event.workflow_dispatch
         run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-          echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
+        echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+        echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
       - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
         run: |
-          echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
-          echo "DRY_RUN=false" >> $GITHUB_ENV
-      - run: "echo push-grafana-tag $VERSION (dry run: $DRY_RUN)"
-      - run: "echo post changelog to forums for $VERSION (dry run: $DRY_RUN)"
-      - run: "echo create github release"
-      - run: "echo publish docs for $VERSION (dry run: $DRY_RUN)"
-      - run: "announce on slack that $VERSION has been released (dry run: $DRY_RUN)"
+        echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
+        echo "DRY_RUN=false" >> $GITHUB_ENV
+      - run: |
+        echo "push-grafana-tag ${VERSION} (dry run: ${DRY_RUN})"
+      - run: |
+        echo "post changelog to forums for ${VERSION} (dry run: ${DRY_RUN})"
+      - run: |
+        echo "create github release for tag ${VERSION} (dry run: ${DRY_RUN})"
+      - run: |
+        echo "publish docs for ${VERSION} (dry run: ${DRY_RUN})"
+      - run: |
+        echo "announce on slack that ${VERSION} has been released (dry run: ${DRY_RUN})"

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -23,19 +23,19 @@ jobs:
     steps:
       - if: github.event.workflow_dispatch
         run: |
-        echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-        echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
       - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
         run: |
-        echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
-        echo "DRY_RUN=false" >> $GITHUB_ENV
+          echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
+          echo "DRY_RUN=false" >> $GITHUB_ENV
       - run: |
-        echo "push-grafana-tag ${VERSION} (dry run: ${DRY_RUN})"
+          echo "push-grafana-tag ${VERSION} (dry run: ${DRY_RUN})"
       - run: |
-        echo "post changelog to forums for ${VERSION} (dry run: ${DRY_RUN})"
+          echo "post changelog to forums for ${VERSION} (dry run: ${DRY_RUN})"
       - run: |
-        echo "create github release for tag ${VERSION} (dry run: ${DRY_RUN})"
+          echo "create github release for tag ${VERSION} (dry run: ${DRY_RUN})"
       - run: |
-        echo "publish docs for ${VERSION} (dry run: ${DRY_RUN})"
+          echo "publish docs for ${VERSION} (dry run: ${DRY_RUN})"
       - run: |
-        echo "announce on slack that ${VERSION} has been released (dry run: ${DRY_RUN})"
+          echo "announce on slack that ${VERSION} has been released (dry run: ${DRY_RUN})"

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -20,7 +20,6 @@ jobs:
   post_release:
     name: Post-release comms
     runs-on: ubuntu-latest
-    env:
     steps:
       - if: github.event.workflow_dispatch
         run: |


### PR DESCRIPTION
Fixes a couple issues with the release-comms workflow that prevented it from running.

here it is running now: https://github.com/grafana/grafana/actions/runs/9670191733/job/26678432046