### PR TITLE
Explore: Interaction tracking for logs pinning and filtering in content outline

### DIFF
--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -79,24 +79,22 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
       top: scrollValue + customOffsetTop,
       behavior: 'smooth',
     });
-
-    // don't report for filters as they have their own interaction tracking setup in the onClick handler
-    if (itemType !== 'filter') {
-      reportInteraction('explore_toolbar_contentoutline_clicked', {
-        item: 'select_section',
-        type: itemPanelId,
-      });
-    }
   };
 
-  const handleItemClicked = (child: ContentOutlineItemContextProps) => {
-    scrollIntoView(child.ref, child.panelId, child.type, child.customTopOffset);
-    if (child.type === 'filter') {
-      activateFilter(child.id);
+  const handleItemClicked = (item: ContentOutlineItemContextProps) => {
+    if (item.level === 'child' && item.type === 'filter') {
+      const activeParent = outlineItems.find((parent) => {
+        return parent.children?.find((child) => child.id === item.id);
+      });
+
+      if (activeParent) {
+        scrollIntoView(activeParent.ref, activeParent.panelId, activeParent.type, activeParent.customTopOffset);
+      }
     } else {
+      scrollIntoView(item.ref, item.panelId, item.type, item.customTopOffset);
       reportInteraction('explore_toolbar_contentoutline_clicked', {
         item: 'select_section',
-        type: child.panelId,
+        type: item.panelId,
       });
     }
   };
@@ -151,16 +149,6 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
       }
     }
   }, [outlineItems, verticalScroll]);
-
-  const activateFilter = (filterId: string) => {
-    const activeParent = outlineItems.find((item) => {
-      return item.children?.find((child) => child.id === filterId);
-    });
-
-    if (activeParent) {
-      handleItemClicked(activeParent);
-    }
-  };
 
   return (
     <PanelContainer className={styles.wrapper} id={panelId}>

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -89,6 +89,18 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
     }
   };
 
+  const handleItemClicked = (child: ContentOutlineItemContextProps) => {
+    scrollIntoView(child.ref, child.panelId, child.type, child.customTopOffset);
+    if (child.type === 'filter') {
+      activateFilter(child.id);
+    } else {
+      reportInteraction('explore_toolbar_contentoutline_clicked', {
+        item: 'select_section',
+        type: child.panelId,
+      });
+    }
+  };
+
   const toggle = () => {
     toggleContentOutlineExpanded();
     reportInteraction('explore_toolbar_contentoutline_clicked', {
@@ -146,7 +158,7 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
     });
 
     if (activeParent) {
-      scrollIntoView(activeParent.ref, activeParent.panelId, 'filter', activeParent.customTopOffset);
+      handleItemClicked(activeParent);
     }
   };
 
@@ -182,7 +194,7 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
                       isChildActive(item, activeSectionChildId) && !contentOutlineExpanded && sectionsExpanded[item.id],
                   })}
                   icon={item.icon}
-                  onClick={() => scrollIntoView(item.ref, item.panelId, item.type)}
+                  onClick={() => handleItemClicked(item)}
                   tooltip={item.title}
                   collapsible={isCollapsible(item)}
                   collapsed={!sectionsExpanded[item.id]}
@@ -217,9 +229,7 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
                           })}
                           indentStyle={styles.indentChild}
                           onClick={(e) => {
-                            child.type === 'filter'
-                              ? activateFilter(child.id)
-                              : scrollIntoView(child.ref, child.panelId, child.type, child.customTopOffset);
+                            handleItemClicked(child);
                             child.onClick?.(e);
                           }}
                           tooltip={child.title}

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -262,6 +262,10 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             highlight: currentLevelSelected && !allLevelsSelected,
             onClick: (e: React.MouseEvent) => {
               toggleLegendRef.current?.(level.levelStr, mapMouseEventToMode(e));
+              reportInteraction('explore_toolbar_contentoutline_clicked', {
+                item: 'section',
+                type: `Logs:filter:${level.levelStr}`,
+              });
             },
             ref: null,
             color: LogLevelColor[level.logLevel],
@@ -658,6 +662,11 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           </Trans>
         </span>
       );
+
+      reportInteraction('explore_toolbar_contentoutline_clicked', {
+        item: 'section',
+        type: 'Logs:pinned:pinned-log-limit-reached',
+      });
       return;
     }
 
@@ -677,16 +686,31 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       ref: null,
       color: LogLevelColor[row.logLevel],
       childOnTop: true,
-      onClick: () => onOpenContext(row, () => {}),
+      onClick: () => {
+        onOpenContext(row, () => {});
+        reportInteraction('explore_toolbar_contentoutline_clicked', {
+          item: 'section',
+          type: 'Logs:pinned:pinned-log-clicked',
+        });
+      },
       onRemove: (id: string) => {
         unregister?.(id);
         if (getPinnedLogsCount() < PINNED_LOGS_LIMIT) {
           setPinLineButtonTooltipTitle('Pin to content outline');
         }
+        reportInteraction('explore_toolbar_contentoutline_clicked', {
+          item: 'section',
+          type: 'Logs:pinned:pinned-log-deleted',
+        });
       },
     });
 
     props.onPinLineCallback?.();
+
+    reportInteraction('explore_toolbar_contentoutline_clicked', {
+      item: 'section',
+      type: 'Logs:pinned:pinned-log-added',
+    });
   };
 
   const getPinnedLogsCount = () => {


### PR DESCRIPTION
This PR adds interaction tracking for logs pinning and filtering in the content outline. Logs pinning was added in #88128 and logs filtering in #86431. 

Thanos has approved these new interaction events. We agreed to just add new type values which will be consistent with the event type we already have for content outline in rudderstack. 

**Which issue(s) does this PR fix?**:

Closes #88730 

**Special notes for your reviewer:**

Please check that:
- [ ] Each interaction in the UX logs a corresponding interaction defined in this PR. 
