### PR TITLE
Docs: Add tooltip options to histogram v11.2

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/histogram/index.md
+++ b/docs/sources/panels-visualizations/visualizations/histogram/index.md
@@ -138,13 +138,21 @@ Transparency of the gradient is calculated based on the values on the Y-axis. Th
 
 Gradient color is generated based on the hue of the line color.
 
-## Standard options
+## Tooltip options
 
-{{< docs/shared lookup="visualizations/standard-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+{{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Legend options
 
 {{< docs/shared lookup="visualizations/legend-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
+## Standard options
+
+{{< docs/shared lookup="visualizations/standard-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
+## Data links
+
+{{< docs/shared lookup="visualizations/datalink-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Value mappings
 
@@ -153,10 +161,6 @@ Gradient color is generated based on the hue of the line color.
 ## Thresholds
 
 {{< docs/shared lookup="visualizations/thresholds-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
-
-## Data links
-
-{{< docs/shared lookup="visualizations/datalink-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Field overrides
 

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -3,7 +3,7 @@ title: Tooltip options
 comments: |
   There are two tooltip shared files, tooltip-options-1.md and tooltip-options-2.md, to cover the most common combinations of options. 
   Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
-  This file is used in the following visualizations: bar chart, pie chart, state timeline, status history
+  This file is used in the following visualizations: bar chart, histogram pie chart, state timeline, status history
 ---
 
 Tooltip options control the information overlay that appears when you hover over data points in the visualization.

--- a/docs/sources/shared/visualizations/tooltip-options-1.md
+++ b/docs/sources/shared/visualizations/tooltip-options-1.md
@@ -3,7 +3,7 @@ title: Tooltip options
 comments: |
   There are two tooltip shared files, tooltip-options-1.md and tooltip-options-2.md, to cover the most common combinations of options. 
   Using two shared files ensures that content remains consistent across visualizations that share the same options and users don't have to figure out which options apply to a specific visualization when reading that content. 
-  This file is used in the following visualizations: bar chart, histogram pie chart, state timeline, status history
+  This file is used in the following visualizations: bar chart, histogram, pie chart, state timeline, status history
 ---
 
 Tooltip options control the information overlay that appears when you hover over data points in the visualization.


### PR DESCRIPTION
- Adds tooltip-options-1.md shared file to histogram visualization
- Reorders options sections
- Updates list of pages the tooltip-options-1.md file is used in
