### PR TITLE
Runtime: Add provider and access hook for location service

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -514,7 +514,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "packages/grafana-runtime/src/services/LocationService.ts:5381": [
+    "packages/grafana-runtime/src/services/LocationService.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],

--- a/packages/grafana-runtime/src/services/LocationService.test.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.test.tsx
@@ -1,4 +1,6 @@
-import { locationService } from './LocationService';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { locationService, HistoryWrapper, useLocationService, LocationServiceProvider } from './LocationService';
 
 describe('LocationService', () => {
   describe('getSearchObject', () => {
@@ -49,6 +51,17 @@ describe('LocationService', () => {
       expect(locationService.getLocation().state).toEqual({
         some: 'stateToPersist',
       });
+    });
+  });
+
+  describe('hook access', () => {
+    it('can set and access service from a context', () => {
+      const locationServiceLocal = new HistoryWrapper();
+      const wrapper: React.FunctionComponent<{ children: React.ReactNode }> = ({ children }) => (
+        <LocationServiceProvider service={locationServiceLocal}>{children}</LocationServiceProvider>
+      );
+      const hookResult = renderHook(() => useLocationService(), { wrapper });
+      expect(hookResult.result.current).toBe(locationServiceLocal);
     });
   });
 });

--- a/packages/grafana-runtime/src/services/LocationService.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.tsx
@@ -1,4 +1,5 @@
 import * as H from 'history';
+import React, { useContext } from 'react';
 
 import { deprecationWarning, UrlQueryMap, urlUtil } from '@grafana/data';
 import { attachDebugger, createLogger } from '@grafana/ui';
@@ -162,3 +163,21 @@ export const navigationLogger = navigationLog.logger;
 
 // For debugging purposes the location service is attached to global _debug variable
 attachDebugger('location', locationService, navigationLog);
+
+// Simple context so the location service can be used without being a singleton
+const LocationServiceContext = React.createContext<LocationService | undefined>(undefined);
+
+export function useLocationService(): LocationService {
+  const service = useContext(LocationServiceContext);
+  if (!service) {
+    throw new Error('useLocationService must be used within a LocationServiceProvider');
+  }
+  return service;
+}
+
+export const LocationServiceProvider: React.FC<{ service: LocationService; children: React.ReactNode }> = ({
+  service,
+  children,
+}) => {
+  return <LocationServiceContext.Provider value={service}>{children}</LocationServiceContext.Provider>;
+};

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -4,7 +4,13 @@ import { Provider } from 'react-redux';
 import { Router, Redirect, Switch, RouteComponentProps } from 'react-router-dom';
 import { CompatRouter, CompatRoute } from 'react-router-dom-v5-compat';
 
-import { config, locationService, navigationLogger, reportInteraction } from '@grafana/runtime';
+import {
+  config,
+  locationService,
+  LocationServiceProvider,
+  navigationLogger,
+  reportInteraction,
+} from '@grafana/runtime';
 import { ErrorBoundaryAlert, GlobalStyles, ModalRoot, PortalContainer, Stack } from '@grafana/ui';
 import { getAppRoutes } from 'app/routes/routes';
 import { store } from 'app/store/store';
@@ -104,29 +110,31 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
                 options={{ enableHistory: true, callbacks: { onSelectAction: commandPaletteActionSelected } }}
               >
                 <Router history={locationService.getHistory()}>
-                  <CompatRouter>
-                    <ModalsContextProvider>
-                      <GlobalStyles />
-                      <div className="grafana-app">
-                        <AppChrome>
-                          <AngularRoot />
-                          <AppNotificationList />
-                          <Stack gap={0} grow={1} direction="column">
-                            {pageBanners.map((Banner, index) => (
-                              <Banner key={index.toString()} />
+                  <LocationServiceProvider service={locationService}>
+                    <CompatRouter>
+                      <ModalsContextProvider>
+                        <GlobalStyles />
+                        <div className="grafana-app">
+                          <AppChrome>
+                            <AngularRoot />
+                            <AppNotificationList />
+                            <Stack gap={0} grow={1} direction="column">
+                              {pageBanners.map((Banner, index) => (
+                                <Banner key={index.toString()} />
+                              ))}
+                              {ready && this.renderRoutes()}
+                            </Stack>
+                            {bodyRenderHooks.map((Hook, index) => (
+                              <Hook key={index.toString()} />
                             ))}
-                            {ready && this.renderRoutes()}
-                          </Stack>
-                          {bodyRenderHooks.map((Hook, index) => (
-                            <Hook key={index.toString()} />
-                          ))}
-                        </AppChrome>
-                      </div>
-                      <LiveConnectionWarning />
-                      <ModalRoot />
-                      <PortalContainer />
-                    </ModalsContextProvider>
-                  </CompatRouter>
+                          </AppChrome>
+                        </div>
+                        <LiveConnectionWarning />
+                        <ModalRoot />
+                        <PortalContainer />
+                      </ModalsContextProvider>
+                    </CompatRouter>
+                  </LocationServiceProvider>
                 </Router>
               </KBarProvider>
             </ThemeProvider>


### PR DESCRIPTION
This is part of the effort to make the LocationService non singleton as part of the Sidecar project, see https://github.com/grafana/grafana/pull/88797.

This right now just adds a provider for the LocationService and adds it into the React tree that renders app plugins. This way app plugins can get the location service from the context instead of relying on the singleton. This means we can later inject different location providers for 2 separate apps and they won't clash on the URL. You can see the plan here https://github.com/grafana/grafana/pull/88797/files#diff-b1d459ae81cb312ba78da28cfe277013ba08a6787c0f5dcc42ac142f06dadd6cR181 with locationService with MemoryHistory being injected to the second app rendering tree.

Currently the injected locationService is the same as global singleton so nothing should change for grafana itself or any app.

This is also required for this Scenes PR that makes it's URL handling not reliant on the locationService singleton.