### PR TITLE
Tempo: Require streaming to be enabled

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -280,7 +280,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       config.featureToggles.traceQLStreaming &&
       this.isFeatureAvailable(FeatureName.streaming) &&
       config.liveEnabled &&
-      this.streamingEnabled?.search !== false
+      this.streamingEnabled?.search
     );
   }
 


### PR DESCRIPTION
**What is this feature?**

Require streaming to be enabled in the datasource config instead of assuming that an empty value means that it is enabled. 
