### PR TITLE
Alerting: Treat nil dimensions as nodata in recording rules

### DIFF
--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -482,8 +482,11 @@ func TestRecordingRule_Integration(t *testing.T) {
 		t.Run("status shows evaluation", func(t *testing.T) {
 			status := process.(*recordingRule).Status()
 
-			// TODO: OK expected for nil result but having a point. Probably should change.
-			require.Equal(t, "ok", status.Health)
+			require.Equal(t, "nodata", status.Health)
+		})
+
+		t.Run("no write was performed", func(t *testing.T) {
+			require.Zero(t, writeTarget.RequestsCount)
 		})
 	})
 }

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -232,7 +232,7 @@ func (w PrometheusWriter) Write(ctx context.Context, name string, t time.Time, f
 	if err, ignored := checkWriteError(writeErr); err != nil {
 		return fmt.Errorf("failed to write time series: %w", err)
 	} else if ignored {
-		l.Debug("Ignored write error", "error", err, "status_code", res.StatusCode)
+		l.Warn("Ignored write error", "error", err, "status_code", res.StatusCode)
 	}
 
 	return nil

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -23,6 +24,10 @@ import (
 )
 
 const backendType = "prometheus"
+
+var (
+	ErrNoData = errors.New("no values to write")
+)
 
 const (
 	// Fixed error messages
@@ -65,7 +70,12 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 	for _, ref := range col.Refs {
 		// Use a default value of NaN if the value is empty or nil.
 		f := math.NaN()
-		if fp, empty, _ := ref.NullableFloat64Value(); !empty && fp != nil {
+		fp, empty, err := ref.NullableFloat64Value()
+		if fp == nil && err == nil {
+			// Match Alert rule behavior where values that are present but nil are treated as a NoData dimension.
+			continue
+		}
+		if !empty {
 			f = *fp
 		}
 
@@ -195,6 +205,9 @@ func (w PrometheusWriter) Write(ctx context.Context, name string, t time.Time, f
 	points, err := PointsFromFrames(name, t, frames, extraLabels)
 	if err != nil {
 		return err
+	}
+	if len(points) == 0 {
+		return fmt.Errorf("skipping write: %w", ErrNoData)
 	}
 
 	series := make([]promremote.TimeSeries, 0, len(points))


### PR DESCRIPTION
**What is this feature?**

Alert rules has a special case for when a returned value is nil. (valid frame, with a value, that value is nil instead of a float)
This is special-cased to act like a NoData dimension:
https://github.com/grafana/grafana/blob/771933bd7414c7c32c4ba49607f489f12398f246/pkg/services/ngalert/eval/eval.go#L752-L753

This PR makes it so that we match behavior in recording rules. It now matches the other NoData semantics - the dimension is not written at all if it's no data.

To support that, we also add handling for when no dimensions are written across the board, in that case the whole evaluation is considered no data.

**Which issue(s) does this PR fix?**:
n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
