### PR TITLE
Chore: Fix scrolling issue after selecting a metric with a lot of labels

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -272,7 +272,6 @@ function getStyles(theme: GrafanaTheme2) {
       flexGrow: 1,
       display: 'flex',
       gap: theme.spacing(1),
-      minHeight: '100%',
       flexDirection: 'column',
       background: theme.isLight ? theme.colors.background.primary : theme.colors.background.canvas,
       padding: theme.spacing(2, 3, 2, 3),


### PR DESCRIPTION
**What is this feature?**

While scrolling through a long list of labels, the label list was visible behind the panel. By deleting `minHeight` the issue was resolved.
Issue can be seen here: [https://play.grafana.org/explore/metrics/trail?from=now-1h&to=now&var-ds=bdi6x8p7vm29[…]FOR_STATE&actionView=overview&layout=grid&var-groupby=$__all](https://play.grafana.org/explore/metrics/trail?from=now-1h&to=now&var-ds=bdi6x8p7vm29sd&var-filters=&metric=ALERTS_FOR_STATE&actionView=overview&layout=grid&var-groupby=$__all)

Kudos to @tomratcliffe 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/90192
