### PR TITLE
docs: added video to gauge panel doc

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/gauge/index.md
+++ b/docs/sources/panels-visualizations/visualizations/gauge/index.md
@@ -31,6 +31,10 @@ Gauges are single-value visualizations that can repeat a gauge for every series,
 
 {{< docs/play title="Grafana Gauge Visualization" url="https://play.grafana.org/d/KIhkVD6Gk/" >}}
 
+The following video provides beginner steps for creating gauge panels. You'll learn the data requirements and caveats, special customizations, and much more:
+
+{{< youtube id="QwXj3y_YpnE" >}}
+
 ## Panel options
 
 {{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -166,7 +166,7 @@ You can add multiple layers of data to a single geomap in order to create rich, 
 
 ### Data
 
-Geomaps need a source of geographical data gathered from a data source query which can return multiple data sets. By default Grafana picks the first data set, this field allows users to pick other data sets if the query returns more than one.
+Geomaps need a source of geographical data gathered from a data source query which can return multiple datasets. By default Grafana picks the first dataset, but this drop-down allows you to pick other datasets if the query returns more than one.
 
 ### Location mode
 

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -170,7 +170,7 @@ Geomaps need a source of geographical data gathered from a data source query whi
 
 ### Location mode
 
-There are four options to map the data returned by the selected query.
+There are four options to map the data returned by the selected query:
 
 - **Auto** automatically searches for location data. Use this option when your query is based on one of the following names for data fields.
   - geohash: “geohash”

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -98,6 +98,10 @@ The initial view configures how the geomap renders when the panel is first loade
     - **Oceania**
 - **Zoom** sets the initial zoom level.
 
+### Share view
+
+The Share view option allows users to link multiple map panels' movement and zoom actions within the same dashboard. The map panels that have this option activated will act in tandem when one of them is moved or zoomed, leaving the deactivated ones independent. _Note: this may require a dashboard reload._
+
 ## Map layers
 
 Geomaps support showing multiple layers. Each layer determines how you visualize geospatial data on top of the base map.
@@ -156,9 +160,13 @@ The layer controls allow you to create layers, change their name, reorder and de
 
 You can add multiple layers of data to a single geomap in order to create rich, detailed visualizations.
 
-### Location
+### Data
 
-Geomaps need a source of geographical data. This data comes from a database query, and there are four mapping options for your data.
+Geomaps need a source of geographical data gathered from a data source query which can return multiple data sets. By default Grafana picks the first data set, this field allows users to pick other data sets if the query returns more than one.
+
+### Location mode
+
+There are four options to map the data returned by the selected query.
 
 - **Auto** automatically searches for location data. Use this option when your query is based on one of the following names for data fields.
   - geohash: “geohash”

--- a/docs/sources/panels-visualizations/visualizations/geomap/index.md
+++ b/docs/sources/panels-visualizations/visualizations/geomap/index.md
@@ -100,7 +100,11 @@ The initial view configures how the geomap renders when the panel is first loade
 
 ### Share view
 
-The Share view option allows users to link multiple map panels' movement and zoom actions within the same dashboard. The map panels that have this option activated will act in tandem when one of them is moved or zoomed, leaving the deactivated ones independent. _Note: this may require a dashboard reload._
+The **Share view** option allows you to link the movement and zoom actions of multiple map visualizations within the same dashboard. The map visualizations that have this option enabled act in tandem when one of them is moved or zoomed, leaving the other ones independent.
+
+{{< admonition type="note" >}}
+You might need to reload the dashboard for this feature to work.
+{{< /admonition >}}
 
 ## Map layers
 


### PR DESCRIPTION
**What is this feature?**

Added a brief description and link to the video explaining the Gauge panel visualization.

**Why do we need this feature?**

It improves the docs' user experience for visual learners by displaying a video.

**Who is this feature for?**

Everyone looking into mastering Grafana Gauge panels.

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
