### PR TITLE
Authn: Remove response writer from auth req

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -201,7 +201,7 @@ func (hs *HTTPServer) LoginAPIPing(c *contextmodel.ReqContext) response.Response
 }
 
 func (hs *HTTPServer) LoginPost(c *contextmodel.ReqContext) response.Response {
-	identity, err := hs.authnService.Login(c.Req.Context(), authn.ClientForm, &authn.Request{HTTPRequest: c.Req, Resp: c.Resp})
+	identity, err := hs.authnService.Login(c.Req.Context(), authn.ClientForm, &authn.Request{HTTPRequest: c.Req})
 	if err != nil {
 		tokenErr := &auth.CreateTokenErr{}
 		if errors.As(err, &tokenErr) {

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -28,7 +28,7 @@ func (hs *HTTPServer) OAuthLogin(reqCtx *contextmodel.ReqContext) {
 
 	code := reqCtx.Query("code")
 
-	req := &authn.Request{HTTPRequest: reqCtx.Req, Resp: reqCtx.Resp}
+	req := &authn.Request{HTTPRequest: reqCtx.Req}
 	if code == "" {
 		redirect, err := hs.authnService.RedirectURL(reqCtx.Req.Context(), authn.ClientWithPrefix(name), req)
 		if err != nil {

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/web"
 )
 
 const (
@@ -186,11 +185,6 @@ type Request struct {
 	OrgID int64
 	// HTTPRequest is the original HTTP request to authenticate
 	HTTPRequest *http.Request
-
-	// Resp is the response writer to use for the request
-	// Used to set cookies and headers
-	Resp web.ResponseWriter
-
 	// metadata is additional information about the auth request
 	metadata map[string]string
 }

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -173,7 +173,6 @@ func TestExtendedJWT_Test(t *testing.T) {
 
 			actual := env.s.Test(context.Background(), &authn.Request{
 				HTTPRequest: validHTTPReq,
-				Resp:        nil,
 			})
 
 			assert.Equal(t, tc.want, actual)
@@ -320,7 +319,6 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			id, err := env.s.Authenticate(context.Background(), &authn.Request{
 				OrgID:       tc.orgID,
 				HTTPRequest: validHTTPReq,
-				Resp:        nil,
 			})
 			if tc.wantErr != nil {
 				assert.ErrorIs(t, err, tc.wantErr)

--- a/pkg/services/authn/clients/jwt_test.go
+++ b/pkg/services/authn/clients/jwt_test.go
@@ -155,7 +155,6 @@ func TestAuthenticateJWT(t *testing.T) {
 			id, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 				OrgID:       1,
 				HTTPRequest: validHTTPReq,
-				Resp:        nil,
 			})
 			require.NoError(t, err)
 
@@ -267,7 +266,6 @@ func TestJWTClaimConfig(t *testing.T) {
 			_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 				OrgID:       1,
 				HTTPRequest: httpReq,
-				Resp:        nil,
 			})
 			if tc.valid {
 				require.NoError(t, err)
@@ -384,7 +382,6 @@ func TestJWTTest(t *testing.T) {
 			got := jwtClient.Test(context.Background(), &authn.Request{
 				OrgID:       1,
 				HTTPRequest: httpReq,
-				Resp:        nil,
 			})
 
 			require.Equal(t, tc.want, got)
@@ -432,7 +429,6 @@ func TestJWTStripParam(t *testing.T) {
 	_, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,
-		Resp:        nil,
 	})
 	require.NoError(t, err)
 	// auth_token should be removed from the query string
@@ -489,7 +485,6 @@ func TestJWTSubClaimsConfig(t *testing.T) {
 	identity, err := jwtClient.Authenticate(context.Background(), &authn.Request{
 		OrgID:       1,
 		HTTPRequest: httpReq,
-		Resp:        nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "mainemail+extraemail02@gmail.com", identity.Email)

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -112,7 +112,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			reqContext.Logger = reqContext.Logger.New("traceID", traceID)
 		}
 
-		id, err := h.authnService.Authenticate(ctx, &authn.Request{HTTPRequest: reqContext.Req, Resp: reqContext.Resp})
+		id, err := h.authnService.Authenticate(ctx, &authn.Request{HTTPRequest: reqContext.Req})
 		if err != nil {
 			// Hack: set all errors on LookupTokenErr, so we can check it in auth middlewares
 			reqContext.LookupTokenErr = err


### PR DESCRIPTION
**What is this feature?**
This was a hack we had when we did token rotation in backend, but we no longer need to have it and I have been meaning to clean it up


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
