### PR TITLE
Combine responses: do not combine frames with different names

### DIFF
--- a/packages/grafana-o11y-ds-frontend/src/combineResponses.test.ts
+++ b/packages/grafana-o11y-ds-frontend/src/combineResponses.test.ts
@@ -508,7 +508,7 @@ describe('combineResponses', () => {
     };
     expect(combineResponses(responseA, responseB)).toEqual({
       data: [metricFrameA, metricFrameB],
-    })
+    });
   });
 
   it('does not combine frames with different refId', () => {
@@ -523,7 +523,7 @@ describe('combineResponses', () => {
     };
     expect(combineResponses(responseA, responseB)).toEqual({
       data: [metricFrameA, metricFrameB],
-    })
+    });
   });
 });
 

--- a/packages/grafana-o11y-ds-frontend/src/combineResponses.test.ts
+++ b/packages/grafana-o11y-ds-frontend/src/combineResponses.test.ts
@@ -495,6 +495,36 @@ describe('combineResponses', () => {
       expect(combineResponses(responseA, responseB).data[0].meta.stats).toHaveLength(0);
     });
   });
+
+  it('does not combine frames with different refId', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.refId = 'A';
+    metricFrameB.refId = 'B';
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [metricFrameA, metricFrameB],
+    })
+  });
+
+  it('does not combine frames with different refId', () => {
+    const { metricFrameA, metricFrameB } = getMockFrames();
+    metricFrameA.name = 'A';
+    metricFrameB.name = 'B';
+    const responseA: DataQueryResponse = {
+      data: [metricFrameA],
+    };
+    const responseB: DataQueryResponse = {
+      data: [metricFrameB],
+    };
+    expect(combineResponses(responseA, responseB)).toEqual({
+      data: [metricFrameA, metricFrameB],
+    })
+  });
 });
 
 describe('combinePanelData', () => {

--- a/packages/grafana-o11y-ds-frontend/src/combineResponses.ts
+++ b/packages/grafana-o11y-ds-frontend/src/combineResponses.ts
@@ -130,7 +130,7 @@ function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
 }
 
 function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
-  if ((frame1.refId !== frame2.refId) || (frame1.name !== frame2.name)) {
+  if (frame1.refId !== frame2.refId || frame1.name !== frame2.name) {
     return false;
   }
 

--- a/packages/grafana-o11y-ds-frontend/src/combineResponses.ts
+++ b/packages/grafana-o11y-ds-frontend/src/combineResponses.ts
@@ -130,7 +130,7 @@ function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
 }
 
 function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
-  if (frame1.refId !== frame2.refId) {
+  if ((frame1.refId !== frame2.refId) || (frame1.name !== frame2.name)) {
     return false;
   }
 


### PR DESCRIPTION
Similar to checking refId, data frames with different names should not be combined.