### PR TITLE
Add support ticket fixed roles to cloud role sync

### DIFF
--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -33,6 +33,10 @@ const (
 	FixedCloudViewerRole = "fixed:cloud:viewer"
 	FixedCloudEditorRole = "fixed:cloud:editor"
 	FixedCloudAdminRole  = "fixed:cloud:admin"
+
+	FixedCloudSupportTicketReader = "fixed:cloud:supportticket:reader"
+	FixedCloudSupportTicketEditor = "fixed:cloud:supportticket:editor"
+	FixedCloudSupportTicketAdmin  = "fixed:cloud:supportticket:admin"
 )
 
 // Roles definition

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"errors"
+
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -96,12 +96,44 @@ func (s *RBACSync) fetchPermissions(ctx context.Context, ident *authn.Identity) 
 	return permissions, nil
 }
 
-// Since Cloud Admin/Editor/Viewer roles are not yet implemented one-to-one in the Grafana, it becomes a confusing experience for users,
-// therefore we are doing granular mapping of all available functionality in the Grafana temporary.
-var fixedCloudRoles = map[org.RoleType][]string{
-	org.RoleViewer: {accesscontrol.FixedCloudViewerRole, accesscontrol.FixedCloudSupportTicketReader},
-	org.RoleEditor: {accesscontrol.FixedCloudEditorRole, accesscontrol.FixedCloudSupportTicketAdmin},
-	org.RoleAdmin:  {accesscontrol.FixedCloudAdminRole, accesscontrol.FixedCloudSupportTicketAdmin},
+func cloudRolesToAddAndRemove(ident *authn.Identity) ([]string, []string, error) {
+	const (
+		expectedRolesToAddCount = 2
+		rolesToRemoveInitialCap = 4
+	)
+	// Since Cloud Admin/Editor/Viewer roles are not yet implemented one-to-one in the Grafana, it becomes a confusing experience for users,
+	// therefore we are doing granular mapping of all available functionality in the Grafana temporary.
+	var fixedCloudRoles = map[org.RoleType][]string{
+		org.RoleViewer: {accesscontrol.FixedCloudViewerRole, accesscontrol.FixedCloudSupportTicketReader},
+		org.RoleEditor: {accesscontrol.FixedCloudEditorRole, accesscontrol.FixedCloudSupportTicketAdmin},
+		org.RoleAdmin:  {accesscontrol.FixedCloudAdminRole, accesscontrol.FixedCloudSupportTicketAdmin},
+	}
+
+	rolesToAdd := make([]string, 0, expectedRolesToAddCount)
+	rolesToRemove := make([]string, 0, rolesToRemoveInitialCap)
+
+	currentRole := ident.GetOrgRole()
+	_, validRole := fixedCloudRoles[currentRole]
+
+	if !validRole {
+		return nil, nil, errInvalidCloudRole.Errorf("invalid role: %s", currentRole)
+	}
+
+	for role, fixedRoles := range fixedCloudRoles {
+		for _, fixedRole := range fixedRoles {
+			if role == currentRole {
+				rolesToAdd = append(rolesToAdd, fixedRole)
+			} else {
+				rolesToRemove = append(rolesToRemove, fixedRole)
+			}
+		}
+	}
+
+	if len(rolesToAdd) != expectedRolesToAddCount {
+		return nil, nil, errInvalidCloudRole.Errorf("invalid role: %s", currentRole)
+	}
+
+	return rolesToAdd, rolesToRemove, nil
 }
 
 func (s *RBACSync) SyncCloudRoles(ctx context.Context, ident *authn.Identity, r *authn.Request) error {
@@ -123,21 +155,9 @@ func (s *RBACSync) SyncCloudRoles(ctx context.Context, ident *authn.Identity, r 
 		return err
 	}
 
-	rolesToAdd := make([]string, 0, 1)
-	rolesToRemove := make([]string, 0, 2)
-
-	for role, fixedRoles := range fixedCloudRoles {
-		for _, fixedRole := range fixedRoles {
-			if role == ident.GetOrgRole() {
-				rolesToAdd = append(rolesToAdd, fixedRole)
-			} else {
-				rolesToRemove = append(rolesToRemove, fixedRole)
-			}
-		}
-	}
-
-	if len(rolesToAdd) != 1 {
-		return errInvalidCloudRole.Errorf("invalid role: %s", ident.GetOrgRole())
+	rolesToAdd, rolesToRemove, err := cloudRolesToAddAndRemove(ident)
+	if err != nil {
+		return err
 	}
 
 	return s.ac.SyncUserRoles(ctx, ident.GetOrgID(), accesscontrol.SyncUserRolesCommand{


### PR DESCRIPTION
**Description**

We have Cloud Admin/Editor/Viewer roles in Grafana Cloud which are being mapped directly to Grafana Cloud Admin/Editor/Viewer roles respectively in the Grafana. 

The Grafana Cloud Admin role does not yet support entire functionality that Cloud Admin role supports, which creates a big confusion. At the moment, Grafana Cloud Admin allows only to manage support tickets.

To remove this confusion, we decided to introduce dedicated roles, Support tickets admin/editor/reader and map Cloud Admin/Editor/Viewer roles to those as we can make that assumption that if you are for example Cloud Admin, you can also create a support ticket.

**Caveats**

We have to keep Grafana Cloud Admin/Editor/Viewer roles for the consistency, additionally we will be slowly adding more and more permissions to these roles. However to avoid the confusion, we will be hiding those roles from the UI for the moment. This will be done in a different PR.