### PR TITLE
Explore metrics: Use state for variables to fix labels loading bug

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5472,10 +5472,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/trails/ActionTabs/utils.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -5468,12 +5468,6 @@ exports[`better eslint`] = {
     "public/app/features/trails/ActionTabs/BreakdownScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
-    "public/app/features/trails/ActionTabs/MetricOverviewScene.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
-    ],
     "public/app/features/trails/ActionTabs/utils.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,3 +1,5 @@
+import { Trans } from 'react-i18next';
+
 import { PromMetricsMetadataItem } from '@grafana/prometheus';
 import {
   QueryVariable,
@@ -66,28 +68,52 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
     const variable = model.getVariable();
     const { loading: labelsLoading, options: labelOptions } = variable.useState();
 
-    const help = metadata?.help;
-    const type = metadata?.type;
-    const unit = metadata?.unit;
-
     return (
       <StatusWrapper isLoading={labelsLoading || metadataLoading}>
         <Stack gap={6}>
           <>
             <Stack direction="column" gap={0.5}>
-              <Text weight={textWeight(help)}>Description</Text>
-              <div style={{ maxWidth: 360 }}>{help}</div>
+              <Text weight={'medium'}>
+                <Trans>Description</Trans>
+              </Text>
+              <div style={{ maxWidth: 360 }}>
+                {metadata?.help ? (
+                  <div>{metadata?.help}</div>
+                ) : (
+                  <i>
+                    <Trans>No description available</Trans>
+                  </i>
+                )}
+              </div>
             </Stack>
             <Stack direction="column" gap={0.5}>
-              <Text weight={textWeight(type)}>Type</Text>
-              {type}
+              <Text weight={'medium'}>
+                <Trans>Type</Trans>
+              </Text>
+              {metadata?.type ? (
+                <div>{metadata?.type}</div>
+              ) : (
+                <i>
+                  <Trans>Unknown</Trans>
+                </i>
+              )}
             </Stack>
             <Stack direction="column" gap={0.5}>
-              <Text weight={textWeight(unit)}>Unit</Text>
-              {unit}
+              <Text weight={'medium'}>
+                <Trans>Unit</Trans>
+              </Text>
+              {metadata?.unit ? (
+                <div>{metadata?.unit}</div>
+              ) : (
+                <i>
+                  <Trans>Unknown</Trans>
+                </i>
+              )}
             </Stack>
             <Stack direction="column" gap={0.5}>
-              <Text weight={'medium'}>Labels</Text>
+              <Text weight={'medium'}>
+                <Trans>Labels</Trans>
+              </Text>
               {labelOptions.length === 0 && 'Unable to fetch labels.'}
               {labelOptions.map((l) => (
                 <TextLink
@@ -119,8 +145,4 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
 
 export function buildMetricOverviewScene() {
   return new MetricOverviewScene({});
-}
-
-function textWeight(data: string | undefined) {
-  return data ? 'medium' : 'light';
 }

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,5 +1,3 @@
-import { Trans } from 'react-i18next';
-
 import { PromMetricsMetadataItem } from '@grafana/prometheus';
 import {
   QueryVariable,
@@ -10,6 +8,7 @@ import {
   VariableDependencyConfig,
 } from '@grafana/scenes';
 import { Stack, Text, TextLink } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
 
 import { MetricScene } from '../MetricScene';
 import { StatusWrapper } from '../StatusWrapper';

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -66,23 +66,25 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
     const variable = model.getVariable();
     const { loading: labelsLoading, options: labelOptions } = variable.useState();
 
+    const help = metadata?.help;
+    const type = metadata?.type;
+    const unit = metadata?.unit;
+
     return (
       <StatusWrapper isLoading={labelsLoading || metadataLoading}>
         <Stack gap={6}>
           <>
             <Stack direction="column" gap={0.5}>
-              <Text weight={'medium'}>Description</Text>
-              <div style={{ maxWidth: 360 }}>
-                {metadata?.help ? <div>{metadata?.help}</div> : <i>No description available</i>}
-              </div>
+              <Text weight={textWeight(help)}>Description</Text>
+              <div style={{ maxWidth: 360 }}>{help ? help : '&nbsp;'}</div>
             </Stack>
             <Stack direction="column" gap={0.5}>
-              <Text weight={'medium'}>Type</Text>
-              {metadata?.type ? <div>{metadata?.type}</div> : <i>Unknown</i>}
+              <Text weight={textWeight(type)}>Type</Text>
+              {type ? type : '&nbsp;'}
             </Stack>
             <Stack direction="column" gap={0.5}>
-              <Text weight={'medium'}>Unit</Text>
-              {metadata?.unit ? <div>{metadata?.unit}</div> : <i>Unknown</i>}
+              <Text weight={textWeight(unit)}>Unit</Text>
+              {unit ? unit : '&nbsp;'}
             </Stack>
             <Stack direction="column" gap={0.5}>
               <Text weight={'medium'}>Labels</Text>
@@ -117,4 +119,8 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
 
 export function buildMetricOverviewScene() {
   return new MetricOverviewScene({});
+}
+
+function textWeight(data: string | undefined) {
+  return data ? 'medium' : 'light';
 }

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -76,15 +76,15 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
           <>
             <Stack direction="column" gap={0.5}>
               <Text weight={textWeight(help)}>Description</Text>
-              <div style={{ maxWidth: 360 }}>{help ? help : '&nbsp;'}</div>
+              <div style={{ maxWidth: 360 }}>{help}</div>
             </Stack>
             <Stack direction="column" gap={0.5}>
               <Text weight={textWeight(type)}>Type</Text>
-              {type ? type : '&nbsp;'}
+              {type}
             </Stack>
             <Stack direction="column" gap={0.5}>
               <Text weight={textWeight(unit)}>Unit</Text>
-              {unit ? unit : '&nbsp;'}
+              {unit}
             </Stack>
             <Stack direction="column" gap={0.5}>
               <Text weight={'medium'}>Labels</Text>

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -9,14 +9,11 @@ import {
 } from '@grafana/scenes';
 import { Stack, Text, TextLink } from '@grafana/ui';
 
-import { ALL_VARIABLE_VALUE } from '../../variables/constants';
 import { MetricScene } from '../MetricScene';
 import { StatusWrapper } from '../StatusWrapper';
 import { reportExploreMetrics } from '../interactions';
 import { VAR_DATASOURCE_EXPR, VAR_GROUP_BY } from '../shared';
 import { getMetricSceneFor, getTrailFor } from '../utils';
-
-import { getLabelOptions } from './utils';
 
 export interface MetricOverviewSceneState extends SceneObjectState {
   metadata?: PromMetricsMetadataItem;
@@ -67,8 +64,7 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
   public static Component = ({ model }: SceneComponentProps<MetricOverviewScene>) => {
     const { metadata, metadataLoading } = model.useState();
     const variable = model.getVariable();
-    const { loading: labelsLoading } = variable.useState();
-    const labelOptions = getLabelOptions(model, variable).filter((l) => l.value !== ALL_VARIABLE_VALUE);
+    const { loading: labelsLoading, options: labelOptions } = variable.useState();
 
     return (
       <StatusWrapper isLoading={labelsLoading || metadataLoading}>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -614,6 +614,7 @@
       "message": "No data sources found"
     }
   },
+  "Description": "Description",
   "explore": {
     "add-to-dashboard": "Add to dashboard",
     "add-to-library-modal": {
@@ -874,6 +875,7 @@
       "refresh": "Refresh"
     }
   },
+  "Labels": "Labels",
   "library-panel": {
     "add-modal": {
       "cancel": "Cancel",
@@ -1428,6 +1430,7 @@
     },
     "title": "Latest from the blog"
   },
+  "No description available": "No description available",
   "notifications": {
     "empty-state": {
       "description": "Notifications you have received will appear here",
@@ -2111,6 +2114,9 @@
       "add-transformation-header": "Start transforming data"
     }
   },
+  "Type": "Type",
+  "Unit": "Unit",
+  "Unknown": "Unknown",
   "user-orgs": {
     "current-org-button": "Current",
     "name-column": "Name",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -614,6 +614,7 @@
       "message": "Ńő đäŧä şőūřčęş ƒőūŉđ"
     }
   },
+  "Description": "Đęşčřįpŧįőŉ",
   "explore": {
     "add-to-dashboard": "Åđđ ŧő đäşĥþőäřđ",
     "add-to-library-modal": {
@@ -874,6 +875,7 @@
       "refresh": "Ŗęƒřęşĥ"
     }
   },
+  "Labels": "Ŀäþęľş",
   "library-panel": {
     "add-modal": {
       "cancel": "Cäŉčęľ",
@@ -1428,6 +1430,7 @@
     },
     "title": "Ŀäŧęşŧ ƒřőm ŧĥę þľőģ"
   },
+  "No description available": "Ńő đęşčřįpŧįőŉ äväįľäþľę",
   "notifications": {
     "empty-state": {
       "description": "Ńőŧįƒįčäŧįőŉş yőū ĥävę řęčęįvęđ ŵįľľ äppęäř ĥęřę",
@@ -2111,6 +2114,9 @@
       "add-transformation-header": "Ŝŧäřŧ ŧřäŉşƒőřmįŉģ đäŧä"
     }
   },
+  "Type": "Ŧypę",
+  "Unit": "Ůŉįŧ",
+  "Unknown": "Ůŉĸŉőŵŉ",
   "user-orgs": {
     "current-org-button": "Cūřřęŉŧ",
     "name-column": "Ńämę",


### PR DESCRIPTION
**What is this feature?**
Bug fix for labels not loading correctly due to state issues 

**Why do we need this feature?**

Labels can be slow to load for customers with a significant amount of labels. Using `variable.useState()` to access labels through the scenes queryVariable is a fix for this. 

**Who is this feature for?**

Explore metrics users with lots of labels 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/89911

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
