### PR TITLE
[v11.1.x] Automation: Verify DEB and RPM packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2957,6 +2957,130 @@ volumes:
 ---
 clone:
   retries: 3
+depends_on: []
+image_pull_secrets:
+- gcr
+- gar
+kind: pipeline
+name: verify-linux-packages
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - 'echo "Step 1: Updating package lists..."'
+  - apt-get update >/dev/null 2>&1
+  - 'echo "Step 2: Installing prerequisites..."'
+  - DEBIAN_FRONTEND=noninteractive apt-get install -yq apt-transport-https software-properties-common
+    wget >/dev/null 2>&1
+  - 'echo "Step 3: Adding Grafana GPG key..."'
+  - mkdir -p /etc/apt/keyrings/
+  - wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg
+    > /dev/null
+  - 'echo "Step 4: Adding Grafana repository..."'
+  - echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable
+    main" | tee -a /etc/apt/sources.list.d/grafana.list
+  - 'echo "Step 5: Installing Grafana..."'
+  - for i in $(seq 1 10); do
+  - '    if apt-get update >/dev/null 2>&1 && DEBIAN_FRONTEND=noninteractive apt-get
+    install -yq grafana=${TAG} >/dev/null 2>&1; then'
+  - '        echo "Command succeeded on attempt $i"'
+  - '        break'
+  - '    else'
+  - '        echo "Attempt $i failed"'
+  - '        if [ $i -eq 10 ]; then'
+  - '            echo ''All attempts failed'''
+  - '            exit 1'
+  - '        fi'
+  - '        echo "Waiting 60 seconds before next attempt..."'
+  - '        sleep 60'
+  - '    fi'
+  - done
+  - 'echo "Step 6: Verifying Grafana installation..."'
+  - 'if dpkg -s grafana | grep -q "Version: ${TAG}"; then'
+  - '    echo "Successfully verified Grafana version ${TAG}"'
+  - else
+  - '    echo "Failed to verify Grafana version ${TAG}"'
+  - '    exit 1'
+  - fi
+  - echo "Verification complete."
+  depends_on: []
+  environment: {}
+  image: ubuntu:22.04
+  name: verify-linux-DEB-packages
+- commands:
+  - 'echo "Step 1: Updating package lists..."'
+  - dnf check-update -y >/dev/null 2>&1 || true
+  - 'echo "Step 2: Installing prerequisites..."'
+  - dnf install -y dnf-utils >/dev/null 2>&1
+  - 'echo "Step 3: Adding Grafana GPG key..."'
+  - rpm --import https://rpm.grafana.com/gpg.key
+  - 'echo "Step 4: Configuring Grafana repository..."'
+  - |-
+    echo '[grafana]
+    name=grafana
+    baseurl=https://rpm.grafana.com
+    repo_gpgcheck=0
+    enabled=1
+    gpgcheck=0
+    gpgkey=https://rpm.grafana.com/gpg.key
+    sslverify=1
+    sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+    ' > /etc/yum.repos.d/grafana.repo
+  - 'echo "Step 5: Checking RPM repository..."'
+  - dnf list available grafana-${TAG}
+  - if [ $? -eq 0 ]; then
+  - '    echo "Grafana package found in repository. Installing from repo..."'
+  - for i in $(seq 1 5); do
+  - '    if dnf install -y --nogpgcheck grafana-${TAG} >/dev/null 2>&1; then'
+  - '        echo "Command succeeded on attempt $i"'
+  - '        break'
+  - '    else'
+  - '        echo "Attempt $i failed"'
+  - '        if [ $i -eq 5 ]; then'
+  - '            echo ''All attempts failed'''
+  - '            exit 1'
+  - '        fi'
+  - '        echo "Waiting 60 seconds before next attempt..."'
+  - '        sleep 60'
+  - '    fi'
+  - done
+  - '    echo "Verifying GPG key..."'
+  - '    rpm --import https://rpm.grafana.com/gpg.key'
+  - '    rpm -qa gpg-pubkey* | xargs rpm -qi | grep -i grafana'
+  - else
+  - '    echo "Grafana package version ${TAG} not found in repository."'
+  - '    dnf repolist'
+  - '    dnf list available grafana*'
+  - '    exit 1'
+  - fi
+  - 'echo "Step 6: Verifying Grafana installation..."'
+  - if rpm -q grafana | grep -q "${TAG}"; then
+  - '    echo "Successfully verified Grafana version ${TAG}"'
+  - else
+  - '    echo "Failed to verify Grafana version ${TAG}"'
+  - '    exit 1'
+  - fi
+  - echo "Verification complete."
+  depends_on: []
+  environment: {}
+  image: rockylinux:9
+  name: verify-linux-RPM-packages
+trigger:
+  event:
+  - promote
+  target: verify-linux-packages
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
 depends_on:
 - publish-artifacts-public
 - publish-docker-public
@@ -3023,6 +3147,107 @@ steps:
     service_account_json:
       from_secret: packages_service_account
     target_bucket: grafana-packages
+- commands:
+  - 'echo "Step 1: Updating package lists..."'
+  - apt-get update >/dev/null 2>&1
+  - 'echo "Step 2: Installing prerequisites..."'
+  - DEBIAN_FRONTEND=noninteractive apt-get install -yq apt-transport-https software-properties-common
+    wget >/dev/null 2>&1
+  - 'echo "Step 3: Adding Grafana GPG key..."'
+  - mkdir -p /etc/apt/keyrings/
+  - wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg
+    > /dev/null
+  - 'echo "Step 4: Adding Grafana repository..."'
+  - echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable
+    main" | tee -a /etc/apt/sources.list.d/grafana.list
+  - 'echo "Step 5: Installing Grafana..."'
+  - for i in $(seq 1 10); do
+  - '    if apt-get update >/dev/null 2>&1 && DEBIAN_FRONTEND=noninteractive apt-get
+    install -yq grafana=${TAG} >/dev/null 2>&1; then'
+  - '        echo "Command succeeded on attempt $i"'
+  - '        break'
+  - '    else'
+  - '        echo "Attempt $i failed"'
+  - '        if [ $i -eq 10 ]; then'
+  - '            echo ''All attempts failed'''
+  - '            exit 1'
+  - '        fi'
+  - '        echo "Waiting 60 seconds before next attempt..."'
+  - '        sleep 60'
+  - '    fi'
+  - done
+  - 'echo "Step 6: Verifying Grafana installation..."'
+  - 'if dpkg -s grafana | grep -q "Version: ${TAG}"; then'
+  - '    echo "Successfully verified Grafana version ${TAG}"'
+  - else
+  - '    echo "Failed to verify Grafana version ${TAG}"'
+  - '    exit 1'
+  - fi
+  - echo "Verification complete."
+  depends_on:
+  - publish-linux-packages-deb
+  environment: {}
+  image: ubuntu:22.04
+  name: verify-linux-DEB-packages
+- commands:
+  - 'echo "Step 1: Updating package lists..."'
+  - dnf check-update -y >/dev/null 2>&1 || true
+  - 'echo "Step 2: Installing prerequisites..."'
+  - dnf install -y dnf-utils >/dev/null 2>&1
+  - 'echo "Step 3: Adding Grafana GPG key..."'
+  - rpm --import https://rpm.grafana.com/gpg.key
+  - 'echo "Step 4: Configuring Grafana repository..."'
+  - |-
+    echo '[grafana]
+    name=grafana
+    baseurl=https://rpm.grafana.com
+    repo_gpgcheck=0
+    enabled=1
+    gpgcheck=0
+    gpgkey=https://rpm.grafana.com/gpg.key
+    sslverify=1
+    sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+    ' > /etc/yum.repos.d/grafana.repo
+  - 'echo "Step 5: Checking RPM repository..."'
+  - dnf list available grafana-${TAG}
+  - if [ $? -eq 0 ]; then
+  - '    echo "Grafana package found in repository. Installing from repo..."'
+  - for i in $(seq 1 5); do
+  - '    if dnf install -y --nogpgcheck grafana-${TAG} >/dev/null 2>&1; then'
+  - '        echo "Command succeeded on attempt $i"'
+  - '        break'
+  - '    else'
+  - '        echo "Attempt $i failed"'
+  - '        if [ $i -eq 5 ]; then'
+  - '            echo ''All attempts failed'''
+  - '            exit 1'
+  - '        fi'
+  - '        echo "Waiting 60 seconds before next attempt..."'
+  - '        sleep 60'
+  - '    fi'
+  - done
+  - '    echo "Verifying GPG key..."'
+  - '    rpm --import https://rpm.grafana.com/gpg.key'
+  - '    rpm -qa gpg-pubkey* | xargs rpm -qi | grep -i grafana'
+  - else
+  - '    echo "Grafana package version ${TAG} not found in repository."'
+  - '    dnf repolist'
+  - '    dnf list available grafana*'
+  - '    exit 1'
+  - fi
+  - 'echo "Step 6: Verifying Grafana installation..."'
+  - if rpm -q grafana | grep -q "${TAG}"; then
+  - '    echo "Successfully verified Grafana version ${TAG}"'
+  - else
+  - '    echo "Failed to verify Grafana version ${TAG}"'
+  - '    exit 1'
+  - fi
+  - echo "Verification complete."
+  depends_on:
+  - publish-linux-packages-rpm
+  environment: {}
+  image: rockylinux:9
+  name: verify-linux-RPM-packages
 - commands:
   - ./bin/build publish grafana-com --edition oss ${DRONE_TAG}
   depends_on:
@@ -4730,6 +4955,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM cypress/included:13.10.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM jwilder/dockerize:0.6.1
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM koalaman/shellcheck:stable
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM rockylinux:9
   depends_on:
   - authenticate-gcr
   image: aquasec/trivy:0.21.0
@@ -4765,6 +4991,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL cypress/included:13.10.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL jwilder/dockerize:0.6.1
   - trivy --exit-code 1 --severity HIGH,CRITICAL koalaman/shellcheck:stable
+  - trivy --exit-code 1 --severity HIGH,CRITICAL rockylinux:9
   depends_on:
   - authenticate-gcr
   environment:
@@ -4996,6 +5223,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: db626ee0a4585a9279be18e92a85af639385bc723af50c154d5341ff66479f54
+hmac: b5fcc6ae02e0b3367e4153e1e64bf599e934a75be2db574b805606204aa4d2d4
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -22,6 +22,8 @@ load(
     "verify_gen_cue_step",
     "verify_gen_jsonnet_step",
     "verify_grafanacom_step",
+    "verify_linux_DEB_packages_step",
+    "verify_linux_RPM_packages_step",
     "wire_install_step",
     "yarn_install_step",
 )
@@ -203,6 +205,8 @@ def publish_packages_pipeline():
         compile_build_cmd(),
         publish_linux_packages_step(package_manager = "deb"),
         publish_linux_packages_step(package_manager = "rpm"),
+        verify_linux_DEB_packages_step(depends_on = ["publish-linux-packages-deb"]),
+        verify_linux_RPM_packages_step(depends_on = ["publish-linux-packages-rpm"]),
         publish_grafanacom_step(ver_mode = "release"),
         verify_grafanacom_step(),
     ]
@@ -221,6 +225,17 @@ def publish_packages_pipeline():
             },
             steps = [
                 verify_grafanacom_step(depends_on = []),
+            ],
+        ),
+        pipeline(
+            name = "verify-linux-packages",
+            trigger = {
+                "event": ["promote"],
+                "target": "verify-linux-packages",
+            },
+            steps = [
+                verify_linux_DEB_packages_step(),
+                verify_linux_RPM_packages_step(),
             ],
         ),
         pipeline(

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1202,6 +1202,110 @@ def publish_linux_packages_step(package_manager = "deb"):
         },
     }
 
+def retry_command(command, attempts = 5, delay = 60):
+    return [
+        "for i in $(seq 1 %d); do" % attempts,
+        "    if %s; then" % command,
+        '        echo "Command succeeded on attempt $i"',
+        "        break",
+        "    else",
+        '        echo "Attempt $i failed"',
+        "        if [ $i -eq %d ]; then" % attempts,
+        "            echo 'All attempts failed'",
+        "            exit 1",
+        "        fi",
+        '        echo "Waiting %d seconds before next attempt..."' % delay,
+        "        sleep %d" % delay,
+        "    fi",
+        "done",
+    ]
+
+def verify_linux_DEB_packages_step(depends_on = []):
+    install_command = "apt-get update >/dev/null 2>&1 && DEBIAN_FRONTEND=noninteractive apt-get install -yq grafana=${TAG} >/dev/null 2>&1"
+
+    return {
+        "name": "verify-linux-DEB-packages",
+        "image": images["ubuntu"],
+        "environment": {},
+        "commands": [
+            'echo "Step 1: Updating package lists..."',
+            "apt-get update >/dev/null 2>&1",
+            'echo "Step 2: Installing prerequisites..."',
+            "DEBIAN_FRONTEND=noninteractive apt-get install -yq apt-transport-https software-properties-common wget >/dev/null 2>&1",
+            'echo "Step 3: Adding Grafana GPG key..."',
+            "mkdir -p /etc/apt/keyrings/",
+            "wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | tee /etc/apt/keyrings/grafana.gpg > /dev/null",
+            'echo "Step 4: Adding Grafana repository..."',
+            'echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | tee -a /etc/apt/sources.list.d/grafana.list',
+            'echo "Step 5: Installing Grafana..."',
+            # The packages take a bit of time to propogate within the repo. This retry will check their availability within 10 minutes.
+        ] + retry_command(install_command, attempts = 10) + [
+            'echo "Step 6: Verifying Grafana installation..."',
+            'if dpkg -s grafana | grep -q "Version: ${TAG}"; then',
+            '    echo "Successfully verified Grafana version ${TAG}"',
+            "else",
+            '    echo "Failed to verify Grafana version ${TAG}"',
+            "    exit 1",
+            "fi",
+            'echo "Verification complete."',
+        ],
+        "depends_on": depends_on,
+    }
+
+def verify_linux_RPM_packages_step(depends_on = []):
+    repo_config = (
+        "[grafana]\n" +
+        "name=grafana\n" +
+        "baseurl=https://rpm.grafana.com\n" +
+        "repo_gpgcheck=0\n" +  # Change this to 0
+        "enabled=1\n" +
+        "gpgcheck=0\n" +  # Change this to 0
+        "gpgkey=https://rpm.grafana.com/gpg.key\n" +
+        "sslverify=1\n" +
+        "sslcacert=/etc/pki/tls/certs/ca-bundle.crt\n"
+    )
+
+    repo_install_command = "dnf install -y --nogpgcheck grafana-${TAG} >/dev/null 2>&1"
+
+    return {
+        "name": "verify-linux-RPM-packages",
+        "image": images["rocky"],
+        "environment": {},
+        "commands": [
+            'echo "Step 1: Updating package lists..."',
+            "dnf check-update -y >/dev/null 2>&1 || true",
+            'echo "Step 2: Installing prerequisites..."',
+            "dnf install -y dnf-utils >/dev/null 2>&1",
+            'echo "Step 3: Adding Grafana GPG key..."',
+            "rpm --import https://rpm.grafana.com/gpg.key",
+            'echo "Step 4: Configuring Grafana repository..."',
+            "echo '" + repo_config + "' > /etc/yum.repos.d/grafana.repo",
+            'echo "Step 5: Checking RPM repository..."',
+            "dnf list available grafana-${TAG}",
+            "if [ $? -eq 0 ]; then",
+            '    echo "Grafana package found in repository. Installing from repo..."',
+        ] + retry_command(repo_install_command, attempts = 5) + [
+            '    echo "Verifying GPG key..."',
+            "    rpm --import https://rpm.grafana.com/gpg.key",
+            "    rpm -qa gpg-pubkey* | xargs rpm -qi | grep -i grafana",
+            "else",
+            '    echo "Grafana package version ${TAG} not found in repository."',
+            "    dnf repolist",
+            "    dnf list available grafana*",
+            "    exit 1",
+            "fi",
+            'echo "Step 6: Verifying Grafana installation..."',
+            'if rpm -q grafana | grep -q "${TAG}"; then',
+            '    echo "Successfully verified Grafana version ${TAG}"',
+            "else",
+            '    echo "Failed to verify Grafana version ${TAG}"',
+            "    exit 1",
+            "fi",
+            'echo "Verification complete."',
+        ],
+        "depends_on": depends_on,
+    }
+
 def verify_gen_cue_step():
     return {
         "name": "verify-gen-cue",

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -34,4 +34,5 @@ images = {
     "cypress": "cypress/included:13.10.0",
     "dockerize": "jwilder/dockerize:0.6.1",
     "shellcheck": "koalaman/shellcheck:stable",
+    "rocky": "rockylinux:9",
 }


### PR DESCRIPTION
Backport d781ec2daab70e5cbd4d1a0630c23a2e1ea22e4c from #90146

---

**What is this feature?**

This automates the validation of the Debian and RPM Grafana artifacts.

**Why do we need this feature?**

It makes dev's lives easier.

**Who is this feature for?**

Grafana devs who build/release/distribute Grafana.

**Which issue(s) does this PR fix?**:

Fixes [this](https://github.com/grafana/grafana-release/issues/1066)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
