### PR TITLE
Zanzana: Run OpenFGA HTTP server in standalone mode

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -136,14 +136,12 @@ func (z *Zanzana) start(ctx context.Context) error {
 }
 
 func (z *Zanzana) running(ctx context.Context) error {
-	if z.cfg.Env == setting.Dev {
+	if z.cfg.Env == setting.Dev && z.cfg.Zanzana.ListenHTTP {
 		go func() {
-			if z.cfg.Zanzana.ListenHTTP {
-				z.logger.Info("Starting OpenFGA HTTP server")
-				err := zanzana.StartOpenFGAHttpSever(z.handle, z.logger)
-				if err != nil {
-					z.logger.Error("failed to start OpenFGA HTTP server", "error", err)
-				}
+			z.logger.Info("Starting OpenFGA HTTP server")
+			err := zanzana.StartOpenFGAHttpSever(z.cfg, z.handle, z.logger)
+			if err != nil {
+				z.logger.Error("failed to start OpenFGA HTTP server", "error", err)
 			}
 		}()
 	}

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -132,6 +132,11 @@ func (z *Zanzana) start(ctx context.Context) error {
 		return fmt.Errorf("failed to register reflection for zanzana: %w", err)
 	}
 
+	go func() {
+		z.logger.Info("Starting OpenFGA HTTP server")
+		zanzana.StartOpenFGAHttpSever(z.handle.GetAddress(), z.logger)
+	}()
+
 	return nil
 }
 

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -132,17 +132,19 @@ func (z *Zanzana) start(ctx context.Context) error {
 		return fmt.Errorf("failed to register reflection for zanzana: %w", err)
 	}
 
-	if z.cfg.Zanzana.ListenHTTP {
-		go func() {
-			z.logger.Info("Starting OpenFGA HTTP server")
-			zanzana.StartOpenFGAHttpSever(z.handle.GetAddress(), z.logger)
-		}()
-	}
-
 	return nil
 }
 
 func (z *Zanzana) running(ctx context.Context) error {
+	// FIXME: openFGA http server should be started after GRPC server, otherwise
+	// there's no address to connect. This is a race condition right now.
+	go func() {
+		if z.cfg.Zanzana.ListenHTTP {
+			z.logger.Info("Starting OpenFGA HTTP server")
+			zanzana.StartOpenFGAHttpSever(z.handle.GetAddress(), z.logger)
+		}
+	}()
+
 	// Run is blocking so we can just run it here
 	return z.handle.Run(ctx)
 }

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -132,10 +132,12 @@ func (z *Zanzana) start(ctx context.Context) error {
 		return fmt.Errorf("failed to register reflection for zanzana: %w", err)
 	}
 
-	go func() {
-		z.logger.Info("Starting OpenFGA HTTP server")
-		zanzana.StartOpenFGAHttpSever(z.handle.GetAddress(), z.logger)
-	}()
+	if z.cfg.Zanzana.ListenHTTP {
+		go func() {
+			z.logger.Info("Starting OpenFGA HTTP server")
+			zanzana.StartOpenFGAHttpSever(z.handle.GetAddress(), z.logger)
+		}()
+	}
 
 	return nil
 }

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -136,15 +136,17 @@ func (z *Zanzana) start(ctx context.Context) error {
 }
 
 func (z *Zanzana) running(ctx context.Context) error {
-	go func() {
-		if z.cfg.Zanzana.ListenHTTP {
-			z.logger.Info("Starting OpenFGA HTTP server")
-			err := zanzana.StartOpenFGAHttpSever(z.handle, z.logger)
-			if err != nil {
-				z.logger.Error("failed to start OpenFGA HTTP server", "error", err)
+	if z.cfg.Env == setting.Dev {
+		go func() {
+			if z.cfg.Zanzana.ListenHTTP {
+				z.logger.Info("Starting OpenFGA HTTP server")
+				err := zanzana.StartOpenFGAHttpSever(z.handle, z.logger)
+				if err != nil {
+					z.logger.Error("failed to start OpenFGA HTTP server", "error", err)
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	// Run is blocking so we can just run it here
 	return z.handle.Run(ctx)

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -136,12 +136,13 @@ func (z *Zanzana) start(ctx context.Context) error {
 }
 
 func (z *Zanzana) running(ctx context.Context) error {
-	// FIXME: openFGA http server should be started after GRPC server, otherwise
-	// there's no address to connect. This is a race condition right now.
 	go func() {
 		if z.cfg.Zanzana.ListenHTTP {
 			z.logger.Info("Starting OpenFGA HTTP server")
-			zanzana.StartOpenFGAHttpSever(z.handle.GetAddress(), z.logger)
+			err := zanzana.StartOpenFGAHttpSever(z.handle, z.logger)
+			if err != nil {
+				z.logger.Error("failed to start OpenFGA HTTP server", "error", err)
+			}
 		}
 	}()
 

--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func NewServer(store storage.OpenFGADatastore, logger log.Logger) (*server.Server, error) {
@@ -42,7 +43,7 @@ func NewServer(store storage.OpenFGADatastore, logger log.Logger) (*server.Serve
 }
 
 // StartOpenFGAHttpSever starts HTTP server which allows to use fga cli.
-func StartOpenFGAHttpSever(srv grpcserver.Provider, logger log.Logger) error {
+func StartOpenFGAHttpSever(cfg *setting.Cfg, srv grpcserver.Provider, logger log.Logger) error {
 	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
@@ -88,7 +89,7 @@ func StartOpenFGAHttpSever(srv grpcserver.Provider, logger log.Logger) error {
 	}
 
 	httpServer := &http.Server{
-		Addr: "127.0.0.1:8080",
+		Addr: cfg.Zanzana.HttpAddr,
 		Handler: cors.New(cors.Options{
 			AllowedOrigins:   []string{"*"},
 			AllowCredentials: true,

--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -1,8 +1,22 @@
 package zanzana
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	httpmiddleware "github.com/openfga/openfga/pkg/middleware/http"
 	"github.com/openfga/openfga/pkg/server"
+	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
+	"github.com/rs/cors"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthv1pb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -23,4 +37,60 @@ func NewServer(store storage.OpenFGADatastore, logger log.Logger) (*server.Serve
 	}
 
 	return srv, nil
+}
+
+// StartOpenFGAHttpSever starts HTTP server which allows to use fga cli.
+func StartOpenFGAHttpSever(addr string, logger log.Logger) {
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	// timeoutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// defer cancel()
+
+	// conn, err := grpc.DialContext(timeoutCtx, addr, dialOpts...)
+	conn, err := grpc.NewClient(addr, dialOpts...)
+	if err != nil {
+		logger.Error("Unable to Dial GRPC", zapcore.Field{Key: "err", Type: zapcore.ErrorType, Interface: err})
+	}
+
+	muxOpts := []runtime.ServeMuxOption{
+		runtime.WithForwardResponseOption(httpmiddleware.HTTPResponseModifier),
+		runtime.WithErrorHandler(func(c context.Context,
+			sr *runtime.ServeMux, mm runtime.Marshaler, w http.ResponseWriter, r *http.Request, e error) {
+			intCode := serverErrors.ConvertToEncodedErrorCode(status.Convert(e))
+			httpmiddleware.CustomHTTPErrorHandler(c, w, r, serverErrors.NewEncodedError(intCode, e.Error()))
+		}),
+		runtime.WithStreamErrorHandler(func(ctx context.Context, e error) *status.Status {
+			intCode := serverErrors.ConvertToEncodedErrorCode(status.Convert(e))
+			encodedErr := serverErrors.NewEncodedError(intCode, e.Error())
+			return status.Convert(encodedErr)
+		}),
+		runtime.WithHealthzEndpoint(healthv1pb.NewHealthClient(conn)),
+		runtime.WithOutgoingHeaderMatcher(func(s string) (string, bool) { return s, true }),
+	}
+	mux := runtime.NewServeMux(muxOpts...)
+	if err := openfgav1.RegisterOpenFGAServiceHandler(context.TODO(), mux, conn); err != nil {
+		logger.Error("failed to register gateway handler", zapcore.Field{Key: "err", Type: zapcore.ErrorType, Interface: err})
+		return
+	}
+
+	httpServer := &http.Server{
+		Addr: "127.0.0.1:8080",
+		Handler: cors.New(cors.Options{
+			AllowedOrigins:   []string{"*"},
+			AllowCredentials: true,
+			AllowedHeaders:   []string{"*"},
+			AllowedMethods: []string{http.MethodGet, http.MethodPost,
+				http.MethodHead, http.MethodPatch, http.MethodDelete, http.MethodPut},
+		}).Handler(mux),
+	}
+	go func() {
+		err = httpServer.ListenAndServe()
+		if err != nil {
+			logger.Error("failed to start http server", zapcore.Field{Key: "err", Type: zapcore.ErrorType, Interface: err})
+		}
+	}()
+	logger.Info(fmt.Sprintf("HTTP server listening on '%s'...", httpServer.Addr))
+	// s.fgaCfg.ApiUrl = fmt.Sprintf("http://%s", httpServer.Addr)
 }

--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -45,10 +45,7 @@ func StartOpenFGAHttpSever(addr string, logger log.Logger) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
 
-	// timeoutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	// defer cancel()
-
-	// conn, err := grpc.DialContext(timeoutCtx, addr, dialOpts...)
+	logger.Info("Connecting to the GRPC", "addr", addr)
 	conn, err := grpc.NewClient(addr, dialOpts...)
 	if err != nil {
 		logger.Error("Unable to Dial GRPC", zapcore.Field{Key: "err", Type: zapcore.ErrorType, Interface: err})

--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -61,7 +61,6 @@ func StartOpenFGAHttpSever(srv grpcserver.Provider, logger log.Logger) error {
 		return fmt.Errorf("failed to start HTTP server: GRPC server unavailable")
 	}
 
-	logger.Info("Connecting to the GRPC", "addr", addr)
 	conn, err := grpc.NewClient(addr, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("Unable to dial GRPC: %w", err)
@@ -103,6 +102,6 @@ func StartOpenFGAHttpSever(srv grpcserver.Provider, logger log.Logger) error {
 			logger.Error("failed to start http server", zapcore.Field{Key: "err", Type: zapcore.ErrorType, Interface: err})
 		}
 	}()
-	logger.Info(fmt.Sprintf("HTTP server listening on '%s'...", httpServer.Addr))
+	logger.Info(fmt.Sprintf("OpenFGA HTTP server listening on '%s'...", httpServer.Addr))
 	return nil
 }

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -18,6 +18,8 @@ type ZanzanaSettings struct {
 	Mode ZanzanaMode
 	// ListenHTTP enables OpenFGA http server which allows to use fga cli
 	ListenHTTP bool
+	// OpenFGA http server address which allows to connect with fga cli
+	HttpAddr string
 }
 
 func (cfg *Cfg) readZanzanaSettings() {
@@ -35,6 +37,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 
 	s.Addr = sec.Key("address").MustString("")
 	s.ListenHTTP = sec.Key("listen_http").MustBool(false)
+	s.HttpAddr = sec.Key("http_addr").MustString("127.0.0.1:8080")
 
 	cfg.Zanzana = s
 }

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -16,6 +16,8 @@ type ZanzanaSettings struct {
 	Addr string
 	// Mode can either be embedded or client
 	Mode ZanzanaMode
+	// ListenHTTP enables OpenFGA http server which allows to use fga cli
+	ListenHTTP bool
 }
 
 func (cfg *Cfg) readZanzanaSettings() {
@@ -32,6 +34,7 @@ func (cfg *Cfg) readZanzanaSettings() {
 	}
 
 	s.Addr = sec.Key("address").MustString("")
+	s.ListenHTTP = sec.Key("listen_http").MustBool(false)
 
 	cfg.Zanzana = s
 }


### PR DESCRIPTION
**What is this feature?**

Run OpenFGA HTTP server when zanzana is running as grafana module (standalone).

**Why do we need this feature?**

It allows to connect and use `fga` CLI tools.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/760

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
