### PR TITLE
docs: updated time series panel visualization

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -73,7 +73,7 @@ refs:
 
 {{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="1200px" caption="Time series" >}}
 
-Time series visualizations are the default and primary way to visualize time series data as a graph. They can render series as lines, points, or bars. They're versatile enough to display almost any time-series data.
+Time series visualizations are the default and primary way to visualize data points listed over intervals of time as a graph. They can render series as lines, points, or bars. They're versatile enough to display almost any time-series data.
 
 {{% admonition type="note" %}}
 You can [link alert rules](ref:link-alert) to time series visualization to observe when alerts fire and are resolved in the form of annotations. In addition, you can create alert rules from the Alert tab within the panel options.
@@ -193,7 +193,7 @@ Set the style of the line. To change the color, use the standard [color scheme](
 
 ### Stack series
 
-_Stacking_ allows Grafana to display series on top of each other. Be cautious when using stacking in the visualization as it can easily create misleading graphs. To read more about why stacking might not be the best approach, refer to [The issue with stacking](https://www.data-to-viz.com/caveat/stacking.html).
+_Stacking_ allows Grafana to display measurements on top of each other within each period displayed. This feature helps to visually represent the cumulative total of the metrics of the data series at each plotted moment. Be cautious when using stacking in the visualization as it can easily create misleading graphs. To read more about why stacking might not be the best approach, refer to [The issue with stacking](https://www.data-to-viz.com/caveat/stacking.html).
 
 ![Stack option](/static/img/docs/time-series-panel/stack-option-v9.png)
 

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -73,7 +73,7 @@ refs:
 
 {{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="1200px" caption="Time series" >}}
 
-Time series visualizations are the default and primary way to visualize data points listed over intervals of time as a graph. They can render series as lines, points, or bars. They're versatile enough to display almost any time-series data.
+Time series visualizations are the default and primary way to visualize data points over intervals of time as a graph. They can render series as lines, points, or bars. They're versatile enough to display almost any time-series data.
 
 {{% admonition type="note" %}}
 You can [link alert rules](ref:link-alert) to time series visualization to observe when alerts fire and are resolved in the form of annotations. In addition, you can create alert rules from the Alert tab within the panel options.


### PR DESCRIPTION
**What is this feature?**

- Small modification in description of timeseries panel to avoid having the described term in the description.
- Added better description in stacking as it was a bit unclear and jumped right away on issues rather than describing better.

**Why do we need this feature?**

The changes will make it easier for users to read the description and understand stacking as it seems to generate multiple questions.

**Who is this feature for?**

All Grafana users looking for docs on Time Series visualizations

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
