### PR TITLE
VizPanelManager: Adapt color palete after plugin change

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^5.3.0",
+    "@grafana/scenes": "^5.3.1",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^5.3.1",
+    "@grafana/scenes": "5.3.2",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -9,6 +9,7 @@ import {
   GrafanaTheme2,
   PanelModel,
   filterFieldConfigOverrides,
+  getPanelOptionsWithDefaults,
   isStandardFieldProp,
   restoreCustomOverrideRules,
 } from '@grafana/data';
@@ -203,6 +204,18 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     }
   }
 
+  public applyPluginOptionDefaults(plugin: PanelPlugin, isAfterPluginChange: boolean) {
+    const options = getPanelOptionsWithDefaults({
+      plugin,
+      currentOptions: this.options,
+      currentFieldConfig: this.fieldConfig,
+      isAfterPluginChange: isAfterPluginChange,
+    });
+
+    this.fieldConfig = options.fieldConfig;
+    this.options = options.options;
+  }
+
   public changePluginType(pluginId: string) {
     const {
       options: prevOptions,
@@ -267,8 +280,9 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     };
 
     const newOptions = newPlugin?.onPanelTypeChanged?.(panel, prevPluginId, prevOptions, prevFieldConfig);
+
     if (newOptions) {
-      newPanel.onOptionsChange(newOptions, true);
+      newPanel.onOptionsChange(newOptions, true, true);
     }
 
     if (newPlugin?.onPanelMigration) {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -9,7 +9,6 @@ import {
   GrafanaTheme2,
   PanelModel,
   filterFieldConfigOverrides,
-  getPanelOptionsWithDefaults,
   isStandardFieldProp,
   restoreCustomOverrideRules,
 } from '@grafana/data';

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -204,18 +204,6 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     }
   }
 
-  public applyPluginOptionDefaults(plugin: PanelPlugin, isAfterPluginChange: boolean) {
-    const options = getPanelOptionsWithDefaults({
-      plugin,
-      currentOptions: this.options,
-      currentFieldConfig: this.fieldConfig,
-      isAfterPluginChange: isAfterPluginChange,
-    });
-
-    this.fieldConfig = options.fieldConfig;
-    this.options = options.options;
-  }
-
   public changePluginType(pluginId: string) {
     const {
       options: prevOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,9 +3580,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "@grafana/scenes@npm:5.3.1"
+"@grafana/scenes@npm:5.3.2":
+  version: 5.3.2
+  resolution: "@grafana/scenes@npm:5.3.2"
   dependencies:
     "@grafana/e2e-selectors": "npm:^11.0.0"
     "@leeoniya/ufuzzy": "npm:^1.0.14"
@@ -3597,7 +3597,7 @@ __metadata:
     "@grafana/ui": ^10.4.1
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/483e1899dbca3756e25a30d170653c53a21f6224e338a9e884e3651397a8d9ba402b5d4c87e202555cf7d8f716fef83b95ed6c4ef771f9cdf9c2f1cd4e368819
+  checksum: 10/90d2dd3b6daa293589a8933de8169d51814956ab4b425d2b5f750b3d504080944373345bce84e6a18a28260cc6fd9bf58c4e4046092a87d8ff0104b085f63e6d
   languageName: node
   linkType: hard
 
@@ -17145,7 +17145,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^5.3.1"
+    "@grafana/scenes": "npm:5.3.2"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,9 +3580,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "@grafana/scenes@npm:5.3.0"
+"@grafana/scenes@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@grafana/scenes@npm:5.3.1"
   dependencies:
     "@grafana/e2e-selectors": "npm:^11.0.0"
     "@leeoniya/ufuzzy": "npm:^1.0.14"
@@ -3597,7 +3597,7 @@ __metadata:
     "@grafana/ui": ^10.4.1
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/625b7e009af1b79de8903eb2fbe9e2da3558e229d51e532bbb385bc72c316f9a5df9e1e81caff49e3b245dd1e00a019331f4ce11cdd980fe112917992c80c3c2
+  checksum: 10/483e1899dbca3756e25a30d170653c53a21f6224e338a9e884e3651397a8d9ba402b5d4c87e202555cf7d8f716fef83b95ed6c4ef771f9cdf9c2f1cd4e368819
   languageName: node
   linkType: hard
 
@@ -17145,7 +17145,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^5.3.0"
+    "@grafana/scenes": "npm:^5.3.1"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
Depends on https://github.com/grafana/scenes/pull/805

**Problem**
When creating a chart, the time series chart is always selected by default. That chart uses a classic palette as the default color strategy.
When changing to Gauge, this chart uses the thresholds strategy as the plugin recommended strategy, but it won't be applied, if the flag doesn't indicate this option change is caused by a plugin change.

**Solution**
When changing the plugin type, the field options must be recomputed with the new plugin. This implies recalculating the optimal color strategy.

