### PR TITLE
I18n: Memoize formatDate/formatDuration methods because they're prett…

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,6 +334,7 @@
     "lucene": "^2.1.1",
     "marked": "12.0.2",
     "memoize-one": "6.0.0",
+    "micro-memoize": "^4.1.2",
     "ml-regression-polynomial": "^3.0.0",
     "ml-regression-simple-linear": "^3.0.0",
     "moment": "2.30.1",

--- a/public/app/core/internationalization/dates.ts
+++ b/public/app/core/internationalization/dates.ts
@@ -1,20 +1,36 @@
 import '@formatjs/intl-durationformat/polyfill';
+import deepEqual from 'fast-deep-equal';
+import memoize from 'micro-memoize';
 
 import { getI18next } from './index';
 
-export function formatDate(value: number | Date | string, format: Intl.DateTimeFormatOptions = {}): string {
-  if (typeof value === 'string') {
-    return formatDate(new Date(value), format);
+const deepMemoize: typeof memoize = (fn) => memoize(fn, { isEqual: deepEqual });
+
+const createDateTimeFormatter = deepMemoize((language: string, options: Intl.DateTimeFormatOptions) => {
+  return new Intl.DateTimeFormat(language, options);
+});
+
+const createDurationFormatter = deepMemoize((language: string, options: Intl.DurationFormatOptions) => {
+  return new Intl.DurationFormat(language, options);
+});
+
+export const formatDate = deepMemoize(
+  (value: number | Date | string, format: Intl.DateTimeFormatOptions = {}): string => {
+    if (typeof value === 'string') {
+      return formatDate(new Date(value), format);
+    }
+
+    const i18n = getI18next();
+    const dateFormatter = createDateTimeFormatter(i18n.language, format);
+    return dateFormatter.format(value);
   }
+);
 
-  const i18n = getI18next();
-  const dateFormatter = new Intl.DateTimeFormat(i18n.language, format);
-  return dateFormatter.format(value);
-}
+export const formatDuration = deepMemoize(
+  (duration: Intl.DurationInput, options: Intl.DurationFormatOptions = {}): string => {
+    const i18n = getI18next();
 
-export function formatDuration(duration: Intl.DurationInput, options: Intl.DurationFormatOptions = {}) {
-  const i18n = getI18next();
-
-  const dateFormatter = new Intl.DurationFormat(i18n.language, options);
-  return dateFormatter.format(duration);
-}
+    const dateFormatter = createDurationFormatter(i18n.language, options);
+    return dateFormatter.format(duration);
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17338,6 +17338,7 @@ __metadata:
     lucene: "npm:^2.1.1"
     marked: "npm:12.0.2"
     memoize-one: "npm:6.0.0"
+    micro-memoize: "npm:^4.1.2"
     mini-css-extract-plugin: "npm:2.9.0"
     ml-regression-polynomial: "npm:^3.0.0"
     ml-regression-simple-linear: "npm:^3.0.0"


### PR DESCRIPTION
@ashharrison90 Identified that the `Intl.DateTimeFormat` / `Intl.DurationFormat` constructors  are pretty slow. `DurationFormat` is probably especially slow as it is polyfilled everywhere except iOS.

This PR caches both the constructors for those classes (so multiple values formatted the same benefit) and the higher-level formatter as well so formatting the same value is cached.

`micro-memoize` is already used in grafana-ui.