### PR TITLE
CloudMigrations: Add ordering to snapshot list query

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -237,6 +237,7 @@ func (ss *sqlStore) GetSnapshotList(ctx context.Context, query cloudmigration.Li
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		offset := (query.Page - 1) * query.Limit
 		sess.Limit(query.Limit, offset)
+		sess.OrderBy("created DESC")
 		return sess.Find(&snapshots, &cloudmigration.CloudMigrationSnapshot{
 			SessionUID: query.SessionUID,
 		})


### PR DESCRIPTION
Sorts snapshots by created time descending, as the frontend will only care about the most recent snapshot for now. 