### PR TITLE
E2C: Set up page route so cloud-migrations doesn't 404

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -108,6 +108,10 @@ func (hs *HTTPServer) registerRoutes() {
 		r.Get("/admin/storage/*", reqSignedIn, hs.Index)
 	}
 
+	if hs.Features.IsEnabledGlobally(featuremgmt.FlagOnPremToCloudMigrations) {
+		r.Get("/admin/migrate-to-cloud", reqOrgAdmin, hs.Index)
+	}
+
 	// feature toggle admin page
 	if hs.Features.IsEnabledGlobally(featuremgmt.FlagFeatureToggleAdminPage) {
 		r.Get("/admin/featuretoggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)


### PR DESCRIPTION
Fix for /admin/migrate-to-cloud page 404-ing