### PR TITLE
[v10.4.x] Docs: add panel options shared content

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/alert-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/alert-list/index.md
@@ -42,6 +42,10 @@ Once you’ve created a [dashboard](https://grafana.com/docs/grafana/<GRAFANA_VE
 
 {{< youtube id="o4rK7_AXZ9Y" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Options
 
 Use the following options to refine your alert list visualization.

--- a/docs/sources/panels-visualizations/visualizations/annotations/index.md
+++ b/docs/sources/panels-visualizations/visualizations/annotations/index.md
@@ -22,6 +22,10 @@ weight: 100
 
 The annotations list shows a list of available annotations you can use to view annotated data. Various options are available to filter the list based on tags and on the current dashboard.
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Annotation query
 
 The following options control the source query for the list of annotations.

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -62,6 +62,10 @@ have multiple time series and you want to compare their last and max value add t
 
 {{< figure src="/static/img/docs/bar-chart-panel/bar-chart-time-series-v8-0.png" max-width="1025px" caption="Bar chart time series example" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Bar chart options
 
 Use these options to refine your visualization.

--- a/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-gauge/index.md
@@ -33,6 +33,10 @@ This panel can show one or more bar gauges depending on how many series, rows, o
 
 {{< docs/play title="Bar Gauge" url="https://play.grafana.org/d/vmie2cmWz/" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value options
 
 Use the following options to refine how your visualization displays the value:

--- a/docs/sources/panels-visualizations/visualizations/candlestick/index.md
+++ b/docs/sources/panels-visualizations/visualizations/candlestick/index.md
@@ -76,6 +76,10 @@ The data is converted as follows:
 
 {{< figure src="/static/img/docs/candlestick-panel/candlestick.png" max-width="1065px" alt="A candlestick visualization showing the price movements of specific asset." >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Mode
 
 The mode options allow you to toggle which dimensions are used for the visualization.

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -172,6 +172,10 @@ If multiple elements use the same field name, and you want to control which elem
 
 {{< video-embed src="/media/docs/grafana/canvas-data-links-9-4-0.mp4" max-width="750px" caption="Data links demo" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Standard options
 
 {{< docs/shared lookup="visualizations/standard-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
+++ b/docs/sources/panels-visualizations/visualizations/dashboard-list/index.md
@@ -44,6 +44,10 @@ Once you’ve created a [dashboard](https://grafana.com/docs/grafana/<GRAFANA_VE
 
 {{< docs/play title="Dashboard List Visualization" url="https://play.grafana.org/d/fdlojrg7daebka/" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Dashboard list options
 
 Use the following options to refine your dashboard list visualization.

--- a/docs/sources/panels-visualizations/visualizations/datagrid/index.md
+++ b/docs/sources/panels-visualizations/visualizations/datagrid/index.md
@@ -127,3 +127,7 @@ To delete or clear multiple rows, take the following steps:
 The same rules apply to columns by clicking the column headers.
 
 To delete all rows, use the "select all" checkbox at the top left corner of the datagrid. This selects all rows and allows you to delete them using the context menu.
+
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/flame-graph/index.md
@@ -23,6 +23,12 @@ Flame graphs let you visualize [profiling](https://grafana.com/docs/pyroscope/la
 
 For example, if you want to understand which parts of a program consume the most resources, such as CPU time, memory, or I/O operations, you can use a flame graph to visualize and analyze where potential performance issues are:
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
+## Flame graph mode
+
 {{< figure src="/static/img/docs/flame-graph-panel/flame-graph-dark-mode.png" max-width="1025px" alt="A flame graph visualization for a system profile with both flame graph and top table mode." >}}
 
 You can use a flame graph visualization if you need to:

--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -31,6 +31,10 @@ Gauges are single-value visualizations that can repeat a gauge for every series,
 
 {{< docs/play title="Grafana Gauge Visualization" url="https://play.grafana.org/d/KIhkVD6Gk/" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value options
 
 Use the following options to refine how your visualization displays the value:

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -61,6 +61,10 @@ The following video provides beginner steps for creating geomap visualizations. 
 
 {{< docs/play title="Geomap Examples" url="https://play.grafana.org/d/panel-geomap/" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Map View
 
 The map view controls the initial view of the map when the dashboard loads.

--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -68,6 +68,10 @@ The data is converted as follows:
 
 {{< figure src="/static/img/docs/heatmap-panel/heatmap.png" max-width="1025px" alt="A heatmap visualization showing the random walk distribution over time" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Heatmap options
 
 ### Calculate from data

--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -92,6 +92,10 @@ The data is converted as follows:
 
 {{< figure src="/static/img/docs/histogram-panel/histogram-example-height-weight.png" max-width="1025px" alt="A histogram visualization showing the male height and weight distribution" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Histogram options
 
 Use the following options to refine your histogram visualization.

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -42,6 +42,10 @@ The following video provides a walkthrough of creating a logs visualization. You
 
 {{< youtube id="jSSi_x-fD_8" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Log level
 
 For logs where a **level** label is specified, we use the value of the label to determine the log level and update color accordingly. If the log doesn't have a level label specified, we try to find out if its content matches any of the supported expressions (see below for more information). The log level is always determined by the first match. In case Grafana is not able to determine a log level, it will be visualized with **unknown** log level. See [supported log levels and mappings of log level abbreviation and expressions](ref:supported-log-levels-and-mappings-of-log-level-abbreviation-and-expressions).

--- a/docs/sources/panels-visualizations/visualizations/news/index.md
+++ b/docs/sources/panels-visualizations/visualizations/news/index.md
@@ -18,7 +18,7 @@ title: News
 weight: 100
 ---
 
-## News
+# News
 
 The news visualization displays an RSS feed. By default, it displays articles from the Grafana Labs blog, but you can change this by entering a different RSS feed URL.
 
@@ -43,6 +43,10 @@ If you're unable to display an RSS feed using the news visualization, you can tr
 ## Supported data formats
 
 The news visualization supports RSS and Atom feeds.
+
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## News options
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -140,3 +140,7 @@ Optional fields:
 | icon          | string        | Name of the icon to show inside the node instead of the default stats. Only Grafana built in icons are allowed (see the available icons [here](https://developers.grafana.com/ui/latest/index.html?path=/story/docs-overview-icon--icons-overview)).                                                                                                                      |
 | nodeRadius    | number        | Radius value in pixels. Used to manage node size.                                                                                                                                                                                                                                                                                                                         |
 | highlighted   | boolean       | Sets whether the node should be highlighted. Useful for example to represent a specific path in the graph by highlighting several nodes and edges. Default: `false`                                                                                                                                                                                                       |
+
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -29,6 +29,10 @@ Pie charts display reduced series, or values in a series, from one or more queri
 
 {{< docs/play title="Grafana Bar Charts and Pie Charts" url="https://play.grafana.org/d/ktMs4D6Mk/" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value options
 
 Use the following options to refine the value in your visualization.

--- a/docs/sources/panels-visualizations/visualizations/stat/index.md
+++ b/docs/sources/panels-visualizations/visualizations/stat/index.md
@@ -102,6 +102,10 @@ You can use the [**Text mode**](#text-mode) to control how the text is displayed
 
 The panel automatically adjusts the layout depending on available width and height in the dashboard. It automatically hides the graph (sparkline) if the panel becomes too small.
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Value options
 
 Use the following options to refine how your visualization displays its values:

--- a/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
+++ b/docs/sources/panels-visualizations/visualizations/state-timeline/index.md
@@ -97,6 +97,10 @@ The data is converted as follows:
 
 If your query results aren't in a table format like the preceding examples, especially for time-series data, you can apply specific [transformations](https://stackoverflow.com/questions/68887416/grafana-state-timeline-panel-with-values-states-supplied-by-label) to achieve this.
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## State timeline options
 
 Use these options to refine the visualization.

--- a/docs/sources/panels-visualizations/visualizations/status-history/index.md
+++ b/docs/sources/panels-visualizations/visualizations/status-history/index.md
@@ -95,6 +95,10 @@ The data is converted as follows:
 
 {{< figure src="/static/img/docs/status-history-panel/status_history.png" max-width="1025px" alt="A status history panel with two time columns showing the status of two servers" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Status history options
 
 Use these options to refine the visualization.

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -63,6 +63,10 @@ Click a column title to change the sort order from default to descending to asce
 
 ![Sort descending](/static/img/docs/tables/sort-descending.png 'Sort descending')
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Table options
 
 {{% admonition type="note" %}}

--- a/docs/sources/panels-visualizations/visualizations/text/index.md
+++ b/docs/sources/panels-visualizations/visualizations/text/index.md
@@ -46,6 +46,10 @@ Use a text visualization when you need to:
 - Provide instructions or guidance on how to interpret different panels, configure settings, or take specific actions based on the displayed data.
 - Announce any scheduled maintenance or downtime that might impact your dashboards.
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Text options
 
 Use the following options to refine your text visualization.

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -71,6 +71,10 @@ The following video guides you through the creation steps and common customizati
 
 {{< docs/play title="Time Series Visualizations in Grafana" url="https://play.grafana.org/d/000000016/" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Tooltip options
 
 {{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/traces/index.md
+++ b/docs/sources/panels-visualizations/visualizations/traces/index.md
@@ -147,3 +147,7 @@ You should now see a list of matching traces in the table visualization. While s
 {{< figure src="/static/img/docs/panels/traces/screenshot-traces-trace-link.png" caption="Selecting the trace link" >}}
 
 {{< figure src="/static/img/docs/panels/traces/screenshot-traces-trace-link-follow.png" caption="Follow the trace link populates the trace ID and displays the traces view" >}}
+
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/trend/index.md
+++ b/docs/sources/panels-visualizations/visualizations/trend/index.md
@@ -44,6 +44,10 @@ For example, you could represent engine power and torque versus speed where spee
 
 {{< figure src="/media/docs/grafana/screenshot-grafana-10-0-trend-panel-new-colors.png" max-width="750px" caption="Trend engine power and torque curves" >}}
 
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 ## Standard options
 
 {{< docs/shared lookup="visualizations/standard-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/shared/visualizations/panel-options.md
+++ b/docs/sources/shared/visualizations/panel-options.md
@@ -1,0 +1,7 @@
+---
+title: Panel options
+comments: |
+  This file is used in all visualizations pages
+---
+
+In the **Panel options** section of the panel editor pane, you set basic options like the panel title and description. You can also configure repeating panels in this section. To learn more, refer to [Configure panel options](../../configure-panel-options/).


### PR DESCRIPTION
Backport f8d9f8541b4af7a499ef092572c099ca4f343b81 from #87258

---

This PR adds a shared file with panel options for visualizations and adds that file to relevant visualizations. This PR also fixes version interpolation syntax and adds Cloud links on some pages.
