### PR TITLE
Alerting: Move alertmanager warning to consistent place within notification policies

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.tsx
@@ -219,6 +219,7 @@ const AmRoutes = () => {
 
   return (
     <>
+      <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={selectedAlertmanager} />
       <TabsBar>
         <Tab
           label={'Notification Policies'}
@@ -249,7 +250,6 @@ const AmRoutes = () => {
           <>
             {policyTreeTabActive && (
               <>
-                <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={selectedAlertmanager} />
                 <Stack direction="column" gap={1}>
                   {rootRoute && (
                     <NotificationPoliciesFilter


### PR DESCRIPTION
**What is this feature?**

Move the alertmanager config warning in Notification Policies to the same place as in other sections, so we have a more consistent experience when switching between alerting sections

Before:
![image](https://github.com/user-attachments/assets/20ecba06-1160-4312-87b1-2e50794a193e)


After:
![image](https://github.com/user-attachments/assets/2881908b-008f-4089-a482-601ce1a98d08)



**Why do we need this feature?**
🔍  Consistency and experience