### PR TITLE
Dashboard: Pulsate the loading icon when streaming

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css, cx, keyframes } from '@emotion/css';
 import { CSSProperties, ReactElement, ReactNode, useId } from 'react';
 import * as React from 'react';
 import { useMeasure, useToggle } from 'react-use';
@@ -375,6 +375,17 @@ const getContentStyle = (
 
 const getStyles = (theme: GrafanaTheme2) => {
   const { background, borderColor, padding } = theme.components.panel;
+  const pulse = keyframes({
+    '0%': {
+      opacity: 0,
+    },
+    '50%': {
+      opacity: 1,
+    },
+    '100%': {
+      opacity: 0,
+    },
+  });
 
   return {
     container: css({
@@ -449,7 +460,12 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'panel-streaming',
       marginRight: 0,
       color: theme.colors.success.text,
-
+      [theme.transitions.handleMotion('no-preference')]: {
+        animationName: pulse,
+        animationIterationCount: 'infinite',
+        animationDuration: '4s',
+        animationDelay: '0.5s',
+      },
       '&:hover': {
         color: theme.colors.success.text,
       },


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes #89415

https://github.com/grafana/grafana/assets/5486686/0465338a-fbe9-4896-9c16-433a077e82f3

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.