### PR TITLE
Elasticsearch: Decouple backend from infra/http

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch_test.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/httpclient"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
 

--- a/pkg/tsdb/elasticsearch/healthcheck_test.go
+++ b/pkg/tsdb/elasticsearch/healthcheck_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 	"github.com/stretchr/testify/assert"
@@ -61,7 +61,7 @@ type FakeInstanceManager struct {
 }
 
 func (fakeInstanceManager *FakeInstanceManager) Get(tx context.Context, pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
-	httpClient, _ := sdkhttpclient.New(sdkhttpclient.Options{})
+	httpClient, _ := httpclient.New(httpclient.Options{})
 	httpClient.Transport = &FakeRoundTripper{isDsHealthy: fakeInstanceManager.isDsHealthy}
 
 	return es.DatasourceInfo{


### PR DESCRIPTION
**What is this feature?**

This PR removes the Elasticsearch datasource's dependency on `infra/http`.

This is the first of three PRs to decouple the Elasticsearch plugin from core grafana imports, part of #72632. For ease of review I've split this into several PRs and targeted them as a chain (`main <- PR 1 <- PR 2 <- PR 3`) but I'll rebase and retarget them as each is merged in turn.

**Why do we need this feature?**
Removing core imports is part of the process of externalizing the plugin. See #72632 for more information.