### PR TITLE
Cloudwatch: Add account Id in groupBy options for Metric Insights

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.test.tsx
@@ -87,7 +87,7 @@ describe('Cloudwatch SQLGroupBy', () => {
     selectEvent.openMenu(screen.getByLabelText(/Group by/));
     expect(screen.queryByText('Account ID')).not.toBeInTheDocument();
   });
-  
+
   it('should not show Account ID in groupBy options if feature flag is disabled', async () => {
     config.featureToggles.cloudwatchMetricInsightsCrossAccount = false;
     const query = makeSQLQuery();

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx
@@ -20,6 +20,7 @@ import {
   setGroupByField,
   setSql,
 } from './utils';
+import { config } from '@grafana/runtime';
 
 interface SQLGroupByProps {
   query: CloudWatchMetricsQuery;
@@ -38,7 +39,14 @@ const SQLGroupBy = ({ query, datasource, onQueryChange }: SQLGroupByProps) => {
   const baseOptions = useDimensionKeys(datasource, { region: query.region, namespace, metricName });
   const options = useMemo(
     // Exclude options we've already selected
-    () => baseOptions.filter((option) => !groupBysFromQuery.some((v) => v.property.name === option.value)),
+    () => {
+      const baseOptionsWithAccountId =
+        config.featureToggles.cloudWatchCrossAccountQuerying &&
+        config.featureToggles.cloudwatchMetricInsightsCrossAccount
+          ? [{ label: 'Account ID', value: 'AWS.AccountId' }, ...baseOptions]
+          : baseOptions;
+      return baseOptionsWithAccountId.filter((option) => !groupBysFromQuery.some((v) => v.property.name === option.value));
+    },
     [baseOptions, groupBysFromQuery]
   );
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx
@@ -40,12 +40,16 @@ const SQLGroupBy = ({ query, datasource, onQueryChange }: SQLGroupByProps) => {
   const options = useMemo(
     // Exclude options we've already selected
     () => {
-      const baseOptionsWithAccountId =
+      const isCrossAccountEnabled =
         config.featureToggles.cloudWatchCrossAccountQuerying &&
-        config.featureToggles.cloudwatchMetricInsightsCrossAccount
-          ? [{ label: 'Account ID', value: 'AWS.AccountId' }, ...baseOptions]
-          : baseOptions;
-      return baseOptionsWithAccountId.filter((option) => !groupBysFromQuery.some((v) => v.property.name === option.value));
+        config.featureToggles.cloudwatchMetricInsightsCrossAccount;
+
+      const baseOptionsWithAccountId = isCrossAccountEnabled
+        ? [{ label: 'Account ID', value: 'AWS.AccountId' }, ...baseOptions]
+        : baseOptions;
+      return baseOptionsWithAccountId.filter(
+        (option) => !groupBysFromQuery.some((v) => v.property.name === option.value)
+      );
     },
     [baseOptions, groupBysFromQuery]
   );

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
@@ -150,7 +150,8 @@ export default class SQLGenerator {
     const startsWithNumber = /^\d/;
 
     const interpolated = this.templateSrv.replace(label, {}, 'raw');
-    if(interpolated !== "AWS.AccountId") { // AWS.AccountId should never be in quotes
+    if (interpolated !== 'AWS.AccountId') {
+      // AWS.AccountId should never be in quotes
       if (specialCharacters.test(interpolated) || startsWithNumber.test(interpolated)) {
         return `"${label}"`;
       }

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
@@ -150,8 +150,10 @@ export default class SQLGenerator {
     const startsWithNumber = /^\d/;
 
     const interpolated = this.templateSrv.replace(label, {}, 'raw');
-    if (specialCharacters.test(interpolated) || startsWithNumber.test(interpolated)) {
-      return `"${label}"`;
+    if(interpolated !== "AWS.AccountId") { // AWS.AccountId should never be in quotes
+      if (specialCharacters.test(interpolated) || startsWithNumber.test(interpolated)) {
+        return `"${label}"`;
+      }
     }
 
     return label;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds an option to group By dropdown in Metric insights if the user has cross account querying enabled. 

**Why do we need this feature?**

Completes the cross-account Metric Insights builder feature

**Who is this feature for?**

Cloudwatch users that want to use SQL queries and who have multiple accounts they want to monitor across

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
