### PR TITLE
[v10.4.x] CI: Sync branch and tag after release

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,27 +1,48 @@
 name: Create or update GitHub release
 on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        description: Needs to match, exactly, the name of a milestone (NO v prefix)
+        type: string
+      latest:
+        required: false
+        default: false
+        description: Mark this release as latest (`1`) or not (`0`, default)
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
         required: true
         description: Needs to match, exactly, the name of a milestone (NO v prefix)
+        type: string
       latest:
         required: false
         description: Mark this release as latest (`1`) or not (`0`, default)
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  # contents: write allows the action(s) to create github releases
+  contents: write
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: "Generate token"
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Create GitHub release (manually invoked)
         uses: grafana/grafana-github-actions-go/github-release@main
         with:
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ inputs.version }}
           metrics_api_key: ${{ secrets.GRAFANA_MISC_STATS_API_KEY }}
           latest: ${{ inputs.latest }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -10,32 +10,69 @@ on:
         default: true
       version:
         required: true
+      latest:
+        type: bool
+        default: false
   pull_request:
     types:
-      - closed
+    - closed
     branches:
-      - 'main'
-      - 'v*.*.*'
+    - 'main'
+    - 'v*.*.*'
 jobs:
-  post_release:
-    name: Post-release comms
+  setup:
+    name: Setup and establish latest
+    outputs:
+      version: ${{ steps.output.outputs.version }}
+      dry_run: ${{ steps.output.outputs.dry_run }}
+      latest: ${{ steps.output.outputs.latest }}
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
-          echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
-      - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
-        run: |
-          echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
-          echo "DRY_RUN=false" >> $GITHUB_ENV
-      - run: |
-          echo "push-grafana-tag ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "post changelog to forums for ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "create github release for tag ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "publish docs for ${VERSION} (dry run: ${DRY_RUN})"
-      - run: |
-          echo "announce on slack that ${VERSION} has been released (dry run: ${DRY_RUN})"
+    - if: ${{ github.event_name == 'workflow_dispatch' }}
+      run: |
+        echo setting up GITHUB_ENV for ${{ github.event_name }}
+        echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+        echo "DRY_RUN=${{ inputs.dry_run }}" >> $GITHUB_ENV
+        echo "LATEST=${{ inputs.latest }}" >> $GITHUB_ENV
+    - if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+      run: |
+        echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
+        echo "DRY_RUN=true" >> $GITHUB_ENV
+        echo "LATEST=${{ contains(github.event.pull_request.labels.*.name, 'release/latest') }}" >> $GITHUB_ENV
+    - id: output
+      run: |
+        echo "dry_run: $DRY_RUN"
+        echo "latest: $LATEST"
+        echo "version: $VERSION"
+
+        echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+        echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+  post_changelog_on_forum:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo post changelog to forums for ${{ needs.setup.outputs.version }}
+        echo dry run: ${{ needs.setup.outputs.dry_run }}
+  create_github_release:
+    # a github release requires a git tag
+    needs: [setup, mirror_tag]
+    uses: ./.github/workflows/github-release.yml
+    with:
+      version: ${{ needs.setup.outputs.version }}
+      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+  publish_docs:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo publish docs for ${{ needs.setup.outputs.version }}
+        echo dry run: ${{ needs.setup.outputs.dry_run }}
+  post_on_slack:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo announce on slack that ${{ needs.setup.outputs.version }} has been released
+        echo dry run: ${{ needs.setup.outputs.dry_run }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,7 +22,16 @@ on:
         description: Branch to backport these changes to
       dry_run:
         required: false
+        default: false
         type: bool
+      latest:
+        required: false
+        default: false
+        type: bool
+
+permissions:
+  content: write
+  pull-requests: write
 
 jobs:
   create-prs:
@@ -30,33 +39,49 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        with:
-          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
-          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
       - name: Checkout Grafana
         uses: actions/checkout@v4
       - name: Configure git user
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local --add --bool push.autoSetupRemote true
       - name: Create branch
         run: git checkout -b "release/${{ github.run_id }}/${{ inputs.version }}"
       - name: Generate changelog
         run: git commit --allow-empty -m "Update changelog placeholder"
-      - name: Update package.json
-        run: git commit --allow-empty -m "Update version in package.json(s) (and yarn install) placeholder"
+      - name: Update package.json versions
+        uses: ./pkg/build/actions/bump-version
+        with:
+          version: ${{ inputs.version }}
+      - name: add package.json changes
+        run: |
+          git add .
+          git commit -m "Update version to ${{ inputs.version }}"
+      - name: git push
+        if: ${{ inputs.dry_run }} != true
+        run: git push
       - name: Create PR without backports
-        if: "${{ github.event.inputs.backport == '' }}"
+        if: "${{ inputs.backport == '' }}"
         run: >
-          gh pr create --dry-run=${{ inputs.dry_run }} -H "release/${{ inputs.version }}" -B "${{ inputs.target }}" --title "Release: ${{ inputs.version }}" --body "These code changes must be merged after a release is complete"
+          gh pr create \
+            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            --dry-run=${{ inputs.dry_run }} \
+            -B "${{ inputs.target }}" \
+            --title "Release: ${{ inputs.version }}" \
+            --body "These code changes must be merged after a release is complete"
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create PR with backports
-        if: "${{ github.event.inputs.backport != '' }}"
+        if: "${{ inputs.backport != '' }}"
         run: >
-          gh pr create -l "backport ${{ inputs.backport }}" --dry-run=${{ inputs.dry_run }} -H "release/${{ inputs.version }}" -B "${{ inputs.target }}" --title "Release: ${{ inputs.version }}" --body "These code changes must be merged after a release is complete"
+          gh pr create \
+            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            -l "backport ${{ inputs.backport }}" \
+            -l "product-approved" \
+            --dry-run=${{ inputs.dry_run }} \
+            -B "${{ inputs.target }}" \
+            --title "Release: ${{ inputs.version }}" \
+            --body "These code changes must be merged after a release is complete"
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Backport 63e715f6a92b422df149a0b7c8f1a3df95ba57e6 from #89967

---

* Added `workflow_call` event to allow other workflows to invoke the "Create or update GitHub release"
* Added `dry_run` to `github-release.yml`
* Added `latest` to `release-pr.yml` which will cause the release PR to add a `release/latest` label.
* Removed unnecessary github app creation from github-release workflow and just used permissions.
