### PR TITLE
Share Drawer: Make adding menu items dynamic

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -1,32 +1,89 @@
+import { useCallback } from 'react';
+
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
-import { Menu } from '@grafana/ui';
+import { SceneObject } from '@grafana/scenes';
+import { IconName, Menu } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
+import { getTrackingSource, shareDashboardType } from 'app/features/dashboard/components/ShareModal/utils';
 
 import { DashboardScene } from '../../scene/DashboardScene';
+import { DashboardInteractions } from '../../utils/interactions';
 import { ShareDrawer } from '../ShareDrawer/ShareDrawer';
+import { SceneShareDrawerState } from '../types';
 
 import { ExportAsJson } from './ExportAsJson';
 
 const newExportButtonSelector = e2eSelectors.pages.Dashboard.DashNav.NewExportButton.Menu;
 
+type CustomDashboardDrawer = new (...args: SceneShareDrawerState[]) => SceneObject;
+
+export interface ExportDrawerMenuItem {
+  shareId: string;
+  testId: string;
+  label: string;
+  description?: string;
+  icon: IconName;
+  renderCondition: boolean;
+  onClick: (d: DashboardScene) => void;
+}
+
+const customShareDrawerItem: ExportDrawerMenuItem[] = [];
+
+export function addDashboardExportDrawerItem(item: ExportDrawerMenuItem) {
+  customShareDrawerItem.push(item);
+}
+
 export default function ExportMenu({ dashboard }: { dashboard: DashboardScene }) {
-  const onExportAsJsonClick = () => {
-    const drawer = new ShareDrawer({
-      title: t('export.json.title', 'Save dashboard JSON'),
-      body: new ExportAsJson({}),
+  const onMenuItemClick = useCallback(
+    (title: string, component: CustomDashboardDrawer) => {
+      const drawer = new ShareDrawer({
+        title,
+        body: new component(),
+      });
+
+      dashboard.showModal(drawer);
+    },
+    [dashboard]
+  );
+
+  const buildMenuItems = useCallback(() => {
+    const menuItems: ExportDrawerMenuItem[] = [];
+
+    customShareDrawerItem.forEach((d) => menuItems.push(d));
+
+    menuItems.push({
+      shareId: shareDashboardType.export,
+      testId: newExportButtonSelector.exportAsJson,
+      icon: 'arrow',
+      label: t('share-dashboard.menu.export-json-title', 'Export as JSON'),
+      renderCondition: true,
+      onClick: () => onMenuItemClick(t('export.json.title', 'Save dashboard JSON'), ExportAsJson),
     });
 
-    dashboard.showModal(drawer);
+    return menuItems.filter((item) => item.renderCondition);
+  }, [onMenuItemClick]);
+
+  const onClick = (item: ExportDrawerMenuItem) => {
+    DashboardInteractions.sharingCategoryClicked({
+      item: item.shareId,
+      shareResource: getTrackingSource(),
+    });
+
+    item.onClick(dashboard);
   };
 
   return (
     <Menu data-testid={newExportButtonSelector.container}>
-      <Menu.Item
-        testId={newExportButtonSelector.exportAsJson}
-        label={t('share-dashboard.menu.export-json-title', 'Export as JSON')}
-        icon="arrow"
-        onClick={onExportAsJsonClick}
-      />
+      {buildMenuItems().map((item) => (
+        <Menu.Item
+          key={item.label}
+          testId={item.testId}
+          label={item.label}
+          icon={item.icon}
+          description={item.description}
+          onClick={() => onClick(item)}
+        />
+      ))}
     </Menu>
   );
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changes the way menu items are added to export menu so both enterprise and oss items can easily be added

**Why do we need this feature?**

Similar to old Share modal of adding tabs using [addDashboardShareTab ](https://github.com/grafana/grafana/blob/aab83303da1e1a31e3e007c6c173085771ba9a07/public/app/features/dashboard-scene/sharing/ShareModal.tsx#L34)method and array, make adding item menus for the new share and export button dynamic as well so we can easily add both enterprise and oss items to the menu

**Who is this feature for?**

Users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/grafana/issues/88996

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
