### PR TITLE
Prometheus: Deprecation message for SigV4 in core Prom

### DIFF
--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
@@ -194,13 +195,14 @@ func Parse(span trace.Span, query backend.DataQuery, dsScrapeInterval string, in
 		return nil, err
 	}
 	span.SetAttributes(attribute.String("rawExpr", model.Expr))
-
+	spew.Dump(model.IntervalMS)
 	// Final step value for prometheus
 	calculatedStep, err := calculatePrometheusInterval(model.Interval, dsScrapeInterval, int64(model.IntervalMS), model.IntervalFactor, query, intervalCalculator)
 	if err != nil {
 		return nil, err
 	}
-
+	spew.Dump("!!!!!!!!!!!!")
+	spew.Dump(model.Interval)
 	// Interpolate variables in expr
 	timeRange := query.TimeRange.To.Sub(query.TimeRange.From)
 	expr := interpolateVariables(
@@ -310,6 +312,8 @@ func calculatePrometheusInterval(
 	if isVariableInterval(queryInterval) {
 		queryInterval = ""
 	}
+	spew.Dump(queryInterval)
+	spew.Dump(intervalMs)
 
 	minInterval, err := gtime.GetIntervalFrom(dsScrapeInterval, queryInterval, intervalMs, 15*time.Second)
 	if err != nil {
@@ -346,6 +350,8 @@ func calculateRateInterval(
 	requestedMinStep string,
 ) time.Duration {
 	scrape := requestedMinStep
+	spew.Dump("###########")
+	spew.Dump(scrape)
 	if scrape == "" {
 		scrape = "15s"
 	}

--- a/pkg/promlib/models/query.go
+++ b/pkg/promlib/models/query.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
@@ -195,14 +194,13 @@ func Parse(span trace.Span, query backend.DataQuery, dsScrapeInterval string, in
 		return nil, err
 	}
 	span.SetAttributes(attribute.String("rawExpr", model.Expr))
-	spew.Dump(model.IntervalMS)
+
 	// Final step value for prometheus
 	calculatedStep, err := calculatePrometheusInterval(model.Interval, dsScrapeInterval, int64(model.IntervalMS), model.IntervalFactor, query, intervalCalculator)
 	if err != nil {
 		return nil, err
 	}
-	spew.Dump("!!!!!!!!!!!!")
-	spew.Dump(model.Interval)
+
 	// Interpolate variables in expr
 	timeRange := query.TimeRange.To.Sub(query.TimeRange.From)
 	expr := interpolateVariables(
@@ -312,8 +310,6 @@ func calculatePrometheusInterval(
 	if isVariableInterval(queryInterval) {
 		queryInterval = ""
 	}
-	spew.Dump(queryInterval)
-	spew.Dump(intervalMs)
 
 	minInterval, err := gtime.GetIntervalFrom(dsScrapeInterval, queryInterval, intervalMs, 15*time.Second)
 	if err != nil {
@@ -350,8 +346,6 @@ func calculateRateInterval(
 	requestedMinStep string,
 ) time.Duration {
 	scrape := requestedMinStep
-	spew.Dump("###########")
-	spew.Dump(scrape)
 	if scrape == "" {
 		scrape = "15s"
 	}

--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -136,8 +136,8 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
       <hr className={`${styles.hrTopSpace} ${styles.hrBottomSpace}`} />
       {sigV4Selected && (
         <Alert title="Deprecation Notice" severity="warning">
-          The SigV4 authentication in the core Prometheus data source is deprecated. Please use the Amazon Prometheus
-          data source to authenticate with SigV4.
+          The SigV4 authentication in the core Prometheus data source is deprecated. Please use the Amazon Managed
+          Service for Prometheus data source to authenticate with SigV4.
         </Alert>
       )}
       <Auth

--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -136,7 +136,7 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
       <hr className={`${styles.hrTopSpace} ${styles.hrBottomSpace}`} />
       {sigV4Selected && (
         <Alert title="Deprecation Notice" severity="warning">
-          The SigV4 authentication in the core Prometheus data source is deprecated. Please use the Prometheus Amazon
+          The SigV4 authentication in the core Prometheus data source is deprecated. Please use the Amazon Prometheus
           data source to authenticate with SigV4.
         </Alert>
       )}

--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { DataSourceSettings } from '@grafana/data';
 import { Auth, ConnectionSettings, convertLegacyAuthProps, AuthMethod } from '@grafana/experimental';
 import { PromOptions, docsTip, overhaulStyles } from '@grafana/prometheus';
-import { SecureSocksProxySettings, useTheme2 } from '@grafana/ui';
+import { Alert, SecureSocksProxySettings, useTheme2 } from '@grafana/ui';
 // NEED TO EXPORT THIS FROM GRAFANA/UI FOR EXTERNAL DS
 import { AzureAuthSettings } from '@grafana/ui/src/components/DataSourceSettings/types';
 
@@ -134,6 +134,12 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
         urlTooltip={urlTooltip}
       />
       <hr className={`${styles.hrTopSpace} ${styles.hrBottomSpace}`} />
+      {sigV4Selected && (
+        <Alert title="Deprecation Notice" severity="warning">
+          The SigV4 authentication in the core Prometheus data source is deprecated. Please use the Prometheus Amazon
+          data source to authenticate with SigV4.
+        </Alert>
+      )}
       <Auth
         {...newAuthProps}
         customMethods={customMethods}


### PR DESCRIPTION
**What is this?**

This is a deprecation message for SigV4 auth in Prometheus. 

<img width="871" alt="Screenshot 2024-07-12 at 7 57 57 AM" src="https://github.com/user-attachments/assets/adeb36f1-82b9-473b-832a-e37da88aa5a5">


**Why**

We have created the Amazon Managed Service for Prometheus data source and will be using SigV4 auth in that instead of core Prometheus. 

**More context for Grafanistas**

[Migration plan](https://docs.google.com/document/d/1KaWUmNoWTuCVL5inL0qmvM2CqQwrpBDsdBhNoYsui4U/edit#heading=h.t7gn8ijy9fiw) from for customers who use SigV4 in core Prometheus to the Amazon Managed Service for Prometheus data source.

Fixes: https://github.com/grafana/grafana/issues/90095

**How do we test this?**

1. Set to true to enable SigV4 authentication option for HTTP-based datasources
`sigv4_auth_enabled = true`
2. Add a new Prometheus data source.
3. Select SigV4 auth.
4. See the deprecation message.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
