### PR TITLE
Table: Update selected row color

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -106,7 +106,7 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       defaultHeight: 400,
     },
     table: {
-      rowHoverBackground: colors.emphasize(colors.background.primary, 0.03),
+      rowHoverBackground: colors.emphasize(colors.background.primary, 0.075),
     },
   };
 }

--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -51,6 +51,7 @@ export interface ThemeComponents {
   };
   table: {
     rowHoverBackground: string;
+    rowSelected: string;
   };
 }
 
@@ -106,7 +107,8 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       defaultHeight: 400,
     },
     table: {
-      rowHoverBackground: colors.emphasize(colors.background.primary, 0.075),
+      rowHoverBackground: colors.action.hover,
+      rowSelected: colors.action.selected,
     },
   };
 }

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -271,7 +271,7 @@ export const RowsList = (props: RowsListProps) => {
       const rowExpanded = nestedDataField && tableState.expanded[row.id];
 
       if (rowHighlightIndex !== undefined && row.index === rowHighlightIndex) {
-        style = { ...style, backgroundColor: theme.components.table.rowHoverBackground };
+        style = { ...style, backgroundColor: theme.colors.background.canvas };
         additionalProps = {
           'aria-selected': 'true',
         };
@@ -350,7 +350,7 @@ export const RowsList = (props: RowsListProps) => {
       tableState.expanded,
       tableStyles,
       textWrapField,
-      theme.components.table.rowHoverBackground,
+      theme.colors.background.canvas,
       theme.typography.fontSize,
       theme.typography.body.lineHeight,
       timeRange,

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -271,7 +271,7 @@ export const RowsList = (props: RowsListProps) => {
       const rowExpanded = nestedDataField && tableState.expanded[row.id];
 
       if (rowHighlightIndex !== undefined && row.index === rowHighlightIndex) {
-        style = { ...style, backgroundColor: theme.colors.background.canvas };
+        style = { ...style, backgroundColor: theme.components.table.rowHoverBackground };
         additionalProps = {
           'aria-selected': 'true',
         };
@@ -350,7 +350,7 @@ export const RowsList = (props: RowsListProps) => {
       tableState.expanded,
       tableStyles,
       textWrapField,
-      theme.colors.background.canvas,
+      theme.components.table.rowHoverBackground,
       theme.typography.fontSize,
       theme.typography.body.lineHeight,
       timeRange,

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -271,7 +271,7 @@ export const RowsList = (props: RowsListProps) => {
       const rowExpanded = nestedDataField && tableState.expanded[row.id];
 
       if (rowHighlightIndex !== undefined && row.index === rowHighlightIndex) {
-        style = { ...style, backgroundColor: theme.components.table.rowHoverBackground };
+        style = { ...style, backgroundColor: theme.components.table.rowSelected };
         additionalProps = {
           'aria-selected': 'true',
         };

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -350,7 +350,7 @@ export const RowsList = (props: RowsListProps) => {
       tableState.expanded,
       tableStyles,
       textWrapField,
-      theme.components.table.rowHoverBackground,
+      theme.components.table.rowSelected,
       theme.typography.fontSize,
       theme.typography.body.lineHeight,
       timeRange,


### PR DESCRIPTION
**What is this feature?**
The current color 


Proposed:
![image](https://github.com/user-attachments/assets/74ec546a-e0e8-49da-a8f7-0823782d8dd6)
![image](https://github.com/user-attachments/assets/9bb47639-927b-4bd7-ae6d-a74282e7a1c2)
<img width="1716" alt="image" src="https://github.com/user-attachments/assets/21a4868e-3752-4508-ad12-c88498c8da4c">


Current:
![image](https://github.com/user-attachments/assets/139c83ed-28f5-4fa8-80b8-62134464887b)
![image](https://github.com/user-attachments/assets/20cfe498-5aa3-4bbe-b7a5-360ee82bee4d)
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/a2906688-6d45-4c1d-b729-a4cd85cf75e8">



**Why do we need this feature?**
Really hard to see which log line is currently selected.

**Who is this feature for?**
Users of table/ explore logs

**Special notes for your reviewer:**
Should we update the colors of the `theme.components.table.rowHoverBackground` to have a bit more contrast instead of using an existing color in our theme? Or is there something else we should use? Would love to hear your thoughts @nmarrs  @staton-hyse11 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
