### PR TITLE
[v10.4.x] Azure: Fix default subscription setting

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/__mocks__/datasourceSettings.ts
+++ b/public/app/plugins/datasource/azuremonitor/__mocks__/datasourceSettings.ts
@@ -1,0 +1,40 @@
+import { KeyValue } from '@grafana/data';
+
+import { AzureDataSourceSettings } from '../types';
+
+import { DeepPartial } from './utils';
+
+export const createMockDatasourceSettings = (
+  overrides?: DeepPartial<AzureDataSourceSettings>,
+  secureJsonFieldsOverrides?: KeyValue<boolean>
+): AzureDataSourceSettings => {
+  return {
+    id: 1,
+    uid: 'uid',
+    orgId: 1,
+    name: 'test-data-source',
+    typeLogoUrl: 'logo',
+    type: 'grafana-azure-monitor-datasource',
+    typeName: 'datasource',
+    access: '',
+    url: '',
+    user: '',
+    database: '',
+    basicAuth: false,
+    basicAuthUser: '',
+    isDefault: false,
+    jsonData: {
+      cloudName: 'azuremonitor',
+      azureAuthType: 'clientsecret',
+
+      tenantId: 'abc-123',
+      clientId: 'def-456',
+      subscriptionId: 'ghi-789',
+      ...overrides?.jsonData,
+    },
+    secureJsonData: { ...overrides?.secureJsonData },
+    secureJsonFields: { ...secureJsonFieldsOverrides },
+    readOnly: false,
+    withCredentials: false,
+  };
+};

--- a/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
 
-import { createMockDatasourceSettings } from '../../__mocks__/datasourceSettings';
+import { createMockDatasourceSettings } from '../__mocks__/datasourceSettings';
 
 import { MonitorConfig, Props } from './MonitorConfig';
 

--- a/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { createMockDatasourceSettings } from '../../__mocks__/datasourceSettings';
+
+import { MonitorConfig, Props } from './MonitorConfig';
+
+const mockDatasourceSettings = createMockDatasourceSettings();
+
+const defaultProps: Props = {
+  options: mockDatasourceSettings,
+  updateOptions: jest.fn(),
+  getSubscriptions: jest.fn().mockResolvedValue([]),
+};
+
+describe('MonitorConfig', () => {
+  it('should render component', () => {
+    render(<MonitorConfig {...defaultProps} />);
+
+    expect(screen.getByText('Azure Cloud')).toBeInTheDocument();
+  });
+
+  it('should render component and set the default auth type if unset', () => {
+    const mockDsSettingsWithoutAuth = createMockDatasourceSettings({
+      jsonData: { azureAuthType: undefined, clientId: undefined, tenantId: undefined },
+    });
+
+    render(<MonitorConfig {...defaultProps} options={mockDsSettingsWithoutAuth} />);
+
+    expect(defaultProps.updateOptions).toHaveBeenCalled();
+    expect(screen.getByText('Azure Cloud')).toBeInTheDocument();
+  });
+  expect(defaultProps.options.jsonData.azureAuthType).toBe('clientsecret');
+
+  it('should render component and set the default subscription if specified', async () => {
+    const mockDsSettingsWithAuth = createMockDatasourceSettings(undefined, { clientSecret: true });
+    const getSubscriptions = jest.fn().mockResolvedValue([{ label: 'Test Sub', value: 'ghi-789' }]);
+    render(<MonitorConfig {...defaultProps} options={mockDsSettingsWithAuth} getSubscriptions={getSubscriptions} />);
+
+    expect(screen.getByText('Azure Cloud')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Test Sub')).toBeInTheDocument());
+  });
+});

--- a/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/MonitorConfig.tsx
@@ -44,8 +44,8 @@ export const MonitorConfig = (props: Props) => {
 
   // The auth type needs to be set on the first load of the data source
   useEffectOnce(() => {
-    if (!options.jsonData.authType) {
-      onCredentialsChange(credentials);
+    if (!options.jsonData.authType || !credentials.authType) {
+      onCredentialsChange(credentials, options.jsonData.subscriptionId);
     }
   });
 


### PR DESCRIPTION
Backport bba26f8e13a0288044ad771deba49dd908471eaa from #90185

---

Fixes a bug introduced in #87481 that prevents the default subscription from being set on existing data sources.

- Add a data source settings mock
- Correctly set subscription ID
