### PR TITLE
User+team: remove startup migration for uid

### DIFF
--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -568,24 +567,4 @@ func (ss *xormStore) RegisterDelete(query string) {
 	ss.deletes = append(ss.deletes, query)
 }
 
-// This is just to ensure that all teams have a valid uid.
-// To protect against upgrade / downgrade we need to run this for a couple of releases.
-// FIXME: Remove this migration and make uid field required https://github.com/grafana/identity-access-team/issues/552
-func (ss *xormStore) uidMigration() error {
-	return ss.db.WithDbSession(context.Background(), func(sess *db.Session) error {
-		switch ss.db.GetDBType() {
-		case migrator.SQLite:
-			_, err := sess.Exec("UPDATE team SET uid=printf('t%09d',id) WHERE uid IS NULL;")
-			return err
-		case migrator.Postgres:
-			_, err := sess.Exec("UPDATE team SET uid='t' || lpad('' || id::text,9,'0') WHERE uid IS NULL;")
-			return err
-		case migrator.MySQL:
-			_, err := sess.Exec("UPDATE team SET uid=concat('t',lpad(id,9,'0')) WHERE uid IS NULL;")
-			return err
-		default:
-			// this branch should be unreachable
-			return nil
-		}
-	})
-}
+

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -566,5 +566,3 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, query *team.GetTeamMemb
 func (ss *xormStore) RegisterDelete(query string) {
 	ss.deletes = append(ss.deletes, query)
 }
-
-

--- a/pkg/services/team/teamimpl/team.go
+++ b/pkg/services/team/teamimpl/team.go
@@ -18,11 +18,6 @@ type Service struct {
 }
 
 func ProvideService(db db.DB, cfg *setting.Cfg, tracer tracing.Tracer) (team.Service, error) {
-	store := &xormStore{db: db, cfg: cfg, deletes: []string{}}
-
-	if err := store.uidMigration(); err != nil {
-		return nil, err
-	}
 	return &Service{
 		store:  &xormStore{db: db, cfg: cfg, deletes: []string{}},
 		tracer: tracer,

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/supportbundles"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -63,10 +62,6 @@ func ProvideService(
 		Reporter:      s.usage,
 	}); err != nil {
 		return s, err
-	}
-
-	if err := s.uidMigration(db); err != nil {
-		return nil, err
 	}
 
 	bundleRegistry.RegisterSupportItemCollector(s.supportBundleCollector())
@@ -528,26 +523,4 @@ func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {
 
 	limits.Set(globalQuotaTag, cfg.Quota.Global.User)
 	return limits, nil
-}
-
-// This is just to ensure that all users have a valid uid.
-// To protect against upgrade / downgrade we need to run this for a couple of releases.
-// FIXME: Remove this migration and make uid field required https://github.com/grafana/identity-access-team/issues/552
-func (s *Service) uidMigration(store db.DB) error {
-	return store.WithDbSession(context.Background(), func(sess *db.Session) error {
-		switch store.GetDBType() {
-		case migrator.SQLite:
-			_, err := sess.Exec("UPDATE user SET uid=printf('u%09d',id) WHERE uid IS NULL;")
-			return err
-		case migrator.Postgres:
-			_, err := sess.Exec("UPDATE `user` SET uid='u' || lpad('' || id::text,9,'0') WHERE uid IS NULL;")
-			return err
-		case migrator.MySQL:
-			_, err := sess.Exec("UPDATE user SET uid=concat('u',lpad(id,9,'0')) WHERE uid IS NULL;")
-			return err
-		default:
-			// this branch should be unreachable
-			return nil
-		}
-	})
 }


### PR DESCRIPTION
**What is this feature?**
We have had these migrations for a couple of versions and can remove them now. All new teams / users are always create with a valid uid.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/552

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
