### PR TITLE
Scopes: Fix debounce for nodes search

### DIFF
--- a/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
+++ b/public/app/features/dashboard-scene/scene/Scopes/ScopesFiltersScene.tsx
@@ -108,10 +108,8 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
     currentNode.isExpanded = isExpanded;
     currentNode.query = query;
 
-    this.setState({ nodes, loadingNodeName: undefined });
-
     if (isExpanded || isDifferentQuery) {
-      this.setState({ loadingNodeName: name });
+      this.setState({ nodes, loadingNodeName: name });
 
       this.nodesFetchingSub = from(fetchNodes(name, query))
         .pipe(
@@ -138,6 +136,8 @@ export class ScopesFiltersScene extends SceneObjectBase<ScopesFiltersSceneState>
 
           this.nodesFetchingSub?.unsubscribe();
         });
+    } else {
+      this.setState({ nodes, loadingNodeName: undefined });
     }
   }
 


### PR DESCRIPTION
**What is this feature?**

Replace the combination of `useMemo` and lodash `debounce` in favor of `useDebounce` React hook.

**Why do we need this feature?**

This will prevent the search field for have its value overwritten by the value that's kept inside the filters scene state.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
