### PR TITLE
[v11.1.x] Frontend: Use safe stringifier in parseBody

### DIFF
--- a/packages/grafana-data/src/utils/object.ts
+++ b/packages/grafana-data/src/utils/object.ts
@@ -10,3 +10,22 @@
 export const isEmptyObject = (value: unknown): value is Record<string, never> => {
   return typeof value === 'object' && value !== null && Object.keys(value).length === 0;
 };
+
+/** Stringifies an object that may contain circular references */
+export function safeStringifyValue(value: unknown) {
+  const getCircularReplacer = () => {
+    const seen = new WeakSet();
+    return (_: string, value: object | null) => {
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) {
+          return;
+        }
+        seen.add(value);
+      }
+
+      return value;
+    };
+  };
+
+  return JSON.stringify(value, getCircularReplacer());
+}

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,6 +1,6 @@
 import { omitBy } from 'lodash';
 
-import { deprecationWarning } from '@grafana/data';
+import { deprecationWarning, safeStringifyValue } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
@@ -93,7 +93,7 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
     return options.data;
   }
 
-  return isAppJson ? JSON.stringify(options.data) : new URLSearchParams(options.data);
+  return isAppJson ? safeStringifyValue(options.data) : new URLSearchParams(options.data);
 };
 
 export async function parseResponseBody<T>(


### PR DESCRIPTION
Backport 434f3869820c7820b41dfd13351017a31409eff3 from #90047

---

The `parseBody` function, used in `parseInitFromOptions` and so `getFromFetchStream`, could throw if the object being stringified contained circular references, as in #88064.
This PR adds a method `safeStringifyValue` to grafana-data (originally from
https://github.com/grafana/scenes/blob/bf6118631e93fd116f9574524c67f708eadde55b/packages/scenes/src/variables/utils.ts#L18) to prevent the error.

Closes #88064

