### PR TITLE
[v10.4.x] docs: updated table panel visualization

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -43,7 +43,7 @@ refs:
 
 # Table
 
-Tables are very flexible, supporting multiple modes for time series and for tables, annotation, and raw JSON data. This visualization also provides date formatting, value formatting, and coloring options.
+Tables are a highly flexible visualization designed to display data in columns and rows. They support various data types, including tables, time series, annotations, and raw JSON data. The table visualization can even take multiple data sets and provide the option to switch between them. With this versatility, it's the preferred visualization for viewing multiple data types, aiding in your data analysis needs.
 
 {{< figure src="/static/img/docs/tables/table_visualization.png" max-width="1200px" lightbox="true" caption="Table visualization" >}}
 
@@ -53,15 +53,21 @@ The following video provides a visual walkthrough of the options you can set in 
 
 {{< docs/play title="Table Visualizations in Grafana" url="https://play.grafana.org/d/OhR1ID6Mk/" >}}
 
-## Annotation and alert support
-
-Annotations and alerts are not currently supported in tables.
+{{< admonition type="note" >}}
+Annotations and alerts are not currently supported for tables.
+{{< /admonition >}}
 
 ## Sort column
 
 Click a column title to change the sort order from default to descending to ascending. Each time you click, the sort order changes to the next option in the cycle. You can sort multiple columns by holding the `shift` key and clicking the column name.
 
 ![Sort descending](/static/img/docs/tables/sort-descending.png 'Sort descending')
+
+## Data set selector
+
+If the data queried contains multiple data sets, a table displays a drop-down list at the bottom, so you can select the data set you want to visualize.
+
+![Table visualization with multiple data sets](/media/docs/grafana/panels-visualizations/TablePanelMultiSet.png)
 
 ## Panel options
 
@@ -124,7 +130,11 @@ If thresholds are set, then the field background is displayed in the appropriate
 
 Cells can be displayed as a graphical gauge, with several different presentation types.
 
-#### Basic
+{{< admonition type="note" >}}
+The maximum and minimum values of the gauges are configured automatically from the smallest and largest values in your whole data set. If you don't want the max/min values to be pulled from the whole data set, you can configure them for each column with field overrides.
+{{< /admonition >}}
+
+##### Basic
 
 The basic mode will show a simple gauge with the threshold levels defining the color of gauge.
 


### PR DESCRIPTION
Backport efdb08ed8cda9b0fad89e87886de3788496052e9 from #90310

---

**What is this feature?**

Updates to the table panel docs to include:

- modified a bit the description and reordered the beginning
- added a section mentioning the behavior when multiple data sets are present and added an image
- added a note on how to define max and minimums when using gauges as note. Looking forward for feedback on the best way to present this
- Transformed a section on Annotations and Alerts into a note. Looking forward to feedback on this change.

**Why do we need this feature?**

These changes will help users to understand better tables, some features that were not explained and flow better modifying some format.

**Who is this feature for?**

All Grafana users looking for docs on Table visualizations

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
