### PR TITLE
Alerting: Remove option to return settings from api/v1/receivers and restrict provisioning action access

### DIFF
--- a/pkg/services/ngalert/api/api_notifications.go
+++ b/pkg/services/ngalert/api/api_notifications.go
@@ -20,7 +20,7 @@ type NotificationSrv struct {
 
 type ReceiverService interface {
 	GetReceiver(ctx context.Context, q models.GetReceiverQuery, u identity.Requester) (definitions.GettableApiReceiver, error)
-	GetReceivers(ctx context.Context, q models.GetReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error)
+	ListReceivers(ctx context.Context, q models.ListReceiversQuery, user identity.Requester) ([]definitions.GettableApiReceiver, error)
 }
 
 func (srv *NotificationSrv) RouteGetTimeInterval(c *contextmodel.ReqContext, name string) response.Response {
@@ -55,15 +55,14 @@ func (srv *NotificationSrv) RouteGetReceiver(c *contextmodel.ReqContext, name st
 }
 
 func (srv *NotificationSrv) RouteGetReceivers(c *contextmodel.ReqContext) response.Response {
-	q := models.GetReceiversQuery{
-		OrgID:   c.SignedInUser.OrgID,
-		Names:   c.QueryStrings("names"),
-		Limit:   c.QueryInt("limit"),
-		Offset:  c.QueryInt("offset"),
-		Decrypt: c.QueryBool("decrypt"),
+	q := models.ListReceiversQuery{
+		OrgID:  c.SignedInUser.OrgID,
+		Names:  c.QueryStrings("names"),
+		Limit:  c.QueryInt("limit"),
+		Offset: c.QueryInt("offset"),
 	}
 
-	receivers, err := srv.receiverService.GetReceivers(c.Req.Context(), q, c.SignedInUser)
+	receivers, err := srv.receiverService.ListReceivers(c.Req.Context(), q, c.SignedInUser)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get receiver groups", err)
 	}

--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -18,6 +18,14 @@ type GetReceiversQuery struct {
 	Decrypt bool
 }
 
+// ListReceiversQuery represents a query for listing receiver groups.
+type ListReceiversQuery struct {
+	OrgID  int64
+	Names  []string
+	Limit  int
+	Offset int
+}
+
 // Receiver is the domain model representation of a receiver / contact point.
 type Receiver struct {
 	UID          string

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -411,7 +411,7 @@ func (ng *AlertNG) init() error {
 
 	configStore := legacy_storage.NewAlertmanagerConfigStore(ng.store)
 	receiverService := notifier.NewReceiverService(
-		ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, true), // TODO: Remove provisioning actions from regular API.
+		ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, false),
 		configStore,
 		ng.store,
 		ng.SecretsService,

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -33,7 +33,7 @@ func TestReceiverService_GetReceiver(t *testing.T) {
 
 	redactedUser := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{
 		1: {
-			accesscontrol.ActionAlertingProvisioningRead: nil,
+			accesscontrol.ActionAlertingNotificationsRead: nil,
 		},
 	}}
 
@@ -61,7 +61,7 @@ func TestReceiverService_GetReceivers(t *testing.T) {
 
 	redactedUser := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{
 		1: {
-			accesscontrol.ActionAlertingProvisioningRead: nil,
+			accesscontrol.ActionAlertingNotificationsRead: nil,
 		},
 	}}
 
@@ -94,7 +94,7 @@ func TestReceiverService_DecryptRedact(t *testing.T) {
 	readUser := &user.SignedInUser{
 		OrgID: 1,
 		Permissions: map[int64]map[string][]string{
-			1: {accesscontrol.ActionAlertingProvisioningRead: nil},
+			1: {accesscontrol.ActionAlertingNotificationsRead: nil},
 		},
 	}
 
@@ -102,8 +102,8 @@ func TestReceiverService_DecryptRedact(t *testing.T) {
 		OrgID: 1,
 		Permissions: map[int64]map[string][]string{
 			1: {
-				accesscontrol.ActionAlertingProvisioningRead:        nil,
-				accesscontrol.ActionAlertingProvisioningReadSecrets: nil,
+				accesscontrol.ActionAlertingNotificationsRead:    nil,
+				accesscontrol.ActionAlertingReceiversReadSecrets: nil,
 			},
 		},
 	}
@@ -190,7 +190,7 @@ func createReceiverServiceSut(t *testing.T, encryptSvc secrets.Service) *Receive
 	provisioningStore := fakes.NewFakeProvisioningStore()
 
 	return NewReceiverService(
-		ac.NewReceiverAccess[*models.Receiver](acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient()), true),
+		ac.NewReceiverAccess[*models.Receiver](acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient()), false),
 		legacy_storage.NewAlertmanagerConfigStore(store),
 		provisioningStore,
 		encryptSvc,

--- a/pkg/services/ngalert/tests/fakes/receivers.go
+++ b/pkg/services/ngalert/tests/fakes/receivers.go
@@ -14,15 +14,15 @@ type ReceiverServiceMethodCall struct {
 }
 
 type FakeReceiverService struct {
-	MethodCalls    []ReceiverServiceMethodCall
-	GetReceiverFn  func(ctx context.Context, q models.GetReceiverQuery, u identity.Requester) (definitions.GettableApiReceiver, error)
-	GetReceiversFn func(ctx context.Context, q models.GetReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error)
+	MethodCalls     []ReceiverServiceMethodCall
+	GetReceiverFn   func(ctx context.Context, q models.GetReceiverQuery, u identity.Requester) (definitions.GettableApiReceiver, error)
+	ListReceiversFn func(ctx context.Context, q models.ListReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error)
 }
 
 func NewFakeReceiverService() *FakeReceiverService {
 	return &FakeReceiverService{
-		GetReceiverFn:  defaultReceiverFn,
-		GetReceiversFn: defaultReceiversFn,
+		GetReceiverFn:   defaultReceiverFn,
+		ListReceiversFn: defaultReceiversFn,
 	}
 }
 
@@ -31,9 +31,9 @@ func (f *FakeReceiverService) GetReceiver(ctx context.Context, q models.GetRecei
 	return f.GetReceiverFn(ctx, q, u)
 }
 
-func (f *FakeReceiverService) GetReceivers(ctx context.Context, q models.GetReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error) {
-	f.MethodCalls = append(f.MethodCalls, ReceiverServiceMethodCall{Method: "GetReceivers", Args: []interface{}{ctx, q}})
-	return f.GetReceiversFn(ctx, q, u)
+func (f *FakeReceiverService) ListReceivers(ctx context.Context, q models.ListReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error) {
+	f.MethodCalls = append(f.MethodCalls, ReceiverServiceMethodCall{Method: "ListReceivers", Args: []interface{}{ctx, q}})
+	return f.ListReceiversFn(ctx, q, u)
 }
 
 func (f *FakeReceiverService) PopMethodCall() ReceiverServiceMethodCall {
@@ -48,13 +48,13 @@ func (f *FakeReceiverService) PopMethodCall() ReceiverServiceMethodCall {
 func (f *FakeReceiverService) Reset() {
 	f.MethodCalls = nil
 	f.GetReceiverFn = defaultReceiverFn
-	f.GetReceiversFn = defaultReceiversFn
+	f.ListReceiversFn = defaultReceiversFn
 }
 
 func defaultReceiverFn(ctx context.Context, q models.GetReceiverQuery, u identity.Requester) (definitions.GettableApiReceiver, error) {
 	return definitions.GettableApiReceiver{}, nil
 }
 
-func defaultReceiversFn(ctx context.Context, q models.GetReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error) {
+func defaultReceiversFn(ctx context.Context, q models.ListReceiversQuery, u identity.Requester) ([]definitions.GettableApiReceiver, error) {
 	return nil, nil
 }


### PR DESCRIPTION
**What is this feature?**

This fixes the following:
- Limits `api/v1/receivers` to only listing receivers without settings as was originally intended. 707543b6cd2cbe4c9138c15396b45c4b56cc64ab
- Removes provisioning-specific RBAC actions from giving access to `api/v1/receivers`. bb14721931cd9181371256c5a3dd38756ddb2ad6

**Why do we need this feature?**

`api/v1/receivers` logic is unique and not in-line with other `receiver_svc` callers. It was originally intended to return a list of receivers with minimal information to help populate the simplified routing drop-down. Instead, it currently:
- If  `decrypt=true` it will return full decrypted receivers if the user has `Secret` permissions.
- If `decrypt=false` it will return redacted receivers if the user has full permission to read the AM Config.
- If `decrypt=false` it will return list-only receivers (no settings) if the user has no permission to read the AM Config but does have List permission.

The ability to list receivers without settings is unique and will potentially be removed in the future. In order to hookup the auth service from #90857, it is beneficial to fix some of these discrepencies first.

**Who is this feature for?**

Developers

**Special notes for your reviewer:**

I opted to leave the option to decrypt for `api/v1/receivers/{name}` since it fits nicely permission-wise with the new auth service, but can remove the option there as well if reviewers prefer.