### PR TITLE
Alerting: Track recording rule health and last eval info ephemerally

### DIFF
--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -23,6 +23,13 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+type RuleStatus struct {
+	Health              string
+	LastError           error
+	EvaluationTimestamp time.Time
+	EvaluationDuration  time.Duration
+}
+
 type recordingRule struct {
 	key ngmodels.AlertRuleKey
 
@@ -68,6 +75,15 @@ func newRecordingRule(parent context.Context, key ngmodels.AlertRuleKey, maxAtte
 		metrics:             metrics,
 		tracer:              tracer,
 		writer:              writer,
+	}
+}
+
+func (r *recordingRule) Status() RuleStatus {
+	return RuleStatus{
+		Health:              r.health.Load(),
+		LastError:           r.lastError.Load(),
+		EvaluationTimestamp: r.evaluationTimestamp.Load(),
+		EvaluationDuration:  r.evaluationDuration.Load(),
 	}
 }
 

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -25,15 +26,20 @@ import (
 type recordingRule struct {
 	key ngmodels.AlertRuleKey
 
-	ctx    context.Context
-	evalCh chan *Evaluation
-	stopFn util.CancelCauseFunc
+	ctx                 context.Context
+	evalCh              chan *Evaluation
+	stopFn              util.CancelCauseFunc
+	health              *atomic.String
+	lastError           *atomic.Error
+	evaluationTimestamp *atomic.Time
+	evaluationDuration  *atomic.Duration
 
 	maxAttempts int64
 
 	clock          clock.Clock
 	evalFactory    eval.EvaluatorFactory
 	featureToggles featuremgmt.FeatureToggles
+	writer         RecordingWriter
 
 	// Event hooks that are only used in tests.
 	evalAppliedHook evalAppliedFunc
@@ -41,25 +47,27 @@ type recordingRule struct {
 	logger  log.Logger
 	metrics *metrics.Scheduler
 	tracer  tracing.Tracer
-
-	writer RecordingWriter
 }
 
 func newRecordingRule(parent context.Context, key ngmodels.AlertRuleKey, maxAttempts int64, clock clock.Clock, evalFactory eval.EvaluatorFactory, ft featuremgmt.FeatureToggles, logger log.Logger, metrics *metrics.Scheduler, tracer tracing.Tracer, writer RecordingWriter) *recordingRule {
 	ctx, stop := util.WithCancelCause(ngmodels.WithRuleKey(parent, key))
 	return &recordingRule{
-		key:            key,
-		ctx:            ctx,
-		evalCh:         make(chan *Evaluation),
-		stopFn:         stop,
-		clock:          clock,
-		evalFactory:    evalFactory,
-		featureToggles: ft,
-		maxAttempts:    maxAttempts,
-		logger:         logger.FromContext(ctx),
-		metrics:        metrics,
-		tracer:         tracer,
-		writer:         writer,
+		key:                 key,
+		ctx:                 ctx,
+		evalCh:              make(chan *Evaluation),
+		stopFn:              stop,
+		health:              atomic.NewString("unknown"),
+		lastError:           atomic.NewError(nil),
+		evaluationTimestamp: atomic.NewTime(time.Time{}),
+		evaluationDuration:  atomic.NewDuration(0),
+		clock:               clock,
+		evalFactory:         evalFactory,
+		featureToggles:      ft,
+		maxAttempts:         maxAttempts,
+		logger:              logger.FromContext(ctx),
+		metrics:             metrics,
+		tracer:              tracer,
+		writer:              writer,
 	}
 }
 
@@ -127,7 +135,12 @@ func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
 
 	defer func() {
 		evalTotal.Inc()
-		evalDuration.Observe(r.clock.Now().Sub(evalStart).Seconds())
+		end := r.clock.Now()
+		dur := end.Sub(evalStart)
+		evalDuration.Observe(dur.Seconds())
+		r.evaluationTimestamp.Store(end)
+		r.evaluationDuration.Store(dur)
+
 		r.evaluationDoneTestHook(ev)
 	}()
 
@@ -183,11 +196,15 @@ func (r *recordingRule) doEvaluate(ctx context.Context, ev *Evaluation) {
 		evalTotalFailures.Inc()
 		span.SetStatus(codes.Error, "rule evaluation failed")
 		span.RecordError(latestError)
+		r.lastError.Store(latestError)
+		r.health.Store("error")
 		if r.maxAttempts > 0 {
 			logger.Error("Recording rule evaluation failed after all attempts", "lastError", latestError)
 		}
 	} else {
 		logger.Debug("Recording rule evaluation succeeded")
+		r.lastError.Store(nil)
+		r.health.Store("ok")
 	}
 }
 
@@ -204,6 +221,7 @@ func (r *recordingRule) tryEvaluation(ctx context.Context, ev *Evaluation, logge
 	if err := eval.FindConditionError(result, ev.rule.Record.From); err != nil {
 		return fmt.Errorf("the query failed with an error: %w", err)
 	}
+	// TODO: This is missing dedicated logic for NoData. If NoData we can skip the write.
 
 	logger.Info("Recording rule evaluated", "results", result, "duration", evalDur)
 	span := trace.SpanFromContext(ctx)


### PR DESCRIPTION
**What is this feature?**

Recording rules know their health and last eval stats. For now, we use a very naive implementation that's purely in memory, and independent to each replica. This is nearly entirely copy pasted from Prometheus.

In-memory seems safe enough for recording rules - especially since it appears to also be good enough for Prometheus. This is purely used for immediate stability tracking, unlike alert rules which use this for notifications and have a more front-and-center concept of state.

**Why do we need this feature?**

n/a

**Who is this feature for?**

n/a

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
