### PR TITLE
notifications: Fix flaky SMTP tests

### DIFF
--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -10,6 +10,7 @@ import (
 	"net/textproto"
 	"strings"
 	"testing"
+	"time"
 
 	smtpmock "github.com/mocktools/go-smtp-mock/v2"
 	"github.com/stretchr/testify/assert"
@@ -150,10 +151,9 @@ func TestSmtpDialer(t *testing.T) {
 }
 
 func TestSmtpSend(t *testing.T) {
-	// Test is currently very flaky. Skipping it for now.
-	t.Skip()
 	srv := smtpmock.New(smtpmock.ConfigurationAttr{
 		MultipleRcptto: true,
+		HostAddress:    "127.0.0.1",
 	})
 	require.NoError(t, srv.Start())
 	defer func() { _ = srv.Stop() }()
@@ -183,6 +183,8 @@ func TestSmtpSend(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
+		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
+		time.Sleep(1 * time.Millisecond)
 		messages := srv.MessagesAndPurge()
 		require.Len(t, messages, 1)
 		sentMsg := messages[0]
@@ -233,6 +235,8 @@ func TestSmtpSend(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
+		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
+		time.Sleep(1 * time.Millisecond)
 		messages := srv.MessagesAndPurge()
 		require.Len(t, messages, 1)
 		sentMsg := messages[0]
@@ -292,6 +296,8 @@ func TestSmtpSend(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 3, count)
 
+		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
+		time.Sleep(1 * time.Millisecond)
 		messages := srv.MessagesAndPurge()
 		require.Len(t, messages, 3)
 


### PR DESCRIPTION
**What is this feature?**

I introduced some new tests in #90559 that use an SMTP server mocking module. Unfortunately, that module suffers from a timing bug causing these tests to be flaky, especially in CI.

The workaround suggested in https://github.com/mocktools/go-smtp-mock/issues/181 involves sleeping for a millisecond before attempting to read messages. I couldn't reproduce the failures locally after adding this.

Note: I originally was able to reproduce it fairly consistently by running the test in a loop:

```console
$ for n in `seq 1 10`; do go test -run=TestSmtpSend -count=100 -failfast ./pkg/services/notifications; done
```

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
