### PR TITLE
Authn: Set requester in middleware

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -112,16 +112,16 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			reqContext.Logger = reqContext.Logger.New("traceID", traceID)
 		}
 
-		identity, err := h.authnService.Authenticate(ctx, &authn.Request{HTTPRequest: reqContext.Req, Resp: reqContext.Resp})
+		id, err := h.authnService.Authenticate(ctx, &authn.Request{HTTPRequest: reqContext.Req, Resp: reqContext.Resp})
 		if err != nil {
 			// Hack: set all errors on LookupTokenErr, so we can check it in auth middlewares
 			reqContext.LookupTokenErr = err
 		} else {
-			reqContext.SignedInUser = identity.SignedInUser()
-			reqContext.UserToken = identity.SessionToken
+			reqContext.SignedInUser = id.SignedInUser()
+			reqContext.UserToken = id.SessionToken
 			reqContext.IsSignedIn = !reqContext.SignedInUser.IsAnonymous
 			reqContext.AllowAnonymous = reqContext.SignedInUser.IsAnonymous
-			reqContext.IsRenderCall = identity.IsAuthenticatedBy(login.RenderModule)
+			reqContext.IsRenderCall = id.IsAuthenticatedBy(login.RenderModule)
 		}
 
 		reqContext.Logger = reqContext.Logger.New("userId", reqContext.UserID, "orgId", reqContext.OrgID, "uname", reqContext.Login)
@@ -138,7 +138,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 		// End the span to make next handlers not wrapped within middleware span
 		span.End()
 
-		next.ServeHTTP(w, r)
+		next.ServeHTTP(w, r.WithContext(identity.WithRequester(ctx, id)))
 	})
 }
 


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/89450 we changed things so we use `identity.GetRequester(ctx)` to get the user.  This works in most places, but previously there was a fallback that would cast the context and get the SignedInUser directly.

This PR updates the auth middleware so it now properly sets the identity.