### PR TITLE
Chore: Add package.json to changelog github action

### DIFF
--- a/.github/workflows/actions/changelog/package.json
+++ b/.github/workflows/actions/changelog/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "changelog",
+  "main": "index.js",
+  "type": "module",
+  "description": "changelog generator"
+}


### PR DESCRIPTION
Add missing package.json to treat this action as a JS module, seems to work now: https://github.com/grafana/grafana/actions/runs/9872724181/job/27263412504