### PR TITLE
Auth: Add support for escaping colon characters in org_mapping

### DIFF
--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -132,7 +132,7 @@ func (m *OrgRoleMapper) ParseOrgMappingSettings(ctx context.Context, mappings []
 	res := map[string]map[int64]org.RoleType{}
 
 	for _, v := range mappings {
-		kv := strings.Split(v, ":")
+		kv := splitOrgMapping(v)
 		if !isValidOrgMappingFormat(kv) {
 			m.logger.Error("Skipping org mapping due to invalid format.", "mapping", fmt.Sprintf("%v", v))
 			if roleStrict {
@@ -201,6 +201,18 @@ func (m *OrgRoleMapper) getAllOrgs() (map[int64]bool, error) {
 		allOrgIDs[org.ID] = true
 	}
 	return allOrgIDs, nil
+}
+
+func splitOrgMapping(mapping string) []string {
+	splitted := strings.Split(mapping, ":")
+	if len(splitted) <= 3 {
+		return splitted
+	}
+	result := make([]string, 3)
+	result[2] = splitted[len(splitted)-1]
+	result[1] = splitted[len(splitted)-2]
+	result[0] = strings.Join(splitted[:len(splitted)-2], ":")
+	return result
 }
 
 func getRoleForInternalOrgMapping(kv []string) org.RoleType {

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -12,7 +12,12 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-const mapperMatchAllOrgID = -1
+const (
+	mapperMatchAllOrgID = -1
+	escapeStr           = `\`
+)
+
+var separatorRegexp = regexp.MustCompile(":")
 
 // OrgRoleMapper maps external orgs/groups to Grafana orgs and basic roles.
 type OrgRoleMapper struct {
@@ -206,16 +211,15 @@ func (m *OrgRoleMapper) getAllOrgs() (map[int64]bool, error) {
 
 func splitOrgMapping(mapping string) []string {
 	result := make([]string, 0, 3)
-	re := regexp.MustCompile(":")
-	matches := re.FindAllStringIndex(mapping, -1)
+	matches := separatorRegexp.FindAllStringIndex(mapping, -1)
 	from := 0
 
 	for _, match := range matches {
 		// match[0] is the start, match[1] is the end of the match
 		start, end := match[0], match[1]
 		// Check if the match is not preceded by two backslashes
-		if start == 0 || mapping[start-1:start] != `\` {
-			result = append(result, strings.ReplaceAll(mapping[from:end-1], `\`, ""))
+		if start == 0 || mapping[start-1:start] != escapeStr {
+			result = append(result, strings.ReplaceAll(mapping[from:end-1], escapeStr, ""))
 			from = end
 		}
 	}

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -270,10 +270,10 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 		},
 		{
 			name:       "should return correct mapping when the first part contains multiple colons",
-			rawMapping: []string{`Groups\:IT:1:Viewer`},
+			rawMapping: []string{"Groups\\:IT\\:ops:1:Viewer"},
 			roleStrict: false,
 			expected: &MappingConfiguration{
-				orgMapping:        map[string]map[int64]org.RoleType{"Groups:IT": {1: org.RoleViewer}},
+				orgMapping:        map[string]map[int64]org.RoleType{"Groups:IT:ops": {1: org.RoleViewer}},
 				strictRoleMapping: false,
 			},
 		},

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -270,10 +270,24 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 		},
 		{
 			name:       "should return correct mapping when the first part contains multiple colons",
-			rawMapping: []string{"Groups:IT:First:1:Viewer"},
+			rawMapping: []string{`Groups\:IT:1:Viewer`},
 			roleStrict: false,
 			expected: &MappingConfiguration{
-				orgMapping:        map[string]map[int64]org.RoleType{"Groups:IT:First": {1: org.RoleViewer}},
+				orgMapping:        map[string]map[int64]org.RoleType{"Groups:IT": {1: org.RoleViewer}},
+				strictRoleMapping: false,
+			},
+		},
+		{
+			name:       "should return correct mapping when the org name contains multiple colons",
+			rawMapping: []string{`Group1:Org\:1:Viewer`},
+			roleStrict: false,
+			setupMock: func(orgService *orgtest.MockService) {
+				orgService.On("GetByName", mock.Anything, mock.MatchedBy(func(query *org.GetOrgByNameQuery) bool {
+					return query.Name == "Org:1"
+				})).Return(&org.Org{ID: 1}, nil)
+			},
+			expected: &MappingConfiguration{
+				orgMapping:        map[string]map[int64]org.RoleType{"Group1": {1: org.RoleViewer}},
 				strictRoleMapping: false,
 			},
 		},

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -269,7 +269,7 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 			},
 		},
 		{
-			name:       "should return correct mapping when the first part contains at least one colon",
+			name:       "should return correct mapping when the first part contains multiple colons",
 			rawMapping: []string{"Groups:IT:First:1:Viewer"},
 			roleStrict: false,
 			expected: &MappingConfiguration{
@@ -282,20 +282,6 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 			rawMapping: nil,
 			expected: &MappingConfiguration{
 				orgMapping:        map[string]map[int64]org.RoleType{},
-				strictRoleMapping: false,
-			},
-		},
-		{
-			name:       "should return only the valid mappings from the raw mappings when strict role mapping is disabled",
-			rawMapping: []string{"External:Org1:First:Organization:SuperEditor", "Second:1:Editor"},
-			roleStrict: false,
-			setupMock: func(orgService *orgtest.MockService) {
-				orgService.On("GetByName", mock.Anything, mock.MatchedBy(func(query *org.GetOrgByNameQuery) bool {
-					return query.Name == "Organization"
-				})).Return(nil, assert.AnError)
-			},
-			expected: &MappingConfiguration{
-				orgMapping:        map[string]map[int64]org.RoleType{"Second": {1: org.RoleEditor}},
 				strictRoleMapping: false,
 			},
 		},

--- a/pkg/login/social/connectors/org_role_mapper_test.go
+++ b/pkg/login/social/connectors/org_role_mapper_test.go
@@ -300,6 +300,24 @@ func TestOrgRoleMapper_ParseOrgMappingSettings(t *testing.T) {
 			},
 		},
 		{
+			name:       "should return empty mapping when one of the org mappings are not in the correct format and strict role mapping is enabled",
+			rawMapping: []string{"Second:Group:1:SuperEditor", "Second:1:Viewer"},
+			roleStrict: true,
+			expected: &MappingConfiguration{
+				orgMapping:        map[string]map[int64]org.RoleType{},
+				strictRoleMapping: true,
+			},
+		},
+		{
+			name:       "should skip org mapping when one of the org mappings are not in the correct format and strict role mapping is enabled",
+			rawMapping: []string{"Second:Group:1:SuperEditor", "Second:1:Admin"},
+			roleStrict: false,
+			expected: &MappingConfiguration{
+				orgMapping:        map[string]map[int64]org.RoleType{"Second": {1: org.RoleAdmin}},
+				strictRoleMapping: false,
+			},
+		},
+		{
 			name:       "should return empty mapping if at least one org was not found or the resolution failed and strict role mapping is enabled",
 			rawMapping: []string{"ExternalOrg1:First:Editor", "ExternalOrg1:NonExistent:Viewer"},
 			roleStrict: true,


### PR DESCRIPTION
**What is this feature?**
Fixes the case when org mapping settings are skipped when the first part (external org/group/team/etc name) contains colon(s).

**Why do we need this feature?**

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #89399

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
