### PR TITLE
K8s: allow factories to be aware of top level devMode option

### DIFF
--- a/pkg/cmd/grafana/apiserver/server.go
+++ b/pkg/cmd/grafana/apiserver/server.go
@@ -110,6 +110,10 @@ func (o *APIServerOptions) Config(tracer tracing.Tracer) (*genericapiserver.Reco
 		}
 	}
 
+	if o.Options.ExtraOptions.DevMode {
+		o.factory.EnableDevMode()
+	}
+
 	serverConfig.DisabledPostStartHooks = serverConfig.DisabledPostStartHooks.Insert("generic-apiserver-start-informers")
 	serverConfig.DisabledPostStartHooks = serverConfig.DisabledPostStartHooks.Insert("priority-and-fairness-config-consumer")
 

--- a/pkg/services/apiserver/standalone/factory.go
+++ b/pkg/services/apiserver/standalone/factory.go
@@ -34,6 +34,9 @@ type APIServerFactory interface {
 	// Given the flags, what can we produce
 	GetEnabled(runtime []RuntimeConfig) ([]schema.GroupVersion, error)
 
+	// Set dev mode
+	EnableDevMode()
+
 	// Any optional middlewares this factory wants configured via apiserver's BuildHandlerChain facility
 	GetOptionalMiddlewares(tracer tracing.Tracer) []web.Middleware
 
@@ -49,6 +52,9 @@ func GetDummyAPIFactory() APIServerFactory {
 }
 
 type DummyAPIFactory struct{}
+
+func (p *DummyAPIFactory) EnableDevMode() {
+}
 
 func (p *DummyAPIFactory) GetOptions() options.OptionsProvider {
 	return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently, it's not possible to use top level standalone API server options at the factory level. This is one way to factories aware of that bool. Open to other ideas if this doesn't seem right.

**Why do we need this feature?**

Factories need to be aware of dev mode to provide better a development story.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
