### PR TITLE
Settings: Allow setting feature toggles via GF_FEATURE_TOGGLES_<feature_name> env vars

### DIFF
--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -681,3 +681,30 @@ func TestDynamicSection(t *testing.T) {
 		assert.Equal(t, value, ds.section.Key(key).String())
 	})
 }
+
+func TestFeatureTogglesEnvVars(t *testing.T) {
+	t.Run("should read feature toggles from ini", func(t *testing.T) {
+		cfg := NewCfg()
+		const feature = "someFeature"
+
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "testdata/feature_toggles.ini"})
+		require.NoError(t, err)
+
+		require.True(t, cfg.IsFeatureToggleEnabled(feature))
+	})
+
+	t.Run("should override feature toggles from env vars", func(t *testing.T) {
+		cfg := NewCfg()
+		const someFeature = "someFeature"
+		const otherFeature = "otherFeature"
+
+		require.NoError(t, os.Setenv("GF_FEATURE_TOGGLES_"+someFeature, "false"))
+		require.NoError(t, os.Setenv("GF_FEATURE_TOGGLES_"+otherFeature, "true"))
+
+		err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "testdata/feature_toggles.ini"})
+		require.NoError(t, err)
+
+		require.False(t, cfg.IsFeatureToggleEnabled(someFeature))
+		require.True(t, cfg.IsFeatureToggleEnabled(otherFeature))
+	})
+}

--- a/pkg/setting/testdata/feature_toggles.ini
+++ b/pkg/setting/testdata/feature_toggles.ini
@@ -1,0 +1,7 @@
+app_mode = production
+
+[server]
+domain = test.com
+
+[feature_toggles]
+someFeature = true


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allows setting feature toggles via env vars:

```
GF_FEATURE_TOGGLES_<feature_name> = true
```

or

```
GF_FEATURE_TOGGLES_<feature_name> = false
```

This complements the existing way of **enabling** a feature toggle using:

```
GF_FEATURE_TOGGLES_ENABLED = featureOne, featureTwo, featureThree
```

This new way is handy to **disable** a feature toggle enabled by default.


**Why do we need this feature?**

Consistent behaviour of setting ini config values with environment values.

**Who is this feature for?**

Grafana users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #88364

**Special notes for your reviewer:**

Needs docs update as well.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
