### PR TITLE
OpenAPI: Fix `ValidationError` message attribute

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -99,8 +99,10 @@ func TestProvisioningApi(t *testing.T) {
 				response := sut.RoutePutPolicyTree(&rc, tree)
 
 				require.Equal(t, 400, response.Status())
-				expBody := `{"message":"invalid object specification: invalid policy tree"}`
-				require.Equal(t, expBody, string(response.Body()))
+				expBody := definitions.ValidationError{Message: "invalid object specification: invalid policy tree"}
+				expBodyJSON, marshalErr := json.Marshal(expBody)
+				require.NoError(t, marshalErr)
+				require.Equal(t, string(expBodyJSON), string(response.Body()))
 			})
 		})
 

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -4316,6 +4316,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4351,7 +4352,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -4386,7 +4387,7 @@
   },
   "ValidationError": {
    "properties": {
-    "msg": {
+    "message": {
      "example": "error message",
      "type": "string"
     }

--- a/pkg/services/ngalert/api/tooling/definitions/shared.go
+++ b/pkg/services/ngalert/api/tooling/definitions/shared.go
@@ -11,7 +11,7 @@ type Ack struct{}
 // swagger:model
 type ValidationError struct {
 	// example: error message
-	Msg string `json:"msg"`
+	Message string `json:"message"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -4387,7 +4387,7 @@
   },
   "ValidationError": {
    "properties": {
-    "msg": {
+    "message": {
      "example": "error message",
      "type": "string"
     }

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -8021,7 +8021,7 @@
     "ValidationError": {
       "type": "object",
       "properties": {
-        "msg": {
+        "message": {
           "type": "string",
           "example": "error message"
         }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -21971,7 +21971,7 @@
     "ValidationError": {
       "type": "object",
       "properties": {
-        "msg": {
+        "message": {
           "type": "string",
           "example": "error message"
         }

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -12029,7 +12029,7 @@
       },
       "ValidationError": {
         "properties": {
-          "msg": {
+          "message": {
             "example": "error message",
             "type": "string"
           }


### PR DESCRIPTION
It's `message`, not `msg`. It's been fixed for a while here: https://github.com/grafana/grafana-openapi-client-go/blob/9ef69836127d783a63b2d0c61b2f8bf3de0c8e86/scripts/pull-schema.sh#L46-L49

I've also reflected the change in the tests