### PR TITLE
Explore: Add setting for default time offset

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1493,6 +1493,9 @@ max_annotations_to_keep =
 # Enable the Explore section
 enabled = true
 
+# set the default offset for the time picker
+defaultTimeOffset = 1h
+
 #################################### Help #############################
 [help]
 # Enable the Help section

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1777,6 +1777,11 @@ For more information about this feature, refer to [Explore]({{< relref "../../ex
 
 Enable or disable the Explore section. Default is `enabled`.
 
+### defaultTimeOffset
+
+Set a default time offset from now on the time picker. Default is 1 hour.
+This setting should be expressed as a duration. Examples: 1h (hour), 1d (day), 1w (week), 1M (month).
+
 ## [help]
 
 Configures the help section.

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -233,6 +233,7 @@ export interface GrafanaConfig {
   listDashboardScopesEndpoint?: string;
   listScopesEndpoint?: string;
   reportingStaticContext?: Record<string, string>;
+  exploreDefaultTimeOffset?: string;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -178,6 +178,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   localFileSystemAvailable: boolean | undefined;
   cloudMigrationIsTarget: boolean | undefined;
   reportingStaticContext?: Record<string, string>;
+  exploreDefaultTimeOffset = '1h';
 
   /**
    * Language used in Grafana's UI. This is after the user's preference (or deteceted locale) is resolved to one of

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -203,6 +203,7 @@ type FrontendSettingsDTO struct {
 	TrustedTypesDefaultPolicyEnabled    bool     `json:"trustedTypesDefaultPolicyEnabled"`
 	CSPReportOnlyEnabled                bool     `json:"cspReportOnlyEnabled"`
 	DisableFrontendSandboxForPlugins    []string `json:"disableFrontendSandboxForPlugins"`
+	ExploreDefaultTimeOffset			string	 `json:"exploreDefaultTimeOffset"`
 
 	Auth FrontendSettingsAuthDTO `json:"auth"`
 

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -203,7 +203,7 @@ type FrontendSettingsDTO struct {
 	TrustedTypesDefaultPolicyEnabled    bool     `json:"trustedTypesDefaultPolicyEnabled"`
 	CSPReportOnlyEnabled                bool     `json:"cspReportOnlyEnabled"`
 	DisableFrontendSandboxForPlugins    []string `json:"disableFrontendSandboxForPlugins"`
-	ExploreDefaultTimeOffset			string	 `json:"exploreDefaultTimeOffset"`
+	ExploreDefaultTimeOffset            string   `json:"exploreDefaultTimeOffset"`
 
 	Auth FrontendSettingsAuthDTO `json:"auth"`
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -227,7 +227,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		RootFolderUID:                       accesscontrol.GeneralFolderUID,
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,
 		ReportingStaticContext:              hs.Cfg.ReportingStaticContext,
-		ExploreDefaultTimeOffset:			hs.Cfg.ExploreDefaultTimeOffset,
+		ExploreDefaultTimeOffset:            hs.Cfg.ExploreDefaultTimeOffset,
 
 		BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
 			HideVersion:   hideVersion,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -227,6 +227,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		RootFolderUID:                       accesscontrol.GeneralFolderUID,
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,
 		ReportingStaticContext:              hs.Cfg.ReportingStaticContext,
+		ExploreDefaultTimeOffset:			hs.Cfg.ExploreDefaultTimeOffset,
 
 		BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
 			HideVersion:   hideVersion,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -514,6 +514,7 @@ type Cfg struct {
 
 	// Explore UI
 	ExploreEnabled bool
+	ExploreDefaultTimeOffset string
 
 	// Help UI
 	HelpEnabled bool
@@ -1172,6 +1173,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	explore := iniFile.Section("explore")
 	cfg.ExploreEnabled = explore.Key("enabled").MustBool(true)
+	cfg.ExploreDefaultTimeOffset = explore.Key("defaultTimeOffset").MustString("1h")
 
 	help := iniFile.Section("help")
 	cfg.HelpEnabled = help.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1173,7 +1173,14 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 	explore := iniFile.Section("explore")
 	cfg.ExploreEnabled = explore.Key("enabled").MustBool(true)
-	cfg.ExploreDefaultTimeOffset = explore.Key("defaultTimeOffset").MustString("1h")
+
+	exploreDefaultTimeOffset := valueAsString(explore, "defaultTimeOffset", "1h")
+	// we want to ensure the value parses as a duration, but we send it forward as a string to the frontend
+	if _, err := gtime.ParseDuration(exploreDefaultTimeOffset); err != nil {
+		return err
+	} else {
+		cfg.ExploreDefaultTimeOffset = exploreDefaultTimeOffset
+	}
 
 	help := iniFile.Section("help")
 	cfg.HelpEnabled = help.Key("enabled").MustBool(true)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -513,7 +513,7 @@ type Cfg struct {
 	AlertingMinInterval         int64
 
 	// Explore UI
-	ExploreEnabled bool
+	ExploreEnabled           bool
 	ExploreDefaultTimeOffset string
 
 	// Help UI

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -20,7 +20,7 @@ import {
   URLRange,
   URLRangeValue,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { DataQuery, DataSourceJsonData, DataSourceRef, TimeZone } from '@grafana/schema';
 import { getLocalRichHistoryStorage } from 'app/core/history/richHistoryStorageProvider';
 import { SortOrder } from 'app/core/utils/richHistory';
@@ -36,7 +36,7 @@ import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 export const MAX_HISTORY_AUTOCOMPLETE_ITEMS = 100;
 
 export const DEFAULT_RANGE = {
-  from: 'now-1h',
+  from: `now-${config.exploreDefaultTimeOffset}`,
   to: 'now',
 };
 


### PR DESCRIPTION
**What is this feature?**

Adds a configuration setting for the default time offset in Explore.

**Why do we need this feature?**

Different underlying data could require different sensible defaults. The default time range for Explore now is 1 hour, but some may find that consistently returning an unusable amount of data - either way too much or way too little. 

This allows an administrator to set a different default that makes sense for their data.

**Which issue(s) does this PR fix?**:

Fixes #77764

**Special notes for your reviewer:**

There is validation for the value to ensure it is a duration. The server will not start if it is an invalid value.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
