### PR TITLE
Chore: change owner for `pkg/services/queryhistory`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,7 +130,7 @@
 /pkg/services/preference/ @grafana/grafana-backend-group
 /pkg/services/provisioning/ @grafana/grafana-search-and-storage
 /pkg/services/query/ @grafana/grafana-app-platform-squad
-/pkg/services/queryhistory/ @grafana/grafana-app-platform-squad
+/pkg/services/queryhistory/ @grafana/explore-squad
 /pkg/services/quota/ @grafana/grafana-search-and-storage
 /pkg/services/screenshot/ @grafana/grafana-backend-group
 /pkg/services/search/ @grafana/grafana-search-and-storage


### PR DESCRIPTION
We reassigned codeownership for `pkg/services/queryhistory` from the backend platform to app platform squad in https://github.com/grafana/grafana/pull/86010/ but its actually owned by the Explore squad