### PR TITLE
CloudMigrations: Sets default grafana domain to prod

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -313,7 +313,7 @@ application_insights_endpoint_url =
 feedback_links_enabled = true
 
 # Static context that is being added to analytics events
-reporting_static_context = 
+reporting_static_context =
 
 #################################### Security ############################
 [security]
@@ -1951,6 +1951,6 @@ fetch_access_policy_timeout = 5s
 # How long to wait for a request to create to delete an access policy to complete
 delete_access_policy_timeout = 5s
 # The domain name used to access cms
-domain = grafana-dev.net
+domain = grafana.net
 # Folder used to store snapshot files. Defaults to the home dir
 snapshot_folder = ""

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -30,7 +30,7 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 	cfg.CloudMigration.IsTarget = cloudMigration.Key("is_target").MustBool(false)
 	cfg.CloudMigration.GcomAPIToken = cloudMigration.Key("gcom_api_token").MustString("")
 	cfg.CloudMigration.SnapshotFolder = cloudMigration.Key("snapshot_folder").MustString("")
-	cfg.CloudMigration.GMSDomain = cloudMigration.Key("domain").MustString("grafana.net")
+	cfg.CloudMigration.GMSDomain = cloudMigration.Key("domain").MustString("")
 	cfg.CloudMigration.GMSValidateKeyTimeout = cloudMigration.Key("validate_key_timeout").MustDuration(5 * time.Second)
 	cfg.CloudMigration.GMSStartSnapshotTimeout = cloudMigration.Key("start_snapshot_timeout").MustDuration(5 * time.Second)
 	cfg.CloudMigration.GMSGetSnapshotStatusTimeout = cloudMigration.Key("get_snapshot_status_timeout").MustDuration(5 * time.Second)

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -30,7 +30,7 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 	cfg.CloudMigration.IsTarget = cloudMigration.Key("is_target").MustBool(false)
 	cfg.CloudMigration.GcomAPIToken = cloudMigration.Key("gcom_api_token").MustString("")
 	cfg.CloudMigration.SnapshotFolder = cloudMigration.Key("snapshot_folder").MustString("")
-	cfg.CloudMigration.GMSDomain = cloudMigration.Key("domain").MustString("")
+	cfg.CloudMigration.GMSDomain = cloudMigration.Key("domain").MustString("grafana.net")
 	cfg.CloudMigration.GMSValidateKeyTimeout = cloudMigration.Key("validate_key_timeout").MustDuration(5 * time.Second)
 	cfg.CloudMigration.GMSStartSnapshotTimeout = cloudMigration.Key("start_snapshot_timeout").MustDuration(5 * time.Second)
 	cfg.CloudMigration.GMSGetSnapshotStatusTimeout = cloudMigration.Key("get_snapshot_status_timeout").MustDuration(5 * time.Second)


### PR DESCRIPTION
Sets default config to `grafana.net` instead of `grafana-dev.net`. This will avoid for customers need to enter this configuration manually (only needed for testing purposes)