### PR TITLE
Auth: Add option to always use backend permissions

### DIFF
--- a/packages/grafana-data/src/rbac/rbac.ts
+++ b/packages/grafana-data/src/rbac/rbac.ts
@@ -1,10 +1,21 @@
+import { getBackendSrv } from '../../../grafana-runtime/src/services/backendSrv'; // hacky import for specific ask. Clean if kept.
 import { WithAccessControlMetadata } from '../types/accesscontrol';
 import { CurrentUserDTO } from '../types/config';
 
-export interface CurrentUser extends Omit<CurrentUserDTO, 'lightTheme'> {}
+
+export interface CurrentUser extends Omit<CurrentUserDTO, 'lightTheme'> { }
 
 export function userHasPermission(action: string, user: CurrentUser): boolean {
-  return !!user.permissions?.[action];
+  let permissions: Record<string, boolean> | undefined;
+  try {
+    getBackendSrv().get('/api/access-control/user/actions', {
+      reloadcache: false,
+    }).then((res: Record<string, boolean>) => { permissions = res; });
+  } catch (e) {
+    console.error(e);
+    permissions = user.permissions;
+  }
+  return !!permissions?.[action];
 }
 
 export function userHasPermissionInMetadata(action: string, object: WithAccessControlMetadata): boolean {

--- a/packages/grafana-data/src/rbac/rbac.ts
+++ b/packages/grafana-data/src/rbac/rbac.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv } from '../../../grafana-runtime/src/services/backendSrv'; // hacky import for specific ask. Clean if kept.
+import { getBackendSrv } from '../../../grafana-runtime/src/services/backendSrv'; // can't be used here, userHasPermission would need to move
 import { WithAccessControlMetadata } from '../types/accesscontrol';
 import { CurrentUserDTO } from '../types/config';
 

--- a/packages/grafana-data/src/rbac/rbac.ts
+++ b/packages/grafana-data/src/rbac/rbac.ts
@@ -7,12 +7,17 @@ export interface CurrentUser extends Omit<CurrentUserDTO, 'lightTheme'> { }
 
 export function userHasPermission(action: string, user: CurrentUser): boolean {
   let permissions: Record<string, boolean> | undefined;
-  try {
-    getBackendSrv().get('/api/access-control/user/actions', {
-      reloadcache: false,
-    }).then((res: Record<string, boolean>) => { permissions = res; });
-  } catch (e) {
-    console.error(e);
+  if (window?.grafanaBootData?.settings?.featureToggles?.noFrontendPermissionCache) {
+    try {
+      // replace with check endpoint in the future
+      getBackendSrv().get('/api/access-control/user/actions', {
+        reloadcache: false,
+      }).then((res: Record<string, boolean>) => { permissions = res; });
+    } catch (e) {
+      console.error(e);
+      permissions = user.permissions;
+    }
+  } else {
     permissions = user.permissions;
   }
   return !!permissions?.[action];

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -193,6 +193,7 @@ export interface FeatureToggles {
   failWrongDSUID?: boolean;
   databaseReadReplica?: boolean;
   zanzana?: boolean;
+  noFrontendPermissionCache?: boolean;
   passScopeToDashboardApi?: boolean;
   alertingApiServer?: boolean;
   dashboardRestoreUI?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1317,6 +1317,14 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
+			Name:              "noFrontendPermissionCache",
+			Description:       "Do not use permission caching in frontend",
+			Stage:             FeatureStageExperimental,
+			Owner:             identityAccessTeam,
+			HideFromDocs:      true,
+			HideFromAdminPage: true,
+		},
+		{
 			Name:              "passScopeToDashboardApi",
 			Description:       "Enables the passing of scopes to dashboards fetching in Grafana",
 			FrontendOnly:      false,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -174,6 +174,7 @@ ssoSettingsLDAP,experimental,@grafana/identity-access-team,false,false,false
 failWrongDSUID,experimental,@grafana/plugins-platform-backend,false,false,false
 databaseReadReplica,experimental,@grafana/grafana-backend-services-squad,false,false,false
 zanzana,experimental,@grafana/identity-access-team,false,false,false
+noFrontendPermissionCache,experimental,@grafana/identity-access-team,false,false,false
 passScopeToDashboardApi,experimental,@grafana/dashboards-squad,false,false,false
 alertingApiServer,experimental,@grafana/alerting-squad,false,true,false
 dashboardRestoreUI,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -707,6 +707,10 @@ const (
 	// Use openFGA as authorization engine.
 	FlagZanzana = "zanzana"
 
+	// FlagNoFrontendPermissionCache
+	// Do not use permission caching in frontend
+	FlagNoFrontendPermissionCache = "noFrontendPermissionCache"
+
 	// FlagPassScopeToDashboardApi
 	// Enables the passing of scopes to dashboards fetching in Grafana
 	FlagPassScopeToDashboardApi = "passScopeToDashboardApi"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1771,6 +1771,20 @@
     },
     {
       "metadata": {
+        "name": "noFrontendPermissionCache",
+        "resourceVersion": "1721290625278",
+        "creationTimestamp": "2024-07-18T08:17:05Z"
+      },
+      "spec": {
+        "description": "Do not use permission caching in frontend",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "nodeGraphDotLayout",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2024-01-31T16:26:12Z"


### PR DESCRIPTION
**What is this feature?**

Add option to always use backend permissions

TODO:
- Add option part

**Why do we need this feature?**

Specific ask on frontend display delays. Testing on if frontend cache actually has a noticeable impact on experience.
