### PR TITLE
[v10.4.x] Docs: Fix typo in text

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/expression-queries/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/expression-queries/index.md
@@ -124,8 +124,8 @@ So if you have numbers with labels like `{host=web01}` in `$A` and another numbe
 
 - An item with no labels will join to anything.
 - If both `$A` and `$B` each contain only one item (one series, or one number), they will join.
-- If labels are exact math they will join.
-- If labels are a subset of the other, for example and item in `$A` is labeled `{host=A,dc=MIA}` and and item in `$B` is labeled `{host=A}` they will join.
+- If labels are exact match they will join.
+- If labels are a subset of the other, for example and item in `$A` is labeled `{host=A,dc=MIA}` and item in `$B` is labeled `{host=A}` they will join.
 - Currently, if within a variable such as `$A` there are different tag _keys_ for each item, the join behavior is undefined.
 
 The relational and logical operators return 0 for false 1 for true.


### PR DESCRIPTION
Backport d6b39498d0b4913073147f1d685cd65caa0a2c17 from #89325

---

Fixes # Typo in text.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
