### PR TITLE
Chore: Add more logs and tracing to hysteresis flows

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -387,8 +387,9 @@ func getExprRequest(ctx EvaluationContext, condition models.Condition, dsCacheSe
 					return nil, fmt.Errorf("recovery threshold '%s' is only allowed to be the alert condition", q.RefID)
 				}
 				if reader != nil {
-					logger.FromContext(ctx.Ctx).Debug("Detected hysteresis threshold command. Populating with the results")
-					err = q.PatchHysteresisExpression(reader.Read())
+					active := reader.Read()
+					logger.FromContext(ctx.Ctx).Debug("Detected hysteresis threshold command. Populating with the results", "items", len(active))
+					err = q.PatchHysteresisExpression(active)
 					if err != nil {
 						return nil, fmt.Errorf("failed to amend hysteresis command '%s': %w", q.RefID, err)
 					}


### PR DESCRIPTION
**What is this feature?**
This PR adds more breadcrumbs in code path used by the recovery threshold command, which should help in troubleshooting of potential problems with this expression.

**Why do we need this feature?**
Help to troubleshoot the recovery threshold

**Who is this feature for?**
Alerting users

**Which issue(s) does this PR fix?**:
Related https://github.com/grafana/grafana/issues/87226
