### PR TITLE
Update bump version flow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -63,7 +63,11 @@ jobs:
           repository: "grafana/grafana-github-actions"
           path: ./actions
           ref: main
-      - uses: actions/setup-node@v3.5.1
+      # Go is required for also updating the schema versions as part of the precommit hook:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Install Actions
@@ -79,3 +83,4 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           metricsWriteAPIKey: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
+          precommit_make_target: gen-cue


### PR DESCRIPTION
Fixes an issue with the version bumping workflow that didn't run the `make gen-cue` pre-commit which causes the version bumping pr to fail CI e.g #90060.