### PR TITLE
Correlations: Fix wrong target data source name in the form

### DIFF
--- a/public/app/features/correlations/Forms/ConfigureCorrelationSourceForm.tsx
+++ b/public/app/features/correlations/Forms/ConfigureCorrelationSourceForm.tsx
@@ -49,7 +49,7 @@ export const ConfigureCorrelationSourceForm = () => {
     );
   }
 
-  const dataSourceName = getDatasourceSrv().getInstanceSettings(correlation?.targetUID)?.name;
+  const dataSourceName = getDatasourceSrv().getInstanceSettings(getValues('targetUID'))?.name;
   return (
     <>
       <FieldSet


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/78106

Use the current for state to get the data source UID on the "source" page of the wizard. Before we tried the correlation state but that has data only if editing an existing correlation.