### PR TITLE
Alerting: Refactor PromQL-style matcher parsing

### DIFF
--- a/public/app/features/alerting/unified/AlertsFolderView.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.tsx
@@ -14,8 +14,9 @@ import { useCombinedRuleNamespaces } from './hooks/useCombinedRuleNamespaces';
 import { usePagination } from './hooks/usePagination';
 import { useURLSearchParams } from './hooks/useURLSearchParams';
 import { fetchPromRulesAction, fetchRulerRulesAction } from './state/actions';
-import { combineMatcherStrings, labelsMatchMatchers, parseMatchers } from './utils/alertmanager';
+import { combineMatcherStrings, labelsMatchMatchers } from './utils/alertmanager';
 import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
+import { parsePromQLStyleMatcherLooseSafe } from './utils/matchers';
 import { createViewLink } from './utils/misc';
 
 interface Props {
@@ -168,7 +169,7 @@ function filterAndSortRules(
   labelFilter: string,
   sortOrder: SortOrder
 ) {
-  const matchers = parseMatchers(labelFilter);
+  const matchers = parsePromQLStyleMatcherLooseSafe(labelFilter);
   let rules = originalRules.filter(
     (rule) => rule.name.toLowerCase().includes(nameFilter.toLowerCase()) && labelsMatchMatchers(rule.labels, matchers)
   );

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -6,7 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Icon, Input, Label, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { logInfo, LogMessages } from '../../Analytics';
-import { parseMatchers } from '../../utils/alertmanager';
+import { parsePromQLStyleMatcherLoose } from '../../utils/matchers';
 
 interface Props {
   defaultQueryString?: string;
@@ -28,13 +28,22 @@ export const MatcherFilter = ({ onFilterChange, defaultQueryString }: Props) => 
   );
 
   const searchIcon = <Icon name={'search'} />;
-  const inputInvalid = defaultQueryString ? parseMatchers(defaultQueryString).length === 0 : false;
+  let inputValid = Boolean(defaultQueryString && defaultQueryString.length > 3);
+  try {
+    if (!defaultQueryString) {
+      inputValid = true;
+    } else {
+      parsePromQLStyleMatcherLoose(defaultQueryString);
+    }
+  } catch (err) {
+    inputValid = false;
+  }
 
   return (
     <Field
       className={styles.fixMargin}
-      invalid={inputInvalid || undefined}
-      error={inputInvalid ? 'Query must use valid matcher syntax. See the examples in the help tooltip.' : null}
+      invalid={!inputValid}
+      error={!inputValid ? 'Query must use valid matcher syntax. See the examples in the help tooltip.' : null}
       label={
         <Label>
           <Stack gap={0.5} alignItems="center">

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -28,7 +28,7 @@ export const MatcherFilter = ({ onFilterChange, defaultQueryString }: Props) => 
   );
 
   const searchIcon = <Icon name={'search'} />;
-  let inputValid = Boolean(defaultQueryString && defaultQueryString.length > 3);
+  let inputValid = Boolean(defaultQueryString && defaultQueryString.length >= 3);
   try {
     if (!defaultQueryString) {
       inputValid = true;

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -10,13 +10,14 @@ import {
   AlertInstanceStateFilter,
   InstanceStateFilter,
 } from 'app/features/alerting/unified/components/rules/AlertInstanceStateFilter';
-import { labelsMatchMatchers, parseMatchers } from 'app/features/alerting/unified/utils/alertmanager';
+import { labelsMatchMatchers } from 'app/features/alerting/unified/utils/alertmanager';
 import { createViewLink, sortAlerts } from 'app/features/alerting/unified/utils/misc';
 import { SortOrder } from 'app/plugins/panel/alertlist/types';
 import { Alert, CombinedRule, PaginationProps } from 'app/types/unified-alerting';
 import { mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
 import { GRAFANA_RULES_SOURCE_NAME, isGrafanaRulesSource } from '../../utils/datasource';
+import { parsePromQLStyleMatcherLooseSafe } from '../../utils/matchers';
 import { isAlertingRule } from '../../utils/rules';
 
 import { AlertInstancesTable } from './AlertInstancesTable';
@@ -148,7 +149,7 @@ function filterAlerts(
 ): Alert[] {
   let filteredAlerts = [...alerts];
   if (alertInstanceLabel) {
-    const matchers = parseMatchers(alertInstanceLabel || '');
+    const matchers = alertInstanceLabel ? parsePromQLStyleMatcherLooseSafe(alertInstanceLabel) : [];
     filteredAlerts = filteredAlerts.filter(({ labels }) => labelsMatchMatchers(labels, matchers));
   }
   if (alertInstanceState) {

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -18,8 +18,9 @@ import {
 
 import { stateHistoryApi } from '../../../api/stateHistoryApi';
 import { usePagination } from '../../../hooks/usePagination';
-import { labelsMatchMatchers, parseMatchers } from '../../../utils/alertmanager';
+import { labelsMatchMatchers } from '../../../utils/alertmanager';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
+import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 import { stringifyErrorLike } from '../../../utils/misc';
 import { AlertLabels } from '../../AlertLabels';
 import { CollapseToggle } from '../../CollapseToggle';
@@ -412,7 +413,7 @@ function useRuleHistoryRecords(stateHistory?: DataFrameJSON, filter?: string) {
       return { historyRecords: [] };
     }
 
-    const filterMatchers = filter ? parseMatchers(filter) : [];
+    const filterMatchers = filter ? parsePromQLStyleMatcherLooseSafe(filter) : [];
 
     const [tsValues, lines] = stateHistory.data.values;
     const timestamps = isNumbers(tsValues) ? tsValues : [];

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -3,7 +3,8 @@ import { groupBy } from 'lodash';
 import { DataFrame, Field as DataFrameField, DataFrameJSON, Field, FieldType } from '@grafana/data';
 import { fieldIndexComparer } from '@grafana/data/src/field/fieldComparers';
 
-import { labelsMatchMatchers, parseMatchers } from '../../../utils/alertmanager';
+import { labelsMatchMatchers } from '../../../utils/alertmanager';
+import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 import { LogRecord } from '../state-history/common';
 import { isLine, isNumbers } from '../state-history/useRuleHistoryRecords';
 
@@ -61,7 +62,7 @@ function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[]): DataFr
   const filterValue = getFilterInQueryParams();
   const dataframesFiltered = dataFrames.filter((frame) => {
     const labels = JSON.parse(frame.name ?? ''); // in name we store the labels stringified
-    const matchers = Boolean(filterValue) ? parseMatchers(filterValue) : [];
+    const matchers = Boolean(filterValue) ? parsePromQLStyleMatcherLooseSafe(filterValue) : [];
     return labelsMatchMatchers(labels, matchers);
   });
   // Extract time fields from filtered data frames

--- a/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx
@@ -13,7 +13,8 @@ import { fieldIndexComparer } from '@grafana/data/src/field/fieldComparers';
 import { MappingType, ThresholdsMode } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
 
-import { labelsMatchMatchers, parseMatchers } from '../../../utils/alertmanager';
+import { labelsMatchMatchers } from '../../../utils/alertmanager';
+import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 
 import { extractCommonLabels, Line, LogRecord, omitLabels } from './common';
 
@@ -50,7 +51,7 @@ export function useRuleHistoryRecords(stateHistory?: DataFrameJSON, filter?: str
 
     const commonLabels = extractCommonLabels(groupLabelsArray);
 
-    const filterMatchers = filter ? parseMatchers(filter) : [];
+    const filterMatchers = filter ? parsePromQLStyleMatcherLooseSafe(filter) : [];
     const filteredGroupedLines = Object.entries(logRecordsByInstance).filter(([key]) => {
       const labels = JSON.parse(key);
       return labelsMatchMatchers(labels, filterMatchers);

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -6,7 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Field, Icon, Input, Label, Tooltip, useStyles2, Stack } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
-import { parseMatchers } from '../../utils/alertmanager';
+import { parsePromQLStyleMatcherLoose } from '../../utils/matchers';
 import { getSilenceFiltersFromUrlParams } from '../../utils/misc';
 
 const getQueryStringKey = () => uniqueId('query-string-');
@@ -30,7 +30,16 @@ export const SilencesFilter = () => {
     setTimeout(() => setQueryStringKey(getQueryStringKey()));
   };
 
-  const inputInvalid = queryString && queryString.length > 3 ? parseMatchers(queryString).length === 0 : false;
+  let inputValid = queryString && queryString.length > 3;
+  try {
+    if (!queryString) {
+      inputValid = true;
+    } else {
+      parsePromQLStyleMatcherLoose(queryString);
+    }
+  } catch (err) {
+    inputValid = false;
+  }
 
   return (
     <div className={styles.flexRow}>
@@ -53,8 +62,8 @@ export const SilencesFilter = () => {
             </Stack>
           </Label>
         }
-        invalid={inputInvalid}
-        error={inputInvalid ? 'Query must use valid matcher syntax' : null}
+        invalid={!inputValid}
+        error={!inputValid ? 'Query must use valid matcher syntax' : null}
       >
         <Input
           key={queryStringKey}

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -23,7 +23,7 @@ import { AlertmanagerAlert, Silence, SilenceState } from 'app/plugins/datasource
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
 import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
-import { parseMatchers } from '../../utils/alertmanager';
+import { parsePromQLStyleMatcherLooseSafe } from '../../utils/matchers';
 import { getSilenceFiltersFromUrlParams, makeAMLink, stringifyErrorLike } from '../../utils/misc';
 import { Authorize } from '../Authorize';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
@@ -220,7 +220,7 @@ const useFilteredSilences = (silences: Silence[], expired = false) => {
         }
       }
       if (queryString) {
-        const matchers = parseMatchers(queryString);
+        const matchers = parsePromQLStyleMatcherLooseSafe(queryString);
         const matchersMatch = matchers.every((matcher) =>
           silence.matchers?.some(
             ({ name, value, isEqual, isRegex }) =>

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -9,10 +9,10 @@ import { CombinedRuleGroup, CombinedRuleNamespace, Rule } from 'app/types/unifie
 import { isPromAlertingRuleState, PromRuleType, RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { applySearchFilterToQuery, getSearchFilterFromQuery, RulesFilter } from '../search/rulesSearchParser';
-import { labelsMatchMatchers, matcherToMatcherField, parseMatchers } from '../utils/alertmanager';
+import { labelsMatchMatchers, matcherToMatcherField } from '../utils/alertmanager';
 import { Annotation } from '../utils/constants';
 import { isCloudRulesSource } from '../utils/datasource';
-import { parseMatcher } from '../utils/matchers';
+import { parseMatcher, parsePromQLStyleMatcherLoose } from '../utils/matchers';
 import {
   getRuleHealth,
   isAlertingRule,
@@ -71,7 +71,7 @@ export function useRulesFilter() {
       dataSource: queryParams.get('dataSource') ?? undefined,
       alertState: queryParams.get('alertState') ?? undefined,
       ruleType: queryParams.get('ruleType') ?? undefined,
-      labels: parseMatchers(queryParams.get('queryString') ?? '').map(matcherToMatcherField),
+      labels: parsePromQLStyleMatcherLoose(queryParams.get('queryString') ?? '').map(matcherToMatcherField),
     };
 
     const hasLegacyFilters = Object.values(legacyFilters).some((legacyFilter) => !isEmpty(legacyFilter));

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -21,7 +21,6 @@ import { DataSourceSrv, GetDataSourceListFilters, config } from '@grafana/runtim
 import { defaultDashboard } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { MOCK_GRAFANA_ALERT_RULE_TITLE } from 'app/features/alerting/unified/mocks/server/handlers/alertRules';
-import { parseMatchers } from 'app/features/alerting/unified/utils/alertmanager';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import {
   AlertManagerCortexConfig,
@@ -63,6 +62,8 @@ import {
 } from 'app/types/unified-alerting-dto';
 
 import { DashboardSearchItem, DashboardSearchItemType } from '../../search/types';
+
+import { parsePromQLStyleMatcherLooseSafe } from './utils/matchers';
 
 let nextDataSourceId = 1;
 
@@ -328,12 +329,12 @@ export const mockSilences = [
   mockSilence({ id: MOCK_SILENCE_ID_EXISTING, comment: 'Happy path silence' }),
   mockSilence({
     id: 'ce031625-61c7-47cd-9beb-8760bccf0ed7',
-    matchers: parseMatchers('foo!=bar'),
+    matchers: parsePromQLStyleMatcherLooseSafe('foo!=bar'),
     comment: 'Silence with negated matcher',
   }),
   mockSilence({
     id: MOCK_SILENCE_ID_EXISTING_ALERT_RULE_UID,
-    matchers: parseMatchers(`__alert_rule_uid__=${MOCK_SILENCE_ID_EXISTING_ALERT_RULE_UID}`),
+    matchers: parsePromQLStyleMatcherLooseSafe(`__alert_rule_uid__=${MOCK_SILENCE_ID_EXISTING_ALERT_RULE_UID}`),
     comment: 'Silence with alert rule UID matcher',
     metadata: {
       rule_title: MOCK_GRAFANA_ALERT_RULE_TITLE,
@@ -341,7 +342,7 @@ export const mockSilences = [
   }),
   mockSilence({
     id: MOCK_SILENCE_ID_LACKING_PERMISSIONS,
-    matchers: parseMatchers('something=else'),
+    matchers: parsePromQLStyleMatcherLooseSafe('something=else'),
     comment: 'Silence without permissions to edit',
     accessControl: {},
   }),

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -1,4 +1,4 @@
-import { MatcherOperator, Route } from '../../../../plugins/datasource/alertmanager/types';
+import { Matcher, MatcherOperator, Route } from '../../../../plugins/datasource/alertmanager/types';
 
 import {
   getMatcherQueryParams,
@@ -7,6 +7,8 @@ import {
   normalizeMatchers,
   parseMatcher,
   parsePromQLStyleMatcher,
+  parsePromQLStyleMatcherLoose,
+  parsePromQLStyleMatcherLooseSafe,
   parseQueryParamMatchers,
   quoteWithEscape,
   unquoteWithUnescape,
@@ -174,5 +176,88 @@ describe('parsePromQLStyleMatcher', () => {
 
   it('should throw when not using correct syntax', () => {
     expect(() => parsePromQLStyleMatcher('foo="bar"')).toThrow();
+  });
+});
+
+describe('parsePromQLStyleMatcherLooseSafe', () => {
+  it('should parse all operators', () => {
+    expect(parsePromQLStyleMatcherLooseSafe('foo=bar, bar=~ba.+, severity!=warning, email!~@grafana.com')).toEqual<
+      Matcher[]
+    >([
+      { name: 'foo', value: 'bar', isRegex: false, isEqual: true },
+      { name: 'bar', value: 'ba.+', isEqual: true, isRegex: true },
+      { name: 'severity', value: 'warning', isRegex: false, isEqual: false },
+      { name: 'email', value: '@grafana.com', isRegex: true, isEqual: false },
+    ]);
+  });
+
+  it('should parse with spaces and brackets', () => {
+    expect(parsePromQLStyleMatcherLooseSafe('{ foo=bar }')).toEqual<Matcher[]>([
+      {
+        name: 'foo',
+        value: 'bar',
+        isRegex: false,
+        isEqual: true,
+      },
+    ]);
+  });
+
+  it('should parse with spaces in the value', () => {
+    expect(parsePromQLStyleMatcherLooseSafe('foo=bar bazz')).toEqual<Matcher[]>([
+      {
+        name: 'foo',
+        value: 'bar bazz',
+        isRegex: false,
+        isEqual: true,
+      },
+    ]);
+  });
+
+  it('should return nothing for invalid operator', () => {
+    expect(parsePromQLStyleMatcherLooseSafe('foo=!bar')).toEqual([
+      {
+        name: 'foo',
+        value: '!bar',
+        isRegex: false,
+        isEqual: true,
+      },
+    ]);
+  });
+
+  it('should parse matchers with or without quotes', () => {
+    expect(parsePromQLStyleMatcherLooseSafe('foo="bar",bar=bazz')).toEqual<Matcher[]>([
+      { name: 'foo', value: 'bar', isRegex: false, isEqual: true },
+      { name: 'bar', value: 'bazz', isEqual: true, isRegex: false },
+    ]);
+  });
+
+  it('should parse matchers for key with special characters', () => {
+    expect(parsePromQLStyleMatcherLooseSafe('foo.bar-baz="bar",baz-bar.foo=bazz')).toEqual<Matcher[]>([
+      { name: 'foo.bar-baz', value: 'bar', isRegex: false, isEqual: true },
+      { name: 'baz-bar.foo', value: 'bazz', isEqual: true, isRegex: false },
+    ]);
+  });
+});
+
+describe('parsePromQLStyleMatcherLoose', () => {
+  it('should throw on invalid matcher', () => {
+    expect(() => {
+      parsePromQLStyleMatcherLoose('foo');
+    }).toThrow();
+
+    expect(() => {
+      parsePromQLStyleMatcherLoose('foo;bar');
+    }).toThrow();
+  });
+
+  it('should return empty array for empty input', () => {
+    expect(parsePromQLStyleMatcherLoose('')).toStrictEqual([]);
+  });
+
+  it('should also accept { } syntax', () => {
+    expect(parsePromQLStyleMatcherLoose('{ foo=bar, bar=baz }')).toStrictEqual([
+      { isEqual: true, isRegex: false, name: 'foo', value: 'bar' },
+      { isEqual: true, isRegex: false, name: 'bar', value: 'baz' },
+    ]);
   });
 });

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -75,6 +75,11 @@ export function parsePromQLStyleMatcher(matcher: string): Matcher[] {
   return parsePromQLStyleMatcherLoose(matcher);
 }
 
+/**
+ * This function behaves the same as "parsePromQLStyleMatcher" but does not check if the matcher is formatted with { }
+ * In other words; it accepts both "{ foo=bar, bar=baz }" and "foo=bar,bar=baz"
+ * @throws
+ */
 export function parsePromQLStyleMatcherLoose(matcher: string): Matcher[] {
   // split by `,` but not when it's used as a label value
   const commaUnlessQuoted = /,(?=(?:[^"]*"[^"]*")*[^"]*$)/;
@@ -89,6 +94,10 @@ export function parsePromQLStyleMatcherLoose(matcher: string): Matcher[] {
     }));
 }
 
+/**
+ * This function behaves the same as "parsePromQLStyleMatcherLoose" but instead of throwing an error for incorrect syntax
+ * it returns an empty Array of matchers instead.
+ */
 export function parsePromQLStyleMatcherLooseSafe(matcher: string): Matcher[] {
   try {
     return parsePromQLStyleMatcherLoose(matcher);

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -57,6 +57,8 @@ export function parseMatcher(matcher: string): Matcher {
 
 /**
  * This function combines parseMatcher and parsePromQLStyleMatcher, always returning an array of Matcher[] regardless of input syntax
+ * 1. { foo=bar, bar=baz }
+ * 2. foo=bar
  */
 export function parseMatcherToArray(matcher: string): Matcher[] {
   return isPromQLStyleMatcher(matcher) ? parsePromQLStyleMatcher(matcher) : [parseMatcher(matcher)];
@@ -70,6 +72,10 @@ export function parsePromQLStyleMatcher(matcher: string): Matcher[] {
     throw new Error('not a PromQL style matcher');
   }
 
+  return parsePromQLStyleMatcherLoose(matcher);
+}
+
+export function parsePromQLStyleMatcherLoose(matcher: string): Matcher[] {
   // split by `,` but not when it's used as a label value
   const commaUnlessQuoted = /,(?=(?:[^"]*"[^"]*")*[^"]*$)/;
   const parts = matcher.replace(/^\{/, '').replace(/\}$/, '').trim().split(commaUnlessQuoted);
@@ -81,6 +87,14 @@ export function parsePromQLStyleMatcher(matcher: string): Matcher[] {
       name: unquoteWithUnescape(matcher.name),
       value: unquoteWithUnescape(matcher.value),
     }));
+}
+
+export function parsePromQLStyleMatcherLooseSafe(matcher: string): Matcher[] {
+  try {
+    return parsePromQLStyleMatcherLoose(matcher);
+  } catch {
+    return [];
+  }
 }
 
 // Parses a list of entries like like "['foo=bar', 'baz=~bad*']" into SilenceMatcher[]

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -25,9 +25,9 @@ import {
   fetchAllPromAndRulerRulesAction,
   fetchPromAndRulerRulesAction,
 } from 'app/features/alerting/unified/state/actions';
-import { parseMatchers } from 'app/features/alerting/unified/utils/alertmanager';
 import { Annotation } from 'app/features/alerting/unified/utils/constants';
 import { GRAFANA_DATASOURCE_NAME, GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+import { parsePromQLStyleMatcherLooseSafe } from 'app/features/alerting/unified/utils/matchers';
 import {
   isAsyncRequestMapSlicePartiallyDispatched,
   isAsyncRequestMapSlicePartiallyFulfilled,
@@ -132,7 +132,7 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
   };
 
   const matcherList = useMemo(
-    () => parseMatchers(parsedOptions.alertInstanceLabelFilter),
+    () => parsePromQLStyleMatcherLooseSafe(parsedOptions.alertInstanceLabelFilter),
     [parsedOptions.alertInstanceLabelFilter]
   );
 

--- a/public/app/plugins/panel/alertlist/util.ts
+++ b/public/app/plugins/panel/alertlist/util.ts
@@ -1,14 +1,15 @@
 import { isEmpty } from 'lodash';
 
 import { Labels } from '@grafana/data';
-import { labelsMatchMatchers, parseMatchers } from 'app/features/alerting/unified/utils/alertmanager';
+import { labelsMatchMatchers } from 'app/features/alerting/unified/utils/alertmanager';
+import { parsePromQLStyleMatcherLooseSafe } from 'app/features/alerting/unified/utils/matchers';
 import { Alert, hasAlertState } from 'app/types/unified-alerting';
 import { GrafanaAlertState, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import { UnifiedAlertListOptions } from './types';
 
 function hasLabelFilter(alertInstanceLabelFilter: string, labels: Labels) {
-  const matchers = parseMatchers(alertInstanceLabelFilter);
+  const matchers = parsePromQLStyleMatcherLooseSafe(alertInstanceLabelFilter);
   return labelsMatchMatchers(labels, matchers);
 }
 


### PR DESCRIPTION
**What is this feature?**

Prior to this PR several areas of Alerting where we allowed filtering by labels had several weird bugs, inconsistencies and couldn't handle UTF-8 characters in case those are supported.

Supersedes https://github.com/grafana/grafana/pull/89934