### PR TITLE
Alerting: Remove some unused mock server methods

### DIFF
--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -7,7 +7,6 @@ import { byRole, byTestId, byText } from 'testing-library-selector';
 import { selectors } from '@grafana/e2e-selectors/src';
 import { setDataSourceSrv } from '@grafana/runtime';
 import { DashboardSearchItem, DashboardSearchItemType } from 'app/features/search/types';
-import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
 import { AccessControlAction } from '../../../types';
@@ -29,7 +28,6 @@ import {
   mockRulerGrafanaRule,
   mockRulerRuleGroup,
 } from './mocks';
-import { mockAlertmanagerConfigResponse } from './mocks/alertmanagerApi';
 import { grafanaRulerRule } from './mocks/grafanaRulerApi';
 import { mockRulerRulesApiResponse, mockRulerRulesGroupApiResponse } from './mocks/rulerApi';
 import { AlertingQueryRunner } from './state/AlertingQueryRunner';
@@ -37,7 +35,6 @@ import { setupDataSources } from './testSetup/datasources';
 import { buildInfoResponse } from './testSetup/featureDiscovery';
 import { RuleFormValues } from './types/rule-form';
 import { Annotation } from './utils/constants';
-import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 import { getDefaultFormValues } from './utils/rule-form';
 import { hashRulerRule } from './utils/rule-id';
 
@@ -80,23 +77,6 @@ function Wrapper({ children }: React.PropsWithChildren<{}>) {
   );
 }
 
-const amConfig: AlertManagerCortexConfig = {
-  alertmanager_config: {
-    receivers: [{ name: 'default' }, { name: 'critical' }],
-    route: {
-      receiver: 'default',
-      group_by: ['alertname'],
-      routes: [
-        {
-          matchers: ['env=prod', 'region!=EU'],
-        },
-      ],
-    },
-    templates: [],
-  },
-  template_files: {},
-};
-
 describe('CloneRuleEditor', function () {
   grantUserPermissions([AccessControlAction.AlertingRuleExternalRead]);
 
@@ -111,7 +91,6 @@ describe('CloneRuleEditor', function () {
           type: DashboardSearchItemType.DashDB,
         }),
       ]);
-      mockAlertmanagerConfigResponse(server, GRAFANA_RULES_SOURCE_NAME, amConfig);
 
       render(
         <CloneRuleEditor sourceRuleId={{ uid: grafanaRulerRule.grafana_alert.uid, ruleSourceName: 'grafana' }} />,
@@ -177,7 +156,6 @@ describe('CloneRuleEditor', function () {
           folderUid: '123',
         }),
       ]);
-      mockAlertmanagerConfigResponse(server, GRAFANA_RULES_SOURCE_NAME, amConfig);
 
       render(
         <CloneRuleEditor

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
@@ -64,7 +64,6 @@ describe('useOnCallIntegration', () => {
         },
       ]);
       mockApi(server).oncall.validateIntegrationName(['grafana-integration', 'alertmanager-integration']);
-      mockApi(server).oncall.createIntegraion();
 
       const { result } = renderHook(() => useOnCallIntegration(), { wrapper: TestProvider });
 

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -1,4 +1,3 @@
-import { uniqueId } from 'lodash';
 import { http, HttpResponse } from 'msw';
 import { setupServer, SetupServer } from 'msw/node';
 
@@ -28,7 +27,7 @@ import {
 } from '../../../plugins/datasource/alertmanager/types';
 import { DashboardSearchItem } from '../../search/types';
 
-import { CreateIntegrationDTO, NewOnCallIntegrationDTO, OnCallIntegrationDTO } from './api/onCallApi';
+import { OnCallIntegrationDTO } from './api/onCallApi';
 
 type Configurator<T> = (builder: T) => T;
 
@@ -158,35 +157,6 @@ class AlertmanagerReceiverBuilder {
   }
 }
 
-export class OnCallIntegrationBuilder {
-  private onCallIntegration: NewOnCallIntegrationDTO = {
-    id: uniqueId('oncall-integration-mock-'),
-    integration: '',
-    integration_url: '',
-    verbal_name: '',
-    connected_escalations_chains_count: 0,
-  };
-
-  withIntegration(integration: string): OnCallIntegrationBuilder {
-    this.onCallIntegration.integration = integration;
-    return this;
-  }
-
-  withIntegrationUrl(integrationUrl: string): OnCallIntegrationBuilder {
-    this.onCallIntegration.integration_url = integrationUrl;
-    return this;
-  }
-
-  withVerbalName(verbalName: string): OnCallIntegrationBuilder {
-    this.onCallIntegration.verbal_name = verbalName;
-    return this;
-  }
-
-  build() {
-    return this.onCallIntegration;
-  }
-}
-
 export function mockApi(server: SetupServer) {
   return {
     getAlertmanagerConfig: (amName: string, configure: (builder: AlertmanagerConfigBuilder) => void) => {
@@ -243,25 +213,6 @@ export function mockApi(server: SetupServer) {
           )
         );
       },
-      createIntegraion: () => {
-        server.use(
-          http.post<{}, CreateIntegrationDTO>(
-            `api/plugin-proxy/grafana-oncall-app/api/internal/v1/alert_receive_channels`,
-            async ({ request }) => {
-              const body = await request.json();
-              const integrationId = uniqueId('oncall-integration-');
-
-              return HttpResponse.json<NewOnCallIntegrationDTO>({
-                id: integrationId,
-                integration: body.integration,
-                integration_url: `https://oncall-endpoint.example.com/${integrationId}`,
-                verbal_name: body.verbal_name,
-                connected_escalations_chains_count: 0,
-              });
-            }
-          )
-        );
-      },
     },
   };
 }
@@ -306,66 +257,15 @@ export function mockFeatureDiscoveryApi(server: SetupServer) {
   };
 }
 
-export function mockProvisioningApi(server: SetupServer) {
-  return {
-    exportRuleGroup: (folderUid: string, groupName: string, response: Record<string, string>) => {
-      server.use(
-        http.get(`/api/v1/provisioning/folder/${folderUid}/rule-groups/${groupName}/export`, ({ request }) => {
-          const url = new URL(request.url);
-          const format = url.searchParams.get('format') ?? 'yaml';
-          return HttpResponse.text(response[format]);
-        })
-      );
-    },
-    exportReceiver: (response: Record<string, string>) => {
-      server.use(
-        http.get(`/api/v1/provisioning/contact-points/export/`, ({ request }) => {
-          const url = new URL(request.url);
-          const format = url.searchParams.get('format') ?? 'yaml';
-          return HttpResponse.text(response[format]);
-        })
-      );
-    },
-  };
-}
-
 export function mockExportApi(server: SetupServer) {
   // exportRule, exportRulesGroup, exportRulesFolder use the same API endpoint but with different parameters
   return {
-    // exportRule requires ruleUid parameter and doesn't allow folderUid and group parameters
-    exportRule: (ruleUid: string, response: Record<string, string>) => {
-      server.use(
-        http.get('/api/ruler/grafana/api/v1/export/rules', ({ request }) => {
-          const url = new URL(request.url);
-          if (url.searchParams.get('ruleUid') === ruleUid) {
-            const format = url.searchParams.get('format') ?? 'yaml';
-            return HttpResponse.text(response[format]);
-          }
-
-          return HttpResponse.text('', { status: 500 });
-        })
-      );
-    },
     // exportRulesGroup requires folderUid and group parameters and doesn't allow ruleUid parameter
     exportRulesGroup: (folderUid: string, group: string, response: Record<string, string>) => {
       server.use(
         http.get('/api/ruler/grafana/api/v1/export/rules', ({ request }) => {
           const url = new URL(request.url);
           if (url.searchParams.get('folderUid') === folderUid && url.searchParams.get('group') === group) {
-            const format = url.searchParams.get('format') ?? 'yaml';
-            return HttpResponse.text(response[format]);
-          }
-
-          return HttpResponse.text('', { status: 500 });
-        })
-      );
-    },
-    // exportRulesFolder requires folderUid parameter
-    exportRulesFolder: (folderUid: string, response: Record<string, string>) => {
-      server.use(
-        http.get('/api/ruler/grafana/api/v1/export/rules', ({ request }) => {
-          const url = new URL(request.url);
-          if (url.searchParams.get('folderUid') === folderUid) {
             const format = url.searchParams.get('format') ?? 'yaml';
             return HttpResponse.text(response[format]);
           }

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -175,20 +175,6 @@ export const mockRulerRuleGroup = (partial: Partial<RulerRuleGroupDTO> = {}): Ru
   ...partial,
 });
 
-export const promRuleFromRulerRule = (
-  rulerRule: RulerAlertingRuleDTO,
-  override?: Partial<AlertingRule>
-): AlertingRule => {
-  return mockPromAlertingRule({
-    name: rulerRule.alert,
-    query: rulerRule.expr,
-    labels: rulerRule.labels,
-    annotations: rulerRule.annotations,
-    type: PromRuleType.Alerting,
-    ...override,
-  });
-};
-
 export const mockPromAlertingRule = (partial: Partial<AlertingRule> = {}): AlertingRule => {
   return {
     type: PromRuleType.Alerting,

--- a/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
@@ -5,11 +5,9 @@ import { grafanaAlertingConfigurationStatusHandler } from 'app/features/alerting
 
 import {
   AlertmanagerChoice,
-  AlertManagerCortexConfig,
   ExternalAlertmanagersStatusResponse,
 } from '../../../../plugins/datasource/alertmanager/types';
 import { GrafanaAlertingConfigurationStatusResponse } from '../api/alertmanagerApi';
-import { getDatasourceAPIUid } from '../utils/datasource';
 
 export const defaultGrafanaAlertingConfigurationStatusResponse: GrafanaAlertingConfigurationStatusResponse = {
   alertmanagersChoice: AlertmanagerChoice.Internal,
@@ -31,16 +29,4 @@ export const emptyExternalAlertmanagersResponse: ExternalAlertmanagersStatusResp
 };
 export function mockAlertmanagersResponse(server: SetupServer, response: ExternalAlertmanagersStatusResponse) {
   server.use(http.get('/api/v1/ngalert/alertmanagers', () => HttpResponse.json(response)));
-}
-
-export function mockAlertmanagerConfigResponse(
-  server: SetupServer,
-  alertManagerSourceName: string,
-  response: AlertManagerCortexConfig
-) {
-  server.use(
-    http.get(`/api/alertmanager/${getDatasourceAPIUid(alertManagerSourceName)}/config/api/v1/alerts`, () =>
-      HttpResponse.json(response)
-    )
-  );
 }


### PR DESCRIPTION
**What is this feature?**

Tidies up some unused mock server methods, identified due to having no code coverage at all when all tests were run

**Why do we need this feature?**

🧹 
