### PR TITLE
Scrollbar: fix scrollTo being called on stale reference

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -61,24 +61,6 @@ export const CustomScrollbar = ({
     }
   }, [ref, scrollRefCallback]);
 
-  /**
-   * Calling scrollTop on a scrollbar ref in a useEffect can race with internal state in react-custom-scrollbars-2, causing scrollTop to get called on a stale reference, which prevents the element from scrolling as desired.
-   * Adding the reference to the useEffect dependency array not notify react that the reference has changed (and is an eslint violation), so we create a custom hook so updates to the reference trigger another render, fixing the race condition bug.
-   *
-   * @param scrollBar
-   * @param scrollTop
-   */
-  function useScrollTop(
-    scrollBar: (Scrollbars & { view: HTMLDivElement; update: () => void }) | null,
-    scrollTop?: number
-  ) {
-    useEffect(() => {
-      if (scrollBar && scrollTop != null) {
-        scrollBar.scrollTop(scrollTop);
-      }
-    }, [scrollTop, scrollBar]);
-  }
-
   useScrollTop(ref.current, scrollTop);
 
   /**
@@ -231,3 +213,21 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
+
+/**
+ * Calling scrollTop on a scrollbar ref in a useEffect can race with internal state in react-custom-scrollbars-2, causing scrollTop to get called on a stale reference, which prevents the element from scrolling as desired.
+ * Adding the reference to the useEffect dependency array not notify react that the reference has changed (and is an eslint violation), so we create a custom hook so updates to the reference trigger another render, fixing the race condition bug.
+ *
+ * @param scrollBar
+ * @param scrollTop
+ */
+function useScrollTop(
+  scrollBar: (Scrollbars & { view: HTMLDivElement; update: () => void }) | null,
+  scrollTop?: number
+) {
+  useEffect(() => {
+    if (scrollBar && scrollTop != null) {
+      scrollBar.scrollTop(scrollTop);
+    }
+  }, [scrollTop, scrollBar]);
+}

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -61,11 +61,26 @@ export const CustomScrollbar = ({
     }
   }, [ref, scrollRefCallback]);
 
-  useEffect(() => {
-    if (ref.current && scrollTop != null) {
-      ref.current.scrollTop(scrollTop);
-    }
-  }, [scrollTop]);
+  /**
+   * Calling scrollTop on a scrollbar ref in a useEffect can race with internal state in react-custom-scrollbars-2, causing scrollTop to get called on the wrong reference,
+   * which prevents the element from scrolling occasionally.
+   * Adding the reference to the useEffect dependency array not notify react that the reference has changed (and is an eslint violation), so we create a custom hook so updates to the reference trigger another render, fixing our race condition bug!
+   *
+   * @param scrollBar
+   * @param scrollTop
+   */
+  function useScrollTop(
+    scrollBar: (Scrollbars & { view: HTMLDivElement; update: () => void }) | null,
+    scrollTop?: number
+  ) {
+    useEffect(() => {
+      if (scrollBar && scrollTop != null) {
+        scrollBar.scrollTop(scrollTop);
+      }
+    }, [scrollTop, scrollBar]);
+  }
+
+  useScrollTop(ref.current, scrollTop);
 
   /**
    * Special logic for doing a update a few milliseconds after mount to check for

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -62,9 +62,8 @@ export const CustomScrollbar = ({
   }, [ref, scrollRefCallback]);
 
   /**
-   * Calling scrollTop on a scrollbar ref in a useEffect can race with internal state in react-custom-scrollbars-2, causing scrollTop to get called on the wrong reference,
-   * which prevents the element from scrolling occasionally.
-   * Adding the reference to the useEffect dependency array not notify react that the reference has changed (and is an eslint violation), so we create a custom hook so updates to the reference trigger another render, fixing our race condition bug!
+   * Calling scrollTop on a scrollbar ref in a useEffect can race with internal state in react-custom-scrollbars-2, causing scrollTop to get called on a stale reference, which prevents the element from scrolling as desired.
+   * Adding the reference to the useEffect dependency array not notify react that the reference has changed (and is an eslint violation), so we create a custom hook so updates to the reference trigger another render, fixing the race condition bug.
    *
    * @param scrollBar
    * @param scrollTop


### PR DESCRIPTION
**What is this fix?**
Fixes a race condition between useEffect in CustomScrollbar, caused by `react-custom-scrollbars-2` updating reference after initial render.

**Why do we need this feature?**
When setting the `scrollTop` prop, the component will occasionally not scroll.

**Who is this feature for?**
Developers using components using CustomScrollbar, e.g. the Table panel. I want to implement the ability for users to copy a link to a specific row in the table, and we noticed that occasionally it doesn't scroll.

**Which issue(s) does this PR fix?**:
None? The scrollTop prop seems to only be used in the Table component, and the Page component, but it doesn't look like the Page component currently passes this in anywhere, at least in core.

**Special notes for your reviewer:**


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
