### PR TITLE
Alerting: Restart rule routines if the type changes

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -108,8 +108,8 @@ const (
 type RuleType string
 
 const (
-	RuleTypeAlerting  = "alerting"
-	RuleTypeRecording = "recording"
+	RuleTypeAlerting  RuleType = "alerting"
+	RuleTypeRecording RuleType = "recording"
 )
 
 func (r RuleType) String() string {

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -495,13 +495,13 @@ func (a *AlertRuleMutators) WithRandomRecordingRules() AlertRuleMutator {
 		if rand.Int63()%2 == 0 {
 			return
 		}
-		convertToRecordingRule(rule)
+		ConvertToRecordingRule(rule)
 	}
 }
 
 func (a *AlertRuleMutators) WithAllRecordingRules() AlertRuleMutator {
 	return func(rule *AlertRule) {
-		convertToRecordingRule(rule)
+		ConvertToRecordingRule(rule)
 	}
 }
 
@@ -1092,7 +1092,7 @@ func (n SilenceMutators) WithEmptyId() Mutator[Silence] {
 	}
 }
 
-func convertToRecordingRule(rule *AlertRule) {
+func ConvertToRecordingRule(rule *AlertRule) {
 	if rule.Record == nil {
 		rule.Record = &Record{}
 	}

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -78,6 +78,8 @@ func newRuleFactory(
 				met,
 				tracer,
 				recordingWriter,
+				evalAppliedHook,
+				stopAppliedHook,
 			)
 		}
 		return newAlertRule(

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -38,6 +38,8 @@ type Rule interface {
 	Eval(eval *Evaluation) (bool, *Evaluation)
 	// Update sends a singal to change the definition of the rule.
 	Update(lastVersion RuleVersionAndPauseStatus) bool
+	// Type gives the type of the rule.
+	Type() ngmodels.RuleType
 }
 
 type ruleFactoryFunc func(context.Context, *ngmodels.AlertRule) Rule
@@ -170,6 +172,10 @@ func newAlertRule(
 		logger:               logger.FromContext(ctx),
 		tracer:               tracer,
 	}
+}
+
+func (a *alertRule) Type() ngmodels.RuleType {
+	return ngmodels.RuleTypeAlerting
 }
 
 // eval signals the rule evaluation routine to perform the evaluation of the rule. Does nothing if the loop is stopped.

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -154,7 +154,7 @@ func TestRecordingRule(t *testing.T) {
 
 func blankRecordingRuleForTests(ctx context.Context) *recordingRule {
 	ft := featuremgmt.WithFeatures(featuremgmt.FlagGrafanaManagedRecordingRules)
-	return newRecordingRule(context.Background(), models.AlertRuleKey{}, 0, nil, nil, ft, log.NewNopLogger(), nil, nil, writer.FakeWriter{})
+	return newRecordingRule(context.Background(), models.AlertRuleKey{}, 0, nil, nil, ft, log.NewNopLogger(), nil, nil, writer.FakeWriter{}, nil, nil)
 }
 
 func TestRecordingRule_Integration(t *testing.T) {

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -15,7 +15,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-var errRuleDeleted = errors.New("rule deleted")
+var (
+	errRuleDeleted   = errors.New("rule deleted")
+	errRuleRestarted = errors.New("rule restarted")
+)
 
 type ruleFactory interface {
 	new(context.Context, *models.AlertRule) Rule

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -255,6 +255,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 
 	readyToRun := make([]readyToRunItem, 0)
 	updatedRules := make([]ngmodels.AlertRuleKeyWithVersion, 0, len(updated)) // this is needed for tests only
+	restartedRules := make([]Rule, 0)
 	missingFolder := make(map[string][]string)
 	ruleFactory := newRuleFactory(
 		sch.appURL,
@@ -285,6 +286,14 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		}
 
 		invalidInterval := item.IntervalSeconds%int64(sch.baseInterval.Seconds()) != 0
+
+		if item.Type() != ruleRoutine.Type() {
+			// Restart rules that need it. For now we just replace them, we'll shut them down at the end of the tick.
+			logger.Debug("Rule restarted because type changed", "old", ruleRoutine.Type(), "new", item.Type())
+			restartedRules = append(restartedRules, ruleRoutine)
+			sch.registry.del(key)
+			ruleRoutine, newRoutine = sch.registry.getOrCreate(ctx, item, ruleFactory)
+		}
 
 		if newRoutine && !invalidInterval {
 			dispatcherGroup.Go(func() error {
@@ -368,6 +377,11 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 				sch.metrics.EvaluationMissed.WithLabelValues(orgID, item.rule.Title).Inc()
 			}
 		})
+	}
+
+	// Stop old routines for rules that got restarted.
+	for _, oldRoutine := range restartedRules {
+		oldRoutine.Stop(errRuleRestarted)
 	}
 
 	// unregister and stop routines of the deleted alert rules


### PR DESCRIPTION
**What is this feature?**

Since we have multiple rule implementations, we need to schedule the right implementation based on properties of the rule definition.

This means if the definition changes in certain ways, we need to restart the whole routine to swap out the logic.

Namely - if you update an existing Alert rule to a Recording rule, we should reschedule it as a recording rule otherwise it'll fail.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
