### PR TITLE
Query History: Enable query history test

### DIFF
--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -264,8 +264,8 @@ func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 
 	testScenarioWithMixedQueriesInQueryHistory(t, "When users tries to get queries with mixed data source it should return correct queries",
 		func(t *testing.T, sc scenarioContext) {
-			sc.reqContext.Req.Form.Add("to", strconv.FormatInt(sc.service.now().UnixMilli()-60, 10))
-			sc.reqContext.Req.Form.Add("from", strconv.FormatInt(sc.service.now().UnixMilli()+60, 10))
+			sc.reqContext.Req.Form.Add("to", strconv.FormatInt(sc.service.now().UnixMilli(), 10))
+			sc.reqContext.Req.Form.Add("from", strconv.FormatInt(sc.service.now().UnixMilli()-60*1000, 10))
 			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)
 
 			resp := sc.service.searchHandler(sc.reqContext)

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -264,7 +264,6 @@ func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 
 	testScenarioWithMixedQueriesInQueryHistory(t, "When users tries to get queries with mixed data source it should return correct queries",
 		func(t *testing.T, sc scenarioContext) {
-			t.Skip() // This test fails a lot at the moment
 			sc.reqContext.Req.Form.Add("to", strconv.FormatInt(sc.service.now().UnixMilli()-60, 10))
 			sc.reqContext.Req.Form.Add("from", strconv.FormatInt(sc.service.now().UnixMilli()+60, 10))
 			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)


### PR DESCRIPTION
Fixes #90596

The test setup inserts a query to the database at `time.Now()` timestamp. Later on the test loads added query via search API but searches within +/- 60ms range from `time.Now()`. If any of the steps between inserting test data and querying the test data takes more than 60ms (which happens quite often in CI), the test may fail because there are no search results within provided timeframe. The fix is to expand the range (similiar to what we do in other tests.