### PR TITLE
Scenes: Fixes issue with panel repeat height calculation

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -155,8 +155,7 @@ describe('PanelRepeaterGridItem', () => {
       numberOfOptions: 5,
     });
 
-    // number of options is 5, total height is 4, max per row is 4, so item height should be 2 (2 rows)
-    scene.activate();
+    activateFullSceneTree(scene);
 
     expect(repeater.state.height).toBe(4);
   });

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -1,6 +1,7 @@
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { setPluginImportUtils } from '@grafana/runtime';
-import { SceneGridLayout, VizPanel } from '@grafana/scenes';
+import { SceneGridLayout, TestVariable, VizPanel } from '@grafana/scenes';
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { activateFullSceneTree, buildPanelRepeaterScene } from '../utils/test-utils';
 
@@ -40,7 +41,7 @@ describe('PanelRepeaterGridItem', () => {
     expect(repeater.state.repeatedPanels?.length).toBe(5);
   });
 
-  it('Should adjust container height to fit panels direction is horizontal', async () => {
+  it('Should adjust container height to fit panels if direction is horizontal', async () => {
     const { scene, repeater } = buildPanelRepeaterScene({ variableQueryTime: 0, maxPerRow: 2, itemHeight: 10 });
 
     const layoutForceRender = jest.fn();
@@ -143,5 +144,58 @@ describe('PanelRepeaterGridItem', () => {
     });
 
     expect(gridItem.getClassName()).toBe('');
+  });
+
+  it('should have correct height after repeat is performed', () => {
+    const { scene, repeater } = buildPanelRepeaterScene({
+      variableQueryTime: 0,
+      height: 4,
+      maxPerRow: 4,
+      repeatDirection: 'h',
+      numberOfOptions: 5,
+    });
+
+    // number of options is 5, total height is 4, max per row is 4, so item height should be 2 (2 rows)
+    scene.activate();
+
+    expect(repeater.state.height).toBe(4);
+  });
+
+  it('should have same item height if number of repititions changes', async () => {
+    const { scene, repeater } = buildPanelRepeaterScene({
+      variableQueryTime: 0,
+      height: 4,
+      maxPerRow: 4,
+      repeatDirection: 'h',
+      numberOfOptions: 5,
+    });
+    activateFullSceneTree(scene);
+
+    scene.state.$variables!.setState({
+      variables: [
+        new TestVariable({
+          name: 'server',
+          query: 'A.*',
+          value: ALL_VARIABLE_VALUE,
+          text: ALL_VARIABLE_TEXT,
+          isMulti: true,
+          includeAll: true,
+          delayMs: 0,
+          optionsToReturn: [
+            { label: 'A', value: '1' },
+            { label: 'B', value: '2' },
+            { label: 'C', value: '3' },
+            { label: 'D', value: '4' },
+            { label: 'E', value: '5' },
+            { label: 'F', value: '6' },
+            { label: 'G', value: '7' },
+            { label: 'H', value: '8' },
+            { label: 'I', value: '9' },
+            { label: 'J', value: '10' },
+          ],
+        }),
+      ],
+    });
+    expect(repeater.state.height).toBe(6);
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -190,20 +190,15 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
 
     const direction = this.getRepeatDirection();
     const stateChange: Partial<DashboardGridItemState> = { repeatedPanels: repeatedPanels };
-    const itemHeight = this.state.itemHeight ?? 10;
-    const prevHeight = this.state.height;
-    const maxPerRow = this.getMaxPerRow();
+    const prevHeight = this.state.height ?? 0;
+    const maxPerRow = direction === 'h' ? this.getMaxPerRow() : 1;
+    const prevRowCount = Math.ceil(prevRepeatCount / maxPerRow);
+    const newRowCount = Math.ceil(repeatedPanels.length / maxPerRow);
 
-    if (direction === 'h') {
-      // If the number of repeated panels has changed (i.e. the repeat var has more/fewer options selected)
-      // we still want the height of each panel to stay the same
-      const rowCount = Math.ceil(repeatedPanels.length / maxPerRow);
-      const prevRowCount = Math.ceil(prevRepeatCount / maxPerRow);
-      const prevItemHeight = (prevHeight ?? 0) / prevRowCount;
-      stateChange.height = Math.ceil(rowCount * prevItemHeight);
-    } else {
-      stateChange.height = repeatedPanels.length * itemHeight;
-    }
+    // If item height is not defined, calculate based on total height and row count
+    const itemHeight = this.state.itemHeight ?? prevHeight / prevRowCount;
+    stateChange.itemHeight = itemHeight;
+    stateChange.height = Math.ceil(newRowCount * itemHeight);
 
     this.setState(stateChange);
 

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -163,6 +163,8 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
       return;
     }
 
+    // Needed to calculate item height
+    const prevRepeatCount = this._prevRepeatValues?.length ?? values.length;
     this._prevRepeatValues = values;
     const panelToRepeat = this.state.body instanceof LibraryVizPanel ? this.state.body.state.panel! : this.state.body;
     const repeatedPanels: VizPanel[] = [];
@@ -193,8 +195,12 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
     const maxPerRow = this.getMaxPerRow();
 
     if (direction === 'h') {
+      // If the number of repeated panels has changed (i.e. the repeat var has more/fewer options selected)
+      // we still want the height of each panel to stay the same
       const rowCount = Math.ceil(repeatedPanels.length / maxPerRow);
-      stateChange.height = rowCount * itemHeight;
+      const prevRowCount = Math.ceil(prevRepeatCount / maxPerRow);
+      const prevItemHeight = (prevHeight ?? 0) / prevRowCount;
+      stateChange.height = Math.ceil(rowCount * prevItemHeight);
     } else {
       stateChange.height = repeatedPanels.length * itemHeight;
     }

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -438,7 +438,6 @@ export function buildGridItemForLibPanel(panel: PanelModel) {
     x: panel.gridPos.x,
     width: panel.gridPos.w,
     height: panel.gridPos.h,
-    itemHeight: panel.gridPos.h,
     body,
   });
 }
@@ -503,7 +502,6 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     y: panel.gridPos.y,
     width: repeatOptions.repeatDirection === 'h' ? 24 : panel.gridPos.w,
     height: panel.gridPos.h,
-    itemHeight: panel.gridPos.h,
     body,
     maxPerRow: panel.maxPerRow,
     ...repeatOptions,

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -96,6 +96,7 @@ interface SceneOptions {
   variableQueryTime: number;
   maxPerRow?: number;
   itemHeight?: number;
+  height?: number;
   repeatDirection?: RepeatDirection;
   x?: number;
   y?: number;
@@ -113,6 +114,7 @@ export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel
     repeatDirection: options.repeatDirection,
     maxPerRow: options.maxPerRow,
     itemHeight: options.itemHeight,
+    height: options.height,
     body:
       source ??
       new VizPanel({


### PR DESCRIPTION
Fixes an issue where the saved grid height of a group of repeated panels was treated as the item height, resulting in panels whose height repeatedly grows when saving/reloading.