### PR TITLE
Table: Fix justifyContent with cellLink overflow

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -41,7 +41,13 @@ export const TableCell = ({
 
   if (cellProps.style) {
     cellProps.style.minWidth = cellProps.style.width;
-    cellProps.style.justifyContent = (cell.column as any).justifyContent;
+    const justifyContent = (cell.column as any).justifyContent;
+    if (justifyContent === 'flex-end') {
+      // justify-content flex-end is not compatible with cellLink overflow; use direction instead
+      cellProps.style.direction = 'rtl';
+    } else {
+      cellProps.style.justifyContent = justifyContent;
+    }
   }
 
   let innerWidth = (typeof cell.column.width === 'number' ? cell.column.width : 24) - tableStyles.cellPadding * 2;

--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -44,6 +44,7 @@ export const TableCell = ({
     const justifyContent = (cell.column as any).justifyContent;
     if (justifyContent === 'flex-end') {
       // justify-content flex-end is not compatible with cellLink overflow; use direction instead
+      cellProps.style.textAlign = 'right';
       cellProps.style.direction = 'rtl';
     } else {
       cellProps.style.justifyContent = justifyContent;


### PR DESCRIPTION
For cell links in table that overflow, justify content flex-end is ignored at the CSS level. Instead of using justify content 'flex-end', use direction 'rtl'.

Before (columns are aligned right):
![image](https://github.com/user-attachments/assets/412a045b-9143-440d-9b2a-58f57150b18b)

After (columns are aligned right):
<img width="868" alt="image" src="https://github.com/user-attachments/assets/bc54b829-3284-43dc-86ab-639aadaad6ca">

Fixes #81300
