### PR TITLE
Revert "Frontend: Use safe stringifier in parseBody"

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -246,7 +246,7 @@ export {
 } from './utils/csv';
 export { parseLabels, findCommonLabels, findUniqueLabels, matchAllLabels, formatLabels } from './utils/labels';
 export { roundDecimals, guessDecimals } from './utils/numbers';
-export { objRemoveUndefined, isEmptyObject, safeStringifyValue } from './utils/object';
+export { objRemoveUndefined, isEmptyObject } from './utils/object';
 export { classicColors } from './utils/namedColorsPalette';
 export { getSeriesTimeStep, hasMsResolution } from './utils/series';
 export { BinaryOperationID, type BinaryOperation, binaryOperators } from './utils/binaryOperators';

--- a/packages/grafana-data/src/utils/object.ts
+++ b/packages/grafana-data/src/utils/object.ts
@@ -10,22 +10,3 @@
 export const isEmptyObject = (value: unknown): value is Record<string, never> => {
   return typeof value === 'object' && value !== null && Object.keys(value).length === 0;
 };
-
-/** Stringifies an object that may contain circular references */
-export function safeStringifyValue(value: unknown) {
-  const getCircularReplacer = () => {
-    const seen = new WeakSet();
-    return (_: string, value: object | null) => {
-      if (typeof value === 'object' && value !== null) {
-        if (seen.has(value)) {
-          return;
-        }
-        seen.add(value);
-      }
-
-      return value;
-    };
-  };
-
-  return JSON.stringify(value, getCircularReplacer());
-}

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,6 +1,6 @@
 import { omitBy } from 'lodash';
 
-import { deprecationWarning, safeStringifyValue } from '@grafana/data';
+import { deprecationWarning } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
@@ -93,7 +93,7 @@ export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
     return options.data;
   }
 
-  return isAppJson ? safeStringifyValue(options.data) : new URLSearchParams(options.data);
+  return isAppJson ? JSON.stringify(options.data) : new URLSearchParams(options.data);
 };
 
 export async function parseResponseBody<T>(


### PR DESCRIPTION
Reverts grafana/grafana#90047

This causes issues when stringifying an object with the same object reference assigned to multiple keys. We found it with the target expressions, where we used a symbol assigned as a datasource, so the datasource property was kept only for the first query, the rest were missing the datasource field.