### PR TITLE
Chore (sqlstore): add validation and testing for repl config

### DIFF
--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -249,7 +249,7 @@ func validateReplicaConfigs(primary *DatabaseConfig, cfgs []*DatabaseConfig) err
 	seen[primary.ConnectionString] = struct{}{}
 	for _, cfg := range cfgs {
 		if _, ok := seen[cfg.ConnectionString]; ok {
-			result = errors.Join(result, fmt.Errorf("found duplicate connection string: %s", cfg.ConnectionString))
+			result = errors.Join(result, errors.New("duplicate connection string"))
 		} else {
 			seen[cfg.ConnectionString] = struct{}{}
 		}

--- a/pkg/services/sqlstore/replstore.go
+++ b/pkg/services/sqlstore/replstore.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"sync/atomic"
 	"time"
@@ -82,6 +83,10 @@ func ProvideServiceWithReadReplica(primary *SQLStore, cfg *setting.Cfg,
 	replCfgs, err := NewRODatabaseConfigs(cfg, features)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := validateReplicaConfigs(primary.dbCfg, replCfgs); err != nil {
+		return nil, fmt.Errorf("failed to validate replica configurations: %w", err)
 	}
 
 	if len(replCfgs) > 0 {

--- a/pkg/services/sqlstore/replstore_test.go
+++ b/pkg/services/sqlstore/replstore_test.go
@@ -32,26 +32,28 @@ func TestReplStore_ReadReplica(t *testing.T) {
 }
 
 func TestNewRODatabaseConfig(t *testing.T) {
-	inicfg, err := ini.Load([]byte(replCfg))
-	require.NoError(t, err)
-	cfg, err := setting.NewCfgFromINIFile(inicfg)
-	require.NoError(t, err)
+	t.Run("valid config", func(t *testing.T) {
+		inicfg, err := ini.Load([]byte(testReplCfg))
+		require.NoError(t, err)
+		cfg, err := setting.NewCfgFromINIFile(inicfg)
+		require.NoError(t, err)
 
-	dbCfgs, err := NewRODatabaseConfigs(cfg, nil)
-	require.NoError(t, err)
+		dbCfgs, err := NewRODatabaseConfigs(cfg, nil)
+		require.NoError(t, err)
 
-	var connStr = func(port int) string {
-		return fmt.Sprintf("grafana:password@tcp(127.0.0.1:%d)/grafana?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true", port)
-	}
-
-	for i, c := range dbCfgs {
-		if !cmp.Equal(c.ConnectionString, connStr(i+3306)) {
-			t.Errorf("wrong result for connection string %d.\nGot: %s,\nWant: %s", i, c.ConnectionString, connStr(i+3306))
+		var connStr = func(port int) string {
+			return fmt.Sprintf("grafana:password@tcp(127.0.0.1:%d)/grafana?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true", port)
 		}
-	}
+
+		for i, c := range dbCfgs {
+			if !cmp.Equal(c.ConnectionString, connStr(i+3306)) {
+				t.Errorf("wrong result for connection string %d.\nGot: %s,\nWant: %s", i, c.ConnectionString, connStr(i+3306))
+			}
+		}
+	})
 }
 
-var replCfg = `
+var testReplCfg = `
 [database_replicas]
 type = mysql
 name = grafana


### PR DESCRIPTION
I've been having nightmares about customers using this to balance between different databases, and while that's probably technically possible with a lot of careful work and planning, it's not realistically possible nor does it make sense, so let's just block it. (We can always remove this limit later). I also added a failing check for a duplicated connection strings, so you can't paste a read replica in multiple times.

The config syntax for `read_replicas` feels a bit weird and I'm open to discussing it. It's modeled after our [pluginsettings](https://github.com/grafana/grafana/blob/main/pkg/setting/setting_plugins.go#L14), but in this case the top-level `[database_replicas]` can be used to configure a single replica, while in plugin settings the top-level `plugins` block is only for general plugin configuration, and every plugin gets it's own `[plugins.something]` block.

In this case, a single replica can be configured under the top level `[database_replicas]` heading, while any additional replicas go in under `[database_replicas.repl1]`, `[database_replicas.us-east]`, etc. Fields in the top-level `[database_replicas]` are used as defaults for the other replicas if not overridden. 

I lean towards leaving this configuration syntax it as-is, because the best practice is to use a single read replica connection and an external solution for load balancing across multiple replicas, and in that setup the config looks good and makes sense.


Example with two replicas:
```
[database_replicas]
instrument_queries = true
type = mysql
name = grafana
user = grafana
password = password
host = 127.0.0.1:3307

[database_replicas.rep1] =
host = 127.0.0.1:3307
```