### PR TITLE
fix(datasources): add option to avoid adding '-- Grafana --' DS

### DIFF
--- a/packages/grafana-runtime/src/services/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/dataSourceSrv.ts
@@ -75,6 +75,9 @@ export interface GetDataSourceListFilters {
 
   /** Only returns datasources matching the specified types (ie. Loki, Prometheus) */
   type?: string | string[];
+
+  /** Set to false to avoid returning '-- Grafana --' datasource */
+  grafana?: boolean;
 }
 
 let singletonInstance: DataSourceSrv;

--- a/packages/grafana-runtime/src/services/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/dataSourceSrv.ts
@@ -75,9 +75,6 @@ export interface GetDataSourceListFilters {
 
   /** Only returns datasources matching the specified types (ie. Loki, Prometheus) */
   type?: string | string[];
-
-  /** Set to false to avoid returning '-- Grafana --' datasource */
-  grafana?: boolean;
 }
 
 let singletonInstance: DataSourceSrv;

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -297,7 +297,7 @@ export class DatasourceSrv implements DataSourceService {
         }
       }
 
-      if (!filters.tracing) {
+      if (!filters.tracing && filters.grafana !== false) {
         const grafanaInstanceSettings = this.getInstanceSettings('-- Grafana --');
         if (grafanaInstanceSettings) {
           base.push(grafanaInstanceSettings);

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -297,9 +297,9 @@ export class DatasourceSrv implements DataSourceService {
         }
       }
 
-      if (!filters.tracing && filters.grafana !== false) {
+      if (!filters.tracing) {
         const grafanaInstanceSettings = this.getInstanceSettings('-- Grafana --');
-        if (grafanaInstanceSettings) {
+        if (grafanaInstanceSettings && filters.filter?.(grafanaInstanceSettings) !== false) {
           base.push(grafanaInstanceSettings);
         }
       }

--- a/public/app/features/plugins/tests/datasource_srv.test.ts
+++ b/public/app/features/plugins/tests/datasource_srv.test.ts
@@ -297,6 +297,11 @@ describe('datasource_srv', () => {
       expect(list[2].name).toBe('${datasource}');
     });
 
+    it('Should filter out the -- Grafana -- datasource', () => {
+      const list = dataSourceSrv.getList({ filter: (x) => x.name !== '-- Grafana --' });
+      expect(list.find((x) => x.name === '-- Grafana --')).toBeUndefined();
+    });
+
     it('Can get list of data sources with tracing: true', () => {
       const list = dataSourceSrv.getList({ tracing: true });
       expect(list[0].name).toBe('Jaeger');


### PR DESCRIPTION
**What is this feature?**

This commit adds a new optional `grafana` field to the filter interface. If explicitly set to `false`, the '-- Grafana --' datasource will not be added to the list of datasources returned.

This should be backwards compatible and should allow developers to prevent that datasource from appearing in the `DataSourcePicker`.

**Why do we need this feature?**

Currently the `getList` method of `DatasourceSrv` adds the '-- Grafana --' datasource in the majority of situations, unless a few of the other filters are set, all of which affect the results in other ways. This is the case even if the `filter` function is passed. This causes the `DataSourcePicker` component to include the '-- Grafana --' datasource in cases it's unsupported, such as in Grafana ML where we only support specific datasource types.

**Who is this feature for?**

Plugin developers using the `datasourceSrv.getList` API (either directly or transitively, where it's harder for them to filter the results).

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/machine-learning/issues/4578.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
