### PR TITLE
Get panel plugin default options on plugin change

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -226,6 +226,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       options: cachedOptions ?? {},
       fieldConfig: newFieldConfig,
       pluginId: pluginId,
+      isAfterPluginChange: true,
       ...restOfOldState,
     });
 


### PR DESCRIPTION
Uses state flag to allow getting default options after plugin type change.

Depends on https://github.com/grafana/scenes/pull/834

Fixes https://github.com/grafana/grafana/issues/89836