### PR TITLE
Chore: increase lint timeout

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,5 +1,5 @@
 [run]
-timeout = "10m"
+timeout = "20m"
 concurrency = 10
 
 [linters-settings.exhaustive]


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:
Increase lint timeout to unblock PRs. Will need to dig in more to understand why lint is taking so long.
