### PR TITLE
Alerting: Use stable identifier of a group when export to HCL

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -590,15 +590,15 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 	convertToResources := func() error {
 		for _, group := range body.Groups {
 			gr := group
-			toHashedGruopIdx := append([]byte(gr.Name), []byte(gr.FolderUID)...)
-			hash, err := fnv.New64().Write(toHashedGruopIdx)
-			if err != nil {
-				resources = append(resources, hcl.Resource{
+           sum := fnv.New64()
+           _, _ = sum.Write([]byte(gr.Name))
+           _, _ = sum.Write([]byte(gr.FolderUID))
+           hash := sum.Sum64()
+           resources = append(resources, hcl.Resource{
 					Type: "grafana_rule_group",
 					Name: fmt.Sprintf("rule_group_%016x", hash),
 					Body: &gr,
 				})
-			}
 
 		}
 		for idx, cp := range body.ContactPoints {

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -588,14 +588,14 @@ func exportResponse(c *contextmodel.ReqContext, body definitions.AlertingFileExp
 func exportHcl(download bool, body definitions.AlertingFileExport) response.Response {
 	resources := make([]hcl.Resource, 0, len(body.Groups)+len(body.ContactPoints)+len(body.Policies)+len(body.MuteTimings))
 	convertToResources := func() error {
-		for idx, group := range body.Groups {
+		for _, group := range body.Groups {
 			gr := group
-			toHashedGruopIdx := append([]byte(gr.Name), []byte(string(idx))...)
+			toHashedGruopIdx := append([]byte(gr.Name), []byte(gr.FolderUID)...)
 			hash, err := fnv.New32().Write(toHashedGruopIdx)
 			if err != nil {
 				resources = append(resources, hcl.Resource{
 					Type: "grafana_rule_group",
-					Name: fmt.Sprintf("rule_group_%04d", hash),
+					Name: fmt.Sprintf("rule_group_%016x", hash),
 					Body: &gr,
 				})
 			}

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -591,7 +591,7 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 		for _, group := range body.Groups {
 			gr := group
 			toHashedGruopIdx := append([]byte(gr.Name), []byte(gr.FolderUID)...)
-			hash, err := fnv.New32().Write(toHashedGruopIdx)
+			hash, err := fnv.New64().Write(toHashedGruopIdx)
 			if err != nil {
 				resources = append(resources, hcl.Resource{
 					Type: "grafana_rule_group",

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -590,16 +590,15 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 	convertToResources := func() error {
 		for _, group := range body.Groups {
 			gr := group
-           sum := fnv.New64()
-           _, _ = sum.Write([]byte(gr.Name))
-           _, _ = sum.Write([]byte(gr.FolderUID))
-           hash := sum.Sum64()
-           resources = append(resources, hcl.Resource{
-					Type: "grafana_rule_group",
-					Name: fmt.Sprintf("rule_group_%016x", hash),
-					Body: &gr,
-				})
-
+			sum := fnv.New64()
+			_, _ = sum.Write([]byte(gr.Name))
+			_, _ = sum.Write([]byte(gr.FolderUID))
+			hash := sum.Sum64()
+			resources = append(resources, hcl.Resource{
+				Type: "grafana_rule_group",
+				Name: fmt.Sprintf("rule_group_%016x", hash),
+				Body: &gr,
+			})
 		}
 		for idx, cp := range body.ContactPoints {
 			upd, err := ContactPointFromContactPointExport(cp)

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -760,7 +760,7 @@ func TestProvisioningApi(t *testing.T) {
 				insertRule(t, sut, rule1)
 				insertRule(t, sut, createTestAlertRule("rule2", 1))
 
-				expectedResponse := `resource "grafana_rule_group" "rule_group_0000" {
+				expectedResponse := `resource "grafana_rule_group" "rule_group_cc0954af8a53fa18" {
   org_id           = 1
   name             = "my-cool-group"
   folder_uid       = "folder-uid"

--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -180,7 +180,6 @@ func TestExportFromPayload(t *testing.T) {
 		rc.Context.Req.Form.Set("download", "false")
 
 		response := srv.ExportFromPayload(rc, body, folder.UID)
-		t.Log(response)
 		response.WriteTo(rc)
 
 		require.Equal(t, 200, response.Status())

--- a/pkg/services/ngalert/api/api_ruler_export_test.go
+++ b/pkg/services/ngalert/api/api_ruler_export_test.go
@@ -180,6 +180,7 @@ func TestExportFromPayload(t *testing.T) {
 		rc.Context.Req.Form.Set("download", "false")
 
 		response := srv.ExportFromPayload(rc, body, folder.UID)
+		t.Log(response)
 		response.WriteTo(rc)
 
 		require.Equal(t, 200, response.Status())

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -1,4 +1,4 @@
-resource "grafana_rule_group" "rule_group_0000" {
+resource "grafana_rule_group" "rule_group_d3e8424bfbf66bc3" {
   org_id           = 1
   name             = "group101"
   folder_uid       = "e4584834-1a87-4dff-8913-8a4748dfca79"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

when exporting to HCL a grafana rule group, it will use a fnv-1 hash of the folder uid and name 

**Why do we need this feature?**

to make the HCL resource identifiner stable and uniqe 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes #88714 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
