### PR TITLE
notifications: Fix confused trace spans in SMTP client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // @grafana/alerting-backend
 	github.com/microsoft/go-mssqldb v1.7.0 // @grafana/grafana-bi-squad
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c //@grafana/identity-access-team
+	github.com/mocktools/go-smtp-mock/v2 v2.3.0 // @grafana/grafana-backend-group
 	github.com/modern-go/reflect2 v1.0.2 // @grafana/alerting-backend
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // @grafana/alerting-backend
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // @grafana/grafana-operator-experience-squad

--- a/go.sum
+++ b/go.sum
@@ -2327,8 +2327,8 @@ github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56 h1:X8IKQ0wu40wp
 github.com/grafana/gomemcache v0.0.0-20240229205252-cd6a66d6fb56/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
 github.com/grafana/grafana-aws-sdk v0.28.0 h1:ShdA+msLPGJGWWS1SFUYnF+ch1G3gUOlAdGJi6h4sgU=
 github.com/grafana/grafana-aws-sdk v0.28.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
-github.com/grafana/grafana-azure-sdk-go/v2 v2.0.4 h1:z6amQ286IJSBctHf6c+ibJq/v0+TvmEjVkrdMNBd4uY=
-github.com/grafana/grafana-azure-sdk-go/v2 v2.0.4/go.mod h1:aKlFPE36IDa8qccRg3KbgZX3MQ5xymS3RelT4j6kkVU=
+github.com/grafana/grafana-azure-sdk-go/v2 v2.1.0 h1:lajVqTWaE96MpbjZToj7EshvqgRWOfYNkD4MbIZizaY=
+github.com/grafana/grafana-azure-sdk-go/v2 v2.1.0/go.mod h1:aKlFPE36IDa8qccRg3KbgZX3MQ5xymS3RelT4j6kkVU=
 github.com/grafana/grafana-cloud-migration-snapshot v1.1.0 h1:96Osqvdm1XXKs7ufmyFy31AW5ZWcikvcDrPX8p5LEpo=
 github.com/grafana/grafana-cloud-migration-snapshot v1.1.0/go.mod h1:rWNhyxYkgiXgV7xZ4yOQzMV08yikO8L8S8M5KNoQNpA=
 github.com/grafana/grafana-google-sdk-go v0.1.0 h1:LKGY8z2DSxKjYfr2flZsWgTRTZ6HGQbTqewE3JvRaNA=
@@ -2837,6 +2837,8 @@ github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
+github.com/mocktools/go-smtp-mock/v2 v2.3.0 h1:jgTDBEoQ8Kpw/fPWxy6qR2pGwtNn5j01T3Wut4xJo5Y=
+github.com/mocktools/go-smtp-mock/v2 v2.3.0/go.mod h1:n8aNpDYncZHH/cZHtJKzQyeYT/Dut00RghVM+J1Ed94=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -1,11 +1,17 @@
 package notifications
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/textproto"
 	"strings"
 	"testing"
 
+	smtpmock "github.com/mocktools/go-smtp-mock/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -140,5 +146,187 @@ func TestSmtpDialer(t *testing.T) {
 
 		require.Equal(t, 0, count)
 		require.EqualError(t, err, "could not load cert or key file: open /var/certs/does-not-exist.pem: no such file or directory")
+	})
+}
+
+func TestSmtpSend(t *testing.T) {
+	srv := smtpmock.New(smtpmock.ConfigurationAttr{
+		MultipleRcptto: true,
+	})
+	require.NoError(t, srv.Start())
+	defer func() { _ = srv.Stop() }()
+
+	cfg := createSmtpConfig()
+	cfg.Smtp.Host = fmt.Sprintf("127.0.0.1:%d", srv.PortNumber())
+	cfg.Smtp.EnableTracing = true
+
+	client, err := NewSmtpClient(cfg.Smtp)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("single message sends", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		message := &Message{
+			From:    "from@example.com",
+			To:      []string{"rcpt@example.com"},
+			Subject: "subject",
+			Body:    map[string]string{"text/plain": "hello world"},
+		}
+
+		count, err := client.Send(ctx, message)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		messages := srv.MessagesAndPurge()
+		require.Len(t, messages, 1)
+		sentMsg := messages[0]
+
+		// read the headers
+		r := bufio.NewReader(strings.NewReader(sentMsg.MsgRequest()))
+		mimeReader := textproto.NewReader(r)
+		hdr, err := mimeReader.ReadMIMEHeader()
+		require.NoError(t, err)
+
+		// make sure the trace is propagated
+		traceId := span.SpanContext().TraceID().String()
+		hasPrefix := strings.HasPrefix(hdr.Get("traceparent"), "00-"+traceId+"-")
+		require.True(t, hasPrefix)
+
+		// one of the lines should be the body we expect!
+		found := false
+		for {
+			line, err := mimeReader.ReadLine()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+
+			t.Logf("line: %q", line)
+			if strings.Contains(line, "hello world") {
+				found = true
+				break
+			}
+		}
+
+		require.True(t, found)
+	})
+
+	t.Run("multiple recipients, single message", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		message := &Message{
+			From:    "from@example.com",
+			To:      []string{"rcpt1@example.com", "rcpt2@example.com", "rcpt3@example.com"},
+			Subject: "subject",
+			Body:    map[string]string{"text/plain": "hello world"},
+		}
+
+		count, err := client.Send(ctx, message)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		messages := srv.MessagesAndPurge()
+		require.Len(t, messages, 1)
+		sentMsg := messages[0]
+
+		rcpts := sentMsg.RcpttoRequestResponse()
+		require.EqualValues(t, [][]string{
+			{"RCPT TO:<rcpt1@example.com>", "250 Received"},
+			{"RCPT TO:<rcpt2@example.com>", "250 Received"},
+			{"RCPT TO:<rcpt3@example.com>", "250 Received"},
+		}, rcpts)
+
+		// read the headers
+		r := bufio.NewReader(strings.NewReader(sentMsg.MsgRequest()))
+		mimeReader := textproto.NewReader(r)
+		hdr, err := mimeReader.ReadMIMEHeader()
+		require.NoError(t, err)
+
+		// make sure the trace is propagated
+		traceId := span.SpanContext().TraceID().String()
+		hasPrefix := strings.HasPrefix(hdr.Get("traceparent"), "00-"+traceId+"-")
+		require.True(t, hasPrefix)
+
+		// one of the lines should be the body we expect!
+		found := false
+		for {
+			line, err := mimeReader.ReadLine()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+
+			t.Logf("line: %q", line)
+			if strings.Contains(line, "hello world") {
+				found = true
+				break
+			}
+		}
+
+		require.True(t, found)
+	})
+
+	t.Run("multiple recipients, multiple messages", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		msgs := []*Message{
+			{From: "from@example.com", To: []string{"rcpt1@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rcpt2@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+			{From: "from@example.com", To: []string{"rcpt3@example.com"},
+				Subject: "subject", Body: map[string]string{"text/plain": "hello world"}},
+		}
+
+		count, err := client.Send(ctx, msgs...)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+
+		messages := srv.MessagesAndPurge()
+		require.Len(t, messages, 3)
+
+		for i, sentMsg := range messages {
+			rcpts := sentMsg.RcpttoRequestResponse()
+			require.EqualValues(t, [][]string{
+				{fmt.Sprintf("RCPT TO:<rcpt%d@example.com>", i+1), "250 Received"},
+			}, rcpts)
+
+			// read the headers
+			r := bufio.NewReader(strings.NewReader(sentMsg.MsgRequest()))
+			mimeReader := textproto.NewReader(r)
+			hdr, err := mimeReader.ReadMIMEHeader()
+			require.NoError(t, err)
+
+			// make sure the trace is propagated
+			traceId := span.SpanContext().TraceID().String()
+			hasPrefix := strings.HasPrefix(hdr.Get("traceparent"), "00-"+traceId+"-")
+			require.True(t, hasPrefix)
+
+			// one of the lines should be the body we expect!
+			found := false
+			for {
+				line, err := mimeReader.ReadLine()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
+
+				t.Logf("line: %q", line)
+				if strings.Contains(line, "hello world") {
+					found = true
+					break
+				}
+			}
+
+			require.True(t, found)
+		}
 	})
 }


### PR DESCRIPTION
**What is this feature?**

When sending multiple messages, trace span attributes were getting overwritten, so we were getting incomplete data.

This also extracts a new method `sendMessage` so we can have separate spans per message send.

I've also improved tests by bringing in a fake SMTP server.

**Why do we need this feature?**

Improved observability!

**Who is this feature for?**

Operators

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
