### PR TITLE
SSE: Support configurable list of data source types that could be converted with forced unique labels

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1841,6 +1841,8 @@ default_timezone = browser
 # Enable or disable the expressions functionality.
 enabled = true
 
+force_unique_labels=graphite,etc
+
 [geomap]
 # Set the JSON configuration for the default basemap
 default_baselayer_config =

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -154,7 +154,7 @@ func TestCheckIfSeriesNeedToBeFixed(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, datasource := range supportedDatasources {
-				fixer := checkIfSeriesNeedToBeFixed(tc.frames, datasource)
+				fixer := checkIfSeriesNeedToBeFixed(tc.frames, datasource, nil)
 				if tc.expectedName == "" {
 					require.Nil(t, fixer)
 				} else {

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -87,6 +87,9 @@ func ProvideService(cfg *setting.Cfg, pluginClient plugins.Client, pCtxProvider 
 		converter: &ResultConverter{
 			Features: features,
 			Tracer:   tracer,
+			Settings: ResultConverterSettings{
+				ForceUniqueLabels: cfg.ExpressionsForceUniqueLabelsDatasourceTypes,
+			},
 		},
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -411,7 +411,8 @@ type Cfg struct {
 	OAuthSkipOrgRoleUpdateSync bool
 
 	// ExpressionsEnabled specifies whether expressions are enabled.
-	ExpressionsEnabled bool
+	ExpressionsEnabled                          bool
+	ExpressionsForceUniqueLabelsDatasourceTypes []string
 
 	ImageUploadProvider string
 
@@ -742,6 +743,15 @@ func (cfg *Cfg) readAnnotationSettings() error {
 func (cfg *Cfg) readExpressionsSettings() {
 	expressions := cfg.Raw.Section("expressions")
 	cfg.ExpressionsEnabled = expressions.Key("enabled").MustBool(true)
+	data := strings.Split(expressions.Key("force_unique_labels").MustString(""), ",")
+	cfg.ExpressionsForceUniqueLabelsDatasourceTypes = make([]string, 0, len(data))
+	for _, datasourceType := range data {
+		d := strings.ToLower(strings.TrimSpace(datasourceType))
+		if d == "" {
+			continue
+		}
+		cfg.ExpressionsForceUniqueLabelsDatasourceTypes = append(cfg.ExpressionsForceUniqueLabelsDatasourceTypes, d)
+	}
 }
 
 type AnnotationCleanupSettings struct {


### PR DESCRIPTION
**What is this feature?**
This feature lets users add data source types supported by logic that tries to find data that would make every dimension to be uniquely identifiable. 


**Why do we need this feature?**
In PR https://github.com/grafana/grafana/pull/71246 we added support for only Graphite and Test data sources but it looks like there are many more that could use this feature. 

**Who is this feature for?**
Alerting users 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
