### PR TITLE
Table panel: Fix text wrapping when fields sorted

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -290,7 +290,7 @@ export const RowsList = (props: RowsListProps) => {
         const seriesIndex = visibleFields.findIndex((field) => field.name === textWrapField.name);
         const pxLineHeight = theme.typography.body.lineHeight * theme.typography.fontSize;
         const bbox = guessTextBoundingBox(
-          textWrapField.values[index],
+          row.values[seriesIndex],
           headerGroups[0].headers[seriesIndex],
           osContext,
           pxLineHeight,
@@ -374,7 +374,7 @@ export const RowsList = (props: RowsListProps) => {
       const seriesIndex = visibleFields.findIndex((field) => field.name === textWrapField.name);
       const pxLineHeight = theme.typography.fontSize * theme.typography.body.lineHeight;
       return guessTextBoundingBox(
-        textWrapField.values[index],
+        row.values[seriesIndex],
         headerGroups[0].headers[seriesIndex],
         osContext,
         pxLineHeight,


### PR DESCRIPTION
This is an in progress PR to fix text wrapping when sorting is applied to fields.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
