### PR TITLE
Tempo: Show search streaming status in query options

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.test.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.test.tsx
@@ -64,6 +64,7 @@ describe('TraceQLSearch', () => {
       ],
     },
   } as TempoDatasource;
+  datasource.isStreamingSearchEnabled = () => false;
   datasource.languageProvider = new TempoLanguageProvider(datasource);
   let query: TempoQuery = {
     refId: 'A',
@@ -216,6 +217,7 @@ describe('TraceQLSearch', () => {
         ],
       },
     } as TempoDatasource;
+    datasource.isStreamingSearchEnabled = () => false;
     datasource.languageProvider = new TempoLanguageProvider(datasource);
     await act(async () => {
       const { container } = render(

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
@@ -253,7 +253,11 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app, addVa
             Edit in TraceQL
           </Button>
         </div>
-        <TempoQueryBuilderOptions onChange={onChange} query={query} />
+        <TempoQueryBuilderOptions
+          onChange={onChange}
+          query={query}
+          isStreaming={datasource.isStreamingSearchEnabled() ?? false}
+        />
       </div>
       {error ? (
         <Alert title="Unable to connect to Tempo search" severity="info" className={styles.alert}>

--- a/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
@@ -69,7 +69,11 @@ export function QueryEditor(props: Props) {
         onRunQuery={props.onRunQuery}
       />
       <div className={styles.optionsContainer}>
-        <TempoQueryBuilderOptions query={query} onChange={props.onChange} />
+        <TempoQueryBuilderOptions
+          query={query}
+          onChange={props.onChange}
+          isStreaming={props.datasource.isStreamingSearchEnabled() ?? false}
+        />
       </div>
     </>
   );

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -11,6 +11,7 @@ import { TempoQuery } from '../types';
 interface Props {
   onChange: (value: TempoQuery) => void;
   query: Partial<TempoQuery> & TempoQuery;
+  isStreaming: boolean;
 }
 
 /**
@@ -26,7 +27,7 @@ const parseIntWithFallback = (val: string, fallback: number) => {
   return isNaN(parsed) ? fallback : parsed;
 };
 
-export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) => {
+export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, isStreaming }) => {
   if (!query.hasOwnProperty('limit')) {
     query.limit = DEFAULT_LIMIT;
   }
@@ -53,6 +54,7 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
     `Spans Limit: ${query.spss || DEFAULT_SPSS}`,
     `Table Format: ${query.tableType === SearchTableType.Traces ? 'Traces' : 'Spans'}`,
     `Step: ${query.step || 'auto'}`,
+    `Streaming: ${isStreaming ? 'Enabled' : 'Disabled'}`,
   ];
 
   return (
@@ -104,10 +106,29 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
               value={query.step}
             />
           </EditorField>
+          <EditorField label="Streaming" tooltip={<StreamingTooltip />} tooltipInteractive>
+            <div>{isStreaming ? 'Enabled' : 'Disabled'}</div>
+          </EditorField>
         </QueryOptionGroup>
       </EditorRow>
     </>
   );
 });
+
+const StreamingTooltip = () => {
+  return (
+    <div style={{ display: 'flex', gap: '4px' }}>
+      <span>Stream partial query results.</span>
+      <a
+        href={'https://grafana.com/docs/tempo/latest/traceql/#stream-query-results'}
+        target={'_blank'}
+        rel="noreferrer"
+        style={{ textDecoration: 'underline' }}
+      >
+        Learn more
+      </a>
+    </div>
+  );
+};
 
 TempoQueryBuilderOptions.displayName = 'TempoQueryBuilderOptions';

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -118,9 +118,13 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query, is
 const StreamingTooltip = () => {
   return (
     <div style={{ display: 'flex', gap: '4px' }}>
-      <span>Stream partial query results.</span>
+      <span>
+        Indicates if streaming is currently enabled. Streaming allows you to view partial query results before the
+        entire query completes.
+      </span>
       <a
         href={'https://grafana.com/docs/tempo/latest/traceql/#stream-query-results'}
+        aria-label={'Learn more about streaming query results'}
         target={'_blank'}
         rel="noreferrer"
         style={{ textDecoration: 'underline' }}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Show the status of query streaming in the query editor options.

![image](https://github.com/user-attachments/assets/0d005168-04be-4a85-8455-6f9e56a38b7d)

![image](https://github.com/user-attachments/assets/7362dd0c-1245-487c-8c0f-1eedd3a86e4d)


**Why do we need this feature?**

This feature has two purposes: first, it works as a way for users to see whether query results streaming is enabled, secondly, it acts as a way to inform users of this feature while providing a quick link to the documentation in the tooltip. 

**Who is this feature for?**

Users of the Tempo datasource.
