### PR TITLE
SoloPanel: Avoid fatal error when panelId correspond to a row

### DIFF
--- a/public/app/features/dashboard-scene/solo/useSoloPanel.test.tsx
+++ b/public/app/features/dashboard-scene/solo/useSoloPanel.test.tsx
@@ -1,0 +1,133 @@
+import { renderHook } from '@testing-library/react';
+
+import { DataSourceRef } from '@grafana/schema';
+
+import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+import { findVizPanelByKey } from '../utils/utils';
+
+import { useSoloPanel } from './useSoloPanel';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({
+    get: async (ref: DataSourceRef) => {
+      // Mocking the build in Grafana data source to avoid annotations data layer errors.
+      return {
+        id: 1,
+        uid: '-- Grafana --',
+        name: 'grafana',
+        type: 'grafana',
+        meta: {
+          id: 'grafana',
+        },
+      };
+    },
+  }),
+}));
+
+describe('useSoloPanel', () => {
+  it('should return undefined panel and error when panel is not found', () => {
+    const { dashboard } = setup();
+    const { result } = renderHook(() => useSoloPanel(dashboard, 'foo-key'));
+
+    expect(result.current[0]).toBeUndefined();
+    expect(result.current[1]).toBe('Panel not found');
+  });
+
+  it('should return the panel when panel is found', () => {
+    const { dashboard } = setup();
+
+    const { result } = renderHook(() => useSoloPanel(dashboard, 'panel-1'));
+    const panel = findVizPanelByKey(dashboard, 'panel-1');
+
+    expect(result.current[0]).toEqual(panel);
+    expect(result.current[1]).toBeUndefined();
+  });
+
+  it('should return the cloned panel when panel is found', () => {
+    const { dashboard } = setup();
+    const { result } = renderHook(() => useSoloPanel(dashboard, 'panel-1_clone'));
+    const panel = findVizPanelByKey(dashboard, 'panel-1');
+
+    expect(result.current[0]).not.toBe(panel);
+    expect(result.current[1]).toBeUndefined();
+  });
+
+  it('should return error when panelId correspond to a non VizPanel', () => {
+    const { dashboard } = setup();
+    const { result } = renderHook(() => useSoloPanel(dashboard, 'panel-2'));
+
+    expect(result.current[0]).toBeUndefined();
+    expect(result.current[1]).toBe('Panel not found');
+  });
+});
+
+const setup = () => {
+  const dashboard = transformSaveModelToScene({ dashboard: TEST_DASHBOARD, meta: {} });
+
+  return { dashboard };
+};
+
+const TEST_DASHBOARD = {
+  title: 'Scenes/PanelEdit/Queries: Edit',
+  annotations: {
+    list: [],
+  },
+  editable: true,
+  fiscalYearStartMonth: 0,
+  graphTooltip: 0,
+  id: 2378,
+  links: [],
+  liveNow: false,
+  panels: [
+    {
+      type: 'timeseries',
+      datasource: 'prometheus',
+      fieldConfig: {
+        defaults: {
+          custom: {},
+        },
+        overrides: [],
+      },
+      gridPos: {
+        h: 9,
+        w: 24,
+        x: 0,
+        y: 0,
+      },
+      id: 1,
+      options: {
+        colorMode: 'background',
+        graphMode: 'area',
+        justifyMode: 'auto',
+        orientation: 'auto',
+        reduceOptions: {
+          calcs: ['lastNotNull', 'last', 'first', 'min', 'max', 'mean', 'sum', 'count'],
+          fields: '',
+          values: false,
+        },
+        text: {},
+      },
+      pluginVersion: '8.0.3',
+    },
+    {
+      id: 2,
+      type: 'row',
+    },
+  ],
+  refresh: '',
+  schemaVersion: 39,
+  tags: [],
+  templating: {
+    list: [],
+  },
+  time: {
+    from: 'now-6h',
+    to: 'now',
+  },
+  timepicker: {},
+  timezone: '',
+  uid: 'ffbe00e2-803c-4d49-adb7-41aad336234f',
+  version: 6,
+  weekStart: '',
+};

--- a/public/app/features/dashboard-scene/solo/useSoloPanel.ts
+++ b/public/app/features/dashboard-scene/solo/useSoloPanel.ts
@@ -17,7 +17,13 @@ export function useSoloPanel(dashboard: DashboardScene, panelId: string): [VizPa
 
     const cleanUp = dashboard.activate();
 
-    const panel = findVizPanelByKey(dashboard, panelId);
+    let panel: VizPanel | null = null;
+    try {
+      panel = findVizPanelByKey(dashboard, panelId);
+    } catch (e) {
+      // do nothing, just the panel is not found or not a VizPanel
+    }
+
     if (panel) {
       activateParents(panel);
       setPanel(panel);
@@ -29,6 +35,8 @@ export function useSoloPanel(dashboard: DashboardScene, panelId: string): [VizPa
           setError('Panel not found');
         }
       });
+    } else {
+      setError('Panel not found');
     }
 
     return cleanUp;


### PR DESCRIPTION
**Problem**
|Before|After|
|-|-|
<img width="1906" alt="Captura de pantalla 2024-07-10 a las 13 00 44" src="https://github.com/grafana/grafana/assets/5699976/e77ae265-f47d-460a-8d5e-dc53d35d5adb">|<img width="1920" alt="Captura de pantalla 2024-07-10 a las 13 00 11" src="https://github.com/grafana/grafana/assets/5699976/ccfa2efb-ab2b-4ac8-bbaf-17af10532489">

When the `panelId` corresponded to a non-VizPanel, the error was not captured.

In the old architecture, we were rendering the row, but empty. The proper behavior is to render "Not found" since the row is not a panel.

**How to reproduce**
1. Create a new dashboard
2. Create a panel within the dashboard
3. Create a row
4. Click in the panel menu > share > embed and get the URL from the iframe
5. Replace panelId by the row panelId, and you will see the "Not found" state. You can see it in the screenshots attached.