### PR TITLE
Table panel: Add alt and title text options to image cell type

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -157,6 +157,12 @@ Toggle the **Apply to entire row** switch, to apply the background color that's 
 
 Cells can be displayed as a graphical gauge, with several different presentation types.
 
+#### Image
+
+If you want to set the alternative text of an image, use the **Alt text** option to do so which will make alternative text avaiable for screen readers and cases when images can't be loaded.
+
+Additionally, if you'd like to set the title text, use the **Title text** option to do so which will make the title text display when the image is hovered with a cursor.
+
 ##### Basic
 
 The basic mode will show a simple gauge with the threshold levels defining the color of gauge.

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -157,12 +157,6 @@ Toggle the **Apply to entire row** switch, to apply the background color that's 
 
 Cells can be displayed as a graphical gauge, with several different presentation types.
 
-#### Image
-
-If you want to set the alternative text of an image, use the **Alt text** option to do so which will make alternative text avaiable for screen readers and cases when images can't be loaded.
-
-Additionally, if you'd like to set the title text, use the **Title text** option to do so which will make the title text display when the image is hovered with a cursor.
-
 ##### Basic
 
 The basic mode will show a simple gauge with the threshold levels defining the color of gauge.
@@ -214,6 +208,10 @@ Shows value formatted as code. If a value is an object the JSON view allowing br
 If you have a field value that is an image URL or a base64 encoded image you can configure the table to display it as an image.
 
 {{< figure src="/static/img/docs/v73/table_hover.gif" max-width="900px" caption="Table hover" >}}
+
+Use the **Alt text** option to set the alternative text of an image. The text will be available for screen readers and in cases when images can't be loaded.
+
+Use the **Title text** option to set the text that's displayed when the image is hovered over with a cursor.
 
 #### Sparkline
 

--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -771,6 +771,8 @@ export interface TableJsonViewCellOptions {
  * Json view cell options
  */
 export interface TableImageCellOptions {
+  alt?: string;
+  title?: string;
   type: TableCellDisplayMode.Image;
 }
 

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -48,6 +48,8 @@ TableJsonViewCellOptions: {
 // Json view cell options
 TableImageCellOptions: {
 	type: TableCellDisplayMode & "image"
+	alt?: string
+	title?: string
 } @cuetsy(kind="interface")
 
 // Show data links in the cell

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -3,41 +3,38 @@ import * as React from 'react';
 import { getCellLinks } from '../../utils';
 import { DataLinksContextMenu } from '../DataLinks/DataLinksContextMenu';
 
-import { TableCellProps } from './types';
+import { TableCellDisplayMode, TableCellProps } from './types';
+import { getCellOptions } from './utils';
 
 const DATALINKS_HEIGHT_OFFSET = 10;
 
 export const ImageCell = (props: TableCellProps) => {
   const { field, cell, tableStyles, row, cellProps } = props;
-
+  const cellOptions = getCellOptions(field);
+  const { title, alt } = cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { title: undefined, alt: undefined };
   const displayValue = field.display!(cell.value);
-
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
+
+  // The image element
+  const img = <img
+    style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
+    src={displayValue.text}
+    className={tableStyles.imageCell}
+    alt={alt}
+    title={title}
+  />
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>
-      {!hasLinks && (
-        <img
-          style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
-          src={displayValue.text}
-          className={tableStyles.imageCell}
-          alt=""
-        />
-      )}
+      {/* If there are no links we simply render the image */}
+      {!hasLinks && img}
+      {/* Otherwise render data links with image */}
       {hasLinks && (
         <DataLinksContextMenu
           style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
           links={() => getCellLinks(field, row) || []}
         >
           {(api) => {
-            const img = (
-              <img
-                style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
-                src={displayValue.text}
-                className={tableStyles.imageCell}
-                alt=""
-              />
-            );
             if (api.openMenu) {
               return (
                 <div

--- a/packages/grafana-ui/src/components/Table/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/ImageCell.tsx
@@ -11,18 +11,21 @@ const DATALINKS_HEIGHT_OFFSET = 10;
 export const ImageCell = (props: TableCellProps) => {
   const { field, cell, tableStyles, row, cellProps } = props;
   const cellOptions = getCellOptions(field);
-  const { title, alt } = cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { title: undefined, alt: undefined };
+  const { title, alt } =
+    cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { title: undefined, alt: undefined };
   const displayValue = field.display!(cell.value);
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
 
   // The image element
-  const img = <img
-    style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
-    src={displayValue.text}
-    className={tableStyles.imageCell}
-    alt={alt}
-    title={title}
-  />
+  const img = (
+    <img
+      style={{ height: tableStyles.cellHeight - DATALINKS_HEIGHT_OFFSET, width: 'auto' }}
+      src={displayValue.text}
+      className={tableStyles.imageCell}
+      alt={alt}
+      title={title}
+    />
+  );
 
   return (
     <div {...cellProps} className={tableStyles.cellContainer}>

--- a/public/app/plugins/panel/table/TableCellOptionEditor.tsx
+++ b/public/app/plugins/panel/table/TableCellOptionEditor.tsx
@@ -9,8 +9,8 @@ import { Field, Select, TableCellDisplayMode, useStyles2 } from '@grafana/ui';
 import { AutoCellOptionsEditor } from './cells/AutoCellOptionsEditor';
 import { BarGaugeCellOptionsEditor } from './cells/BarGaugeCellOptionsEditor';
 import { ColorBackgroundCellOptionsEditor } from './cells/ColorBackgroundCellOptionsEditor';
-import { SparklineCellOptionsEditor } from './cells/SparklineCellOptionsEditor';
 import { ImageCellOptionsEditor } from './cells/ImageCellOptionsEditor';
+import { SparklineCellOptionsEditor } from './cells/SparklineCellOptionsEditor';
 
 // The props that any cell type editor are expected
 // to handle. In this case the generic type should

--- a/public/app/plugins/panel/table/TableCellOptionEditor.tsx
+++ b/public/app/plugins/panel/table/TableCellOptionEditor.tsx
@@ -10,6 +10,7 @@ import { AutoCellOptionsEditor } from './cells/AutoCellOptionsEditor';
 import { BarGaugeCellOptionsEditor } from './cells/BarGaugeCellOptionsEditor';
 import { ColorBackgroundCellOptionsEditor } from './cells/ColorBackgroundCellOptionsEditor';
 import { SparklineCellOptionsEditor } from './cells/SparklineCellOptionsEditor';
+import { ImageCellOptionsEditor } from './cells/ImageCellOptionsEditor';
 
 // The props that any cell type editor are expected
 // to handle. In this case the generic type should
@@ -72,6 +73,9 @@ export const TableCellOptionEditor = ({ value, onChange }: Props) => {
       )}
       {cellType === TableCellDisplayMode.Sparkline && (
         <SparklineCellOptionsEditor cellOptions={value} onChange={onCellOptionsChange} />
+      )}
+      {cellType === TableCellDisplayMode.Image && (
+        <ImageCellOptionsEditor cellOptions={value} onChange={onCellOptionsChange} />
       )}
     </div>
   );

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -22,11 +22,11 @@ export const ImageCellOptionsEditor = ({
     return (
         <>
             <Field label="Alt text" description="Alternative text that will be displayed if an image can't be displayed or for users that use a screen reader">
-                <Input onChange={onAltChange} value={cellOptions.alt} />
+                <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
             </Field>
 
             <Field label="Title text" description="Text that will show when the image is hovered by a cursor">
-                <Input onChange={onTitleChange} value={cellOptions.title} />
+                <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
             </Field>
         </>
     );

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -15,7 +15,7 @@ export const ImageCellOptionsEditor = ({
     };
 
     const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
-        cellOptions.alt = e.currentTarget.value;
+        cellOptions.title = e.currentTarget.value;
         onChange(cellOptions);
     }
 

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -5,29 +5,29 @@ import { Field, Input } from '@grafana/ui';
 
 import { TableCellEditorProps } from '../TableCellOptionEditor';
 
-export const ImageCellOptionsEditor = ({
-    cellOptions,
-    onChange,
-}: TableCellEditorProps<TableImageCellOptions>) => {
-    const onAltChange = (e: FormEvent<HTMLInputElement>) => {
-        cellOptions.alt = e.currentTarget.value;
-        onChange(cellOptions);
-    };
+export const ImageCellOptionsEditor = ({ cellOptions, onChange }: TableCellEditorProps<TableImageCellOptions>) => {
+  const onAltChange = (e: FormEvent<HTMLInputElement>) => {
+    cellOptions.alt = e.currentTarget.value;
+    onChange(cellOptions);
+  };
 
-    const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
-        cellOptions.title = e.currentTarget.value;
-        onChange(cellOptions);
-    }
+  const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
+    cellOptions.title = e.currentTarget.value;
+    onChange(cellOptions);
+  };
 
-    return (
-        <>
-            <Field label="Alt text" description="Alternative text that will be displayed if an image can't be displayed or for users that use a screen reader">
-                <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
-            </Field>
+  return (
+    <>
+      <Field
+        label="Alt text"
+        description="Alternative text that will be displayed if an image can't be displayed or for users that use a screen reader"
+      >
+        <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
+      </Field>
 
-            <Field label="Title text" description="Text that will show when the image is hovered by a cursor">
-                <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
-            </Field>
-        </>
-    );
+      <Field label="Title text" description="Text that will show when the image is hovered by a cursor">
+        <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
+      </Field>
+    </>
+  );
 };

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -1,3 +1,5 @@
+import { FormEvent } from 'react';
+
 import { TableImageCellOptions } from '@grafana/schema';
 import { Field, Input } from '@grafana/ui';
 
@@ -7,24 +9,24 @@ export const ImageCellOptionsEditor = ({
     cellOptions,
     onChange,
 }: TableCellEditorProps<TableImageCellOptions>) => {
-    const onAltChange = (e: any) => {
-        console.log(e);
-        // onChange(cellOptions);
+    const onAltChange = (e: FormEvent<HTMLInputElement>) => {
+        cellOptions.alt = e.currentTarget.value;
+        onChange(cellOptions);
     };
 
-    const onTitleChange = (e: any) => {
-        console.log(e);
-        // onChange(cellOptions);
+    const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
+        cellOptions.alt = e.currentTarget.value;
+        onChange(cellOptions);
     }
 
     return (
         <>
             <Field label="Alt text" description="Alternative text that will be displayed if an image can't be displayed or for users that use a screen reader">
-                <Input onChange={(e) => { onAltChange(e) }} onKeyUp={(e) => console.log('i was called')} />
+                <Input onChange={onAltChange} value={cellOptions.alt} />
             </Field>
 
             <Field label="Title text" description="Text that will show when the image is hovered by a cursor">
-                <Input onChange={(e) => { onTitleChange(e) }} />
+                <Input onChange={onTitleChange} value={cellOptions.title} />
             </Field>
         </>
     );

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -6,28 +6,28 @@ import { Field, Input } from '@grafana/ui';
 import { TableCellEditorProps } from '../TableCellOptionEditor';
 
 export const ImageCellOptionsEditor = ({ cellOptions, onChange }: TableCellEditorProps<TableImageCellOptions>) => {
-  const onAltChange = (e: FormEvent<HTMLInputElement>) => {
-    cellOptions.alt = e.currentTarget.value;
-    onChange(cellOptions);
-  };
+    const onAltChange = (e: FormEvent<HTMLInputElement>) => {
+        cellOptions.alt = e.currentTarget.value;
+        onChange(cellOptions);
+    };
 
-  const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
-    cellOptions.title = e.currentTarget.value;
-    onChange(cellOptions);
-  };
+    const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
+        cellOptions.title = e.currentTarget.value;
+        onChange(cellOptions);
+    };
 
-  return (
-    <>
-      <Field
-        label="Alt text"
-        description="Alternative text that will be displayed if an image can't be displayed or for users that use a screen reader"
-      >
-        <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
-      </Field>
+    return (
+        <>
+            <Field
+                label="Alt text"
+                description="Alternative text that will be displayed if an image can't be displayed or for users who use a screen reader"
+            >
+                <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
+            </Field>
 
-      <Field label="Title text" description="Text that will show when the image is hovered by a cursor">
-        <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
-      </Field>
-    </>
-  );
+            <Field label="Title text" description="Text that will be displayed when the image is hovered by a cursor">
+                <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
+            </Field>
+        </>
+    );
 };

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -6,28 +6,28 @@ import { Field, Input } from '@grafana/ui';
 import { TableCellEditorProps } from '../TableCellOptionEditor';
 
 export const ImageCellOptionsEditor = ({ cellOptions, onChange }: TableCellEditorProps<TableImageCellOptions>) => {
-    const onAltChange = (e: FormEvent<HTMLInputElement>) => {
-        cellOptions.alt = e.currentTarget.value;
-        onChange(cellOptions);
-    };
+  const onAltChange = (e: FormEvent<HTMLInputElement>) => {
+    cellOptions.alt = e.currentTarget.value;
+    onChange(cellOptions);
+  };
 
-    const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
-        cellOptions.title = e.currentTarget.value;
-        onChange(cellOptions);
-    };
+  const onTitleChange = (e: FormEvent<HTMLInputElement>) => {
+    cellOptions.title = e.currentTarget.value;
+    onChange(cellOptions);
+  };
 
-    return (
-        <>
-            <Field
-                label="Alt text"
-                description="Alternative text that will be displayed if an image can't be displayed or for users who use a screen reader"
-            >
-                <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
-            </Field>
+  return (
+    <>
+      <Field
+        label="Alt text"
+        description="Alternative text that will be displayed if an image can't be displayed or for users who use a screen reader"
+      >
+        <Input onChange={onAltChange} defaultValue={cellOptions.alt} />
+      </Field>
 
-            <Field label="Title text" description="Text that will be displayed when the image is hovered by a cursor">
-                <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
-            </Field>
-        </>
-    );
+      <Field label="Title text" description="Text that will be displayed when the image is hovered by a cursor">
+        <Input onChange={onTitleChange} defaultValue={cellOptions.title} />
+      </Field>
+    </>
+  );
 };

--- a/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/ImageCellOptionsEditor.tsx
@@ -1,0 +1,31 @@
+import { TableImageCellOptions } from '@grafana/schema';
+import { Field, Input } from '@grafana/ui';
+
+import { TableCellEditorProps } from '../TableCellOptionEditor';
+
+export const ImageCellOptionsEditor = ({
+    cellOptions,
+    onChange,
+}: TableCellEditorProps<TableImageCellOptions>) => {
+    const onAltChange = (e: any) => {
+        console.log(e);
+        // onChange(cellOptions);
+    };
+
+    const onTitleChange = (e: any) => {
+        console.log(e);
+        // onChange(cellOptions);
+    }
+
+    return (
+        <>
+            <Field label="Alt text" description="Alternative text that will be displayed if an image can't be displayed or for users that use a screen reader">
+                <Input onChange={(e) => { onAltChange(e) }} onKeyUp={(e) => console.log('i was called')} />
+            </Field>
+
+            <Field label="Title text" description="Text that will show when the image is hovered by a cursor">
+                <Input onChange={(e) => { onTitleChange(e) }} />
+            </Field>
+        </>
+    );
+};


### PR DESCRIPTION
**What is this feature?**

This PR adds the ability to edit alt text and title text in the image cell type of the table panel. This is important for accessibility and provides another avenue for surfacing data (via hovering with title text).

**Why do we need this feature?**

Improves accessibility and usability of the table panel image cell

**Who is this feature for?**

Users of the table image cell

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
