### PR TITLE
Alerting: Use Runbook URL label everywhere and add validation in the alert rule…

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -145,10 +145,7 @@ const AnnotationsStep = () => {
                       <ValueInputComponent
                         data-testid={`annotation-value-${index}`}
                         className={cx(styles.annotationValueInput, { [styles.textarea]: !isUrl })}
-                        {...register(`annotations.${index}.value`, {
-                          validate: (value: string) =>
-                            isUrl && !value.startsWith('http') ? 'URL must start with http' : true,
-                        })}
+                        {...register(`annotations.${index}.value`)}
                         placeholder={
                           isUrl
                             ? 'https://'

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -5,7 +5,7 @@ import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Field, Input, Text, TextArea, useStyles2, Stack } from '@grafana/ui';
+import { Button, Field, Input, Stack, Text, TextArea, useStyles2 } from '@grafana/ui';
 
 import { DashboardModel } from '../../../../dashboard/state';
 import { RuleFormValues } from '../../types/rule-form';
@@ -145,7 +145,10 @@ const AnnotationsStep = () => {
                       <ValueInputComponent
                         data-testid={`annotation-value-${index}`}
                         className={cx(styles.annotationValueInput, { [styles.textarea]: !isUrl })}
-                        {...register(`annotations.${index}.value`)}
+                        {...register(`annotations.${index}.value`, {
+                          validate: (value: string) =>
+                            isUrl && !value.startsWith('http') ? 'URL must start with http' : true,
+                        })}
                         placeholder={
                           isUrl
                             ? 'https://'

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -148,14 +148,18 @@ const createMetadata = (rule: CombinedRule): PageInfoItem[] => {
   const interval = group.interval;
 
   if (runbookUrl) {
+    /* TODO instead of truncating the string, we should use flex and text overflow properly to allow it to take up all of the horizontal space available */
+    const truncatedUrl = truncate(runbookUrl, { length: 42 });
+    const valueToAdd = isValidRunbookURL(runbookUrl) ? (
+      <TextLink variant="bodySmall" href={runbookUrl} external>
+        {truncatedUrl}
+      </TextLink>
+    ) : (
+      <Text variant="bodySmall">{truncatedUrl}</Text>
+    );
     metadata.push({
       label: 'Runbook URL',
-      value: (
-        <TextLink variant="bodySmall" href={runbookUrl} external>
-          {/* TODO instead of truncating the string, we should use flex and text overflow properly to allow it to take up all of the horizontal space available */}
-          {truncate(runbookUrl, { length: 42 })}
-        </TextLink>
-      ),
+      value: valueToAdd,
     });
   }
 
@@ -359,5 +363,19 @@ const getStyles = () => ({
     minWidth: 0,
   }),
 });
+
+function isValidRunbookURL(url: string) {
+  const isRelative = url.startsWith('/');
+  let isAbsolute = false;
+
+  try {
+    new URL(url);
+    isAbsolute = true;
+  } catch (_) {
+    return false;
+  }
+
+  return isRelative || isAbsolute;
+}
 
 export default RuleViewer;

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -149,7 +149,7 @@ const createMetadata = (rule: CombinedRule): PageInfoItem[] => {
 
   if (runbookUrl) {
     metadata.push({
-      label: 'Runbook',
+      label: 'Runbook URL',
       value: (
         <TextLink variant="bodySmall" href={runbookUrl} external>
           {/* TODO instead of truncating the string, we should use flex and text overflow properly to allow it to take up all of the horizontal space available */}


### PR DESCRIPTION
**What is this feature?**

This PR updates the UI to consistently display `Runbook URL` everywhere. 
It also renders a link in the alert detail view only when this url is valid, other wise it renders a text.

If users prefer to use an annotation for their runbook storage, they can use a custom annotation for this purpose.

[Slack discussion](https://raintank-corp.slack.com/archives/C035H7HNJDR/p1721055935444859)

**Why do we need this feature?**

To have a consistent UI.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

[Escalation related ](https://github.com/grafana/support-escalations/issues/11378)

**Special notes for your reviewer:**

<img width="1649" alt="Screenshot 2024-07-17 at 12 30 21" src="https://github.com/user-attachments/assets/4eaaf8b6-2307-405d-b44c-c3cc6b1d9f1d">

<img width="635" alt="Screenshot 2024-07-17 at 12 30 33" src="https://github.com/user-attachments/assets/a362cae5-06b0-4c19-bd97-a7d13b0268df">

<img width="547" alt="Screenshot 2024-07-17 at 14 04 19" src="https://github.com/user-attachments/assets/c60b7169-9a44-408e-a064-9a03c6e7997e">




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
