### PR TITLE
Scopes: Persist selected scopes when searching

### DIFF
--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -17,7 +17,7 @@ import { t, Trans } from 'app/core/internationalization';
 
 import { ScopesInput } from './ScopesInput';
 import { ScopesScene } from './ScopesScene';
-import { ScopesTreeLevel } from './ScopesTreeLevel';
+import { ScopesTree } from './ScopesTree';
 import { fetchNodes, fetchScope, fetchSelectedScopes } from './api';
 import { NodesMap, SelectedScope, TreeScope } from './types';
 import { getBasicScope } from './utils';
@@ -47,13 +47,13 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
       nodes: {
         '': {
           name: '',
+          type: 'result',
           nodeType: 'container',
           title: '',
           isExpandable: true,
           isSelectable: false,
           isExpanded: true,
           query: '',
-          persistedNodes: {},
           nodes: {},
         },
       },
@@ -120,16 +120,19 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
           })
         )
         .subscribe((childNodes) => {
-          currentNode.persistedNodes = this.state.treeScopes
+          const persistedNodes = this.state.treeScopes
             .map(({ path }) => path[path.length - 1])
             .filter((nodeName) => nodeName in currentNode.nodes && !(nodeName in childNodes))
             .reduce<NodesMap>((acc, nodeName) => {
-              acc[nodeName] = currentNode.nodes[nodeName];
+              acc[nodeName] = {
+                ...currentNode.nodes[nodeName],
+                type: 'persisted',
+              };
 
               return acc;
             }, {});
 
-          currentNode.nodes = childNodes;
+          currentNode.nodes = { ...persistedNodes, ...childNodes };
 
           this.setState({ nodes });
 
@@ -294,7 +297,7 @@ export function ScopesFiltersSceneRenderer({ model }: SceneComponentProps<Scopes
           {isLoadingScopes ? (
             <Spinner data-testid="scopes-filters-loading" />
           ) : (
-            <ScopesTreeLevel
+            <ScopesTree
               nodes={nodes}
               nodePath={['']}
               loadingNodeName={loadingNodeName}

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -53,6 +53,7 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
           isSelectable: false,
           isExpanded: true,
           query: '',
+          persistedNodes: {},
           nodes: {},
         },
       },
@@ -119,6 +120,15 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
           })
         )
         .subscribe((childNodes) => {
+          currentNode.persistedNodes = this.state.treeScopes
+            .map(({ path }) => path[path.length - 1])
+            .filter((nodeName) => nodeName in currentNode.nodes && !(nodeName in childNodes))
+            .reduce<NodesMap>((acc, nodeName) => {
+              acc[nodeName] = currentNode.nodes[nodeName];
+
+              return acc;
+            }, {});
+
           currentNode.nodes = childNodes;
 
           this.setState({ nodes });

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -19,7 +19,7 @@ import { ScopesInput } from './ScopesInput';
 import { ScopesScene } from './ScopesScene';
 import { ScopesTree } from './ScopesTree';
 import { fetchNodes, fetchScope, fetchSelectedScopes } from './api';
-import { NodesMap, SelectedScope, TreeScope } from './types';
+import { NodeReason, NodesMap, SelectedScope, TreeScope } from './types';
 import { getBasicScope } from './utils';
 
 export interface ScopesFiltersSceneState extends SceneObjectState {
@@ -47,7 +47,7 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
       nodes: {
         '': {
           name: '',
-          type: 'result',
+          reason: NodeReason.Result,
           nodeType: 'container',
           title: '',
           isExpandable: true,
@@ -126,7 +126,7 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
             .reduce<NodesMap>((acc, nodeName) => {
               acc[nodeName] = {
                 ...currentNode.nodes[nodeName],
-                type: 'persisted',
+                reason: NodeReason.Persisted,
               };
 
               return acc;

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesInput.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesInput.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { groupBy } from 'lodash';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { IconButton, Input, Tooltip } from '@grafana/ui';
@@ -27,6 +27,12 @@ export function ScopesInput({
   onRemoveAllClick,
 }: ScopesInputProps) {
   const styles = useStyles2(getStyles);
+
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
+  useEffect(() => {
+    setIsTooltipVisible(false);
+  }, [scopes]);
 
   const scopesPaths = useMemo(() => {
     const pathsTitles = scopes.map(({ scope, path }) => {
@@ -64,7 +70,7 @@ export function ScopesInput({
 
     const groupedByPath = groupBy(pathsTitles, ([path]) => path);
 
-    return Object.entries(groupedByPath)
+    const scopesPaths = Object.entries(groupedByPath)
       .map(([path, pathScopes]) => {
         const scopesTitles = pathScopes.map(([, scopeTitle]) => scopeTitle).join(', ');
 
@@ -75,41 +81,44 @@ export function ScopesInput({
           {path}
         </p>
       ));
+
+    return <>{scopesPaths}</>;
   }, [nodes, scopes, styles]);
 
   const scopesTitles = useMemo(() => scopes.map(({ scope }) => scope.spec.title).join(', '), [scopes]);
 
-  const input = (
-    <Input
-      readOnly
-      placeholder={t('scopes.filters.input.placeholder', 'Select scopes...')}
-      loading={isLoading}
-      value={scopesTitles}
-      aria-label={t('scopes.filters.input.placeholder', 'Select scopes...')}
-      data-testid="scopes-filters-input"
-      suffix={
-        scopes.length > 0 && !isDisabled ? (
-          <IconButton
-            aria-label={t('scopes.filters.input.removeAll', 'Remove all scopes')}
-            name="times"
-            onClick={() => onRemoveAllClick()}
-          />
-        ) : undefined
-      }
-      onClick={() => {
-        if (!isDisabled) {
-          onInputClick();
+  const input = useMemo(
+    () => (
+      <Input
+        readOnly
+        placeholder={t('scopes.filters.input.placeholder', 'Select scopes...')}
+        loading={isLoading}
+        value={scopesTitles}
+        aria-label={t('scopes.filters.input.placeholder', 'Select scopes...')}
+        data-testid="scopes-filters-input"
+        suffix={
+          scopes.length > 0 && !isDisabled ? (
+            <IconButton
+              aria-label={t('scopes.filters.input.removeAll', 'Remove all scopes')}
+              name="times"
+              onClick={() => onRemoveAllClick()}
+            />
+          ) : undefined
         }
-      }}
-    />
+        onMouseOver={() => setIsTooltipVisible(true)}
+        onMouseOut={() => setIsTooltipVisible(false)}
+        onClick={() => {
+          if (!isDisabled) {
+            onInputClick();
+          }
+        }}
+      />
+    ),
+    [isDisabled, isLoading, onInputClick, onRemoveAllClick, scopes, scopesTitles]
   );
 
-  if (scopes.length === 0) {
-    return input;
-  }
-
   return (
-    <Tooltip content={<>{scopesPaths}</>} interactive={true}>
+    <Tooltip content={scopesPaths} show={scopes.length === 0 ? false : isTooltipVisible}>
       {input}
     </Tooltip>
   );

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesInput.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesInput.tsx
@@ -3,8 +3,7 @@ import { groupBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { IconButton, Input, Tooltip } from '@grafana/ui';
-import { useStyles2 } from '@grafana/ui/';
+import { IconButton, Input, Tooltip, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { NodesMap, SelectedScope } from './types';

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -19,7 +19,6 @@ import {
   getApplicationsClustersSlothClusterNorthSelect,
   getApplicationsClustersSlothClusterSouthSelect,
   getApplicationsExpand,
-  getApplicationsSearch,
   getApplicationsSlothPictureFactorySelect,
   getApplicationsSlothPictureFactoryTitle,
   getApplicationsSlothVoteTrackerSelect,
@@ -35,6 +34,7 @@ import {
   getDashboardsExpand,
   getDashboardsSearch,
   getMock,
+  getTreeSearch,
   mocksScopes,
   queryAllDashboard,
   queryFiltersApply,
@@ -175,13 +175,13 @@ describe('ScopesScene', () => {
       it('Search works', async () => {
         await userEvents.click(getFiltersInput());
         await userEvents.click(getApplicationsExpand());
-        await userEvents.type(getApplicationsSearch(), 'Clusters');
+        await userEvents.type(getTreeSearch(), 'Clusters');
         await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
         expect(queryApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
         expect(queryApplicationsSlothVoteTrackerTitle()).not.toBeInTheDocument();
         expect(getApplicationsClustersSelect()).toBeInTheDocument();
-        await userEvents.clear(getApplicationsSearch());
-        await userEvents.type(getApplicationsSearch(), 'sloth');
+        await userEvents.clear(getTreeSearch());
+        await userEvents.type(getTreeSearch(), 'sloth');
         await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(4));
         expect(getApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
         expect(getApplicationsSlothVoteTrackerSelect()).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -51,6 +51,7 @@ import {
   getClustersSlothClusterEastRadio,
   getNotFoundForFilterClear,
   getNotFoundNoScopes,
+  getTreeHeadline,
 } from './testUtils';
 
 jest.mock('@grafana/runtime', () => ({
@@ -197,6 +198,19 @@ describe('ScopesScene', () => {
         await userEvents.click(getFiltersApply());
         await userEvents.click(getFiltersInput());
         expect(queryApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+      });
+
+      it('Shows the proper headline', async () => {
+        await userEvents.click(getFiltersInput());
+        expect(getTreeHeadline()).toHaveTextContent('Recommended');
+        await userEvents.type(getTreeSearch(), 'Applications');
+        await waitFor(() => {
+          expect(getTreeHeadline()).toHaveTextContent('Results');
+        });
+        await userEvents.type(getTreeSearch(), 'unknown');
+        await waitFor(() => {
+          expect(getTreeHeadline()).toHaveTextContent('No results found for your query');
+        });
       });
     });
 

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -28,6 +28,7 @@ import {
   getNotFoundNoScopes,
   getPersistedApplicationsSlothPictureFactorySelect,
   getPersistedApplicationsSlothPictureFactoryTitle,
+  getPersistedApplicationsSlothVoteTrackerTitle,
   getResultApplicationsClustersExpand,
   getResultApplicationsClustersSelect,
   getResultApplicationsClustersSlothClusterNorthSelect,
@@ -225,6 +226,37 @@ describe('ScopesScene', () => {
         await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
         expect(queryPersistedApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
         expect(getResultApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+      });
+
+      it('Removes persisted nodes', async () => {
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.type(getTreeSearch(), 'slothVoteTracker');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        await userEvents.clear(getTreeSearch());
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(4));
+        expect(queryPersistedApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
+        expect(queryPersistedApplicationsSlothVoteTrackerTitle()).not.toBeInTheDocument();
+        expect(getResultApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+        expect(getResultApplicationsSlothVoteTrackerTitle()).toBeInTheDocument();
+      });
+
+      it('Persists nodes from search', async () => {
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.type(getTreeSearch(), 'sloth');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
+        await userEvents.type(getTreeSearch(), 'slothunknown');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(4));
+        expect(getPersistedApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+        expect(getPersistedApplicationsSlothVoteTrackerTitle()).toBeInTheDocument();
+        await userEvents.clear(getTreeSearch());
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(5));
+        expect(getResultApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+        expect(getResultApplicationsSlothVoteTrackerTitle()).toBeInTheDocument();
       });
 
       it('Selects a persisted scope', async () => {

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesScene.test.tsx
@@ -10,48 +10,53 @@ import { ScopesFiltersScene } from './ScopesFiltersScene';
 import { ScopesScene } from './ScopesScene';
 import {
   buildTestScene,
-  fetchSuggestedDashboardsSpy,
   fetchNodesSpy,
   fetchScopeSpy,
   fetchSelectedScopesSpy,
-  getApplicationsClustersExpand,
-  getApplicationsClustersSelect,
-  getApplicationsClustersSlothClusterNorthSelect,
-  getApplicationsClustersSlothClusterSouthSelect,
-  getApplicationsExpand,
-  getApplicationsSlothPictureFactorySelect,
-  getApplicationsSlothPictureFactoryTitle,
-  getApplicationsSlothVoteTrackerSelect,
-  getFiltersApply,
-  getFiltersCancel,
-  getFiltersInput,
-  getClustersExpand,
-  getClustersSelect,
-  getClustersSlothClusterNorthRadio,
-  getClustersSlothClusterSouthRadio,
+  fetchSuggestedDashboardsSpy,
   getDashboard,
   getDashboardsContainer,
   getDashboardsExpand,
   getDashboardsSearch,
+  getFiltersApply,
+  getFiltersCancel,
+  getFiltersInput,
   getMock,
+  getNotFoundForFilter,
+  getNotFoundForFilterClear,
+  getNotFoundForScope,
+  getNotFoundNoScopes,
+  getPersistedApplicationsSlothPictureFactorySelect,
+  getPersistedApplicationsSlothPictureFactoryTitle,
+  getResultApplicationsClustersExpand,
+  getResultApplicationsClustersSelect,
+  getResultApplicationsClustersSlothClusterNorthSelect,
+  getResultApplicationsClustersSlothClusterSouthSelect,
+  getResultApplicationsExpand,
+  getResultApplicationsSlothPictureFactorySelect,
+  getResultApplicationsSlothPictureFactoryTitle,
+  getResultApplicationsSlothVoteTrackerSelect,
+  getResultApplicationsSlothVoteTrackerTitle,
+  getResultClustersExpand,
+  getResultClustersSelect,
+  getResultClustersSlothClusterEastRadio,
+  getResultClustersSlothClusterNorthRadio,
+  getResultClustersSlothClusterSouthRadio,
+  getTreeHeadline,
   getTreeSearch,
   mocksScopes,
   queryAllDashboard,
-  queryFiltersApply,
-  queryApplicationsClustersTitle,
-  queryApplicationsSlothPictureFactoryTitle,
-  queryApplicationsSlothVoteTrackerTitle,
   queryDashboard,
   queryDashboardsContainer,
   queryDashboardsExpand,
-  renderDashboard,
-  getNotFoundForScope,
   queryDashboardsSearch,
-  getNotFoundForFilter,
-  getClustersSlothClusterEastRadio,
-  getNotFoundForFilterClear,
-  getNotFoundNoScopes,
-  getTreeHeadline,
+  queryFiltersApply,
+  queryPersistedApplicationsSlothPictureFactoryTitle,
+  queryPersistedApplicationsSlothVoteTrackerTitle,
+  queryResultApplicationsClustersTitle,
+  queryResultApplicationsSlothPictureFactoryTitle,
+  queryResultApplicationsSlothVoteTrackerTitle,
+  renderDashboard,
 } from './testUtils';
 
 jest.mock('@grafana/runtime', () => ({
@@ -107,15 +112,15 @@ describe('ScopesScene', () => {
     describe('Tree', () => {
       it('Navigates through scopes nodes', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsClustersExpand());
-        await userEvents.click(getApplicationsExpand());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsClustersExpand());
+        await userEvents.click(getResultApplicationsExpand());
       });
 
       it('Fetches scope details on select', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
         await waitFor(() => expect(fetchScopeSpy).toHaveBeenCalledTimes(1));
       });
 
@@ -127,90 +132,136 @@ describe('ScopesScene', () => {
           ])
         );
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        expect(getApplicationsSlothVoteTrackerSelect()).toBeChecked();
-        expect(getApplicationsSlothPictureFactorySelect()).toBeChecked();
+        await userEvents.click(getResultApplicationsExpand());
+        expect(getResultApplicationsSlothVoteTrackerSelect()).toBeChecked();
+        expect(getResultApplicationsSlothPictureFactorySelect()).toBeChecked();
       });
 
       it('Can select scopes from same level', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
-        await userEvents.click(getApplicationsClustersSelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsClustersSelect());
         await userEvents.click(getFiltersApply());
         expect(getFiltersInput().value).toBe('slothVoteTracker, slothPictureFactory, Cluster Index Helper');
       });
 
       it('Can select a node from an inner level', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
-        await userEvents.click(getApplicationsClustersExpand());
-        await userEvents.click(getApplicationsClustersSlothClusterNorthSelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsClustersExpand());
+        await userEvents.click(getResultApplicationsClustersSlothClusterNorthSelect());
         await userEvents.click(getFiltersApply());
         expect(getFiltersInput().value).toBe('slothClusterNorth');
       });
 
       it('Can select a node from an upper level', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getClustersSelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultClustersSelect());
         await userEvents.click(getFiltersApply());
         expect(getFiltersInput().value).toBe('Cluster Index Helper');
       });
 
       it('Respects only one select per container', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getClustersExpand());
-        await userEvents.click(getClustersSlothClusterNorthRadio());
-        expect(getClustersSlothClusterNorthRadio().checked).toBe(true);
-        expect(getClustersSlothClusterSouthRadio().checked).toBe(false);
-        await userEvents.click(getClustersSlothClusterSouthRadio());
-        expect(getClustersSlothClusterNorthRadio().checked).toBe(false);
-        expect(getClustersSlothClusterSouthRadio().checked).toBe(true);
+        await userEvents.click(getResultClustersExpand());
+        await userEvents.click(getResultClustersSlothClusterNorthRadio());
+        expect(getResultClustersSlothClusterNorthRadio().checked).toBe(true);
+        expect(getResultClustersSlothClusterSouthRadio().checked).toBe(false);
+        await userEvents.click(getResultClustersSlothClusterSouthRadio());
+        expect(getResultClustersSlothClusterNorthRadio().checked).toBe(false);
+        expect(getResultClustersSlothClusterSouthRadio().checked).toBe(true);
       });
 
       it('Search works', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
+        await userEvents.click(getResultApplicationsExpand());
         await userEvents.type(getTreeSearch(), 'Clusters');
         await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
-        expect(queryApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
-        expect(queryApplicationsSlothVoteTrackerTitle()).not.toBeInTheDocument();
-        expect(getApplicationsClustersSelect()).toBeInTheDocument();
+        expect(queryResultApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
+        expect(queryResultApplicationsSlothVoteTrackerTitle()).not.toBeInTheDocument();
+        expect(getResultApplicationsClustersSelect()).toBeInTheDocument();
         await userEvents.clear(getTreeSearch());
         await userEvents.type(getTreeSearch(), 'sloth');
         await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(4));
-        expect(getApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
-        expect(getApplicationsSlothVoteTrackerSelect()).toBeInTheDocument();
-        expect(queryApplicationsClustersTitle()).not.toBeInTheDocument();
+        expect(getResultApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+        expect(getResultApplicationsSlothVoteTrackerSelect()).toBeInTheDocument();
+        expect(queryResultApplicationsClustersTitle()).not.toBeInTheDocument();
       });
 
       it('Opens to a selected scope', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getClustersExpand());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultClustersExpand());
         await userEvents.click(getFiltersApply());
         await userEvents.click(getFiltersInput());
-        expect(queryApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+        expect(queryResultApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+      });
+
+      it('Persists a scope', async () => {
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.type(getTreeSearch(), 'slothVoteTracker');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        expect(getPersistedApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+        expect(queryPersistedApplicationsSlothVoteTrackerTitle()).not.toBeInTheDocument();
+        expect(queryResultApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
+        expect(getResultApplicationsSlothVoteTrackerTitle()).toBeInTheDocument();
+      });
+
+      it('Does not persist a retrieved scope', async () => {
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.type(getTreeSearch(), 'slothPictureFactory');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        expect(queryPersistedApplicationsSlothPictureFactoryTitle()).not.toBeInTheDocument();
+        expect(getResultApplicationsSlothPictureFactoryTitle()).toBeInTheDocument();
+      });
+
+      it('Selects a persisted scope', async () => {
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.type(getTreeSearch(), 'slothVoteTracker');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getFiltersApply());
+        expect(getFiltersInput().value).toBe('slothPictureFactory, slothVoteTracker');
+      });
+
+      it('Deselects a persisted scope', async () => {
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
+        await userEvents.type(getTreeSearch(), 'slothVoteTracker');
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getFiltersApply());
+        expect(getFiltersInput().value).toBe('slothPictureFactory, slothVoteTracker');
+        await userEvents.click(getFiltersInput());
+        await userEvents.click(getPersistedApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getFiltersApply());
+        expect(getFiltersInput().value).toBe('slothVoteTracker');
       });
 
       it('Shows the proper headline', async () => {
         await userEvents.click(getFiltersInput());
         expect(getTreeHeadline()).toHaveTextContent('Recommended');
         await userEvents.type(getTreeSearch(), 'Applications');
-        await waitFor(() => {
-          expect(getTreeHeadline()).toHaveTextContent('Results');
-        });
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(2));
+        expect(getTreeHeadline()).toHaveTextContent('Results');
         await userEvents.type(getTreeSearch(), 'unknown');
-        await waitFor(() => {
-          expect(getTreeHeadline()).toHaveTextContent('No results found for your query');
-        });
+        await waitFor(() => expect(fetchNodesSpy).toHaveBeenCalledTimes(3));
+        expect(getTreeHeadline()).toHaveTextContent('No results found for your query');
       });
     });
 
@@ -222,7 +273,7 @@ describe('ScopesScene', () => {
 
       it('Fetches scope details on save', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getClustersSelect());
+        await userEvents.click(getResultClustersSelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => expect(fetchSelectedScopesSpy).toHaveBeenCalled());
         expect(filtersScene.getSelectedScopes()).toEqual(
@@ -232,7 +283,7 @@ describe('ScopesScene', () => {
 
       it("Doesn't save the scopes on close", async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getClustersSelect());
+        await userEvents.click(getResultClustersSelect());
         await userEvents.click(getFiltersCancel());
         await waitFor(() => expect(fetchSelectedScopesSpy).not.toHaveBeenCalled());
         expect(filtersScene.getSelectedScopes()).toEqual([]);
@@ -240,7 +291,7 @@ describe('ScopesScene', () => {
 
       it('Shows selected scopes', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getClustersSelect());
+        await userEvents.click(getResultClustersSelect());
         await userEvents.click(getFiltersApply());
         expect(getFiltersInput().value).toEqual('Cluster Index Helper');
       });
@@ -254,8 +305,8 @@ describe('ScopesScene', () => {
 
       it('Does not fetch dashboards list when the list is not expanded', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => expect(fetchSuggestedDashboardsSpy).not.toHaveBeenCalled());
       });
@@ -263,16 +314,16 @@ describe('ScopesScene', () => {
       it('Fetches dashboards list when the list is expanded', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => expect(fetchSuggestedDashboardsSpy).toHaveBeenCalled());
       });
 
       it('Fetches dashboards list when the list is expanded after scope selection', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await userEvents.click(getDashboardsExpand());
         await waitFor(() => expect(fetchSuggestedDashboardsSpy).toHaveBeenCalled());
@@ -281,22 +332,22 @@ describe('ScopesScene', () => {
       it('Shows dashboards for multiple scopes', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         expect(getDashboard('1')).toBeInTheDocument();
         expect(getDashboard('2')).toBeInTheDocument();
         expect(queryDashboard('3')).not.toBeInTheDocument();
         expect(queryDashboard('4')).not.toBeInTheDocument();
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
         await userEvents.click(getFiltersApply());
         expect(getDashboard('1')).toBeInTheDocument();
         expect(getDashboard('2')).toBeInTheDocument();
         expect(getDashboard('3')).toBeInTheDocument();
         expect(getDashboard('4')).toBeInTheDocument();
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         expect(queryDashboard('1')).not.toBeInTheDocument();
         expect(queryDashboard('2')).not.toBeInTheDocument();
@@ -307,8 +358,8 @@ describe('ScopesScene', () => {
       it('Filters the dashboards list', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         expect(getDashboard('1')).toBeInTheDocument();
         expect(getDashboard('2')).toBeInTheDocument();
@@ -319,10 +370,10 @@ describe('ScopesScene', () => {
       it('Deduplicates the dashboards list', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsClustersExpand());
-        await userEvents.click(getApplicationsClustersSlothClusterNorthSelect());
-        await userEvents.click(getApplicationsClustersSlothClusterSouthSelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsClustersExpand());
+        await userEvents.click(getResultApplicationsClustersSlothClusterNorthSelect());
+        await userEvents.click(getResultApplicationsClustersSlothClusterSouthSelect());
         await userEvents.click(getFiltersApply());
         expect(queryAllDashboard('5')).toHaveLength(1);
         expect(queryAllDashboard('6')).toHaveLength(1);
@@ -339,8 +390,8 @@ describe('ScopesScene', () => {
       it('Does not show the input when there are no dashboards found for scope', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getClustersExpand());
-        await userEvents.click(getClustersSlothClusterEastRadio());
+        await userEvents.click(getResultClustersExpand());
+        await userEvents.click(getResultClustersSlothClusterEastRadio());
         await userEvents.click(getFiltersApply());
         expect(getNotFoundForScope()).toBeInTheDocument();
         expect(queryDashboardsSearch()).not.toBeInTheDocument();
@@ -349,8 +400,8 @@ describe('ScopesScene', () => {
       it('Does show the input and a message when there are no dashboards found for filter', async () => {
         await userEvents.click(getDashboardsExpand());
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await userEvents.type(getDashboardsSearch(), 'unknown');
         expect(queryDashboardsSearch()).toBeInTheDocument();
@@ -394,8 +445,8 @@ describe('ScopesScene', () => {
     describe('Enrichers', () => {
       it('Data requests', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => {
           const queryRunner = sceneGraph.findObject(dashboardScene, (o) => o.state.key === 'data-query-runner')!;
@@ -405,7 +456,7 @@ describe('ScopesScene', () => {
         });
 
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => {
           const queryRunner = sceneGraph.findObject(dashboardScene, (o) => o.state.key === 'data-query-runner')!;
@@ -417,7 +468,7 @@ describe('ScopesScene', () => {
         });
 
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => {
           const queryRunner = sceneGraph.findObject(dashboardScene, (o) => o.state.key === 'data-query-runner')!;
@@ -429,8 +480,8 @@ describe('ScopesScene', () => {
 
       it('Filters requests', async () => {
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsExpand());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsExpand());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => {
           expect(dashboardScene.enrichFiltersRequest().scopes).toEqual(
@@ -439,7 +490,7 @@ describe('ScopesScene', () => {
         });
 
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsSlothVoteTrackerSelect());
+        await userEvents.click(getResultApplicationsSlothVoteTrackerSelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => {
           expect(dashboardScene.enrichFiltersRequest().scopes).toEqual(
@@ -450,7 +501,7 @@ describe('ScopesScene', () => {
         });
 
         await userEvents.click(getFiltersInput());
-        await userEvents.click(getApplicationsSlothPictureFactorySelect());
+        await userEvents.click(getResultApplicationsSlothPictureFactorySelect());
         await userEvents.click(getFiltersApply());
         await waitFor(() => {
           expect(dashboardScene.enrichFiltersRequest().scopes).toEqual(

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
@@ -1,0 +1,127 @@
+import { css } from '@emotion/css';
+import { debounce } from 'lodash';
+import { useMemo } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, Input, useStyles2 } from '@grafana/ui';
+import { t, Trans } from 'app/core/internationalization';
+
+import { ScopesTreeLevel } from './ScopesTreeLevel';
+import { Node, NodesMap, TreeScope } from './types';
+
+export interface ScopesTreeProps {
+  nodes: NodesMap;
+  nodePath: string[];
+  loadingNodeName: string | undefined;
+  scopes: TreeScope[];
+  onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
+  onNodeSelectToggle: (path: string[]) => void;
+}
+
+export function ScopesTree({
+  nodes,
+  nodePath,
+  loadingNodeName,
+  scopes,
+  onNodeUpdate,
+  onNodeSelectToggle,
+}: ScopesTreeProps) {
+  const styles = useStyles2(getStyles);
+
+  const nodeId = nodePath[nodePath.length - 1];
+  const node = nodes[nodeId];
+  const childNodesArr = Object.values(node.nodes);
+
+  const { persistedNodes, resultsNodes } = childNodesArr.reduce<Record<string, Node[]>>(
+    (acc, node) => {
+      switch (node.type) {
+        case 'persisted':
+          acc.persistedNodes.push(node);
+          break;
+
+        case 'result':
+          acc.resultsNodes.push(node);
+          break;
+      }
+
+      return acc;
+    },
+    {
+      persistedNodes: [],
+      resultsNodes: [],
+    }
+  );
+
+  const isNodeLoading = loadingNodeName === nodeId;
+
+  const scopeNames = scopes.map(({ scopeName }) => scopeName);
+  const anyChildExpanded = childNodesArr.some(({ isExpanded }) => isExpanded);
+  const anyChildSelected = childNodesArr.some(({ linkId }) => linkId && scopeNames.includes(linkId!));
+
+  const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
+
+  return (
+    <>
+      {!anyChildExpanded && (
+        <Input
+          prefix={<Icon name="filter" />}
+          className={styles.searchInput}
+          placeholder={t('scopes.tree.search', 'Search')}
+          defaultValue={node.query}
+          data-testid={`scopes-tree-${nodeId}-search`}
+          onInput={(evt) => onQueryUpdate(nodePath, true, evt.currentTarget.value)}
+        />
+      )}
+
+      <ScopesTreeLevel
+        anyChildExpanded={anyChildExpanded}
+        anyChildSelected={anyChildSelected}
+        isNodeLoading={isNodeLoading}
+        loadingNodeName={loadingNodeName}
+        node={node}
+        nodePath={nodePath}
+        nodes={persistedNodes}
+        scopes={scopes}
+        scopeNames={scopeNames}
+        onNodeSelectToggle={onNodeSelectToggle}
+        onNodeUpdate={onNodeUpdate}
+      />
+
+      {!anyChildExpanded ? (
+        <h6 className={styles.headline}>
+          {!node.query ? (
+            <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
+          ) : (
+            <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
+          )}
+        </h6>
+      ) : null}
+
+      <ScopesTreeLevel
+        anyChildExpanded={anyChildExpanded}
+        anyChildSelected={anyChildSelected}
+        isNodeLoading={isNodeLoading}
+        loadingNodeName={loadingNodeName}
+        node={node}
+        nodePath={nodePath}
+        nodes={resultsNodes}
+        scopes={scopes}
+        scopeNames={scopeNames}
+        onNodeSelectToggle={onNodeSelectToggle}
+        onNodeUpdate={onNodeUpdate}
+      />
+    </>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    searchInput: css({
+      margin: theme.spacing(1, 0),
+    }),
+    headline: css({
+      color: theme.colors.text.secondary,
+      margin: theme.spacing(1, 0),
+    }),
+  };
+};

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import { useMemo } from 'react';
+import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, Input, useStyles2 } from '@grafana/ui';
@@ -73,43 +74,49 @@ export function ScopesTree({
         />
       )}
 
-      <ScopesTreeLevel
-        anyChildExpanded={anyChildExpanded}
-        anyChildSelected={anyChildSelected}
-        isNodeLoading={isNodeLoading}
-        loadingNodeName={loadingNodeName}
-        node={node}
-        nodePath={nodePath}
-        nodes={persistedNodes}
-        scopes={scopes}
-        scopeNames={scopeNames}
-        onNodeSelectToggle={onNodeSelectToggle}
-        onNodeUpdate={onNodeUpdate}
-      />
+      {isNodeLoading ? (
+        <Skeleton count={5} className={styles.loader} />
+      ) : (
+        <>
+          <ScopesTreeLevel
+            anyChildExpanded={anyChildExpanded}
+            anyChildSelected={anyChildSelected}
+            isNodeLoading={isNodeLoading}
+            loadingNodeName={loadingNodeName}
+            node={node}
+            nodePath={nodePath}
+            nodes={persistedNodes}
+            scopes={scopes}
+            scopeNames={scopeNames}
+            onNodeSelectToggle={onNodeSelectToggle}
+            onNodeUpdate={onNodeUpdate}
+          />
 
-      {!anyChildExpanded ? (
-        <h6 className={styles.headline}>
-          {!node.query ? (
-            <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
-          ) : (
-            <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
-          )}
-        </h6>
-      ) : null}
+          {!anyChildExpanded ? (
+            <h6 className={styles.headline}>
+              {!node.query ? (
+                <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
+              ) : (
+                <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
+              )}
+            </h6>
+          ) : null}
 
-      <ScopesTreeLevel
-        anyChildExpanded={anyChildExpanded}
-        anyChildSelected={anyChildSelected}
-        isNodeLoading={isNodeLoading}
-        loadingNodeName={loadingNodeName}
-        node={node}
-        nodePath={nodePath}
-        nodes={resultsNodes}
-        scopes={scopes}
-        scopeNames={scopeNames}
-        onNodeSelectToggle={onNodeSelectToggle}
-        onNodeUpdate={onNodeUpdate}
-      />
+          <ScopesTreeLevel
+            anyChildExpanded={anyChildExpanded}
+            anyChildSelected={anyChildSelected}
+            isNodeLoading={isNodeLoading}
+            loadingNodeName={loadingNodeName}
+            node={node}
+            nodePath={nodePath}
+            nodes={resultsNodes}
+            scopes={scopes}
+            scopeNames={scopeNames}
+            onNodeSelectToggle={onNodeSelectToggle}
+            onNodeUpdate={onNodeUpdate}
+          />
+        </>
+      )}
     </>
   );
 }
@@ -122,6 +129,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     headline: css({
       color: theme.colors.text.secondary,
       margin: theme.spacing(1, 0),
+    }),
+    loader: css({
+      margin: theme.spacing(0.5, 0),
     }),
   };
 };

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
@@ -1,13 +1,9 @@
-import { css } from '@emotion/css';
-import { debounce } from 'lodash';
 import { useMemo } from 'react';
-import Skeleton from 'react-loading-skeleton';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, Input, useStyles2 } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
-
+import { ScopesTreeHeadline } from './ScopesTreeHeadline';
 import { ScopesTreeItem } from './ScopesTreeItem';
+import { ScopesTreeLoading } from './ScopesTreeLoading';
+import { ScopesTreeSearch } from './ScopesTreeSearch';
 import { Node, NodeReason, NodesMap, TreeScope } from './types';
 
 export interface ScopesTreeProps {
@@ -27,108 +23,76 @@ export function ScopesTree({
   onNodeUpdate,
   onNodeSelectToggle,
 }: ScopesTreeProps) {
-  const styles = useStyles2(getStyles);
-
   const nodeId = nodePath[nodePath.length - 1];
   const node = nodes[nodeId];
-  const childNodesArr = Object.values(node.nodes);
-
-  const { persistedNodes, resultsNodes } = childNodesArr.reduce<Record<string, Node[]>>(
-    (acc, node) => {
-      switch (node.reason) {
-        case NodeReason.Persisted:
-          acc.persistedNodes.push(node);
-          break;
-
-        case NodeReason.Result:
-          acc.resultsNodes.push(node);
-          break;
-      }
-
-      return acc;
-    },
-    {
-      persistedNodes: [],
-      resultsNodes: [],
-    }
-  );
-
+  const childNodes = Object.values(node.nodes);
   const isNodeLoading = loadingNodeName === nodeId;
-
   const scopeNames = scopes.map(({ scopeName }) => scopeName);
-  const anyChildExpanded = childNodesArr.some(({ isExpanded }) => isExpanded);
+  const anyChildExpanded = childNodes.some(({ isExpanded }) => isExpanded);
 
-  const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
+  const { persistedNodes, resultsNodes } = useMemo(
+    () =>
+      childNodes.reduce<Record<string, Node[]>>(
+        (acc, node) => {
+          switch (node.reason) {
+            case NodeReason.Persisted:
+              acc.persistedNodes.push(node);
+              break;
+
+            case NodeReason.Result:
+              acc.resultsNodes.push(node);
+              break;
+          }
+
+          return acc;
+        },
+        {
+          persistedNodes: [],
+          resultsNodes: [],
+        }
+      ),
+    [childNodes]
+  );
 
   return (
     <>
-      {!anyChildExpanded && (
-        <Input
-          prefix={<Icon name="filter" />}
-          className={styles.searchInput}
-          placeholder={t('scopes.tree.search', 'Search')}
-          defaultValue={node.query}
-          data-testid={`scopes-tree-${nodeId}-search`}
-          onInput={(evt) => onQueryUpdate(nodePath, true, evt.currentTarget.value)}
+      <ScopesTreeSearch
+        anyChildExpanded={anyChildExpanded}
+        nodeId={nodeId}
+        nodePath={nodePath}
+        query={node.query}
+        onNodeUpdate={onNodeUpdate}
+      />
+
+      <ScopesTreeLoading isNodeLoading={isNodeLoading}>
+        <ScopesTreeItem
+          anyChildExpanded={anyChildExpanded}
+          isNodeLoading={isNodeLoading}
+          loadingNodeName={loadingNodeName}
+          node={node}
+          nodePath={nodePath}
+          nodes={persistedNodes}
+          scopes={scopes}
+          scopeNames={scopeNames}
+          onNodeSelectToggle={onNodeSelectToggle}
+          onNodeUpdate={onNodeUpdate}
         />
-      )}
 
-      {isNodeLoading ? (
-        <Skeleton count={5} className={styles.loader} />
-      ) : (
-        <>
-          <ScopesTreeItem
-            anyChildExpanded={anyChildExpanded}
-            isNodeLoading={isNodeLoading}
-            loadingNodeName={loadingNodeName}
-            node={node}
-            nodePath={nodePath}
-            nodes={persistedNodes}
-            scopes={scopes}
-            scopeNames={scopeNames}
-            onNodeSelectToggle={onNodeSelectToggle}
-            onNodeUpdate={onNodeUpdate}
-          />
+        <ScopesTreeHeadline anyChildExpanded={anyChildExpanded} query={node.query} resultsNodes={resultsNodes} />
 
-          {!anyChildExpanded ? (
-            <h6 className={styles.headline}>
-              {!node.query ? (
-                <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
-              ) : (
-                <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
-              )}
-            </h6>
-          ) : null}
-
-          <ScopesTreeItem
-            anyChildExpanded={anyChildExpanded}
-            isNodeLoading={isNodeLoading}
-            loadingNodeName={loadingNodeName}
-            node={node}
-            nodePath={nodePath}
-            nodes={resultsNodes}
-            scopes={scopes}
-            scopeNames={scopeNames}
-            onNodeSelectToggle={onNodeSelectToggle}
-            onNodeUpdate={onNodeUpdate}
-          />
-        </>
-      )}
+        <ScopesTreeItem
+          anyChildExpanded={anyChildExpanded}
+          isNodeLoading={isNodeLoading}
+          loadingNodeName={loadingNodeName}
+          node={node}
+          nodePath={nodePath}
+          nodes={resultsNodes}
+          scopes={scopes}
+          scopeNames={scopeNames}
+          onNodeSelectToggle={onNodeSelectToggle}
+          onNodeUpdate={onNodeUpdate}
+        />
+      </ScopesTreeLoading>
     </>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    searchInput: css({
-      margin: theme.spacing(1, 0),
-    }),
-    headline: css({
-      color: theme.colors.text.secondary,
-      margin: theme.spacing(1, 0),
-    }),
-    loader: css({
-      margin: theme.spacing(0.5, 0),
-    }),
-  };
-};

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
@@ -57,7 +57,6 @@ export function ScopesTree({
 
   const scopeNames = scopes.map(({ scopeName }) => scopeName);
   const anyChildExpanded = childNodesArr.some(({ isExpanded }) => isExpanded);
-  const anyChildSelected = childNodesArr.some(({ linkId }) => linkId && scopeNames.includes(linkId!));
 
   const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
 
@@ -80,7 +79,6 @@ export function ScopesTree({
         <>
           <ScopesTreeItem
             anyChildExpanded={anyChildExpanded}
-            anyChildSelected={anyChildSelected}
             isNodeLoading={isNodeLoading}
             loadingNodeName={loadingNodeName}
             node={node}
@@ -104,7 +102,6 @@ export function ScopesTree({
 
           <ScopesTreeItem
             anyChildExpanded={anyChildExpanded}
-            anyChildSelected={anyChildSelected}
             isNodeLoading={isNodeLoading}
             loadingNodeName={loadingNodeName}
             node={node}

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
@@ -58,7 +58,6 @@ export function ScopesTree({
     <>
       <ScopesTreeSearch
         anyChildExpanded={anyChildExpanded}
-        nodeId={nodeId}
         nodePath={nodePath}
         query={node.query}
         onNodeUpdate={onNodeUpdate}
@@ -74,6 +73,7 @@ export function ScopesTree({
           nodes={persistedNodes}
           scopes={scopes}
           scopeNames={scopeNames}
+          type="persisted"
           onNodeSelectToggle={onNodeSelectToggle}
           onNodeUpdate={onNodeUpdate}
         />
@@ -89,6 +89,7 @@ export function ScopesTree({
           nodes={resultsNodes}
           scopes={scopes}
           scopeNames={scopeNames}
+          type="result"
           onNodeSelectToggle={onNodeSelectToggle}
           onNodeUpdate={onNodeUpdate}
         />

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTree.tsx
@@ -7,8 +7,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, Input, useStyles2 } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
-import { ScopesTreeLevel } from './ScopesTreeLevel';
-import { Node, NodesMap, TreeScope } from './types';
+import { ScopesTreeItem } from './ScopesTreeItem';
+import { Node, NodeReason, NodesMap, TreeScope } from './types';
 
 export interface ScopesTreeProps {
   nodes: NodesMap;
@@ -35,12 +35,12 @@ export function ScopesTree({
 
   const { persistedNodes, resultsNodes } = childNodesArr.reduce<Record<string, Node[]>>(
     (acc, node) => {
-      switch (node.type) {
-        case 'persisted':
+      switch (node.reason) {
+        case NodeReason.Persisted:
           acc.persistedNodes.push(node);
           break;
 
-        case 'result':
+        case NodeReason.Result:
           acc.resultsNodes.push(node);
           break;
       }
@@ -78,7 +78,7 @@ export function ScopesTree({
         <Skeleton count={5} className={styles.loader} />
       ) : (
         <>
-          <ScopesTreeLevel
+          <ScopesTreeItem
             anyChildExpanded={anyChildExpanded}
             anyChildSelected={anyChildSelected}
             isNodeLoading={isNodeLoading}
@@ -102,7 +102,7 @@ export function ScopesTree({
             </h6>
           ) : null}
 
-          <ScopesTreeLevel
+          <ScopesTreeItem
             anyChildExpanded={anyChildExpanded}
             anyChildSelected={anyChildSelected}
             isNodeLoading={isNodeLoading}

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeHeadline.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeHeadline.tsx
@@ -20,11 +20,13 @@ export function ScopesTreeHeadline({ anyChildExpanded, query, resultsNodes }: Sc
   }
 
   return (
-    <h6 className={styles.container}>
+    <h6 className={styles.container} data-testid="scopes-tree-headline">
       {!query ? (
         <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
-      ) : (
+      ) : resultsNodes.length > 0 ? (
         <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
+      ) : (
+        <Trans i18nKey="scopes.tree.headline.noResults">Results</Trans>
       )}
     </h6>
   );

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeHeadline.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeHeadline.tsx
@@ -23,10 +23,10 @@ export function ScopesTreeHeadline({ anyChildExpanded, query, resultsNodes }: Sc
     <h6 className={styles.container} data-testid="scopes-tree-headline">
       {!query ? (
         <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
-      ) : resultsNodes.length > 0 ? (
-        <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
+      ) : resultsNodes.length === 0 ? (
+        <Trans i18nKey="scopes.tree.headline.noResults">No results found for your query</Trans>
       ) : (
-        <Trans i18nKey="scopes.tree.headline.noResults">Results</Trans>
+        <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
       )}
     </h6>
   );

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeHeadline.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeHeadline.tsx
@@ -1,0 +1,40 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
+
+import { Node } from './types';
+
+export interface ScopesTreeHeadlineProps {
+  anyChildExpanded: boolean;
+  query: string;
+  resultsNodes: Node[];
+}
+
+export function ScopesTreeHeadline({ anyChildExpanded, query, resultsNodes }: ScopesTreeHeadlineProps) {
+  const styles = useStyles2(getStyles);
+
+  if (anyChildExpanded) {
+    return null;
+  }
+
+  return (
+    <h6 className={styles.container}>
+      {!query ? (
+        <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
+      ) : (
+        <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
+      )}
+    </h6>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      color: theme.colors.text.secondary,
+      margin: theme.spacing(1, 0),
+    }),
+  };
+};

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -40,8 +40,6 @@ export function ScopesTreeItem({
       {nodes.map((childNode) => {
         const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
 
-        console.log(childNode.title, anyChildExpanded, childNode.isExpanded, isSelected);
-
         if (anyChildExpanded && !childNode.isExpanded) {
           return null;
         }

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -16,6 +16,7 @@ export interface ScopesTreeItemProps {
   nodes: Node[];
   scopeNames: string[];
   scopes: TreeScope[];
+  type: 'persisted' | 'result';
   onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
   onNodeSelectToggle: (path: string[]) => void;
 }
@@ -28,6 +29,7 @@ export function ScopesTreeItem({
   nodes,
   scopeNames,
   scopes,
+  type,
   onNodeSelectToggle,
   onNodeUpdate,
 }: ScopesTreeItemProps) {
@@ -56,7 +58,7 @@ export function ScopesTreeItem({
                     name={radioName}
                     checked={isSelected}
                     label=""
-                    data-testid={`scopes-tree-${childNode.name}-radio`}
+                    data-testid={`scopes-tree-${type}-${childNode.name}-radio`}
                     onClick={() => {
                       onNodeSelectToggle(childNodePath);
                     }}
@@ -64,7 +66,7 @@ export function ScopesTreeItem({
                 ) : (
                   <Checkbox
                     checked={isSelected}
-                    data-testid={`scopes-tree-${childNode.name}-checkbox`}
+                    data-testid={`scopes-tree-${type}-${childNode.name}-checkbox`}
                     onChange={() => {
                       onNodeSelectToggle(childNodePath);
                     }}
@@ -75,7 +77,7 @@ export function ScopesTreeItem({
               {childNode.isExpandable ? (
                 <button
                   className={styles.expand}
-                  data-testid={`scopes-tree-${childNode.name}-expand`}
+                  data-testid={`scopes-tree-${type}-${childNode.name}-expand`}
                   aria-label={
                     childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
                   }
@@ -88,7 +90,7 @@ export function ScopesTreeItem({
                   {childNode.title}
                 </button>
               ) : (
-                <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+                <span data-testid={`scopes-tree-${type}-${childNode.name}-title`}>{childNode.title}</span>
               )}
             </div>
 

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, IconButton, RadioButtonDot, useStyles2 } from '@grafana/ui';
+import { Checkbox, Icon, RadioButtonDot, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { ScopesTree } from './ScopesTree';
@@ -72,20 +72,24 @@ export function ScopesTreeItem({
                 )
               ) : null}
 
-              {childNode.isExpandable && (
-                <IconButton
-                  name={!childNode.isExpanded ? 'angle-right' : 'angle-down'}
+              {childNode.isExpandable ? (
+                <button
+                  className={styles.expand}
+                  data-testid={`scopes-tree-${childNode.name}-expand`}
                   aria-label={
                     childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
                   }
-                  data-testid={`scopes-tree-${childNode.name}-expand`}
                   onClick={() => {
                     onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
                   }}
-                />
-              )}
+                >
+                  <Icon name={!childNode.isExpanded ? 'angle-right' : 'angle-down'} />
 
-              <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+                  {childNode.title}
+                </button>
+              ) : (
+                <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
+              )}
             </div>
 
             <div className={styles.children}>
@@ -120,6 +124,15 @@ const getStyles = (theme: GrafanaTheme2) => {
       '& > label': css({
         gap: 0,
       }),
+    }),
+    expand: css({
+      alignItems: 'center',
+      background: 'none',
+      border: 0,
+      display: 'flex',
+      gap: theme.spacing(1),
+      margin: 0,
+      padding: 0,
     }),
     children: css({
       paddingLeft: theme.spacing(4),

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -40,7 +40,9 @@ export function ScopesTreeItem({
       {nodes.map((childNode) => {
         const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
 
-        if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
+        console.log(childNode.title, anyChildExpanded, childNode.isExpanded, isSelected);
+
+        if (anyChildExpanded && !childNode.isExpanded) {
           return null;
         }
 

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -48,7 +48,7 @@ export function ScopesTreeItem({
 
         return (
           <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
-            <div className={styles.itemTitle}>
+            <div className={styles.title}>
               {childNode.isSelectable && !childNode.isExpanded ? (
                 node.disableMultiSelect ? (
                   <RadioButtonDot
@@ -88,7 +88,7 @@ export function ScopesTreeItem({
               <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
             </div>
 
-            <div className={styles.itemChildren}>
+            <div className={styles.children}>
               {childNode.isExpanded && (
                 <ScopesTree
                   nodes={node.nodes}
@@ -109,7 +109,7 @@ export function ScopesTreeItem({
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    itemTitle: css({
+    title: css({
       alignItems: 'center',
       display: 'flex',
       gap: theme.spacing(1),
@@ -121,7 +121,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         gap: 0,
       }),
     }),
-    itemChildren: css({
+    children: css({
       paddingLeft: theme.spacing(4),
     }),
   };

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -5,7 +5,7 @@ import { Checkbox, Icon, RadioButtonDot, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 import { ScopesTree } from './ScopesTree';
-import { Node, TreeScope } from './types';
+import { Node, OnNodeSelectToggle, OnNodeUpdate, TreeScope } from './types';
 
 export interface ScopesTreeItemProps {
   anyChildExpanded: boolean;
@@ -17,8 +17,8 @@ export interface ScopesTreeItemProps {
   scopeNames: string[];
   scopes: TreeScope[];
   type: 'persisted' | 'result';
-  onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
-  onNodeSelectToggle: (path: string[]) => void;
+  onNodeUpdate: OnNodeUpdate;
+  onNodeSelectToggle: OnNodeSelectToggle;
 }
 
 export function ScopesTreeItem({

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -7,7 +7,7 @@ import { t } from 'app/core/internationalization';
 import { ScopesTree } from './ScopesTree';
 import { Node, TreeScope } from './types';
 
-export interface ScopesTreeLevelProps {
+export interface ScopesTreeItemProps {
   anyChildExpanded: boolean;
   anyChildSelected: boolean;
   isNodeLoading: boolean;
@@ -21,7 +21,7 @@ export interface ScopesTreeLevelProps {
   onNodeSelectToggle: (path: string[]) => void;
 }
 
-export function ScopesTreeLevel({
+export function ScopesTreeItem({
   anyChildExpanded,
   anyChildSelected,
   loadingNodeName,
@@ -32,7 +32,7 @@ export function ScopesTreeLevel({
   scopes,
   onNodeSelectToggle,
   onNodeUpdate,
-}: ScopesTreeLevelProps) {
+}: ScopesTreeItemProps) {
   const styles = useStyles2(getStyles);
 
   return (

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeItem.tsx
@@ -9,7 +9,6 @@ import { Node, TreeScope } from './types';
 
 export interface ScopesTreeItemProps {
   anyChildExpanded: boolean;
-  anyChildSelected: boolean;
   isNodeLoading: boolean;
   loadingNodeName: string | undefined;
   node: Node;
@@ -23,7 +22,6 @@ export interface ScopesTreeItemProps {
 
 export function ScopesTreeItem({
   anyChildExpanded,
-  anyChildSelected,
   loadingNodeName,
   node,
   nodePath,

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -1,176 +1,120 @@
 import { css } from '@emotion/css';
-import { debounce } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, FilterInput, Icon, RadioButtonDot, useStyles2 } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Checkbox, IconButton, RadioButtonDot, useStyles2 } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
 
-import { NodesMap, TreeScope } from './types';
+import { ScopesTree } from './ScopesTree';
+import { Node, TreeScope } from './types';
 
 export interface ScopesTreeLevelProps {
-  nodes: NodesMap;
-  nodePath: string[];
+  anyChildExpanded: boolean;
+  anyChildSelected: boolean;
+  isNodeLoading: boolean;
   loadingNodeName: string | undefined;
+  node: Node;
+  nodePath: string[];
+  nodes: Node[];
+  scopeNames: string[];
   scopes: TreeScope[];
   onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
   onNodeSelectToggle: (path: string[]) => void;
 }
 
 export function ScopesTreeLevel({
-  nodes,
-  nodePath,
+  anyChildExpanded,
+  anyChildSelected,
+  isNodeLoading,
   loadingNodeName,
+  node,
+  nodePath,
+  nodes,
+  scopeNames,
   scopes,
-  onNodeUpdate,
   onNodeSelectToggle,
+  onNodeUpdate,
 }: ScopesTreeLevelProps) {
   const styles = useStyles2(getStyles);
 
-  const nodeId = nodePath[nodePath.length - 1];
-  const node = nodes[nodeId];
-  const childNodes = node.nodes;
-  const childNodesArr = Object.values(childNodes);
-  const isNodeLoading = loadingNodeName === nodeId;
-
-  const scopeNames = scopes.map(({ scopeName }) => scopeName);
-  const anyChildExpanded = childNodesArr.some(({ isExpanded }) => isExpanded);
-
-  const [queryValue, setQueryValue] = useState(node.query);
-  useEffect(() => {
-    setQueryValue(node.query);
-  }, [node.query]);
-  const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
-
   return (
-    <>
-      {!anyChildExpanded && (
-        <FilterInput
-          placeholder={t('scopes.tree.search', 'Search')}
-          value={queryValue}
-          className={styles.searchInput}
-          data-testid={`scopes-tree-${nodeId}-search`}
-          onChange={(value) => {
-            setQueryValue(value);
-            onQueryUpdate(nodePath, true, value);
-          }}
-        />
-      )}
+    <div role="tree">
+      {isNodeLoading && <Skeleton count={5} className={styles.loader} />}
+      {!isNodeLoading &&
+        nodes.map((childNode) => {
+          const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
 
-      {Object.keys(node.persistedNodes).length > 0 && (
-        <div className={styles.itemChildren}>
-          <ScopesTreeLevel
-            nodes={node.persistedNodes}
-            nodePath={nodePath}
-            loadingNodeName={loadingNodeName}
-            scopes={scopes}
-            onNodeUpdate={onNodeUpdate}
-            onNodeSelectToggle={onNodeSelectToggle}
-          />
-        </div>
-      )}
+          if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
+            return null;
+          }
 
-      {!anyChildExpanded ? (
-        <h6 className={styles.headline}>
-          {!node.query ? (
-            <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
-          ) : (
-            <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
-          )}
-        </h6>
-      ) : null}
+          const childNodePath = [...nodePath, childNode.name];
 
-      <div role="tree">
-        {isNodeLoading && <Skeleton count={5} className={styles.loader} />}
+          const radioName = childNodePath.join('.');
 
-        {!isNodeLoading &&
-          childNodesArr.map((childNode) => {
-            const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
-
-            if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
-              return null;
-            }
-
-            const childNodePath = [...nodePath, childNode.name];
-
-            const radioName = childNodePath.join('.');
-
-            return (
-              <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
-                <div className={styles.itemTitle}>
-                  {childNode.isSelectable && !childNode.isExpanded ? (
-                    node.disableMultiSelect ? (
-                      <RadioButtonDot
-                        id={radioName}
-                        name={radioName}
-                        checked={isSelected}
-                        label=""
-                        data-testid={`scopes-tree-${childNode.name}-radio`}
-                        onClick={() => {
-                          onNodeSelectToggle(childNodePath);
-                        }}
-                      />
-                    ) : (
-                      <Checkbox
-                        checked={isSelected}
-                        data-testid={`scopes-tree-${childNode.name}-checkbox`}
-                        onChange={() => {
-                          onNodeSelectToggle(childNodePath);
-                        }}
-                      />
-                    )
-                  ) : null}
-
-                  {childNode.isExpandable ? (
-                    <button
-                      className={styles.itemExpand}
-                      data-testid={`scopes-tree-${childNode.name}-expand`}
-                      aria-label={
-                        childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
-                      }
+          return (
+            <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
+              <div className={styles.itemTitle}>
+                {childNode.isSelectable && !childNode.isExpanded ? (
+                  node.disableMultiSelect ? (
+                    <RadioButtonDot
+                      id={radioName}
+                      name={radioName}
+                      checked={isSelected}
+                      label=""
+                      data-testid={`scopes-tree-${childNode.name}-radio`}
                       onClick={() => {
-                        onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
+                        onNodeSelectToggle(childNodePath);
                       }}
-                    >
-                      <Icon name={!childNode.isExpanded ? 'angle-right' : 'angle-down'} />
-
-                      {childNode.title}
-                    </button>
-                  ) : (
-                    <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
-                  )}
-                </div>
-
-                <div className={styles.itemChildren}>
-                  {childNode.isExpanded && (
-                    <ScopesTreeLevel
-                      nodes={node.nodes}
-                      nodePath={childNodePath}
-                      loadingNodeName={loadingNodeName}
-                      scopes={scopes}
-                      onNodeUpdate={onNodeUpdate}
-                      onNodeSelectToggle={onNodeSelectToggle}
                     />
-                  )}
-                </div>
+                  ) : (
+                    <Checkbox
+                      checked={isSelected}
+                      data-testid={`scopes-tree-${childNode.name}-checkbox`}
+                      onChange={() => {
+                        onNodeSelectToggle(childNodePath);
+                      }}
+                    />
+                  )
+                ) : null}
+
+                {childNode.isExpandable && (
+                  <IconButton
+                    name={!childNode.isExpanded ? 'angle-right' : 'angle-down'}
+                    aria-label={
+                      childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
+                    }
+                    data-testid={`scopes-tree-${childNode.name}-expand`}
+                    onClick={() => {
+                      onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
+                    }}
+                  />
+                )}
+
+                <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
               </div>
-            );
-          })}
-      </div>
-    </>
+
+              <div className={styles.itemChildren}>
+                {childNode.isExpanded && (
+                  <ScopesTree
+                    nodes={node.nodes}
+                    nodePath={childNodePath}
+                    loadingNodeName={loadingNodeName}
+                    scopes={scopes}
+                    onNodeUpdate={onNodeUpdate}
+                    onNodeSelectToggle={onNodeSelectToggle}
+                  />
+                )}
+              </div>
+            </div>
+          );
+        })}
+    </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    searchInput: css({
-      margin: theme.spacing(1, 0),
-    }),
-    headline: css({
-      color: theme.colors.text.secondary,
-      margin: theme.spacing(1, 0),
-    }),
     loader: css({
       margin: theme.spacing(0.5, 0),
     }),
@@ -185,15 +129,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       '& > label': css({
         gap: 0,
       }),
-    }),
-    itemExpand: css({
-      alignItems: 'center',
-      background: 'none',
-      border: 0,
-      display: 'flex',
-      gap: theme.spacing(1),
-      margin: 0,
-      padding: 0,
     }),
     itemChildren: css({
       paddingLeft: theme.spacing(4),

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Checkbox, IconButton, RadioButtonDot, useStyles2 } from '@grafana/ui';
@@ -25,7 +24,6 @@ export interface ScopesTreeLevelProps {
 export function ScopesTreeLevel({
   anyChildExpanded,
   anyChildSelected,
-  isNodeLoading,
   loadingNodeName,
   node,
   nodePath,
@@ -39,85 +37,80 @@ export function ScopesTreeLevel({
 
   return (
     <div role="tree">
-      {isNodeLoading && <Skeleton count={5} className={styles.loader} />}
-      {!isNodeLoading &&
-        nodes.map((childNode) => {
-          const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
+      {nodes.map((childNode) => {
+        const isSelected = childNode.isSelectable && scopeNames.includes(childNode.linkId!);
 
-          if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
-            return null;
-          }
+        if (anyChildExpanded && !childNode.isExpanded && !isSelected) {
+          return null;
+        }
 
-          const childNodePath = [...nodePath, childNode.name];
+        const childNodePath = [...nodePath, childNode.name];
 
-          const radioName = childNodePath.join('.');
+        const radioName = childNodePath.join('.');
 
-          return (
-            <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
-              <div className={styles.itemTitle}>
-                {childNode.isSelectable && !childNode.isExpanded ? (
-                  node.disableMultiSelect ? (
-                    <RadioButtonDot
-                      id={radioName}
-                      name={radioName}
-                      checked={isSelected}
-                      label=""
-                      data-testid={`scopes-tree-${childNode.name}-radio`}
-                      onClick={() => {
-                        onNodeSelectToggle(childNodePath);
-                      }}
-                    />
-                  ) : (
-                    <Checkbox
-                      checked={isSelected}
-                      data-testid={`scopes-tree-${childNode.name}-checkbox`}
-                      onChange={() => {
-                        onNodeSelectToggle(childNodePath);
-                      }}
-                    />
-                  )
-                ) : null}
-
-                {childNode.isExpandable && (
-                  <IconButton
-                    name={!childNode.isExpanded ? 'angle-right' : 'angle-down'}
-                    aria-label={
-                      childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
-                    }
-                    data-testid={`scopes-tree-${childNode.name}-expand`}
+        return (
+          <div key={childNode.name} role="treeitem" aria-selected={childNode.isExpanded}>
+            <div className={styles.itemTitle}>
+              {childNode.isSelectable && !childNode.isExpanded ? (
+                node.disableMultiSelect ? (
+                  <RadioButtonDot
+                    id={radioName}
+                    name={radioName}
+                    checked={isSelected}
+                    label=""
+                    data-testid={`scopes-tree-${childNode.name}-radio`}
                     onClick={() => {
-                      onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
+                      onNodeSelectToggle(childNodePath);
                     }}
                   />
-                )}
-
-                <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
-              </div>
-
-              <div className={styles.itemChildren}>
-                {childNode.isExpanded && (
-                  <ScopesTree
-                    nodes={node.nodes}
-                    nodePath={childNodePath}
-                    loadingNodeName={loadingNodeName}
-                    scopes={scopes}
-                    onNodeUpdate={onNodeUpdate}
-                    onNodeSelectToggle={onNodeSelectToggle}
+                ) : (
+                  <Checkbox
+                    checked={isSelected}
+                    data-testid={`scopes-tree-${childNode.name}-checkbox`}
+                    onChange={() => {
+                      onNodeSelectToggle(childNodePath);
+                    }}
                   />
-                )}
-              </div>
+                )
+              ) : null}
+
+              {childNode.isExpandable && (
+                <IconButton
+                  name={!childNode.isExpanded ? 'angle-right' : 'angle-down'}
+                  aria-label={
+                    childNode.isExpanded ? t('scopes.tree.collapse', 'Collapse') : t('scopes.tree.expand', 'Expand')
+                  }
+                  data-testid={`scopes-tree-${childNode.name}-expand`}
+                  onClick={() => {
+                    onNodeUpdate(childNodePath, !childNode.isExpanded, childNode.query);
+                  }}
+                />
+              )}
+
+              <span data-testid={`scopes-tree-${childNode.name}-title`}>{childNode.title}</span>
             </div>
-          );
-        })}
+
+            <div className={styles.itemChildren}>
+              {childNode.isExpanded && (
+                <ScopesTree
+                  nodes={node.nodes}
+                  nodePath={childNodePath}
+                  loadingNodeName={loadingNodeName}
+                  scopes={scopes}
+                  onNodeUpdate={onNodeUpdate}
+                  onNodeSelectToggle={onNodeSelectToggle}
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    loader: css({
-      margin: theme.spacing(0.5, 0),
-    }),
     itemTitle: css({
       alignItems: 'center',
       display: 'flex',

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLevel.tsx
@@ -58,11 +58,28 @@ export function ScopesTreeLevel({
         />
       )}
 
-      {!anyChildExpanded && !node.query && (
-        <h6 className={styles.headline}>
-          <Trans i18nKey="scopes.tree.headline">Recommended</Trans>
-        </h6>
+      {Object.keys(node.persistedNodes).length > 0 && (
+        <div className={styles.itemChildren}>
+          <ScopesTreeLevel
+            nodes={node.persistedNodes}
+            nodePath={nodePath}
+            loadingNodeName={loadingNodeName}
+            scopes={scopes}
+            onNodeUpdate={onNodeUpdate}
+            onNodeSelectToggle={onNodeSelectToggle}
+          />
+        </div>
       )}
+
+      {!anyChildExpanded ? (
+        <h6 className={styles.headline}>
+          {!node.query ? (
+            <Trans i18nKey="scopes.tree.headline.recommended">Recommended</Trans>
+          ) : (
+            <Trans i18nKey="scopes.tree.headline.results">Results</Trans>
+          )}
+        </h6>
+      ) : null}
 
       <div role="tree">
         {isNodeLoading && <Skeleton count={5} className={styles.loader} />}

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLoading.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeLoading.tsx
@@ -1,0 +1,29 @@
+import { css } from '@emotion/css';
+import { ReactNode } from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export interface ScopesTreeLoadingProps {
+  children: ReactNode;
+  isNodeLoading: boolean;
+}
+
+export function ScopesTreeLoading({ children, isNodeLoading }: ScopesTreeLoadingProps) {
+  const styles = useStyles2(getStyles);
+
+  if (isNodeLoading) {
+    return <Skeleton count={5} className={styles.loader} />;
+  }
+
+  return children;
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    loader: css({
+      margin: theme.spacing(0.5, 0),
+    }),
+  };
+};

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
@@ -6,11 +6,13 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
+import { OnNodeUpdate } from './types';
+
 export interface ScopesTreeSearchProps {
   anyChildExpanded: boolean;
   nodePath: string[];
   query: string;
-  onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
+  onNodeUpdate: OnNodeUpdate;
 }
 
 export function ScopesTreeSearch({ anyChildExpanded, nodePath, query, onNodeUpdate }: ScopesTreeSearchProps) {

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
@@ -8,13 +8,12 @@ import { t } from 'app/core/internationalization';
 
 export interface ScopesTreeSearchProps {
   anyChildExpanded: boolean;
-  nodeId: string;
   nodePath: string[];
   query: string;
   onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
 }
 
-export function ScopesTreeSearch({ anyChildExpanded, nodeId, nodePath, query, onNodeUpdate }: ScopesTreeSearchProps) {
+export function ScopesTreeSearch({ anyChildExpanded, nodePath, query, onNodeUpdate }: ScopesTreeSearchProps) {
   const styles = useStyles2(getStyles);
 
   const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
@@ -29,7 +28,7 @@ export function ScopesTreeSearch({ anyChildExpanded, nodeId, nodePath, query, on
       className={styles.input}
       placeholder={t('scopes.tree.search', 'Search')}
       defaultValue={query}
-      data-testid={`scopes-tree-${nodeId}-search`}
+      data-testid="scopes-tree-search"
       onInput={(evt) => onQueryUpdate(nodePath, true, evt.currentTarget.value)}
     />
   );

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, Input, useStyles2 } from '@grafana/ui';
+import { FilterInput, useStyles2 } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 
 export interface ScopesTreeSearchProps {
@@ -16,6 +16,12 @@ export interface ScopesTreeSearchProps {
 export function ScopesTreeSearch({ anyChildExpanded, nodePath, query, onNodeUpdate }: ScopesTreeSearchProps) {
   const styles = useStyles2(getStyles);
 
+  const [queryValue, setQueryValue] = useState(query);
+
+  useEffect(() => {
+    setQueryValue(query);
+  }, [query]);
+
   const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
 
   if (anyChildExpanded) {
@@ -23,13 +29,15 @@ export function ScopesTreeSearch({ anyChildExpanded, nodePath, query, onNodeUpda
   }
 
   return (
-    <Input
-      prefix={<Icon name="filter" />}
-      className={styles.input}
+    <FilterInput
       placeholder={t('scopes.tree.search', 'Search')}
-      defaultValue={query}
+      value={queryValue}
+      className={styles.input}
       data-testid="scopes-tree-search"
-      onInput={(evt) => onQueryUpdate(nodePath, true, evt.currentTarget.value)}
+      onChange={(value) => {
+        setQueryValue(value);
+        onQueryUpdate(nodePath, true, value);
+      }}
     />
   );
 }

--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesTreeSearch.tsx
@@ -1,0 +1,44 @@
+import { css } from '@emotion/css';
+import { debounce } from 'lodash';
+import { useMemo } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, Input, useStyles2 } from '@grafana/ui';
+import { t } from 'app/core/internationalization';
+
+export interface ScopesTreeSearchProps {
+  anyChildExpanded: boolean;
+  nodeId: string;
+  nodePath: string[];
+  query: string;
+  onNodeUpdate: (path: string[], isExpanded: boolean, query: string) => void;
+}
+
+export function ScopesTreeSearch({ anyChildExpanded, nodeId, nodePath, query, onNodeUpdate }: ScopesTreeSearchProps) {
+  const styles = useStyles2(getStyles);
+
+  const onQueryUpdate = useMemo(() => debounce(onNodeUpdate, 500), [onNodeUpdate]);
+
+  if (anyChildExpanded) {
+    return null;
+  }
+
+  return (
+    <Input
+      prefix={<Icon name="filter" />}
+      className={styles.input}
+      placeholder={t('scopes.tree.search', 'Search')}
+      defaultValue={query}
+      data-testid={`scopes-tree-${nodeId}-search`}
+      onInput={(evt) => onQueryUpdate(nodePath, true, evt.currentTarget.value)}
+    />
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    input: css({
+      margin: theme.spacing(1, 0),
+    }),
+  };
+};

--- a/public/app/features/dashboard-scene/scene/Scopes/api.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/api.ts
@@ -1,8 +1,8 @@
-import { Scope, ScopeSpec, ScopeNode, ScopeDashboardBinding } from '@grafana/data';
+import { Scope, ScopeDashboardBinding, ScopeNode, ScopeSpec } from '@grafana/data';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 
-import { NodesMap, SelectedScope, SuggestedDashboard, TreeScope } from './types';
+import { NodeReason, NodesMap, SelectedScope, SuggestedDashboard, TreeScope } from './types';
 import { getBasicScope, mergeScopes } from './utils';
 
 const group = 'scope.grafana.app';
@@ -37,7 +37,7 @@ export async function fetchNodes(parent: string, query: string): Promise<NodesMa
       isSelectable: spec.linkType === 'scope',
       isExpanded: false,
       query: '',
-      type: 'result',
+      reason: NodeReason.Result,
       nodes: {},
     };
     return acc;

--- a/public/app/features/dashboard-scene/scene/Scopes/api.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/api.ts
@@ -37,7 +37,7 @@ export async function fetchNodes(parent: string, query: string): Promise<NodesMa
       isSelectable: spec.linkType === 'scope',
       isExpanded: false,
       query: '',
-      persistedNodes: {},
+      type: 'result',
       nodes: {},
     };
     return acc;

--- a/public/app/features/dashboard-scene/scene/Scopes/api.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/api.ts
@@ -37,6 +37,7 @@ export async function fetchNodes(parent: string, query: string): Promise<NodesMa
       isSelectable: spec.linkType === 'scope',
       isExpanded: false,
       query: '',
+      persistedNodes: {},
       nodes: {},
     };
     return acc;

--- a/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
@@ -316,10 +316,10 @@ const selectors = {
   tree: {
     search: 'scopes-tree-search',
     headline: 'scopes-tree-headline',
-    select: (nodeId: string) => `scopes-tree-${nodeId}-checkbox`,
-    radio: (nodeId: string) => `scopes-tree-${nodeId}-radio`,
-    expand: (nodeId: string) => `scopes-tree-${nodeId}-expand`,
-    title: (nodeId: string) => `scopes-tree-${nodeId}-title`,
+    select: (nodeId: string, type: 'result' | 'persisted') => `scopes-tree-${type}-${nodeId}-checkbox`,
+    radio: (nodeId: string, type: 'result' | 'persisted') => `scopes-tree-${type}-${nodeId}-radio`,
+    expand: (nodeId: string, type: 'result' | 'persisted') => `scopes-tree-${type}-${nodeId}-expand`,
+    title: (nodeId: string, type: 'result' | 'persisted') => `scopes-tree-${type}-${nodeId}-title`,
   },
   filters: {
     input: 'scopes-filters-input',
@@ -362,33 +362,50 @@ export const getNotFoundForFilterClear = () => screen.getByTestId(selectors.dash
 
 export const getTreeSearch = () => screen.getByTestId<HTMLInputElement>(selectors.tree.search);
 export const getTreeHeadline = () => screen.getByTestId(selectors.tree.headline);
-export const getApplicationsExpand = () => screen.getByTestId(selectors.tree.expand('applications'));
-export const queryApplicationsSlothPictureFactoryTitle = () =>
-  screen.queryByTestId(selectors.tree.title('applications-slothPictureFactory'));
-export const getApplicationsSlothPictureFactoryTitle = () =>
-  screen.getByTestId(selectors.tree.title('applications-slothPictureFactory'));
-export const getApplicationsSlothPictureFactorySelect = () =>
-  screen.getByTestId(selectors.tree.select('applications-slothPictureFactory'));
-export const queryApplicationsSlothVoteTrackerTitle = () =>
-  screen.queryByTestId(selectors.tree.title('applications-slothVoteTracker'));
-export const getApplicationsSlothVoteTrackerSelect = () =>
-  screen.getByTestId(selectors.tree.select('applications-slothVoteTracker'));
-export const queryApplicationsClustersTitle = () => screen.queryByTestId(selectors.tree.title('applications.clusters'));
-export const getApplicationsClustersSelect = () => screen.getByTestId(selectors.tree.select('applications.clusters'));
-export const getApplicationsClustersExpand = () => screen.getByTestId(selectors.tree.expand('applications.clusters'));
-export const getApplicationsClustersSlothClusterNorthSelect = () =>
-  screen.getByTestId(selectors.tree.select('applications.clusters-slothClusterNorth'));
-export const getApplicationsClustersSlothClusterSouthSelect = () =>
-  screen.getByTestId(selectors.tree.select('applications.clusters-slothClusterSouth'));
+export const getResultApplicationsExpand = () => screen.getByTestId(selectors.tree.expand('applications', 'result'));
+export const queryResultApplicationsSlothPictureFactoryTitle = () =>
+  screen.queryByTestId(selectors.tree.title('applications-slothPictureFactory', 'result'));
+export const getResultApplicationsSlothPictureFactoryTitle = () =>
+  screen.getByTestId(selectors.tree.title('applications-slothPictureFactory', 'result'));
+export const getResultApplicationsSlothPictureFactorySelect = () =>
+  screen.getByTestId(selectors.tree.select('applications-slothPictureFactory', 'result'));
+export const queryPersistedApplicationsSlothPictureFactoryTitle = () =>
+  screen.queryByTestId(selectors.tree.title('applications-slothPictureFactory', 'persisted'));
+export const getPersistedApplicationsSlothPictureFactoryTitle = () =>
+  screen.getByTestId(selectors.tree.title('applications-slothPictureFactory', 'persisted'));
+export const getPersistedApplicationsSlothPictureFactorySelect = () =>
+  screen.getByTestId(selectors.tree.select('applications-slothPictureFactory', 'persisted'));
+export const queryResultApplicationsSlothVoteTrackerTitle = () =>
+  screen.queryByTestId(selectors.tree.title('applications-slothVoteTracker', 'result'));
+export const getResultApplicationsSlothVoteTrackerTitle = () =>
+  screen.getByTestId(selectors.tree.title('applications-slothVoteTracker', 'result'));
+export const getResultApplicationsSlothVoteTrackerSelect = () =>
+  screen.getByTestId(selectors.tree.select('applications-slothVoteTracker', 'result'));
+export const queryPersistedApplicationsSlothVoteTrackerTitle = () =>
+  screen.queryByTestId(selectors.tree.title('applications-slothVoteTracker', 'persisted'));
+export const getPersistedApplicationsSlothVoteTrackerTitle = () =>
+  screen.getByTestId(selectors.tree.title('applications-slothVoteTracker', 'persisted'));
+export const getPersistedApplicationsSlothVoteTrackerSelect = () =>
+  screen.getByTestId(selectors.tree.select('applications-slothVoteTracker', 'persisted'));
+export const queryResultApplicationsClustersTitle = () =>
+  screen.queryByTestId(selectors.tree.title('applications.clusters', 'result'));
+export const getResultApplicationsClustersSelect = () =>
+  screen.getByTestId(selectors.tree.select('applications.clusters', 'result'));
+export const getResultApplicationsClustersExpand = () =>
+  screen.getByTestId(selectors.tree.expand('applications.clusters', 'result'));
+export const getResultApplicationsClustersSlothClusterNorthSelect = () =>
+  screen.getByTestId(selectors.tree.select('applications.clusters-slothClusterNorth', 'result'));
+export const getResultApplicationsClustersSlothClusterSouthSelect = () =>
+  screen.getByTestId(selectors.tree.select('applications.clusters-slothClusterSouth', 'result'));
 
-export const getClustersSelect = () => screen.getByTestId(selectors.tree.select('clusters'));
-export const getClustersExpand = () => screen.getByTestId(selectors.tree.expand('clusters'));
-export const getClustersSlothClusterNorthRadio = () =>
-  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterNorth'));
-export const getClustersSlothClusterSouthRadio = () =>
-  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterSouth'));
-export const getClustersSlothClusterEastRadio = () =>
-  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterEast'));
+export const getResultClustersSelect = () => screen.getByTestId(selectors.tree.select('clusters', 'result'));
+export const getResultClustersExpand = () => screen.getByTestId(selectors.tree.expand('clusters', 'result'));
+export const getResultClustersSlothClusterNorthRadio = () =>
+  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterNorth', 'result'));
+export const getResultClustersSlothClusterSouthRadio = () =>
+  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterSouth', 'result'));
+export const getResultClustersSlothClusterEastRadio = () =>
+  screen.getByTestId<HTMLInputElement>(selectors.tree.radio('clusters-slothClusterEast', 'result'));
 
 export function buildTestScene(overrides: Partial<DashboardScene> = {}) {
   return new DashboardScene({

--- a/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
@@ -385,8 +385,6 @@ export const queryPersistedApplicationsSlothVoteTrackerTitle = () =>
   screen.queryByTestId(selectors.tree.title('applications-slothVoteTracker', 'persisted'));
 export const getPersistedApplicationsSlothVoteTrackerTitle = () =>
   screen.getByTestId(selectors.tree.title('applications-slothVoteTracker', 'persisted'));
-export const getPersistedApplicationsSlothVoteTrackerSelect = () =>
-  screen.getByTestId(selectors.tree.select('applications-slothVoteTracker', 'persisted'));
 export const queryResultApplicationsClustersTitle = () =>
   screen.queryByTestId(selectors.tree.title('applications.clusters', 'result'));
 export const getResultApplicationsClustersSelect = () =>

--- a/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/testUtils.tsx
@@ -314,7 +314,8 @@ export const getMock = jest
 
 const selectors = {
   tree: {
-    search: (nodeId: string) => `scopes-tree-${nodeId}-search`,
+    search: 'scopes-tree-search',
+    headline: 'scopes-tree-headline',
     select: (nodeId: string) => `scopes-tree-${nodeId}-checkbox`,
     radio: (nodeId: string) => `scopes-tree-${nodeId}-radio`,
     expand: (nodeId: string) => `scopes-tree-${nodeId}-expand`,
@@ -359,8 +360,9 @@ export const getNotFoundForScope = () => screen.getByTestId(selectors.dashboards
 export const getNotFoundForFilter = () => screen.getByTestId(selectors.dashboards.notFoundForFilter);
 export const getNotFoundForFilterClear = () => screen.getByTestId(selectors.dashboards.notFoundForFilterClear);
 
+export const getTreeSearch = () => screen.getByTestId<HTMLInputElement>(selectors.tree.search);
+export const getTreeHeadline = () => screen.getByTestId(selectors.tree.headline);
 export const getApplicationsExpand = () => screen.getByTestId(selectors.tree.expand('applications'));
-export const getApplicationsSearch = () => screen.getByTestId<HTMLInputElement>(selectors.tree.search('applications'));
 export const queryApplicationsSlothPictureFactoryTitle = () =>
   screen.queryByTestId(selectors.tree.title('applications-slothPictureFactory'));
 export const getApplicationsSlothPictureFactoryTitle = () =>
@@ -374,8 +376,6 @@ export const getApplicationsSlothVoteTrackerSelect = () =>
 export const queryApplicationsClustersTitle = () => screen.queryByTestId(selectors.tree.title('applications.clusters'));
 export const getApplicationsClustersSelect = () => screen.getByTestId(selectors.tree.select('applications.clusters'));
 export const getApplicationsClustersExpand = () => screen.getByTestId(selectors.tree.expand('applications.clusters'));
-export const queryApplicationsClustersSlothClusterNorthTitle = () =>
-  screen.queryByTestId(selectors.tree.title('applications.clusters-slothClusterNorth'));
 export const getApplicationsClustersSlothClusterNorthSelect = () =>
   screen.getByTestId(selectors.tree.select('applications.clusters-slothClusterNorth'));
 export const getApplicationsClustersSlothClusterSouthSelect = () =>

--- a/public/app/features/dashboard-scene/scene/Scopes/types.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/types.ts
@@ -32,3 +32,6 @@ export interface SuggestedDashboard {
   dashboardTitle: string;
   items: ScopeDashboardBinding[];
 }
+
+export type OnNodeUpdate = (path: string[], isExpanded: boolean, query: string) => void;
+export type OnNodeSelectToggle = (path: string[]) => void;

--- a/public/app/features/dashboard-scene/scene/Scopes/types.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/types.ts
@@ -1,8 +1,13 @@
 import { Scope, ScopeDashboardBinding, ScopeNodeSpec } from '@grafana/data';
 
+export enum NodeReason {
+  Persisted,
+  Result,
+}
+
 export interface Node extends ScopeNodeSpec {
   name: string;
-  type: 'persisted' | 'result';
+  reason: NodeReason;
   isExpandable: boolean;
   isSelectable: boolean;
   isExpanded: boolean;

--- a/public/app/features/dashboard-scene/scene/Scopes/types.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/types.ts
@@ -2,11 +2,11 @@ import { Scope, ScopeDashboardBinding, ScopeNodeSpec } from '@grafana/data';
 
 export interface Node extends ScopeNodeSpec {
   name: string;
+  type: 'persisted' | 'result';
   isExpandable: boolean;
   isSelectable: boolean;
   isExpanded: boolean;
   query: string;
-  persistedNodes: NodesMap;
   nodes: NodesMap;
 }
 

--- a/public/app/features/dashboard-scene/scene/Scopes/types.ts
+++ b/public/app/features/dashboard-scene/scene/Scopes/types.ts
@@ -6,6 +6,7 @@ export interface Node extends ScopeNodeSpec {
   isSelectable: boolean;
   isExpanded: boolean;
   query: string;
+  persistedNodes: NodesMap;
   nodes: NodesMap;
 }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1670,7 +1670,10 @@
     "tree": {
       "collapse": "Collapse",
       "expand": "Expand",
-      "headline": "Recommended",
+      "headline": {
+        "recommended": "Recommended",
+        "results": "Results"
+      },
       "search": "Search"
     }
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1671,6 +1671,7 @@
       "collapse": "Collapse",
       "expand": "Expand",
       "headline": {
+        "noResults": "No results found for your query",
         "recommended": "Recommended",
         "results": "Results"
       },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1671,6 +1671,7 @@
       "collapse": "Cőľľäpşę",
       "expand": "Ēχpäŉđ",
       "headline": {
+        "noResults": "Ńő řęşūľŧş ƒőūŉđ ƒőř yőūř qūęřy",
         "recommended": "Ŗęčőmmęŉđęđ",
         "results": "Ŗęşūľŧş"
       },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1670,7 +1670,10 @@
     "tree": {
       "collapse": "Cőľľäpşę",
       "expand": "Ēχpäŉđ",
-      "headline": "Ŗęčőmmęŉđęđ",
+      "headline": {
+        "recommended": "Ŗęčőmmęŉđęđ",
+        "results": "Ŗęşūľŧş"
+      },
       "search": "Ŝęäřčĥ"
     }
   },


### PR DESCRIPTION
**What is this feature?**

Persist the scope nodes if they are selected and a new search is performed.

**Why do we need this feature?**

Allow scopes de-selection without altering the search.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
