### PR TITLE
Alerting: More graceful handling of NoData in recording rules

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -477,7 +477,6 @@ func queryDataResponseToExecutionResults(c models.Condition, execResp *backend.Q
 	result.Error = FindConditionError(execResp, c.Condition)
 
 	for refID, res := range execResp.Responses {
-
 		if IsNoData(res) {
 			// To make sure NoData is nil when Results are also nil we wait to initialize
 			// NoData until there is at least one query or expression that returned no data

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -443,7 +443,7 @@ func IsNoData(res backend.DataResponse) bool {
 	if len(res.Frames) <= 1 {
 		hasNoFrames := len(res.Frames) == 0
 		hasNoFields := len(res.Frames) == 1 && len(res.Frames[0].Fields) == 0
-		return hasNoFrames && hasNoFields
+		return hasNoFrames || hasNoFields
 	}
 	return false
 }

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -240,7 +240,7 @@ func (r *recordingRule) tryEvaluation(ctx context.Context, ev *Evaluation, logge
 	}
 	// TODO: This is missing dedicated logic for NoData. If NoData we can skip the write.
 
-	logger.Info("Recording rule query completed", "resultCount", len(result.Responses), "duration", evalDur)
+	logger.Debug("Recording rule query completed", "resultCount", len(result.Responses), "duration", evalDur)
 	span := trace.SpanFromContext(ctx)
 	span.AddEvent("query succeeded", trace.WithAttributes(
 		attribute.Int64("results", int64(len(result.Responses))),

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -252,6 +252,7 @@ func (r *recordingRule) tryEvaluation(ctx context.Context, ev *Evaluation, logge
 			attribute.String("reason", err.Error()),
 		))
 		logger.Debug("Query returned no data", "reason", err)
+		r.health.Store("nodata")
 		return nil
 	}
 


### PR DESCRIPTION
**What is this feature?**

Previously, NoData wasn't handled in a consistent way - in the event of a NoData response (of which there are multiple formats) we'd either sporadically fail with an error about frames being empty, or write nothing if we return a frame with no points - the behavior was not consistent.

In this PR, NoData is treated in a consistent way. We choose a default behavior that tries to be consistent with other areas:
- in NoData, we write nothing (consistent with prometheus semantics)
- in NoData, we set things up to use a special health `nodata` as an indicator (consistent with Grafana rules, not consistent with prometheus which simply treats nodata rules as "ok")

We can revise this default in the future, the important thing for now is we treat the case consistently.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
