### PR TITLE
Alerting: Hide edit/view rule buttons according to deleting/creating state

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -1,13 +1,8 @@
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { render, userEvent, screen } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { setPluginExtensionsHook } from '@grafana/runtime';
 import { mockApi, setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { configureStore } from 'app/store/configureStore';
-import { CombinedRule } from 'app/types/unified-alerting';
 
 import { AlertRuleAction, useAlertRuleAbility } from '../../hooks/useAbilities';
 import { getCloudRule, getGrafanaRule, getMockPluginMeta } from '../../mocks';
@@ -36,18 +31,6 @@ const ui = {
   },
 };
 
-function renderRulesTable(rule: CombinedRule) {
-  const store = configureStore();
-
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <RulesTable rules={[rule]} />
-      </MemoryRouter>
-    </Provider>
-  );
-}
-
 const user = userEvent.setup();
 const server = setupMswServer();
 
@@ -57,6 +40,7 @@ describe('RulesTable RBAC', () => {
       ...getMockPluginMeta('grafana-incident-app', 'Grafana Incident'),
     });
   });
+
   describe('Grafana rules action buttons', () => {
     const grafanaRule = getGrafanaRule({ name: 'Grafana' });
 
@@ -64,7 +48,8 @@ describe('RulesTable RBAC', () => {
       mocks.useAlertRuleAbility.mockImplementation((_rule, action) => {
         return action === AlertRuleAction.Update ? [true, false] : [true, true];
       });
-      renderRulesTable(grafanaRule);
+
+      render(<RulesTable rules={[grafanaRule]} />);
 
       expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
     });
@@ -74,7 +59,8 @@ describe('RulesTable RBAC', () => {
         return action === AlertRuleAction.Delete ? [true, false] : [true, true];
       });
 
-      renderRulesTable(grafanaRule);
+      render(<RulesTable rules={[grafanaRule]} />);
+
       await user.click(ui.actionButtons.more.get());
 
       expect(ui.moreActionItems.delete.query()).not.toBeInTheDocument();
@@ -84,7 +70,8 @@ describe('RulesTable RBAC', () => {
       mocks.useAlertRuleAbility.mockImplementation((_rule, action) => {
         return action === AlertRuleAction.Update ? [true, true] : [false, false];
       });
-      renderRulesTable(grafanaRule);
+      render(<RulesTable rules={[grafanaRule]} />);
+
       expect(ui.actionButtons.edit.get()).toBeInTheDocument();
     });
 
@@ -93,11 +80,55 @@ describe('RulesTable RBAC', () => {
         return action === AlertRuleAction.Delete ? [true, true] : [false, false];
       });
 
-      renderRulesTable(grafanaRule);
+      render(<RulesTable rules={[grafanaRule]} />);
 
       expect(ui.actionButtons.more.get()).toBeInTheDocument();
       await user.click(ui.actionButtons.more.get());
       expect(ui.moreActionItems.delete.get()).toBeInTheDocument();
+    });
+
+    describe('rules in creating/deleting states', () => {
+      const { promRule, ...creatingRule } = grafanaRule;
+      const { rulerRule, ...deletingRule } = grafanaRule;
+      const rulesSource = 'grafana';
+
+      /**
+       * Preloaded state that implies the rulerRules have finished loading
+       *
+       * @todo Remove this state and test at a higher level to avoid mocking the store.
+       * We need to manually populate this, as the component hierarchy expects that we will
+       * have already called the necessary APIs to get the rulerRules data
+       */
+      const preloadedState = {
+        unifiedAlerting: { rulerRules: { [rulesSource]: { result: {}, loading: false, dispatched: true } } },
+      };
+
+      beforeEach(() => {
+        mocks.useAlertRuleAbility.mockImplementation(() => {
+          return [true, true];
+        });
+      });
+
+      it('does not render View button when rule is creating', async () => {
+        render(<RulesTable rules={[creatingRule]} />, {
+          // @ts-ignore
+          preloadedState,
+        });
+
+        expect(await screen.findByText('Creating')).toBeInTheDocument();
+        expect(ui.actionButtons.view.query()).not.toBeInTheDocument();
+      });
+
+      it('does not render View or Edit button when rule is deleting', async () => {
+        render(<RulesTable rules={[deletingRule]} />, {
+          // @ts-ignore
+          preloadedState,
+        });
+
+        expect(await screen.findByText('Deleting')).toBeInTheDocument();
+        expect(ui.actionButtons.view.query()).not.toBeInTheDocument();
+        expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -109,7 +140,8 @@ describe('RulesTable RBAC', () => {
         return action === AlertRuleAction.Update ? [true, false] : [true, true];
       });
 
-      renderRulesTable(cloudRule);
+      render(<RulesTable rules={[cloudRule]} />);
+
       expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
     });
 
@@ -118,7 +150,8 @@ describe('RulesTable RBAC', () => {
         return action === AlertRuleAction.Delete ? [true, false] : [true, true];
       });
 
-      renderRulesTable(cloudRule);
+      render(<RulesTable rules={[cloudRule]} />);
+
       await user.click(ui.actionButtons.more.get());
       expect(ui.moreActionItems.delete.query()).not.toBeInTheDocument();
     });
@@ -128,7 +161,8 @@ describe('RulesTable RBAC', () => {
         return action === AlertRuleAction.Update ? [true, true] : [false, false];
       });
 
-      renderRulesTable(cloudRule);
+      render(<RulesTable rules={[cloudRule]} />);
+
       expect(ui.actionButtons.edit.get()).toBeInTheDocument();
     });
 
@@ -137,7 +171,8 @@ describe('RulesTable RBAC', () => {
         return action === AlertRuleAction.Delete ? [true, true] : [false, false];
       });
 
-      renderRulesTable(cloudRule);
+      render(<RulesTable rules={[cloudRule]} />);
+
       await user.click(ui.actionButtons.more.get());
       expect(ui.moreActionItems.delete.get()).toBeInTheDocument();
     });


### PR DESCRIPTION
**What is this feature?**

Updates the rule action buttons to render accordingly:
* If the rule is deleting, don't show view or edit
  * edit should already have been hidden from view in this case, due to `rulerRule` checks in the action buttons. It won't refresh within a given session, as we don't clear the `rulerRule` from memory, but on a fresh load, if a rule is deleting, it should hide the edit button
* If the rule is creating, don't show view

**Why do we need this feature?**

In Cloud instances, it may take up to a minute for rule additions / deletions to be propagated in the Prometheus rule status endpoints. This means that it can take a while before a rule is completed "deleted" or "created". In these scenarios, the easiest fix to ensure a predictable UI is to not allow the user to view the alert details.
Similarly, if a rule is being deleted, users probably shouldn't be able to edit the definition

**Who is this feature for?**

Alerting users on Cloud ruler
