### PR TITLE
CI: Sync branch and tag after release

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,5 +1,18 @@
 name: Create or update GitHub release
 on:
+  workflow_run:
+    inputs:
+      version:
+        required: true
+        description: Needs to match, exactly, the name of a milestone (NO v prefix)
+      latest:
+        required: false
+        default: false
+        description: Mark this release as latest (`1`) or not (`0`, default)
+      dry_run:
+        required: false
+        default: false
+        type: bool
   workflow_dispatch:
     inputs:
       version:
@@ -8,20 +21,24 @@ on:
       latest:
         required: false
         description: Mark this release as latest (`1`) or not (`0`, default)
+      dry_run:
+        required: false
+        default: false
+        type: bool
+
+permissions:
+  # contents: write allows the action(s) to create github releases
+  contents: write
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: "Generate token"
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Create GitHub release (manually invoked)
         uses: grafana/grafana-github-actions-go/github-release@main
         with:
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ inputs.version }}
           metrics_api_key: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
           latest: ${{ inputs.latest }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,30 +1,34 @@
 name: Create or update GitHub release
 on:
-  workflow_run:
+  workflow_call:
     inputs:
       version:
         required: true
         description: Needs to match, exactly, the name of a milestone (NO v prefix)
+        type: string
       latest:
         required: false
         default: false
         description: Mark this release as latest (`1`) or not (`0`, default)
+        type: string
       dry_run:
         required: false
         default: false
-        type: bool
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
         required: true
         description: Needs to match, exactly, the name of a milestone (NO v prefix)
+        type: string
       latest:
         required: false
         description: Mark this release as latest (`1`) or not (`0`, default)
+        type: string
       dry_run:
         required: false
         default: false
-        type: bool
+        type: boolean
 
 permissions:
   # contents: write allows the action(s) to create github releases

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -10,32 +10,91 @@ on:
         default: true
       version:
         required: true
+      latest:
+        type: bool
+        default: false
   pull_request:
     types:
-      - closed
+    - closed
     branches:
-      - 'main'
-      - 'v*.*.*'
+    - 'main'
+    - 'v*.*.*'
 jobs:
-  post_release:
-    name: Post-release comms
+  setup:
+    name: Setup and establish latest
+    outputs:
+      version: ${{ steps.output.outputs.version }}
+      dry_run: ${{ steps.output.outputs.dry_run }}
+      latest: ${{ steps.output.outputs.latest }}
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-          echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
-      - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
-        run: |
-          echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
-          echo "DRY_RUN=false" >> $GITHUB_ENV
-      - run: |
-          echo "push-grafana-tag ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "post changelog to forums for ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "create github release for tag ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "publish docs for ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "announce on slack that ${VERSION} has been released (dry run: ${DRY_RUN})"
+    - if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        echo setting up GITHUB_ENV for ${{ github.event_name }}
+        echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+        echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
+        echo "LATEST=${{ inputs.latest }}" >> $GITHUB_ENV
+    - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+      run: |
+        echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
+        echo "DRY_RUN=true" >> $GITHUB_ENV
+        echo "LATEST=${{ contains(github.event.pull_request.labels.*.name, 'release/latest') }}" >> $GITHUB_ENV
+    - id: output
+      run: |
+        echo "dry_run: $DRY_RUN"
+        echo "latest: $LATEST"
+        echo "version: $VERSION"
+
+        echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+        echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+  mirror_branch:
+    name: Mirror release branch
+    needs: setup
+    uses: grafana/security-patch-actions/.github/workflows/mirror-branch.yml@main
+    with:
+      ref: "release-${{ needs.setup.outputs.version }}"
+      src_repo: grafana/grafana-security-mirror
+      dest_repo: grafana/grafana
+      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+    secrets: inherit
+  mirror_tag:
+    # Because the tag is almost always on the release-branch, we should make sure we mirror the release branch before
+    # mirroring the tag
+    needs: [setup, mirror_branch]
+    name: Mirror tag
+    uses: grafana/security-patch-actions/.github/workflows/mirror-tag.yml@main
+    with:
+      tag: "v${{ needs.setup.outputs.version }}"
+      src_repo: grafana/grafana-security-mirror
+      dest_repo: grafana/grafana
+      dry_run: ${{ needs.setup.outputs.dry_run == 'true'}}
+    secrets: inherit
+  post_changelog_on_forum:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo post changelog to forums for ${{ needs.setup.outputs.version }}
+        echo dry run: ${{ needs.setup.outputs.dry_run }}
+  create_github_release:
+    # a github release requires a git tag
+    needs: [setup, mirror_tag]
+    uses: ./.github/workflows/github-release.yml
+    with:
+      version: ${{ needs.setup.outputs.version }}
+      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+  publish_docs:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo publish docs for ${{ needs.setup.outputs.version }}
+        echo dry run: ${{ needs.setup.outputs.dry_run }}
+  post_on_slack:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo announce on slack that ${{ needs.setup.outputs.version }} has been released
+        echo dry run: ${{ needs.setup.outputs.dry_run }}

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -48,28 +48,6 @@ jobs:
         echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
         echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-  mirror_branch:
-    name: Mirror release branch
-    needs: setup
-    uses: grafana/security-patch-actions/.github/workflows/mirror-branch.yml@main
-    with:
-      ref: "release-${{ needs.setup.outputs.version }}"
-      src_repo: grafana/grafana-security-mirror
-      dest_repo: grafana/grafana
-      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
-    secrets: inherit
-  mirror_tag:
-    # Because the tag is almost always on the release-branch, we should make sure we mirror the release branch before
-    # mirroring the tag
-    needs: [setup, mirror_branch]
-    name: Mirror tag
-    uses: grafana/security-patch-actions/.github/workflows/mirror-tag.yml@main
-    with:
-      tag: "v${{ needs.setup.outputs.version }}"
-      src_repo: grafana/grafana-security-mirror
-      dest_repo: grafana/grafana
-      dry_run: ${{ needs.setup.outputs.dry_run == 'true'}}
-    secrets: inherit
   post_changelog_on_forum:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -29,18 +29,16 @@ on:
         default: false
         type: bool
 
+permissions:
+  content: write
+  pull-requests: write
+
 jobs:
   create-prs:
     name: Create Release PR
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Checkout Grafana
         uses: actions/checkout@v4
       - name: Configure git user
@@ -73,7 +71,7 @@ jobs:
             --title "Release: ${{ inputs.version }}" \
             --body "These code changes must be merged after a release is complete"
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create PR with backports
         if: "${{ inputs.backport != '' }}"
         run: >
@@ -86,4 +84,4 @@ jobs:
             --title "Release: ${{ inputs.version }}" \
             --body "These code changes must be merged after a release is complete"
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,6 +24,10 @@ on:
         required: false
         default: false
         type: bool
+      latest:
+        required: false
+        default: false
+        type: bool
 
 jobs:
   create-prs:
@@ -62,12 +66,24 @@ jobs:
       - name: Create PR without backports
         if: "${{ inputs.backport == '' }}"
         run: >
-          gh pr create --dry-run=${{ inputs.dry_run }} -B "${{ inputs.target }}" --title "Release: ${{ inputs.version }}" --body "These code changes must be merged after a release is complete"
+          gh pr create \
+            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            --dry-run=${{ inputs.dry_run }} \
+            -B "${{ inputs.target }}" \
+            --title "Release: ${{ inputs.version }}" \
+            --body "These code changes must be merged after a release is complete"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
       - name: Create PR with backports
         if: "${{ inputs.backport != '' }}"
         run: >
-          gh pr create -l "backport ${{ inputs.backport }}" -l "product-approved" --dry-run=${{ inputs.dry_run }} -B "${{ inputs.target }}" --title "Release: ${{ inputs.version }}" --body "These code changes must be merged after a release is complete"
+          gh pr create \
+            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            -l "backport ${{ inputs.backport }}" \
+            -l "product-approved" \
+            --dry-run=${{ inputs.dry_run }} \
+            -B "${{ inputs.target }}" \
+            --title "Release: ${{ inputs.version }}" \
+            --body "These code changes must be merged after a release is complete"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
* Added `workflow_call` event to allow other workflows to invoke the "Create or update GitHub release"
* Added `dry_run` to `github-release.yml`
* Added `latest` to `release-pr.yml` which will cause the release PR to add a `release/latest` label.
* Removed unnecessary github app creation from github-release workflow and just used permissions.