### PR TITLE
Table: Don't error if first frame is field-less (empty response)

### DIFF
--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -26,7 +26,7 @@ export function TablePanel(props: Props) {
     ? migrateFromParentRowIndexToNestedFrames(data.series)
     : data.series;
   const count = frames?.length;
-  const hasFields = frames[0]?.fields.length;
+  const hasFields = frames.some((frame) => frame.fields.length > 0);
   const currentIndex = getCurrentFrameIndex(frames, options);
   const main = frames[currentIndex];
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11225