### PR TITLE
feat(querier): return directly on error

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -350,6 +350,7 @@ func (b *QueryAPIBuilder) handleExpressions(ctx context.Context, req parsedReque
 					}
 					vars[refId] = res
 				} else {
+
 					// This should error in the parsing phase
 					err := fmt.Errorf("missing variable %s for %s", refId, expression.RefID)
 					qdr.Responses[refId] = backend.DataResponse{

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -153,12 +153,21 @@ func (b *QueryAPIBuilder) execute(ctx context.Context, req parsedRequestInfo) (q
 		qdr = &backend.QueryDataResponse{}
 	case 1:
 		qdr, err = b.handleQuerySingleDatasource(ctx, req.Requests[0])
+		if err != nil {
+			return
+		}
 	default:
 		qdr, err = b.executeConcurrentQueries(ctx, req.Requests)
+		if err != nil {
+			return
+		}
 	}
 
 	if len(req.Expressions) > 0 {
 		qdr, err = b.handleExpressions(ctx, req, qdr)
+		if err != nil {
+			return
+		}
 	}
 
 	// Remove hidden results


### PR DESCRIPTION
Currently, when the querier runs into an error, we don't return directly but continue and run `handleExpressions` at the end. This causes all errors to look something like this: 
`apiserver received an error that is not an metav1.Status: &errors.errorString{s:\"missing variable A for B\"}: missing variable A for B`

This PR returns as soon as we face an error.