### PR TITLE
Scenes: Upgrade to v5.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "5.3.2",
+    "@grafana/scenes": "^5.3.4",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,9 +3580,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:5.3.2":
-  version: 5.3.2
-  resolution: "@grafana/scenes@npm:5.3.2"
+"@grafana/scenes@npm:^5.3.4":
+  version: 5.3.4
+  resolution: "@grafana/scenes@npm:5.3.4"
   dependencies:
     "@grafana/e2e-selectors": "npm:^11.0.0"
     "@leeoniya/ufuzzy": "npm:^1.0.14"
@@ -3597,7 +3597,7 @@ __metadata:
     "@grafana/ui": ^10.4.1
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/90d2dd3b6daa293589a8933de8169d51814956ab4b425d2b5f750b3d504080944373345bce84e6a18a28260cc6fd9bf58c4e4046092a87d8ff0104b085f63e6d
+  checksum: 10/a312258eeb22c9d78f2d17404bba2a50e749e113fc0ad1af1d0e42f647ff823097c3065da2fc1efe35b55fcff6ebd26f306fa121a226817ccc9edd8a12400301
   languageName: node
   linkType: hard
 
@@ -17145,7 +17145,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:5.3.2"
+    "@grafana/scenes": "npm:^5.3.4"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
# v5.3.4 (Tue Jul 02 2024)

#### 🐛 Bug Fix

- `@grafana/scenes`
  - Revert "VizPanel: Load plugin prefered default options when activating" [#812](https://github.com/grafana/scenes/pull/812) ([@ivanortegaalba](https://github.com/ivanortegaalba))

#### Authors: 1

- Ivan Ortega Alba ([@ivanortegaalba](https://github.com/ivanortegaalba))

---

# v5.3.3 (Tue Jul 02 2024)

#### 🐛 Bug Fix

- `@grafana/scenes`
  - Fix variable interpolation in query options interval [#810](https://github.com/grafana/scenes/pull/810) ([@mdvictor](https://github.com/mdvictor))

#### Authors: 1

- Victor Marin ([@mdvictor](https://github.com/mdvictor))

