### PR TITLE
Alerting: Acquire database lock during periodic alert state sync

### DIFF
--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -66,7 +66,8 @@ to be enabled. By default, it saves the states every 5 minutes to the database a
 can also be configured using the `state_periodic_save_interval` configuration flag.
 
 The time it takes to write to the database periodically can be monitored using the `state_full_sync_duration_seconds` metric
-that is exposed by Grafana.
+that is exposed by Grafana. Additionally, the `state_full_sync_last_time` metric allows you to track the timestamp of the last full state save.
+Periodic state writes are performed under a database-level lock. If Grafana is [configured for high availability]({{< relref "../configure-high-availability" >}}), this locking mechanism ensures that only one Grafana instance writes to the database at any given time.
 
 If Grafana crashes or is force killed, then the database can be up to `state_periodic_save_interval` seconds out of date.
 When Grafana restarts, the UI might show incorrect state for some alerts until the alerts are re-evaluated.

--- a/pkg/services/ngalert/metrics/state.go
+++ b/pkg/services/ngalert/metrics/state.go
@@ -8,6 +8,7 @@ import (
 type State struct {
 	StateUpdateDuration   prometheus.Histogram
 	StateFullSyncDuration prometheus.Histogram
+	StateFullSyncLastTime prometheus.Gauge
 	r                     prometheus.Registerer
 }
 
@@ -37,5 +38,11 @@ func NewStateMetrics(r prometheus.Registerer) *State {
 				Buckets:   []float64{0.01, 0.1, 1, 2, 5, 10, 60},
 			},
 		),
+		StateFullSyncLastTime: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "state_full_sync_last_time",
+			Help:      "Timestamp of the last full sync in seconds.",
+		}),
 	}
 }

--- a/pkg/services/ngalert/state/persister_async.go
+++ b/pkg/services/ngalert/state/persister_async.go
@@ -57,7 +57,7 @@ func (a *AsyncStatePersister) fullSync(ctx context.Context, cache *cache) error 
 	instances := cache.asInstances(a.doNotSaveNormalState)
 	if err := a.store.FullSync(ctx, instances); err != nil {
 		if errors.Is(err, store.ErrLockDB) {
-			a.log.Warn("Full state sync failed to acquire the lock, probably another full sync is in progress")
+			a.log.Warn("Full state sync failed to acquire the lock, another full sync may be in progress")
 			return nil
 		}
 

--- a/pkg/services/ngalert/state/persister_async_test.go
+++ b/pkg/services/ngalert/state/persister_async_test.go
@@ -1,25 +1,33 @@
 package state
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
 func TestAsyncStatePersister_Async(t *testing.T) {
 	t.Run("It should save on tick", func(t *testing.T) {
 		mockClock := clock.NewMock()
 		store := &FakeInstanceStore{}
+		reg := prometheus.NewPedanticRegistry()
+		stateMetrics := metrics.NewStateMetrics(reg)
 		logger := log.New("async.test")
 
 		persister := NewAsyncStatePersister(logger, mockClock.Ticker(1*time.Second), ManagerCfg{
 			InstanceStore: store,
+			Metrics:       stateMetrics,
 		})
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -44,7 +52,18 @@ func TestAsyncStatePersister_Async(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return len(store.RecordedOps()) == 1
 		}, time.Second*5, time.Second)
+
+		expectedMetric := fmt.Sprintf(
+			`# HELP grafana_alerting_state_full_sync_last_time Timestamp of the last full sync in seconds.
+			 # TYPE grafana_alerting_state_full_sync_last_time gauge
+			 grafana_alerting_state_full_sync_last_time %[1]d
+			`,
+			mockClock.Now().Unix(),
+		)
+		err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_state_full_sync_last_time")
+		require.NoError(t, err)
 	})
+
 	t.Run("It should save on context done", func(t *testing.T) {
 		mockClock := clock.NewMock()
 		store := &FakeInstanceStore{}

--- a/pkg/services/ngalert/store/locks.go
+++ b/pkg/services/ngalert/store/locks.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+var ErrLockDB = errors.New("failed to acquire the database lock")
+
+// WithLock acquires a database lock, executes the provided function, and releases the lock.
+// Uses migrator.Lock which supports MySQL, and PostgreSQL, and for SQLite it does nothing.
+// Does not wait for the lock to be acquired, if the lock is already acquired by another session it will return ErrLockDB.
+func (st *DBstore) WithLock(ctx context.Context, lockName string, f func(ctx context.Context) error) error {
+	return st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
+		cfg := migrator.LockCfg{
+			Session: sess.Session,
+			// The key must be a number in a string format, to be compatible with PostgreSQL,
+			// so we generate a checksum of the lockName.
+			Key: fmt.Sprint(crc32.ChecksumIEEE([]byte(lockName))),
+		}
+		err := st.SQLStore.GetDialect().Lock(cfg)
+		// If Lock returns migrator.ErrLockDB, the lock is already acquired by another session.
+		if err != nil && errors.Is(err, migrator.ErrLockDB) {
+			return ErrLockDB
+		}
+		if err != nil {
+			return fmt.Errorf("failed to acquire the database lock (%s): %w", cfg.Key, err)
+		}
+
+		defer func() {
+			err := st.SQLStore.GetDialect().Unlock(cfg)
+			if err != nil {
+				st.Logger.Error("Failed to release the database lock", "err", err, "lock_name", cfg.Key)
+			}
+		}()
+
+		return f(ctx)
+	})
+}

--- a/pkg/services/ngalert/store/locks.go
+++ b/pkg/services/ngalert/store/locks.go
@@ -26,10 +26,10 @@ func (st *DBstore) WithLock(ctx context.Context, lockName string, f func(ctx con
 		err := st.SQLStore.GetDialect().Lock(cfg)
 		// If Lock returns migrator.ErrLockDB, the lock is already acquired by another session.
 		if err != nil {
-		    if errors.Is(err, migrator.ErrLockDB) {
-		        return ErrLockDB
-		    }
-		    return fmt.Errorf("failed to acquire the database lock (%s): %w", cfg.Key, err)
+			if errors.Is(err, migrator.ErrLockDB) {
+				return ErrLockDB
+			}
+			return fmt.Errorf("failed to acquire the database lock (%s): %w", cfg.Key, err)
 		}
 
 		defer func() {

--- a/pkg/services/ngalert/store/locks.go
+++ b/pkg/services/ngalert/store/locks.go
@@ -25,10 +25,10 @@ func (st *DBstore) WithLock(ctx context.Context, lockName string, f func(ctx con
 		}
 		err := st.SQLStore.GetDialect().Lock(cfg)
 		// If Lock returns migrator.ErrLockDB, the lock is already acquired by another session.
+		if errors.Is(err, migrator.ErrLockDB) {
+			return ErrLockDB
+		}
 		if err != nil {
-			if errors.Is(err, migrator.ErrLockDB) {
-				return ErrLockDB
-			}
 			return fmt.Errorf("failed to acquire the database lock (%s): %w", cfg.Key, err)
 		}
 

--- a/pkg/services/ngalert/store/locks.go
+++ b/pkg/services/ngalert/store/locks.go
@@ -25,11 +25,11 @@ func (st *DBstore) WithLock(ctx context.Context, lockName string, f func(ctx con
 		}
 		err := st.SQLStore.GetDialect().Lock(cfg)
 		// If Lock returns migrator.ErrLockDB, the lock is already acquired by another session.
-		if err != nil && errors.Is(err, migrator.ErrLockDB) {
-			return ErrLockDB
-		}
 		if err != nil {
-			return fmt.Errorf("failed to acquire the database lock (%s): %w", cfg.Key, err)
+		    if errors.Is(err, migrator.ErrLockDB) {
+		        return ErrLockDB
+		    }
+		    return fmt.Errorf("failed to acquire the database lock (%s): %w", cfg.Key, err)
 		}
 
 		defer func() {

--- a/pkg/services/ngalert/store/locks_test.go
+++ b/pkg/services/ngalert/store/locks_test.go
@@ -1,0 +1,53 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/ngalert/tests"
+)
+
+func TestIntegrationWithLock(t *testing.T) {
+	_, dbstore := tests.SetupTestEnv(t, 10)
+
+	if db.IsTestDbSQLite() {
+		t.Skip("skipping test for sqlite")
+	}
+
+	t.Run("second transaction should fail to acquire the same lock", func(t *testing.T) {
+		ctx := context.Background()
+		defer ctx.Done()
+
+		lockName := "test-lock"
+
+		// Acquire the lock in a goroutine
+		go func() {
+			err := dbstore.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+				lockErr := dbstore.WithLock(ctx, lockName, func(ctx context.Context) error {
+					<-ctx.Done()
+					return nil
+				})
+				require.NoError(t, lockErr, "expected no error from WithLock")
+				return nil
+			})
+			require.NoError(t, err)
+		}()
+
+		// Wait for the lock to be acquired
+		time.Sleep(100 * time.Millisecond)
+
+		// Try to acquire the lock for the second time in a separate transaction, this should fail
+		err := dbstore.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+			lockErr := dbstore.WithLock(context.Background(), lockName, func(ctx context.Context) error {
+				return nil
+			})
+			require.Error(t, lockErr, "expected error from WithLock due to lock acquisition failure")
+			return nil
+		})
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

The PR adds a database session-level lock (for MySQL and PostgreSQL) during the periodic alert state synchronization process (feature flag `alertingSaveStatePeriodic`). This ensures that parallel full syncs are prevented in HA mode. 

Also added a new metric `grafana_alerting_state_full_sync_last_time` with the timestamp of the last full sync.

**Why do we need this feature?**

Without that, concurrent full syncs might encounter deadlock and uniqueness constraint violation errors, depending on the transaction isolation level.

**How to reproduce**

##### MySQL

I started two Grafana instances locally, and with MySQL and read-commited isolation level, when two full syncs insert new rows into the database, sometimes they conflict with each other. If the rows aren't new, `DELETE` that full sync does in the beginning, locks them so there are no conflicts. But if they are new, this is happening:

```
ERROR[07-04|12:51:14] Failed to do a full state sync to database 
logger=ngalert.state.manager.persist err="failed to insert into alert_instance table:
Error 1062 (23000): Duplicate entry '1-adp8tx0qwaubke-1ad57d46f975bacbcc2db8702313edaf5cc75718' 
for key 'alert_instance.PRIMARY'"
```

In the default repeatable read, deadlocks sometimes occur:
```
ERROR[07-04|12:49:09] Failed to do a full state sync to database
logger=ngalert.state.manager.persist err="failed to insert into alert_instance table:
Error 1213 (40001): Deadlock found when trying to get lock; 
try restarting transaction"
```
##### PostgreSQL

With PostgreSQL with its default settings the same duplicate error happens when two Grafana instances try to sync the state:

```
logger=ngalert.state.manager.persist t=2024-07-09T14:24:24.123356+02:00 level=error msg="Full state sync failed" duration=975.762291ms instances=2000
logger=ngalert.state.manager.persist t=2024-07-09T14:24:24.123367+02:00 level=error msg="Failed to do a full state sync to database" err="failed to insert into alert_instance table: pq: duplicate key value violates unique constraint \"alert_instance_pkey\"
```

---
With this PR the instance that wasn't able to acquire the lock logs a warning:

```
WARN [07-04|12:53:32] Full state sync failed to acquire the lock, probably another full sync is in progress logger=ngalert.state.manager.persist
```

**Which issue(s) does this PR fix?**:

Fixes #88474 and similar issues reported in [Slack](https://raintank-corp.slack.com/archives/C01LJ5F8NRX/p1719488159792859?thread_ts=1719391676.669009&cid=C01LJ5F8NRX)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
