### PR TITLE
ExploreMetrics: disable route if disabled (or missing permissions)

### DIFF
--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -505,7 +505,7 @@ export function getAppRoutes(): RouteDescriptor[] {
         () => import(/* webpackChunkName: "NotificationsPage"*/ 'app/features/notifications/NotificationsPage')
       ),
     },
-    {
+    config.featureToggles.exploreMetrics && {
       path: '/explore/metrics',
       chromeless: false,
       exact: false,

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -509,6 +509,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       path: '/explore/metrics',
       chromeless: false,
       exact: false,
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.DataSourcesExplore]),
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "DataTrailsPage"*/ 'app/features/trails/DataTrailsPage')
       ),


### PR DESCRIPTION
**What is this feature?**

If Explore Metrics was explicitly disabled, it was still possible to access it via `/explore/metrics`
If the user didn't have permissions for this feature, this would lead to a broken interface with access errors.

- Now uses existing `datasources:explore` permission to disable menu item & direct URL access.
- If `exploreMetrics` feature flag is set to false, direct URL access will no longer show the feature.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
