### PR TITLE
CloudMigrations: Query GMS for snapshot status with a results offset 

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -441,7 +441,7 @@ func (m *gmsClientMock) StartSnapshot(_ context.Context, _ cloudmigration.CloudM
 	return nil, nil
 }
 
-func (m *gmsClientMock) GetSnapshotStatus(_ context.Context, _ cloudmigration.CloudMigrationSession, _ cloudmigration.CloudMigrationSnapshot) (*cloudmigration.GetSnapshotStatusResponse, error) {
+func (m *gmsClientMock) GetSnapshotStatus(_ context.Context, _ cloudmigration.CloudMigrationSession, _ cloudmigration.CloudMigrationSnapshot, _ int) (*cloudmigration.GetSnapshotStatusResponse, error) {
 	m.getStatusCalled++
 	return m.getSnapshotResponse, nil
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -257,6 +257,7 @@ func Test_SnapshotResources(t *testing.T) {
 			cloudmigration.ItemStatusOK:      3,
 			cloudmigration.ItemStatusPending: 1,
 		}, stats.CountsByStatus)
+		assert.Equal(t, 4, stats.Total)
 
 		// delete snapshot resources
 		err = s.DeleteSnapshotResources(ctx, "poiuy")

--- a/pkg/services/cloudmigration/gmsclient/client.go
+++ b/pkg/services/cloudmigration/gmsclient/client.go
@@ -10,7 +10,7 @@ type Client interface {
 	ValidateKey(context.Context, cloudmigration.CloudMigrationSession) error
 	MigrateData(context.Context, cloudmigration.CloudMigrationSession, cloudmigration.MigrateDataRequest) (*cloudmigration.MigrateDataResponse, error)
 	StartSnapshot(context.Context, cloudmigration.CloudMigrationSession) (*cloudmigration.StartSnapshotResponse, error)
-	GetSnapshotStatus(context.Context, cloudmigration.CloudMigrationSession, cloudmigration.CloudMigrationSnapshot) (*cloudmigration.GetSnapshotStatusResponse, error)
+	GetSnapshotStatus(context.Context, cloudmigration.CloudMigrationSession, cloudmigration.CloudMigrationSnapshot, int) (*cloudmigration.GetSnapshotStatusResponse, error)
 }
 
 const logPrefix = "cloudmigration.gmsclient"

--- a/pkg/services/cloudmigration/gmsclient/gms_client.go
+++ b/pkg/services/cloudmigration/gmsclient/gms_client.go
@@ -162,12 +162,12 @@ func (c *gmsClientImpl) StartSnapshot(ctx context.Context, session cloudmigratio
 	return &result, nil
 }
 
-func (c *gmsClientImpl) GetSnapshotStatus(ctx context.Context, session cloudmigration.CloudMigrationSession, snapshot cloudmigration.CloudMigrationSnapshot) (*cloudmigration.GetSnapshotStatusResponse, error) {
+func (c *gmsClientImpl) GetSnapshotStatus(ctx context.Context, session cloudmigration.CloudMigrationSession, snapshot cloudmigration.CloudMigrationSnapshot, offset int) (*cloudmigration.GetSnapshotStatusResponse, error) {
 	c.getStatusMux.Lock()
 	defer c.getStatusMux.Unlock()
 	logger := c.log.FromContext(ctx)
 
-	path := fmt.Sprintf("%s/api/v1/status/%s/status", c.buildBasePath(session.ClusterSlug), snapshot.GMSSnapshotUID)
+	path := fmt.Sprintf("%s/api/v1/status/%s/status?offset=%d", c.buildBasePath(session.ClusterSlug), snapshot.GMSSnapshotUID, offset)
 
 	// Send the request to gms with the associated auth token
 	req, err := http.NewRequest(http.MethodGet, path, nil)

--- a/pkg/services/cloudmigration/gmsclient/inmemory_client.go
+++ b/pkg/services/cloudmigration/gmsclient/inmemory_client.go
@@ -67,7 +67,7 @@ func (c *memoryClientImpl) StartSnapshot(context.Context, cloudmigration.CloudMi
 	return c.snapshot, nil
 }
 
-func (c *memoryClientImpl) GetSnapshotStatus(ctx context.Context, session cloudmigration.CloudMigrationSession, snapshot cloudmigration.CloudMigrationSnapshot) (*cloudmigration.GetSnapshotStatusResponse, error) {
+func (c *memoryClientImpl) GetSnapshotStatus(ctx context.Context, session cloudmigration.CloudMigrationSession, snapshot cloudmigration.CloudMigrationSnapshot, offset int) (*cloudmigration.GetSnapshotStatusResponse, error) {
 	gmsResp := &cloudmigration.GetSnapshotStatusResponse{
 		State: cloudmigration.SnapshotStateFinished,
 		Results: []cloudmigration.CloudMigrationResource{

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -91,7 +91,6 @@ const (
 	ItemStatusOK      ItemStatus = "OK"
 	ItemStatusError   ItemStatus = "ERROR"
 	ItemStatusPending ItemStatus = "PENDING"
-	ItemStatusUnknown ItemStatus = "UNKNOWN"
 )
 
 type SnapshotResourceStats struct {

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -97,6 +97,7 @@ const (
 type SnapshotResourceStats struct {
 	CountsByType   map[MigrateDataType]int
 	CountsByStatus map[ItemStatus]int
+	Total          int
 }
 
 // Deprecated, use GetSnapshotResult for the async workflow


### PR DESCRIPTION
Part of https://github.com/grafana/grafana-operator-experience-squad/issues/865.

Without an offset, GMS will return all results, including ones that we already have, leading to a lot of unnecessary update calls to the database. 

Uses numResources - pendingResources to get the offset GMS should use in its result list. 