### PR TITLE
Folders: Fix folder pagination for cloud instances with many folders

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -64,13 +64,7 @@ func (hs *HTTPServer) GetFolders(c *contextmodel.ReqContext) response.Response {
 		}
 
 		hits := make([]dtos.FolderSearchHit, 0)
-		requesterIsSvcAccount := c.SignedInUser.GetID().Namespace() == identity.NamespaceServiceAccount
 		for _, f := range folders {
-			// only list k6 folders when requested by a service account - prevents showing k6 folders in the UI for users
-			if (f.UID == accesscontrol.K6FolderUID || f.ParentUID == accesscontrol.K6FolderUID) && !requesterIsSvcAccount {
-				continue
-			}
-
 			hits = append(hits, dtos.FolderSearchHit{
 				ID:        f.ID, // nolint:staticcheck
 				UID:       f.UID,

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -700,16 +700,9 @@ func makeQueryResult(query *dashboards.FindPersistedDashboardsQuery, res []dashb
 	hitList := make([]*model.Hit, 0)
 	hits := make(map[int64]*model.Hit)
 
-	requesterIsSvcAccount := query.SignedInUser.GetID().Namespace() == identity.NamespaceServiceAccount
-
 	for _, item := range res {
 		hit, exists := hits[item.ID]
 		if !exists {
-			// Don't list k6 items for users, we don't want users to interact with k6 folders directly through folder UI
-			if (item.UID == accesscontrol.K6FolderUID || item.FolderUID == accesscontrol.K6FolderUID) && !requesterIsSvcAccount {
-				continue
-			}
-
 			metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
 			hit = &model.Hit{
 				ID:          item.ID,

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -180,12 +180,7 @@ func (s *Service) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*
 		}
 	}
 
-	result := make([]*folder.Folder, 0, len(dashFolders))
-	for _, folder := range dashFolders {
-		result = append(result, folder)
-	}
-
-	return result, nil
+	return dashFolders, nil
 }
 
 func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Folder, error) {

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -180,13 +180,8 @@ func (s *Service) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*
 		}
 	}
 
-	// only list k6 folders when requested by a service account - prevents showing k6 folders in the UI for users
 	result := make([]*folder.Folder, 0, len(dashFolders))
-	requesterIsSvcAccount := qry.SignedInUser.GetID().Namespace() == identity.NamespaceServiceAccount
 	for _, folder := range dashFolders {
-		if (folder.UID == accesscontrol.K6FolderUID || folder.ParentUID == accesscontrol.K6FolderUID) && !requesterIsSvcAccount {
-			continue
-		}
 		result = append(result, folder)
 	}
 

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -730,6 +732,68 @@ func TestIntegrationGetChildren(t *testing.T) {
 		if diff := cmp.Diff(treeLeaves, childrenUIDs); diff != "" {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
 		}
+	})
+
+	t.Run("should hide k6-app folder for users but not for service accounts", func(t *testing.T) {
+		_, err = folderStore.Create(context.Background(), folder.CreateFolderCommand{
+			Title: "k6-app-folder",
+			OrgID: orgID,
+			UID:   accesscontrol.K6FolderUID,
+		})
+		require.NoError(t, err)
+
+		children, err := folderStore.GetChildren(context.Background(), folder.GetChildrenQuery{
+			OrgID:        orgID,
+			SignedInUser: usr,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(children))
+		assert.Equal(t, parent.UID, children[0].UID)
+
+		// Service account should be able to list k6 folder
+		children, err = folderStore.GetChildren(context.Background(), folder.GetChildrenQuery{
+			OrgID:        orgID,
+			SignedInUser: &user.SignedInUser{UserID: 2, OrgID: orgID, IsServiceAccount: true},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, len(children))
+		childrenUIDs := make([]string, 0, len(children))
+		for _, child := range children {
+			childrenUIDs = append(childrenUIDs, child.UID)
+		}
+		assert.EqualValues(t, []string{parent.UID, accesscontrol.K6FolderUID}, childrenUIDs)
+	})
+
+	t.Run("pagination works if k6-app folder is hidden", func(t *testing.T) {
+		for i := 0; i < 4; i++ {
+			_, err = folderStore.Create(context.Background(), folder.CreateFolderCommand{
+				Title: fmt.Sprintf("root-%d", i),
+				OrgID: orgID,
+				UID:   fmt.Sprintf("root-%d", i),
+			})
+			require.NoError(t, err)
+		}
+
+		// Should skip k6-app folder but get parent folder and two more folders
+		children, err := folderStore.GetChildren(context.Background(), folder.GetChildrenQuery{
+			OrgID:        orgID,
+			SignedInUser: usr,
+			Limit:        3,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 3, len(children))
+		assert.EqualValues(t, []string{parent.UID, "root-0", "root-1"}, []string{children[0].UID, children[1].UID, children[2].UID})
+
+		// Should get the two remaining folders
+		children, err = folderStore.GetChildren(context.Background(), folder.GetChildrenQuery{
+			OrgID:        orgID,
+			SignedInUser: usr,
+			Page:         2,
+			Limit:        3,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, len(children))
+		assert.EqualValues(t, []string{"root-2", "root-3"}, []string{children[0].UID, children[1].UID})
 	})
 }
 

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -131,7 +131,7 @@ func (f DashboardFilter) Where() (string, []any) {
 type K6FolderFilter struct{}
 
 func (f K6FolderFilter) Where() (string, []any) {
-	filter := fmt.Sprintf("dashboard.uid != ? AND (dashboard.folder_uid != ? OR dashboard.folder_uid IS NULL)")
+	filter := "dashboard.uid != ? AND (dashboard.folder_uid != ? OR dashboard.folder_uid IS NULL)"
 	params := []any{accesscontrol.K6FolderUID, accesscontrol.K6FolderUID}
 	return filter, params
 }

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -125,6 +126,14 @@ type DashboardFilter struct {
 
 func (f DashboardFilter) Where() (string, []any) {
 	return sqlUIDin("dashboard.uid", f.UIDs)
+}
+
+type K6FolderFilter struct{}
+
+func (f K6FolderFilter) Where() (string, []any) {
+	filter := fmt.Sprintf("dashboard.uid != ? AND (dashboard.folder_uid != ? OR dashboard.folder_uid IS NULL)")
+	params := []any{accesscontrol.K6FolderUID, accesscontrol.K6FolderUID}
+	return filter, params
 }
 
 type TagsFilter struct {


### PR DESCRIPTION
**What is this feature?**

Filter k6 folder out during the SQL query rather than during post processing to ensure that the correct number of results is always returned and that frontend keeps fetching folders until the end of the folder list is reached.

**Why do we need this feature?**

Filtering out the k6 folder after the results were fetched meant that we're returning one less result to the frontend, which the frontend interprets as reaching the end of the folder list.

We want to keep hiding the k6 folder, as we don't want users to store dashboards or alerts in it, accidentally delete it etc.

**Who is this feature for?**

HG users

**Special notes for your reviewer:**

I've tested this with:
* users and service accounts (service accounts should keep seeing the k6 folder)
* with over 100 root level folders (to ensure that pagination works correctly)
