### PR TITLE
E2C: Create Snapshot frontend

### DIFF
--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -26,8 +26,41 @@ const injectedRtkApi = api.injectEndpoints({
     runCloudMigration: build.mutation<RunCloudMigrationApiResponse, RunCloudMigrationApiArg>({
       query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}/run`, method: 'POST' }),
     }),
+    createSnapshot: build.mutation<CreateSnapshotApiResponse, CreateSnapshotApiArg>({
+      query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}/snapshot`, method: 'POST' }),
+    }),
+    getSnapshot: build.query<GetSnapshotApiResponse, GetSnapshotApiArg>({
+      query: (queryArg) => ({
+        url: `/cloudmigration/migration/${queryArg.uid}/snapshot/${queryArg.snapshotUid}`,
+        params: { resultPage: queryArg.resultPage, resultLimit: queryArg.resultLimit },
+      }),
+    }),
+    cancelSnapshot: build.mutation<CancelSnapshotApiResponse, CancelSnapshotApiArg>({
+      query: (queryArg) => ({
+        url: `/cloudmigration/migration/${queryArg.uid}/snapshot/${queryArg.snapshotUid}/cancel`,
+        method: 'POST',
+      }),
+    }),
+    uploadSnapshot: build.mutation<UploadSnapshotApiResponse, UploadSnapshotApiArg>({
+      query: (queryArg) => ({
+        url: `/cloudmigration/migration/${queryArg.uid}/snapshot/${queryArg.snapshotUid}/upload`,
+        method: 'POST',
+      }),
+    }),
+    getShapshotList: build.query<GetShapshotListApiResponse, GetShapshotListApiArg>({
+      query: (queryArg) => ({
+        url: `/cloudmigration/migration/${queryArg.uid}/snapshots`,
+        params: { page: queryArg.page, limit: queryArg.limit },
+      }),
+    }),
+    getCloudMigrationToken: build.query<GetCloudMigrationTokenApiResponse, GetCloudMigrationTokenApiArg>({
+      query: () => ({ url: `/cloudmigration/token` }),
+    }),
     createCloudMigrationToken: build.mutation<CreateCloudMigrationTokenApiResponse, CreateCloudMigrationTokenApiArg>({
       query: () => ({ url: `/cloudmigration/token`, method: 'POST' }),
+    }),
+    deleteCloudMigrationToken: build.mutation<DeleteCloudMigrationTokenApiResponse, DeleteCloudMigrationTokenApiArg>({
+      query: (queryArg) => ({ url: `/cloudmigration/token/${queryArg.uid}`, method: 'DELETE' }),
     }),
     getDashboardByUid: build.query<GetDashboardByUidApiResponse, GetDashboardByUidApiArg>({
       query: (queryArg) => ({ url: `/dashboards/uid/${queryArg.uid}` }),
@@ -57,7 +90,7 @@ export type GetSessionApiArg = {
   /** UID of a migration session */
   uid: string;
 };
-export type GetCloudMigrationRunListApiResponse = /** status 200 (empty) */ SnapshotListDto;
+export type GetCloudMigrationRunListApiResponse = /** status 200 (empty) */ CloudMigrationRunListDto;
 export type GetCloudMigrationRunListApiArg = {
   /** UID of a migration */
   uid: string;
@@ -67,8 +100,54 @@ export type RunCloudMigrationApiArg = {
   /** UID of a migration */
   uid: string;
 };
+export type CreateSnapshotApiResponse = /** status 200 (empty) */ CreateSnapshotResponseDto;
+export type CreateSnapshotApiArg = {
+  /** UID of a session */
+  uid: string;
+};
+export type GetSnapshotApiResponse = /** status 200 (empty) */ GetSnapshotResponseDto;
+export type GetSnapshotApiArg = {
+  /** ResultPage is used for pagination with ResultLimit */
+  resultPage?: number;
+  /** Max limit for snapshot results returned. */
+  resultLimit?: number;
+  /** Session UID of a session */
+  uid: string;
+  /** UID of a snapshot */
+  snapshotUid: string;
+};
+export type CancelSnapshotApiResponse = /** status 200 (empty) */ void;
+export type CancelSnapshotApiArg = {
+  /** Session UID of a session */
+  uid: string;
+  /** UID of a snapshot */
+  snapshotUid: string;
+};
+export type UploadSnapshotApiResponse = /** status 200 (empty) */ void;
+export type UploadSnapshotApiArg = {
+  /** Session UID of a session */
+  uid: string;
+  /** UID of a snapshot */
+  snapshotUid: string;
+};
+export type GetShapshotListApiResponse = /** status 200 (empty) */ SnapshotListResponseDto;
+export type GetShapshotListApiArg = {
+  /** Page is used for pagination with limit */
+  page?: number;
+  /** Max limit for results returned. */
+  limit?: number;
+  /** Session UID of a session */
+  uid: string;
+};
+export type GetCloudMigrationTokenApiResponse = /** status 200 (empty) */ GetAccessTokenResponseDto;
+export type GetCloudMigrationTokenApiArg = void;
 export type CreateCloudMigrationTokenApiResponse = /** status 200 (empty) */ CreateAccessTokenResponseDto;
 export type CreateCloudMigrationTokenApiArg = void;
+export type DeleteCloudMigrationTokenApiResponse = /** status 204 (empty) */ void;
+export type DeleteCloudMigrationTokenApiArg = {
+  /** UID of a cloud migration token */
+  uid: string;
+};
 export type GetDashboardByUidApiResponse = /** status 200 (empty) */ DashboardFullWithMeta;
 export type GetDashboardByUidApiArg = {
   uid: string;
@@ -98,7 +177,7 @@ export type CloudMigrationSessionRequestDto = {
 export type MigrateDataResponseItemDto = {
   error?: string;
   refId: string;
-  status: 'OK' | 'ERROR';
+  status: 'OK' | 'ERROR' | 'PENDING' | 'UNKNOWN';
   type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER';
 };
 export type MigrateDataResponseDto = {
@@ -108,8 +187,55 @@ export type MigrateDataResponseDto = {
 export type MigrateDataResponseListDto = {
   uid?: string;
 };
-export type SnapshotListDto = {
+export type CloudMigrationRunListDto = {
   runs?: MigrateDataResponseListDto[];
+};
+export type CreateSnapshotResponseDto = {
+  uid?: string;
+};
+export type GetSnapshotResponseDto = {
+  created?: string;
+  finished?: string;
+  results?: MigrateDataResponseItemDto[];
+  sessionUid?: string;
+  status?:
+    | 'INITIALIZING'
+    | 'CREATING'
+    | 'PENDING_UPLOAD'
+    | 'UPLOADING'
+    | 'PENDING_PROCESSING'
+    | 'PROCESSING'
+    | 'FINISHED'
+    | 'ERROR'
+    | 'UNKNOWN';
+  uid?: string;
+};
+export type SnapshotDto = {
+  created?: string;
+  finished?: string;
+  sessionUid?: string;
+  status?:
+    | 'INITIALIZING'
+    | 'CREATING'
+    | 'PENDING_UPLOAD'
+    | 'UPLOADING'
+    | 'PENDING_PROCESSING'
+    | 'PROCESSING'
+    | 'FINISHED'
+    | 'ERROR'
+    | 'UNKNOWN';
+  uid?: string;
+};
+export type SnapshotListResponseDto = {
+  snapshots?: SnapshotDto[];
+};
+export type GetAccessTokenResponseDto = {
+  createdAt?: string;
+  displayName?: string;
+  expiresAt?: string;
+  firstUsedAt?: string;
+  id?: string;
+  lastUsedAt?: string;
 };
 export type CreateAccessTokenResponseDto = {
   token?: string;
@@ -165,6 +291,13 @@ export const {
   useGetSessionQuery,
   useGetCloudMigrationRunListQuery,
   useRunCloudMigrationMutation,
+  useCreateSnapshotMutation,
+  useGetSnapshotQuery,
+  useCancelSnapshotMutation,
+  useUploadSnapshotMutation,
+  useGetShapshotListQuery,
+  useGetCloudMigrationTokenQuery,
   useCreateCloudMigrationTokenMutation,
+  useDeleteCloudMigrationTokenMutation,
   useGetDashboardByUidQuery,
 } = injectedRtkApi;

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -11,20 +11,11 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.cloudMigrationSessionRequestDto,
       }),
     }),
-    getCloudMigrationRun: build.query<GetCloudMigrationRunApiResponse, GetCloudMigrationRunApiArg>({
-      query: (queryArg) => ({ url: `/cloudmigration/migration/run/${queryArg.runUid}` }),
-    }),
     deleteSession: build.mutation<DeleteSessionApiResponse, DeleteSessionApiArg>({
       query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}`, method: 'DELETE' }),
     }),
     getSession: build.query<GetSessionApiResponse, GetSessionApiArg>({
       query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}` }),
-    }),
-    getCloudMigrationRunList: build.query<GetCloudMigrationRunListApiResponse, GetCloudMigrationRunListApiArg>({
-      query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}/run` }),
-    }),
-    runCloudMigration: build.mutation<RunCloudMigrationApiResponse, RunCloudMigrationApiArg>({
-      query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}/run`, method: 'POST' }),
     }),
     createSnapshot: build.mutation<CreateSnapshotApiResponse, CreateSnapshotApiArg>({
       query: (queryArg) => ({ url: `/cloudmigration/migration/${queryArg.uid}/snapshot`, method: 'POST' }),
@@ -75,11 +66,6 @@ export type CreateSessionApiResponse = /** status 200 (empty) */ CloudMigrationS
 export type CreateSessionApiArg = {
   cloudMigrationSessionRequestDto: CloudMigrationSessionRequestDto;
 };
-export type GetCloudMigrationRunApiResponse = /** status 200 (empty) */ MigrateDataResponseDto;
-export type GetCloudMigrationRunApiArg = {
-  /** RunUID of a migration run */
-  runUid: string;
-};
 export type DeleteSessionApiResponse = unknown;
 export type DeleteSessionApiArg = {
   /** UID of a migration session */
@@ -88,16 +74,6 @@ export type DeleteSessionApiArg = {
 export type GetSessionApiResponse = /** status 200 (empty) */ CloudMigrationSessionResponseDto;
 export type GetSessionApiArg = {
   /** UID of a migration session */
-  uid: string;
-};
-export type GetCloudMigrationRunListApiResponse = /** status 200 (empty) */ CloudMigrationRunListDto;
-export type GetCloudMigrationRunListApiArg = {
-  /** UID of a migration */
-  uid: string;
-};
-export type RunCloudMigrationApiResponse = /** status 200 (empty) */ MigrateDataResponseDto;
-export type RunCloudMigrationApiArg = {
-  /** UID of a migration */
   uid: string;
 };
 export type CreateSnapshotApiResponse = /** status 200 (empty) */ CreateSnapshotResponseDto;
@@ -174,24 +150,14 @@ export type ErrorResponseBody = {
 export type CloudMigrationSessionRequestDto = {
   authToken?: string;
 };
+export type CreateSnapshotResponseDto = {
+  uid?: string;
+};
 export type MigrateDataResponseItemDto = {
   error?: string;
   refId: string;
   status: 'OK' | 'ERROR' | 'PENDING' | 'UNKNOWN';
   type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER';
-};
-export type MigrateDataResponseDto = {
-  items?: MigrateDataResponseItemDto[];
-  uid?: string;
-};
-export type MigrateDataResponseListDto = {
-  uid?: string;
-};
-export type CloudMigrationRunListDto = {
-  runs?: MigrateDataResponseListDto[];
-};
-export type CreateSnapshotResponseDto = {
-  uid?: string;
 };
 export type GetSnapshotResponseDto = {
   created?: string;
@@ -286,11 +252,8 @@ export type DashboardFullWithMeta = {
 export const {
   useGetSessionListQuery,
   useCreateSessionMutation,
-  useGetCloudMigrationRunQuery,
   useDeleteSessionMutation,
   useGetSessionQuery,
-  useGetCloudMigrationRunListQuery,
-  useRunCloudMigrationMutation,
   useCreateSnapshotMutation,
   useGetSnapshotQuery,
   useCancelSnapshotMutation,

--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -4,42 +4,45 @@ import { BaseQueryFn, EndpointDefinition } from '@reduxjs/toolkit/dist/query';
 import { generatedAPI } from './endpoints.gen';
 
 export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
-  addTagTypes: ['cloud-migration-config', 'cloud-migration-run', 'cloud-migration-run-list'],
+  addTagTypes: ['cloud-migration-session', 'cloud-migration-snapshot'],
+
   endpoints: {
     // Cloud-side - create token
     createCloudMigrationToken: suppressErrorsOnQuery,
 
     // List Cloud Configs
     getSessionList: {
-      providesTags: ['cloud-migration-config'] /* should this be a -list? */,
+      providesTags: ['cloud-migration-session'] /* should this be a -list? */,
     },
 
     // Create Cloud Config
     createSession(endpoint) {
       suppressErrorsOnQuery(endpoint);
-      endpoint.invalidatesTags = ['cloud-migration-config'];
+      endpoint.invalidatesTags = ['cloud-migration-session'];
     },
 
     // Get one Cloud Config
     getSession: {
-      providesTags: ['cloud-migration-config'],
+      providesTags: ['cloud-migration-session'],
     },
 
     // Delete one Cloud Config
     deleteSession: {
-      invalidatesTags: ['cloud-migration-config'],
+      invalidatesTags: ['cloud-migration-session', 'cloud-migration-snapshot'],
     },
 
-    getCloudMigrationRunList: {
-      providesTags: ['cloud-migration-run-list'],
+    // Snapshot management
+    getSnapshot: {
+      providesTags: ['cloud-migration-snapshot'],
     },
-
-    getCloudMigrationRun: {
-      providesTags: ['cloud-migration-run'],
+    getShapshotList: {
+      providesTags: ['cloud-migration-snapshot'],
     },
-
-    runCloudMigration: {
-      invalidatesTags: ['cloud-migration-run-list'],
+    createSnapshot: {
+      invalidatesTags: ['cloud-migration-snapshot'],
+    },
+    uploadSnapshot: {
+      invalidatesTags: ['cloud-migration-snapshot'],
     },
 
     getDashboardByUid: suppressErrorsOnQuery,

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -68,14 +68,12 @@ function useGetLatestSnapshot(sessionUid?: string) {
   });
 
   useEffect(() => {
-    const shouldPoll = SHOULD_POLL_STATUSES.includes(snapshotResult.data?.status)
+    const shouldPoll = SHOULD_POLL_STATUSES.includes(snapshotResult.data?.status);
     setShouldPoll(shouldPoll);
-    }
   }, [snapshotResult?.data?.status]);
 
   return {
     ...snapshotResult,
-
 
     error: listResult.error || snapshotResult.error,
 

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -76,7 +76,6 @@ function useGetLatestSnapshot(sessionUid?: string) {
   return {
     ...snapshotResult,
 
-    data: snapshotResult.data,
 
     error: listResult.error || snapshotResult.error,
 

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -68,10 +68,8 @@ function useGetLatestSnapshot(sessionUid?: string) {
   });
 
   useEffect(() => {
-    if (SHOULD_POLL_STATUSES.includes(snapshotResult.data?.status)) {
-      setShouldPoll(true);
-    } else {
-      setShouldPoll(false);
+    const shouldPoll = SHOULD_POLL_STATUSES.includes(snapshotResult.data?.status)
+    setShouldPoll(shouldPoll);
     }
   }, [snapshotResult?.data?.status]);
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -969,7 +969,8 @@
       "run-migration-error-description": "See the Grafana server logs for more details",
       "run-migration-error-title": "There was an error migrating your resources",
       "start-migration": "Build snapshot",
-      "target-stack-title": "Uploading to"
+      "target-stack-title": "Uploading to",
+      "upload-migration": "Upload & migrate snapshot"
     },
     "token-status": {
       "active": "Token created and active",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -968,7 +968,7 @@
       "disconnect-error-title": "There was an error disconnecting",
       "run-migration-error-description": "See the Grafana server logs for more details",
       "run-migration-error-title": "There was an error migrating your resources",
-      "start-migration": "Upload everything",
+      "start-migration": "Build snapshot",
       "target-stack-title": "Uploading to"
     },
     "token-status": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -968,7 +968,7 @@
       "disconnect-error-title": "Ŧĥęřę ŵäş äŉ ęřřőř đįşčőŉŉęčŧįŉģ",
       "run-migration-error-description": "Ŝęę ŧĥę Ğřäƒäŉä şęřvęř ľőģş ƒőř mőřę đęŧäįľş",
       "run-migration-error-title": "Ŧĥęřę ŵäş äŉ ęřřőř mįģřäŧįŉģ yőūř řęşőūřčęş",
-      "start-migration": "Ůpľőäđ ęvęřyŧĥįŉģ",
+      "start-migration": "ßūįľđ şŉäpşĥőŧ",
       "target-stack-title": "Ůpľőäđįŉģ ŧő"
     },
     "token-status": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -969,7 +969,8 @@
       "run-migration-error-description": "Ŝęę ŧĥę Ğřäƒäŉä şęřvęř ľőģş ƒőř mőřę đęŧäįľş",
       "run-migration-error-title": "Ŧĥęřę ŵäş äŉ ęřřőř mįģřäŧįŉģ yőūř řęşőūřčęş",
       "start-migration": "ßūįľđ şŉäpşĥőŧ",
-      "target-stack-title": "Ůpľőäđįŉģ ŧő"
+      "target-stack-title": "Ůpľőäđįŉģ ŧő",
+      "upload-migration": "Ůpľőäđ & mįģřäŧę şŉäpşĥőŧ"
     },
     "token-status": {
       "active": "Ŧőĸęŉ čřęäŧęđ äŉđ äčŧįvę",

--- a/scripts/generate-rtk-apis.ts
+++ b/scripts/generate-rtk-apis.ts
@@ -12,14 +12,25 @@ const config: ConfigFile = {
       apiFile: '../public/app/features/migrate-to-cloud/api/baseAPI.ts',
       apiImport: 'baseAPI',
       filterEndpoints: [
-        'createCloudMigrationToken',
         'getSessionList',
         'getSession',
-        'createSession',
         'deleteSession',
-        'runCloudMigration',
-        'getCloudMigrationRun',
+        'createSession',
+
         'getCloudMigrationRunList',
+        'getCloudMigrationRun',
+        'runCloudMigration',
+
+        'getShapshotList',
+        'getSnapshot',
+        'uploadSnapshot',
+        'createSnapshot',
+        'cancelSnapshot',
+
+        'createCloudMigrationToken',
+        'deleteCloudMigrationToken',
+        'getCloudMigrationToken',
+
         'getDashboardByUid',
       ],
     },

--- a/scripts/generate-rtk-apis.ts
+++ b/scripts/generate-rtk-apis.ts
@@ -17,10 +17,6 @@ const config: ConfigFile = {
         'deleteSession',
         'createSession',
 
-        'getCloudMigrationRunList',
-        'getCloudMigrationRun',
-        'runCloudMigration',
-
         'getShapshotList',
         'getSnapshot',
         'uploadSnapshot',


### PR DESCRIPTION
Updates Cloud Migration to use the new Async Snapshot APIs. This is not the final UI - just the bare minimum required to get the new APIs to work.

 - Uses `getShapshotList` / `getSnapshot` to retrieve status of snapshot
 - Uses `createSnapshot` to build the snapshot
 - Polls `getSnapshot` on certain status to get live-ish progress updates
 - Uses `uploadSnapshot` to upload the snapshot and do the migration
 - Removes old 'migration run' APIs

Proper UI updates will come in later PR

Fixes https://github.com/grafana/grafana/issues/89534 