### PR TITLE
Auth: Add organization mapping configuration to the UI

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -189,13 +189,18 @@ func (s *SocialAzureAD) Reload(ctx context.Context, settings ssoModels.SSOSettin
 	return nil
 }
 
-func (s *SocialAzureAD) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialAzureAD) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
 
-	err = validateInfo(info, requester)
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
+
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -75,13 +75,18 @@ func NewGenericOAuthProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMa
 	return provider
 }
 
-func (s *SocialGenericOAuth) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialGenericOAuth) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
 
-	err = validateInfo(info, requester)
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
+
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/github_oauth.go
+++ b/pkg/login/social/connectors/github_oauth.go
@@ -82,13 +82,18 @@ func NewGitHubProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper *
 	return provider
 }
 
-func (s *SocialGithub) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialGithub) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
 
-	err = validateInfo(info, requester)
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
+
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/gitlab_oauth.go
+++ b/pkg/login/social/connectors/gitlab_oauth.go
@@ -64,13 +64,18 @@ func NewGitLabProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper *
 	return provider
 }
 
-func (s *SocialGitlab) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialGitlab) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
 
-	err = validateInfo(info, requester)
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
+
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -65,13 +65,17 @@ func NewGoogleProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper *
 	return provider
 }
 
-func (s *SocialGoogle) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialGoogle) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
 
-	err = validateInfo(info, requester)
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/grafana_com_oauth.go
+++ b/pkg/login/social/connectors/grafana_com_oauth.go
@@ -54,13 +54,18 @@ func NewGrafanaComProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapp
 	return provider
 }
 
-func (s *SocialGrafanaCom) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialGrafanaCom) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
 
-	err = validateInfo(info, requester)
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
+
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/okta_oauth.go
+++ b/pkg/login/social/connectors/okta_oauth.go
@@ -61,13 +61,18 @@ func NewOktaProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper *Or
 	return provider
 }
 
-func (s *SocialOkta) Validate(ctx context.Context, settings ssoModels.SSOSettings, _ ssoModels.SSOSettings, requester identity.Requester) error {
-	info, err := CreateOAuthInfoFromKeyValues(settings.Settings)
+func (s *SocialOkta) Validate(ctx context.Context, newSettings ssoModels.SSOSettings, oldSettings ssoModels.SSOSettings, requester identity.Requester) error {
+	info, err := CreateOAuthInfoFromKeyValues(newSettings.Settings)
 	if err != nil {
 		return ssosettings.ErrInvalidSettings.Errorf("SSO settings map cannot be converted to OAuthInfo: %v", err)
 	}
 
-	err = validateInfo(info, requester)
+	oldInfo, err := CreateOAuthInfoFromKeyValues(oldSettings.Settings)
+	if err != nil {
+		oldInfo = &social.OAuthInfo{}
+	}
+
+	err = validateInfo(info, oldInfo, requester)
 	if err != nil {
 		return err
 	}

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -263,5 +263,7 @@ func validateInfo(info *social.OAuthInfo, requester identity.Requester) error {
 	return validation.Validate(info, requester,
 		validation.RequiredValidator(info.ClientId, "Client Id"),
 		validation.AllowAssignGrafanaAdminValidator,
-		validation.SkipOrgRoleSyncAllowAssignGrafanaAdminValidator)
+		validation.SkipOrgRoleSyncAllowAssignGrafanaAdminValidator,
+		validation.OrgAttributePathValidator,
+		validation.OrgMappingValidator)
 }

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -259,11 +259,11 @@ func getRoleFromSearch(role string) (org.RoleType, bool) {
 	return org.RoleType(cases.Title(language.Und).String(role)), false
 }
 
-func validateInfo(info *social.OAuthInfo, requester identity.Requester) error {
+func validateInfo(info *social.OAuthInfo, oldInfo *social.OAuthInfo, requester identity.Requester) error {
 	return validation.Validate(info, requester,
 		validation.RequiredValidator(info.ClientId, "Client Id"),
-		validation.AllowAssignGrafanaAdminValidator,
+		validation.AllowAssignGrafanaAdminValidator(info, oldInfo, requester),
 		validation.SkipOrgRoleSyncAllowAssignGrafanaAdminValidator,
-		validation.OrgAttributePathValidator,
-		validation.OrgMappingValidator)
+		validation.OrgAttributePathValidator(info, oldInfo, requester),
+		validation.OrgMappingValidator(info, oldInfo, requester))
 }

--- a/pkg/services/ssosettings/validation/oauth_validators.go
+++ b/pkg/services/ssosettings/validation/oauth_validators.go
@@ -17,6 +17,20 @@ func AllowAssignGrafanaAdminValidator(info *social.OAuthInfo, requester identity
 	return nil
 }
 
+func OrgMappingValidator(info *social.OAuthInfo, requester identity.Requester) error {
+	if len(info.OrgMapping) > 0 && !requester.GetIsGrafanaAdmin() {
+		return ssosettings.ErrInvalidOAuthConfig("Organization mapping can only be updated by Grafana Server Admins.")
+	}
+	return nil
+}
+
+func OrgAttributePathValidator(info *social.OAuthInfo, requester identity.Requester) error {
+	if info.OrgAttributePath != "" && !requester.GetIsGrafanaAdmin() {
+		return ssosettings.ErrInvalidOAuthConfig("Organization attribute path can only be updated by Grafana Server Admins.")
+	}
+	return nil
+}
+
 func SkipOrgRoleSyncAllowAssignGrafanaAdminValidator(info *social.OAuthInfo, requester identity.Requester) error {
 	if info.AllowAssignGrafanaAdmin && info.SkipOrgRoleSync {
 		return ssosettings.ErrInvalidOAuthConfig("Allow assign Grafana Admin and Skip org role sync are both set thus Grafana Admin role will not be synced. Consider setting one or the other.")

--- a/pkg/services/ssosettings/validation/oauth_validators.go
+++ b/pkg/services/ssosettings/validation/oauth_validators.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -10,25 +11,34 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings"
 )
 
-func AllowAssignGrafanaAdminValidator(info *social.OAuthInfo, requester identity.Requester) error {
-	if info.AllowAssignGrafanaAdmin && !requester.GetIsGrafanaAdmin() {
-		return ssosettings.ErrInvalidOAuthConfig("Allow assign Grafana Admin can only be updated by Grafana Server Admins.")
+func AllowAssignGrafanaAdminValidator(info *social.OAuthInfo, oldInfo *social.OAuthInfo, requester identity.Requester) ssosettings.ValidateFunc[social.OAuthInfo] {
+	return func(info *social.OAuthInfo, requester identity.Requester) error {
+		hasChanged := info.AllowAssignGrafanaAdmin != oldInfo.AllowAssignGrafanaAdmin
+		if hasChanged && !requester.GetIsGrafanaAdmin() {
+			return ssosettings.ErrInvalidOAuthConfig("Allow assign Grafana Admin can only be updated by Grafana Server Admins.")
+		}
+		return nil
 	}
-	return nil
 }
 
-func OrgMappingValidator(info *social.OAuthInfo, requester identity.Requester) error {
-	if len(info.OrgMapping) > 0 && !requester.GetIsGrafanaAdmin() {
-		return ssosettings.ErrInvalidOAuthConfig("Organization mapping can only be updated by Grafana Server Admins.")
+func OrgMappingValidator(info *social.OAuthInfo, oldInfo *social.OAuthInfo, requester identity.Requester) ssosettings.ValidateFunc[social.OAuthInfo] {
+	return func(info *social.OAuthInfo, requester identity.Requester) error {
+		hasChanged := !slices.Equal(oldInfo.OrgMapping, info.OrgMapping)
+		if hasChanged && !requester.GetIsGrafanaAdmin() {
+			return ssosettings.ErrInvalidOAuthConfig("Organization mapping can only be updated by Grafana Server Admins.")
+		}
+		return nil
 	}
-	return nil
 }
 
-func OrgAttributePathValidator(info *social.OAuthInfo, requester identity.Requester) error {
-	if info.OrgAttributePath != "" && !requester.GetIsGrafanaAdmin() {
-		return ssosettings.ErrInvalidOAuthConfig("Organization attribute path can only be updated by Grafana Server Admins.")
+func OrgAttributePathValidator(info *social.OAuthInfo, oldInfo *social.OAuthInfo, requester identity.Requester) ssosettings.ValidateFunc[social.OAuthInfo] {
+	return func(info *social.OAuthInfo, requester identity.Requester) error {
+		hasChanged := info.OrgAttributePath != oldInfo.OrgAttributePath
+		if hasChanged && !requester.GetIsGrafanaAdmin() {
+			return ssosettings.ErrInvalidOAuthConfig("Organization attribute path can only be updated by Grafana Server Admins.")
+		}
+		return nil
 	}
-	return nil
 }
 
 func SkipOrgRoleSyncAllowAssignGrafanaAdminValidator(info *social.OAuthInfo, requester identity.Requester) error {

--- a/pkg/services/ssosettings/validation/oauth_validators_test.go
+++ b/pkg/services/ssosettings/validation/oauth_validators_test.go
@@ -153,3 +153,75 @@ func TestSkipOrgRoleSyncAllowAssignGrafanaAdminValidator(t *testing.T) {
 		})
 	}
 }
+
+func TestOrgMappingValidator(t *testing.T) {
+	tc := []testCase{
+		{
+			name: "passes when user is grafana admin and org mapping is set",
+			input: &social.OAuthInfo{
+				OrgMapping: []string{"group1:1:Viewer"},
+			},
+			requester: &user.SignedInUser{
+				IsGrafanaAdmin: true,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "fails when user is not grafana admin and org mapping is set",
+			input: &social.OAuthInfo{
+				OrgMapping: []string{"group1:1:Viewer"},
+			},
+			requester: &user.SignedInUser{
+				IsGrafanaAdmin: false,
+			},
+			wantErr: ssosettings.ErrInvalidOAuthConfig("Organization mapping can only be updated by Grafana Server Admins."),
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			err := OrgMappingValidator(tt.input, tt.requester)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestOrgAttributePathValidator(t *testing.T) {
+	tc := []testCase{
+		{
+			name: "passes when user is grafana admin and org attribute path is set",
+			input: &social.OAuthInfo{
+				OrgAttributePath: "path",
+			},
+			requester: &user.SignedInUser{
+				IsGrafanaAdmin: true,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "fails when user is not grafana admin and org attribute path is set",
+			input: &social.OAuthInfo{
+				OrgAttributePath: "path",
+			},
+			requester: &user.SignedInUser{
+				IsGrafanaAdmin: false,
+			},
+			wantErr: ssosettings.ErrInvalidOAuthConfig("Organization attribute path can only be updated by Grafana Server Admins."),
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			err := OrgAttributePathValidator(tt.input, tt.requester)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/public/app/features/auth-config/ProviderConfigForm.test.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.test.tsx
@@ -61,6 +61,14 @@ const testConfig: SSOProvider = {
   },
 };
 
+jest.mock('app/core/core', () => {
+  return {
+    contextSrv: {
+      isGrafanaAdmin: true,
+    },
+  };
+});
+
 const emptyConfig = {
   ...testConfig,
   settings: { ...testConfig.settings, enabled: false, clientId: '', clientSecret: '' },
@@ -146,7 +154,7 @@ describe('ProviderConfigForm', () => {
             clientSecret: 'test-client-secret',
             enabled: true,
             name: 'GitHub',
-            orgMapping: "[\"Group A:1:Editor\",\"Group B:2:Admin\"]",
+            orgMapping: '["Group A:1:Editor","Group B:2:Admin"]',
             roleAttributePath: 'new-attribute-path',
             roleAttributeStrict: true,
             scopes: 'user:email',
@@ -207,6 +215,7 @@ describe('ProviderConfigForm', () => {
             tlsClientKey: '',
             usePkce: false,
             useRefreshToken: false,
+            orgMapping: '',
           },
         },
         { showErrorAlert: false }

--- a/public/app/features/auth-config/ProviderConfigForm.test.tsx
+++ b/public/app/features/auth-config/ProviderConfigForm.test.tsx
@@ -57,6 +57,7 @@ const testConfig: SSOProvider = {
     allowedDomains: '',
     allowedGroups: '',
     scopes: '',
+    orgMapping: '',
   },
 };
 
@@ -120,6 +121,8 @@ describe('ProviderConfigForm', () => {
     await user.click(screen.getByText('User mapping'));
     await user.type(screen.getByRole('textbox', { name: /Role attribute path/i }), 'new-attribute-path');
     await user.click(screen.getByRole('checkbox', { name: /Role attribute strict mode/i }));
+    await user.type(screen.getByRole('combobox', { name: /Organization mapping/i }), 'Group A:1:Editor{enter}');
+    await user.type(screen.getByRole('combobox', { name: /Organization mapping/i }), 'Group B:2:Admin{enter}');
 
     await user.click(screen.getByText('Extra security measures'));
     await user.type(screen.getByRole('combobox', { name: /Allowed domains/i }), 'grafana.com{enter}');
@@ -143,6 +146,7 @@ describe('ProviderConfigForm', () => {
             clientSecret: 'test-client-secret',
             enabled: true,
             name: 'GitHub',
+            orgMapping: "[\"Group A:1:Editor\",\"Group B:2:Admin\"]",
             roleAttributePath: 'new-attribute-path',
             roleAttributeStrict: true,
             scopes: 'user:email',

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -38,7 +38,7 @@ export const sectionFields: Section = {
     {
       name: 'User mapping',
       id: 'user',
-      fields: ['roleAttributePath', 'roleAttributeStrict', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
+      fields: ['roleAttributePath', 'roleAttributeStrict', 'orgMapping', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
     },
     {
       name: 'Extra security measures',
@@ -86,6 +86,8 @@ export const sectionFields: Section = {
         'idTokenAttributeName',
         'roleAttributePath',
         'roleAttributeStrict',
+        'orgMapping',
+        'orgAttributePath',
         'allowAssignGrafanaAdmin',
         'skipOrgRoleSync',
       ],
@@ -121,7 +123,7 @@ export const sectionFields: Section = {
     {
       name: 'User mapping',
       id: 'user',
-      fields: ['roleAttributePath', 'roleAttributeStrict', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
+      fields: ['roleAttributePath', 'roleAttributeStrict', 'orgMapping', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
     },
     {
       name: 'Extra security measures',
@@ -149,7 +151,7 @@ export const sectionFields: Section = {
     {
       name: 'User mapping',
       id: 'user',
-      fields: ['roleAttributePath', 'roleAttributeStrict', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
+      fields: ['roleAttributePath', 'roleAttributeStrict', 'orgMapping', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
     },
     {
       name: 'Extra security measures',
@@ -176,7 +178,7 @@ export const sectionFields: Section = {
     {
       name: 'User mapping',
       id: 'user',
-      fields: ['roleAttributePath', 'roleAttributeStrict', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
+      fields: ['roleAttributePath', 'roleAttributeStrict', 'orgMapping', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
     },
     {
       name: 'Extra security measures',
@@ -213,7 +215,14 @@ export const sectionFields: Section = {
     {
       name: 'User mapping',
       id: 'user',
-      fields: ['roleAttributePath', 'roleAttributeStrict', 'allowAssignGrafanaAdmin', 'skipOrgRoleSync'],
+      fields: [
+        'roleAttributePath',
+        'roleAttributeStrict',
+        'orgMapping',
+        'orgAttributePath',
+        'allowAssignGrafanaAdmin',
+        'skipOrgRoleSync',
+      ],
     },
     {
       name: 'Extra security measures',
@@ -448,6 +457,20 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       description: 'Prevent synchronizing users’ organization roles from your IdP.',
       type: 'switch',
     },
+    orgMapping: {
+      label: 'Organization mapping',
+      description: orgMappingDescription(provider),
+      type: 'select',
+      multi: true,
+      allowCustomValue: true,
+      options: [],
+      placeholder: 'Enter mappings (my-team:1:Viewer...) and press Enter to add',
+    },
+    orgAttributePath: {
+      label: 'Organization attribute path',
+      description: 'JMESPath expression to use for organization lookup.',
+      type: 'text',
+    },
     defineAllowedGroups: {
       label: 'Define allowed groups',
       type: 'switch',
@@ -602,3 +625,20 @@ export function fieldMap(provider: string): Record<string, FieldData> {
 function isNumeric(value: string) {
   return /^-?\d+$/.test(value);
 }
+
+function orgMappingDescription(provider: string): string {
+  switch (provider) {
+    case 'azuread':
+      return 'List of "<GroupID>:<OrgIdOrName>:<Role>" mappings.';
+    case 'github':
+        return 'List of "<GitHubTeamName>:<OrgIdOrName>:<Role>" mappings.';
+    case 'gitlab':
+      return 'List of "<GitlabGroupName>:<OrgIdOrName>:<Role>';
+    case 'google':
+        return 'List of "<GoogleGroupName>:<OrgIdOrName>:<Role>';
+    default:
+      // Generic OAuth, Okta
+      return 'List of "<ExternalName>:<OrgIdOrName>:<Role>" mappings.';
+  }
+}
+

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -461,6 +461,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       label: 'Organization mapping',
       description: orgMappingDescription(provider),
       type: 'select',
+      hidden: !contextSrv.isGrafanaAdmin,
       multi: true,
       allowCustomValue: true,
       options: [],
@@ -470,6 +471,7 @@ export function fieldMap(provider: string): Record<string, FieldData> {
       label: 'Organization attribute path',
       description: 'JMESPath expression to use for organization lookup.',
       type: 'text',
+      hidden: !['generic_oauth', 'okta'].includes(provider),
     },
     defineAllowedGroups: {
       label: 'Define allowed groups',
@@ -641,4 +643,3 @@ function orgMappingDescription(provider: string): string {
       return 'List of "<ExternalName>:<OrgIdOrName>:<Role>" mappings.';
   }
 }
-

--- a/public/app/features/auth-config/fields.tsx
+++ b/public/app/features/auth-config/fields.tsx
@@ -633,11 +633,11 @@ function orgMappingDescription(provider: string): string {
     case 'azuread':
       return 'List of "<GroupID>:<OrgIdOrName>:<Role>" mappings.';
     case 'github':
-        return 'List of "<GitHubTeamName>:<OrgIdOrName>:<Role>" mappings.';
+      return 'List of "<GitHubTeamName>:<OrgIdOrName>:<Role>" mappings.';
     case 'gitlab':
       return 'List of "<GitlabGroupName>:<OrgIdOrName>:<Role>';
     case 'google':
-        return 'List of "<GoogleGroupName>:<OrgIdOrName>:<Role>';
+      return 'List of "<GoogleGroupName>:<OrgIdOrName>:<Role>';
     default:
       // Generic OAuth, Okta
       return 'List of "<ExternalName>:<OrgIdOrName>:<Role>" mappings.';

--- a/public/app/features/auth-config/types.ts
+++ b/public/app/features/auth-config/types.ts
@@ -36,6 +36,7 @@ export type SSOProviderSettingsBase = {
   roleAttributeStrict?: boolean;
   signoutRedirectUrl?: string;
   skipOrgRoleSync?: boolean;
+  orgAttributePath?: string;
   teamIdsAttributePath?: string;
   teamsUrl?: string;
   tlsClientCa?: string;
@@ -70,6 +71,7 @@ export type SSOProvider = {
     allowedDomains?: string;
     allowedGroups?: string;
     scopes?: string;
+    orgMapping?: string;
   };
 };
 
@@ -80,6 +82,7 @@ export type SSOProviderDTO = Partial<SSOProviderSettingsBase> & {
   allowedDomains?: Array<SelectableValue<string>>;
   allowedGroups?: Array<SelectableValue<string>>;
   scopes?: Array<SelectableValue<string>>;
+  orgMapping?: Array<SelectableValue<string>>;
 };
 
 export interface AuthConfigState {

--- a/public/app/features/auth-config/utils/data.ts
+++ b/public/app/features/auth-config/utils/data.ts
@@ -51,6 +51,11 @@ const strToValue = (val: string | string[]): SelectableValue[] => {
   if (Array.isArray(val)) {
     return val.map((v) => ({ label: v, value: v }));
   }
+  // Support parsing from JSON array format
+  if (val.startsWith('[') && val.endsWith(']')) {
+    return JSON.parse(val).map((v: string) => ({ label: v, value: v }));
+  }
+
   return val.split(/[\s,]/).map((s) => ({ label: s, value: s }));
 };
 
@@ -70,7 +75,11 @@ export function dataToDTO(data?: SSOProvider): SSOProviderDTO {
 }
 
 const valuesToString = (values: Array<SelectableValue<string>>) => {
-  return values.map(({ value }) => value).join(',');
+  if (values.length <= 1) {
+    return values.map(({ value }) => value).join(',');
+  }
+  // Store as JSON array if there are multiple values
+  return JSON.stringify(values.map(({ value }) => value));
 };
 
 const getFieldsForProvider = (provider: string) => {

--- a/public/app/features/auth-config/utils/data.ts
+++ b/public/app/features/auth-config/utils/data.ts
@@ -51,7 +51,7 @@ const strToValue = (val: string | string[]): SelectableValue[] => {
   if (Array.isArray(val)) {
     return val.map((v) => ({ label: v, value: v }));
   }
-  // Support parsing from JSON array format
+  // Stored as JSON Array
   if (val.startsWith('[') && val.endsWith(']')) {
     return JSON.parse(val).map((v: string) => ({ label: v, value: v }));
   }


### PR DESCRIPTION
**What is this feature?**
1. This PR adds the capability to configure the `org_mapping` and the `org_attribute_path` for the OAuth providers.
1. Fixes parsing of config stored in JSON array format and it changes the default behaviour for storing arrays: from now on arrays are stored in JSON array format if the array contains multiple values.

**Why do we need this feature?**
- Makes configuring org_mapping and org_attribute_path from the UI possible.
- Fixes parsing of configuration stored in JSON array format.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
