### PR TITLE
Frontend: Use safe stringifier in parseBody

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -206,7 +206,7 @@ export {
 
 export { parseLabels, findCommonLabels, findUniqueLabels, matchAllLabels, formatLabels } from './utils/labels';
 export { roundDecimals, guessDecimals } from './utils/numbers';
-export { objRemoveUndefined, isEmptyObject } from './utils/object';
+export { objRemoveUndefined, isEmptyObject, safeStringifyValue } from './utils/object';
 export { classicColors } from './utils/namedColorsPalette';
 export { getSeriesTimeStep, hasMsResolution } from './utils/series';
 export { BinaryOperationID, type BinaryOperation, binaryOperators } from './utils/binaryOperators';

--- a/packages/grafana-data/src/utils/object.ts
+++ b/packages/grafana-data/src/utils/object.ts
@@ -10,3 +10,28 @@
 export const isEmptyObject = (value: unknown): value is Record<string, never> => {
   return typeof value === 'object' && value !== null && Object.keys(value).length === 0;
 };
+
+export function safeStringifyValue(value: unknown) {
+  // Avoid circular references ignoring those references
+  const getCircularReplacer = () => {
+    const seen = new WeakSet();
+    return (_: string, value: object | null) => {
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) {
+          return;
+        }
+        seen.add(value);
+      }
+
+      return value;
+    };
+  };
+
+  try {
+    return JSON.stringify(value, getCircularReplacer());
+  } catch (error) {
+    console.error(error);
+  }
+
+  return '';
+}

--- a/packages/grafana-data/src/utils/object.ts
+++ b/packages/grafana-data/src/utils/object.ts
@@ -11,8 +11,8 @@ export const isEmptyObject = (value: unknown): value is Record<string, never> =>
   return typeof value === 'object' && value !== null && Object.keys(value).length === 0;
 };
 
+/** Stringifies an object that may contain circular references */
 export function safeStringifyValue(value: unknown) {
-  // Avoid circular references ignoring those references
   const getCircularReplacer = () => {
     const seen = new WeakSet();
     return (_: string, value: object | null) => {
@@ -27,11 +27,5 @@ export function safeStringifyValue(value: unknown) {
     };
   };
 
-  try {
-    return JSON.stringify(value, getCircularReplacer());
-  } catch (error) {
-    console.error(error);
-  }
-
-  return '';
+  return JSON.stringify(value, getCircularReplacer());
 }

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,6 +1,6 @@
 import { omitBy } from 'lodash';
 
-import { deprecationWarning } from '@grafana/data';
+import { deprecationWarning, safeStringifyValue } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
@@ -93,7 +93,7 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
     return options.data;
   }
 
-  return isAppJson ? JSON.stringify(options.data) : new URLSearchParams(options.data);
+  return isAppJson ? safeStringifyValue(options.data) : new URLSearchParams(options.data);
 };
 
 export async function parseResponseBody<T>(


### PR DESCRIPTION
The `parseBody` function, used in `parseInitFromOptions` and so `getFromFetchStream`, could throw if the object being stringified contained circular references, as in #88064.
This PR adds a method `safeStringifyValue` to grafana-data (originally from
https://github.com/grafana/scenes/blob/bf6118631e93fd116f9574524c67f708eadde55b/packages/scenes/src/variables/utils.ts#L18) to prevent the error.

Closes #88064

