### PR TITLE
Unified Storage: Fix Compare method

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -241,7 +241,7 @@ func removeMeta(obj runtime.Object) []byte {
 	// we don't want to compare meta fields
 	delete(unstObj, "metadata")
 
-	jsonObj, err := json.Marshal(cpy)
+	jsonObj, err := json.Marshal(unstObj)
 	if err != nil {
 		return nil
 	}

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	playlist "github.com/grafana/grafana/pkg/apis/playlist/v0alpha1"
 )
 
 func TestSetDualWritingMode(t *testing.T) {
@@ -59,24 +62,44 @@ func TestSetDualWritingMode(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
+	var examplePlaylistGen1 = &playlist.Playlist{ObjectMeta: metav1.ObjectMeta{Generation: 1}, Spec: playlist.Spec{Title: "Example Playlist"}}
+	var examplePlaylistGen2 = &playlist.Playlist{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Spec: playlist.Spec{Title: "Example Playlist"}}
+	var anotherPlaylist = &playlist.Playlist{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Spec: playlist.Spec{Title: "Another Playlist"}}
+
 	testCase := []struct {
 		name     string
-		input    runtime.Object
+		input1   runtime.Object
+		input2   runtime.Object
 		expected bool
 	}{
 		{
 			name:     "should return true when both objects are the same",
-			input:    exampleObj,
+			input1:   exampleObj,
+			input2:   exampleObj,
 			expected: true,
 		},
 		{
-			name:  "should return false when objects are different",
-			input: anotherObj,
+			name:     "should return false when objects are different",
+			input1:   exampleObj,
+			input2:   anotherObj,
+			expected: false,
+		},
+		{
+			name:     "should return true when Playlists are the same, but different metadata (generation)",
+			input1:   examplePlaylistGen1,
+			input2:   examplePlaylistGen2,
+			expected: true,
+		},
+		{
+			name:     "should return false when Playlists different",
+			input1:   examplePlaylistGen1,
+			input2:   anotherPlaylist,
+			expected: false,
 		},
 	}
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, Compare(tt.input, exampleObj))
+			assert.Equal(t, tt.expected, Compare(tt.input1, tt.input2))
 		})
 	}
 }

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	// nolint:depguard
 	playlist "github.com/grafana/grafana/pkg/apis/playlist/v0alpha1"
 )
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the Unified Storage Dual Writer Compare method. 

**Why do we need this feature?**

The Compare method logic was incorrect. It was rendering the unmodified copy of the input, instead of the `unstObj`.

**Who is this feature for?**

n/a

**Which issue(s) does this PR fix?**:
n/a

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
