### PR TITLE
Transformations: Fix null for reduceSeriesToRows

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/reduce.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.test.ts
@@ -27,6 +27,14 @@ const seriesAWithMultipleFields = toDataFrame({
   ],
 });
 
+const seriesAWithAllNulls = toDataFrame({
+  name: 'A',
+  fields: [
+    { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+    { name: 'temperature', type: FieldType.number, values: [null, null, null, null, null] },
+  ],
+});
+
 const seriesBWithSingleField = toDataFrame({
   name: 'B',
   fields: [
@@ -41,6 +49,14 @@ const seriesBWithMultipleFields = toDataFrame({
     { name: 'time', type: FieldType.time, values: [1000, 3000, 5000, 7000] },
     { name: 'temperature', type: FieldType.number, values: [1, 3, 5, 7] },
     { name: 'humidity', type: FieldType.number, values: [11000.1, 11000.3, 11000.5, 11000.7] },
+  ],
+});
+
+const seriesBWithAllNulls = toDataFrame({
+  name: 'B',
+  fields: [
+    { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000] },
+    { name: 'temperature', type: FieldType.number, values: [null, null, null, null, null] },
   ],
 });
 
@@ -166,6 +182,99 @@ describe('Reducer Transformer', () => {
             name: 'Last',
             type: FieldType.number,
             values: [6, 7],
+            config: {},
+          },
+        ];
+
+        expect(processed.length).toEqual(1);
+        expect(processed[0].length).toEqual(2);
+        expect(processed[0].fields).toEqual(expected);
+      }
+    );
+  });
+
+  it('reduces multiple data frames, one having all null values', async () => {
+    const cfg = {
+      id: DataTransformerID.reduce,
+      options: {
+        reducers: [ReducerID.first, ReducerID.min, ReducerID.max, ReducerID.last],
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [seriesAWithAllNulls, seriesBWithSingleField])).toEmitValuesWith(
+      (received) => {
+        const processed = received[0];
+        const expected: Field[] = [
+          {
+            name: 'Field',
+            type: FieldType.string,
+            values: ['A temperature', 'B temperature'],
+            config: {},
+          },
+          {
+            name: 'First',
+            type: FieldType.number,
+            values: [NaN, 1],
+            config: {},
+          },
+          {
+            name: 'Min',
+            type: FieldType.number,
+            values: [NaN, 1],
+            config: {},
+          },
+          {
+            name: 'Max',
+            type: FieldType.number,
+            values: [NaN, 7],
+            config: {},
+          },
+          {
+            name: 'Last',
+            type: FieldType.number,
+            values: [NaN, 7],
+            config: {},
+          },
+        ];
+
+        expect(processed.length).toEqual(1);
+        expect(processed[0].length).toEqual(2);
+        expect(processed[0].fields).toEqual(expected);
+      }
+    );
+
+    await expect(transformDataFrame([cfg], [seriesAWithSingleField, seriesBWithAllNulls])).toEmitValuesWith(
+      (received) => {
+        const processed = received[0];
+        const expected: Field[] = [
+          {
+            name: 'Field',
+            type: FieldType.string,
+            values: ['A temperature', 'B temperature'],
+            config: {},
+          },
+          {
+            name: 'First',
+            type: FieldType.number,
+            values: [3, NaN],
+            config: {},
+          },
+          {
+            name: 'Min',
+            type: FieldType.number,
+            values: [3, NaN],
+            config: {},
+          },
+          {
+            name: 'Max',
+            type: FieldType.number,
+            values: [6, NaN],
+            config: {},
+          },
+          {
+            name: 'Last',
+            type: FieldType.number,
+            values: [6, NaN],
             config: {},
           },
         ];

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -132,7 +132,12 @@ function reduceSeriesToRows(
 
       for (const info of calculators) {
         const v = results[info.id];
-        calcs[info.id][i] = v;
+        if (v === null) {
+          // NaN ensures proper row index, null results in shift
+          calcs[info.id][i] = NaN;
+        } else {
+          calcs[info.id][i] = v;
+        }
       }
     }
 


### PR DESCRIPTION
When using Reduce series to rows, null calculations will shift rows. Replacing nulls with NaN's ensures proper row index.

JSON for testing (can probably add a wider range of numbers): 
[Reduce Bug-1721179199666.json](https://github.com/user-attachments/files/16258070/Reduce.Bug-1721179199666.json)

- [x] Add tests


Before:
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/afbef095-2e75-4f94-b358-ce518c239fa0">
<img width="1291" alt="image" src="https://github.com/user-attachments/assets/a02412e2-92ce-47ad-9c60-27206975e24b">

After:
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/d68965b0-5f87-4f6d-9366-42d3d5f83c23">
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/6ca98d2f-96d2-41b0-aa0c-ca26adb38650">

Fixes https://github.com/grafana/support-escalations/issues/11412