### PR TITLE
Select: Properly show group separator for virtualized selects

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -31,6 +31,7 @@ const manyGroupedOptions = [
       return { label: person, value: person };
     }),
   },
+  { label: 'Bar', value: '3' },
 ];
 
 const meta: Meta = {
@@ -250,6 +251,7 @@ export const MultiSelectWithOptionGroups: StoryFn = (args) => {
               { label: 'Eagle', value: '13' },
             ],
           },
+          { label: 'Bar', value: '3' },
         ]}
         value={value}
         onChange={(v) => {

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -12,7 +12,6 @@ import { useTheme2 } from '../../themes/ThemeContext';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 import { Icon } from '../Icon/Icon';
 
-import { SelectVirtualizedSeparator } from './SelectVirtualizedSeparator';
 import { getSelectStyles } from './getSelectStyles';
 
 interface SelectMenuProps {
@@ -93,7 +92,7 @@ export const VirtualizedSelectMenu = ({
       return [
         childWithoutChildren,
         ...child.props.children,
-        <SelectVirtualizedSeparator key={`${DIVIDER_KEY}-${flattenedOptions[index].label}`} />,
+        <div key={`${DIVIDER_KEY}-${flattenedOptions[index].label}`} className={styles.virtualizedSeparator} />,
       ];
     }
     return [child];

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -3,7 +3,7 @@ import { max } from 'lodash';
 import { RefCallback, useEffect, useMemo, useRef } from 'react';
 import * as React from 'react';
 import { MenuListProps } from 'react-select';
-import { FixedSizeList as List } from 'react-window';
+import { VariableSizeList as List } from 'react-window';
 
 import { SelectableValue, toIconName } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -12,6 +12,7 @@ import { useTheme2 } from '../../themes/ThemeContext';
 import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
 import { Icon } from '../Icon/Icon';
 
+import { SelectVirtualizedSeparator } from './SelectVirtualizedSeparator';
 import { getSelectStyles } from './getSelectStyles';
 
 interface SelectMenuProps {
@@ -36,8 +37,10 @@ export const SelectMenu = ({ children, maxHeight, innerRef, innerProps }: React.
 SelectMenu.displayName = 'SelectMenu';
 
 const VIRTUAL_LIST_ITEM_HEIGHT = 37;
+const VIRTUAL_DIVIDER_HEIGHT = 1;
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
 const VIRTUAL_LIST_PADDING = 8;
+const DIVIDER_KEY = 'divider';
 // Some list items have icons or checkboxes so we need some extra width
 const VIRTUAL_LIST_WIDTH_EXTRA = 36;
 
@@ -81,13 +84,17 @@ export const VirtualizedSelectMenu = ({
 
   // flatten the children to account for any categories
   // these will have array children that are the individual options
-  const flattenedChildren = children.flatMap((child) => {
+  const flattenedChildren = children.flatMap((child, index) => {
     if (hasArrayChildren(child)) {
       // need to remove the children from the category else they end up in the DOM twice
       const childWithoutChildren = React.cloneElement(child, {
         children: null,
       });
-      return [childWithoutChildren, ...child.props.children];
+      return [
+        childWithoutChildren,
+        ...child.props.children,
+        <SelectVirtualizedSeparator key={`${DIVIDER_KEY}-${flattenedOptions[index].label}`} />,
+      ];
     }
     return [child];
   });
@@ -97,6 +104,15 @@ export const VirtualizedSelectMenu = ({
     longestOption * VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER + VIRTUAL_LIST_PADDING * 2 + VIRTUAL_LIST_WIDTH_EXTRA;
   const heightEstimate = Math.min(flattenedChildren.length * VIRTUAL_LIST_ITEM_HEIGHT, maxHeight);
 
+  const getRowHeight = (rowIndex: number) => {
+    const row = flattenedChildren[rowIndex];
+    if (row.key.includes(DIVIDER_KEY)) {
+      return VIRTUAL_DIVIDER_HEIGHT;
+    }
+
+    return VIRTUAL_LIST_ITEM_HEIGHT;
+  };
+
   return (
     <List
       ref={listRef}
@@ -105,7 +121,8 @@ export const VirtualizedSelectMenu = ({
       width={widthEstimate}
       aria-label="Select options menu"
       itemCount={flattenedChildren.length}
-      itemSize={VIRTUAL_LIST_ITEM_HEIGHT}
+      itemSize={getRowHeight}
+      estimatedItemSize={VIRTUAL_LIST_ITEM_HEIGHT}
     >
       {({ index, style }) => <div style={{ ...style, overflow: 'hidden' }}>{flattenedChildren[index]}</div>}
     </List>

--- a/packages/grafana-ui/src/components/Select/SelectVirtualizedSeparator.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectVirtualizedSeparator.tsx
@@ -1,9 +1,0 @@
-import { useStyles2 } from '../../themes/ThemeContext';
-
-import { getSelectStyles } from './getSelectStyles';
-
-export const SelectVirtualizedSeparator = () => {
-  const styles = useStyles2(getSelectStyles);
-
-  return <div className={styles.virtualizedSeparator} />;
-};

--- a/packages/grafana-ui/src/components/Select/SelectVirtualizedSeparator.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectVirtualizedSeparator.tsx
@@ -1,0 +1,9 @@
+import { useStyles2 } from '../../themes/ThemeContext';
+
+import { getSelectStyles } from './getSelectStyles';
+
+export const SelectVirtualizedSeparator = () => {
+  const styles = useStyles2(getSelectStyles);
+
+  return <div className={styles.virtualizedSeparator} />;
+};

--- a/packages/grafana-ui/src/components/Select/getSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/getSelectStyles.ts
@@ -163,5 +163,8 @@ export const getSelectStyles = stylesFactory((theme: GrafanaTheme2) => {
         borderBottom: `1px solid ${theme.colors.border.weak}`,
       },
     }),
+    virtualizedSeparator: css({
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+    }),
   };
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- properly shows a separator between groups in virtualized selects
- adjusts the story slightly to show ungrouped options after the last group

**Why do we need this feature?**

- so users can distinguish the option groups in a virtualized select

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
