### PR TITLE
Loki: Remove unnecessary `featuremgmt`

### DIFF
--- a/pkg/plugins/backendplugin/coreplugin/registry.go
+++ b/pkg/plugins/backendplugin/coreplugin/registry.go
@@ -222,7 +222,7 @@ func NewPlugin(pluginID string, cfg *setting.Cfg, httpClientProvider *httpclient
 	case InfluxDB:
 		svc = influxdb.ProvideService(httpClientProvider, features)
 	case Loki:
-		svc = loki.ProvideService(httpClientProvider, features, tracer)
+		svc = loki.ProvideService(httpClientProvider, tracer)
 	case OpenTSDB:
 		svc = opentsdb.ProvideService(httpClientProvider)
 	case Prometheus:

--- a/pkg/services/pluginsintegration/plugins_integration_test.go
+++ b/pkg/services/pluginsintegration/plugins_integration_test.go
@@ -81,7 +81,7 @@ func TestIntegrationPluginManager(t *testing.T) {
 	es := elasticsearch.ProvideService(hcp)
 	grap := graphite.ProvideService(hcp, tracer)
 	idb := influxdb.ProvideService(hcp, features)
-	lk := loki.ProvideService(hcp, features, tracer)
+	lk := loki.ProvideService(hcp, tracer)
 	otsdb := opentsdb.ProvideService(hcp)
 	pr := prometheus.ProvideService(hcp)
 	tmpo := tempo.ProvideService(hcp)

--- a/pkg/tsdb/loki/healthcheck_test.go
+++ b/pkg/tsdb/loki/healthcheck_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -93,10 +92,9 @@ func Test_healthcheck(t *testing.T) {
 	t.Run("should do a successful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckSuccessRoundTripper]()
 		s := &Service{
-			im:       datasource.NewInstanceManager(newInstanceSettings(httpProvider)),
-			features: featuremgmt.WithFeatures(featuremgmt.FlagLokiLogsDataplane, featuremgmt.FlagLokiMetricDataplane),
-			tracer:   tracing.InitializeTracerForTest(),
-			logger:   backend.NewLoggerWith("logger", "loki test"),
+			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider)),
+			tracer: tracing.InitializeTracerForTest(),
+			logger: backend.NewLoggerWith("logger", "loki test"),
 		}
 
 		req := &backend.CheckHealthRequest{
@@ -112,10 +110,9 @@ func Test_healthcheck(t *testing.T) {
 	t.Run("should return an error for an unsuccessful health check", func(t *testing.T) {
 		httpProvider := getMockProvider[*healthCheckFailRoundTripper]()
 		s := &Service{
-			im:       datasource.NewInstanceManager(newInstanceSettings(httpProvider)),
-			features: featuremgmt.WithFeatures(featuremgmt.FlagLokiLogsDataplane, featuremgmt.FlagLokiMetricDataplane),
-			tracer:   tracing.InitializeTracerForTest(),
-			logger:   backend.NewLoggerWith("logger", "loki test"),
+			im:     datasource.NewInstanceManager(newInstanceSettings(httpProvider)),
+			tracer: tracing.InitializeTracerForTest(),
+			logger: backend.NewLoggerWith("logger", "loki test"),
 		}
 
 		req := &backend.CheckHealthRequest{


### PR DESCRIPTION
**What is this feature?**

With https://github.com/grafana/grafana/pull/90684 we moved to a new way of getting feature toggles. This PR removes unused `featuremgmt` dependencies and adds a helper method.