### PR TITLE
[v11.1.x] Admin: Fixes an issue where user accounts could not be enabled

### DIFF
--- a/pkg/api/admin_users.go
+++ b/pkg/api/admin_users.go
@@ -334,7 +334,7 @@ func (hs *HTTPServer) AdminEnableUser(c *contextmodel.ReqContext) response.Respo
 		return response.Error(http.StatusInternalServerError, "Could not enable external user", nil)
 	}
 
-	isDisabled := true
+	isDisabled := false
 	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{UserID: userID, IsDisabled: &isDisabled}); err != nil {
 		if errors.Is(err, user.ErrUserNotFound) {
 			return response.Error(http.StatusNotFound, user.ErrUserNotFound.Error(), nil)


### PR DESCRIPTION
Backport b9f2e883b0bda0a77e63092e7f659e669462ec71 from #88117

---

### What happened?

Upon attempting to enable a user account, the system displays a success message; however, the user's status remains disabled.
