### PR TITLE
Dashboard scene: Ignore repeat row process for non multi variables.

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2882,6 +2882,9 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
+    "public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/dashboard-scene/scene/Scopes/ScopesInput.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.test.tsx
@@ -94,6 +94,24 @@ describe('RowRepeaterBehavior', () => {
     });
   });
 
+  describe('Should not repeat row', () => {
+    it('Should ignore repeat process if the variable is not a multi select variable', async () => {
+      const { scene, grid, repeatBehavior } = buildScene({ variableQueryTime: 0 }, undefined, { isMulti: false });
+      const gridStateUpdates = [];
+      grid.subscribeToState((state) => gridStateUpdates.push(state));
+
+      activateFullSceneTree(scene);
+      await new Promise((r) => setTimeout(r, 1));
+
+      // trigger another repeat cycle by changing the variable
+      repeatBehavior.performRepeat();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(gridStateUpdates.length).toBe(0);
+    });
+  });
+
   describe('Given scene empty row', () => {
     let scene: DashboardScene;
     let grid: SceneGridLayout;
@@ -139,7 +157,11 @@ interface SceneOptions {
   repeatDirection?: RepeatDirection;
 }
 
-function buildScene(options: SceneOptions, variableOptions?: VariableValueOption[]) {
+function buildScene(
+  options: SceneOptions,
+  variableOptions?: VariableValueOption[],
+  variableStateOverrides?: { isMulti: boolean }
+) {
   const repeatBehavior = new RowRepeaterBehavior({ variableName: 'server' });
 
   const grid = new SceneGridLayout({
@@ -223,6 +245,7 @@ function buildScene(options: SceneOptions, variableOptions?: VariableValueOption
             { label: 'D', value: 'D1' },
             { label: 'E', value: 'E1' },
           ],
+          ...variableStateOverrides,
         }),
       ],
     }),

--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
@@ -77,14 +77,14 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
       return;
     }
 
-    if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
-      return;
-    } else {
+    if (variable instanceof MultiValueVariable) {
       if (!(variable as MultiValueVariable).state.isMulti) {
         // There is no use in repeating a row for a variable that is not a multi value select variable.
         return;
       }
+    } else {
+      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      return;
     }
 
     const rowToRepeat = this._getRow();

--- a/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/RowRepeaterBehavior.ts
@@ -80,6 +80,11 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     if (!(variable instanceof MultiValueVariable)) {
       console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
       return;
+    } else {
+      if (!(variable as MultiValueVariable).state.isMulti) {
+        // There is no use in repeating a row for a variable that is not a multi value select variable.
+        return;
+      }
     }
 
     const rowToRepeat = this._getRow();


### PR DESCRIPTION
**What is this feature?**
This eliminates the repeat process when we're trying to repeat a row for a variable that is not a multi value variable. Repeating rows for a variable that can never have more than one value should not be necessary.

Fixes #90049