### PR TITLE
Query Library: Use current namespace when calling API

### DIFF
--- a/pkg/registry/apis/peakq/register.go
+++ b/pkg/registry/apis/peakq/register.go
@@ -31,9 +31,6 @@ func NewPeakQAPIBuilder() *PeakQAPIBuilder {
 }
 
 func RegisterAPIService(features featuremgmt.FeatureToggles, apiregistration builder.APIRegistrar, reg prometheus.Registerer) *PeakQAPIBuilder {
-	if !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) {
-		return nil // skip registration unless opting into experimental apis
-	}
 	builder := NewPeakQAPIBuilder()
 	apiregistration.RegisterAPI(NewPeakQAPIBuilder())
 	return builder

--- a/pkg/registry/apis/peakq/register.go
+++ b/pkg/registry/apis/peakq/register.go
@@ -31,7 +31,7 @@ func NewPeakQAPIBuilder() *PeakQAPIBuilder {
 }
 
 func RegisterAPIService(features featuremgmt.FeatureToggles, apiregistration builder.APIRegistrar, reg prometheus.Registerer) *PeakQAPIBuilder {
-	if !(features.IsEnabledGlobally(featuremgmt.FlagQueryService) ||
+	if !((features.IsEnabledGlobally(featuremgmt.FlagQueryService) && features.IsEnabledGlobally(featuremgmt.FlagQueryLibrary)) ||
 		features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs)) {
 		return nil // skip registration unless explicitly added (or all experimental are added)
 	}

--- a/pkg/registry/apis/peakq/register.go
+++ b/pkg/registry/apis/peakq/register.go
@@ -31,6 +31,10 @@ func NewPeakQAPIBuilder() *PeakQAPIBuilder {
 }
 
 func RegisterAPIService(features featuremgmt.FeatureToggles, apiregistration builder.APIRegistrar, reg prometheus.Registerer) *PeakQAPIBuilder {
+	if !(features.IsEnabledGlobally(featuremgmt.FlagQueryService) ||
+		features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs)) {
+		return nil // skip registration unless explicitly added (or all experimental are added)
+	}
 	builder := NewPeakQAPIBuilder()
 	apiregistration.RegisterAPI(NewPeakQAPIBuilder())
 	return builder

--- a/public/app/features/query-library/api/query.ts
+++ b/public/app/features/query-library/api/query.ts
@@ -1,6 +1,7 @@
 import { BaseQueryFn } from '@reduxjs/toolkit/query/react';
 import { lastValueFrom } from 'rxjs';
 
+import { config } from '@grafana/runtime';
 import { BackendSrvRequest, getBackendSrv, isFetchError } from '@grafana/runtime/src/services/backendSrv';
 
 import { DataQuerySpecResponse } from './types';
@@ -22,7 +23,7 @@ export enum QueryTemplateKinds {
  *
  * @alpha
  */
-export const BASE_URL = `/apis/${API_VERSION}/namespaces/default/querytemplates/`;
+export const BASE_URL = `/apis/${API_VERSION}/namespaces/${config.namespace}/querytemplates/`;
 
 // URL is optional for these requests
 interface QueryLibraryBackendRequest extends Pick<BackendSrvRequest, 'data' | 'method'> {


### PR DESCRIPTION
We need to pass the correct API for each instance instead of `default`. The value is already passed in the config and available at bootstrap.

This also changes that Query Library API can be explicitly enabled with a feature toggle `queryLibrary` (as long as `queryService` which it depends on is enabled too). This way it can be enabled with a toggle in production mode (`FlagGrafanaAPIServerWithExperimentalAPIs` toggle can be used only in dev mode)

You can test it at https://ephemeral1511182190423ifrost.grafana-dev.net/

Fixes #90424
