### PR TITLE
Tempo: Only generate query for query history if there are filters

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -29,6 +29,10 @@ export const interpolateFilters = (filters: TraceqlFilter[], scopedVars?: Scoped
 };
 
 export const generateQueryFromFilters = (filters: TraceqlFilter[]) => {
+  if (!filters) {
+    return '';
+  }
+
   return `{${filters
     .filter((f) => f.tag && f.operator && f.value?.length)
     .map((f) => `${scopeHelper(f)}${tagHelper(f, filters)}${f.operator}${valueHelper(f)}`)

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -822,7 +822,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     }
 
     const appliedQuery = this.applyVariables(query, {});
-    return appliedQuery.filters ? generateQueryFromFilters(appliedQuery.filters) : '';
+    return generateQueryFromFilters(appliedQuery.filters);
   }
 }
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -822,7 +822,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     }
 
     const appliedQuery = this.applyVariables(query, {});
-    return generateQueryFromFilters(appliedQuery.filters);
+    return appliedQuery.filters ? generateQueryFromFilters(appliedQuery.filters) : '';
   }
 }
 


### PR DESCRIPTION
**What is this feature?**

Only generate query for Tempo query history if there are filters.

**Why do we need this feature?**

Prevent bug.

**Who is this feature for?**

Tempo users.
