### PR TITLE
Zanzana: Sync team memberships

### DIFF
--- a/pkg/services/accesscontrol/migrator/zanzana.go
+++ b/pkg/services/accesscontrol/migrator/zanzana.go
@@ -29,9 +29,14 @@ type ZanzanaSynchroniser struct {
 
 func NewZanzanaSynchroniser(client zanzana.Client, store db.DB, collectors ...TupleCollector) *ZanzanaSynchroniser {
 	// Append shared collectors that is used by both enterprise and oss
-	collectors = append(collectors, managedPermissionsCollector(store))
+	collectors = append(
+		collectors,
+		teamMembershipCollector(store),
+		managedPermissionsCollector(store),
+	)
 
 	return &ZanzanaSynchroniser{
+		client:     client,
 		log:        log.New("zanzana.sync"),
 		collectors: collectors,
 	}
@@ -74,15 +79,16 @@ func managedPermissionsCollector(store db.DB) TupleCollector {
 	return func(ctx context.Context, tuples map[string][]*openfgav1.TupleKey) error {
 		const collectorID = "managed"
 		const query = `
-		SELECT u.uid as user_uid, t.uid as team_uid, p.action, p.kind, p.identifier, r.org_id FROM permission p
-		INNER JOIN role r ON p.role_id = r.id
-		LEFT JOIN user_role ur ON r.id = ur.role_id
-		LEFT JOIN user u ON u.id = ur.user_id
-		LEFT JOIN team_role tr ON r.id = tr.role_id
-		LEFT JOIN team t ON tr.team_id = t.id
-		LEFT JOIN builtin_role br ON r.id  = br.role_id
-		WHERE r.name LIKE 'managed:%'
-	`
+			SELECT u.uid as user_uid, t.uid as team_uid, p.action, p.kind, p.identifier, r.org_id
+			FROM permission p
+			INNER JOIN role r ON p.role_id = r.id
+			LEFT JOIN user_role ur ON r.id = ur.role_id
+			LEFT JOIN user u ON u.id = ur.user_id
+			LEFT JOIN team_role tr ON r.id = tr.role_id
+			LEFT JOIN team t ON tr.team_id = t.id
+			LEFT JOIN builtin_role br ON r.id  = br.role_id
+			WHERE r.name LIKE 'managed:%'
+		`
 		type Permission struct {
 			RoleName   string `xorm:"role_name"`
 			OrgID      int64  `xorm:"org_id"`
@@ -122,6 +128,51 @@ func managedPermissionsCollector(store db.DB) TupleCollector {
 			// sync new data when more actions are supported
 			key := fmt.Sprintf("%s-%s", collectorID, p.Action)
 			tuples[key] = append(tuples[key], tuple)
+		}
+
+		return nil
+	}
+}
+
+func teamMembershipCollector(store db.DB) TupleCollector {
+	return func(ctx context.Context, tuples map[string][]*openfgav1.TupleKey) error {
+		const collectorID = "team_membership"
+		const query = `
+			SELECT t.uid as team_uid, u.uid as user_uid, tm.permission
+			FROM team_member tm
+			INNER JOIN team t ON tm.team_id = t.id
+			INNER JOIN user u ON tm.user_id = u.id
+		`
+
+		type membership struct {
+			TeamUID    string `xorm:"team_uid"`
+			UserUID    string `xorm:"user_uid"`
+			Permission int
+		}
+
+		var memberships []membership
+		err := store.WithDbSession(ctx, func(sess *db.Session) error {
+			return sess.SQL(query).Find(&memberships)
+		})
+
+		if err != nil {
+			return err
+		}
+
+		for _, m := range memberships {
+			tuple := &openfgav1.TupleKey{
+				User:   zanzana.NewObject(zanzana.TypeUser, m.UserUID),
+				Object: zanzana.NewObject(zanzana.TypeTeam, m.TeamUID),
+			}
+
+			// Admin permission is 4 and member 0
+			if m.Permission == 4 {
+				tuple.Relation = zanzana.RelationTeamAdmin
+			} else {
+				tuple.Relation = zanzana.RelationTeamMember
+			}
+
+			tuples[collectorID] = append(tuples[collectorID], tuple)
 		}
 
 		return nil

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -14,7 +14,7 @@ const (
 
 const (
 	RelationTeamMember string = "member"
-	RelationTeamAdmin  string = "member"
+	RelationTeamAdmin  string = "admin"
 )
 
 func NewObject(typ, id string) string {

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -12,6 +12,11 @@ const (
 	TypeTeam string = "team"
 )
 
+const (
+	RelationTeamMember string = "member"
+	RelationTeamAdmin  string = "member"
+)
+
 func NewObject(typ, id string) string {
 	return fmt.Sprintf("%s:%s", typ, id)
 }
@@ -49,7 +54,7 @@ func TranslateToTuple(user string, action, kind, identifier string, orgID int64)
 	tuple.User = user
 	tuple.Relation = relation
 
-	// UID in grafana are not guarantee to be unique across orgs so we need to scope them.
+	// Some uid:s in grafana are not guarantee to be unique across orgs so we need to scope them.
 	if t.orgScoped {
 		tuple.Object = NewScopedObject(t.typ, identifier, strconv.FormatInt(orgID, 10))
 	} else {


### PR DESCRIPTION
**What is this feature?**
Add a simple tuple collector for team member ships. We don't have to use managed permissions.

I also changed to use uid:s for both users and teams as identifiers in openFGA. This does not cover syncting teams relation to orgs.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
