### PR TITLE
Alerting: Fix Recording Rules creation issues

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -6,7 +6,9 @@ import { PanelData, CoreApp, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
+import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 import { LokiQueryType } from 'app/plugins/datasource/loki/dataquery.gen';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -99,14 +101,19 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
   return (
     <>
       {queries.length && (
-        <QueryEditor
-          query={queries[0]}
-          queries={queries}
-          app={CoreApp.UnifiedAlerting}
-          onChange={handleChangedQuery}
-          onRunQuery={runQueries}
-          datasource={dataSource}
-        />
+        <>
+          <QueryEditor
+            query={queries[0]}
+            queries={queries}
+            app={CoreApp.UnifiedAlerting}
+            onChange={handleChangedQuery}
+            onRunQuery={runQueries}
+            datasource={dataSource}
+          />
+          {(data?.errors || []).map((err) => {
+            return <QueryErrorAlert key={err.message} error={err} />;
+          })}
+        </>
       )}
 
       {data && (

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -391,7 +391,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
           <RecordingRuleEditor
             dataSourceName={dataSourceName}
             queries={queries}
-            runQueries={runQueriesPreview}
+            runQueries={() => runQueriesPreview()}
             onChangeQuery={onChangeRecordingRulesQueries}
             panelData={queryPreviewData}
           />


### PR DESCRIPTION
### What is this feature?

Fixes three problems with creation of recording rules:
* When clicking the `Run query` button in recording rule UI, we were incorrectly passing the click event through to the `runQueriesPreview` method. We weren't getting a type error from this as [the typing for `onRunQuery`](https://github.com/grafana/grafana/blob/03311f6c6c65b9274fb2ef75e7577b67fceb081b/packages/grafana-data/src/types/datasource.ts#L437) is assuming that its `() => void`, but [the LokiQueryEditor passes the event out](https://github.com/grafana/grafana/blob/03311f6c6c65b9274fb2ef75e7577b67fceb081b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx#L187). I haven't touched those other components here though
* We weren't showing errors below the recording rule query editor, so any issues in the response from the API weren't being shown the user
* For Loki recording rules, the options weren't defaulting to the correct value for `queryType`. I've changed this to use `instant` when not set, and should otherwise fall back to the value from the actual query

### Who is this feature for? 

Alerting users who want to create Loki recording rules.
There are workaround to two of the issues - you can simply not click the `run query` button, and wait for the `onChange` handlers to run the query instead. You can also toggle the options between range/instant to get it to update correctly

### Special notes for your reviewer:
I haven't added tests here, as it became quite complex and a bit of a rabbit hole, involving adding multiple new MSW handlers, changing the datasource test setup, and removing a mock of the dynamic plugin imports logic. After all of that as well, there's another issue that I haven't solved with registration of custom monaco-editor commands.
The tests will be added in a followup PR