### PR TITLE
Remove unused metric

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -106,7 +106,6 @@ func (d *DualWriterMode2) Get(ctx context.Context, name string, options *metav1.
 
 	// if there is no object in storage, we return the object from legacy
 	if objStorage == nil {
-		d.recordReadLegacyCount(options.Kind, method)
 		return objLegacy, nil
 	}
 	return objStorage, err
@@ -185,7 +184,6 @@ func (d *DualWriterMode2) List(ctx context.Context, options *metainternalversion
 		return sl, nil
 	}
 	log.Info("lists from legacy and storage are not the same size")
-	d.recordReadLegacyCount(options.Kind, method)
 	return ll, nil
 }
 

--- a/pkg/apiserver/rest/metrics.go
+++ b/pkg/apiserver/rest/metrics.go
@@ -9,10 +9,9 @@ import (
 )
 
 type dualWriterMetrics struct {
-	legacy      *prometheus.HistogramVec
-	storage     *prometheus.HistogramVec
-	outcome     *prometheus.HistogramVec
-	legacyReads *prometheus.CounterVec
+	legacy  *prometheus.HistogramVec
+	storage *prometheus.HistogramVec
+	outcome *prometheus.HistogramVec
 }
 
 // DualWriterStorageDuration is a metric summary for dual writer storage duration per mode
@@ -38,12 +37,6 @@ var DualWriterOutcome = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace:                   "grafana",
 	NativeHistogramBucketFactor: 1.1,
 }, []string{"mode", "name", "method"})
-
-var DualWriterReadLegacyCounts = prometheus.NewCounterVec(prometheus.CounterOpts{
-	Name:      "dual_writer_read_legacy_count",
-	Help:      "Histogram for the runtime of dual writer reads from legacy",
-	Namespace: "grafana",
-}, []string{"kind", "method"})
 
 func (m *dualWriterMetrics) init(reg prometheus.Registerer) {
 	log := klog.NewKlogr()
@@ -74,8 +67,4 @@ func (m *dualWriterMetrics) recordOutcome(mode string, name string, outcome bool
 		observeValue = 1
 	}
 	m.outcome.WithLabelValues(mode, name, method).Observe(observeValue)
-}
-
-func (m *dualWriterMetrics) recordReadLegacyCount(kind string, method string) {
-	m.legacyReads.WithLabelValues(kind, method).Inc()
 }


### PR DESCRIPTION
We can count logs such as `log.Info("object not found in storage, fetching from legacy")`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
