### PR TITLE
Alerting/Datasources: Include `appSubUrl` in datasource button

### DIFF
--- a/public/app/features/datasources/components/picker/AddNewDataSourceButton.tsx
+++ b/public/app/features/datasources/components/picker/AddNewDataSourceButton.tsx
@@ -1,3 +1,4 @@
+import { config } from '@grafana/runtime';
 import { LinkButton, ButtonVariant } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { Trans } from 'app/core/internationalization';
@@ -11,7 +12,7 @@ interface AddNewDataSourceButtonProps {
 
 export function AddNewDataSourceButton({ variant, onClick }: AddNewDataSourceButtonProps) {
   const hasCreateRights = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
-  const newDataSourceURL = CONNECTIONS_ROUTES.DataSourcesNew;
+  const newDataSourceURL = `${config.appSubUrl}${CONNECTIONS_ROUTES.DataSourcesNew}`;
 
   return (
     <LinkButton


### PR DESCRIPTION
**What is this feature?**

Includes the `appSubUrl` when linking from `AddNewDataSourceButton`

**Why do we need this feature?**
Reported within alerting, when creating a recording rule. Clicking the "Configure a new data source" button would not include the sub path, so the link is broken when serving under another sub path (the example given was under `/grafana/`


**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/88580
