### PR TITLE
CloudWatch: add account dropdown to metric insights

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx
@@ -4,6 +4,7 @@ import { useAsyncFn } from 'react-use';
 
 import { SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton, EditorList, InputGroup } from '@grafana/experimental';
+import { config } from '@grafana/runtime';
 import { Alert, Select, useStyles2 } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../../../datasource';
@@ -27,7 +28,6 @@ import {
   setOperatorExpressionValue,
   setSql,
 } from './utils';
-import { config } from '@grafana/runtime';
 
 interface SQLFilterProps {
   query: CloudWatchMetricsQuery;
@@ -113,7 +113,10 @@ const FilterItem = (props: FilterItemProps) => {
     region: query.region,
     namespace,
     metricName,
-    ...(config.featureToggles.cloudWatchCrossAccountQuerying ? { accountId: query.accountId } : {}),
+    ...(config.featureToggles.cloudWatchCrossAccountQuerying &&
+    config.featureToggles.cloudwatchMetricInsightsCrossAccount
+      ? { accountId: query.accountId }
+      : {}),
   });
 
   const loadDimensionValues = async () => {
@@ -127,7 +130,10 @@ const FilterItem = (props: FilterItemProps) => {
         namespace,
         metricName,
         dimensionKey: filter.property.name,
-        ...(config.featureToggles.cloudWatchCrossAccountQuerying ? { accountId: query.accountId } : {}),
+        ...(config.featureToggles.cloudWatchCrossAccountQuerying &&
+        config.featureToggles.cloudwatchMetricInsightsCrossAccount
+          ? { accountId: query.accountId }
+          : {}),
       })
       .then((result: Array<SelectableValue<string>>) => {
         return appendTemplateVariables(datasource, result);

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -332,15 +332,19 @@ describe('QueryEditor should render right editor', () => {
   });
 
   describe('metric insights in builder mode', () => {
-    let originalValue: boolean | undefined;
+    let originalValueCloudWatchCrossAccountQuerying: boolean | undefined;
+    let originalValueCloudwatchMetricInsightsCrossAccount: boolean | undefined;
     beforeEach(() => {
-      originalValue = config.featureToggles.cloudWatchCrossAccountQuerying;
+      originalValueCloudWatchCrossAccountQuerying = config.featureToggles.cloudWatchCrossAccountQuerying;
+      originalValueCloudwatchMetricInsightsCrossAccount = config.featureToggles.cloudwatchMetricInsightsCrossAccount;
     });
     afterEach(() => {
-      config.featureToggles.cloudWatchCrossAccountQuerying = originalValue;
+      config.featureToggles.cloudWatchCrossAccountQuerying = originalValueCloudWatchCrossAccountQuerying;
+      config.featureToggles.cloudwatchMetricInsightsCrossAccount = originalValueCloudwatchMetricInsightsCrossAccount;
     });
     it('should have an account selector when the feature is enabled', async () => {
       config.featureToggles.cloudWatchCrossAccountQuerying = true;
+      config.featureToggles.cloudwatchMetricInsightsCrossAccount = true;
       props.datasource.resources.getAccounts = jest.fn().mockResolvedValue(['account123']);
       render(<QueryEditor {...props} query={validMetricQueryBuilderQuery} />);
       await screen.findByText('Metric Query');

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -330,4 +330,21 @@ describe('QueryEditor should render right editor', () => {
       expect(screen.queryByText('Are you sure?')).toBeNull();
     });
   });
+
+  describe('metric insights in builder mode', () => {
+    let originalValue: boolean | undefined;
+    beforeEach(() => {
+      originalValue = config.featureToggles.cloudWatchCrossAccountQuerying;
+    });
+    afterEach(() => {
+      config.featureToggles.cloudWatchCrossAccountQuerying = originalValue;
+    });
+    it('should have an account selector when the feature is enabled', async () => {
+      config.featureToggles.cloudWatchCrossAccountQuerying = true;
+      props.datasource.resources.getAccounts = jest.fn().mockResolvedValue(['account123']);
+      render(<QueryEditor {...props} query={validMetricQueryBuilderQuery} />);
+      await screen.findByText('Metric Query');
+      expect(await screen.findByText('Account')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
**What is this feature?**

Starting dev work to add account id selection to the query builder of metric insights queries in cloudwatch. 

**Why do we need this feature?**

Cloudwatch users right now can query across multiple accounts in a single query when in a single region as long as they are making metric search queries. However if a user wanted to write a sql query with metric insights, our builder did not support that functionality. This was because at the time, it wasn't supported by the API, however AWS has since released support for cross account observability for metrics insights queries. 

It is currently possible to write a cross account query with metric insights in "Code" mode but not in the "Builder" mode. This one of several dev steps we need to get that query to work. Rather than do it in all one big pr, we've broken this work up across several tickets. 

This one: 
- adds the dropdown behind a feature flag
- and updates grafana's query object to have accountId in it
- and then filters subsequent calls for dimension keys with that account id. 

It does not actually affect the returned data yet that is happening in another PR. 

**Who is this feature for?**

(no one yet, not ready for users)

**Which issue(s) does this PR fix?**:

Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/969

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
