### PR TITLE
Bugfix: Fix Testdata CSV empty scenario

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/csv_data.go
+++ b/pkg/tsdb/grafana-testdata-datasource/csv_data.go
@@ -28,7 +28,7 @@ func (s *Service) handleCsvContentScenario(ctx context.Context, req *backend.Que
 
 		csvContent := model.CsvContent
 		if len(csvContent) == 0 {
-			return backend.NewQueryDataResponse(), nil
+			continue
 		}
 
 		alias := model.Alias


### PR DESCRIPTION
Avoid returning a empty response if from multiple queries, one is empty.