### PR TITLE
Chore: Skip flakey search test

### DIFF
--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -264,6 +264,7 @@ func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 
 	testScenarioWithMixedQueriesInQueryHistory(t, "When users tries to get queries with mixed data source it should return correct queries",
 		func(t *testing.T, sc scenarioContext) {
+			t.Skip() // This test fails a lot at the moment
 			sc.reqContext.Req.Form.Add("to", strconv.FormatInt(sc.service.now().UnixMilli()-60, 10))
 			sc.reqContext.Req.Form.Add("from", strconv.FormatInt(sc.service.now().UnixMilli()+60, 10))
 			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)


### PR DESCRIPTION
this test is failing a lot in CI -- lets disable and reenable when it is more stable