### PR TITLE
[v11.0.x] Prometheus: Reintroduce Azure audience override feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -177,4 +177,5 @@ export interface FeatureToggles {
   ssoSettingsSAML?: boolean;
   usePrometheusFrontendPackage?: boolean;
   oauthRequireSubClaim?: boolean;
+  prometheusAzureOverrideAudience?: boolean;
 }

--- a/pkg/promlib/heuristics_test.go
+++ b/pkg/promlib/heuristics_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 type heuristicsSuccessRoundTripper struct {
@@ -41,7 +42,7 @@ func newHeuristicsSDKProvider(hrt heuristicsSuccessRoundTripper) *sdkhttpclient.
 	return sdkhttpclient.NewProvider(sdkhttpclient.ProviderOptions{Middlewares: []sdkhttpclient.Middleware{mid}})
 }
 
-func mockExtendClientOpts(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options) error {
+func mockExtendClientOpts(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options, log log.Logger) error {
 	return nil
 }
 

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -32,7 +32,7 @@ type instance struct {
 	versionCache *cache.Cache
 }
 
-type ExtendOptions func(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options) error
+type ExtendOptions func(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options, log log.Logger) error
 
 func NewService(httpClientProvider *sdkhttpclient.Provider, plog log.Logger, extendOptions ExtendOptions) *Service {
 	if httpClientProvider == nil {
@@ -53,7 +53,7 @@ func newInstanceSettings(httpClientProvider *sdkhttpclient.Provider, log log.Log
 		}
 
 		if extendOptions != nil {
-			err = extendOptions(ctx, settings, opts)
+			err = extendOptions(ctx, settings, opts, log)
 			if err != nil {
 				return nil, fmt.Errorf("error extending transport options: %v", err)
 			}

--- a/pkg/promlib/library_test.go
+++ b/pkg/promlib/library_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +61,7 @@ func getMockPromTestSDKProvider(f *fakeHTTPClientProvider) *sdkhttpclient.Provid
 	return sdkhttpclient.NewProvider(sdkhttpclient.ProviderOptions{Middlewares: []sdkhttpclient.Middleware{mid}})
 }
 
-func mockExtendTransportOptions(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options) error {
+func mockExtendTransportOptions(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options, log log.Logger) error {
 	return nil
 }
 
@@ -103,7 +104,7 @@ func TestService(t *testing.T) {
 	t.Run("extendOptions function provided", func(t *testing.T) {
 		f := &fakeHTTPClientProvider{}
 		httpProvider := getMockPromTestSDKProvider(f)
-		service := NewService(httpProvider, backend.NewLoggerWith("logger", "test"), func(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options) error {
+		service := NewService(httpProvider, backend.NewLoggerWith("logger", "test"), func(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options, log log.Logger) error {
 			fmt.Println(ctx, settings, clientOpts)
 			require.NotNil(t, ctx)
 			require.NotNil(t, settings)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1190,6 +1190,13 @@ var (
 			HideFromDocs:      true,
 			HideFromAdminPage: true,
 		},
+		{
+			Name:        "prometheusAzureOverrideAudience",
+			Description: "Deprecated. Allow override default AAD audience for Azure Prometheus endpoint. Enabled by default. This feature should no longer be used and will be removed in the future.",
+			Stage:       FeatureStageDeprecated,
+			Owner:       grafanaPartnerPluginsSquad,
+			Expression:  "true", // Enabled by default for now
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -158,3 +158,4 @@ scopeFilters,experimental,@grafana/dashboards-squad,false,false,false
 ssoSettingsSAML,experimental,@grafana/identity-access-team,false,false,false
 usePrometheusFrontendPackage,experimental,@grafana/observability-metrics,false,false,true
 oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
+prometheusAzureOverrideAudience,deprecated,@grafana/partner-datasources,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -642,4 +642,8 @@ const (
 	// FlagOauthRequireSubClaim
 	// Require that sub claims is present in oauth tokens.
 	FlagOauthRequireSubClaim = "oauthRequireSubClaim"
+
+	// FlagPrometheusAzureOverrideAudience
+	// Deprecated. Allow override default AAD audience for Azure Prometheus endpoint. Enabled by default. This feature should no longer be used and will be removed in the future.
+	FlagPrometheusAzureOverrideAudience = "prometheusAzureOverrideAudience"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2052,6 +2052,18 @@
         "hideFromAdminPage": true,
         "hideFromDocs": true
       }
+    },
+    {
+      "metadata": {
+        "name": "prometheusAzureOverrideAudience",
+        "resourceVersion": "1721244365188",
+        "creationTimestamp": "2024-07-17T19:26:05Z"
+      },
+      "spec": {
+        "description": "Deprecated. Allow override default AAD audience for Azure Prometheus endpoint. Enabled by default. This feature should no longer be used and will be removed in the future.",
+        "stage": "deprecated",
+        "codeowner": "@grafana/partner-datasources"
+      }
     }
   ]
 }

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/grafana/grafana/pkg/promlib"
 	"github.com/grafana/grafana/pkg/tsdb/prometheus/azureauth"
@@ -45,7 +46,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	return s.lib.CheckHealth(ctx, req)
 }
 
-func extendClientOpts(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options) error {
+func extendClientOpts(ctx context.Context, settings backend.DataSourceInstanceSettings, clientOpts *sdkhttpclient.Options, plog log.Logger) error {
 	// Set SigV4 service namespace
 	if clientOpts.SigV4 != nil {
 		clientOpts.SigV4.Service = "aps"
@@ -56,9 +57,11 @@ func extendClientOpts(ctx context.Context, settings backend.DataSourceInstanceSe
 		return fmt.Errorf("failed to read Azure settings from Grafana: %v", err)
 	}
 
+	audienceOverride := backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled("prometheusAzureOverrideAudience")
+
 	// Set Azure authentication
 	if azureSettings.AzureAuthEnabled {
-		err = azureauth.ConfigureAzureAuthentication(settings, azureSettings, clientOpts)
+		err = azureauth.ConfigureAzureAuthentication(settings, azureSettings, clientOpts, audienceOverride, plog)
 		if err != nil {
 			return fmt.Errorf("error configuring Azure auth: %v", err)
 		}

--- a/pkg/tsdb/prometheus/prometheus_test.go
+++ b/pkg/tsdb/prometheus/prometheus_test.go
@@ -28,7 +28,7 @@ func TestExtendClientOpts(t *testing.T) {
 		}
 		ctx := backend.WithGrafanaConfig(context.Background(), cfg)
 		opts := &sdkhttpclient.Options{}
-		err := extendClientOpts(ctx, settings, opts)
+		err := extendClientOpts(ctx, settings, opts, backend.Logger)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(opts.Middlewares))
 	})
@@ -47,7 +47,7 @@ func TestExtendClientOpts(t *testing.T) {
 				SecretKey: "secretkey",
 			},
 		}
-		err := extendClientOpts(context.Background(), settings, opts)
+		err := extendClientOpts(context.Background(), settings, opts, backend.Logger)
 		require.NoError(t, err)
 		require.Equal(t, "aps", opts.SigV4.Service)
 	})

--- a/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
@@ -13,6 +13,7 @@ import { AzureCredentialsForm } from './AzureCredentialsForm';
 export const AzureAuthSettings = (props: HttpSettingsBaseProps) => {
   const { dataSourceConfig, onChange } = props;
 
+  const [overrideAudienceAllowed] = useState<boolean>(!!config.featureToggles.prometheusAzureOverrideAudience);
   const [overrideAudienceChecked, setOverrideAudienceChecked] = useState<boolean>(
     !!dataSourceConfig.jsonData.azureEndpointResourceId
   );
@@ -64,25 +65,29 @@ export const AzureAuthSettings = (props: HttpSettingsBaseProps) => {
         onCredentialsChange={onCredentialsChange}
         disabled={dataSourceConfig.readOnly}
       />
-      <h6>Azure configuration</h6>
-      <div className="gf-form-group">
-        <InlineFieldRow>
-          <InlineField labelWidth={labelWidth} label="Override AAD audience" disabled={dataSourceConfig.readOnly}>
-            <InlineSwitch value={overrideAudienceChecked} onChange={onOverrideAudienceChange} />
-          </InlineField>
-        </InlineFieldRow>
-        {overrideAudienceChecked && (
-          <InlineFieldRow>
-            <InlineField labelWidth={labelWidth} label="Resource ID" disabled={dataSourceConfig.readOnly}>
-              <Input
-                className={cx(prometheusConfigOverhaulAuth ? 'width-20' : 'width-30')}
-                value={dataSourceConfig.jsonData.azureEndpointResourceId || ''}
-                onChange={onResourceIdChange}
-              />
-            </InlineField>
-          </InlineFieldRow>
-        )}
-      </div>
+      {overrideAudienceAllowed && (
+        <>
+          <h6>Azure configuration</h6>
+          <div className="gf-form-group">
+            <InlineFieldRow>
+              <InlineField labelWidth={labelWidth} label="Override AAD audience" disabled={dataSourceConfig.readOnly}>
+                <InlineSwitch value={overrideAudienceChecked} onChange={onOverrideAudienceChange} />
+              </InlineField>
+            </InlineFieldRow>
+            {overrideAudienceChecked && (
+              <InlineFieldRow>
+                <InlineField labelWidth={labelWidth} label="Resource ID" disabled={dataSourceConfig.readOnly}>
+                  <Input
+                    className={cx(prometheusConfigOverhaulAuth ? 'width-20' : 'width-30')}
+                    value={dataSourceConfig.jsonData.azureEndpointResourceId || ''}
+                    onChange={onResourceIdChange}
+                  />
+                </InlineField>
+              </InlineFieldRow>
+            )}
+          </div>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Backport 2616366a0a90de214a30393d4681ea193204d3f6 from #90339

---

This PR reintroduces the feature flag removed in #71599. This feature flag is being reintroduced and marked as deprecated with the goal of removing this functionality in a future Grafana version. The reason for this deprecation is the scopes defined by the SDK should be used by default and there should no longer be a need to override the scope.

This is not a breaking change as the feature toggle will be enabled by default for now with the goal to disable and remove this toggle and functionality in a future version.

# Deprecation notice

The functionality to specify an Azure audience override in the Prometheus data source has been deprecated. The `prometheusAzureOverrideAudience` feature toggle has been introduced to allow Grafana administrators to disable this functionality as the required audience should be auto-configured by the data source. This functionality will be removed in a future release along with this feature toggle. If you have any issues please let us know!
