### PR TITLE
Chore: Fix flaky frontend e2e tests with the explore page

### DIFF
--- a/e2e/scenes/various-suite/frontend-sandbox-datasource.spec.ts
+++ b/e2e/scenes/various-suite/frontend-sandbox-datasource.spec.ts
@@ -1,5 +1,7 @@
 import { random } from 'lodash';
 
+import { selectors } from '@grafana/e2e-selectors';
+
 import { e2e } from '../utils';
 
 const DATASOURCE_ID = 'sandbox-test-datasource';
@@ -87,6 +89,11 @@ describe.skip('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
+        // make sure the datasource was correctly selected and rendered
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
+
         cy.wait(300); // wait to prevent false positives because cypress checks too fast
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('not.exist');
       });
@@ -95,6 +102,10 @@ describe.skip('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+        // make sure the datasource was correctly selected and rendered
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         const valueToType = 'test' + random(100);
 
@@ -115,6 +126,10 @@ describe.skip('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+        // make sure the datasource was correctly selected and rendered
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('exist');
       });
@@ -123,6 +138,10 @@ describe.skip('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+        // make sure the datasource was correctly selected and rendered
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         const valueToType = 'test' + random(100);
 

--- a/e2e/scenes/various-suite/frontend-sandbox-datasource.spec.ts
+++ b/e2e/scenes/various-suite/frontend-sandbox-datasource.spec.ts
@@ -1,7 +1,5 @@
 import { random } from 'lodash';
 
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 
 const DATASOURCE_ID = 'sandbox-test-datasource';
@@ -90,9 +88,7 @@ describe.skip('Datasource sandbox', () => {
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         cy.wait(300); // wait to prevent false positives because cypress checks too fast
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('not.exist');
@@ -103,9 +99,7 @@ describe.skip('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         const valueToType = 'test' + random(100);
 
@@ -127,9 +121,7 @@ describe.skip('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('exist');
       });
@@ -139,9 +131,7 @@ describe.skip('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         const valueToType = 'test' + random(100);
 

--- a/e2e/various-suite/frontend-sandbox-datasource.spec.ts
+++ b/e2e/various-suite/frontend-sandbox-datasource.spec.ts
@@ -1,5 +1,7 @@
 import { random } from 'lodash';
 
+import { selectors } from '@grafana/e2e-selectors';
+
 import { e2e } from '../utils';
 
 const DATASOURCE_ID = 'sandbox-test-datasource';
@@ -86,7 +88,9 @@ describe('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         cy.wait(300); // wait to prevent false positives because cypress checks too fast
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('not.exist');
@@ -98,7 +102,9 @@ describe('Datasource sandbox', () => {
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
         // make sure the datasource was correctly selected and rendered
-        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         const valueToType = 'test' + random(100);
 
@@ -120,7 +126,9 @@ describe('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('exist');
       });
@@ -131,7 +139,9 @@ describe('Datasource sandbox', () => {
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
         // make sure the datasource was correctly selected and rendered
-        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
+        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
+          'be.visible'
+        );
 
         const valueToType = 'test' + random(100);
 

--- a/e2e/various-suite/frontend-sandbox-datasource.spec.ts
+++ b/e2e/various-suite/frontend-sandbox-datasource.spec.ts
@@ -1,7 +1,5 @@
 import { random } from 'lodash';
 
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 
 const DATASOURCE_ID = 'sandbox-test-datasource';
@@ -88,9 +86,7 @@ describe('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         cy.wait(300); // wait to prevent false positives because cypress checks too fast
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('not.exist');
@@ -102,9 +98,7 @@ describe('Datasource sandbox', () => {
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         const valueToType = 'test' + random(100);
 
@@ -126,9 +120,7 @@ describe('Datasource sandbox', () => {
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('exist');
       });
@@ -139,9 +131,7 @@ describe('Datasource sandbox', () => {
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
 
         // make sure the datasource was correctly selected and rendered
-        cy.get(`span[data-testid="${selectors.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME)}"]`).should(
-          'be.visible'
-        );
+        e2e.components.Breadcrumbs.breadcrumb(DATASOURCE_TYPED_NAME).should('be.visible');
 
         const valueToType = 'test' + random(100);
 

--- a/e2e/various-suite/frontend-sandbox-datasource.spec.ts
+++ b/e2e/various-suite/frontend-sandbox-datasource.spec.ts
@@ -85,6 +85,8 @@ describe('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+        // make sure the datasource was correctly selected and rendered
+        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
 
         cy.wait(300); // wait to prevent false positives because cypress checks too fast
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('not.exist');
@@ -94,6 +96,9 @@ describe('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+
+        // make sure the datasource was correctly selected and rendered
+        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
 
         const valueToType = 'test' + random(100);
 
@@ -114,6 +119,8 @@ describe('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+        // make sure the datasource was correctly selected and rendered
+        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
 
         cy.get(`div[data-plugin-sandbox="${DATASOURCE_ID}"]`).should('exist');
       });
@@ -122,6 +129,9 @@ describe('Datasource sandbox', () => {
         e2e.pages.Explore.visit();
         e2e.components.DataSourcePicker.container().should('be.visible').click();
         cy.contains(DATASOURCE_TYPED_NAME).scrollIntoView().should('be.visible').click();
+
+        // make sure the datasource was correctly selected and rendered
+        cy.get('span[data-testid="data-testid SandboxDatasourceInstance breadcrumb"]').should('exist');
 
         const valueToType = 'test' + random(100);
 


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky e2e related to the frontend sandbox

**Why do we need this feature?**

To keep the CI pipeline running green

**Who is this feature for?**

Grafana developers
