### PR TITLE
Keybinds E2E: simplify keybinds e2e even further

### DIFF
--- a/e2e/scenes/various-suite/keybinds.spec.ts
+++ b/e2e/scenes/various-suite/keybinds.spec.ts
@@ -60,11 +60,5 @@ describe.skip('Keyboard shortcuts', () => {
     e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     expectedRange = `Time range selected: 2024-06-05 10:04:00 to 2024-06-05 10:05:00`; // 1 min back
     e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
-
-    cy.log('Trying one shift-right');
-    cy.get('body').type('t{rightarrow}');
-    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
-    expectedRange = `Time range selected: 2024-06-05 10:05:00 to 2024-06-05 10:06:00`; // 1 min forward
-    e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
   });
 });

--- a/e2e/various-suite/keybinds.spec.ts
+++ b/e2e/various-suite/keybinds.spec.ts
@@ -61,11 +61,5 @@ describe('Keyboard shortcuts', () => {
     e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
     expectedRange = `Time range selected: 2024-06-05 10:04:00 to 2024-06-05 10:05:00`; // 1 min back
     e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
-
-    cy.log('Trying one shift-right');
-    cy.get('body').type('t{rightarrow}');
-    e2e.components.RefreshPicker.runButtonV2().should('have.text', 'Run query');
-    expectedRange = `Time range selected: 2024-06-05 10:05:00 to 2024-06-05 10:06:00`; // 1 min forward
-    e2e.components.TimePicker.openButton().should('have.attr', 'aria-label', expectedRange);
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- simplifies the keybinds e2e test even further
  - have seen further failures, e.g. https://drone.grafana.net/grafana/grafana/185144/6/19

**Why do we need this feature?**

- this is still flakey

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
