### PR TITLE
Table Panel: Fix Image hover without datalinks

### DIFF
--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -16,7 +16,14 @@ export const ImageCell = (props: TableCellProps) => {
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
-      {!hasLinks && <img style={{ height: tableStyles.cellHeight, width: 'auto' }} src={displayValue.text} className={tableStyles.imageCell} alt="" />}
+      {!hasLinks && (
+        <img
+          style={{ height: tableStyles.cellHeight, width: 'auto' }}
+          src={displayValue.text}
+          className={tableStyles.imageCell}
+          alt=""
+        />
+      )}
       {hasLinks && (
         <DataLinksContextMenu
           style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -18,7 +18,7 @@ export const ImageCell = (props: TableCellProps) => {
     <div {...cellProps} className={tableStyles.cellContainer}>
       {!hasLinks && (
         <img
-          style={{ height: tableStyles.cellHeight, width: 'auto' }}
+          style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
           src={displayValue.text}
           className={tableStyles.imageCell}
           alt=""

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -16,7 +16,7 @@ export const ImageCell = (props: TableCellProps) => {
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
-      {!hasLinks && <img src={displayValue.text} className={tableStyles.imageCell} alt="" />}
+      {!hasLinks && <img style={{ height: tableStyles.cellHeight, width: 'auto' }} src={displayValue.text} className={tableStyles.imageCell} alt="" />}
       {hasLinks && (
         <DataLinksContextMenu
           style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}


### PR DESCRIPTION
This builds on a previous fix in which images when hovered would be displayed at full height. A somewhat infuriating if also somewhat amusing bug. This PR applies the same fix that was used in the datalinks case.


### Before

https://github.com/grafana/grafana/assets/199847/04fe2844-6d09-4c14-9a9e-878e8a9b7d61


### After

https://github.com/grafana/grafana/assets/199847/3eec1199-9412-4c5b-8115-33e569272f4b


Fixes https://github.com/grafana/support-escalations/issues/11028


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
