### PR TITLE
Alerting: Refactor scheduler's rule evaluator to store rule key

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -149,7 +149,7 @@ func newAlertRule(
 	evalAppliedHook func(ngmodels.AlertRuleKey, time.Time),
 	stopAppliedHook func(ngmodels.AlertRuleKey),
 ) *alertRule {
-	ctx, stop := util.WithCancelCause(parent)
+	ctx, stop := util.WithCancelCause(ngmodels.WithRuleKey(parent, key))
 	return &alertRule{
 		key:                  key,
 		evalCh:               make(chan *Evaluation),
@@ -167,7 +167,7 @@ func newAlertRule(
 		evalAppliedHook:      evalAppliedHook,
 		stopAppliedHook:      stopAppliedHook,
 		metrics:              met,
-		logger:               logger,
+		logger:               logger.FromContext(ctx),
 		tracer:               tracer,
 	}
 }
@@ -221,8 +221,8 @@ func (a *alertRule) Stop(reason error) {
 }
 
 func (a *alertRule) Run() error {
-	grafanaCtx := ngmodels.WithRuleKey(a.ctx, a.key)
-	logger := a.logger.FromContext(grafanaCtx)
+	grafanaCtx := a.ctx
+	logger := a.logger
 	logger.Debug("Alert rule routine started")
 
 	var currentFingerprint fingerprint

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -248,7 +248,7 @@ func TestAlertRule(t *testing.T) {
 		rule := blankRuleForTests(context.Background())
 		runResult := make(chan error)
 		go func() {
-			runResult <- rule.Run(models.AlertRuleKey{})
+			runResult <- rule.Run()
 		}()
 
 		rule.Stop(nil)
@@ -263,7 +263,7 @@ func TestAlertRule(t *testing.T) {
 }
 
 func blankRuleForTests(ctx context.Context) *alertRule {
-	return newAlertRule(context.Background(), nil, false, 0, nil, nil, nil, nil, nil, nil, log.NewNopLogger(), nil, nil, nil)
+	return newAlertRule(context.Background(), models.AlertRuleKey{}, nil, false, 0, nil, nil, nil, nil, nil, nil, log.NewNopLogger(), nil, nil, nil)
 }
 
 func TestRuleRoutine(t *testing.T) {
@@ -301,7 +301,7 @@ func TestRuleRoutine(t *testing.T) {
 			t.Cleanup(cancel)
 			ruleInfo := factory.new(ctx, rule)
 			go func() {
-				_ = ruleInfo.Run(rule.GetKey())
+				_ = ruleInfo.Run()
 			}()
 
 			expectedTime := time.UnixMicro(rand.Int63())
@@ -464,7 +464,7 @@ func TestRuleRoutine(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			ruleInfo := factory.new(ctx, rule)
 			go func() {
-				err := ruleInfo.Run(models.AlertRuleKey{})
+				err := ruleInfo.Run()
 				stoppedChan <- err
 			}()
 
@@ -484,7 +484,7 @@ func TestRuleRoutine(t *testing.T) {
 			factory := ruleFactoryFromScheduler(sch)
 			ruleInfo := factory.new(context.Background(), rule)
 			go func() {
-				err := ruleInfo.Run(rule.GetKey())
+				err := ruleInfo.Run()
 				stoppedChan <- err
 			}()
 
@@ -515,7 +515,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
-			_ = ruleInfo.Run(rule.GetKey())
+			_ = ruleInfo.Run()
 		}()
 
 		// init evaluation loop so it got the rule version
@@ -597,7 +597,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
-			_ = ruleInfo.Run(rule.GetKey())
+			_ = ruleInfo.Run()
 		}()
 
 		ruleInfo.Eval(&Evaluation{
@@ -716,7 +716,7 @@ func TestRuleRoutine(t *testing.T) {
 			ruleInfo := factory.new(ctx, rule)
 
 			go func() {
-				_ = ruleInfo.Run(rule.GetKey())
+				_ = ruleInfo.Run()
 			}()
 
 			ruleInfo.Eval(&Evaluation{
@@ -750,7 +750,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
-			_ = ruleInfo.Run(rule.GetKey())
+			_ = ruleInfo.Run()
 		}()
 
 		ruleInfo.Eval(&Evaluation{
@@ -787,7 +787,7 @@ func TestRuleRoutine(t *testing.T) {
 		ruleInfo := factory.new(ctx, rule)
 
 		go func() {
-			_ = ruleInfo.Run(rule.GetKey())
+			_ = ruleInfo.Run()
 		}()
 
 		// Evaluate 10 times:

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -255,7 +255,7 @@ func (r *recordingRule) evaluationDoneTestHook(ev *Evaluation) {
 		return
 	}
 
-	r.evalAppliedHook(ev.rule.GetKey(), ev.scheduledAt)
+	r.evalAppliedHook(r.key, ev.scheduledAt)
 }
 
 func (r *recordingRule) frameRef(refID string, resp *backend.QueryDataResponse) (data.Frames, error) {

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	models "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/writer"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRecordingRule(t *testing.T) {
@@ -131,7 +132,7 @@ func TestRecordingRule(t *testing.T) {
 		rule := blankRecordingRuleForTests(context.Background())
 		runResult := make(chan error)
 		go func() {
-			runResult <- rule.Run(models.AlertRuleKey{})
+			runResult <- rule.Run()
 		}()
 
 		rule.Stop(nil)
@@ -147,7 +148,7 @@ func TestRecordingRule(t *testing.T) {
 
 func blankRecordingRuleForTests(ctx context.Context) *recordingRule {
 	ft := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaManagedRecordingRules)
-	return newRecordingRule(context.Background(), 0, nil, nil, ft, log.NewNopLogger(), nil, nil, writer.FakeWriter{})
+	return newRecordingRule(context.Background(), models.AlertRuleKey{}, 0, nil, nil, ft, log.NewNopLogger(), nil, nil, writer.FakeWriter{})
 }
 
 func TestRecordingRule_Integration(t *testing.T) {
@@ -168,7 +169,7 @@ func TestRecordingRule_Integration(t *testing.T) {
 	now := time.Now()
 
 	go func() {
-		_ = process.Run(rule.GetKey())
+		_ = process.Run()
 	}()
 	process.Eval(&Evaluation{
 		scheduledAt: now,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -282,7 +283,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 		if newRoutine && !invalidInterval {
 			dispatcherGroup.Go(func() error {
-				return ruleRoutine.Run(key)
+				return ruleRoutine.Run()
 			})
 		}
 


### PR DESCRIPTION
Just a small refactoring that encapsulates the rule key in the struct, simplifying methods signatures.