### PR TITLE
Tempo: Fix grpc streaming support over pdc-agent

### DIFF
--- a/pkg/tsdb/tempo/grpc.go
+++ b/pkg/tsdb/tempo/grpc.go
@@ -49,8 +49,8 @@ func newGrpcClient(ctx context.Context, settings backend.DataSourceInstanceSetti
 		return nil, fmt.Errorf("error getting dial options: %w", err)
 	}
 
-	// grpc.Dial is deprecated in favor of grpc.NewClient, but grpc.NewClient chaged the default resolver to dns from passthrough.
-	// This is a problem because the getDialOpts function appends a custom dialer to the dial options to support Grafana Cloud PDC.
+	// grpc.Dial() is deprecated in favor of grpc.NewClient(), but grpc.NewClient() changed the default resolver to dns from passthrough.
+	// This is a problem because the getDialOpts() function appends a custom dialer to the dial options to support Grafana Cloud PDC.
 	//
 	// See the following quote from the grpc package documentation:
 	//     One subtle difference between NewClient and Dial and DialContext is that the
@@ -61,9 +61,9 @@ func newGrpcClient(ctx context.Context, settings backend.DataSourceInstanceSetti
 	// https://github.com/grpc/grpc-go/blob/fa274d77904729c2893111ac292048d56dcf0bb1/clientconn.go#L209
 	//
 	// Unfortunately, the passthrough resolver isn't exported by the grpc package, so we can't use it.
-	// The options are to continue using grpc.Dial or implement a custom resolver.
-	// Since the grpc package maintainers intend to continue supporting grpc.Dial through the 1.x series,
-	// we'll continue using grpc.Dial until we have a compelling reason or bandwidth to implement the custom resolver.
+	// The options are to continue using grpc.Dial() or implement a custom resolver.
+	// Since the go-grpc package maintainers intend to continue supporting grpc.Dial() through the 1.x series,
+	// we'll continue using grpc.Dial() until we have a compelling reason or bandwidth to implement the custom resolver.
 	// Reference: https://github.com/grpc/grpc-go/blob/f199062ef31ddda54152e1ca5e3d15fb63903dc3/clientconn.go#L204
 	//
 	// See this issue for more information: https://github.com/grpc/grpc-go/issues/7091

--- a/pkg/tsdb/tempo/grpc.go
+++ b/pkg/tsdb/tempo/grpc.go
@@ -48,7 +48,26 @@ func newGrpcClient(ctx context.Context, settings backend.DataSourceInstanceSetti
 	if err != nil {
 		return nil, fmt.Errorf("error getting dial options: %w", err)
 	}
-	clientConn, err := grpc.NewClient(onlyHost, dialOpts...)
+
+	// grpc.Dial is deprecated in favor of grpc.NewClient, but grpc.NewClient chaged the default resolver to dns from passthrough.
+	// This is a problem because the getDialOpts function appends a custom dialer to the dial options to support Grafana Cloud PDC.
+	//
+	// See the following quote from the grpc package documentation:
+	//     One subtle difference between NewClient and Dial and DialContext is that the
+	//     former uses "dns" as the default name resolver, while the latter use
+	//     "passthrough" for backward compatibility.  This distinction should not matter
+	//     to most users, but could matter to legacy users that specify a custom dialer
+	//     and expect it to receive the target string directly.
+	// https://github.com/grpc/grpc-go/blob/fa274d77904729c2893111ac292048d56dcf0bb1/clientconn.go#L209
+	//
+	// Unfortunately, the passthrough resolver isn't exported by the grpc package, so we can't use it.
+	// The options are to continue using grpc.Dial or implement a custom resolver.
+	// Since the grpc package maintainers intend to continue supporting grpc.Dial through the 1.x series,
+	// we'll continue using grpc.Dial until we have a compelling reason or bandwidth to implement the custom resolver.
+	// Reference: https://github.com/grpc/grpc-go/blob/f199062ef31ddda54152e1ca5e3d15fb63903dc3/clientconn.go#L204
+	//
+	// See this issue for more information: https://github.com/grpc/grpc-go/issues/7091
+	clientConn, err := grpc.Dial(onlyHost, dialOpts...)
 	if err != nil {
 		logger.Error("Error dialing gRPC client", "error", err, "URL", settings.URL, "function", logEntrypoint())
 		return nil, err

--- a/pkg/tsdb/tempo/grpc.go
+++ b/pkg/tsdb/tempo/grpc.go
@@ -67,6 +67,8 @@ func newGrpcClient(ctx context.Context, settings backend.DataSourceInstanceSetti
 	// Reference: https://github.com/grpc/grpc-go/blob/f199062ef31ddda54152e1ca5e3d15fb63903dc3/clientconn.go#L204
 	//
 	// See this issue for more information: https://github.com/grpc/grpc-go/issues/7091
+	// Ignore the lint check as this fails the build and for the reasons above.
+	// nolint:staticcheck
 	clientConn, err := grpc.Dial(onlyHost, dialOpts...)
 	if err != nil {
 		logger.Error("Error dialing gRPC client", "error", err, "URL", settings.URL, "function", logEntrypoint())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I believe https://github.com/grafana/grafana/pull/88219 inadvertently broke Tempo streaming over pdc-agent. This PR suggests a fix for #89882

`grpc.Dial()` has been deprecated in favor of `grpc.NewClient()`, but `grpc.NewClient()` changed the default resolver to dns from passthrough. This is a problem because the `getDialOpts()` function appends a custom dialer to the dial options to support Grafana Cloud PDC.

See the following quote from the grpc package documentation:

> One subtle difference between NewClient and Dial and DialContext is that the former uses "dns" as the default name resolver, while the latter use "passthrough" for backward compatibility. This distinction should not matter to most users, but could matter to legacy users that specify a custom dialer and expect it to receive the target string directly.

https://github.com/grpc/grpc-go/blob/fa274d77904729c2893111ac292048d56dcf0bb1/clientconn.go#L209

Unfortunately, the passthrough resolver isn't exported by the grpc package, so we can't use it. The options are to continue using `grpc.Dial()` or implement a custom resolver. Since the grpc package maintainers intend to continue supporting `grpc.Dial()` through the 1.x series, I suggest using `grpc.Dial()` until there is a compelling reason or sufficient bandwidth to implement the custom resolver.

Reference: https://github.com/grpc/grpc-go/blob/f199062ef31ddda54152e1ca5e3d15fb63903dc3/clientconn.go#L204

See this issue for more information: https://github.com/grpc/grpc-go/issues/7091

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #89882

**Special notes for your reviewer:**

I am not familiar with the testing procedure for the pdc-agent, so I was not able to directly test that this change resolved the problem. If there is a way for me to test it, I'd be more than happy to do so.

I did, however, build and run Grafana and connect it to a Tempo data source. I was able to confirm that I am still able to query the data source from the Search tab within the Explore page.

![image](https://github.com/grafana/grafana/assets/3466119/a013ac65-e672-4302-98a8-fc6c5f14a89f)
 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
