### PR TITLE
fix(querier): use most specific timerange available

### DIFF
--- a/pkg/registry/apis/query/parser.go
+++ b/pkg/registry/apis/query/parser.go
@@ -70,14 +70,6 @@ func (p *queryParser) parseRequest(ctx context.Context, input *query.QueryDataRe
 		RefIDTypes: make(map[string]string, len(input.Queries)),
 	}
 
-	// Ensure a valid time range
-	if input.From == "" {
-		input.From = "now-6h"
-	}
-	if input.To == "" {
-		input.To = "now"
-	}
-
 	for _, q := range input.Queries {
 		_, found := queryRefIDs[q.RefID]
 		if found {
@@ -123,7 +115,7 @@ func (p *queryParser) parseRequest(ctx context.Context, input *query.QueryDataRe
 					PluginId: ds.Type,
 					UID:      ds.UID,
 					Request: &data.QueryDataRequest{
-						TimeRange: input.TimeRange,
+						TimeRange: getTimeRangeForQuery(&input.TimeRange, q.TimeRange),
 						Debug:     input.Debug,
 						// no queries
 					},
@@ -187,6 +179,19 @@ func (p *queryParser) parseRequest(ctx context.Context, input *query.QueryDataRe
 		}
 	}
 	return rsp, nil
+}
+
+func getTimeRangeForQuery(parentTimerange, queryTimerange *data.TimeRange) data.TimeRange {
+	if queryTimerange != nil && queryTimerange.From != "" && queryTimerange.To != "" {
+		return *queryTimerange
+	}
+	if parentTimerange != nil && parentTimerange.To != "" && parentTimerange.From != "" {
+		return *parentTimerange
+	}
+	return data.TimeRange{
+		From: "now-6h",
+		To:   "now",
+	}
 }
 
 func (p *queryParser) getValidDataSourceRef(ctx context.Context, ds *data.DataSourceRef, id int64) (*data.DataSourceRef, error) {

--- a/pkg/registry/apis/query/parser.go
+++ b/pkg/registry/apis/query/parser.go
@@ -189,8 +189,8 @@ func getTimeRangeForQuery(parentTimerange, queryTimerange *data.TimeRange) data.
 		return *parentTimerange
 	}
 	return data.TimeRange{
-		From: "now-6h",
-		To:   "now",
+		From: "0",
+		To:   "0",
 	}
 }
 

--- a/pkg/registry/apis/query/parser_test.go
+++ b/pkg/registry/apis/query/parser_test.go
@@ -65,7 +65,58 @@ func TestQuerySplitting(t *testing.T) {
 		require.Equal(t, "now-6h", split.Requests[0].Request.From)
 		require.Equal(t, "now", split.Requests[0].Request.To)
 	})
+	t.Run("applies query time range if present", func(t *testing.T) {
+		split, err := parser.parseRequest(ctx, &query.QueryDataRequest{
+			QueryDataRequest: data.QueryDataRequest{
+				TimeRange: data.TimeRange{}, // missing
+				Queries: []data.DataQuery{{
+					CommonQueryProperties: data.CommonQueryProperties{
+						RefID: "A",
+						Datasource: &data.DataSourceRef{
+							Type: "x",
+							UID:  "abc",
+						},
+						TimeRange: &data.TimeRange{
+							From: "now-1d",
+							To:   "now",
+						},
+					},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, split.Requests, 1)
+		require.Equal(t, "now-1d", split.Requests[0].Request.From)
+		require.Equal(t, "now", split.Requests[0].Request.To)
+	})
 
+	t.Run("applies query time range if all time ranges are present", func(t *testing.T) {
+		split, err := parser.parseRequest(ctx, &query.QueryDataRequest{
+			QueryDataRequest: data.QueryDataRequest{
+				TimeRange: data.TimeRange{
+					From: "now-1h",
+					To:   "now",
+				},
+				Queries: []data.DataQuery{{
+					CommonQueryProperties: data.CommonQueryProperties{
+						RefID: "A",
+						Datasource: &data.DataSourceRef{
+							Type: "x",
+							UID:  "abc",
+						},
+						TimeRange: &data.TimeRange{
+							From: "now-1d",
+							To:   "now",
+						},
+					},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, split.Requests, 1)
+		require.Equal(t, "now-1d", split.Requests[0].Request.From)
+		require.Equal(t, "now", split.Requests[0].Request.To)
+	})
 	t.Run("verify tests", func(t *testing.T) {
 		files, err := os.ReadDir("testdata")
 		require.NoError(t, err)

--- a/pkg/registry/apis/query/parser_test.go
+++ b/pkg/registry/apis/query/parser_test.go
@@ -45,7 +45,7 @@ func TestQuerySplitting(t *testing.T) {
 		require.Empty(t, split.Requests)
 	})
 
-	t.Run("applies default time range", func(t *testing.T) {
+	t.Run("applies zero time range if time range is missing", func(t *testing.T) {
 		split, err := parser.parseRequest(ctx, &query.QueryDataRequest{
 			QueryDataRequest: data.QueryDataRequest{
 				TimeRange: data.TimeRange{}, // missing
@@ -62,8 +62,8 @@ func TestQuerySplitting(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, split.Requests, 1)
-		require.Equal(t, "now-6h", split.Requests[0].Request.From)
-		require.Equal(t, "now", split.Requests[0].Request.To)
+		require.Equal(t, "0", split.Requests[0].Request.From)
+		require.Equal(t, "0", split.Requests[0].Request.To)
 	})
 	t.Run("applies query time range if present", func(t *testing.T) {
 		split, err := parser.parseRequest(ctx, &query.QueryDataRequest{


### PR DESCRIPTION
This PR ensures that we select the right timerange for a query, based on the following criteria:

- If a query has its own timerange, use that.
- If a query don't have it's own timerange
  - Try first to get the timerange from the parent request
  - Otherwise use the default `0`, `0` 

This is important as backend services like alerting don't set any timerange in the request itself but only on the queries. This caused all queries to run on a 6 hour range, which caused high latency and resource drain. 