### PR TITLE
Alerting: Fix flaky test in scheduler's tests

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -248,8 +248,8 @@ func (a *alertRule) Run(key ngmodels.AlertRuleKey) error {
 
 				evalStart := a.clock.Now()
 				defer func() {
-					a.evalApplied(key, ctx.scheduledAt)
 					evalDuration.Observe(a.clock.Now().Sub(evalStart).Seconds())
+					a.evalApplied(key, ctx.scheduledAt)
 				}()
 
 				for attempt := int64(1); attempt <= a.maxAttempts; attempt++ {


### PR DESCRIPTION
Attempt to fix a flaky test https://drone.grafana.net/grafana/grafana-enterprise/72603/2/8
```
--- FAIL: TestRuleRoutine (2.14s)
    --- FAIL: TestRuleRoutine/when_rule_evaluation_happens_(evaluation_state_Normal) (0.01s)
        --- FAIL: TestRuleRoutine/when_rule_evaluation_happens_(evaluation_state_Normal)/it_reports_metrics (0.01s)
            alert_rule_test.go:448: 
                	Error Trace:	/drone/src/pkg/services/ngalert/schedule/alert_rule_test.go:448
                	Error:      	Received unexpected error:
                	            	
                	            	
                	            	Diff:
                	            	--- metric output does not match expectation; want
                	            	+++ got:
                	            	@@ -8,18 +8,18 @@
                	            	 # TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="0.01"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="0.1"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="0.5"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="1"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="5"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="10"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="15"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="30"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="60"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="120"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="180"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="240"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="300"} 1
                	            	-grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="+Inf"} 1
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="0.01"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="0.1"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="0.5"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="1"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="5"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="10"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="15"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="30"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="60"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="120"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="180"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="240"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="300"} 0
                	            	+grafana_alerting_rule_evaluation_duration_seconds_bucket{org="1021",le="+Inf"} 0
                	            	 grafana_alerting_rule_evaluation_duration_seconds_sum{org="1021"} 0
                	            	-grafana_alerting_rule_evaluation_duration_seconds_count{org="1021"} 1
                	            	+grafana_alerting_rule_evaluation_duration_seconds_count{org="1021"} 0
                	            	 # HELP grafana_alerting_rule_evaluation_failures_total The total number of rule evaluation failures.
                	Test:       	TestRuleRoutine/when_rule_evaluation_happens_(evaluation_state_Normal)/it_reports_metrics
FAIL
coverage: 18.0% of statements
FAIL	github.com/grafana/grafana/pkg/services/ngalert/schedule	3.354s
```

The test is structured in a way that it looks like everything worked because previous other tests passed. I guess this could be due to a possible race condition due to the fact that we unblock test thread before updating the metrics.