### PR TITLE
Chore: update changelog workflow

### DIFF
--- a/.github/workflows/actions/changelog/action.yml
+++ b/.github/workflows/actions/changelog/action.yml
@@ -1,11 +1,11 @@
 name: Changelog generator
 description: Generates and publishes a changelog for the given release version
 inputs:
-  version:
-    description: Version number
+  target:
+    description: Target tag, branch or commit hash for the changelog
     required: true
-  prev_version:
-    description: Previous version number
+  previous:
+    description: Previous tag, branch or commit hash to start changelog from
     required: false
   github_token:
     description: GitHub token with read/write access to all necessary repositories

--- a/.github/workflows/actions/changelog/action.yml
+++ b/.github/workflows/actions/changelog/action.yml
@@ -7,7 +7,7 @@ inputs:
   prev_version:
     description: Previous version number
     required: false
-  token:
+  github_token:
     description: GitHub token with read/write access to all necessary repositories
     required: true
   output_file:

--- a/.github/workflows/actions/changelog/index.js
+++ b/.github/workflows/actions/changelog/index.js
@@ -292,10 +292,10 @@ ${items
   `;
 
   // Render all present sections for the given changelog
-  return `${section('Breaking changes', changelog.breaking)}
+  return `${section('Features and enhancements', changelog.features)}
 ${section('Bug fixes', changelog.bugfixes)}
+${section('Breaking changes', changelog.breaking)}
 ${section('Plugin development fixes & changes', changelog.plugins)}
-${section('Features and enhancements', changelog.features)}
 `;
 };
 

--- a/.github/workflows/actions/changelog/index.js
+++ b/.github/workflows/actions/changelog/index.js
@@ -235,9 +235,9 @@ const prevVersionTag = versionToTag(prevVersion);
 LOG(`Previous version: ${prevVersion} (tag ${prevVersionTag})`);
 
 // Get all changelog items from Grafana OSS
-const oss = await getChangeLogItems('grafana', 'grafana', prevVersion, version);
+const oss = await getChangeLogItems('grafana', 'grafana', prevVersionTag, versionTag);
 // Get all changelog items from Grafana Enterprise
-const entr = await getChangeLogItems('grafana-enterprise', 'grafana', prevVersion, version);
+const entr = await getChangeLogItems('grafana-enterprise', 'grafana', prevVersionTag, versionTag);
 
 LOG(`Found OSS PRs: ${oss.length}`);
 LOG(`Found Enterprise PRs: ${entr.length}`);

--- a/.github/workflows/actions/changelog/index.js
+++ b/.github/workflows/actions/changelog/index.js
@@ -214,8 +214,6 @@ const getChangeLogItems = async (name, owner, from, to) => {
 // ======================================================
 //                 GENERATE CHANGELOG
 // ======================================================
-const tagToVersion = tag => tag.replace(/^v/, '');
-const versionToTag = ver => 'v' + tagToVersion(ver);
 
 LOG(`Changelog action started`);
 
@@ -224,20 +222,17 @@ if (!ghtoken) {
   throw 'GITHUB_TOKEN is not set and "github_token" input is empty';
 }
 
-const version = tagToVersion(process.argv[2] || process.env.INPUT_VERSION);
-const versionTag = versionToTag(version);
+const target = process.argv[2] || process.env.INPUT_VERSION;
+LOG(`Target version tag/branch/commit: ${target}`);
 
-LOG(`Target version: ${version} (tag ${versionTag})`);
+const previous = process.argv[3] || process.env.INPUT_PREV_VERSION || (await getPreviousVersion(target));
 
-const prevVersion = tagToVersion(process.argv[3] || process.env.INPUT_PREV_VERSION || (await getPreviousVersion(version)));
-const prevVersionTag = versionToTag(prevVersion);
-
-LOG(`Previous version: ${prevVersion} (tag ${prevVersionTag})`);
+LOG(`Previous version tag: ${previous}`);
 
 // Get all changelog items from Grafana OSS
-const oss = await getChangeLogItems('grafana', 'grafana', prevVersionTag, versionTag);
+const oss = await getChangeLogItems('grafana', 'grafana', previous, target);
 // Get all changelog items from Grafana Enterprise
-const entr = await getChangeLogItems('grafana-enterprise', 'grafana', prevVersionTag, versionTag);
+const entr = await getChangeLogItems('grafana-enterprise', 'grafana', previous, target);
 
 LOG(`Found OSS PRs: ${oss.length}`);
 LOG(`Found Enterprise PRs: ${entr.length}`);

--- a/.github/workflows/actions/changelog/index.js
+++ b/.github/workflows/actions/changelog/index.js
@@ -52,9 +52,9 @@ const getPreviousVersion = async (version) => {
     .filter((tag) => tag)
     .sort(semverCompare)
     .find((tag) => semverCompare(tag, semverParse(version)) > 0);
-	if (!prev) {
-		throw `Could not find previous git tag for ${version}`;
-	}
+  if (!prev) {
+    throw `Could not find previous git tag for ${version}`;
+  }
   return prev[4];
 };
 
@@ -317,4 +317,3 @@ if (process.env.INPUT_OUTPUT_FILE) {
   LOG(`Output to ${process.env.INPUT_OUTPUT_FILE}`);
   writeFileSync(process.env.INPUT_OUTPUT_FILE, md);
 }
-

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,6 +5,18 @@ on:
       version:
         required: true
         description: 'Target release version (semver, git tag, branch or commit)'
+      target:
+        required: true
+        type: string
+        description: 'The base branch that these changes are being merged into'
+      dry_run:
+        required: false
+        default: false
+        type: bool
+
+permissions:
+  pull-requests: write
+
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -17,6 +29,11 @@ jobs:
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+      - name: "Configure git user"
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local --add --bool push.autoSetupRemote true
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v4"
         with:
@@ -25,6 +42,8 @@ jobs:
             CHANGELOG.md
           fetch-depth: 0
           fetch-tags: true
+      - name: "Create branch"
+        run: git checkout -b "release/${{ github.run_id }}/${{ inputs.version }}"
       - name: "Generate changelog"
         id: changelog
         uses: ./.github/workflows/actions/changelog
@@ -61,10 +80,16 @@ jobs:
           fi
 
           git diff CHANGELOG.md
-      - name: "Draft Github Release"
+      - name: "Commit changelog changes"
+        run: git commit --allow-empty -m "Update changelog placeholder" CHANGELOG.md
+      - name: Create changelog PR
+        if: "${{ inputs.backport == '' }}"
+        run: >
+          gh pr create \
+            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            --dry-run=${{ inputs.dry_run }} \
+            -B "${{ inputs.target }}" \
+            --title "Release: ${{ inputs.version }}" \
+            --body "Changelog changes for release ${{ inputs.version }}"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          cat changelog_items.md
-          # skip for now
-          # gh release create --draft ${{ inputs.version }} --notes-file _changelog.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-      - name: "Configure git user"
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local --add --bool push.autoSetupRemote true
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v4"
         with:
@@ -42,6 +37,11 @@ jobs:
             CHANGELOG.md
           fetch-depth: 0
           fetch-tags: true
+      - name: "Configure git user"
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local --add --bool push.autoSetupRemote true
       - name: "Create branch"
         run: git checkout -b "release/${{ github.run_id }}/${{ inputs.version }}"
       - name: "Generate changelog"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,12 +37,10 @@ jobs:
           # Prepare CHANGELOG.md content with version delimiters
           (
             echo
-            echo "# ${{ inputs.version}} $(date '+%F')"
+            echo "# ${{ inputs.version}} ($(date '+%F'))"
             echo
             cat changelog_items.md
           ) > CHANGELOG.part
-
-          cat CHANGELOG.part
 
           # Check if a version exists in the changelog
           if grep -q "<!-- ${{ inputs.version}} START" CHANGELOG.md ; then

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -93,7 +93,7 @@ jobs:
         if: "${{ inputs.backport == '' }}"
         run: >
           gh pr create \
-            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            $( [ "x${{ inputs.latest }}" == "xtrue" ] && printf %s '-l "release/latest"') \
             --dry-run=${{ inputs.dry_run }} \
             -B "${{ inputs.target }}" \
             --title "Release: ${{ inputs.version }}" \

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -54,9 +54,9 @@ jobs:
             # Prepend changelog part to the main changelog file
             echo "Version ${{ inputs.version }} not found in the CHANGELOG.md"
             (
-              echo "<!-- ${{ inputs.version }} START -->
+              echo "<!-- ${{ inputs.version }} START -->"
               cat CHANGELOG.part
-              echo "<!-- ${{ inputs.version }} END -->
+              echo "<!-- ${{ inputs.version }} END -->"
               cat CHANGELOG.md
             ) > CHANGELOG.tmp
             mv CHANGELOG.tmp CHANGELOG.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
         id: changelog
         uses: ./.github/workflows/actions/changelog
         with:
-          token: ${{ steps.generate_token.outputs.token }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           version: ${{ inputs.version }}
           prev_version: ${{ inputs.prev_version }}
           output_file: _changelog.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,10 +4,7 @@ on:
     inputs:
       version:
         required: true
-        description: 'Target release version (git tag)'
-      prev_version:
-        required: true
-        description: 'Previous release version (git tag)'
+        description: 'Target release version (semver, git tag, branch or commit)'
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -23,7 +20,9 @@ jobs:
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v4"
         with:
-          sparse-checkout: .github/workflows
+          sparse-checkout: |
+            .github/workflows
+            CHANGELOG.md
           fetch-depth: 0
           fetch-tags: true
       - name: "Generate changelog"
@@ -31,13 +30,20 @@ jobs:
         uses: ./.github/workflows/actions/changelog
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
-          version: ${{ inputs.version }}
-          prev_version: ${{ inputs.prev_version }}
-          output_file: _changelog.md
+          target: v${{ inputs.version }}
+          output_file: changelog_items.md
+      - name: "Patch CHANGELOG.md"
+        run: |
+          # Replace text between the delimiters with new changelog_items.md content
+          sed -i '/${{ inputs.version }} START/,/${{ inputs.version }} END/{
+            //!d
+            e cat changelog_items.md
+          }' CHANGELOG.md
+          git diff CHANGELOG.md
       - name: "Draft Github Release"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          cat _changelog.md
+          cat changelog_items.md
           # skip for now
           # gh release create --draft ${{ inputs.version }} --notes-file _changelog.md

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -34,13 +34,34 @@ jobs:
           output_file: changelog_items.md
       - name: "Patch CHANGELOG.md"
         run: |
-          # Replace text between version delimiters with new changelog_items.md content
-          sed -i '/${{ inputs.version }} START/,/${{ inputs.version }} END/{
-            //!d
-            a <!-- ${{ inputs.version}} START -->
-            e cat changelog_items.md
-            a <!-- ${{ inputs.version}} END -->
-          }' CHANGELOG.md
+          # Prepare CHANGELOG.md content with version delimiters
+          (
+            echo
+            echo "# ${{ inputs.version}} $(date '+%F')"
+            echo
+            cat changelog_items.md
+          ) > CHANGELOG.part
+
+          cat CHANGELOG.part
+
+          # Check if a version exists in the changelog
+          if grep -q "<!-- ${{ inputs.version}} START" CHANGELOG.md ; then
+            # Replace the content between START and END delimiters
+            echo "Version ${{ inputs.version }} is found in the CHANGELOG.md, patching contents..."
+            sed -i -e '/${{ inputs.version }} START/,/${{ inputs.version }} END/{//!d;}' \
+                   -e '/${{ inputs.version }} START/r changelog_items.md' CHANGELOG.md
+          else
+            # Prepend changelog part to the main changelog file
+            echo "Version ${{ inputs.version }} not found in the CHANGELOG.md"
+            (
+              echo "<!-- ${{ inputs.version }} START -->
+              cat CHANGELOG.part
+              echo "<!-- ${{ inputs.version }} END -->
+              cat CHANGELOG.md
+            ) > CHANGELOG.tmp
+            mv CHANGELOG.tmp CHANGELOG.md
+          fi
+
           git diff CHANGELOG.md
       - name: "Draft Github Release"
         env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -86,7 +86,10 @@ jobs:
           git diff CHANGELOG.md
       - name: "Commit changelog changes"
         run: git commit --allow-empty -m "Update changelog placeholder" CHANGELOG.md
-      - name: Create changelog PR
+      - name: "git push"
+        if: ${{ inputs.dry_run }} != true
+        run: git push
+      - name: "Create changelog PR"
         if: "${{ inputs.backport == '' }}"
         run: >
           gh pr create \

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -49,7 +49,7 @@ jobs:
             # Replace the content between START and END delimiters
             echo "Version ${{ inputs.version }} is found in the CHANGELOG.md, patching contents..."
             sed -i -e '/${{ inputs.version }} START/,/${{ inputs.version }} END/{//!d;}' \
-                   -e '/${{ inputs.version }} START/r changelog_items.md' CHANGELOG.md
+                   -e '/${{ inputs.version }} START/r CHANGELOG.part' CHANGELOG.md
           else
             # Prepend changelog part to the main changelog file
             echo "Version ${{ inputs.version }} not found in the CHANGELOG.md"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -34,10 +34,12 @@ jobs:
           output_file: changelog_items.md
       - name: "Patch CHANGELOG.md"
         run: |
-          # Replace text between the delimiters with new changelog_items.md content
+          # Replace text between version delimiters with new changelog_items.md content
           sed -i '/${{ inputs.version }} START/,/${{ inputs.version }} END/{
             //!d
+            a <!-- ${{ inputs.version}} START -->
             e cat changelog_items.md
+            a <!-- ${{ inputs.version}} END -->
           }' CHANGELOG.md
           git diff CHANGELOG.md
       - name: "Draft Github Release"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,10 @@ on:
         required: false
         default: false
         type: bool
+      latest:
+        required: false
+        default: false
+        type: bool
 
 permissions:
   pull-requests: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -50,11 +50,6 @@ jobs:
       - name: Checkout Grafana
         uses: actions/checkout@v4
         with:
-          sparse-checkout: |
-            .github/workflows
-            pkg/build
-            package.json
-            CHANGELOG.md
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Checkout Grafana
         uses: actions/checkout@v4
         with:
+          sparse-checkout: |
+            .github/workflows
+            pkg/build
+            package.json
+            CHANGELOG.md
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Configure git user

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -39,46 +39,100 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'grafana/grafana'
     steps:
+
+      - name: Generate bot token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
       - name: Checkout Grafana
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+
       - name: Configure git user
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local --add --bool push.autoSetupRemote true
+
       - name: Create branch
         run: git checkout -b "release/${{ github.run_id }}/${{ inputs.version }}"
+
       - name: Generate changelog
-        run: git commit --allow-empty -m "Update changelog placeholder"
+        id: changelog
+        uses: ./.github/workflows/actions/changelog
+        with:
+          github_token: ${{ steps.generate_token.outputs.token }}
+          target: v${{ inputs.version }}
+          output_file: changelog_items.md
+
+      - name: Patch CHANGELOG.md
+        run: |
+          # Prepare CHANGELOG.md content with version delimiters
+          (
+            echo
+            echo "# ${{ inputs.version}} ($(date '+%F'))"
+            echo
+            cat changelog_items.md
+          ) > CHANGELOG.part
+
+          # Check if a version exists in the changelog
+          if grep -q "<!-- ${{ inputs.version}} START" CHANGELOG.md ; then
+            # Replace the content between START and END delimiters
+            echo "Version ${{ inputs.version }} is found in the CHANGELOG.md, patching contents..."
+            sed -i -e '/${{ inputs.version }} START/,/${{ inputs.version }} END/{//!d;}' \
+                   -e '/${{ inputs.version }} START/r CHANGELOG.part' CHANGELOG.md
+          else
+            # Prepend changelog part to the main changelog file
+            echo "Version ${{ inputs.version }} not found in the CHANGELOG.md"
+            (
+              echo "<!-- ${{ inputs.version }} START -->"
+              cat CHANGELOG.part
+              echo "<!-- ${{ inputs.version }} END -->"
+              cat CHANGELOG.md
+            ) > CHANGELOG.tmp
+            mv CHANGELOG.tmp CHANGELOG.md
+          fi
+
+          git diff CHANGELOG.md
+
+      - name: Commit CHANGELOG.md changes
+        run: git commit --allow-empty -m "Update changelog placeholder" CHANGELOG.md
+
       - name: Update package.json versions
         uses: ./pkg/build/actions/bump-version
         with:
           version: ${{ inputs.version }}
-      - name: add package.json changes
+
+      - name: Add package.json changes
         run: |
           git add .
           git commit -m "Update version to ${{ inputs.version }}"
-      - name: git push
+
+      - name: Git push
         if: ${{ inputs.dry_run }} != true
         run: git push
+
       - name: Create PR without backports
         if: "${{ inputs.backport == '' }}"
         run: >
           gh pr create \
-            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            $( [ "x${{ inputs.latest }}" == "xtrue" ] && printf %s '-l "release/latest"') \
             --dry-run=${{ inputs.dry_run }} \
             -B "${{ inputs.target }}" \
             --title "Release: ${{ inputs.version }}" \
             --body "These code changes must be merged after a release is complete"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create PR with backports
         if: "${{ inputs.backport != '' }}"
         run: >
           gh pr create \
-            $( (( ${{ inputs.latest }} == "true" )) && printf %s '-l "release/latest"') \
+            $( [ "x${{ inputs.latest }}" == "xtrue" ] && printf %s '-l "release/latest"') \
             -l "backport ${{ inputs.backport }}" \
             -l "product-approved" \
             --dry-run=${{ inputs.dry_run }} \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -98,6 +98,8 @@ jobs:
             mv CHANGELOG.tmp CHANGELOG.md
           fi
 
+          rm -f CHANGELOG.part changelog_items.md
+
           git diff CHANGELOG.md
 
       - name: Commit CHANGELOG.md changes

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout Grafana
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Configure git user
         run: |
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -30,7 +30,7 @@ on:
         type: bool
 
 permissions:
-  content: write
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This contains a series of changes to the changelog Github action and a test workflow to try it live:

* Better inputs naming:
   - changelog action tags a `target` (tag, branch, commit) for the "end" of the changelog
   - also an optional `previous` for the "start" of the changelog (otherwise it's resolved automatically)
   - dry_run to disable actual PR creation
   - latest to mimic release_pr behaviour
   - token is renamed to `github_token` to be more specific
* Previous release date it resolved only in grafana repo, once. Saves some time and is more reliable.
* Release date and release version are not part of the changelog github action, only a list of changelog PRs is returned.

This also updates `release-pr.yml` accordingly.