### PR TITLE
Alerting: Skip loading alert rules for dashboards when disabled [v10.4.x] 

### DIFF
--- a/public/app/features/alerting/unified/initAlerting.tsx
+++ b/public/app/features/alerting/unified/initAlerting.tsx
@@ -14,15 +14,17 @@ const AlertRulesToolbarButton = React.lazy(
 
 export function initAlerting() {
   const grafanaRulesPermissions = getRulesPermissions(GRAFANA_RULES_SOURCE_NAME);
+  const alertingEnabled = config.unifiedAlertingEnabled || (config.featureToggles.alertingPreviewUpgrade ?? false);
 
   if (contextSrv.hasPermission(grafanaRulesPermissions.read)) {
     addCustomRightAction({
-      show: () => config.unifiedAlertingEnabled || (config.featureToggles.alertingPreviewUpgrade ?? false),
-      component: ({ dashboard }) => (
-        <React.Suspense fallback={null} key="alert-rules-button">
-          {dashboard && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}
-        </React.Suspense>
-      ),
+      show: () => alertingEnabled,
+      component: ({ dashboard }) =>
+        alertingEnabled ? (
+          <React.Suspense fallback={null} key="alert-rules-button">
+            {dashboard && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}
+          </React.Suspense>
+        ) : null,
       index: -2,
     });
   }


### PR DESCRIPTION
Backport 781e39411830baddf591e015d4b83dcf0c19cb54 from #89361

---

**What is this feature?**

Prevents the `AlertRulesToolbarButton` from being loaded (and thus firing off requests) when alerting has been disabled.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/87891
Fixes: #90239
