### PR TITLE
Change comment style for InfluxDb flux

### DIFF
--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -102,13 +102,17 @@ class UnthemedCodeEditor extends PureComponent<Props> {
   };
 
   handleOnMount = (editor: MonacoEditorType, monaco: Monaco) => {
-    const { getSuggestions, language, onChange, onEditorDidMount } = this.props;
+    const { getSuggestions, language, onChange, onEditorDidMount, languageConfiguration } = this.props;
 
     this.modelId = editor.getModel()?.id;
     this.getEditorValue = () => editor.getValue();
 
     if (getSuggestions && this.modelId) {
       this.completionCancel = registerSuggestions(monaco, language, getSuggestions, this.modelId);
+    }
+
+    if (languageConfiguration) {
+      monaco.languages.setLanguageConfiguration(language, languageConfiguration);
     }
 
     // Save when pressing Ctrl+S or Cmd+S

--- a/packages/grafana-ui/src/components/Monaco/types.ts
+++ b/packages/grafana-ui/src/components/Monaco/types.ts
@@ -28,6 +28,7 @@ export interface CodeEditorProps {
   showMiniMap?: boolean;
   showLineNumbers?: boolean;
   monacoOptions?: MonacoOptions;
+  languageConfiguration?: monacoType.languages.LanguageConfiguration;
 
   /**
    * Callback before the editor has mounted that gives you raw access to monaco

--- a/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/flux/FluxQueryEditor.tsx
@@ -12,6 +12,7 @@ import {
   MonacoEditor,
   Segment,
   Themeable2,
+  monacoTypes,
   withTheme2,
 } from '@grafana/ui/src';
 
@@ -27,6 +28,8 @@ interface Props extends Themeable2 {
   // and then we can probably remove the datasource attribute.
   datasource: InfluxDatasource;
 }
+
+const INFLUX_COMMENT_TYPE = '//';
 
 const samples: Array<SelectableValue<string>> = [
   { label: 'Show buckets', description: 'List the available buckets (table)', value: 'buckets()' },
@@ -162,6 +165,10 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
     setTimeout(() => editor.layout(), 100);
   };
 
+  languageConfiguration: monacoTypes.languages.LanguageConfiguration = {
+    comments: { lineComment: INFLUX_COMMENT_TYPE },
+  };
+
   render() {
     const { query, theme } = this.props;
     const styles = getStyles(theme);
@@ -179,6 +186,7 @@ class UnthemedFluxQueryEditor extends PureComponent<Props> {
           height={'100%'}
           containerStyles={styles.editorContainerStyles}
           language="sql"
+          languageConfiguration={this.languageConfiguration}
           value={query.query || ''}
           onBlur={this.onFluxQueryChange}
           onSave={this.onFluxQueryChange}


### PR DESCRIPTION
…  for influxDb

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is feature is to change influxDb flux to have comment token as `//` instead of `--` in the code editor.

**Why do we need this feature?**

Incorrect comment token is not useful as it breaks the query as per the requirement

**Who is this feature for?**

Users using influxDB as source with flux code editor

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #87021

**Special notes for your reviewer:**

ScreenRecord for the fix:

https://github.com/grafana/grafana/assets/36930204/9d2cc055-8f76-436f-a140-66afa4cede5c

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
