### PR TITLE
[v11.1.x] Docs: Refactor time series page - part 1

### DIFF
--- a/docs/sources/panels-visualizations/configure-standard-options/index.md
+++ b/docs/sources/panels-visualizations/configure-standard-options/index.md
@@ -237,6 +237,8 @@ Select one of the following schemes:
 | Multiple continuous colors (by value) | Grafana automatically assigns colors based on the percentage of a value relative to the min and the max of the field or series. For some visualizations, you also need to choose if the color is set by the **Last**, **Min**, or **Max** value of the field or series. Select from: **Green-Yellow-Red**, **Red-Yellow-Green**, **Blue-Yellow-Red**, **Yellow-Red**, **Blue-Purple**, and **Yellow-Blue**. |
 | Single continuous color (by value)    | Grafana automatically assigns shades of one color based on the percentage of a value relative to the min and the max of the field or series. For some visualizations, you also need to choose if the color is set by the **Last**, **Min**, or **Max** value of the field or series. Select from: **Blues**, **Reds**, **Greens**, and **Purples**.                                                         |
 
+You can also use the legend to open the color picker by clicking the legend series color icon. Setting color this way automatically creates an override rule that set's a specific color for a specific series.
+
 ### No value
 
 Enter what Grafana should display if the field value is empty or null. The default value is a hyphen (-).

--- a/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/bar-chart/index.md
@@ -154,6 +154,22 @@ Transparency of the gradient is calculated based on the values on the y-axis. Op
 
 Gradient color is generated based on the hue of the line color.
 
+#### Scheme gradient mode
+
+The **Gradient mode** option located under the **Graph styles** has a mode named **Scheme**. When you enable **Scheme**, the bar receives a gradient color defined from the selected **Color scheme**.
+
+##### From thresholds
+
+If the **Color scheme** is set to **From thresholds (by value)** and **Gradient mode** is set to **Scheme**, then the bar color changes as they cross the defined thresholds.
+
+{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_thresholds_bars.png" max-width="1200px" caption="Color scheme: From thresholds" >}}
+
+##### Gradient color schemes
+
+The following image shows a bar chart with the **Green-Yellow-Red (by value)** color scheme option selected.
+
+{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_bars.png" max-width="1200px" caption="Color scheme: Green-Yellow-Red" >}}
+
 ## Tooltip options
 
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/panels-visualizations/visualizations/time-series/index.md
@@ -31,6 +31,7 @@ labels:
     - oss
 description: Configure options for Grafana's time series visualization
 title: Time series
+menuTitle: Time series
 weight: 10
 refs:
   configure-standard-options:
@@ -39,10 +40,6 @@ refs:
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-standard-options/#max
   color-scheme:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-standard-options/#color-scheme
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/#color-scheme
     - pattern: /docs/grafana-cloud/
@@ -57,11 +54,6 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides/
-  alert-list:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/alert-list/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/alert-list/
   link-alert:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/
@@ -71,18 +63,15 @@ refs:
 
 # Time series
 
-{{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="1200px" caption="Time series" >}}
-
 Time series visualizations are the default and primary way to visualize data points over intervals of time as a graph. They can render series as lines, points, or bars. They're versatile enough to display almost any time-series data.
 
-{{% admonition type="note" %}}
-You can [link alert rules](ref:link-alert) to time series visualization to observe when alerts fire and are resolved in the form of annotations. In addition, you can create alert rules from the Alert tab within the panel options.
-At the moment, alerts are only supported in the time series and [alert list](ref:alert-list) visualizations.
-{{% /admonition %}}
+{{< figure src="/static/img/docs/time-series-panel/time_series_small_example.png" max-width="1200px" alt="Time series" >}}
 
-{{% admonition type="note" %}}
+{{< admonition type="note" >}}
 You can migrate from the old Graph visualization to the new time series visualization. To migrate, open the panel and click the **Migrate** button in the side pane.
-{{% /admonition %}}
+{{< /admonition >}}
+
+## Configure a time series visualization
 
 The following video guides you through the creation steps and common customizations of time series visualizations and is great for beginners:
 
@@ -90,19 +79,110 @@ The following video guides you through the creation steps and common customizati
 
 {{< docs/play title="Time Series Visualizations in Grafana" url="https://play.grafana.org/d/000000016/" >}}
 
-## Panel options
+## Supported data formats
+
+Time series visualizations require time series data; that is a sequence of measurements, ordered in time, where every row in the table represents one individual measurement at a specific time. Learn more about [time series data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/timeseries/).
+
+## Alert rules
+
+You can [link alert rules](ref:link-alert) to time series visualizations to observe when alerts fire and are resolved in the form of annotations. In addition, you can create alert rules from the **Alert** tab within the panel editor.
+
+## Transform override property
+
+Use the **Transform** override property to transform series values without affecting the values shown in the tooltip, context menu, or legend.
+
+<!-- add more information about how to access this property -->
+
+- **Negative Y transform:** Flip the results to negative values on the Y axis.
+- **Constant:** Show the first value as a constant line.
+
+{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
+
+<!-- update shared filed above to add actual steps for adding this override -->
+
+## Add the Fill below to override
+
+The **Fill below to** option fills the area between two series. This option is only available as a series/field override.
+
+1. Edit the panel and click **Overrides**.
+1. Select the fields to fill below.
+1. In **Add override property**, select **Fill below to**.
+1. Select the series for which you want the fill to stop.
+
+The following example shows three series: Min, Max, and Value. The Min and Max series have **Line width** set to 0. Max has a **Fill below to** override set to Min, which fills the area between Max and Min with the Max line color.
+
+{{< figure src="/static/img/docs/time-series-panel/fill-below-to-7-4.png" max-width="600px" alt="Fill below to example" >}}
+
+## Configuration options
+
+### Panel options
 
 {{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-## Tooltip options
+### Tooltip options
 
-{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+{{< docs/shared lookup="visualizations/tooltip-options-2.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1">}}
 
-## Legend options
+### Legend options
 
-{{< docs/shared lookup="visualizations/legend-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+{{< docs/shared lookup="visualizations/legend-options-1.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
 
-## Graph styles
+### Axis options
+
+Options under the axis category change how the x- and y-axes are rendered. Some options do not take effect until you click outside of the field option box you are editing. You can also or press `Enter`.
+
+| Option                             | Description                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Time zone                          | Set the desired time zone(s) to display along the x-axis.                                                                                                                                                                                                                                                                                                                         |
+| [Placement](#placement)            | Select the placement of the y-axis.                                                                                                                                                                                                                                                                                                                                               |
+| Label                              | Set a y-axis text label. If you have more than one y-axis, then you can assign different labels using an override.                                                                                                                                                                                                                                                                |
+| Width                              | Set a fixed width of the axis. By default, Grafana dynamically calculates the width of an axis. By setting the width of the axis, data with different axes types can share the same display proportions. This setting makes it easier for you to compare more than one graph’s worth of data because the axes are not shifted or stretched within visual proximity to each other. |
+| Show grid lines                    | Set the axis grid line visibility.<br>                                                                                                                                                                                                                                                                                                                                            |
+| Color                              | Set the color of the axis.                                                                                                                                                                                                                                                                                                                                                        |
+| Show border                        | Set the axis border visibility.                                                                                                                                                                                                                                                                                                                                                   |
+| Scale                              | Set the y-axis values scale.<br>                                                                                                                                                                                                                                                                                                                                                  |
+| Centered zero                      | Set the y-axis to be centered on zero.                                                                                                                                                                                                                                                                                                                                            |
+| [Soft min](#soft-min-and-soft-max) | Set a soft min to better control the y-axis limits. zero.                                                                                                                                                                                                                                                                                                                         |
+| [Soft max](#soft-min-and-soft-max) | Set a soft max to better control the y-axis limits. zero.                                                                                                                                                                                                                                                                                                                         |
+
+#### Placement
+
+Select the placement of the y-axis.
+
+- **Auto:** Automatically assigns the y-axis to the series. When there are two or more series with different units, Grafana assigns the left axis to the first unit and the right axis to the units that follow.
+- **Left:** Display all y-axes on the left side.
+- **Right:** Display all y-axes on the right side.
+- **Hidden:** Hide all axes. To selectively hide axes, [Add a field override](ref:add-a-field-override) that targets specific fields.
+
+#### Soft min and soft max
+
+Set a **Soft min** or **soft max** option for better control of y-axis limits. By default, Grafana sets the range for the y-axis automatically based on the dataset.
+
+**Soft min** and **soft max** settings can prevent small variations in the data from being magnified when it's mostly flat. In contrast, hard min and max values help prevent obscuring useful detail in the data by clipping intermittent spikes past a specific point.
+
+To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](ref:configure-standard-options).
+
+![Label example](/static/img/docs/time-series-panel/axis-soft-min-max-7-4.png)
+
+### Graph styles options
+
+| Option                                      | Description                                                                                                                                                                                                                           |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Style](#style)                             | Use this option to define how to display your time series data.                                                                                                                                                                       |
+| [Line interpolation](#line-interpolation)   | This option controls how the graph interpolates the series line.                                                                                                                                                                      |
+| [Line width](#line-width)                   | Line width is a slider that controls the thickness for series lines or the outline for bars.                                                                                                                                          |
+| [Fill opacity](#fill-opacity)               | Use opacity to specify the series area fill color.                                                                                                                                                                                    |
+| [Gradient mode](#gradient-mode)             | Gradient mode specifies the gradient fill, which is based on the series color.                                                                                                                                                        |
+| [Line style](#line-style)                   | Set the style of the line.                                                                                                                                                                                                            |
+| [Connect null values](#connect-null-values) | Choose how null values, which are gaps in the data, appear on the graph.                                                                                                                                                              |
+| [Disconnect values](#disconnect-values)     | Choose whether to set a threshold above which values in the data should be disconnected.                                                                                                                                              |
+| [Show points](#show-points)                 | You can configure your visualization to add points to lines or bars.                                                                                                                                                                  |
+| Point size                                  | Set the size of the points, from 1 to 40 pixels in diameter.                                                                                                                                                                          |
+| [Stack series](#stack-series)               | Stacking allows Grafana to display series on top of each other.                                                                                                                                                                       |
+| [Bar alignment](#bar-alignment)             | Set the position of the bar relative to a data point.                                                                                                                                                                                 |
+| Bar width factor                            | Set the width of the bar relative to minimum space between data points. A factor of 0.5 means that the bars take up half of the available space between data points. A factor of 1.0 means that the bars take up all available space. |
+
+#### Style
 
 Use this option to define how to display your time series data. You can use overrides to combine multiple styles in the same graph.
 
@@ -112,30 +192,26 @@ Use this option to define how to display your time series data. You can use over
 
 ![Style modes](/static/img/docs/time-series-panel/style-modes-v9.png)
 
-### Bar alignment
+#### Line interpolation
 
-Set the position of the bar relative to a data point. In the examples below, **Show points** is set to **Always** which makes it easier to see the difference this setting makes. The points do not change; the bars change in relationship to the points.
+This option controls how the graph interpolates the series line.
 
-- **Before** ![Bar alignment before icon](/static/img/docs/time-series-panel/bar-alignment-before.png)
-  The bar is drawn before the point. The point is placed on the trailing corner of the bar.
-- **Center** ![Bar alignment center icon](/static/img/docs/time-series-panel/bar-alignment-center.png)
-  The bar is drawn around the point. The point is placed in the center of the bar. This is the default.
-- **After** ![Bar alignment after icon](/static/img/docs/time-series-panel/bar-alignment-after.png)
-  The bar is drawn after the point. The point is placed on the leading corner of the bar.
+- **Linear:** Points are joined by straight lines.
+- **Smooth:** Points are joined by curved lines that smooths transitions between points.
+- **Step before:** The line is displayed as steps between points. Points are rendered at the end of the step.
+- **Step after:** The line is displayed as steps between points. Points are rendered at the beginning of the step.
 
-### Line width
+#### Line width
 
 Line width is a slider that controls the thickness for series lines or the outline for bars.
 
-![Line thickness 5 example](/static/img/docs/time-series-panel/line-width-5.png)
-
-### Fill opacity
+#### Fill opacity
 
 Use opacity to specify the series area fill color.
 
 ![Fill opacity examples](/static/img/docs/time-series-panel/fill-opacity.png)
 
-### Gradient mode
+#### Gradient mode
 
 Gradient mode specifies the gradient fill, which is based on the series color. To change the color, use the standard color scheme field option. For more information, refer to [Color scheme](ref:color-scheme).
 
@@ -148,34 +224,25 @@ Gradient appearance is influenced by the **Fill opacity** setting. The following
 
 ![Gradient mode examples](/static/img/docs/time-series-panel/gradient-modes-v9.png)
 
-### Show points
+##### Scheme gradient mode
 
-You can configure your visualization to add points to lines or bars.
+The **Gradient mode** option located under the **Graph styles** has a mode named **Scheme**. When you enable **Scheme**, the line or bar receives a gradient color defined from the selected **Color scheme**.
 
-- **Auto:** Grafana determines to show or not to show points based on the density of the data. If the density is low, then points appear.
-- **Always:** Show the points regardless of how dense the data set is.
-- **Never:** Do not show points.
+###### From thresholds
 
-### Point size
+If the **Color scheme** is set to **From thresholds (by value)** and **Gradient mode** is set to **Scheme**, then the line or bar color changes as they cross the defined thresholds.
 
-Set the size of the points, from 1 to 40 pixels in diameter.
+{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_thresholds_line.png" max-width="1200px" alt="Colors scheme: From thresholds" >}}
 
-### Line interpolation
+###### Gradient color schemes
 
-This option controls how the graph interpolates the series line.
+The following image shows a line chart with the **Green-Yellow-Red (by value)** color scheme option selected.
 
-![Line interpolation option](/static/img/docs/time-series-panel/line-interpolation-option.png)
+{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_line.png" max-width="1200px" alt="Color scheme: Green-Yellow-Red" >}}
 
-- **Linear:** Points are joined by straight lines.
-- **Smooth:** Points are joined by curved lines that smooths transitions between points.
-- **Step before:** The line is displayed as steps between points. Points are rendered at the end of the step.
-- **Step after:** The line is displayed as steps between points. Points are rendered at the beginning of the step.
-
-### Line style
+#### Line style
 
 Set the style of the line. To change the color, use the standard [color scheme](ref:color-scheme) field option.
-
-![Line style option](/static/img/docs/time-series-panel/line-style-option-v9.png)
 
 - **Solid:** Display a solid line. This is the default setting.
 - **Dash:** Display a dashed line. When you choose this option, a list appears for you to select the length and gap (length, gap) for the line dashes. Dash spacing set to 10, 10 (default).
@@ -183,21 +250,27 @@ Set the style of the line. To change the color, use the standard [color scheme](
 
 ![Line styles examples](/static/img/docs/time-series-panel/line-styles-examples-v9.png)
 
-{{< docs/shared lookup="visualizations/connect-null-values.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+{{< docs/shared lookup="visualizations/connect-null-values.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
 
-{{< docs/shared lookup="visualizations/disconnect-values.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+{{< docs/shared lookup="visualizations/disconnect-values.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}
 
-### Stack series
+#### Show points
 
-_Stacking_ allows Grafana to display measurements on top of each other within each period displayed. This feature helps to visually represent the cumulative total of the metrics of the data series at each plotted moment. Be cautious when using stacking in the visualization as it can easily create misleading graphs. To read more about why stacking might not be the best approach, refer to [The issue with stacking](https://www.data-to-viz.com/caveat/stacking.html).
+You can configure your visualization to add points to lines or bars.
 
-![Stack option](/static/img/docs/time-series-panel/stack-option-v9.png)
+- **Auto:** Grafana determines to show or not to show points based on the density of the data. If the density is low, then points appear.
+- **Always:** Show the points regardless of how dense the data set is.
+- **Never:** Do not show points.
+
+#### Stack series
+
+_Stacking_ allows Grafana to display series on top of each other. Be cautious when using stacking in the visualization as it can easily create misleading graphs. To read more about why stacking might not be the best approach, refer to [The issue with stacking](https://www.data-to-viz.com/caveat/stacking.html).
 
 - **Off:** Turns off series stacking. When **Off**, all series share the same space in the visualization.
 - **Normal:** Stacks series on top of each other.
 - **100%:** Stack by percentage where all series add up to 100%.
 
-#### Stack series in groups
+##### Stack series in groups
 
 The stacking group option is only available as an override. For more information about creating an override, refer to [Configure field overrides](ref:configure-field-overrides).
 
@@ -208,159 +281,33 @@ The stacking group option is only available as an override. For more information
 
    The stacking group name option is only available when you create an override.
 
-### Fill below to
+#### Bar alignment
 
-The **Fill below to** option fills the area between two series. This option is only available as a series/field override.
+Set the position of the bar relative to a data point. In the examples below, **Show points** is set to **Always** which makes it easier to see the difference this setting makes. The points do not change; the bars change in relationship to the points.
 
-1. Edit the panel and click **Overrides**.
-1. Select the fields to fill below.
-1. In **Add override property**, select **Fill below to**.
-1. Select the series for which you want the fill to stop.
+- **Before** ![Bar alignment before icon](/static/img/docs/time-series-panel/bar-alignment-before.png)
+  The bar is drawn before the point. The point is placed on the trailing corner of the bar.
+- **Center** ![Bar alignment center icon](/static/img/docs/time-series-panel/bar-alignment-center.png)
+  The bar is drawn around the point. The point is placed in the center of the bar. This is the default.
+- **After** ![Bar alignment after icon](/static/img/docs/time-series-panel/bar-alignment-after.png)
+  The bar is drawn after the point. The point is placed on the leading corner of the bar.
 
-The following example shows three series: Min, Max, and Value. The Min and Max series have **Line width** set to 0. Max has a **Fill below to** override set to Min, which fills the area between Max and Min with the Max line color.
-
-{{< figure src="/static/img/docs/time-series-panel/fill-below-to-7-4.png" max-width="600px" caption="Fill below to example" >}}
-
-## Axis options
-
-Options under the axis category change how the x- and y-axes are rendered. Some options do not take effect until you click outside of the field option box you are editing. You can also or press `Enter`.
-
-### Time zone
-
-Set the desired time zone(s) to display along the x-axis.
-
-### Placement
-
-Select the placement of the y-axis.
-
-- **Auto:** Automatically assigns the y-axis to the series. When there are two or more series with different units, Grafana assigns the left axis to the first unit and the right axis to the units that follow.
-- **Left:** Display all y-axes on the left side.
-- **Right:** Display all y-axes on the right side.
-- **Hidden:** Hide all axes.
-
-To selectively hide axes, [Add a field override](ref:add-a-field-override) that targets specific fields.
-
-### Label
-
-Set a y-axis text label. If you have more than one y-axis, then you can assign different labels using an override.
-
-### Width
-
-Set a fixed width of the axis. By default, Grafana dynamically calculates the width of an axis.
-
-By setting the width of the axis, data with different axes types can share the same display proportions. This setting makes it easier for you to compare more than one graph’s worth of data because the axes are not shifted or stretched within visual proximity to each other.
-
-### Show grid lines
-
-Set the axis grid line visibility.
-
-- **Auto:** Automatically show grid lines based on the density of the data.
-- **On:** Always show grid lines.
-- **Off:** Never show grid lines.
-
-### Color
-
-Set the color of the axis.
-
-- **Text:** Set the color based on theme text color.
-- **Series:** Set the color based on the series color.
-
-### Show border
-
-Set the axis border visibility.
-
-### Scale
-
-Set the y-axis values scale.
-
-- **Linear:** Divides the scale into equal parts.
-- **Logarithmic:** Use a logarithmic scale. When you select this option, a list appears for you to choose a binary (base 2) or common (base 10) logarithmic scale.
-- **Symlog:** Use a symmetrical logarithmic scale. When you select this option, a list appears for you to choose a binary (base 2) or common (base 10) logarithmic scale. The linear threshold option allows you to set the threshold at which the scale changes from linear to logarithmic.
-
-### Centered zero
-
-Set the y-axis to be centered on zero.
-
-### Soft min and soft max
-
-Set a **Soft min** or **soft max** option for better control of y-axis limits. By default, Grafana sets the range for the y-axis automatically based on the dataset.
-
-**Soft min** and **soft max** settings can prevent small variations in the data from being magnified when it's mostly flat. In contrast, hard min and max values help prevent obscuring useful detail in the data by clipping intermittent spikes past a specific point.
-
-To define hard limits of the y-axis, set standard min/max options. For more information, refer to [Configure standard options](ref:configure-standard-options).
-
-![Label example](/static/img/docs/time-series-panel/axis-soft-min-max-7-4.png)
-
-### Transform
-
-Use this option to transform the series values without affecting the values shown in the tooltip, context menu, or legend.
-
-- **Negative Y transform:** Flip the results to negative values on the Y axis.
-- **Constant:** Show the first value as a constant line.
-
-{{% admonition type="note" %}}
-The transform option is only available as an override.
-{{% /admonition %}}
-
-{{< docs/shared lookup="visualizations/multiple-y-axes.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+2" >}}
-
-## Color options
-
-By default, the graph uses the standard [Color scheme](ref:color-scheme) option to assign series colors. You can also use the legend to open the color picker by clicking the legend series color icon. Setting
-color this way automatically creates an override rule that set's a specific color for a specific series.
-
-### Classic palette
-
-The most common setup is to use the **Classic palette** for graphs. This scheme automatically assigns a color for each field or series based on its order. If the order of a field changes in your query, the color also changes. You can manually configure a color for a specific field using an override rule.
-
-### Single color
-
-Use this mode to specify a color. You can also click the colored line icon next to each series in the Legend to open the color picker. This automatically creates a new override that sets the color scheme to single color and the selected color.
-
-### By value color schemes
-
-If you select a by value color scheme like **From thresholds (by value)** or **Green-Yellow-Red (by value)**, the **Color series by** option appears. This option controls which value (Last, Min, Max) to use to assign the series its color.
-
-### Scheme gradient mode
-
-The **Gradient mode** option located under the **Graph styles** has a mode named **Scheme**. When you enable **Scheme**, the line or bar receives a gradient color defined from the selected **Color scheme**.
-
-#### From thresholds
-
-If the **Color scheme** is set to **From thresholds (by value)** and **Gradient mode** is set to **Scheme**, then the line or bar color changes as they cross the defined thresholds.
-
-{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_thresholds_line.png" max-width="1200px" caption="Colors scheme: From thresholds" >}}
-
-The following image shows bars mode enabled.
-
-{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_thresholds_bars.png" max-width="1200px" caption="Color scheme: From thresholds" >}}
-
-#### Gradient color schemes
-
-The following image shows a line chart with the **Green-Yellow-Red (by value)** color scheme option selected.
-
-{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_line.png" max-width="1200px" caption="Color scheme: Green-Yellow-Red" >}}
-
-The following image shows a bar chart with the **Green-Yellow-Red (by value)** color scheme option selected.
-
-{{< figure src="/static/img/docs/time-series-panel/gradient_mode_scheme_bars.png" max-width="1200px" caption="Color scheme: Green-Yellow-Red" >}}
-
-## Standard options
+### Standard options
 
 {{< docs/shared lookup="visualizations/standard-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-## Data links
+### Data links
 
 {{< docs/shared lookup="visualizations/datalink-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-## Value mappings
+### Value mappings
 
 {{< docs/shared lookup="visualizations/value-mappings-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-## Thresholds
+### Thresholds
 
 {{< docs/shared lookup="visualizations/thresholds-options-1.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-## Field overrides
+### Field overrides
 
 {{< docs/shared lookup="visualizations/overrides-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/shared/visualizations/connect-null-values.md
+++ b/docs/sources/shared/visualizations/connect-null-values.md
@@ -6,8 +6,6 @@ title: Connect null values
 
 Choose how null values, which are gaps in the data, appear on the graph. Null values can be connected to form a continuous line or set to a threshold above which gaps in the data are no longer connected.
 
-![Connect null values option](/static/img/docs/time-series-panel/connect-null-values-option-v9.png)
-
 - **Never:** Time series data points with gaps in the data are never connected.
 - **Always:** Time series data points with gaps in the data are always connected.
 - **Threshold:** Specify a threshold above which gaps in the data are no longer connected. This can be useful when the connected gaps in the data are of a known size and/or within a known range, and gaps outside this range should no longer be connected.

--- a/docs/sources/shared/visualizations/disconnect-values.md
+++ b/docs/sources/shared/visualizations/disconnect-values.md
@@ -6,7 +6,5 @@ title: Disconnect values
 
 Choose whether to set a threshold above which values in the data should be disconnected.
 
-{{< figure src="/media/docs/grafana/screenshot-grafana-10-1-disconnect-values.png" max-width="750px" alt="Disconnect values options" >}}
-
 - **Never:** Time series data points in the data are never disconnected.
 - **Threshold:** Specify a threshold above which values in the data are disconnected. This can be useful when desired values in the data are of a known size and/or within a known range, and values outside this range should no longer be connected.

--- a/docs/sources/shared/visualizations/legend-options-1.md
+++ b/docs/sources/shared/visualizations/legend-options-1.md
@@ -8,28 +8,10 @@ comments: |
 
 Legend options control the series names and statistics that appear under or to the right of the graph. For more information about the legend, refer to [Configure a legend](../configure-legend/).
 
-### Visibility
-
-Toggle the switch to turn the legend on or off.
-
-### Mode
-
-Use these settings to define how the legend appears in your visualization.
-
-- **List -** Displays the legend as a list. This is a default display mode of the legend.
-- **Table -** Displays the legend as a table.
-
-### Placement
-
-Choose where to display the legend.
-
-- **Bottom -** Below the graph.
-- **Right -** To the right of the graph.
-
-#### Width
-
-Control how wide the legend is when placed on the right side of the visualization. This option is only displayed if you set the legend placement to **Right**.
-
-### Values
-
-Choose which of the [standard calculations](../../query-transform-data/calculation-types/) to show in the legend. You can have more than one.
+| Option     | Description                                                                                                                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Visibility | Toggle the switch to turn the legend on or off.                                                                                                                                                            |
+| Mode       | Use these settings to define how the legend appears in your visualization. **List** displays the legend as a list. This is a default display mode of the legend. **Table** displays the legend as a table. |
+| Placement  | Choose where to display the legend. **Bottom -** Below the graph. **Right -** To the right of the graph.                                                                                                   |
+| Width      | Control how wide the legend is when placed on the right side of the visualization. This option is only displayed if you set the legend placement to **Right**.                                             |
+| Values     | Choose which of the [standard calculations](../../query-transform-data/calculation-types/) to show in the legend. You can have more than one.                                                              |

--- a/docs/sources/shared/visualizations/overrides-options.md
+++ b/docs/sources/shared/visualizations/overrides-options.md
@@ -8,10 +8,12 @@ Overrides allow you to customize visualization settings for specific fields or s
 
 Choose from one the following override options:
 
-- **Fields with name** - Select a field from the list of all available fields.
-- **Fields with name matching regex** - Specify fields to override with a regular expression.
-- **Fields with type** - Select fields by type, such as string, numeric, or time.
-- **Fields returned by query** - Select all fields returned by a specific query, such as A, B, or C.
-- **Fields with values** - Select all fields returned by your defined reducer condition, such as **Min**, **Max**, **Count**, **Total**.
+| Option                         | Description                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Fields with name               | Select a field from the list of all available fields.                                                         |
+| Field with name matching regex | Specify fields to override with a regular expression.                                                         |
+| Fields with type               | Select fields by type, such as string, numeric, or time.                                                      |
+| Fields returned by query       | Select all fields returned by a specific query, such as A, B, or C.                                           |
+| Fields with values             | Select all fields returned by your defined reducer condition, such as **Min**, **Max**, **Count**, **Total**. |
 
 To learn more, refer to [Configure field overrides](../../configure-overrides/).

--- a/docs/sources/shared/visualizations/standard-options.md
+++ b/docs/sources/shared/visualizations/standard-options.md
@@ -8,12 +8,14 @@ comments: |
 
 You can customize the following standard options:
 
-- **Unit** - Choose which unit a field should use.
-- **Min**/**Max** - Set the minimum and maximum values used in percentage threshold calculations or leave these field empty for them to be calculated automatically.
-- **Field min/max** - Enable **Field min/max** to have Grafana calculate the min or max of each field individually, based on the minimum or maximum value of the field.
-- **Decimals** - Specify the number of decimals Grafana includes in the rendered value.
-- **Display name** - Set the display title of all fields. You can use variables in the field title.
-- **Color scheme** - Set single or multiple colors for your entire visualization.
-- **No value** - Enter what Grafana should display if the field value is empty or null. The default value is a hyphen (-).
+| Option        | Description                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit          | Choose which unit a field should use.                                                                                                             |
+| Min/Max       | Set the minimum and maximum values used in percentage threshold calculations or leave these field empty for them to be calculated automatically.  |
+| Field min/max | Enable **Field min/max** to have Grafana calculate the min or max of each field individually, based on the minimum or maximum value of the field. |
+| Decimals      | Specify the number of decimals Grafana includes in the rendered value.                                                                            |
+| Display name  | Set the display title of all fields. You can use variables in the field title.                                                                    |
+| Color scheme  | Set single or multiple colors for your entire visualization.                                                                                      |
+| No value      | Enter what Grafana should display if the field value is empty or null. The default value is a hyphen (-).                                         |
 
 To learn more, refer to [Configure standard options](../../configure-standard-options/).

--- a/docs/sources/shared/visualizations/thresholds-options-1.md
+++ b/docs/sources/shared/visualizations/thresholds-options-1.md
@@ -10,10 +10,10 @@ A threshold is a value or limit you set for a metric that’s reflected visually
 
 Set the following options:
 
-- **Value** - Set the value for each threshold.
-- **Thresholds mode** - Choose from:
-  - **Absolute**
-  - **Percentage**
-- **Show thresholds** - Choose from a variety of display options including not displaying thresholds at all.
+| Option          | Description                                                                          |
+| --------------- | ------------------------------------------------------------------------------------ |
+| Value           | Set the value for each threshold.                                                    |
+| Thresholds mode | Choose from **Absolute** and **Percentage**.                                         |
+| Show thresholds | Choose from a variety of display options including not displaying thresholds at all. |
 
 To learn more, refer to [Configure thresholds](../../configure-thresholds/).

--- a/docs/sources/shared/visualizations/tooltip-options-2.md
+++ b/docs/sources/shared/visualizations/tooltip-options-2.md
@@ -8,6 +8,14 @@ comments: |
 
 Tooltip options control the information overlay that appears when you hover over data points in the visualization.
 
+| Option                                  | Description                                                                                                                    |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [Tooltip mode](#tooltip-mode)           | When you hover your cursor over the visualization, Grafana can display tooltips. Choose how tooltips behave.                   |
+| [Values sort order](#values-sort-order) | This option controls the order in which values are listed in a tooltip.                                                        |
+| [Hover proximity](#hover-proximity)     | Set the hover proximity (in pixels) to control how close the cursor must be to a data point to trigger the tooltip to display. |
+| Max width                               | Set the maximum width of the tooltip box.                                                                                      |
+| Max height                              | Set the maximum height of the tooltip box. The default is 600 pixels.                                                          |
+
 ### Tooltip mode
 
 When you hover your cursor over the visualization, Grafana can display tooltips. Choose how tooltips behave.
@@ -31,11 +39,3 @@ When you set the **Tooltip mode** to **All**, the **Values sort order** option i
 Set the hover proximity (in pixels) to control how close the cursor must be to a data point to trigger the tooltip to display.
 
 ![Adding a hover proximity limit for tooltips](/media/docs/grafana/gif-grafana-10-4-hover-proximity.gif)
-
-### Max width
-
-Set the maximum width of the tooltip box.
-
-### Max height
-
-Set the maximum height of the tooltip box. The default is 600 pixels.


### PR DESCRIPTION
Backport e3150b4eb8c5474110b35ea7bc2d699f00caffdf from #90098

---

This PR restructures the Time series page and moves some content to the Bar chart and Configure standard options pages. 
It also:

- Removes some unnecessary images
- Fixes some high-level styling issues including links
- Updates shared files to use more table formatting
