### PR TITLE
ResourceServer: Update twice should return an ErrOptimisticLockingFailed

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -338,6 +338,10 @@ func (s *server) Update(ctx context.Context, req *UpdateRequest) (*UpdateRespons
 		return nil, apierrors.NewBadRequest("current value does not exist")
 	}
 
+	if req.ResourceVersion > 0 && latest.ResourceVersion != req.ResourceVersion {
+		return nil, ErrOptimisticLockingFailed
+	}
+
 	builder, err := s.newEventBuilder(ctx, req.Key, req.Value, latest.Value)
 	if err != nil {
 		rsp.Status, err = errToStatus(err)


### PR DESCRIPTION
**What is this feature?**
Add a check to ensure updates returns an ErrOptimisticLockingFailed error when the same object is updated twice.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
