### PR TITLE
Explore Metrics: Save and restore the breakdown layout view from LocalStorage

### DIFF
--- a/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
+++ b/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
@@ -4,6 +4,7 @@ import { Field, RadioButtonGroup } from '@grafana/ui';
 
 import { MetricScene } from '../MetricScene';
 import { reportExploreMetrics } from '../interactions';
+import { RECENT_TRAILS_KEY, TRAIL_BREAKDOWN_VIEW_KEY } from '../shared';
 
 import { LayoutType } from './types';
 
@@ -38,6 +39,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> {
 
   public onLayoutChange = (layout: LayoutType) => {
     reportExploreMetrics('breakdown_layout_changed', { layout });
+    localStorage.setItem(TRAIL_BREAKDOWN_VIEW_KEY, layout);
     this.getMetricScene().setState({ layout });
   };
 

--- a/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
+++ b/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
@@ -4,7 +4,7 @@ import { Field, RadioButtonGroup } from '@grafana/ui';
 
 import { MetricScene } from '../MetricScene';
 import { reportExploreMetrics } from '../interactions';
-import { RECENT_TRAILS_KEY, TRAIL_BREAKDOWN_VIEW_KEY } from '../shared';
+import { TRAIL_BREAKDOWN_VIEW_KEY } from '../shared';
 
 import { LayoutType } from './types';
 

--- a/public/app/features/trails/ActionTabs/types.ts
+++ b/public/app/features/trails/ActionTabs/types.ts
@@ -1,1 +1,7 @@
-export type LayoutType = 'single' | 'grid' | 'rows';
+const LAYOUT_TYPES = ['single', 'grid', 'rows'] as const;
+
+export type LayoutType = (typeof LAYOUT_TYPES)[number];
+
+export function isLayoutType(layoutType: string | null | undefined): layoutType is LayoutType {
+  return !!layoutType && layoutType in LAYOUT_TYPES;
+}

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -19,7 +19,7 @@ import { getExploreUrl } from '../../core/utils/explore';
 import { buildBreakdownActionScene } from './ActionTabs/BreakdownScene';
 import { buildMetricOverviewScene } from './ActionTabs/MetricOverviewScene';
 import { buildRelatedMetricsScene } from './ActionTabs/RelatedMetricsScene';
-import { LayoutType } from './ActionTabs/types';
+import { isLayoutType, LayoutType } from './ActionTabs/types';
 import { getAutoQueriesForMetric } from './AutomaticMetricQueries/AutoQueryEngine';
 import { AutoQueryDef, AutoQueryInfo } from './AutomaticMetricQueries/types';
 import { MAIN_PANEL_MAX_HEIGHT, MAIN_PANEL_MIN_HEIGHT, MetricGraphScene } from './MetricGraphScene';
@@ -54,7 +54,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
 
   public constructor(state: MakeOptional<MetricSceneState, 'body' | 'autoQuery' | 'layout'>) {
     const autoQuery = state.autoQuery ?? getAutoQueriesForMetric(state.metric);
-    const layout = localStorage.getItem(TRAIL_BREAKDOWN_VIEW_KEY) ?? 'grid';
+    const layout = localStorage.getItem(TRAIL_BREAKDOWN_VIEW_KEY);
     super({
       $variables: state.$variables ?? getVariableSet(state.metric),
       body: state.body ?? new MetricGraphScene({}),

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -32,6 +32,7 @@ import {
   getVariablesWithMetricConstant,
   MakeOptional,
   MetricSelectedEvent,
+  TRAIL_BREAKDOWN_VIEW_KEY,
   trailDS,
   VAR_GROUP_BY,
   VAR_METRIC_EXPR,
@@ -53,12 +54,13 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
 
   public constructor(state: MakeOptional<MetricSceneState, 'body' | 'autoQuery' | 'layout'>) {
     const autoQuery = state.autoQuery ?? getAutoQueriesForMetric(state.metric);
+    const layout = localStorage.getItem(TRAIL_BREAKDOWN_VIEW_KEY) ?? 'grid';
     super({
       $variables: state.$variables ?? getVariableSet(state.metric),
       body: state.body ?? new MetricGraphScene({}),
       autoQuery,
       queryDef: state.queryDef ?? autoQuery.main,
-      layout: state.layout ?? 'grid',
+      layout: layout as LayoutType,
       ...state,
     });
 

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -60,7 +60,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
       body: state.body ?? new MetricGraphScene({}),
       autoQuery,
       queryDef: state.queryDef ?? autoQuery.main,
-      layout: layout as LayoutType,
+      layout: isLayoutType(layout) ? layout : 'grid',
       ...state,
     });
 

--- a/public/app/features/trails/shared.ts
+++ b/public/app/features/trails/shared.ts
@@ -34,6 +34,8 @@ export const RECENT_TRAILS_KEY = 'grafana.trails.recent';
 
 export const TRAIL_BOOKMARKS_KEY = 'grafana.trails.bookmarks';
 
+export const TRAIL_BREAKDOWN_VIEW_KEY = 'grafana.trails.breakdown.view';
+
 export type MakeOptional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
 export function getVariablesWithMetricConstant(metric: string) {


### PR DESCRIPTION
**What is this feature?**

Adds the ability to read breakdown layout view from localStorage.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/84990

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
