### PR TITLE
Chore: Remove unused method in db.DB

### DIFF
--- a/pkg/infra/db/db.go
+++ b/pkg/infra/db/db.go
@@ -24,9 +24,6 @@ type DB interface {
 	// through [context.Context] or if that's not present, as non-transactional database
 	// operations.
 	WithDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error
-	// WithNewDbSession behaves like [DB.WithDbSession] without picking up a transaction
-	// from the context.
-	WithNewDbSession(ctx context.Context, callback sqlstore.DBTransactionFunc) error
 	// GetDialect returns an object that contains information about the peculiarities of
 	// the particular database type available to the runtime.
 	GetDialect() migrator.Dialect

--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -74,15 +74,6 @@ func (ss *SQLStore) WithDbSession(ctx context.Context, callback DBTransactionFun
 	return ss.withDbSession(ctx, ss.engine, callback)
 }
 
-// WithNewDbSession calls the callback with a new session that is closed upon completion.
-// In case of sqlite3.ErrLocked or sqlite3.ErrBusy failure it will be retried at most five times before giving up.
-func (ss *SQLStore) WithNewDbSession(ctx context.Context, callback DBTransactionFunc) error {
-	sess := &DBSession{Session: ss.engine.NewSession(), transactionOpen: false}
-	defer sess.Close()
-	retry := 0
-	return retryer.Retry(ss.retryOnLocks(ctx, callback, sess, retry), ss.dbCfg.QueryRetries, time.Millisecond*time.Duration(10), time.Second)
-}
-
 func (ss *SQLStore) retryOnLocks(ctx context.Context, callback DBTransactionFunc, sess *DBSession, retry int) func() (retryer.RetrySignal, error) {
 	return func() (retryer.RetrySignal, error) {
 		retry++

--- a/pkg/services/sqlstore/session_test.go
+++ b/pkg/services/sqlstore/session_test.go
@@ -16,8 +16,7 @@ func TestRetryingDisabled(t *testing.T) {
 	require.Equal(t, 0, store.dbCfg.QueryRetries)
 
 	funcToTest := map[string]func(ctx context.Context, callback DBTransactionFunc) error{
-		"WithDbSession":    store.WithDbSession,
-		"WithNewDbSession": store.WithNewDbSession,
+		"WithDbSession": store.WithDbSession,
 	}
 
 	for name, f := range funcToTest {
@@ -67,8 +66,7 @@ func TestRetryingOnFailures(t *testing.T) {
 	store.dbCfg.QueryRetries = 5
 
 	funcToTest := map[string]func(ctx context.Context, callback DBTransactionFunc) error{
-		"WithDbSession":    store.WithDbSession,
-		"WithNewDbSession": store.WithNewDbSession,
+		"WithDbSession": store.WithDbSession,
 	}
 
 	for name, f := range funcToTest {

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -16,7 +16,7 @@ func TestIntegrationGetOrCreateOrg(t *testing.T) {
 	}
 	ss, _ := InitTestDB(t)
 
-	err := ss.WithNewDbSession(context.Background(), func(sess *DBSession) error {
+	err := ss.WithDbSession(context.Background(), func(sess *DBSession) error {
 		// Create the org only:
 		ss.cfg.AutoAssignOrg = true
 		ss.cfg.DisableInitAdminCreation = true
@@ -28,7 +28,7 @@ func TestIntegrationGetOrCreateOrg(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = ss.WithNewDbSession(context.Background(), func(sess *DBSession) error {
+	err = ss.WithDbSession(context.Background(), func(sess *DBSession) error {
 		// Run it a second time and verify that it finds the org that was
 		// created above.
 		gotOrgId, err := ss.getOrCreateOrg(sess, mainOrgName)


### PR DESCRIPTION
A minor change, removes a completely unused method from db.DB and SQLStore interfaces. All of the code is using `WithDbSession` instead (which creates a new session if needed, otherwise reuses an existing one). So far there seems to be no use cases to forcefully re-open a new session.