### PR TITLE
Alerting: Add validation for path separators in the rule group edit modal

### DIFF
--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -28,6 +28,7 @@ import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 import { decodeGrafanaNamespace, encodeGrafanaNamespace } from '../expressions/util';
 import { EvaluationGroupQuickPick } from '../rule-editor/EvaluationGroupQuickPick';
 import { MIN_TIME_RANGE_STEP_S } from '../rule-editor/GrafanaEvaluationBehavior';
+import { checkForPathSeparator } from '../rule-editor/util';
 
 const ITEMS_PER_PAGE = 10;
 
@@ -296,6 +297,11 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                     readOnly={intervalEditOnly || isGrafanaManagedGroup}
                     {...register('namespaceName', {
                       required: 'Namespace name is required.',
+                      validate: {
+                        // for Grafana-managed we do not validate the name of the folder because we use the UID anyway
+                        pathSeparator: (namespaceName) =>
+                          isGrafanaManagedGroup ? true : checkForPathSeparator(namespaceName),
+                      },
                     })}
                   />
                 </Field>
@@ -328,6 +334,9 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
                 readOnly={intervalEditOnly}
                 {...register('groupName', {
                   required: 'Evaluation group name is required.',
+                  validate: {
+                    pathSeparator: (namespace) => checkForPathSeparator(namespace),
+                  },
                 })}
               />
             </Field>


### PR DESCRIPTION
Prior to this PR we were not validating the namespace and rule group names when using the "edit rule group" modal from the list view to prevent `\` and `/` characters from being used.

This PR adds the correct form validation.