### PR TITLE
Alerting: Fix parseMatchers function to handle slashes and doble quotes

### DIFF
--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -125,12 +125,14 @@ export function matcherToObjectMatcher(matcher: Matcher): ObjectMatcher {
 }
 
 export function parseMatchers(matcherQueryString: string): Matcher[] {
-  const matcherRegExp = /\b([\w.-]+)(=~|!=|!~|=(?="?\w))"?([^"\n,}]*)"?/g;
+  const matcherRegExp = /\b([\w.-]+)(=~|!=|!~|=)(?:"([^"\n}]*)"|([^\s,]+))/g;
   const matchers: Matcher[] = [];
 
-  matcherQueryString.replace(matcherRegExp, (_, key, operator, value) => {
+  matcherQueryString.replace(matcherRegExp, (_, key, operator, quotedValue, unquotedValue) => {
+    const value = quotedValue || unquotedValue; // Use quotedValue if available, otherwise use unquotedValue
     const isEqual = operator === MatcherOperator.equal || operator === MatcherOperator.regex;
     const isRegex = operator === MatcherOperator.regex || operator === MatcherOperator.notRegex;
+
     matchers.push({
       name: key,
       value: isRegex ? getValidRegexString(value.trim()) : value.trim(),


### PR DESCRIPTION
**What is this feature?**

This PR fixes filtering labels containing slashes and/or doble quotes.This bug affects all the filters by labels in the alerting UI.

Example: `handler=/metrics` or `handler="/metrics"`

**Why do we need this feature?**

Filtering by labels should handle this use cases.

**Who is this feature for?**

All alerting users.


**Special notes for your reviewer:**



https://github.com/grafana/grafana/assets/33540275/423d169a-487a-4e34-839d-759fcd1acf6f





Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
