### PR TITLE
Cloudwatch: Add support for adding account id to sql query

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -119,8 +119,9 @@ const SQLBuilderSelectRow = ({ datasource, query, onQueryChange }: SQLBuilderSel
                 const newWheres: QueryEditorArrayExpression = {
                   type: QueryEditorExpressionType.And,
                   expressions:
-                    // we don't keep app in the where clause because we don't need to add it to the preview/sql string query
-                    // we still select account id in the query object so we can use it in the dropdown
+                    // if the selection is all we remove it from the where clause (because it's absense means all),
+                    // we still store the account id in the top level of the query object so as to show the selection in the dropdown
+                    // otherwise we add the accountId to the where clauses so that it is included in the query and sql preview
                     accountId === 'all' ? nonAccountWheres : [...nonAccountWheres, newAccountWhereClause],
                 };
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx
@@ -66,8 +66,8 @@ const SQLFilter = ({ query, onQueryChange, datasource }: SQLFilterProps) => {
       }
     }
 
+    // preserve previous account id selection even if it's not visible in the filters themselves
     const { oldAccountWhere } = splitWheresOnAccountId(query.sql?.where?.expressions || []);
-
     if (oldAccountWhere) {
       validExpressions.push(oldAccountWhere);
     }

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/utils.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/utils.ts
@@ -102,6 +102,13 @@ export function getFlattenedFilters(sql: SQLExpression): QueryEditorOperatorExpr
   return flattenOperatorExpressions(where?.expressions ?? []);
 }
 
+/** Removes the AccountId filter from the list of filters, as it is already visible in the account dropdown */
+export function filterOutAccountId(filters: QueryEditorOperatorExpression[]): QueryEditorOperatorExpression[] {
+  return filters.filter((exp) => {
+    return exp?.property.name !== 'AccountId';
+  });
+}
+
 /**
  * Given an array of Expressions, flattens them to the leaf Operator expressions.
  * Note, this loses context of any nested ANDs or ORs, so will not be useful once we support nested conditions */
@@ -123,13 +130,6 @@ function flattenGroupByExpressions(
 export function getFlattenedGroupBys(sql: SQLExpression): QueryEditorGroupByExpression[] {
   const groupBy = sql.groupBy;
   return flattenGroupByExpressions(groupBy?.expressions ?? []);
-}
-
-/** Removes the AccountId filter from the list of filters */
-export function filterOutAccountId(filters: QueryEditorOperatorExpression[]): QueryEditorOperatorExpression[] {
-  return filters.filter((exp) => {
-    return exp?.property.name !== 'AccountId';
-  });
 }
 
 /** takes an array of where expressions and separates out the account expression from the rest of the where expressions */

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { cloneDeep } from 'lodash';
-import { select } from 'react-select-event';
 
 import { QueryEditorProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -16,6 +15,7 @@ import {
 } from '../../__mocks__/queries';
 import { CloudWatchDatasource } from '../../datasource';
 import { CloudWatchQuery, CloudWatchJsonData, MetricEditorMode, MetricQueryType } from '../../types';
+import { selectOptionInTest } from '../../utils/testUtils';
 
 import { QueryEditor } from './QueryEditor';
 
@@ -501,9 +501,3 @@ describe('QueryEditor should render right editor', () => {
     });
   });
 });
-
-// Used to select an option or options from a Select in unit tests
-export const selectOptionInTest = async (
-  input: HTMLElement,
-  optionOrOptions: string | RegExp | Array<string | RegExp>
-) => await waitFor(() => select(input, optionOrOptions, { container: document.body }));

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Account.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Account.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import selectEvent from 'react-select-event';
 
 import { selectOptionInTest } from '../../utils/testUtils';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Account.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Account.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 
+import { selectOptionInTest } from '../../utils/testUtils';
+
 import { Account } from './Account';
 
 export const AccountOptions = [
@@ -39,26 +41,25 @@ describe('Account', () => {
 
   it('should not render if there are no accounts', async () => {
     render(<Account {...props} accountOptions={[]} />);
-    expect(screen.queryByLabelText('Account Selection')).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Account' })).not.toBeInTheDocument();
   });
 
   it('should render a selectable field of accounts if there are accounts', async () => {
     const onChange = jest.fn();
     render(<Account {...props} onChange={onChange} />);
-    expect(screen.getByLabelText('Account Selection')).toBeInTheDocument();
-    await selectEvent.select(screen.getByLabelText('Account Selection'), 'test-account3', { container: document.body });
+    await selectOptionInTest(screen.getByRole('combobox', { name: 'Account' }), 'test-account3');
     expect(onChange).toBeCalledWith('999999999999');
   });
 
   it("should default to 'all' if there is no selection", () => {
     render(<Account {...props} accountId={undefined} />);
-    expect(screen.getByLabelText('Account Selection')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Account' })).toBeInTheDocument();
     expect(screen.getByText('All')).toBeInTheDocument();
   });
 
   it('should select an uninterpolated template variable if it has been selected', () => {
     render(<Account {...props} accountId={'$fakeVar'} />);
-    expect(screen.getByLabelText('Account Selection')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: 'Account' })).toBeInTheDocument();
     expect(screen.getByText('$fakeVar')).toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Account.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Account.tsx
@@ -37,12 +37,13 @@ export function Account({ accountId, onChange, accountOptions }: Props) {
 
   return (
     <EditorField
+      htmlFor="account-selection"
       label="Account"
       width={26}
       tooltip="A CloudWatch monitoring account views data from source accounts so you can centralize monitoring and troubleshooting activities across multiple accounts. Go to the CloudWatch settings page in the AWS console for more details."
     >
       <Select
-        aria-label="Account Selection"
+        inputId="account-selection"
         value={selectedAccountExistsInOptions ? accountId : ALL_ACCOUNTS_OPTION.value}
         options={[ALL_ACCOUNTS_OPTION, ...accountOptions]}
         onChange={({ value }) => {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -134,7 +134,7 @@ describe('LogGroupsSelector', () => {
     await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
     expect(fetchLogGroups).toBeCalledTimes(1);
     expect(screen.getAllByRole('checkbox').length).toBe(2);
-    await selectEvent.select(screen.getByLabelText('Account Selection'), 'Account Name 123', {
+    await selectEvent.select(screen.getByLabelText('Account'), 'Account Name 123', {
       container: document.body,
     });
     expect(screen.getByText('Loading...')).toBeInTheDocument();

--- a/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
@@ -24,6 +24,7 @@ export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   sql: undefined,
   sqlExpression: '',
   matchExact: true,
+  accountId: undefined,
 };
 
 export const DEFAULT_ANNOTATIONS_QUERY: Omit<CloudWatchAnnotationQuery, 'refId'> = {

--- a/public/app/plugins/datasource/cloudwatch/utils/testUtils.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/testUtils.ts
@@ -1,0 +1,8 @@
+import { waitFor } from '@testing-library/react';
+import { select } from 'react-select-event';
+
+// Used to select an option or options from a Select in unit tests
+export const selectOptionInTest = async (
+  input: HTMLElement,
+  optionOrOptions: string | RegExp | Array<string | RegExp>
+) => await waitFor(() => select(input, optionOrOptions, { container: document.body }));


### PR DESCRIPTION
**What is this feature?**

Makes the account dropdown operational for the new cross account selection for Metric Insights in the Cloudwatch Datasource

**Why do we need this feature?**

So that we are one step closer to supporting cross account queries when using the metric insights api to query cloudwatch data. 

**Who is this feature for?**

Probably no one yet since it's all behind a feature flag, although it is possible to start testing now. It will eventually be a good fit for cloudwatch users who like to write sql queries to better understand their data, and who have multiple accounts they'd like to monitor in the same region.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/oss-plugin-partnerships/issues/970

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
