### PR TITLE
RBAC: Refactor RBAC plugin interface code

### DIFF
--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -129,16 +129,6 @@ type Licensing interface {
 	AppURL() string
 }
 
-// RoleRegistry handles the plugin RBAC roles and their assignments
-type RoleRegistry interface {
-	DeclarePluginRoles(ctx context.Context, ID, name string, registrations []RoleRegistration) error
-}
-
-// ActionSetRegistry handles the plugin RBAC actionsets
-type ActionSetRegistry interface {
-	RegisterActionSets(ctx context.Context, ID string, registrations []ActionSet) error
-}
-
 // ClientMiddleware is an interface representing the ability to create a middleware
 // that implements the Client interface.
 type ClientMiddleware interface {

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -35,7 +35,6 @@ import (
 	"github.com/grafana/grafana/pkg/login/social/socialimpl"
 	"github.com/grafana/grafana/pkg/middleware/csrf"
 	"github.com/grafana/grafana/pkg/middleware/loggermw"
-	"github.com/grafana/grafana/pkg/plugins"
 	apiregistry "github.com/grafana/grafana/pkg/registry/apis"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
@@ -103,6 +102,7 @@ import (
 	plugindashboardsservice "github.com/grafana/grafana/pkg/services/plugindashboards/service"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration"
 	pluginDashboards "github.com/grafana/grafana/pkg/services/pluginsintegration/dashboards"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/preference/prefimpl"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	publicdashboardsApi "github.com/grafana/grafana/pkg/services/publicdashboards/api"
@@ -352,7 +352,7 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(secretsMigrations.SecretMigrationProvider), new(*secretsMigrations.SecretMigrationProviderImpl)),
 	resourcepermissions.NewActionSetService,
 	wire.Bind(new(accesscontrol.ActionResolver), new(resourcepermissions.ActionSetService)),
-	wire.Bind(new(plugins.ActionSetRegistry), new(resourcepermissions.ActionSetService)),
+	wire.Bind(new(pluginaccesscontrol.ActionSetRegistry), new(resourcepermissions.ActionSetService)),
 	acimpl.ProvideAccessControl,
 	navtreeimpl.ProvideService,
 	wire.Bind(new(accesscontrol.AccessControl), new(*acimpl.AccessControl)),

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/login/authinfoimpl"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/provisioning"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	publicdashboardsApi "github.com/grafana/grafana/pkg/services/publicdashboards/api"
@@ -61,7 +62,7 @@ var wireExtsBasicSet = wire.NewSet(
 	wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),
 	acimpl.ProvideService,
 	wire.Bind(new(accesscontrol.RoleRegistry), new(*acimpl.Service)),
-	wire.Bind(new(plugins.RoleRegistry), new(*acimpl.Service)),
+	wire.Bind(new(pluginaccesscontrol.RoleRegistry), new(*acimpl.Service)),
 	wire.Bind(new(accesscontrol.Service), new(*acimpl.Service)),
 	validations.ProvideValidator,
 	wire.Bind(new(validations.PluginRequestValidator), new(*validations.OSSPluginRequestValidator)),

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -30,11 +30,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var _ plugins.RoleRegistry = &Service{}
+var _ pluginaccesscontrol.RoleRegistry = &Service{}
 
 const (
 	cacheTTL = 60 * time.Second

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -8,13 +8,14 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
 type fullAccessControl interface {
 	accesscontrol.AccessControl
 	accesscontrol.Service
-	plugins.RoleRegistry
+	pluginaccesscontrol.RoleRegistry
 	RegisterFixedRoles(context.Context) error
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -12,18 +12,18 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var _ plugins.ActionSetRegistry = (*InMemoryActionSets)(nil)
+var _ pluginaccesscontrol.ActionSetRegistry = (*InMemoryActionSets)(nil)
 
 type Store interface {
 	// SetUserResourcePermission sets permission for managed user role on a resource
@@ -440,7 +440,7 @@ type ActionSetService interface {
 
 	StoreActionSet(name string, actions []string)
 
-	plugins.ActionSetRegistry
+	pluginaccesscontrol.ActionSetRegistry
 }
 
 // ActionSet is a struct that represents a set of actions that can be performed on a resource.

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/process"
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/plugins/manager/signature"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 )
 
 func ProvideDiscoveryStage(cfg *config.PluginManagementCfg, pf finder.Finder, pr registry.Service) *discovery.Discovery {
@@ -60,8 +61,8 @@ func ProvideValidationStage(cfg *config.PluginManagementCfg, sv signature.Valida
 
 func ProvideInitializationStage(cfg *config.PluginManagementCfg, pr registry.Service, bp plugins.BackendFactoryProvider,
 	pm process.Manager, externalServiceRegistry auth.ExternalServiceRegistry,
-	roleRegistry plugins.RoleRegistry,
-	actionSetRegistry plugins.ActionSetRegistry,
+	roleRegistry pluginaccesscontrol.RoleRegistry,
+	actionSetRegistry pluginaccesscontrol.ActionSetRegistry,
 	pluginEnvProvider envvars.Provider,
 	tracer tracing.Tracer) *initialization.Initialize {
 	return initialization.New(cfg, initialization.Opts{

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/plugins/manager/signature"
 	"github.com/grafana/grafana/pkg/plugins/pfs"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
 )
 
 // ExternalServiceRegistration implements an InitializeFunc for registering external services.
@@ -70,15 +71,15 @@ func (r *ExternalServiceRegistration) Register(ctx context.Context, p *plugins.P
 // RegisterPluginRoles implements an InitializeFunc for registering plugin roles.
 type RegisterPluginRoles struct {
 	log          log.Logger
-	roleRegistry plugins.RoleRegistry
+	roleRegistry pluginaccesscontrol.RoleRegistry
 }
 
 // RegisterPluginRolesStep returns a new InitializeFunc for registering plugin roles.
-func RegisterPluginRolesStep(roleRegistry plugins.RoleRegistry) initialization.InitializeFunc {
+func RegisterPluginRolesStep(roleRegistry pluginaccesscontrol.RoleRegistry) initialization.InitializeFunc {
 	return newRegisterPluginRoles(roleRegistry).Register
 }
 
-func newRegisterPluginRoles(registry plugins.RoleRegistry) *RegisterPluginRoles {
+func newRegisterPluginRoles(registry pluginaccesscontrol.RoleRegistry) *RegisterPluginRoles {
 	return &RegisterPluginRoles{
 		log:          log.New("plugins.roles.registration"),
 		roleRegistry: registry,
@@ -97,15 +98,15 @@ func (r *RegisterPluginRoles) Register(ctx context.Context, p *plugins.Plugin) (
 // RegisterActionSets implements an InitializeFunc for registering plugin action sets.
 type RegisterActionSets struct {
 	log               log.Logger
-	actionSetRegistry plugins.ActionSetRegistry
+	actionSetRegistry pluginaccesscontrol.ActionSetRegistry
 }
 
 // RegisterActionSetsStep returns a new InitializeFunc for registering plugin action sets.
-func RegisterActionSetsStep(actionRegistry plugins.ActionSetRegistry) initialization.InitializeFunc {
+func RegisterActionSetsStep(actionRegistry pluginaccesscontrol.ActionSetRegistry) initialization.InitializeFunc {
 	return newRegisterActionSets(actionRegistry).Register
 }
 
-func newRegisterActionSets(registry plugins.ActionSetRegistry) *RegisterActionSets {
+func newRegisterActionSets(registry pluginaccesscontrol.ActionSetRegistry) *RegisterActionSets {
 	return &RegisterActionSets{
 		log:               log.New("plugins.actionsets.registration"),
 		actionSetRegistry: registry,

--- a/pkg/services/pluginsintegration/pluginaccesscontrol/accesscontrol.go
+++ b/pkg/services/pluginsintegration/pluginaccesscontrol/accesscontrol.go
@@ -1,6 +1,9 @@
 package pluginaccesscontrol
 
 import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/plugins"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -22,6 +25,16 @@ var (
 	// Protects access to the Configuration > Plugins page
 	AdminAccessEvaluator = ac.EvalAny(ac.EvalPermission(ActionWrite), ac.EvalPermission(ActionInstall))
 )
+
+// RoleRegistry handles the plugin RBAC roles and their assignments
+type RoleRegistry interface {
+	DeclarePluginRoles(ctx context.Context, ID, name string, registrations []plugins.RoleRegistration) error
+}
+
+// ActionSetRegistry handles the plugin RBAC actionsets
+type ActionSetRegistry interface {
+	RegisterActionSets(ctx context.Context, ID string, registrations []plugins.ActionSet) error
+}
 
 func ReqCanAdminPlugins(cfg *setting.Cfg) func(rc *contextmodel.ReqContext) bool {
 	// Legacy handler that protects access to the Configuration > Plugins page


### PR DESCRIPTION
Move RBAC plugin interfaces, based on this feedback: https://github.com/grafana/grafana/pull/88776#discussion_r1679578248

`pluginaccesscontrol` package feels like a reasonable place to move them to, but can also consider other packages under `pluginsintegration`.

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/6914