### PR TITLE
Alerting: Make whitespace more visible on labels

### DIFF
--- a/packages/grafana-ui/src/components/Tags/Tag.tsx
+++ b/packages/grafana-ui/src/components/Tags/Tag.tsx
@@ -82,7 +82,7 @@ const getTagStyles = (theme: GrafanaTheme2, name: string, colorIndex?: number) =
       verticalAlign: 'baseline',
       backgroundColor: colors.color,
       color: theme.v1.palette.gray98,
-      whiteSpace: 'nowrap',
+      whiteSpace: 'pre',
       textShadow: 'none',
       padding: '3px 6px',
       borderRadius: theme.shape.radius.default,

--- a/public/app/features/alerting/unified/components/Label.tsx
+++ b/public/app/features/alerting/unified/components/Label.tsx
@@ -102,7 +102,7 @@ const getStyles = (theme: GrafanaTheme2, color?: string, size?: string) => {
       borderLeft: 'none',
       borderTopRightRadius: theme.shape.borderRadius(2),
       borderBottomRightRadius: theme.shape.borderRadius(2),
-      whiteSpace: 'nowrap',
+      whiteSpace: 'pre',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       maxWidth: '300px',

--- a/public/app/features/alerting/unified/components/notification-policies/Matchers.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Matchers.tsx
@@ -80,6 +80,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
         border: `solid 1px ${borderColor}`,
         borderRadius: theme.shape.borderRadius(2),
+
+        // Ensure we preserve whitespace, as otherwise it's not noticeable _at all_
+        // when rendering the matcher, and is only noticeable when editing
+        whiteSpace: 'pre',
       }),
     };
   },


### PR DESCRIPTION
**What is this feature?**

Makes whitepace more visible on labels within Alerting. 

**Before**
<img width="278" alt="image" src="https://github.com/grafana/grafana/assets/868844/f6114692-4728-43a7-b1d6-319ecc485041">

**After**
<img width="274" alt="image" src="https://github.com/grafana/grafana/assets/868844/797eb717-e5c4-418c-ba4f-a91037e56e8c">


**Why do we need this feature?**

https://github.com/grafana/grafana/issues/89203 includes a case where it was very hard to spot additional whitespace in labels, and I also ran into this with an old notification policy that I'd created that had additional spaces.

**Who is this feature for?**

Alerting users who have spaces at the start/end of label values

**Which issue(s) does this PR fix?**:
Helps with https://github.com/grafana/grafana/issues/89203 


