### PR TITLE
Docs: Add missing alt text for heatmap 

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/heatmap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/heatmap/index.md
@@ -16,7 +16,7 @@ weight: 600
 
 The Heatmap panel visualization allows you to view histograms over time. For more information about histograms, refer to [Introduction to histograms and heatmaps]({{< relref "../../../fundamentals/intro-histograms/" >}}).
 
-![](/static/img/docs/v43/heatmap_panel_cover.jpg)
+![A heatmap visualization](/static/img/docs/v43/heatmap_panel_cover.jpg)
 
 ## Calculate from data
 


### PR DESCRIPTION
This change should also be backported to v7.0
