### PR TITLE
Auth: Fix grafana-auth-app menu not being displayed 

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -86,6 +86,7 @@ func (root *NavTreeRoot) AddSection(node *NavLink) {
 	root.Children = append(root.Children, node)
 }
 
+// RemoveSection removes a section from the root node. Does not recurse into children.
 func (root *NavTreeRoot) RemoveSection(node *NavLink) {
 	var result []*NavLink
 
@@ -96,6 +97,26 @@ func (root *NavTreeRoot) RemoveSection(node *NavLink) {
 	}
 
 	root.Children = result
+}
+
+// RemoveSectionByID removes a section by ID from the root node and all its children
+func (root *NavTreeRoot) RemoveSectionByID(id string) bool {
+	var result []*NavLink
+
+	for i, child := range root.Children {
+		if child.Id == id {
+			// Remove the node by slicing it out
+			result = append(root.Children[:i], root.Children[i+1:]...)
+			root.Children = result
+			return true
+		} else if len(child.Children) > 0 {
+			if removed := RemoveById(child, id); removed {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (root *NavTreeRoot) FindById(id string) *NavLink {
@@ -226,4 +247,23 @@ func FindByURL(nodes []*NavLink, url string) *NavLink {
 	}
 
 	return nil
+}
+
+func RemoveById(node *NavLink, id string) bool {
+	var result []*NavLink
+
+	for i, child := range node.Children {
+		if child.Id == id {
+			// Remove the node by slicing it out
+			result = append(node.Children[:i], node.Children[i+1:]...)
+			node.Children = result
+			return true
+		} else if len(child.Children) > 0 {
+			if removed := RemoveById(child, id); removed {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -163,9 +163,8 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Children: accessNodeLinks,
 	}
 
-	if len(usersNode.Children) > 0 {
-		configNodes = append(configNodes, usersNode)
-	}
+	// Always append admin access as it's injected by grafana-auth-app.
+	configNodes = append(configNodes, usersNode)
 
 	if authConfigUIAvailable && hasAccess(ssoutils.EvalAuthenticationSettings(s.cfg)) ||
 		(hasAccess(ssoutils.OauthSettingsEvaluator(s.cfg)) && s.features.IsEnabled(ctx, featuremgmt.FlagSsoSettingsApi)) {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -163,6 +163,11 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		return nil, err
 	}
 
+	// remove user access if empty. Happens if grafana-auth-app is not injected
+	if sec := treeRoot.FindById(navtree.NavIDCfgAccess); sec != nil && (sec.Children == nil || len(sec.Children) == 0) {
+		treeRoot.RemoveSectionByID(navtree.NavIDCfgAccess)
+	}
+
 	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagPinNavItems) {
 		bookmarks := s.buildBookmarksNavLinks(prefs, treeRoot)
 


### PR DESCRIPTION
Fix grafana-auth-app menu not being displayed if user only has access to cloud access policies.

grafana-auth-app is injected through different means than regular items into the users & access menu.

grafana-auth-app now supports RBAC allowing a viewer to have access to access policies but no other item in the user access menu.

This caused the user access menu to not be added to the nav tree.

This specific implementation fixes this by removing the menu if it's still empty after the auth-app links are supposed to be injected


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
