### PR TITLE
Docs: Improve Keycloak configuration steps

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
@@ -100,6 +100,14 @@ editor
 viewer
 ```
 
+4. Add the _client roles_ mapper to the dedicated client scope with
+   the following settings:
+
+- Token Claim Name: `roles`
+- Add to ID token: `ON`
+
+This allows Grafana to extract the roles from the ID token.
+
 ## Teamsync
 
 {{% admonition type="note" %}}

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/keycloak/index.md
@@ -103,8 +103,8 @@ viewer
 4. Add the _client roles_ mapper to the dedicated client scope with
    the following settings:
 
-- Token Claim Name: `roles`
-- Add to ID token: `ON`
+    - Token Claim Name: `roles`
+    - Add to ID token: `ON`
 
 This allows Grafana to extract the roles from the ID token.
 


### PR DESCRIPTION
The latest available Keycloak version (v25) doesn't add the roles to the ID token. Thus Grafana is not able to extract the roles.

This commit improves the docs by adding a step which explains how to include the roles in the ID token.

---

Please check that:
- [x] **(not applicable)** It works as expected from a user's perspective.
- [x] **(not applicable)** If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
