### PR TITLE
docs: updated logs panel visualization

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -64,5 +64,5 @@ Use these settings to refine your visualization:
 - **Wrap lines -** Toggle line wrapping.
 - **Prettify JSON -** Set this to `true` to pretty print all JSON logs. This setting does not affect logs in any format other than JSON.
 - **Enable log details -** Toggle option to see the log details view for each log row. The default setting is true.
-- **Deduplication -** Hides log messages that are duplicates of others shown according to criteria such as: Exact (ignoring ISO datetimes), Numerical (ignoring those that only differ by numbers such as IPs or latencies), or Signatures (removing successive lines with identical punctutaion and white space).
+- **Deduplication -** Hides log messages that are duplicates of others shown according to your selected criteria. Choose from: **Exact** (ignoring ISO datetimes), **Numerical** (ignoring only those that differ by numbers such as IPs or latencies), or **Signatures** (removing successive lines with identical punctuation and white space).
 - **Order -** Display results in descending or ascending time order. The default is **Descending**, showing the newest logs first. Set to **Ascending** to show the oldest log lines first.

--- a/docs/sources/panels-visualizations/visualizations/logs/index.md
+++ b/docs/sources/panels-visualizations/visualizations/logs/index.md
@@ -54,10 +54,6 @@ For logs where a **level** label is specified, we use the value of the label to 
 
 Each log row has an extendable area with its labels and detected fields, for more robust interaction. Each field or label has a stats icon to display ad-hoc statistics in relation to all displayed logs.
 
-### Data links
-
-By using data links, you can turn any part of a log message into an internal or external link. The created link is visible as a button in the **Links** section inside the **Log details** view.
-
 ### Display options
 
 Use these settings to refine your visualization:
@@ -68,5 +64,5 @@ Use these settings to refine your visualization:
 - **Wrap lines -** Toggle line wrapping.
 - **Prettify JSON -** Set this to `true` to pretty print all JSON logs. This setting does not affect logs in any format other than JSON.
 - **Enable log details -** Toggle option to see the log details view for each log row. The default setting is true.
-- **Deduplication -** Hides log messages that are duplicates of others shown according to criteria such as exact match, or those that only differ by numbers such as IPs or latencies.
+- **Deduplication -** Hides log messages that are duplicates of others shown according to criteria such as: Exact (ignoring ISO datetimes), Numerical (ignoring those that only differ by numbers such as IPs or latencies), or Signatures (removing successive lines with identical punctutaion and white space).
 - **Order -** Display results in descending or ascending time order. The default is **Descending**, showing the newest logs first. Set to **Ascending** to show the oldest log lines first.


### PR DESCRIPTION
**What is this feature?**

- Removed the section about data links as logs have no data links.
- Added listed descriptions of what each of the deduplication options do.

**Why do we need this feature?**

Logs do not have data links, not supported in them: https://grafana.com/docs/grafana/latest/panels-visualizations/configure-data-links/#supported-visualizations
Also the description off deduplication was sort of confusing.

**Who is this feature for?**

Every Grafana user that needs to better understand the Logs Panel

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
