### PR TITLE
SAML: Update `access_token_url`

### DIFF
--- a/pkg/services/ssosettings/strategies/saml_strategy.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy.go
@@ -32,6 +32,7 @@ func (s *SAMLStrategy) GetProviderConfig(_ context.Context, provider string) (ma
 func (s *SAMLStrategy) loadSAMLSettings() map[string]any {
 	section := s.settingsProvider.Section("auth.saml")
 	result := map[string]any{
+		"access_token_url":           section.KeyValue("access_token_url").MustString(""),
 		"enabled":                    section.KeyValue("enabled").MustBool(false),
 		"single_logout":              section.KeyValue("single_logout").MustBool(false),
 		"allow_sign_up":              section.KeyValue("allow_sign_up").MustBool(false),
@@ -65,7 +66,6 @@ func (s *SAMLStrategy) loadSAMLSettings() map[string]any {
 		"skip_org_role_sync":         section.KeyValue("skip_org_role_sync").MustBool(false),
 		"client_id":                  section.KeyValue("client_id").MustString(""),
 		"client_secret":              section.KeyValue("client_secret").MustString(""),
-		"token_url":                  section.KeyValue("token_url").MustString(""),
 		"force_use_graph_api":        section.KeyValue("force_use_graph_api").MustBool(false),
 	}
 	return result

--- a/pkg/services/ssosettings/strategies/saml_strategy_test.go
+++ b/pkg/services/ssosettings/strategies/saml_strategy_test.go
@@ -16,6 +16,7 @@ var (
 	[auth.saml]
 	enabled = true
 	single_logout = true
+	access_token_url = http://localhost:8086/auth/realms/grafana/protocol/openid-connect/token
 	allow_sign_up = true
 	auto_login = false
 	certificate = devenv/docker/blocks/auth/saml-enterprise/cert.crt
@@ -45,7 +46,6 @@ var (
 	name_id_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
 	skip_org_role_sync = false
 	role_values_none = guest disabled
-	token_url = http://localhost:8086/auth/realms/grafana/protocol/openid-connect/token
 	client_id = grafana
 	client_secret = grafana
 	force_use_graph_api = false
@@ -83,7 +83,7 @@ var (
 		"name_id_format":             "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
 		"skip_org_role_sync":         false,
 		"role_values_none":           "guest disabled",
-		"token_url":                  "http://localhost:8086/auth/realms/grafana/protocol/openid-connect/token",
+		"access_token_url":           "http://localhost:8086/auth/realms/grafana/protocol/openid-connect/token",
 		"client_id":                  "grafana",
 		"client_secret":              "grafana",
 		"force_use_graph_api":        false,


### PR DESCRIPTION
**What is this feature?**

Update the variable used to resolve the URL for the access token. Used by SAML integrations.

**Why do we need this feature?**

An incomplete rename was done, the system was unable to resolve the url.

**Who is this feature for?**

IAM

[Enterprise PR](https://github.com/grafana/grafana-enterprise/pull/6817)