### PR TITLE
Elasticsearch: Decouple backend from infra/log

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -17,8 +17,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	exp "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
@@ -55,7 +55,7 @@ type Client interface {
 
 // NewClient creates a new elasticsearch client
 var NewClient = func(ctx context.Context, ds *DatasourceInfo, logger log.Logger, tracer tracing.Tracer) (Client, error) {
-	logger = logger.New("entity", "client")
+	logger = logger.FromContext(ctx).With("entity", "client")
 
 	ip, err := newIndexPattern(ds.Interval, ds.Database)
 	if err != nil {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
@@ -67,7 +67,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 			To:   to,
 		}
 
-		c, err := NewClient(context.Background(), &ds, log.New("test", "test"), tracing.InitializeTracerForTest())
+		c, err := NewClient(context.Background(), &ds, log.New(), tracing.InitializeTracerForTest())
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -163,7 +163,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 			To:   to2,
 		}
 
-		c, err := NewClient(context.Background(), &ds, log.New("test", "test"), tracing.InitializeTracerForTest())
+		c, err := NewClient(context.Background(), &ds, log.New(), tracing.InitializeTracerForTest())
 		require.NoError(t, err)
 		require.NotNil(t, c)
 
@@ -260,7 +260,7 @@ func TestClient_Index(t *testing.T) {
 				To:   to,
 			}
 
-			c, err := NewClient(context.Background(), &ds, log.New("test", "test"), tracing.InitializeTracerForTest())
+			c, err := NewClient(context.Background(), &ds, log.New(), tracing.InitializeTracerForTest())
 			require.NoError(t, err)
 			require.NotNil(t, c)
 

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )

--- a/pkg/tsdb/elasticsearch/data_query_test.go
+++ b/pkg/tsdb/elasticsearch/data_query_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
@@ -1862,6 +1862,6 @@ func executeElasticsearchDataQuery(c es.Client, body string, from, to time.Time)
 			},
 		},
 	}
-	query := newElasticsearchDataQuery(context.Background(), c, &dataRequest, log.New("test.logger"), tracing.InitializeTracerForTest())
+	query := newElasticsearchDataQuery(context.Background(), c, &dataRequest, log.New(), tracing.InitializeTracerForTest())
 	return query.execute()
 }

--- a/pkg/tsdb/elasticsearch/healthcheck.go
+++ b/pkg/tsdb/elasticsearch/healthcheck.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	logger := eslog.FromContext(ctx)
+	logger := s.logger.FromContext(ctx)
 
 	ds, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {

--- a/pkg/tsdb/elasticsearch/healthcheck_test.go
+++ b/pkg/tsdb/elasticsearch/healthcheck_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 	"github.com/stretchr/testify/assert"
 )
@@ -75,6 +76,7 @@ func (*FakeInstanceManager) Do(_ context.Context, _ backend.PluginContext, _ ins
 
 func GetMockService(isDsHealthy bool) *Service {
 	return &Service{
-		im: &FakeInstanceManager{isDsHealthy: isDsHealthy},
+		im:     &FakeInstanceManager{isDsHealthy: isDsHealthy},
+		logger: log.New(),
 	}
 }

--- a/pkg/tsdb/elasticsearch/parse_query.go
+++ b/pkg/tsdb/elasticsearch/parse_query.go
@@ -2,9 +2,9 @@ package elasticsearch
 
 import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 func parseQuery(tsdbQuery []backend.DataQuery, logger log.Logger) ([]*Query, error) {

--- a/pkg/tsdb/elasticsearch/parse_query_test.go
+++ b/pkg/tsdb/elasticsearch/parse_query_test.go
@@ -3,7 +3,7 @@ package elasticsearch
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,7 +61,7 @@ func TestParseQuery(t *testing.T) {
 			}`
 			dataQuery, err := newDataQuery(body)
 			require.NoError(t, err)
-			queries, err := parseQuery(dataQuery.Queries, log.New("test.logger"))
+			queries, err := parseQuery(dataQuery.Queries, log.New())
 			require.NoError(t, err)
 			require.Len(t, queries, 1)
 

--- a/pkg/tsdb/elasticsearch/querydata_test.go
+++ b/pkg/tsdb/elasticsearch/querydata_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
@@ -142,7 +142,7 @@ func queryDataTestWithResponseCode(queriesBytes []byte, responseStatusCode int, 
 		return nil
 	})
 
-	result, err := queryData(context.Background(), &req, dsInfo, log.New("test.logger"), tracing.InitializeTracerForTest())
+	result, err := queryData(context.Background(), &req, dsInfo, log.New(), tracing.InitializeTracerForTest())
 	if err != nil {
 		return queryDataTestResult{}, err
 	}

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"go.opentelemetry.io/otel/attribute"
@@ -19,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 	"github.com/grafana/grafana/pkg/tsdb/elasticsearch/instrumentation"

--- a/pkg/tsdb/elasticsearch/response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/response_parser_test.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
@@ -3677,12 +3677,12 @@ func parseTestResponse(tsdbQueries map[string]string, responseBody string, keepL
 		return nil, err
 	}
 
-	queries, err := parseQuery(tsdbQuery.Queries, log.New("test.logger"))
+	queries, err := parseQuery(tsdbQuery.Queries, log.New())
 	if err != nil {
 		return nil, err
 	}
 
-	return parseResponse(context.Background(), response.Responses, queries, configuredFields, keepLabelsInResponse, log.New("test.logger"), tracing.InitializeTracerForTest())
+	return parseResponse(context.Background(), response.Responses, queries, configuredFields, keepLabelsInResponse, log.New(), tracing.InitializeTracerForTest())
 }
 
 func requireTimeValue(t *testing.T, expected int64, frame *data.Frame, index int) {


### PR DESCRIPTION
**What is this feature?**

This PR removes the Elasticsearch datasource's dependency on `infra/log`.

This is the second of three PRs to decouple the Elasticsearch plugin from core grafana imports, part of #72632. For ease of review I've split this into several PRs and targeted them as a chain (`main <- PR 1 <- PR 2 <- PR 3`) but I'll rebase and retarget them as each is merged in turn.

**Why do we need this feature?**
Removing core imports is part of the process of externalizing the plugin. See #72632 for more information.