### PR TITLE
[v10.3.x] Chore: update changelog workflow

### DIFF
--- a/.github/workflows/actions/changelog/action.yml
+++ b/.github/workflows/actions/changelog/action.yml
@@ -1,0 +1,22 @@
+name: Changelog generator
+description: Generates and publishes a changelog for the given release version
+inputs:
+  target:
+    description: Target tag, branch or commit hash for the changelog
+    required: true
+  previous:
+    description: Previous tag, branch or commit hash to start changelog from
+    required: false
+  github_token:
+    description: GitHub token with read/write access to all necessary repositories
+    required: true
+  output_file:
+    description: A file to store resulting changelog markdown
+    required: false
+outputs:
+  changelog:
+    description: Changelog contents between the two given versions in Markdown format
+runs:
+  using: 'node20'
+  main: 'index.js'
+  

--- a/.github/workflows/actions/changelog/index.js
+++ b/.github/workflows/actions/changelog/index.js
@@ -1,0 +1,319 @@
+import { appendFileSync, writeFileSync } from 'fs';
+import { exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+
+//
+// Github Action core utils: logging (notice + debug log levels), must escape
+// newlines and percent signs
+//
+const escapeData = (s) => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+const LOG = (msg) => console.log(`::notice::${escapeData(msg)}`);
+
+//
+// Semver utils: parse, compare, sort etc (using official regexp)
+// https://regex101.com/r/Ly7O1x/3/
+//
+const semverRegExp =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+const semverParse = (tag) => {
+  const m = tag.match(semverRegExp);
+  if (!m) {
+    return;
+  }
+  const [_, major, minor, patch, prerelease] = m;
+  return [+major, +minor, +patch, prerelease, tag];
+};
+
+// semverCompare takes two parsed semver tags and comparest them more or less
+// according to the semver specs
+const semverCompare = (a, b) => {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) {
+      return a[i] < b[i] ? 1 : -1;
+    }
+  }
+  if (a[3] !== b[3]) {
+    return a[3] < b[3] ? 1 : -1;
+  }
+  return 0;
+};
+
+// Using `git tag -l` output find the tag (version) that goes semantically
+// right before the given version. This might not work correctly with some
+// pre-release versions, which is why it's possible to pass previous version
+// into this action explicitly to avoid this step.
+const getPreviousVersion = async (version) => {
+  const exec = promisify(execCallback);
+  const { stdout } = await exec('git tag -l');
+  const prev = stdout
+    .split('\n')
+    .map(semverParse)
+    .filter((tag) => tag)
+    .sort(semverCompare)
+    .find((tag) => semverCompare(tag, semverParse(version)) > 0);
+  if (!prev) {
+    throw `Could not find previous git tag for ${version}`;
+  }
+  return prev[4];
+};
+
+// A helper for Github GraphQL API endpoint
+const graphql = async (ghtoken, query, variables) => {
+  const { env } = process;
+  const results = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${ghtoken}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const { data } = await results.json();
+  return data;
+};
+
+// Using Github GraphQL API find the timestamp for the given tag/commit hash.
+// This is required for PR listing, because Github API only takes date/time as
+// a "since" parameter while listing. Currently there is no way to provide two
+// "commitish" items and get a list of PRs in between them.
+const getCommitishDate = async (name, owner, target) => {
+  const result = await graphql(
+    ghtoken,
+    `
+      query getCommitDate($owner: String!, $name: String!, $target: String!) {
+        repository(owner: $owner, name: $name) {
+          object(expression: $target) {
+            ... on Commit {
+              committedDate
+            }
+          }
+        }
+      }
+    `,
+    { name, owner, target }
+  );
+  return result.repository.object.committedDate;
+};
+
+// Using Github GraphQL API get a list of PRs between the two "commitish" items.
+// This resoves the "since" item's timestamp first and iterates over all PRs
+// till "target" using naïve pagination.
+const getHistory = async (name, owner, target, sinceDate) => {
+  LOG(`Fetching ${owner}/${name} PRs since ${sinceDate} till ${target}`);
+  const query = `
+  query findCommitsWithAssociatedPullRequests(
+    $name: String!
+    $owner: String!
+    $target: String!
+    $sinceDate: GitTimestamp
+    $cursor: String
+  ) {
+    repository(name: $name, owner: $owner) {
+      object(expression: $target) {
+        ... on Commit {
+          history(first: 50, since: $sinceDate, after: $cursor) {
+            totalCount
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              associatedPullRequests(first: 1) {
+                nodes {
+                  title
+                  number
+                  labels(first: 10) {
+                    nodes {
+                      name
+                    }
+                  }
+                  commits(first: 1) {
+                    nodes {
+                      commit {
+                        author {
+                          user {
+                            login
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+
+  let cursor;
+  let nodes = [];
+  for (;;) {
+    const result = await graphql(ghtoken, query, {
+      name,
+      owner,
+      target,
+      sinceDate,
+      cursor,
+    });
+    LOG(`GraphQL: ${JSON.stringify(result)}`);
+    nodes = [...nodes, ...result.repository.object.history.nodes];
+    const { hasNextPage, endCursor } = result.repository.object.history.pageInfo;
+    if (!hasNextPage) {
+      break;
+    }
+    cursor = endCursor;
+  }
+  return nodes;
+};
+
+// The main function for this action: given two "commitish" items it gets a
+// list of PRs between them and filters/groups the PRs by category (bugfix,
+// feature, deprecation, breaking change and plugin fixes/enhancements).
+//
+// PR grouping relies on Github labels only, not on the PR contents.
+const getChangeLogItems = async (name, owner, sinceDate, to) => {
+  // check if a node contains a certain label
+  const hasLabel = ({ labels }, label) => labels.nodes.some(({ name }) => name === label);
+  // get all the PRs between the two "commitish" items
+  const history = await getHistory(name, owner, to, sinceDate);
+
+  const items = history.flatMap((node) => {
+    // discard PRs without a "changelog" label
+    const changes = node.associatedPullRequests.nodes.filter((PR) => hasLabel(PR, 'add to changelog'));
+    if (changes.length === 0) {
+      return [];
+    }
+    const item = changes[0];
+    const { number, url, labels } = item;
+    const title = item.title.replace(/^\[[^\]]+\]:?\s*/, '');
+    // for changelog PRs try to find a suitable category.
+    // Note that we can not detect "deprecation notices" like that
+    // as there is no suitable label yet.
+    const isBug = /fix/i.test(title) || hasLabel({ labels }, 'type/bug');
+    const isBreaking = hasLabel({ labels }, 'breaking change');
+    const isPlugin =
+      hasLabel({ labels }, 'area/grafana/ui') ||
+      hasLabel({ labels }, 'area/grafana/toolkit') ||
+      hasLabel({ labels }, 'area/grafana/runtime');
+    const author = item.commits.nodes[0].commit.author.user.login;
+    return {
+      repo: name,
+      number,
+      title,
+      author,
+      isBug,
+      isPlugin,
+      isBreaking,
+    };
+  });
+  return items;
+};
+
+// ======================================================
+//                 GENERATE CHANGELOG
+// ======================================================
+
+LOG(`Changelog action started`);
+
+const ghtoken = process.env.GITHUB_TOKEN || process.env.INPUT_GITHUB_TOKEN;
+if (!ghtoken) {
+  throw 'GITHUB_TOKEN is not set and "github_token" input is empty';
+}
+
+const target = process.argv[2] || process.env.INPUT_TARGET;
+LOG(`Target tag/branch/commit: ${target}`);
+
+const previous = process.argv[3] || process.env.INPUT_PREVIOUS || (await getPreviousVersion(target));
+
+LOG(`Previous tag/commit: ${previous}`);
+
+const sinceDate = await getCommitishDate('grafana', 'grafana', previous);
+LOG(`Previous tag/commit timestamp: ${sinceDate}`);
+
+// Get all changelog items from Grafana OSS
+const oss = await getChangeLogItems('grafana', 'grafana', sinceDate, target);
+// Get all changelog items from Grafana Enterprise
+const entr = await getChangeLogItems('grafana-enterprise', 'grafana', sinceDate, target);
+
+LOG(`Found OSS PRs: ${oss.length}`);
+LOG(`Found Enterprise PRs: ${entr.length}`);
+
+// Sort PRs and categorise them into sections
+const changelog = [...oss, ...entr]
+  .sort((a, b) => (a.title < b.title ? -1 : 1))
+  .reduce(
+    (changelog, item) => {
+      if (item.isPlugin) {
+        changelog.plugins.push(item);
+      } else if (item.isBug) {
+        changelog.bugfixes.push(item);
+      } else if (item.isBreaking) {
+        changelog.breaking.push(item);
+      } else {
+        changelog.features.push(item);
+      }
+      return changelog;
+    },
+    {
+      breaking: [],
+      plugins: [],
+      bugfixes: [],
+      features: [],
+    }
+  );
+
+// Convert PR numbers to Github links
+const pullRequestLink = (n) => `[#${n}](https://github.com/grafana/grafana/pull/${n})`;
+// Convert Github user IDs to Github links
+const userLink = (u) => `[@${u}](https://github.com/${u})`;
+
+// Now that we have a changelog - we can render some markdown as an output
+const markdown = (changelog) => {
+  // This convers a list of changelog items into a markdown section with a list of titles/links
+  const section = (title, items) =>
+    items.length === 0
+      ? ''
+      : `### ${title}
+
+${items
+  .map(
+    (item) =>
+      `- ${item.title.replace(/^([^:]*:)/gm, '**$1**')} ${
+        item.repo === 'grafana-enterprise'
+          ? '(Enterprise)'
+          : `${pullRequestLink(item.number)}, ${userLink(item.author)}`
+      }`
+  )
+  .join('\n')}
+  `;
+
+  // Render all present sections for the given changelog
+  return `${section('Features and enhancements', changelog.features)}
+${section('Bug fixes', changelog.bugfixes)}
+${section('Breaking changes', changelog.breaking)}
+${section('Plugin development fixes & changes', changelog.plugins)}
+`;
+};
+
+const md = markdown(changelog);
+
+// Print changelog, mostly for debugging
+LOG(`Resulting markdown: ${md}`);
+
+// Save changelog as an output for this action
+if (process.env.GITHUB_OUTPUT) {
+  LOG(`Output to ${process.env.GITHUB_OUTPUT}`);
+  appendFileSync(process.env.GITHUB_OUTPUT, `changelog<<EOF\n${escapeData(md)}\nEOF`);
+} else {
+  LOG('GITHUB_OUTPUT is not set');
+}
+
+// Save changelog as an output file (if requested)
+if (process.env.INPUT_OUTPUT_FILE) {
+  LOG(`Output to ${process.env.INPUT_OUTPUT_FILE}`);
+  writeFileSync(process.env.INPUT_OUTPUT_FILE, md);
+}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,25 +1,14 @@
-# This workflow creates a new PR in Grafana which is triggered after a release is completed.
-# It should include all code changes that are needed after a release is done. This includes the changelog update and
-# version bumps, but could include more in the future.
-# Please refrain from including any processes that do not result in code changes in this workflow. Instead, they should
-# either be triggered in the release promotion process or in the release comms process (that is triggered by merging
-# this PR).
-name: Complete a Grafana release
+name: Generate changelog
 on:
   workflow_dispatch:
     inputs:
       version:
         required: true
-        type: string
-        description: The version of Grafana that is being released
+        description: 'Target release version (semver, git tag, branch or commit)'
       target:
         required: true
         type: string
-        description: The base branch that these changes are being merged into
-      backport:
-        required: false
-        type: string
-        description: Branch to backport these changes to
+        description: 'The base branch that these changes are being merged into'
       dry_run:
         required: false
         default: false
@@ -30,47 +19,43 @@ on:
         type: bool
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:
-  create-prs:
-    name: Create Release PR
+  main:
     runs-on: ubuntu-latest
-    if: github.repository == 'grafana/grafana'
+    permissions:
+      contents: write
     steps:
-
-      - name: Generate bot token
+      - name: "Generate token"
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
         with:
           app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
           private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
-
-      - name: Checkout Grafana
-        uses: actions/checkout@v4
+      - name: "Checkout Grafana repo"
+        uses: "actions/checkout@v4"
         with:
+          sparse-checkout: |
+            .github/workflows
+            CHANGELOG.md
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Configure git user
+      - name: "Configure git user"
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local --add --bool push.autoSetupRemote true
-
-      - name: Create branch
+      - name: "Create branch"
         run: git checkout -b "release/${{ github.run_id }}/${{ inputs.version }}"
-
-      - name: Generate changelog
+      - name: "Generate changelog"
         id: changelog
         uses: ./.github/workflows/actions/changelog
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
           target: v${{ inputs.version }}
           output_file: changelog_items.md
-
-      - name: Patch CHANGELOG.md
+      - name: "Patch CHANGELOG.md"
         run: |
           # Prepare CHANGELOG.md content with version delimiters
           (
@@ -98,28 +83,13 @@ jobs:
             mv CHANGELOG.tmp CHANGELOG.md
           fi
 
-          rm -f CHANGELOG.part changelog_items.md
-
           git diff CHANGELOG.md
-
-      - name: Commit CHANGELOG.md changes
+      - name: "Commit changelog changes"
         run: git commit --allow-empty -m "Update changelog placeholder" CHANGELOG.md
-
-      - name: Update package.json versions
-        uses: ./pkg/build/actions/bump-version
-        with:
-          version: ${{ inputs.version }}
-
-      - name: Add package.json changes
-        run: |
-          git add .
-          git commit -m "Update version to ${{ inputs.version }}"
-
-      - name: Git push
+      - name: "git push"
         if: ${{ inputs.dry_run }} != true
         run: git push
-
-      - name: Create PR without backports
+      - name: "Create changelog PR"
         if: "${{ inputs.backport == '' }}"
         run: >
           gh pr create \
@@ -127,20 +97,6 @@ jobs:
             --dry-run=${{ inputs.dry_run }} \
             -B "${{ inputs.target }}" \
             --title "Release: ${{ inputs.version }}" \
-            --body "These code changes must be merged after a release is complete"
+            --body "Changelog changes for release ${{ inputs.version }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create PR with backports
-        if: "${{ inputs.backport != '' }}"
-        run: >
-          gh pr create \
-            $( [ "x${{ inputs.latest }}" == "xtrue" ] && printf %s '-l "release/latest"') \
-            -l "backport ${{ inputs.backport }}" \
-            -l "product-approved" \
-            --dry-run=${{ inputs.dry_run }} \
-            -B "${{ inputs.target }}" \
-            --title "Release: ${{ inputs.version }}" \
-            --body "These code changes must be merged after a release is complete"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Backport f8b092aba62115fe28116ddde663ff9909e9bf31 from #90608

---

This contains a series of changes to the changelog Github action and a test workflow to try it live:

* Better inputs naming:
   - changelog action tags a `target` (tag, branch, commit) for the "end" of the changelog
   - also an optional `previous` for the "start" of the changelog (otherwise it's resolved automatically)
   - dry_run to disable actual PR creation
   - latest to mimic release_pr behaviour
   - token is renamed to `github_token` to be more specific
* Previous release date it resolved only in grafana repo, once. Saves some time and is more reliable.
* Release date and release version are not part of the changelog github action, only a list of changelog PRs is returned.

This also updates `release-pr.yml` accordingly.
