### PR TITLE
QueryEditor: Break with Scenes because the default query is not empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "5.4.0",
+    "@grafana/scenes": "5.4.1",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -860,8 +860,8 @@ describe('templateSrv', () => {
       window.__grafanaSceneContext = new EmbeddedScene({
         $variables: new SceneVariableSet({
           variables: [
-            new QueryVariable({ name: 'server', value: 'serverA', text: 'Server A' }),
-            new QueryVariable({ name: 'pods', value: ['pA', 'pB'], text: ['podA', 'podB'] }),
+            new QueryVariable({ name: 'server', value: 'serverA', text: 'Server A', query: { refId: 'A' } }),
+            new QueryVariable({ name: 'pods', value: ['pA', 'pB'], text: ['podA', 'podB'], query: { refId: 'A' } }),
             new DataSourceVariable({ name: 'ds', value: 'dsA', text: 'dsA', pluginId: 'prometheus' }),
             new CustomVariable({ name: 'custom', value: 'A', text: 'A', query: 'A, B, C' }),
             new IntervalVariable({ name: 'interval', value: '1m', intervals: ['1m', '2m'] }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,9 +3553,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:5.4.0":
-  version: 5.4.0
-  resolution: "@grafana/scenes@npm:5.4.0"
+"@grafana/scenes@npm:5.4.1":
+  version: 5.4.1
+  resolution: "@grafana/scenes@npm:5.4.1"
   dependencies:
     "@grafana/e2e-selectors": "npm:^11.0.0"
     "@leeoniya/ufuzzy": "npm:^1.0.14"
@@ -3570,7 +3570,7 @@ __metadata:
     "@grafana/ui": ">=10.4"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/9f0143ce6b178d7996757c74c66b2cb0ead48e28b9c6dfc19848a601e796a76d710f98484e42294e27863aa7056a1e3987ce6abc5158729ada2c74c8f387b028
+  checksum: 10/761ba65d492a047eb2235d081c7077c159cbfe623fb860521428c949abe7dfbc78ccb8e235eaabc6a6ad771bdc55e71e781959d5ecba600918d836cab25e86f8
   languageName: node
   linkType: hard
 
@@ -17106,7 +17106,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:5.4.0"
+    "@grafana/scenes": "npm:5.4.1"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^1.3.0-rc1"


### PR DESCRIPTION
Upgrade to v5.4.1 to include:

#### 🐛 Bug Fix

- `@grafana/scenes`
  - QueryVariable: Query is empty string by default [#837](https://github.com/grafana/scenes/pull/837) ([@ivanortegaalba](https://github.com/ivanortegaalba))
  - fix(lazyloader): fix trying to run inexistent callbacks [#833](https://github.com/grafana/scenes/pull/833) ([@svennergr](https://github.com/svennergr))

#### Authors: 2

- Ivan Ortega Alba ([@ivanortegaalba](https://github.com/ivanortegaalba))
- Sven Grossmann ([@svennergr](https://github.com/svennergr))