### PR TITLE
Alerting: Skip fetching alerts for unsaved dashboards

### DIFF
--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { TestProvider } from 'test/helpers/TestProvider';
-import { byTestId } from 'testing-library-selector';
+import { byTestId, byText } from 'testing-library-selector';
 
 import { DataSourceApi } from '@grafana/data';
 import { PromOptions, PrometheusDatasource } from '@grafana/prometheus';
@@ -25,6 +25,7 @@ import {
   mockRulerAlertingRule,
   mockRulerRuleGroup,
 } from './mocks';
+import { captureRequests } from './mocks/server/events';
 import { RuleFormValues } from './types/rule-form';
 import * as config from './utils/config';
 import { Annotation } from './utils/constants';
@@ -183,6 +184,7 @@ const panel = new PanelModel({
 const ui = {
   row: byTestId('row'),
   createButton: byTestId<HTMLAnchorElement>('create-alert-rule-button'),
+  notSavedYet: byText('Dashboard not saved'),
 };
 
 const server = setupMswServer();
@@ -279,6 +281,29 @@ describe('PanelAlertTabContent', () => {
       intervalMs: 300000,
       maxDataPoints: 100,
     });
+  });
+
+  it('should not make requests for unsaved dashboard', async () => {
+    const capture = captureRequests();
+
+    const unsavedDashboard = {
+      ...dashboard,
+      uid: null,
+    } as DashboardModel;
+
+    renderAlertTabContent(
+      unsavedDashboard,
+      new PanelModel({
+        ...panel,
+        datasource: undefined,
+        maxDataPoints: 100,
+        interval: '10s',
+      })
+    );
+
+    expect(await ui.notSavedYet.find()).toBeInTheDocument();
+    const requests = await capture;
+    expect(requests.length).toBe(0);
   });
 
   it('Will take into account datasource minInterval', async () => {

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -468,7 +468,7 @@ function hashQuery(query: string) {
   This hook returns combined Grafana rules. Optionally, it can filter rules by dashboard UID and panel ID.
 */
 export function useCombinedRules(
-  dashboardUID?: string,
+  dashboardUID?: string | null,
   panelId?: number,
   poll?: boolean
 ): {
@@ -483,10 +483,12 @@ export function useCombinedRules(
   } = alertRuleApi.endpoints.prometheusRuleNamespaces.useQuery(
     {
       ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
-      dashboardUid: dashboardUID,
+      dashboardUid: dashboardUID ?? undefined,
       panelId,
     },
     {
+      // "null" means the dashboard isn't saved yet, as opposed to "undefined" which means we don't want to filter by dashboard UID
+      skip: dashboardUID === null,
       pollingInterval: poll ? RULE_LIST_POLL_INTERVAL_MS : undefined,
     }
   );
@@ -498,10 +500,11 @@ export function useCombinedRules(
   } = alertRuleApi.endpoints.rulerRules.useQuery(
     {
       rulerConfig: grafanaRulerConfig,
-      filter: { dashboardUID, panelId },
+      filter: { dashboardUID: dashboardUID ?? undefined, panelId },
     },
     {
       pollingInterval: poll ? RULE_LIST_POLL_INTERVAL_MS : undefined,
+      skip: dashboardUID === null,
     }
   );
 

--- a/public/app/features/alerting/unified/hooks/usePanelCombinedRules.ts
+++ b/public/app/features/alerting/unified/hooks/usePanelCombinedRules.ts
@@ -3,7 +3,7 @@ import { CombinedRule } from 'app/types/unified-alerting';
 import { useCombinedRules } from './useCombinedRuleNamespaces';
 
 interface Options {
-  dashboardUID: string;
+  dashboardUID: string | null;
   panelId: number;
 
   poll?: boolean;


### PR DESCRIPTION
**What is this feature?**

Prior to this PR we would fetch and display all Grafana-managed alert rules and assume those were linked to an unsaved dashboard (since we were passing `null` as a UID filter, which is interpreted as not filtering by dashboard UID at all).

**Special notes for your reviewer:**

Adds a regression test to make sure we aren't fetching anything.