### PR TITLE
DashboardScenes: TemplateSrv should return timeRange from scenes if context found

### DIFF
--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -30,12 +30,18 @@ variableAdapters.setInit(() => [
 ]);
 
 const interpolateMock = jest.fn();
+const timeRangeMock = jest
+  .fn()
+  .mockReturnValue({
+    state: { value: { from: dateTime(1594671549254), to: dateTime(1594671549254), raw: { from: '12', to: '14' } } },
+  });
 
 jest.mock('@grafana/scenes', () => ({
   ...jest.requireActual('@grafana/scenes'),
   sceneGraph: {
     ...jest.requireActual('@grafana/scenes').sceneGraph,
     interpolate: (...args: unknown[]) => interpolateMock(...args),
+    getTimeRange: (...args: unknown[]) => timeRangeMock(...args),
   },
 }));
 
@@ -888,6 +894,21 @@ describe('templateSrv', () => {
       expect(podVar.type).toBe('query');
       expect(podVar.current.value).toEqual(['pA', 'pB']);
       expect(podVar.current.text).toEqual(['podA', 'podB']);
+    });
+
+    it('Should return timeRange from scenes context', () => {
+      window.__grafanaSceneContext = new EmbeddedScene({
+        body: new SceneCanvasText({ text: 'hello' }),
+      });
+
+      window.__grafanaSceneContext.activate();
+
+      const timeRange = _templateSrv.timeRange;
+
+      expect(timeRange).not.toBeNull();
+      expect(timeRange).not.toBeUndefined();
+      expect(timeRange!.raw).toEqual({ from: '12', to: '14' });
+      expect(timeRangeMock).toHaveBeenCalled();
     });
   });
 });

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -898,15 +898,22 @@ describe('templateSrv', () => {
       window.__grafanaSceneContext = new EmbeddedScene({
         body: new SceneCanvasText({ text: 'hello' }),
       });
+      _templateSrv.updateTimeRange({
+        from: dateTime(1594671549254),
+        to: dateTime(1594671549254),
+        raw: { from: '10', to: '10' },
+      });
 
-      window.__grafanaSceneContext.activate();
+      const deactivate = window.__grafanaSceneContext.activate();
 
-      const timeRange = _templateSrv.timeRange;
-
-      expect(timeRange).not.toBeNull();
-      expect(timeRange).not.toBeUndefined();
-      expect(timeRange!.raw).toEqual({ from: '12', to: '14' });
+      expect(_templateSrv.timeRange).not.toBeNull();
+      expect(_templateSrv.timeRange).not.toBeUndefined();
+      expect(_templateSrv.timeRange!.raw).toEqual({ from: '12', to: '14' });
       expect(timeRangeMock).toHaveBeenCalled();
+
+      deactivate();
+
+      expect(_templateSrv.timeRange!.raw).toEqual({ from: '10', to: '10' });
     });
   });
 });

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -30,11 +30,9 @@ variableAdapters.setInit(() => [
 ]);
 
 const interpolateMock = jest.fn();
-const timeRangeMock = jest
-  .fn()
-  .mockReturnValue({
-    state: { value: { from: dateTime(1594671549254), to: dateTime(1594671549254), raw: { from: '12', to: '14' } } },
-  });
+const timeRangeMock = jest.fn().mockReturnValue({
+  state: { value: { from: dateTime(1594671549254), to: dateTime(1594671549254), raw: { from: '12', to: '14' } } },
+});
 
 jest.mock('@grafana/scenes', () => ({
   ...jest.requireActual('@grafana/scenes'),

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -51,7 +51,7 @@ export class TemplateSrv implements BaseTemplateSrv {
   private regex = variableRegex;
   private index: any = {};
   private grafanaVariables = new Map<string, any>();
-  private timeRange?: TimeRange | null = null;
+  private _timeRange?: TimeRange | null = null;
   private _adhocFiltersDeprecationWarningLogged = new Map<string, boolean>();
 
   constructor(private dependencies: TemplateSrvDependencies = runtimeDependencies) {
@@ -60,7 +60,7 @@ export class TemplateSrv implements BaseTemplateSrv {
 
   init(variables: any, timeRange?: TimeRange) {
     this._variables = variables;
-    this.timeRange = timeRange;
+    this._timeRange = timeRange;
     this.updateIndex();
   }
 
@@ -81,6 +81,16 @@ export class TemplateSrv implements BaseTemplateSrv {
     }
 
     return this.dependencies.getVariables();
+  }
+
+  get timeRange(): TimeRange | null | undefined {
+    if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
+      const sceneTimeRange = sceneGraph.getTimeRange(window.__grafanaSceneContext);
+
+      return sceneTimeRange.state.value;
+    }
+
+    return this._timeRange;
   }
 
   updateIndex() {
@@ -110,7 +120,7 @@ export class TemplateSrv implements BaseTemplateSrv {
   }
 
   updateTimeRange(timeRange: TimeRange) {
-    this.timeRange = timeRange;
+    this._timeRange = timeRange;
     this.updateIndex();
   }
 


### PR DESCRIPTION
We have an issue around the ADX DS, where the timerange is not found on query. The time range is being pulled from templateSrv [here](https://github.com/grafana/azure-data-explorer-datasource/blob/4e52da60758a51f898040bb9fd4829e1aab6d6a7/src/datasource.ts#L501), but with the new scenes architecture this range is null/never updated in templateSrv. This PR updates the timerange to check in scenes context as well.