### PR TITLE
Switch: Improve a11y by adding role & aria-checked

### DIFF
--- a/packages/grafana-ui/src/components/AutoSaveField/AutoSaveField.test.tsx
+++ b/packages/grafana-ui/src/components/AutoSaveField/AutoSaveField.test.tsx
@@ -391,7 +391,7 @@ describe('Switch, as AutoSaveField child, ', () => {
     setupSwitch();
     //Is there another way to find the switch element? Filtering by name doesn't work
     expect(
-      screen.getByRole('checkbox', {
+      screen.getByRole('switch', {
         checked: false,
       })
     ).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -27,8 +27,10 @@ export const Switch = forwardRef<HTMLInputElement, Props>(
       <div className={cx(styles.switch, invalid && styles.invalid)}>
         <input
           type="checkbox"
+          role="switch"
           disabled={disabled}
           checked={value}
+          aria-checked={value}
           onChange={(event) => {
             !disabled && onChange?.(event);
           }}


### PR DESCRIPTION
**What is this feature?**

Add role and aria-checked to the `Switch` component.

**Why do we need this feature?**

In order to improve `a11y`, although the `Switch` has a `checked` prop that is indeed recognized by screen readers, using `role="switch"` provides a more semantically accurate description, especially when the UI element visually resembles a switch rather than a checkbox

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
