### PR TITLE
Explore: Fix new-old-new query history bug 

### DIFF
--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -39,11 +39,7 @@ export function useStateSync(params: ExploreQueryParams) {
     const unsubscribe = dispatch(
       addListener({
         predicate: (action) => syncToURLPredicate(paused, action),
-        effect: async (_, { cancelActiveListeners, delay, getState }) => {
-          // The following 2 lines will debounce updates to avoid creating history entries when rapid changes
-          // are committed to the store.
-          cancelActiveListeners();
-          await delay(200);
+        effect: async (_, { getState }) => {
           syncToURL(getState().explore, prevParams, initState, location);
         },
       })

--- a/public/app/features/explore/hooks/useStateSync/index.ts
+++ b/public/app/features/explore/hooks/useStateSync/index.ts
@@ -39,7 +39,11 @@ export function useStateSync(params: ExploreQueryParams) {
     const unsubscribe = dispatch(
       addListener({
         predicate: (action) => syncToURLPredicate(paused, action),
-        effect: async (_, { getState }) => {
+        effect: async (_, { cancelActiveListeners, delay, getState }) => {
+          // The following 2 lines will debounce updates to avoid creating history entries when rapid changes
+          // are committed to the store.
+          cancelActiveListeners();
+          await delay(200);
           syncToURL(getState().explore, prevParams, initState, location);
         },
       })

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -570,7 +570,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
     }));
 
     if (datasourceInstance != null) {
-      handleHistory(dispatch, getState().explore, datasourceInstance, queries);
+      await handleHistory(dispatch, getState().explore, datasourceInstance, queries);
     }
 
     const cachedValue = getResultsFromCache(cache, absoluteRange);


### PR DESCRIPTION
This was a tricky bug and although I have a solution and some assumptions of what is going on, I'm still not completely sure. Here's the description of the issue #89530 (the issue also happens in query builder mode) and also a video below that illustrates it:

Before:

https://github.com/grafana/grafana/assets/58232930/4eb833a0-3c19-42b9-9b5b-da28a356b52a

With the fix in this PR:

https://github.com/grafana/grafana/assets/58232930/bd4b5a04-c060-4216-9aa3-49972a9d4275

First I looked into removing cancelActiveListeners() and delay() function 
https://github.com/grafana/grafana/blob/2d5c58cb90ca948f373d4ffd81f38934be1f5297/public/app/features/explore/hooks/useStateSync/index.ts#L43-L46

Maybe I'm misunderstanding the comment above them, but I've tested this and didn't see creating additional history entries. 

Anyway, I found a different and probably better solution. These functions were creating an unresolved promise error for `handleHistory()` function invoked here:
https://github.com/grafana/grafana/blob/2d5c58cb90ca948f373d4ffd81f38934be1f5297/public/app/features/explore/state/query.ts#L573
Error:
![Screenshot 2024-07-03 at 11 44 32 AM](https://github.com/grafana/grafana/assets/58232930/667a8b6a-537f-4a30-b464-1491ba1e8b25)

So, the solution was to wait for this function to resolve. 

**Which issue(s) does this PR fix?**:

Fixes #89530 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] That unexpected history entries are not being created
- [ ] Verify that the URL updates when running a query from the query history
