### PR TITLE
accesscontrol service read replica

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -463,7 +463,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 	actionSets := resourcepermissions.NewActionSetService()
 	acSvc := acimpl.ProvideOSSService(
 		sc.cfg, acdb.ProvideService(sc.db), actionSets, localcache.ProvideService(),
-		features, tracing.InitializeTracerForTest(), zanzana.NewNoopClient(), sc.db,
+		features, tracing.InitializeTracerForTest(), zanzana.NewNoopClient(), sc.db.DB(),
 	)
 
 	folderPermissions, err := ossaccesscontrol.ProvideFolderPermissions(

--- a/pkg/cmd/grafana-cli/commands/conflict_user_command.go
+++ b/pkg/cmd/grafana-cli/commands/conflict_user_command.go
@@ -70,7 +70,7 @@ func initializeConflictResolver(cmd *utils.ContextCommandLine, f Formatter, ctx 
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to load configuration", err)
 	}
-	s, err := getSqlStore(cfg, tracer, features)
+	s, replstore, err := getSqlStore(cfg, tracer, features)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to get to sql", err)
 	}
@@ -90,7 +90,7 @@ func initializeConflictResolver(cmd *utils.ContextCommandLine, f Formatter, ctx 
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to initialize tracer service", err)
 	}
-	acService, err := acimpl.ProvideService(cfg, s, routing, nil, nil, nil, features, tracer, zanzana.NewNoopClient())
+	acService, err := acimpl.ProvideService(cfg, replstore, routing, nil, nil, nil, features, tracer, zanzana.NewNoopClient())
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", "failed to get access control", err)
 	}
@@ -99,9 +99,15 @@ func initializeConflictResolver(cmd *utils.ContextCommandLine, f Formatter, ctx 
 	return &resolver, nil
 }
 
-func getSqlStore(cfg *setting.Cfg, tracer tracing.Tracer, features featuremgmt.FeatureToggles) (*sqlstore.SQLStore, error) {
+func getSqlStore(cfg *setting.Cfg, tracer tracing.Tracer, features featuremgmt.FeatureToggles) (*sqlstore.SQLStore, *sqlstore.ReplStore, error) {
 	bus := bus.ProvideBus(tracer)
-	return sqlstore.ProvideService(cfg, features, &migrations.OSSMigrations{}, bus, tracer)
+	ss, err := sqlstore.ProvideService(cfg, features, &migrations.OSSMigrations{}, bus, tracer)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	replStore, err := sqlstore.ProvideServiceWithReadReplica(ss, cfg, features, &migrations.OSSMigrations{}, bus, tracer)
+	return ss, replStore, err
 }
 
 func runListConflictUsers() func(context *cli.Context) error {

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -396,6 +396,7 @@ var wireSet = wire.NewSet(
 	wire.Bind(new(notifications.WebhookSender), new(*notifications.NotificationService)),
 	wire.Bind(new(notifications.EmailSender), new(*notifications.NotificationService)),
 	wire.Bind(new(db.DB), new(*sqlstore.SQLStore)),
+	wire.Bind(new(db.ReplDB), new(*sqlstore.ReplStore)),
 	prefimpl.ProvideService,
 	oauthtoken.ProvideService,
 	wire.Bind(new(oauthtoken.OAuthTokenService), new(*oauthtoken.Service)),

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -413,6 +413,7 @@ var wireCLISet = wire.NewSet(
 	wire.Bind(new(notifications.WebhookSender), new(*notifications.NotificationService)),
 	wire.Bind(new(notifications.EmailSender), new(*notifications.NotificationService)),
 	wire.Bind(new(db.DB), new(*sqlstore.SQLStore)),
+	wire.Bind(new(db.ReplDB), new(*sqlstore.ReplStore)),
 	prefimpl.ProvideService,
 	oauthtoken.ProvideService,
 	wire.Bind(new(oauthtoken.OAuthTokenService), new(*oauthtoken.Service)),

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -48,7 +48,7 @@ var SharedWithMeFolderPermission = accesscontrol.Permission{
 var OSSRolesPrefixes = []string{accesscontrol.ManagedRolePrefix, accesscontrol.ExternalServiceRolePrefix}
 
 func ProvideService(
-	cfg *setting.Cfg, db db.DB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
+	cfg *setting.Cfg, db db.ReplDB, routeRegister routing.RouteRegister, cache *localcache.CacheService,
 	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver,
 	features featuremgmt.FeatureToggles, tracer tracing.Tracer, zclient zanzana.Client,
 ) (*Service, error) {
@@ -73,7 +73,7 @@ func ProvideService(
 func ProvideOSSService(
 	cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver,
 	cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
-	zclient zanzana.Client, db db.DB,
+	zclient zanzana.Client, db db.ReplDB,
 ) *Service {
 	s := &Service{
 		actionResolver: actionResolver,

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -52,7 +52,7 @@ func ProvideService(
 	accessControl accesscontrol.AccessControl, actionResolver accesscontrol.ActionResolver,
 	features featuremgmt.FeatureToggles, tracer tracing.Tracer, zclient zanzana.Client,
 ) (*Service, error) {
-	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer, zclient, db)
+	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer, zclient, db.DB())
 
 	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
@@ -73,7 +73,7 @@ func ProvideService(
 func ProvideOSSService(
 	cfg *setting.Cfg, store accesscontrol.Store, actionResolver accesscontrol.ActionResolver,
 	cache *localcache.CacheService, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
-	zclient zanzana.Client, db db.ReplDB,
+	zclient zanzana.Client, db db.DB,
 ) *Service {
 	s := &Service{
 		actionResolver: actionResolver,

--- a/pkg/services/accesscontrol/acimpl/service_bench_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_bench_test.go
@@ -25,7 +25,7 @@ import (
 // - each managed role will have 3 permissions {"resources:action2", "resources:id:x"} where x belongs to [1, 3]
 func setupBenchEnv(b *testing.B, usersCount, resourceCount int) (accesscontrol.Service, *user.SignedInUser) {
 	now := time.Now()
-	sqlStore := db.InitTestDB(b)
+	sqlStore := db.InitTestReplDB(b)
 	store := database.ProvideService(sqlStore)
 	acService := &Service{
 		cfg:           setting.NewCfg(),

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -41,8 +41,8 @@ func setupTestEnv(t testing.TB) *Service {
 		log:           log.New("accesscontrol"),
 		registrations: accesscontrol.RegistrationList{},
 		roles:         accesscontrol.BuildBasicRoleDefinitions(),
-		store:         database.ProvideService(db.InitTestDB(t)),
 		tracer:        tracing.InitializeTracerForTest(),
+		store:         database.ProvideService(db.InitTestReplDB(t)),
 	}
 	require.NoError(t, ac.RegisterFixedRoles(context.Background()))
 	return ac
@@ -65,7 +65,7 @@ func TestUsageMetrics(t *testing.T) {
 
 			s := ProvideOSSService(
 				cfg,
-				database.ProvideService(db.InitTestDB(t)),
+				database.ProvideService(db.InitTestReplDB(t)),
 				&resourcepermissions.FakeActionSetSvc{},
 				localcache.ProvideService(),
 				featuremgmt.WithFeatures(),

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -36,17 +36,17 @@ const (
 	WHERE br.role = ?`
 )
 
-func ProvideService(sql db.DB) *AccessControlStore {
+func ProvideService(sql db.ReplDB) *AccessControlStore {
 	return &AccessControlStore{sql}
 }
 
 type AccessControlStore struct {
-	sql db.DB
+	sql db.ReplDB
 }
 
 func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query accesscontrol.GetUserPermissionsQuery) ([]accesscontrol.Permission, error) {
 	result := make([]accesscontrol.Permission, 0)
-	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	err := s.sql.DB().WithDbSession(ctx, func(sess *db.Session) error {
 		if query.UserID == 0 && len(query.TeamIDs) == 0 && len(query.Roles) == 0 {
 			// no permission to fetch
 			return nil
@@ -104,7 +104,7 @@ func (s *AccessControlStore) GetTeamsPermissions(ctx context.Context, query acce
 	orgID := query.OrgID
 	rolePrefixes := query.RolePrefixes
 	result := make([]teamPermission, 0)
-	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	err := s.sql.ReadReplica().WithDbSession(ctx, func(sess *db.Session) error {
 		if len(teams) == 0 {
 			// no permission to fetch
 			return nil
@@ -172,7 +172,7 @@ func (s *AccessControlStore) SearchUsersPermissions(ctx context.Context, orgID i
 		}
 	}
 
-	if err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	if err := s.sql.ReadReplica().WithDbSession(ctx, func(sess *db.Session) error {
 		roleNameFilterJoin := ""
 		if len(options.RolePrefixes) > 0 {
 			roleNameFilterJoin = "INNER JOIN role AS r ON up.role_id = r.id"
@@ -198,7 +198,7 @@ func (s *AccessControlStore) SearchUsersPermissions(ctx context.Context, orgID i
 			params = append(params, userID)
 		}
 
-		grafanaAdmin := fmt.Sprintf(grafanaAdminAssignsSQL, s.sql.Quote("user"))
+		grafanaAdmin := fmt.Sprintf(grafanaAdminAssignsSQL, s.sql.ReadReplica().Quote("user"))
 		params = append(params, accesscontrol.RoleGrafanaAdmin)
 		if options.NamespacedID != "" {
 			grafanaAdmin += " AND sa.user_id = ?"
@@ -284,11 +284,11 @@ func (s *AccessControlStore) GetUsersBasicRoles(ctx context.Context, userFilter 
 		IsAdmin bool   `xorm:"is_admin"`
 	}
 	dbRoles := make([]UserOrgRole, 0)
-	if err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	if err := s.sql.ReadReplica().WithDbSession(ctx, func(sess *db.Session) error {
 		// Find roles
 		q := `
 		SELECT u.id, ou.role, u.is_admin
-		FROM ` + s.sql.GetDialect().Quote("user") + ` AS u
+		FROM ` + s.sql.ReadReplica().GetDialect().Quote("user") + ` AS u
 		LEFT JOIN org_user AS ou ON u.id = ou.user_id
 		WHERE (u.is_admin OR ou.org_id = ?)
 		`
@@ -318,7 +318,7 @@ func (s *AccessControlStore) GetUsersBasicRoles(ctx context.Context, userFilter 
 }
 
 func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
-	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	err := s.sql.DB().WithDbSession(ctx, func(sess *db.Session) error {
 		roleDeleteQuery := "DELETE FROM user_role WHERE user_id = ?"
 		roleDeleteParams := []any{roleDeleteQuery, userID}
 		if orgID != accesscontrol.GlobalOrgID {
@@ -383,7 +383,7 @@ func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, u
 }
 
 func (s *AccessControlStore) DeleteTeamPermissions(ctx context.Context, orgID, teamID int64) error {
-	err := s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	err := s.sql.DB().WithDbSession(ctx, func(sess *db.Session) error {
 		roleDeleteQuery := "DELETE FROM team_role WHERE team_id = ? AND org_id = ?"
 		roleDeleteParams := []any{roleDeleteQuery, teamID, orgID}
 

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -46,7 +46,7 @@ type AccessControlStore struct {
 
 func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query accesscontrol.GetUserPermissionsQuery) ([]accesscontrol.Permission, error) {
 	result := make([]accesscontrol.Permission, 0)
-	err := s.sql.DB().WithDbSession(ctx, func(sess *db.Session) error {
+	err := s.sql.ReadReplica().WithDbSession(ctx, func(sess *db.Session) error {
 		if query.UserID == 0 && len(query.TeamIDs) == 0 && len(query.Roles) == 0 {
 			// no permission to fetch
 			return nil

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -470,8 +470,8 @@ func createUsersAndTeams(t *testing.T, store db.DB, svcs helperServices, orgID i
 	return res
 }
 
-func setupTestEnv(t testing.TB) (*database.AccessControlStore, rs.Store, user.Service, team.Service, org.Service, *sqlstore.SQLStore) {
-	sql, cfg := db.InitTestDBWithCfg(t)
+func setupTestEnv(t testing.TB) (*database.AccessControlStore, rs.Store, user.Service, team.Service, org.Service, *sqlstore.ReplStore) {
+	sql, cfg := db.InitTestReplDBWithCfg(t)
 	cfg.AutoAssignOrg = true
 	cfg.AutoAssignOrgRole = "Viewer"
 	cfg.AutoAssignOrgId = 1

--- a/pkg/services/accesscontrol/database/externalservices.go
+++ b/pkg/services/accesscontrol/database/externalservices.go
@@ -18,7 +18,7 @@ func extServiceRoleName(externalServiceID string) string {
 
 func (s *AccessControlStore) DeleteExternalServiceRole(ctx context.Context, externalServiceID string) error {
 	uid := accesscontrol.PrefixedRoleUID(extServiceRoleName(externalServiceID))
-	return s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	return s.sql.DB().WithDbSession(ctx, func(sess *db.Session) error {
 		stored, errGet := getRoleByUID(ctx, sess, uid)
 		if errGet != nil {
 			// Role not found, nothing to do
@@ -55,7 +55,7 @@ func (s *AccessControlStore) SaveExternalServiceRole(ctx context.Context, cmd ac
 	role := genExternalServiceRole(cmd)
 	assignment := genExternalServiceAssignment(cmd)
 
-	return s.sql.WithDbSession(ctx, func(sess *db.Session) error {
+	return s.sql.DB().WithDbSession(ctx, func(sess *db.Session) error {
 		// Create or update the role
 		existingRole, errSaveRole := s.saveRole(ctx, sess, &role)
 		if errSaveRole != nil {

--- a/pkg/services/accesscontrol/migrator/migrator_bench_test.go
+++ b/pkg/services/accesscontrol/migrator/migrator_bench_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func benchScopeSplitConcurrent(b *testing.B, count int) {
-	store := db.InitTestDB(b)
+	store := db.InitTestReplDB(b)
 	// Populate permissions
 	require.NoError(b, batchInsertPermissions(count, store), "could not insert permissions")
 	logger := log.New("migrator.test")

--- a/pkg/services/accesscontrol/migrator/migrator_test.go
+++ b/pkg/services/accesscontrol/migrator/migrator_test.go
@@ -46,7 +46,7 @@ func batchInsertPermissions(cnt int, sqlStore db.DB) error {
 // TestIntegrationMigrateScopeSplit tests the scope split migration
 // also tests the scope split truncation logic
 func TestIntegrationMigrateScopeSplitTruncation(t *testing.T) {
-	sqlStore := db.InitTestDB(t)
+	sqlStore := db.InitTestReplDB(t)
 	logger := log.New("accesscontrol.migrator.test")
 
 	batchSize = 20

--- a/pkg/services/accesscontrol/migrator/zanzana.go
+++ b/pkg/services/accesscontrol/migrator/zanzana.go
@@ -31,7 +31,7 @@ func NewZanzanaSynchroniser(client zanzana.Client, store db.ReplDB, collectors .
 	// Append shared collectors that is used by both enterprise and oss
 	collectors = append(
 		collectors,
-		teamMembershipCollector(store),
+		teamMembershipCollector(store.DB()),
 		managedPermissionsCollector(store),
 	)
 

--- a/pkg/services/accesscontrol/migrator/zanzana.go
+++ b/pkg/services/accesscontrol/migrator/zanzana.go
@@ -31,7 +31,7 @@ func NewZanzanaSynchroniser(client zanzana.Client, store db.ReplDB, collectors .
 	// Append shared collectors that is used by both enterprise and oss
 	collectors = append(
 		collectors,
-		teamMembershipCollector(store.DB()),
+		teamMembershipCollector(store),
 		managedPermissionsCollector(store),
 	)
 
@@ -134,7 +134,7 @@ func managedPermissionsCollector(store db.ReplDB) TupleCollector {
 	}
 }
 
-func teamMembershipCollector(store db.DB) TupleCollector {
+func teamMembershipCollector(store db.ReplDB) TupleCollector {
 	return func(ctx context.Context, tuples map[string][]*openfgav1.TupleKey) error {
 		const collectorID = "team_membership"
 		const query = `
@@ -151,7 +151,7 @@ func teamMembershipCollector(store db.DB) TupleCollector {
 		}
 
 		var memberships []membership
-		err := store.WithDbSession(ctx, func(sess *db.Session) error {
+		err := store.DB().WithDbSession(ctx, func(sess *db.Session) error {
 			return sess.SQL(query).Find(&memberships)
 		})
 

--- a/pkg/services/accesscontrol/migrator/zanzana.go
+++ b/pkg/services/accesscontrol/migrator/zanzana.go
@@ -27,7 +27,7 @@ type ZanzanaSynchroniser struct {
 	collectors []TupleCollector
 }
 
-func NewZanzanaSynchroniser(client zanzana.Client, store db.ReplDB, collectors ...TupleCollector) *ZanzanaSynchroniser {
+func NewZanzanaSynchroniser(client zanzana.Client, store db.DB, collectors ...TupleCollector) *ZanzanaSynchroniser {
 	// Append shared collectors that is used by both enterprise and oss
 	collectors = append(
 		collectors,
@@ -75,7 +75,7 @@ func (z *ZanzanaSynchroniser) Sync(ctx context.Context) error {
 // managedPermissionsCollector collects managed permissions into provided tuple map.
 // It will only store actions that are supported by our schema. Managed permissions can
 // be directly mapped to user/team/role without having to write an intermediate role.
-func managedPermissionsCollector(store db.ReplDB) TupleCollector {
+func managedPermissionsCollector(store db.DB) TupleCollector {
 	return func(ctx context.Context, tuples map[string][]*openfgav1.TupleKey) error {
 		const collectorID = "managed"
 		const query = `
@@ -100,7 +100,7 @@ func managedPermissionsCollector(store db.ReplDB) TupleCollector {
 		}
 
 		var permissions []Permission
-		err := store.DB().WithDbSession(ctx, func(sess *db.Session) error {
+		err := store.WithDbSession(ctx, func(sess *db.Session) error {
 			return sess.SQL(query).Find(&permissions)
 		})
 
@@ -134,7 +134,7 @@ func managedPermissionsCollector(store db.ReplDB) TupleCollector {
 	}
 }
 
-func teamMembershipCollector(store db.ReplDB) TupleCollector {
+func teamMembershipCollector(store db.DB) TupleCollector {
 	return func(ctx context.Context, tuples map[string][]*openfgav1.TupleKey) error {
 		const collectorID = "team_membership"
 		const query = `
@@ -151,7 +151,7 @@ func teamMembershipCollector(store db.ReplDB) TupleCollector {
 		}
 
 		var memberships []membership
-		err := store.DB().WithDbSession(ctx, func(sess *db.Session) error {
+		err := store.WithDbSession(ctx, func(sess *db.Session) error {
 			return sess.SQL(query).Find(&memberships)
 		})
 

--- a/pkg/services/accesscontrol/migrator/zanzana.go
+++ b/pkg/services/accesscontrol/migrator/zanzana.go
@@ -27,7 +27,7 @@ type ZanzanaSynchroniser struct {
 	collectors []TupleCollector
 }
 
-func NewZanzanaSynchroniser(client zanzana.Client, store db.DB, collectors ...TupleCollector) *ZanzanaSynchroniser {
+func NewZanzanaSynchroniser(client zanzana.Client, store db.ReplDB, collectors ...TupleCollector) *ZanzanaSynchroniser {
 	// Append shared collectors that is used by both enterprise and oss
 	collectors = append(
 		collectors,
@@ -75,7 +75,7 @@ func (z *ZanzanaSynchroniser) Sync(ctx context.Context) error {
 // managedPermissionsCollector collects managed permissions into provided tuple map.
 // It will only store actions that are supported by our schema. Managed permissions can
 // be directly mapped to user/team/role without having to write an intermediate role.
-func managedPermissionsCollector(store db.DB) TupleCollector {
+func managedPermissionsCollector(store db.ReplDB) TupleCollector {
 	return func(ctx context.Context, tuples map[string][]*openfgav1.TupleKey) error {
 		const collectorID = "managed"
 		const query = `
@@ -100,7 +100,7 @@ func managedPermissionsCollector(store db.DB) TupleCollector {
 		}
 
 		var permissions []Permission
-		err := store.WithDbSession(ctx, func(sess *db.Session) error {
+		err := store.DB().WithDbSession(ctx, func(sess *db.Session) error {
 			return sess.SQL(query).Find(&permissions)
 		})
 

--- a/pkg/services/sqlstore/replstore.go
+++ b/pkg/services/sqlstore/replstore.go
@@ -192,3 +192,15 @@ func InitTestReplDB(t sqlutil.ITestDB, opts ...InitTestDBOpt) (*ReplStore, *sett
 	}
 	return &ReplStore{ss, ss}, cfg
 }
+
+// InitTestReplDBWithMigration initializes the test DB given custom migrations.
+func InitTestReplDBWithMigration(t sqlutil.ITestDB, migration registry.DatabaseMigrator, opts ...InitTestDBOpt) *ReplStore {
+	t.Helper()
+	features := getFeaturesForTesting(opts...)
+	cfg := getCfgForTesting(opts...)
+	ss, err := initTestDB(t, cfg, features, migration, opts...)
+	if err != nil {
+		t.Fatalf("failed to initialize sql store: %s", err)
+	}
+	return &ReplStore{ss, ss}
+}


### PR DESCRIPTION
This PR has a corresponding enterprise PR: https://github.com/grafana/grafana-enterprise/pull/6832

This PR refactors the accesscontrol service to take a `db.ReplDB` in place of the `db.DB` interface and modifies the access control store to use the `db.DB()` or `db.ReadReplica()` depending on the sql. This will have no effect in Grafana instances that don't use the readReplica feature toggle. If the toggle is on, but the replica isn't configured, Grafana will return the primary `DB()` in place of the `ReadReplica()`. 

