### PR TITLE
Alerting: time interval service to support addressing intervals by Base64 encoded name

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -297,7 +297,14 @@ func (srv *ProvisioningSrv) RoutePostMuteTiming(c *contextmodel.ReqContext, mt d
 }
 
 func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTimeInterval, name string) response.Response {
-	mt.Name = name
+	// if body does not specify name, assume that the path contains the name
+	if mt.Name == "" {
+		mt.Name = name
+	}
+	// if body contains a name, and it's different from the one in the path, assume the latter to be UID
+	if mt.Name != name {
+		mt.UID = name
+	}
 	mt.Provenance = determineProvenance(c)
 	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), mt, c.SignedInUser.GetOrgID())
 	if err != nil {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -117,6 +117,7 @@ type MuteTimingHeaders struct {
 
 // swagger:model
 type MuteTimeInterval struct {
+	UID                     string `json:"-" yaml:"-"`
 	config.MuteTimeInterval `json:",inline" yaml:",inline"`
 	Version                 string     `json:"version,omitempty"`
 	Provenance              Provenance `json:"provenance,omitempty"`

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -127,6 +127,7 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 	return definitions.MuteTimeInterval{
+		UID:              getIntervalUID(mt.MuteTimeInterval),
 		MuteTimeInterval: mt.MuteTimeInterval,
 		Version:          calculateMuteTimeIntervalFingerprint(mt.MuteTimeInterval),
 		Provenance:       mt.Provenance,
@@ -189,6 +190,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 	return definitions.MuteTimeInterval{
+		UID:              getIntervalUID(mt.MuteTimeInterval),
 		MuteTimeInterval: mt.MuteTimeInterval,
 		Version:          calculateMuteTimeIntervalFingerprint(mt.MuteTimeInterval),
 		Provenance:       mt.Provenance,

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -73,7 +73,7 @@ func (svc *MuteTimingService) GetMuteTiming(ctx context.Context, name string, or
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	mt, idx := getMuteTiming(rev, name)
+	mt, idx := getMuteTimingByName(rev, nameOrUID)
 	if idx == -1 {
 		return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
 	}
@@ -102,7 +102,7 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	_, idx := getMuteTiming(revision, mt.Name)
+	_, idx := getMuteTimingByName(revision, mt.Name)
 	if idx != -1 {
 		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
 	}
@@ -148,7 +148,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, nil
 	}
 
-	old, idx := getMuteTiming(revision, mt.Name)
+	old, idx := getMuteTimingByName(revision, mt.Name)
 	if idx == -1 {
 		return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
 	}
@@ -184,7 +184,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 		return err
 	}
 
-	existing, idx := getMuteTiming(revision, name)
+	existing, idx := getMuteTimingByName(revision, name)
 	if idx == -1 {
 		svc.log.FromContext(ctx).Debug("Time interval was not found. Skip deleting", "name", name)
 		return nil
@@ -243,7 +243,7 @@ func isMuteTimeInUseInRoutes(name string, route *definitions.Route) bool {
 	return false
 }
 
-func getMuteTiming(rev *cfgRevision, name string) (config.MuteTimeInterval, int) {
+func getMuteTimingByName(rev *cfgRevision, name string) (config.MuteTimeInterval, int) {
 	idx := slices.IndexFunc(rev.cfg.AlertmanagerConfig.MuteTimeIntervals, func(interval config.MuteTimeInterval) bool {
 		return interval.Name == name
 	})

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -63,12 +63,17 @@ func TestGetMuteTimings(t *testing.T) {
 		require.Equal(t, "Test1", result[0].Name)
 		require.EqualValues(t, provenances["Test1"], result[0].Provenance)
 		require.NotEmpty(t, result[0].Version)
+		require.Equal(t, getIntervalUID(result[0].MuteTimeInterval), result[0].UID)
+
 		require.Equal(t, "Test2", result[1].Name)
 		require.EqualValues(t, provenances["Test2"], result[1].Provenance)
 		require.NotEmpty(t, result[1].Version)
+		require.Equal(t, getIntervalUID(result[1].MuteTimeInterval), result[1].UID)
+
 		require.Equal(t, "Test3", result[2].Name)
 		require.EqualValues(t, "", result[2].Provenance)
 		require.NotEmpty(t, result[2].Version)
+		require.Equal(t, getIntervalUID(result[2].MuteTimeInterval), result[2].UID)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -147,6 +152,7 @@ func TestGetMuteTiming(t *testing.T) {
 
 		require.Equal(t, "Test1", result.Name)
 		require.EqualValues(t, models.ProvenanceAPI, result.Provenance)
+		require.Equal(t, getIntervalUID(result.MuteTimeInterval), result.UID)
 		require.NotEmpty(t, result.Version)
 
 		require.Len(t, store.Calls, 1)
@@ -302,6 +308,7 @@ func TestCreateMuteTimings(t *testing.T) {
 
 		require.EqualValues(t, expected, result.MuteTimeInterval)
 		require.EqualValues(t, expectedProvenance, result.Provenance)
+		require.Equal(t, getIntervalUID(expected), result.UID)
 		require.NotEmpty(t, result.Version)
 
 		require.Len(t, store.Calls, 2)
@@ -585,6 +592,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.EqualValues(t, expected, result.MuteTimeInterval)
 		require.EqualValues(t, expectedProvenance, result.Provenance)
 		require.EqualValues(t, expectedVersion, result.Version)
+		require.Equal(t, getIntervalUID(result.MuteTimeInterval), result.UID)
 
 		require.Len(t, store.Calls, 2)
 		require.Equal(t, "Get", store.Calls[0].Method)

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -154,6 +154,14 @@ func TestGetMuteTiming(t *testing.T) {
 		require.Equal(t, orgID, store.Calls[0].Args[1])
 
 		prov.AssertCalled(t, "GetProvenance", mock.Anything, &result, orgID)
+
+		t.Run("and by UID", func(t *testing.T) {
+			result2, err := sut.GetMuteTiming(context.Background(), result.UID, orgID)
+
+			require.NoError(t, err)
+
+			require.Equal(t, result, result2)
+		})
 	})
 
 	t.Run("service returns ErrTimeIntervalNotFound if no mute timings", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**
This PR updates time interval service to support search of time intervals by hash of the name. 
- A new field `UID` is introduced to `definitions.MuteTimeInterval`. This field is not marshaled and populated only by internal logic.
- the MuteTimeService methods are updated to populate the UID using the URL-safe Base64 with no padding. 
    - Update method is changed to decode UID if it's specified, and then search by that name. This is needed in the future to support renaming of time intervals.
    - Get and Delete methods that accept a string, which can be either name or UID, treat the string as name and fallback to UID if no interval found. This makes sure that name-happened-to-be-base64-string is still treated correctly.
- Provisioning PUT API is updated to assume UID from path parameter if it is different than name provided in body.

All changes are backward compatible. The service falls back to search by name.

**Why do we need this feature?**
1. To support renaming time intervals (future PR)
2. To support addressing time intervals by UID as a fallback option. This can be useful in Grafana Cloud, which de-escapes forward slashes in paths and therefore makes Grafana fail to match the route. https://github.com/grafana/grafana/issues/90561

**Who is this feature for?**
Developers and users of provisioning in cloud

**Which issue(s) does this PR fix?**:
Related https://github.com/grafana/grafana/issues/90561

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
