### PR TITLE
TemplateSrv: Backportable version of 90808

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6124,6 +6124,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
+    "public/app/plugins/datasource/dashboard/datasource.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/plugins/datasource/dashboard/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./runSharedRequest\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`./DashboardQueryEditor\`)", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -5441,8 +5441,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Do not use any type assertions.", "9"],
       [0, 0, 0, "Do not use any type assertions.", "10"],
-      [0, 0, 0, "Do not use any type assertions.", "11"],
-      [0, 0, 0, "Do not use any type assertions.", "12"]
+      [0, 0, 0, "Do not use any type assertions.", "11"]
     ],
     "public/app/features/trails/ActionTabs/AddToFiltersGraphAction.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -7,7 +7,6 @@ import {
   EmbeddedScene,
   IntervalVariable,
   QueryVariable,
-  SafeSerializableSceneObject,
   SceneCanvasText,
   SceneVariableSet,
   TestVariable,
@@ -835,16 +834,6 @@ describe('templateSrv', () => {
       const variable = new TestVariable({});
 
       _templateSrv.replace('test ${test}', { __sceneObject: { value: variable, text: 'foo' } });
-
-      expect(interpolateMock).toHaveBeenCalledTimes(1);
-      expect(interpolateMock.mock.calls[0][0]).toEqual(variable);
-      expect(interpolateMock.mock.calls[0][1]).toEqual('test ${test}');
-    });
-
-    it('should use scene interpolator when scoped var provided via SafeSerializableSceneObject', () => {
-      const variable = new TestVariable({});
-      const serializable = new SafeSerializableSceneObject(variable);
-      _templateSrv.replace('test ${test}', { __sceneObject: serializable });
 
       expect(interpolateMock).toHaveBeenCalledTimes(1);
       expect(interpolateMock.mock.calls[0][0]).toEqual(variable);

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -7,6 +7,7 @@ import {
   EmbeddedScene,
   IntervalVariable,
   QueryVariable,
+  SafeSerializableSceneObject,
   SceneCanvasText,
   SceneVariableSet,
   TestVariable,
@@ -834,6 +835,16 @@ describe('templateSrv', () => {
       const variable = new TestVariable({});
 
       _templateSrv.replace('test ${test}', { __sceneObject: { value: variable, text: 'foo' } });
+
+      expect(interpolateMock).toHaveBeenCalledTimes(1);
+      expect(interpolateMock.mock.calls[0][0]).toEqual(variable);
+      expect(interpolateMock.mock.calls[0][1]).toEqual('test ${test}');
+    });
+
+    it('should use scene interpolator when scoped var provided via SafeSerializableSceneObject', () => {
+      const variable = new TestVariable({});
+      const serializable = new SafeSerializableSceneObject(variable);
+      _templateSrv.replace('test ${test}', { __sceneObject: serializable });
 
       expect(interpolateMock).toHaveBeenCalledTimes(1);
       expect(interpolateMock.mock.calls[0][0]).toEqual(variable);

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -15,7 +15,7 @@ import {
   TemplateSrv as BaseTemplateSrv,
   VariableInterpolation,
 } from '@grafana/runtime';
-import { sceneGraph, VariableCustomFormatterFn, SafeSerializableSceneObject } from '@grafana/scenes';
+import { sceneGraph, VariableCustomFormatterFn, SceneObject } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 
 import { getVariablesCompatibility } from '../dashboard-scene/utils/getVariablesCompatibility';
@@ -249,7 +249,8 @@ export class TemplateSrv implements BaseTemplateSrv {
   ): string {
     // Scenes compatability (primary method) is via SceneObject inside scopedVars. This way we get a much more accurate "local" scope for the evaluation
     if (scopedVars && scopedVars.__sceneObject) {
-      const sceneObject = (scopedVars.__sceneObject.value as SafeSerializableSceneObject).valueOf();
+      // We are using valueOf here as __sceneObject can be after scenes 5.6.0 a SafeSerializableSceneObject that overrides valueOf to return the underlying SceneObject
+      const sceneObject: SceneObject = scopedVars.__sceneObject.value.valueOf();
       return sceneGraph.interpolate(
         sceneObject,
         target,

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -8,7 +8,7 @@ import {
   TestDataSourceResponse,
   ScopedVar,
 } from '@grafana/data';
-import { SafeSerializableSceneObject, SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
+import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
 
 import { DashboardQuery } from './types';

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -27,13 +27,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
     const sceneScopedVar: ScopedVar | undefined = options.scopedVars?.__sceneObject;
-    let scene: SceneObject | undefined;
-
-    if (!(sceneScopedVar instanceof SafeSerializableSceneObject)) {
-      throw new Error('Scene object from scopedVars is not safe serializable.');
-    }
-
-    scene = sceneScopedVar.valueOf();
+    let scene: SceneObject | undefined = sceneScopedVar ? (sceneScopedVar.valueOf() as SceneObject) : undefined;
 
     if (options.requestId.indexOf('mixed') > -1) {
       throw new Error('Dashboard data source cannot be used with Mixed data source.');


### PR DESCRIPTION
This is the same thing as #90808, but without tests case that requires scenes 5.6.x. It's created to backport this to 11.1.x so that scenes apps using scenes 5.6.x can be run agains Grafana 11.1.x