### PR TITLE
Prometheus: Display multiple hints at the same time on query code editor

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryCodeEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryCodeEditor.tsx
@@ -9,6 +9,7 @@ import { PromQueryField } from '../../components/PromQueryField';
 import { PromQueryEditorProps } from '../../components/types';
 
 import { PromQueryBuilderExplained } from './PromQueryBuilderExplained';
+import { QueryEditorHints } from '../shared/QueryEditorHints';
 
 type PromQueryCodeEditorProps = PromQueryEditorProps & {
   showExplain: boolean;
@@ -33,8 +34,8 @@ export function PromQueryCodeEditor(props: PromQueryCodeEditorProps) {
         data={data}
         app={app}
       />
-
       {showExplain && <PromQueryBuilderExplained query={query.expr} />}
+      <QueryEditorHints query={query} datasource={datasource} data={data} onChange={onChange} onRunQuery={onRunQuery} />
     </div>
   );
 }

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryCodeEditor.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryCodeEditor.tsx
@@ -7,9 +7,9 @@ import { useStyles2 } from '@grafana/ui';
 
 import { PromQueryField } from '../../components/PromQueryField';
 import { PromQueryEditorProps } from '../../components/types';
+import { QueryEditorHints } from '../shared/QueryEditorHints';
 
 import { PromQueryBuilderExplained } from './PromQueryBuilderExplained';
-import { QueryEditorHints } from '../shared/QueryEditorHints';
 
 type PromQueryCodeEditorProps = PromQueryEditorProps & {
   showExplain: boolean;

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
@@ -47,5 +47,3 @@ export function QueryEditorHints(props: PromQueryEditorProps) {
     </>
   );
 }
-
-QueryEditorHints.displayName = 'QueryEditorHints';

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
-import { PromQueryEditorProps } from '../../components/types';
+
 import { QueryHint } from '@grafana/data';
-import { Button, Tooltip } from '@grafana/ui';
 import { reportInteraction } from '@grafana/runtime';
+import { Button, Tooltip } from '@grafana/ui';
+
+import { PromQueryEditorProps } from '../../components/types';
 
 export function QueryEditorHints(props: PromQueryEditorProps) {
   const [hints, setHints] = useState<QueryHint[]>([]);

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
@@ -8,12 +8,15 @@ import { PromQueryEditorProps } from '../../components/types';
 
 export function QueryEditorHints(props: PromQueryEditorProps) {
   const [hints, setHints] = useState<QueryHint[]>([]);
+  const { query, data, datasource } = props;
 
   useEffect(() => {
-    const query = { expr: props.query.expr, refId: props.query.refId };
-    const hints = props.datasource.getQueryHints(query, props.data?.series || []).filter((hint) => hint.fix?.action);
+    const promQuery = { expr: props.query.expr, refId: props.query.refId };
+    const hints = props.datasource
+      .getQueryHints(promQuery, props.data?.series || [])
+      .filter((hint) => hint.fix?.action);
     setHints(hints);
-  }, [props.datasource, props.data, props.query]);
+  }, [datasource, data, query]);
 
   return (
     <>

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { PromQueryEditorProps } from '../../components/types';
+import { QueryHint } from '@grafana/data';
+import { Button, Tooltip } from '@grafana/ui';
+import { reportInteraction } from '@grafana/runtime';
+
+export function QueryEditorHints(props: PromQueryEditorProps) {
+  const [hints, setHints] = useState<QueryHint[]>([]);
+
+  useEffect(() => {
+    const query = { expr: props.query.expr, refId: props.query.refId };
+    const hints = props.datasource.getQueryHints(query, props.data?.series || []).filter((hint) => hint.fix?.action);
+    setHints(hints);
+  }, [props.datasource, props.data, props.query]);
+
+  return (
+    <>
+      {hints.length > 0 && (
+        <div>
+          {hints.map((hint) => {
+            return (
+              <Tooltip content={`${hint.label} ${hint.fix?.label}`} key={hint.type}>
+                <Button
+                  onClick={() => {
+                    reportInteraction('grafana_query_builder_hints_clicked', {
+                      hint: hint.type,
+                      datasourceType: props.datasource.type,
+                    });
+
+                    if (hint.fix?.action) {
+                      const newQuery = props.datasource.modifyQuery(props.query, hint.fix.action);
+                      return props.onChange(newQuery);
+                    }
+                  }}
+                  fill="outline"
+                  size="sm"
+                >
+                  hint: {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
+                </Button>
+              </Tooltip>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
+QueryEditorHints.displayName = 'QueryEditorHints';

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
@@ -22,21 +22,7 @@ export function QueryEditorHints(props: PromQueryEditorProps) {
           {hints.map((hint) => {
             return (
               <Tooltip content={`${hint.label} ${hint.fix?.label}`} key={hint.type}>
-                <Button
-                  onClick={() => {
-                    reportInteraction('grafana_query_builder_hints_clicked', {
-                      hint: hint.type,
-                      datasourceType: props.datasource.type,
-                    });
-
-                    if (hint.fix?.action) {
-                      const newQuery = props.datasource.modifyQuery(props.query, hint.fix.action);
-                      return props.onChange(newQuery);
-                    }
-                  }}
-                  fill="outline"
-                  size="sm"
-                >
+                <Button onClick={() => onHintButtonClick(hint, props)} fill="outline" size="sm">
                   hint: {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
                 </Button>
               </Tooltip>
@@ -46,4 +32,16 @@ export function QueryEditorHints(props: PromQueryEditorProps) {
       )}
     </>
   );
+}
+
+function onHintButtonClick(hint: QueryHint, props: PromQueryEditorProps) {
+  reportInteraction('grafana_query_builder_hints_clicked', {
+    hint: hint.type,
+    datasourceType: props.datasource.type,
+  });
+
+  if (hint.fix?.action) {
+    const newQuery = props.datasource.modifyQuery(props.query, hint.fix.action);
+    return props.onChange(newQuery);
+  }
 }

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryEditorHints.tsx
@@ -1,31 +1,31 @@
+import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 
-import { QueryHint } from '@grafana/data';
+import { GrafanaTheme2, QueryHint } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Button, Tooltip } from '@grafana/ui';
+import { Button, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { PromQueryEditorProps } from '../../components/types';
 
 export function QueryEditorHints(props: PromQueryEditorProps) {
   const [hints, setHints] = useState<QueryHint[]>([]);
   const { query, data, datasource } = props;
+  const styles = useStyles2(getStyles);
 
   useEffect(() => {
-    const promQuery = { expr: props.query.expr, refId: props.query.refId };
-    const hints = props.datasource
-      .getQueryHints(promQuery, props.data?.series || [])
-      .filter((hint) => hint.fix?.action);
+    const promQuery = { expr: query.expr, refId: query.refId };
+    const hints = datasource.getQueryHints(promQuery, data?.series || []).filter((hint) => hint.fix?.action);
     setHints(hints);
   }, [datasource, data, query]);
 
   return (
     <>
       {hints.length > 0 && (
-        <div>
+        <div className={styles.container}>
           {hints.map((hint) => {
             return (
               <Tooltip content={`${hint.label} ${hint.fix?.label}`} key={hint.type}>
-                <Button onClick={() => onHintButtonClick(hint, props)} fill="outline" size="sm">
+                <Button onClick={() => onHintButtonClick(hint, props)} fill="outline" size="sm" className={styles.hint}>
                   hint: {hint.fix?.title || hint.fix?.action?.type.toLowerCase().replace('_', ' ')}
                 </Button>
               </Tooltip>
@@ -48,3 +48,16 @@ function onHintButtonClick(hint: QueryHint, props: PromQueryEditorProps) {
     return props.onChange(newQuery);
   }
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      display: 'flex',
+      alignItems: 'start',
+    }),
+    hint: css({
+      marginRight: theme.spacing(1),
+      padEnd: theme.spacing(2),
+    }),
+  };
+};


### PR DESCRIPTION
**What is this feature?**

Adds hints to Prometheus Native Histogram in Code Editor mode

**Why do we need this feature?**

We already have the hints in query builder in Prometheus. This PR adds the same to Code Editor too.

**Who is this feature for?**

Prometheus plugin users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #88564

**Special notes for your reviewer:**

Please refer to #87017 on how to replicate this in local.

Here is the video of it working on my local

https://github.com/grafana/grafana/assets/36930204/84c742a6-806c-458a-9cbc-ab545f0d5c61


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
