### PR TITLE
API Server: fix http_addr parsing

### DIFF
--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -15,9 +15,13 @@ import (
 
 func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o *options.Options) error {
 	defaultLogLevel := 0
-	ip := net.ParseIP(cfg.HTTPAddr)
-	if ip == nil {
-		return fmt.Errorf("invalid IP address: %s", cfg.HTTPAddr)
+	ip := net.IPv4(0, 0, 0, 0)
+	if cfg.HTTPAddr != "" {
+		httpAddr, err := net.ResolveIPAddr("ip", cfg.HTTPAddr)
+		if err != nil {
+			return fmt.Errorf("failed to parse IP address (%q): %w", cfg.HTTPAddr, err)
+		}
+		ip = httpAddr.IP
 	}
 	apiURL := cfg.AppURL
 	port, err := strconv.Atoi(cfg.HTTPPort)


### PR DESCRIPTION
`net.ParseIP()` expects a literal IP string and thus won't handle `localhost`, etc.

Fixes #89661

Caveats:

1) as noted on https://github.com/grafana/grafana/issues/89661#issuecomment-2205741941 - resolving, `[::1]` for example, is considered wrong for this API. Brackets are only valid on `[host]:port` combinations. I don't know how to best handle this regression for existing configs.

2) Resolving by "ip" leads to v4 resolves first, falling back to IPv6 afterwards. Favoring v6 would need to resolve ip6 and then falling back to v4 with a 2nd resolve call. 

