### PR TITLE
Keep split button on the toolbar

### DIFF
--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -80,7 +80,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
   );
   const loading = useSelector(selectIsWaitingForData(exploreId));
   const isLargerPane = useSelector((state: StoreState) => state.explore.largerExploreId === exploreId);
-  const showSmallTimePicker = useSelector((state) => splitted || state.explore.panes[exploreId]!.containerWidth < 1210);
+  const showSmallPickerElement = useSelector((state) => splitted || state.explore.panes[exploreId]!.containerWidth < 1210);
   const showSmallDataSourcePicker = useSelector(
     (state) => state.explore.panes[exploreId]!.containerWidth < (splitted ? 700 : 800)
   );
@@ -285,7 +285,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
               splitted={splitted}
               syncedTimes={syncedTimes}
               onChangeTimeSync={onChangeTimeSync}
-              hideText={showSmallTimePicker}
+              hideText={showSmallPickerElement}
               onChangeTimeZone={onChangeTimeZone}
               onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}
             />
@@ -295,14 +295,14 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
             onIntervalChanged={onChangeRefreshInterval}
             value={refreshInterval}
             isLoading={loading}
-            text={showSmallTimePicker ? undefined : refreshPickerLabel}
-            tooltip={showSmallTimePicker ? refreshPickerLabel : undefined}
+            text={showSmallPickerElement ? undefined : refreshPickerLabel}
+            tooltip={showSmallPickerElement ? refreshPickerLabel : undefined}
             intervals={contextSrv.getValidIntervals(defaultIntervals)}
             isLive={isLive}
             onRefresh={() => onRunQuery(loading)}
             noIntervalPicker={isLive}
             primary={true}
-            width={(showSmallTimePicker ? 35 : 108) + 'px'}
+            width={(showSmallPickerElement ? 35 : 108) + 'px'}
           />,
           datasourceInstance?.meta.streaming && (
             <LiveTailControls key="liveControls" exploreId={exploreId}>

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -80,7 +80,8 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
   );
   const loading = useSelector(selectIsWaitingForData(exploreId));
   const isLargerPane = useSelector((state: StoreState) => state.explore.largerExploreId === exploreId);
-  const showSmallPickerElement = useSelector((state) => splitted || state.explore.panes[exploreId]!.containerWidth < 1210);
+  const showSmallPickerElement = useSelector(
+    (state) => splitted || state.explore.panes[exploreId]!.containerWidth < (datasourceInstance?.meta.streaming ? 1305: 1210));
   const showSmallDataSourcePicker = useSelector(
     (state) => state.explore.panes[exploreId]!.containerWidth < (splitted ? 700 : 800)
   );


### PR DESCRIPTION
What is this feature?
This PR introduces two changes to the toolbar in Grafana.

Why do we need this feature?
Currently, for live stream available data sources, the split button is not displayed on the toolbar. Instead, users need to click the triple dots on the right corner of the toolbar, which weakens the user experience. This PR proposes a solution to improve the user experience by adjusting when the texts of the time range picker and refresh picker are hidden for live stream available data sources.

Who is this feature for?
This feature is for Grafana users who utilize live stream available data sources and seek a more streamlined and intuitive toolbar experience.

Which issue(s) does this PR fix?
This PR addresses the user experience issue related to the toolbar for live stream available data sources.
(Additionally, Changed the showSmallTimePicker variable name to showSmallPickerElement to make the name more consistent as it is used for making small both refresh picker and time range texts.)


Previously how toolbar looked like,
![image](https://github.com/grafana/grafana/assets/114523187/56eb159f-bd92-4897-8b57-3a2753f0124b)

Now 
![image](https://github.com/grafana/grafana/assets/114523187/f8c24142-d4cc-4ce6-a190-698cf08a24bb)


(Both screenshots taken after the threshold value proposed (1305px))