### PR TITLE
Users: Ensure default admin is created with  a valid uid

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -64,6 +64,7 @@ func (ss *SQLStore) createUser(ctx context.Context, sess *DBSession, args user.C
 
 	// create user
 	usr = user.User{
+		UID:        util.GenerateShortUID(),
 		Email:      args.Email,
 		Login:      args.Login,
 		IsAdmin:    args.IsAdmin,


### PR DESCRIPTION
**What is this feature?**
When starting a fresh grafana instance initial seeded admin is created without uid. The migration to add uid:s happens before this so it will only affect fresh instances, https://github.com/grafana/grafana/pull/89953 covered this before.

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
