### PR TITLE
SearchV2: Support soft deletion

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -849,7 +849,8 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 			rows := make([]*dashboardQueryResult, 0)
 			err := l.sql.WithDbSession(dashboardQueryCtx, func(sess *db.Session) error {
 				sess.Table("dashboard").
-					Where("org_id = ?", orgID)
+					Where("org_id = ?", orgID).
+					Where("deleted IS NULL") // don't index soft delete files
 
 				if lastID > 0 {
 					sess.Where("id > ?", lastID)

--- a/pkg/services/searchV2/index_test.go
+++ b/pkg/services/searchV2/index_test.go
@@ -12,11 +12,21 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgtest"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/store"
 	"github.com/grafana/grafana/pkg/services/store/entity"
+	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -729,5 +739,77 @@ func TestDashboardIndex_MultiTermPrefixMatch(t *testing.T) {
 				DashboardQuery{Query: tt.query},
 			)
 		})
+	}
+}
+
+func setupIntegrationEnv(t *testing.T, folderCount, dashboardsPerFolder int, sqlStore *sqlstore.SQLStore) (*StandardSearchService, *user.SignedInUser, error) {
+	err := populateDB(folderCount, dashboardsPerFolder, sqlStore)
+	require.NoError(t, err, "error when populating the database for integration test")
+
+	// load all dashboards and folders
+	dbLoadingBatchSize := (dashboardsPerFolder + 1) * folderCount
+	cfg := &setting.Cfg{Search: setting.SearchSettings{DashboardLoadingBatchSize: dbLoadingBatchSize}}
+	features := featuremgmt.WithFeatures()
+	orgSvc := &orgtest.FakeOrgService{
+		ExpectedOrgs: []*org.OrgDTO{{ID: 1}},
+	}
+	searchService, ok := ProvideService(cfg, sqlStore, store.NewDummyEntityEventsService(), actest.FakeService{},
+		tracing.InitializeTracerForTest(), features, orgSvc, nil, foldertest.NewFakeService()).(*StandardSearchService)
+	require.True(t, ok)
+
+	err = runSearchService(searchService)
+	require.NoError(t, err, "error when running search service for integration test")
+
+	user := getSignedInUser(folderCount, dashboardsPerFolder)
+
+	return searchService, user, nil
+}
+
+func TestIntegrationSoftDeletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Set up search v2.
+	folderCount := 1
+	dashboardsPerFolder := 1
+	sqlStore, cfg := db.InitTestDBWithCfg(t)
+	searchService, testUser, err := setupIntegrationEnv(t, folderCount, dashboardsPerFolder, sqlStore)
+	require.NoError(t, err)
+
+	// Query search v2 to ensure "dashboard2" is present.
+	result := searchService.doDashboardQuery(context.Background(), testUser, 1, DashboardQuery{Kind: []string{string(entityKindDashboard)}})
+	require.NoError(t, result.Error)
+	require.NotZero(t, len(result.Frames))
+	for _, field := range result.Frames[0].Fields {
+		if field.Name == "uid" {
+			require.Equal(t, dashboardsPerFolder, field.Len())
+			break
+		}
+	}
+
+	// Set up dashboard store.
+	quotaService := quotatest.New(false, nil)
+	featureToggles := featuremgmt.WithFeatures(featuremgmt.FlagPanelTitleSearch, featuremgmt.FlagDashboardRestore)
+	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featureToggles, tagimpl.ProvideService(sqlStore), quotaService)
+	require.NoError(t, err)
+
+	// Soft delete "dashboard2".
+	err = dashboardStore.SoftDeleteDashboard(context.Background(), 1, "dashboard2")
+	require.NoError(t, err)
+
+	// Reindex to ensure "dashboard2" is excluded from the index.
+	searchService.dashboardIndex.reIndexFromScratch(context.Background())
+
+	// Query search v2 to ensure "dashboard2" is no longer present.
+	expectedResultCount := dashboardsPerFolder - 1
+	result2 := searchService.doDashboardQuery(context.Background(), testUser, 1, DashboardQuery{Kind: []string{string(entityKindDashboard)}})
+	require.NoError(t, result2.Error)
+	require.NotZero(t, len(result2.Frames))
+	for _, field := range result2.Frames[0].Fields {
+		if field.Name == "uid" {
+			require.Equal(t, expectedResultCount, field.Len())
+			break
+		}
 	}
 }

--- a/pkg/services/searchV2/service_bench_test.go
+++ b/pkg/services/searchV2/service_bench_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/services/store"
@@ -41,7 +42,7 @@ func setupBenchEnv(b *testing.B, folderCount, dashboardsPerFolder int) (*Standar
 		ExpectedOrgs: []*org.OrgDTO{{ID: 1}},
 	}
 	searchService, ok := ProvideService(cfg, sqlStore, store.NewDummyEntityEventsService(), actest.FakeService{},
-		tracing.InitializeTracerForTest(), features, orgSvc, nil, nil).(*StandardSearchService)
+		tracing.InitializeTracerForTest(), features, orgSvc, nil, foldertest.NewFakeService()).(*StandardSearchService)
 	require.True(b, ok)
 
 	err = runSearchService(searchService)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds search v2 support for soft deletion.

**Why do we need this feature?**

Soft deleted dashboards appear as query results of searchV2 otherwise.

**Who is this feature for?**

Users who have both `dashboardRestore` and `panelTitleSearch` features enabled.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/grafana/issues/88825

**Special notes for your reviewer:**

- I didn't add a special check for panel searches. This seems to be covered by existing tests such as [panels-panel-removed-on-dashboard-removed](https://github.com/grafana/grafana/blob/suntala/search-v2-soft-delete-test/pkg/services/searchV2/index_test.go#L549). Indexing (including of panels) happens based on dashboards that are loaded ([code](https://github.com/grafana/grafana/blob/suntala/search-v2-soft-delete-test/pkg/services/searchV2/index.go#L484-L499)). Existing tests, such as the one mentioned before, ensure that given a set of dashboards, the correct panels are indexed. The test introduced in this PR takes care of the missing piece--ensuring that soft-deleted dashboards don't get loaded.
- Looked superficially through the possibility of folders being soft deleted. Didn't see folders being specifically mentioned as part of the feature in the [Restore dashboards epic](https://github.com/grafana/grafana/issues/83620) so didn't spend much time considering how this would be addressed in search v2. I'll gladly look into it if others think it worthwhile.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
