### PR TITLE
Graphite: Ensure all Graphite query references are interpolated

### DIFF
--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -210,17 +210,20 @@ export default class GraphiteQuery {
     // render nested query
     const targetsByRefId = keyBy(targets, 'refId');
 
-    // no references to self
-    delete targetsByRefId[target.refId];
-
     const nestedSeriesRefRegex = /\#([A-Z])/g;
     let targetWithNestedQueries = target.target;
 
     // Use ref count to track circular references
     each(targetsByRefId, (t, id) => {
       const regex = RegExp(`\#(${id})`, 'g');
-      const refMatches = targetWithNestedQueries.match(regex);
-      t.refCount = refMatches?.length ?? 0;
+      let refCount = 0;
+      each(targetsByRefId, (t2, id2) => {
+        if (id2 !== id) {
+          const refMatches = t2.target.match(regex);
+          refCount += refMatches?.length ?? 0;
+        }
+      });
+      t.refCount = refCount;
     });
 
     // Keep interpolating until there are no query references


### PR DESCRIPTION
Graphite queries can reference other Graphite queries. There was a fix made to ensure these queries were appropriately interpolated in #56497 but it did not appropriately account for nested query references.

This fix ensures the interpolation is carried out for all targets, thereby leaving no query references in the resultant `targetFull` value.

To test:
- Run the devenv in `devenv/docker/blocks/graphite`
- Create an alert rule with the following queries and references:
```
A: carbon.agents.*.cpuUsage
D: alias(timeShift(#A, '-1min', true), '-1min')
E: alias(timeShift(#A, '-2min', true), '-2min')
F: aggregateSeriesLists(#D, #E, "sum")
```
The alert should succeed with the changes in this PR. If you run the same alert rule without the changes, it will fail.

Fixes grafana/support-escalations#11363