### PR TITLE
Chore: Bump fast-loops

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15920,9 +15920,9 @@ __metadata:
   linkType: hard
 
 "fast-loops@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "fast-loops@npm:1.1.3"
-  checksum: 10/1bf9f102d8ed48a8c8304e2b27fd32afa65d370498db9b49d5762696ac4aa8c55593d505c142c2b7e25ca79f45207c4b25f778afd80f35df98cb2caaaf9609b7
+  version: 1.1.4
+  resolution: "fast-loops@npm:1.1.4"
+  checksum: 10/52516fc8bb95a60e512271e731c4dc7b7672af90c5e54681004ee2f509d6ccc8e62d5222e731377dafd48a31218f915fd6d0d02efe602b1b822e1ff93994d2a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps transitive dependency `fast-loops` to avoid prototype pollution https://github.com/advisories/GHSA-3q56-9cc2-46j4

Here's how we depend on fast-loops (via react-use)

```
├─ @grafana-plugins/grafana-azure-monitor-datasource@workspace:public/app/plugins/datasource/azuremonitor
│  ├─ @grafana/data@workspace:packages/grafana-data [655a6] (via workspace:* [655a6])
│  ├─ @grafana/experimental@npm:1.7.12 [655a6] (via npm:1.7.12 [655a6])
│  │  └─ react-use@npm:17.5.0 [655a6] (via npm:17.5.0 [655a6])
│  │     └─ nano-css@npm:5.6.1 [88df5] (via npm:^5.6.1 [88df5])
│  │        └─ inline-style-prefixer@npm:7.0.0 (via npm:^7.0.0)
│  │           └─ fast-loops@npm:1.1.4 (via npm:^1.1.3)
│  ├─ @grafana/ui@workspace:packages/grafana-ui [655a6] (via workspace:* [655a6])
│  └─ react-use@npm:17.5.0 [655a6] (via npm:17.5.0 [655a6])
```

It's only used in react-use [via the `useCss` hook](https://github.com/search?q=repo%3Astreamich%2Freact-use%20nano-css&type=code) which we do not use in Grafana repo nor in grafana-experimental, making this all non-explotable.