### PR TITLE
Query Library: Use a tooltip to show full query

### DIFF
--- a/public/app/features/explore/QueryLibrary/QueryTemplatesTable/QueryDescriptionCell.tsx
+++ b/public/app/features/explore/QueryLibrary/QueryTemplatesTable/QueryDescriptionCell.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { CellProps } from 'react-table';
 
-import { Spinner } from '@grafana/ui';
+import { Spinner, Tooltip } from '@grafana/ui';
 
 import { useDatasource } from '../utils/useDatasource';
 
@@ -20,6 +20,7 @@ export function QueryDescriptionCell(props: CellProps<QueryTemplateRow>) {
     return <div>No queries</div>;
   }
   const query = props.row.original.query;
+  const queryDisplayText = datasourceApi?.getQueryDisplayText?.(query) || '';
   const description = props.row.original.description;
   const dsName = datasourceApi?.name || '';
 
@@ -33,7 +34,9 @@ export function QueryDescriptionCell(props: CellProps<QueryTemplateRow>) {
         />
         {dsName}
       </p>
-      <p className={cx(styles.mainText, styles.singleLine)}>{datasourceApi?.getQueryDisplayText?.(query)}</p>
+      <Tooltip content={queryDisplayText} placement="bottom-start">
+        <p className={cx(styles.mainText, styles.singleLine)}>{queryDisplayText}</p>
+      </Tooltip>
       <p className={cx(styles.otherText, styles.singleLine)}>{description}</p>
     </div>
   );


### PR DESCRIPTION
Long queries are truncated in the query templates list. To allow the user to see the query we will show the tooltip on hover:

<img width="842" alt="Screenshot 2024-07-15 at 10 45 38" src="https://github.com/user-attachments/assets/bf64ff67-07b2-49d3-af59-f467b8f21c03">

Fixes #90420