### PR TITLE
Table: Fix cell units

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -42,7 +42,9 @@ export const TableCell = ({
   if (cellProps.style) {
     cellProps.style.minWidth = cellProps.style.width;
     const justifyContent = (cell.column as any).justifyContent;
-    if (justifyContent === 'flex-end') {
+
+    // If cell has a unit we should avoid setting direction to rtl
+    if (justifyContent === 'flex-end' && !field.config.unit) {
       // justify-content flex-end is not compatible with cellLink overflow; use direction instead
       cellProps.style.textAlign = 'right';
       cellProps.style.direction = 'rtl';


### PR DESCRIPTION
It [was recently reported](https://raintank-corp.slack.com/archives/C065F70N2Q7/p1721294072963189) that cell units were prepending vs appending the values in table cells.

It turns out this was a regression caused by [this PR](https://github.com/grafana/grafana/pull/90353)

This PR implements a quick fix to handle the case when the cell's field has a unit set.

Before

<img width="801" alt="Screenshot 2024-07-22 at 2 59 29 PM" src="https://github.com/user-attachments/assets/120ad967-a35c-403a-abc6-0dd646f693d5">


After

<img width="796" alt="Screenshot 2024-07-22 at 2 59 07 PM" src="https://github.com/user-attachments/assets/1bf14a33-c505-47f1-9c70-f04ece6291d9">

Repro dashboard
[debug-Panel Title-2024-07-22 15_02_28.json.txt](https://github.com/user-attachments/files/16340149/debug-Panel.Title-2024-07-22.15_02_28.json.txt)
