### PR TITLE
UserTable: Remove sorting on licensed role

### DIFF
--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { UseTableRowProps } from 'react-table';
 
 import {
   Avatar,

--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -91,8 +91,6 @@ export const UsersTable = ({
                   </Stack>
                 );
               },
-              sortType: (a: UseTableRowProps<UserDTO>, b: UseTableRowProps<UserDTO>) =>
-                (a.original.orgs?.length || 0) - (b.original.orgs?.length || 0),
             },
           ]
         : []),
@@ -113,8 +111,6 @@ export const UsersTable = ({
                   value
                 );
               },
-              // Needs the assertion here, the types are not inferred correctly due to the  conditional assignment
-              sortType: 'string' as const,
             },
           ]
         : []),


### PR DESCRIPTION
**What is this feature?**

Currently, the backend cannot sort users based on their licensed roles. 
Attempting to sort the user table by this criteria results in a "Bad Request" error for users.

![error](https://github.com/user-attachments/assets/320ff7d4-f220-436f-ad8b-280036ebd39e)

This PR addresses the issue by disabling the sorting functionality for licensed roles in the user interface.

The same happens for sorting orgs.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
