### PR TITLE
Expr: Make math expression scalars compliant with dataplane contract

### DIFF
--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -88,7 +88,10 @@ func (s Scalar) AsDataFrame() *data.Frame { return s.Frame }
 func NewScalar(name string, f *float64) Scalar {
 	frame := data.NewFrame("",
 		data.NewField(name, nil, []*float64{f}),
-	)
+	).SetMeta(&data.FrameMeta{
+		Type:        data.FrameTypeNumericMulti,
+		TypeVersion: data.FrameTypeVersion{0, 1},
+	})
 	return Scalar{frame}
 }
 

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -2419,7 +2419,11 @@ func TestIntegrationEval(t *testing.T) {
 								"nullable": true
 							  }
 							}
-						  ]
+						  ],
+						  "meta": {
+						    "type": "numeric-multi",
+							"typeVersion": [0, 1]
+						  }
 						},
 						"data": {
 						  "values": [
@@ -2477,7 +2481,11 @@ func TestIntegrationEval(t *testing.T) {
 								"nullable": true
 							  }
 							}
-						  ]
+						  ],
+						  "meta": {
+						    "type": "numeric-multi",
+							"typeVersion": [0, 1]
+						  }
 						},
 						"data": {
 						  "values": [
@@ -2568,7 +2576,11 @@ func TestIntegrationEval(t *testing.T) {
 								"nullable": true
 							  }
 							}
-						  ]
+						  ],
+						  "meta": {
+						    "type": "numeric-multi",
+							"typeVersion": [0, 1]
+						  }
 						},
 						"data": {
 						  "values": [


### PR DESCRIPTION
**What is this feature?**

Scalars produce a frame containing a single point with nil metadata, thus no type or type version is set. Such a dataframe can be produced by the following expression:

```
{
	"datasourceUid": "__expr__",
	"type":"math",
	"expression":"2 + 1"
}
```

This produces exactly this frame - a scalar with no meta. This is invalid according to the dataplane contract, which requires a type and typeversion to be set: https://grafana.com/developers/dataplane/numeric
This causes certain readers, like the CollectionReader, to reject such a frame.

Technically a scalar point with no labels matches all three kinds of numeric frame layouts, so any of the three type ought to be valid. Here I chose `FrameTypeNumericMulti` as it's consistent with the expression engine's Number type: https://github.com/grafana/grafana/blob/5d798f45d1047fefc2d05e25e0b5834d722415d6/pkg/expr/mathexp/types.go#L137-L146

So it seems to follow existing precedent.


**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
