### PR TITLE
Table: Support one click data links

### DIFF
--- a/packages/grafana-schema/src/raw/composable/table/panelcfg/x/TablePanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/table/panelcfg/x/TablePanelCfg_types.gen.ts
@@ -26,6 +26,10 @@ export interface Options {
    */
   frameIndex: number;
   /**
+   * Controls one click data link functionality
+   */
+  oneClickLinks?: boolean;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -16,7 +16,19 @@ import { TableCellProps, CustomCellRendererProps, TableCellOptions } from './typ
 import { getCellColors, getCellOptions } from './utils';
 
 export const DefaultCell = (props: TableCellProps) => {
-  const { field, cell, tableStyles, row, cellProps, frame, rowStyled, rowExpanded, textWrapped, height } = props;
+  const {
+    field,
+    cell,
+    tableStyles,
+    row,
+    cellProps,
+    frame,
+    rowStyled,
+    rowExpanded,
+    textWrapped,
+    height,
+    oneClickLinks,
+  } = props;
 
   const inspectEnabled = Boolean(field.config.custom?.inspect);
   const displayValue = field.display!(cell.value);
@@ -83,6 +95,9 @@ export const DefaultCell = (props: TableCellProps) => {
     cellProps.style = { ...cellProps.style, textWrap: 'wrap' };
   }
 
+  // currently struggling to figure out how to pass this prop into the cell context...
+  console.log(oneClickLinks, 'oneClickLinks');
+
   return (
     <div
       {...cellProps}
@@ -95,7 +110,7 @@ export const DefaultCell = (props: TableCellProps) => {
       {hasLinks && (
         <DataLinksContextMenu links={() => getCellLinks(field, row) || []}>
           {(api) => {
-            if (api.openMenu) {
+            if (api.openMenu && !oneClickLinks) {
               return (
                 <button
                   className={cx(clearButtonStyle, getLinkStyle(tableStyles, cellOptions, api.targetClassName))}

--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -58,6 +58,7 @@ export const Table = memo((props: Props) => {
     enableSharedCrosshair = false,
     initialRowIndex = undefined,
     fieldConfig,
+    oneClickLinks = false,
   } = props;
 
   const listRef = useRef<VariableSizeList>(null);
@@ -115,8 +116,8 @@ export const Table = memo((props: Props) => {
 
   // React-table column definitions
   const memoizedColumns = useMemo(
-    () => getColumns(data, width, columnMinWidth, hasNestedData, footerItems, isCountRowsSet),
-    [data, width, columnMinWidth, footerItems, hasNestedData, isCountRowsSet]
+    () => getColumns(data, width, columnMinWidth, hasNestedData, oneClickLinks, footerItems, isCountRowsSet),
+    [data, width, columnMinWidth, footerItems, hasNestedData, isCountRowsSet, oneClickLinks]
   );
 
   // we need a ref to later store the `toggleAllRowsExpanded` function, returned by `useTable`.

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -100,6 +100,7 @@ export interface Props {
   // The index of the field value that the table will initialize scrolled to
   initialRowIndex?: number;
   fieldConfig?: FieldConfigSource;
+  oneClickLinks?: boolean;
 }
 
 /**

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -82,6 +82,7 @@ export function getColumns(
   availableWidth: number,
   columnMinWidth: number,
   expander: boolean,
+  oneClickLinks: boolean,
   footerValues?: FooterItem[],
   isCountRowsSet?: boolean
 ): GrafanaTableColumn[] {

--- a/public/app/core/components/OptionsUI/links.tsx
+++ b/public/app/core/components/OptionsUI/links.tsx
@@ -4,12 +4,14 @@ import { DataLinksInlineEditor } from '@grafana/ui';
 type Props = StandardEditorProps<DataLink[], DataLinksFieldConfigSettings>;
 
 export const DataLinksValueEditor = ({ value, onChange, context }: Props) => {
+  // Ideally we can implement the one-click toggle here but I'm not sure how to do it
   return (
     <DataLinksInlineEditor
       links={value}
       onChange={onChange}
       data={context.data}
       getSuggestions={() => (context.getSuggestions ? context.getSuggestions(VariableSuggestionsScope.Values) : [])}
+      oneClickEnabled={context.options?.oneClickLinks}
     />
   );
 };

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -63,6 +63,7 @@ export function TablePanel(props: Props) {
       timeRange={timeRange}
       enableSharedCrosshair={config.featureToggles.tableSharedCrosshair && enableSharedCrosshair}
       fieldConfig={fieldConfig}
+      oneClickLinks={options.oneClickLinks}
     />
   );
 

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -176,6 +176,15 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
         path: 'footer.enablePagination',
         name: 'Enable pagination',
         editor: PaginationEditor,
+      })
+      .addCustomEditor({
+        id: 'enableOneClick',
+        path: 'oneClickLinks',
+        name: 'One-click data links',
+        description:
+          'When enabled and there are multiple data links, the first data link will open with a single click',
+        editor: standardEditorsRegistry.get('boolean').editor,
+        defaultValue: false,
       });
   })
   .setSuggestionsSupplier(new TableSuggestionsSupplier());

--- a/public/app/plugins/panel/table/panelcfg.cue
+++ b/public/app/plugins/panel/table/panelcfg.cue
@@ -44,6 +44,8 @@ composableKinds: PanelCfg: {
 					}
 					// Controls the height of the rows
 					cellHeight?: ui.TableCellHeight & (*"sm" | _)
+					// Controls one click data link functionality
+					oneClickLinks?: bool
 				} @cuetsy(kind="interface")
 				FieldConfig: {
 					ui.TableFieldOptions

--- a/public/app/plugins/panel/table/panelcfg.gen.ts
+++ b/public/app/plugins/panel/table/panelcfg.gen.ts
@@ -24,6 +24,10 @@ export interface Options {
    */
   frameIndex: number;
   /**
+   * Controls one click data link functionality
+   */
+  oneClickLinks?: boolean;
+  /**
    * Controls whether the panel should show the header
    */
   showHeader: boolean;


### PR DESCRIPTION
Rough WIP

While implementing this it occurred to me that perhaps we do not need to support one-click datalink functionality for table as it currently already has support (provided you add a single data link). Even for the data link cell type each link is accessible via a single click...

Similar concept for panels such as piechart that also have "one-click" capability already enabled

Digging into this code though it is apparent that there will be some challenges in adding support to other panels as it will most likely mean modifying the shared data link editor that is shared across all visualizations

<img width="1340" alt="Screenshot 2024-07-12 at 5 35 48 PM" src="https://github.com/user-attachments/assets/029047c2-4bab-4c05-becc-adbc6b9447a1">
