### PR TITLE
Chore: Update DataViz github automation

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -373,14 +373,6 @@
   },
   {
     "type": "label",
-    "name": "area/panel/icon",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
-    "type": "label",
     "name": "area/panel/piechart",
     "action": "addToProject",
     "addToProject": {
@@ -438,6 +430,22 @@
   {
     "type": "label",
     "name": "area/panel/table",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/tooltip",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/legend",
     "action": "addToProject",
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/56"

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,198 +1,198 @@
 [
   {
-    "type":"label",
-    "name":"bot/question",
-    "addLabel":"type/question",
-    "removeLabel":"bot/question",
-    "action":"close",
-    "comment":"Please ask your question on [community.grafana.com/](https://community.grafana.com/). To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "type": "label",
+    "name": "bot/question",
+    "addLabel": "type/question",
+    "removeLabel": "bot/question",
+    "action": "close",
+    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/). To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
-    "type":"comment",
-    "name":"duplicate",
-    "allowUsers":[],
-    "action":"close",
-    "addLabel":"type/duplicate"
+    "type": "comment",
+    "name": "duplicate",
+    "allowUsers": [],
+    "action": "close",
+    "addLabel": "type/duplicate"
   },
   {
-    "type":"label",
-    "name":"bot/duplicate",
-    "addLabel":"type/duplicate",
-    "removeLabel":"bot/duplicate",
-    "action":"close",
-    "comment":"Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue.\n\nTo avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "type": "label",
+    "name": "bot/duplicate",
+    "addLabel": "type/duplicate",
+    "removeLabel": "bot/duplicate",
+    "action": "close",
+    "comment": "Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue.\n\nTo avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
-    "type":"comment",
-    "name":"needsMoreInfo",
-    "allowUsers":[],
-    "action":"updateLabels",
-    "addLabel":"bot/needs more info"
+    "type": "comment",
+    "name": "needsMoreInfo",
+    "allowUsers": [],
+    "action": "updateLabels",
+    "addLabel": "bot/needs more info"
   },
   {
-    "type":"label",
-    "name":"bot/needs more info",
-    "action":"updateLabels",
-    "addLabel":"needs more info",
-    "removeLabel":"bot/needs more info",
-    "comment":"Thanks for creating this issue! We think it's missing some basic information. \r\n\r\nFollow the issue template and add additional information that will help us replicate the problem. \r\nFor data visualization issues: \r\n- Query results from the inspect drawer (data tab & query inspector)\r\n- Panel settings can be extracted in the panel inspect drawer JSON tab\r\n\r\nFor dashboard related issues: \r\n- Dashboard JSON can be found in the dashboard settings JSON model view\r\n\r\nFor authentication, provisioning and alerting issues, Grafana server logs are useful. \r\n\r\nHappy graphing!"
+    "type": "label",
+    "name": "bot/needs more info",
+    "action": "updateLabels",
+    "addLabel": "needs more info",
+    "removeLabel": "bot/needs more info",
+    "comment": "Thanks for creating this issue! We think it's missing some basic information. \r\n\r\nFollow the issue template and add additional information that will help us replicate the problem. \r\nFor data visualization issues: \r\n- Query results from the inspect drawer (data tab & query inspector)\r\n- Panel settings can be extracted in the panel inspect drawer JSON tab\r\n\r\nFor dashboard related issues: \r\n- Dashboard JSON can be found in the dashboard settings JSON model view\r\n\r\nFor authentication, provisioning and alerting issues, Grafana server logs are useful. \r\n\r\nHappy graphing!"
   },
   {
-    "type":"label",
-    "name":"bot/no new info",
-    "action":"close",
-    "removeLabel":"needs more info",
-    "comment":"We've closed this issue since it needs more information and hasn't had any activity recently. We can re-open it after you you add more information. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "type": "label",
+    "name": "bot/no new info",
+    "action": "close",
+    "removeLabel": "needs more info",
+    "comment": "We've closed this issue since it needs more information and hasn't had any activity recently. We can re-open it after you you add more information. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
-    "type":"label",
-    "name":"bot/close feature request",
-    "action":"close",
-    "addLabel":"not implemented",
-    "comment":"This feature request has been open for a long time with few received upvotes or comments, so we are closing it. We're trying to limit open GitHub issues in order to better track planned work and features.  \r\n\r\nThis doesn't mean that we'll never ever implement it or that we will never accept a PR for it. A closed issue can still attract upvotes and act as a ticket to track feature demand\/interest. \r\n\r\nThank You to you for taking the time to create this issue!"
+    "type": "label",
+    "name": "bot/close feature request",
+    "action": "close",
+    "addLabel": "not implemented",
+    "comment": "This feature request has been open for a long time with few received upvotes or comments, so we are closing it. We're trying to limit open GitHub issues in order to better track planned work and features.  \r\n\r\nThis doesn't mean that we'll never ever implement it or that we will never accept a PR for it. A closed issue can still attract upvotes and act as a ticket to track feature demand\/interest. \r\n\r\nThank You to you for taking the time to create this issue!"
   },
   {
-    "type":"label",
-    "name":"area/plugins-catalog",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/76"
+    "type": "label",
+    "name": "area/plugins-catalog",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/76"
     }
   },
   {
-    "type":"label",
-    "name":"type/docs",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/69"
+    "type": "label",
+    "name": "type/docs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/69"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Azure",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/190"
+    "type": "label",
+    "name": "datasource/Azure",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/CloudWatch",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/97"
+    "type": "label",
+    "name": "datasource/CloudWatch",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/CloudWatch Logs",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/97"
+    "type": "label",
+    "name": "datasource/CloudWatch Logs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/GoogleCloudMonitoring",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/190"
+    "type": "label",
+    "name": "datasource/GoogleCloudMonitoring",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Prometheus",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/112"
+    "type": "label",
+    "name": "datasource/Prometheus",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/112"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/InfluxDB",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/190"
+    "type": "label",
+    "name": "datasource/InfluxDB",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Graphite",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/190"
+    "type": "label",
+    "name": "datasource/Graphite",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/OpenTSDB",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/190"
+    "type": "label",
+    "name": "datasource/OpenTSDB",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Loki",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/203"
+    "type": "label",
+    "name": "datasource/Loki",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/203"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Tempo",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/221"
+    "type": "label",
+    "name": "datasource/Tempo",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/grafana-pyroscope",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/221"
+    "type": "label",
+    "name": "datasource/grafana-pyroscope",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Parca",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/221"
+    "type": "label",
+    "name": "datasource/Parca",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Elasticsearch",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/203"
+    "type": "label",
+    "name": "datasource/Elasticsearch",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/203"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Jaeger",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/221"
+    "type": "label",
+    "name": "datasource/Jaeger",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type":"label",
-    "name":"datasource/Zipkin",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/221"
+    "type": "label",
+    "name": "datasource/Zipkin",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type":"label",
-    "name":"area/explore",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/111"
+    "type": "label",
+    "name": "area/explore",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/111"
     }
   },
   {
@@ -440,10 +440,10 @@
     "name": "area/panel/table",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/72"
+      "url": "https://github.com/orgs/grafana/projects/56"
     }
   },
-   {
+  {
     "type": "label",
     "name": "grafana program",
     "action": "addToProject",

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1,198 +1,198 @@
 [
   {
-    "type": "label",
-    "name": "bot/question",
-    "addLabel": "type/question",
-    "removeLabel": "bot/question",
-    "action": "close",
-    "comment": "Please ask your question on [community.grafana.com/](https://community.grafana.com/). To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "type":"label",
+    "name":"bot/question",
+    "addLabel":"type/question",
+    "removeLabel":"bot/question",
+    "action":"close",
+    "comment":"Please ask your question on [community.grafana.com/](https://community.grafana.com/). To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
-    "type": "comment",
-    "name": "duplicate",
-    "allowUsers": [],
-    "action": "close",
-    "addLabel": "type/duplicate"
+    "type":"comment",
+    "name":"duplicate",
+    "allowUsers":[],
+    "action":"close",
+    "addLabel":"type/duplicate"
   },
   {
-    "type": "label",
-    "name": "bot/duplicate",
-    "addLabel": "type/duplicate",
-    "removeLabel": "bot/duplicate",
-    "action": "close",
-    "comment": "Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue.\n\nTo avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "type":"label",
+    "name":"bot/duplicate",
+    "addLabel":"type/duplicate",
+    "removeLabel":"bot/duplicate",
+    "action":"close",
+    "comment":"Thanks for creating this issue! It looks like this has already been reported by another user. We’ve closed this in favor of the existing one. Please consider adding any details you think is missing to that issue.\n\nTo avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
-    "type": "comment",
-    "name": "needsMoreInfo",
-    "allowUsers": [],
-    "action": "updateLabels",
-    "addLabel": "bot/needs more info"
+    "type":"comment",
+    "name":"needsMoreInfo",
+    "allowUsers":[],
+    "action":"updateLabels",
+    "addLabel":"bot/needs more info"
   },
   {
-    "type": "label",
-    "name": "bot/needs more info",
-    "action": "updateLabels",
-    "addLabel": "needs more info",
-    "removeLabel": "bot/needs more info",
-    "comment": "Thanks for creating this issue! We think it's missing some basic information. \r\n\r\nFollow the issue template and add additional information that will help us replicate the problem. \r\nFor data visualization issues: \r\n- Query results from the inspect drawer (data tab & query inspector)\r\n- Panel settings can be extracted in the panel inspect drawer JSON tab\r\n\r\nFor dashboard related issues: \r\n- Dashboard JSON can be found in the dashboard settings JSON model view\r\n\r\nFor authentication, provisioning and alerting issues, Grafana server logs are useful. \r\n\r\nHappy graphing!"
+    "type":"label",
+    "name":"bot/needs more info",
+    "action":"updateLabels",
+    "addLabel":"needs more info",
+    "removeLabel":"bot/needs more info",
+    "comment":"Thanks for creating this issue! We think it's missing some basic information. \r\n\r\nFollow the issue template and add additional information that will help us replicate the problem. \r\nFor data visualization issues: \r\n- Query results from the inspect drawer (data tab & query inspector)\r\n- Panel settings can be extracted in the panel inspect drawer JSON tab\r\n\r\nFor dashboard related issues: \r\n- Dashboard JSON can be found in the dashboard settings JSON model view\r\n\r\nFor authentication, provisioning and alerting issues, Grafana server logs are useful. \r\n\r\nHappy graphing!"
   },
   {
-    "type": "label",
-    "name": "bot/no new info",
-    "action": "close",
-    "removeLabel": "needs more info",
-    "comment": "We've closed this issue since it needs more information and hasn't had any activity recently. We can re-open it after you you add more information. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
+    "type":"label",
+    "name":"bot/no new info",
+    "action":"close",
+    "removeLabel":"needs more info",
+    "comment":"We've closed this issue since it needs more information and hasn't had any activity recently. We can re-open it after you you add more information. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {
-    "type": "label",
-    "name": "bot/close feature request",
-    "action": "close",
-    "addLabel": "not implemented",
-    "comment": "This feature request has been open for a long time with few received upvotes or comments, so we are closing it. We're trying to limit open GitHub issues in order to better track planned work and features.  \r\n\r\nThis doesn't mean that we'll never ever implement it or that we will never accept a PR for it. A closed issue can still attract upvotes and act as a ticket to track feature demand\/interest. \r\n\r\nThank You to you for taking the time to create this issue!"
+    "type":"label",
+    "name":"bot/close feature request",
+    "action":"close",
+    "addLabel":"not implemented",
+    "comment":"This feature request has been open for a long time with few received upvotes or comments, so we are closing it. We're trying to limit open GitHub issues in order to better track planned work and features.  \r\n\r\nThis doesn't mean that we'll never ever implement it or that we will never accept a PR for it. A closed issue can still attract upvotes and act as a ticket to track feature demand\/interest. \r\n\r\nThank You to you for taking the time to create this issue!"
   },
   {
-    "type": "label",
-    "name": "area/plugins-catalog",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/76"
+    "type":"label",
+    "name":"area/plugins-catalog",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/76"
     }
   },
   {
-    "type": "label",
-    "name": "type/docs",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/69"
+    "type":"label",
+    "name":"type/docs",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/69"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Azure",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/190"
+    "type":"label",
+    "name":"datasource/Azure",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/CloudWatch",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/97"
+    "type":"label",
+    "name":"datasource/CloudWatch",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/97"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/CloudWatch Logs",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/97"
+    "type":"label",
+    "name":"datasource/CloudWatch Logs",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/97"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/GoogleCloudMonitoring",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/190"
+    "type":"label",
+    "name":"datasource/GoogleCloudMonitoring",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Prometheus",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/112"
+    "type":"label",
+    "name":"datasource/Prometheus",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/112"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/InfluxDB",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/190"
+    "type":"label",
+    "name":"datasource/InfluxDB",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Graphite",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/190"
+    "type":"label",
+    "name":"datasource/Graphite",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/OpenTSDB",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/190"
+    "type":"label",
+    "name":"datasource/OpenTSDB",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Loki",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/203"
+    "type":"label",
+    "name":"datasource/Loki",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/203"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Tempo",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+    "type":"label",
+    "name":"datasource/Tempo",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/grafana-pyroscope",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+    "type":"label",
+    "name":"datasource/grafana-pyroscope",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Parca",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+    "type":"label",
+    "name":"datasource/Parca",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Elasticsearch",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/203"
+    "type":"label",
+    "name":"datasource/Elasticsearch",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/203"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Jaeger",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+    "type":"label",
+    "name":"datasource/Jaeger",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type": "label",
-    "name": "datasource/Zipkin",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+    "type":"label",
+    "name":"datasource/Zipkin",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
-    "type": "label",
-    "name": "area/explore",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/111"
+    "type":"label",
+    "name":"area/explore",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/111"
     }
   },
   {

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -2,8 +2,8 @@
   {
     "type": "changedfiles",
     "matches": [
-      "docs/**/*",
-      "contribute/**/*"
+        "docs/**/*",
+        "contribute/**/*"
     ],
     "action": "updateLabel",
     "addLabel": "type/docs"
@@ -11,21 +11,21 @@
   {
     "type": "changedfiles",
     "matches": [
-      "public/**/*",
-      "packages/**/*",
-      "e2e/**/*",
-      "plugins-bundled/**/*",
-      "scripts/build/release-packages.sh",
-      "scripts/circle-release-next-packages.sh",
-      "scripts/ci-frontend-metrics.sh",
-      "scripts/grunt/**/*",
-      "scripts/webpack/**/*",
-      "package.json",
-      "tsconfig.json",
-      "lerna.json",
-      ".prettierrc.js",
-      ".eslintrc",
-      "**/*.mdx"
+        "public/**/*",
+        "packages/**/*",
+        "e2e/**/*",
+        "plugins-bundled/**/*",
+        "scripts/build/release-packages.sh",
+        "scripts/circle-release-next-packages.sh",
+        "scripts/ci-frontend-metrics.sh",
+        "scripts/grunt/**/*",
+        "scripts/webpack/**/*",
+        "package.json",
+        "tsconfig.json",
+        "lerna.json",
+        ".prettierrc.js",
+        ".eslintrc",
+        "**/*.mdx"
     ],
     "action": "updateLabel",
     "addLabel": "area/frontend"
@@ -33,11 +33,11 @@
   {
     "type": "changedfiles",
     "matches": [
-      "**/*.go",
-      "go.mod",
-      "go.sum",
-      "contribute/style-guides/backend.md",
-      "contribute/architecture/backend/**/*"
+        "**/*.go",
+        "go.mod",
+        "go.sum",
+        "contribute/style-guides/backend.md",
+        "contribute/architecture/backend/**/*"
     ],
     "action": "updateLabel",
     "addLabel": "area/backend"
@@ -45,17 +45,15 @@
   {
     "type": "changedfiles",
     "matches": [
-      "pkg/services/sqlstore/migrations/**/*",
-      "**/*_mig.go"
+        "pkg/services/sqlstore/migrations/**/*",
+        "**/*_mig.go"
     ],
     "action": "updateLabel",
     "addLabel": "area/backend/db/migration"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/features/explore/**/*"
-    ],
+    "matches": [ "public/app/features/explore/**/*"],
     "action": "updateLabel",
     "addLabel": "area/explore"
   },
@@ -84,348 +82,246 @@
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/azuremonitor/**/*",
-      "pkg/tsdb/azuremonitor/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/azuremonitor/**/*", "pkg/tsdb/azuremonitor/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Azure"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/cloud-monitoring/**/*",
-      "pkg/tsdb/cloud-monitoring/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/cloud-monitoring/**/*", "pkg/tsdb/cloud-monitoring/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/GoogleCloudMonitoring"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/cloudwatch/**/*",
-      "pkg/tsdb/cloudwatch/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/cloudwatch/**/*", "pkg/tsdb/cloudwatch/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/CloudWatch"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/elasticsearch/**/*",
-      "pkg/tsdb/elasticsearch/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/elasticsearch/**/*", "pkg/tsdb/elasticsearch/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Elasticsearch"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/graphite/**/*",
-      "pkg/tsdb/graphite/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/graphite/**/*", "pkg/tsdb/graphite/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Graphite"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/influxdb/**/*",
-      "pkg/tsdb/influx/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/influxdb/**/*", "pkg/tsdb/influx/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/InfluxDB"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/jaeger/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/jaeger/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Jaeger"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/loki/**/*",
-      "pkg/tsdb/loki/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/loki/**/*", "pkg/tsdb/loki/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Loki"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/mssql/**/*",
-      "pkg/tsdb/mssql/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/mssql/**/*", "pkg/tsdb/mssql/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/MSSQL"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/mysql/**/*",
-      "pkg/tsdb/mysql/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/mysql/**/*", "pkg/tsdb/mysql/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/MySQL"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/opentsdb/**/*",
-      "pkg/tsdb/opentsdb/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/opentsdb/**/*", "pkg/tsdb/opentsdb/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/OpenTSDB"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/parca/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/parca/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Parca"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*",
-      "pkg/tsdb/grafana-pyroscope-datasource/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*", "pkg/tsdb/grafana-pyroscope-datasource/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/grafana-pyroscope"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/grafana-postgresql-datasource/**/*",
-      "pkg/tsdb/grafana-postgresql-datasource/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/grafana-postgresql-datasource/**/*", "pkg/tsdb/grafana-postgresql-datasource/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Postgres"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/prometheus/**/*",
-      "pkg/tsdb/prometheus/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/prometheus/**/*", "pkg/tsdb/prometheus/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Prometheus"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/tempo/**/*",
-      "pkg/tsdb/tempo/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/tempo/**/*", "pkg/tsdb/tempo/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Tempo"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/datasource/zipkin/**/*"
-    ],
+    "matches": [ "public/app/plugins/datasource/zipkin/**/*"],
     "action": "updateLabel",
     "addLabel": "datasource/Zipkin"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/features/variables/**/*",
-      "public/app/features/templating/**/*"
-    ],
+    "matches": ["public/app/features/variables/**/*", "public/app/features/templating/**/*"],
     "action": "updateLabel",
     "addLabel": "area/dashboard/templating"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "/pkg/services/ngalert/**/*",
-      "/pkg/services/sqlstore/migrations/ualert/**/*",
-      "/pkg/services/alerting/**/*",
-      "/public/app/features/alerting/**/*",
-      "/pkg/tests/api/alerting/**/*"
-    ],
+    "matches": ["/pkg/services/ngalert/**/*", "/pkg/services/sqlstore/migrations/ualert/**/*", "/pkg/services/alerting/**/*", "/public/app/features/alerting/**/*", "/pkg/tests/api/alerting/**/*"],
     "action": "updateLabel",
     "addLabel": "area/alerting"
   },
   {
     "type": "author",
     "name": "pr/external",
-    "notMemberOf": {
-      "org": "grafana"
-    },
-    "ignoreList": [
-      "renovate[bot]",
-      "dependabot[bot]",
-      "grafana-delivery-bot[bot]",
-      "grafanabot"
-    ],
+    "notMemberOf": { "org": "grafana" },
+    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   },
   {
-    "type": "label",
-    "name": "type/docs",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/69"
+    "type":"label",
+    "name":"type/docs",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/69"
     }
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/candlestick/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/candlestick/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/candlestick"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/canvas/**/*",
-      "/public/app/features/canvas/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/canvas/**/*", "/public/app/features/canvas/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/canvas"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/barchart/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/barchart/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/barchart"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/geomap/**/*",
-      "/public/app/features/geo/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/geomap/**/*", "/public/app/features/geo/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/geomap"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/graph/**/*",
-      "/packages/grafana-ui/src/components/Graph/**/*",
-      "/packages/grafana-ui/src/components/GraphNG/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/graph/**/*", "/packages/grafana-ui/src/components/Graph/**/*", "/packages/grafana-ui/src/components/GraphNG/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/graph"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/heatmap/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/heatmap/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/heatmap"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/histogram/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/histogram/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/histogram"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/state-timeline/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/state-timeline/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/state-timeline"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/status-history/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/status-history/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/status-history"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/timeseries/**/*",
-      "/packages/grafana-ui/src/components/TimeSeries/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/timeseries/**/*", "/packages/grafana-ui/src/components/TimeSeries/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/timeseries"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/xychart/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/xychart/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/xychart"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/trend/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/trend/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/trend"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "/packages/grafana-ui/src/components/VizLegend/**/*"
-    ],
+    "matches": ["/packages/grafana-ui/src/components/VizLegend/**/*"],
     "action": "updateLabel",
     "addLabel": "area/legend"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "/packages/grafana-ui/src/components/VizTooltip/**/*",
-      "public/app/feature/visualization/data-hover/**/*"
-    ],
+    "matches": ["/packages/grafana-ui/src/components/VizTooltip/**/*", "public/app/feature/visualization/data-hover/**/*" ],
     "action": "updateLabel",
     "addLabel": "area/tooltip"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/gauge/**/*",
-      "/packages/grafana-ui/src/components/Gauge/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/gauge/**/*", "/packages/grafana-ui/src/components/Gauge/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/gauge"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/bargauge/**/*",
-      "/packages/grafana-ui/src/components/BarGauge/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/bargauge/**/*", "/packages/grafana-ui/src/components/BarGauge/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/bargauge"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/stat/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/stat/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/stat"
   },
   {
     "type": "changedfiles",
-    "matches": [
-      "public/app/plugins/panel/piechart/**/*"
-    ],
+    "matches": ["public/app/plugins/panel/piechart/**/*"],
     "action": "updateLabel",
     "addLabel": "area/panel/piechart"
+  },
+  {
+    "type": "changedfiles",
+    "matches": ["public/app/plugins/panel/table/**/*", "/packages/grafana-ui/src/components/Table/**/*"],
+    "action": "updateLabel",
+    "addLabel": "area/panel/table"
   }
 ]

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -2,8 +2,8 @@
   {
     "type": "changedfiles",
     "matches": [
-        "docs/**/*",
-        "contribute/**/*"
+      "docs/**/*",
+      "contribute/**/*"
     ],
     "action": "updateLabel",
     "addLabel": "type/docs"
@@ -11,21 +11,21 @@
   {
     "type": "changedfiles",
     "matches": [
-        "public/**/*",
-        "packages/**/*",
-        "e2e/**/*",
-        "plugins-bundled/**/*",
-        "scripts/build/release-packages.sh",
-        "scripts/circle-release-next-packages.sh",
-        "scripts/ci-frontend-metrics.sh",
-        "scripts/grunt/**/*",
-        "scripts/webpack/**/*",
-        "package.json",
-        "tsconfig.json",
-        "lerna.json",
-        ".prettierrc.js",
-        ".eslintrc",
-        "**/*.mdx"
+      "public/**/*",
+      "packages/**/*",
+      "e2e/**/*",
+      "plugins-bundled/**/*",
+      "scripts/build/release-packages.sh",
+      "scripts/circle-release-next-packages.sh",
+      "scripts/ci-frontend-metrics.sh",
+      "scripts/grunt/**/*",
+      "scripts/webpack/**/*",
+      "package.json",
+      "tsconfig.json",
+      "lerna.json",
+      ".prettierrc.js",
+      ".eslintrc",
+      "**/*.mdx"
     ],
     "action": "updateLabel",
     "addLabel": "area/frontend"
@@ -33,11 +33,11 @@
   {
     "type": "changedfiles",
     "matches": [
-        "**/*.go",
-        "go.mod",
-        "go.sum",
-        "contribute/style-guides/backend.md",
-        "contribute/architecture/backend/**/*"
+      "**/*.go",
+      "go.mod",
+      "go.sum",
+      "contribute/style-guides/backend.md",
+      "contribute/architecture/backend/**/*"
     ],
     "action": "updateLabel",
     "addLabel": "area/backend"
@@ -45,15 +45,17 @@
   {
     "type": "changedfiles",
     "matches": [
-        "pkg/services/sqlstore/migrations/**/*",
-        "**/*_mig.go"
+      "pkg/services/sqlstore/migrations/**/*",
+      "**/*_mig.go"
     ],
     "action": "updateLabel",
     "addLabel": "area/backend/db/migration"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/features/explore/**/*"],
+    "matches": [
+      "public/app/features/explore/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/explore"
   },
@@ -82,384 +84,348 @@
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/azuremonitor/**/*", "pkg/tsdb/azuremonitor/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/azuremonitor/**/*",
+      "pkg/tsdb/azuremonitor/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Azure"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/cloud-monitoring/**/*", "pkg/tsdb/cloud-monitoring/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/cloud-monitoring/**/*",
+      "pkg/tsdb/cloud-monitoring/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/GoogleCloudMonitoring"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/cloudwatch/**/*", "pkg/tsdb/cloudwatch/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/cloudwatch/**/*",
+      "pkg/tsdb/cloudwatch/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/CloudWatch"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/elasticsearch/**/*", "pkg/tsdb/elasticsearch/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/elasticsearch/**/*",
+      "pkg/tsdb/elasticsearch/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Elasticsearch"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/graphite/**/*", "pkg/tsdb/graphite/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/graphite/**/*",
+      "pkg/tsdb/graphite/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Graphite"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/influxdb/**/*", "pkg/tsdb/influx/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/influxdb/**/*",
+      "pkg/tsdb/influx/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/InfluxDB"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/jaeger/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/jaeger/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Jaeger"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/loki/**/*", "pkg/tsdb/loki/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/loki/**/*",
+      "pkg/tsdb/loki/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Loki"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/mssql/**/*", "pkg/tsdb/mssql/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/mssql/**/*",
+      "pkg/tsdb/mssql/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/MSSQL"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/mysql/**/*", "pkg/tsdb/mysql/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/mysql/**/*",
+      "pkg/tsdb/mysql/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/MySQL"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/opentsdb/**/*", "pkg/tsdb/opentsdb/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/opentsdb/**/*",
+      "pkg/tsdb/opentsdb/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/OpenTSDB"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/parca/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/parca/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Parca"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*", "pkg/tsdb/grafana-pyroscope-datasource/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/grafana-pyroscope-datasource/**/*",
+      "pkg/tsdb/grafana-pyroscope-datasource/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/grafana-pyroscope"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/grafana-postgresql-datasource/**/*", "pkg/tsdb/grafana-postgresql-datasource/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/grafana-postgresql-datasource/**/*",
+      "pkg/tsdb/grafana-postgresql-datasource/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Postgres"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/prometheus/**/*", "pkg/tsdb/prometheus/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/prometheus/**/*",
+      "pkg/tsdb/prometheus/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Prometheus"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/tempo/**/*", "pkg/tsdb/tempo/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/tempo/**/*",
+      "pkg/tsdb/tempo/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Tempo"
   },
   {
     "type": "changedfiles",
-    "matches": [ "public/app/plugins/datasource/zipkin/**/*"],
+    "matches": [
+      "public/app/plugins/datasource/zipkin/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "datasource/Zipkin"
   },
   {
     "type": "changedfiles",
-    "matches": ["public/app/features/variables/**/*", "public/app/features/templating/**/*"],
+    "matches": [
+      "public/app/features/variables/**/*",
+      "public/app/features/templating/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/dashboard/templating"
   },
   {
     "type": "changedfiles",
-    "matches": ["/pkg/services/ngalert/**/*", "/pkg/services/sqlstore/migrations/ualert/**/*", "/pkg/services/alerting/**/*", "/public/app/features/alerting/**/*", "/pkg/tests/api/alerting/**/*"],
+    "matches": [
+      "/pkg/services/ngalert/**/*",
+      "/pkg/services/sqlstore/migrations/ualert/**/*",
+      "/pkg/services/alerting/**/*",
+      "/public/app/features/alerting/**/*",
+      "/pkg/tests/api/alerting/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/alerting"
   },
   {
     "type": "author",
     "name": "pr/external",
-    "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate[bot]","dependabot[bot]","grafana-delivery-bot[bot]","grafanabot"],
+    "notMemberOf": {
+      "org": "grafana"
+    },
+    "ignoreList": [
+      "renovate[bot]",
+      "dependabot[bot]",
+      "grafana-delivery-bot[bot]",
+      "grafanabot"
+    ],
     "action": "updateLabel",
     "addLabel": "pr/external"
   },
   {
-    "type":"label",
-    "name":"type/docs",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/69"
+    "type": "label",
+    "name": "type/docs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/69"
     }
   },
   {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/candlestick/**/*"],
+    "matches": [
+      "public/app/plugins/panel/candlestick/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/candlestick"
   },
   {
-    "type": "label",
-    "name": "area/panel/candlestick",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/canvas/**/*", "/public/app/features/canvas/**/*"],
+    "matches": [
+      "public/app/plugins/panel/canvas/**/*",
+      "/public/app/features/canvas/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/canvas"
   },
   {
-    "type": "label",
-    "name": "area/panel/canvas",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/barchart/**/*"],
+    "matches": [
+      "public/app/plugins/panel/barchart/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/barchart"
   },
   {
-    "type": "label",
-    "name": "area/panel/barchart",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/geomap/**/*", "/public/app/features/geo/**/*"],
+    "matches": [
+      "public/app/plugins/panel/geomap/**/*",
+      "/public/app/features/geo/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/geomap"
   },
   {
-    "type": "label",
-    "name": "area/panel/geomap",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/graph/**/*", "/packages/grafana-ui/src/components/Graph/**/*", "/packages/grafana-ui/src/components/GraphNG/**/*"],
+    "matches": [
+      "public/app/plugins/panel/graph/**/*",
+      "/packages/grafana-ui/src/components/Graph/**/*",
+      "/packages/grafana-ui/src/components/GraphNG/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/graph"
   },
   {
-    "type": "label",
-    "name": "area/panel/graph",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/heatmap/**/*"],
+    "matches": [
+      "public/app/plugins/panel/heatmap/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/heatmap"
   },
   {
-    "type": "label",
-    "name": "area/panel/heatmap",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/histogram/**/*"],
+    "matches": [
+      "public/app/plugins/panel/histogram/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/histogram"
   },
   {
-    "type": "label",
-    "name": "area/panel/histogram",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/state-timeline/**/*"],
+    "matches": [
+      "public/app/plugins/panel/state-timeline/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/state-timeline"
   },
   {
-    "type": "label",
-    "name": "area/panel/state-timeline",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/status-history/**/*"],
+    "matches": [
+      "public/app/plugins/panel/status-history/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/status-history"
   },
   {
-    "type": "label",
-    "name": "area/panel/status-history",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/timeseries/**/*", "/packages/grafana-ui/src/components/TimeSeries/**/*"],
+    "matches": [
+      "public/app/plugins/panel/timeseries/**/*",
+      "/packages/grafana-ui/src/components/TimeSeries/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/timeseries"
   },
   {
-    "type": "label",
-    "name": "area/panel/timeseries",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/xychart/**/*"],
+    "matches": [
+      "public/app/plugins/panel/xychart/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/xychart"
   },
   {
-    "type": "label",
-    "name": "area/panel/xychart",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/trend/**/*"],
+    "matches": [
+      "public/app/plugins/panel/trend/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/trend"
   },
   {
-    "type": "label",
-    "name": "area/panel/trend",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["/packages/grafana-ui/src/components/VizLegend/**/*"],
+    "matches": [
+      "/packages/grafana-ui/src/components/VizLegend/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/legend"
   },
   {
-    "type": "label",
-    "name": "area/legend",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["/packages/grafana-ui/src/components/VizTooltip/**/*", "public/app/feature/visualization/data-hover/**/*" ],
+    "matches": [
+      "/packages/grafana-ui/src/components/VizTooltip/**/*",
+      "public/app/feature/visualization/data-hover/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/tooltip"
   },
   {
-    "type": "label",
-    "name": "area/tooltip",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/gauge/**/*", "/packages/grafana-ui/src/components/Gauge/**/*"],
+    "matches": [
+      "public/app/plugins/panel/gauge/**/*",
+      "/packages/grafana-ui/src/components/Gauge/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/gauge"
   },
   {
-    "type": "label",
-    "name": "area/panel/gauge",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/bargauge/**/*", "/packages/grafana-ui/src/components/BarGauge/**/*"],
+    "matches": [
+      "public/app/plugins/panel/bargauge/**/*",
+      "/packages/grafana-ui/src/components/BarGauge/**/*"
+    ],
     "action": "updateLabel",
-    "addLabel": "area/panel/gauge"
-  },
-  {
-    "type": "label",
-    "name": "area/panel/bargauge",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
+    "addLabel": "area/panel/bargauge"
   },
   {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/stat/**/*"],
+    "matches": [
+      "public/app/plugins/panel/stat/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/stat"
   },
   {
-    "type": "label",
-    "name": "area/panel/stat",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
-  },
-  {
     "type": "changedfiles",
-    "matches": ["public/app/plugins/panel/piechart/**/*"],
+    "matches": [
+      "public/app/plugins/panel/piechart/**/*"
+    ],
     "action": "updateLabel",
     "addLabel": "area/panel/piechart"
-  },
-  {
-    "type": "label",
-    "name": "area/panel/piechart",
-    "action": "addToProject",
-    "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/56"
-    }
   }
 ]


### PR DESCRIPTION
Update GitHub automation for DataViz squad
- Add table to dataviz project instead of deprecated BI
- Remove add to project commands from `pr-commands.json` as they were not working as expected and instead only include them in `commands.json` file
- Remove icon panel reference as [this alpha panel was removed a while back](https://github.com/grafana/grafana/pull/68573)

Note: Will create a follow-up PR linting these files as there are a number of styling issues