### PR TITLE
OpenAPI: Make `ReportSchedule` dates nullable

### DIFF
--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4806,6 +4806,7 @@
             "PENDING_PROCESSING",
             "PROCESSING",
             "FINISHED",
+            "CANCELED",
             "ERROR",
             "UNKNOWN"
           ]
@@ -5490,7 +5491,7 @@
       "type": "object",
       "title": "NavbarPreference defines model for NavbarPreference.",
       "properties": {
-        "savedItemIds": {
+        "bookmarkIds": {
           "type": "array",
           "items": {
             "type": "string"
@@ -6561,7 +6562,8 @@
         },
         "endDate": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "frequency": {
           "type": "string"
@@ -6575,7 +6577,8 @@
         },
         "startDate": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "timeZone": {
           "type": "string"
@@ -7217,6 +7220,7 @@
             "PENDING_PROCESSING",
             "PROCESSING",
             "FINISHED",
+            "CANCELED",
             "ERROR",
             "UNKNOWN"
           ]
@@ -8376,6 +8380,23 @@
           "format": "date-time"
         },
         "userAgent": {
+          "type": "string"
+        }
+      }
+    },
+    "healthResponse": {
+      "type": "object",
+      "properties": {
+        "commit": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "enterpriseCommit": {
+          "type": "string"
+        },
+        "version": {
           "type": "string"
         }
       }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -19217,7 +19217,8 @@
         },
         "endDate": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "frequency": {
           "type": "string"
@@ -19231,7 +19232,8 @@
         },
         "startDate": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "timeZone": {
           "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -9294,6 +9294,7 @@
           },
           "endDate": {
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "frequency": {
@@ -9308,6 +9309,7 @@
           },
           "startDate": {
             "format": "date-time",
+            "nullable": true,
             "type": "string"
           },
           "timeZone": {


### PR DESCRIPTION
We've had this override in the client for a while now: https://github.com/grafana/grafana-openapi-client-go/blob/9ef69836127d783a63b2d0c61b2f8bf3de0c8e86/scripts/pull-schema.sh#L41-L44
