### PR TITLE
Scenes: Save height as itemHeight for repeat panels

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -172,7 +172,7 @@ export function gridItemToPanel(
     x = gridItem.state.x ?? 0;
     y = gridItem.state.y ?? 0;
     w = gridItem.state.width ?? 0;
-    h = gridItem.state.height ?? 0;
+    h = gridItem.state.itemHeight ?? 0;
 
     return libraryVizPanelToPanel(gridItem.state.body, { x, y, w, h });
   }
@@ -200,7 +200,7 @@ export function gridItemToPanel(
   x = gridItem_.state.x ?? 0;
   y = gridItem_.state.y ?? 0;
   w = gridItem_.state.width ?? 0;
-  h = gridItem_.state.height ?? 0;
+  h = gridItem_.state.itemHeight ?? 0;
 
   if (!vizPanel) {
     throw new Error('Unsupported grid item type');

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -172,7 +172,7 @@ export function gridItemToPanel(
     x = gridItem.state.x ?? 0;
     y = gridItem.state.y ?? 0;
     w = gridItem.state.width ?? 0;
-    h = gridItem.state.itemHeight ?? 0;
+    h = gridItem.state.itemHeight ?? gridItem.state.height ?? 0;
 
     return libraryVizPanelToPanel(gridItem.state.body, { x, y, w, h });
   }
@@ -200,7 +200,7 @@ export function gridItemToPanel(
   x = gridItem_.state.x ?? 0;
   y = gridItem_.state.y ?? 0;
   w = gridItem_.state.width ?? 0;
-  h = gridItem_.state.itemHeight ?? 0;
+  h = gridItem_.state.itemHeight ?? gridItem_.state.height ?? 0;
 
   if (!vizPanel) {
     throw new Error('Unsupported grid item type');


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/90221 as it caused other issues.
There's still a slight issue in that when a repeat "group" is resized, the item heights aren't quantized and so will be different before/after saving