### PR TITLE
Transformations: Fix filterByValue interpolation

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -56,39 +56,40 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
       interpolatedFilters.push(
         ...filters.map((filter) => {
           if (filter.config.id === ValueMatcherID.between) {
+            let valueFrom = filter.config.options.from;
+            let valueTo = filter.config.options.from;
+
             if (typeof filter.config.options.from === 'string') {
-              filter.config.options.from = ctx.interpolate(filter.config.options.from);
+              valueFrom = ctx.interpolate(filter.config.options.from);
             }
             if (typeof filter.config.options.to === 'string') {
-              filter.config.options.to = ctx.interpolate(filter.config.options.to);
+              valueTo = ctx.interpolate(filter.config.options.to);
             }
 
-            const newFilter = {
+            return {
               ...filter,
               config: {
                 ...filter.config,
                 options: {
                   ...filter.config.options,
-                  to: filter.config.options.to,
-                  from: filter.config.options.from,
+                  to: valueTo,
+                  from: valueFrom,
                 },
               },
             };
-
-            return newFilter;
           } else if (filter.config.id === ValueMatcherID.regex) {
             // Due to colliding syntaxes, interpolating regex filters will cause issues.
             return filter;
           } else if (filter.config.options.value) {
+            let value = filter.config.options.value;
             if (typeof filter.config.options.value === 'string') {
-              filter.config.options.value = ctx.interpolate(filter.config.options.value);
+              value = ctx.interpolate(value);
             }
 
-            const newFilter = {
+            return {
               ...filter,
-              config: { ...filter.config, options: { ...filter.config.options, value: filter.config.options.value } },
+              config: { ...filter.config, options: { ...filter.config.options, value } },
             };
-            return newFilter;
           }
 
           return filter;

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -57,13 +57,13 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
         ...filters.map((filter) => {
           if (filter.config.id === ValueMatcherID.between) {
             let valueFrom = filter.config.options.from;
-            let valueTo = filter.config.options.from;
+            let valueTo = filter.config.options.to;
 
             if (typeof filter.config.options.from === 'string') {
-              valueFrom = ctx.interpolate(filter.config.options.from);
+              valueFrom = ctx.interpolate(valueFrom);
             }
             if (typeof filter.config.options.to === 'string') {
-              valueTo = ctx.interpolate(filter.config.options.to);
+              valueTo = ctx.interpolate(valueTo);
             }
 
             return {


### PR DESCRIPTION
Before

![filterByValue_before](https://github.com/user-attachments/assets/f2bc6145-65ba-474e-bd2e-4387fd70cee3)


After

https://github.com/user-attachments/assets/c68c7fdf-f9f5-4d5a-ac0e-12f70ea51b6b



Fixes https://github.com/grafana/support-escalations/issues/11207

**Special notes for your reviewer:**
Relates to https://github.com/grafana/grafana/pull/89418

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
