### PR TITLE
Alerting: Return error when writing recorded metrics instead of default writing NaN

### DIFF
--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -482,8 +482,8 @@ func TestRecordingRule_Integration(t *testing.T) {
 		t.Run("status shows evaluation", func(t *testing.T) {
 			status := process.(*recordingRule).Status()
 
-			// TODO: OK expected for nil result but having a point. Probably should change.
-			require.Equal(t, "ok", status.Health)
+			//TODO: assert "error" to fix test, update to "nodata" in the future
+			require.Equal(t, "error", status.Health)
 		})
 	})
 }

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -3,7 +3,6 @@ package writer
 import (
 	"context"
 	"fmt"
-	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -63,15 +62,14 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 
 	points := make([]Point, 0, len(col.Refs))
 	for _, ref := range col.Refs {
-		// Use a default value of NaN if the value is empty or nil.
-		f := math.NaN()
-		if fp, empty, _ := ref.NullableFloat64Value(); !empty && fp != nil {
-			f = *fp
+		fp, empty, _ := ref.NullableFloat64Value()
+		if empty || fp == nil {
+			return nil, fmt.Errorf("unable to read float64 value")
 		}
 
 		metric := Metric{
 			T: t,
-			V: f,
+			V: *fp,
 		}
 
 		labels := ref.GetLabels().Copy()


### PR DESCRIPTION
**What is this feature?**

This PR changes the behavior of the recording rules writer to avoid writing out NaN to prometheus if a float cannot be extracted from the rule's data frame output. 

**Why do we need this feature?**

This should help in cases where Grafana is configured in HA mode, where we want to ensure another cluster node can attempt to write the metric if one or more nodes fails to retrieve data from the rule's query.

**Who is this feature for?**

Users of recording rules

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
