### PR TITLE
[v11.1.x] TemplateSrv: Backportable version of 90808

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6236,6 +6236,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
+    "public/app/plugins/datasource/dashboard/datasource.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/plugins/datasource/dashboard/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./runSharedRequest\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`./DashboardQueryEditor\`)", "1"],

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -15,7 +15,7 @@ import {
   TemplateSrv as BaseTemplateSrv,
   VariableInterpolation,
 } from '@grafana/runtime';
-import { sceneGraph, VariableCustomFormatterFn } from '@grafana/scenes';
+import { sceneGraph, VariableCustomFormatterFn, SceneObject } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 
 import { getVariablesCompatibility } from '../dashboard-scene/utils/getVariablesCompatibility';
@@ -249,8 +249,10 @@ export class TemplateSrv implements BaseTemplateSrv {
   ): string {
     // Scenes compatability (primary method) is via SceneObject inside scopedVars. This way we get a much more accurate "local" scope for the evaluation
     if (scopedVars && scopedVars.__sceneObject) {
+      // We are using valueOf here as __sceneObject can be after scenes 5.6.0 a SafeSerializableSceneObject that overrides valueOf to return the underlying SceneObject
+      const sceneObject: SceneObject = scopedVars.__sceneObject.value.valueOf();
       return sceneGraph.interpolate(
-        scopedVars.__sceneObject.value,
+        sceneObject,
         target,
         scopedVars,
         format as string | VariableCustomFormatterFn | undefined,

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -27,7 +27,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
     const sceneScopedVar: ScopedVar | undefined = options.scopedVars?.__sceneObject;
-    let scene: SceneObject | undefined = sceneScopedVar ? (sceneScopedVar.valueOf() as SceneObject) : undefined;
+    let scene: SceneObject | undefined = sceneScopedVar ? (sceneScopedVar.value.valueOf() as SceneObject) : undefined;
 
     if (options.requestId.indexOf('mixed') > -1) {
       throw new Error('Dashboard data source cannot be used with Mixed data source.');

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -6,6 +6,7 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   TestDataSourceResponse,
+  ScopedVar,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
@@ -25,7 +26,8 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   }
 
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
-    const scene: SceneObject | undefined = options.scopedVars?.__sceneObject?.value;
+    const sceneScopedVar: ScopedVar | undefined = options.scopedVars?.__sceneObject;
+    let scene: SceneObject | undefined = sceneScopedVar ? (sceneScopedVar.valueOf() as SceneObject) : undefined;
 
     if (options.requestId.indexOf('mixed') > -1) {
       throw new Error('Dashboard data source cannot be used with Mixed data source.');


### PR DESCRIPTION
Backport 6849a6b86b40a09cf2a46860e40724ecd60903f6 from #90816

---

This is the same thing as #90808, but without tests case that requires scenes 5.6.x. It's created to backport this to 11.1.x so that scenes apps using scenes 5.6.x can be run agains Grafana 11.1.x
