### PR TITLE
Loki datasource: interpolate query before adding adhoc filters

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -290,7 +290,7 @@ describe('LokiDatasource', () => {
           value: 'v2',
         },
       ];
-      ds.applyTemplateVariables(query, {}, adhocFilters)
+      ds.applyTemplateVariables(query, {}, adhocFilters);
       expect(templateSrv.replace).toHaveBeenCalledWith(query.expr, expect.any(Object), expect.any(Function));
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -35,6 +35,7 @@ import {
 import { LokiVariableSupport } from './LokiVariableSupport';
 import { createLokiDatasource } from './__mocks__/datasource';
 import { createMetadataRequest } from './__mocks__/metadataRequest';
+import { placeHolderScopedVars } from './components/monaco-query-field/monaco-completion-provider/validation';
 import { LokiDatasource, REF_ID_DATA_SAMPLES } from './datasource';
 import { runSplitQuery } from './querySplitting';
 import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, SupportingQueryType } from './types';
@@ -270,6 +271,28 @@ describe('LokiDatasource', () => {
       expect(ds.applyTemplateVariables(query, {}, adhocFilters).expr).toBe(
         'rate({bar="baz", job="foo", k1=~"v.*", k2=~"v\\\\\'.*"} |= "bar" [5m])'
       );
+    });
+
+    it('should interpolate before adding adhoc filters', async () => {
+      const templateSrv = {
+        replace: jest.fn().mockImplementation((input: string) => input),
+        getVariables: () => [],
+      };
+      const ds = createLokiDatasource(templateSrv);
+      const adhocFilters = [
+        {
+          key: 'k1',
+          operator: '=',
+          value: 'v1',
+        },
+        {
+          key: 'k2',
+          operator: '!=',
+          value: 'v2',
+        },
+      ];
+      ds.applyTemplateVariables(query, {}, adhocFilters)
+      expect(templateSrv.replace).toHaveBeenCalledWith(query.expr, expect.any(Object), expect.any(Function));
     });
   });
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -35,7 +35,6 @@ import {
 import { LokiVariableSupport } from './LokiVariableSupport';
 import { createLokiDatasource } from './__mocks__/datasource';
 import { createMetadataRequest } from './__mocks__/metadataRequest';
-import { placeHolderScopedVars } from './components/monaco-query-field/monaco-completion-provider/validation';
 import { LokiDatasource, REF_ID_DATA_SAMPLES } from './datasource';
 import { runSplitQuery } from './querySplitting';
 import { LokiOptions, LokiQuery, LokiQueryType, LokiVariableQueryType, SupportingQueryType } from './types';

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -1089,8 +1089,6 @@ export class LokiDatasource
     // alerting/ML queries and we want to have consistent interpolation for all queries
     const { __auto, __interval, __interval_ms, __range, __range_s, __range_ms, ...rest } = scopedVars || {};
 
-    const exprWithAdHoc = this.addAdHocFilters(target.expr, adhocFilters);
-
     const variables = {
       ...rest,
 
@@ -1102,10 +1100,13 @@ export class LokiDatasource
         value: '$__interval_ms',
       },
     };
+
+    const exprWithAdHoc = this.addAdHocFilters(this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr), adhocFilters)
+
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
-      expr: this.templateSrv.replace(exprWithAdHoc, variables, this.interpolateQueryExpr),
+      expr: exprWithAdHoc,
     };
   }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -1101,7 +1101,10 @@ export class LokiDatasource
       },
     };
 
-    const exprWithAdHoc = this.addAdHocFilters(this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr), adhocFilters)
+    const exprWithAdHoc = this.addAdHocFilters(
+      this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr),
+      adhocFilters
+    );
 
     return {
       ...target,


### PR DESCRIPTION
While working in Explore Logs, @cyriltovena noticed an unexpected behavior with adhoc filters and queries, where `modifyQuery` was receiving queries like 

> quantile_over_time(0.5, __V_2__filters__V__ __V_2__patterns__V__ __V_2__logsFormat__V__ __V_2__fields__V__ __V_2__lineFilter__V__ | unwrap caller [__V_0____auto__V__]) by (detected_level,eventType,component,level,msg)

and incorrectly producing 

> quantile_over_time(0.5, {service_name=`distributor`}   | logfmt   | unwrap caller [$__auto]) by (detected_level,{eventType\"\", component\"\", level\"\", msg)\"\", service_name=\"distributor\"}

The reason for the error, besides receiving a non-interpolated query, was that the parser was hallucinating that there was a selector around the characters in the aggregation, which only seems to happen when it tries to parse that amount of gibberish.

![imagen](https://github.com/grafana/grafana/assets/1069378/6d37788e-f666-4a43-bda5-593784f9212f)

For other queries it had less chances of failing because it would return early here https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/modifyQuery.ts#L158-L161

### How to reproduce

With Explore Logs:

- Use this branch in Grafana
- Run Explore Logs as a plugin
- Look at executed query, interpolation should be correct and the added filters should be present in the queries
- Alternatively, log what `modifyQuery` receives, it should be an interpolated query and not a collection of placeholders.