### PR TITLE
Clarify that data source request reports are not for bugs or support requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
+++ b/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
@@ -16,7 +16,7 @@ body:
         
         Please check our [roadmap](https://github.com/orgs/grafana/projects/619?pane=info) for existing requests and subscribe to stay informed of our plans. If no request exists, please fill out the following information.
 
-        Please do not request support or file bug reports here.
+        Please do not request support or file bug reports and feature requests for existing plugins here.
         - For support, please use the community support resources [here](https://grafana.com/help/)
         - To report a bug, please use the [New Bug Report option here](https://github.com/grafana/grafana/issues/new/choose)
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
+++ b/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
@@ -15,6 +15,10 @@ body:
         Grafana Labs regularly reviews these requests and uses them to inform our prioritization. Note: we cannot offer any guarantees on whether we or our community will build a given data source.
         
         Please check our [roadmap](https://github.com/orgs/grafana/projects/619?pane=info) for existing requests and subscribe to stay informed of our plans. If no request exists, please fill out the following information.
+
+        Please do not request support or file bug reports here.
+        - For support, please use the community support resources [here](https://grafana.com/help/)
+        - To report a bug, please use the [New Bug Report option here](https://github.com/grafana/grafana/issues/new/choose)
   - type: textarea
     id: background
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
+++ b/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
@@ -18,7 +18,7 @@ body:
 
         Please do not request support or file bug reports and feature requests for existing plugins here.
         - For support, please use the community support resources [here](https://grafana.com/help/)
-        - To report a bug, please use the [New Bug Report option here](https://github.com/grafana/grafana/issues/new/choose)
+        - Please consider the `New Bug Report` or `Feature Requests` [issue templates](https://github.com/grafana/grafana/issues/new/choose) for other requests.
   - type: textarea
     id: background
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
+++ b/.github/ISSUE_TEMPLATE/3-data_source_request.yaml
@@ -17,7 +17,7 @@ body:
         Please check our [roadmap](https://github.com/orgs/grafana/projects/619?pane=info) for existing requests and subscribe to stay informed of our plans. If no request exists, please fill out the following information.
 
         Please do not request support or file bug reports and feature requests for existing plugins here.
-        - For support, please use the community support resources [here](https://grafana.com/help/)
+        - For support, please use the community support resources [here](https://grafana.com/help/).
         - Please consider the `New Bug Report` or `Feature Requests` [issue templates](https://github.com/grafana/grafana/issues/new/choose) for other requests.
   - type: textarea
     id: background


### PR DESCRIPTION
**Why do we need this feature?**
We've already received [one request for support](https://github.com/grafana/grafana/issues/90641) in the data source issue template. Clarify that bug reports and support requests belong elsewhere.