### PR TITLE
Table: Prevent runtime error when resizing columns with onColumnResize

### DIFF
--- a/packages/grafana-ui/src/components/Table/reducer.ts
+++ b/packages/grafana-ui/src/components/Table/reducer.ts
@@ -15,12 +15,12 @@ export function useTableStateReducer({ onColumnResize, onSortByChange, data }: P
       switch (action.type) {
         case 'columnDoneResizing':
           if (onColumnResize) {
-            const info = (newState.columnResizing.headerIdWidths as any)[0];
-            const columnIdString = info[0];
+            const info = (newState.columnResizing?.headerIdWidths as any)?.[0];
+            const columnIdString = info?.[0];
             const fieldIndex = parseInt(columnIdString, 10);
-            const width = Math.round(newState.columnResizing.columnWidths[columnIdString]);
+            const width = Math.round(newState.columnResizing.columnWidths?.[columnIdString]);
 
-            const field = data.fields[fieldIndex];
+            const field = data.fields?.[fieldIndex];
             if (!field) {
               return newState;
             }


### PR DESCRIPTION
**What is this feature?**
Preventing runtime error when using onColumnResize

```
reducer.ts:18 Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at reducer.ts:18:51
    at react-table.development.js:1055:1
    at Array.reduce (<anonymous>)
    at react-table.development.js:1054:1
    at updateReducer (react-dom.development.js:16664:1)
    at Object.useReducer (react-dom.development.js:17898:1)
    at Object.useReducer (react.development.js:1626:1)
    at useTable (react-table.development.js:1059:1)
    at Table.tsx:189:15
    at renderWithHooks (react-dom.development.js:16305:1)
```

**Why do we need this feature?**

 `newState.columnResizing?.headerIdWidths` is occasionally undefined when the user is dragging beyond the bounds of the table/columns

**Who is this feature for?**
Developers building on top of <Table>

**Special notes for your reviewer:**
Hard to reproduce, the error is thrown pretty rarely, but I can repro somewhat consistently when resizing columns beyond the bounds of the table, and after a few columns are already resized. Not sure what the root cause is, but since it only seems to be thrown when an invalid column width is selected, I think returning early and avoiding the runtime error is a good enough solution.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
