### PR TITLE
Canvas: Always show rotation in layout editor

### DIFF
--- a/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
@@ -121,10 +121,8 @@ export function PlacementEditor({ item }: Props) {
         <>
           {places.map((p) => {
             const v = placement![p];
-            if (v == null) {
-              if (p !== 'rotation') {
-                return null;
-              }
+            if (v == null && p !== 'rotation') {
+              return null;
             }
 
             // Need to set explicit min/max for rotation as logic only can handle 0-360

--- a/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
@@ -122,7 +122,9 @@ export function PlacementEditor({ item }: Props) {
           {places.map((p) => {
             const v = placement![p];
             if (v == null) {
-              return null;
+              if (p !== 'rotation') {
+                return null;
+              }
             }
 
             // Need to set explicit min/max for rotation as logic only can handle 0-360
@@ -132,7 +134,7 @@ export function PlacementEditor({ item }: Props) {
             return (
               <InlineFieldRow key={p}>
                 <InlineField label={p} labelWidth={8} grow={true}>
-                  <NumberInput min={min} max={max} value={v} onChange={(v) => onPositionChange(v, p)} />
+                  <NumberInput min={min} max={max} value={v ?? min} onChange={(v) => onPositionChange(v, p)} />
                 </InlineField>
               </InlineFieldRow>
             );

--- a/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
@@ -48,6 +48,10 @@ export function PlacementEditor({ item }: Props) {
   const { options } = element;
   const { placement, constraint: layout } = options;
 
+  if (placement) {
+    placement.rotation = placement?.rotation ?? 0;
+  }
+
   const reselectElementAfterChange = () => {
     setTimeout(() => {
       settings.scene.select({ targets: [element.div!] });
@@ -121,7 +125,7 @@ export function PlacementEditor({ item }: Props) {
         <>
           {places.map((p) => {
             const v = placement![p];
-            if (v == null && p !== 'rotation') {
+            if (v == null) {
               return null;
             }
 
@@ -132,7 +136,7 @@ export function PlacementEditor({ item }: Props) {
             return (
               <InlineFieldRow key={p}>
                 <InlineField label={p} labelWidth={8} grow={true}>
-                  <NumberInput min={min} max={max} value={v ?? min} onChange={(v) => onPositionChange(v, p)} />
+                  <NumberInput min={min} max={max} value={v} onChange={(v) => onPositionChange(v, p)} />
                 </InlineField>
               </InlineFieldRow>
             );


### PR DESCRIPTION
Always show rotation in layout editor, even before a value has been set via the inline editor.

Before:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/b3400090-7d07-4742-80b3-1c79aa65e893">

After:
<img width="816" alt="image" src="https://github.com/user-attachments/assets/e8a9fc83-a8be-4b05-bbed-392aac8a7379">


