### PR TITLE
(Docs) Updates RBAC actions for Adaptive Metrics

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -219,8 +219,8 @@ The following list contains role-based access control actions used by Grafana Ad
 | `grafana‑adaptive‑metrics‑app.rules:read`            | n/a              | Read aggregation rules.                              |
 | `grafana‑adaptive‑metrics‑app.rules:write`           | n/a              | Create aggregation rules.                            |
 | `grafana‑adaptive‑metrics‑app.rules:delete`          | n/a              | Delete aggregation rules.                            |
-| `grafana‑adaptive‑metrics‑app.exemptions:read`       | n/a              | Read rule exemptions.                                |
-| `grafana‑adaptive‑metrics‑app.exemptions:write`      | n/a              | Create, update, and delete rule exemptions.          |
+| `grafana‑adaptive‑metrics‑app.exemptions:read`       | n/a              | Read recommendation exemptions.                                |
+| `grafana‑adaptive‑metrics‑app.exemptions:write`      | n/a              | Create, update, and delete recommendation exemptions.          |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -209,18 +209,18 @@ The following list contains role-based access control actions used by Grafana On
 
 The following list contains role-based access control actions used by Grafana Adaptive Metrics.
 
-| Action                                             | Applicable scope | Description                                          |
-| -------------------------------------------------- | ---------------- | ---------------------------------------------------- |
-| `grafana‑adaptive‑metrics‑app.plugin:access`         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
-| `grafana‑adaptive‑metrics‑app.config:read`           | n/a              | Read the Adaptive Metrics app configuration.         |
-| `grafana‑adaptive‑metrics‑app.config:write`          | n/a              | Update the Adaptive Metrics app configuration.       |
-| `grafana‑adaptive‑metrics‑app.recommendations:read`  | n/a              | Read aggregation recommendations.                    |
-| `grafana‑adaptive‑metrics‑app.recommendations:apply` | n/a              | Apply aggregation recommendations.                   |
-| `grafana‑adaptive‑metrics‑app.rules:read`            | n/a              | Read aggregation rules.                              |
-| `grafana‑adaptive‑metrics‑app.rules:write`           | n/a              | Create aggregation rules.                            |
-| `grafana‑adaptive‑metrics‑app.rules:delete`          | n/a              | Delete aggregation rules.                            |
-| `grafana‑adaptive‑metrics‑app.exemptions:read`       | n/a              | Read recommendation exemptions.                                |
-| `grafana‑adaptive‑metrics‑app.exemptions:write`      | n/a              | Create, update, and delete recommendation exemptions.          |
+| Action                                               | Applicable scope | Description                                           |
+| ---------------------------------------------------- | ---------------- | ----------------------------------------------------- |
+| `grafana‑adaptive‑metrics‑app.plugin:access`         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud.  |
+| `grafana‑adaptive‑metrics‑app.config:read`           | n/a              | Read the Adaptive Metrics app configuration.          |
+| `grafana‑adaptive‑metrics‑app.config:write`          | n/a              | Update the Adaptive Metrics app configuration.        |
+| `grafana‑adaptive‑metrics‑app.recommendations:read`  | n/a              | Read aggregation recommendations.                     |
+| `grafana‑adaptive‑metrics‑app.recommendations:apply` | n/a              | Apply aggregation recommendations.                    |
+| `grafana‑adaptive‑metrics‑app.rules:read`            | n/a              | Read aggregation rules.                               |
+| `grafana‑adaptive‑metrics‑app.rules:write`           | n/a              | Create aggregation rules.                             |
+| `grafana‑adaptive‑metrics‑app.rules:delete`          | n/a              | Delete aggregation rules.                             |
+| `grafana‑adaptive‑metrics‑app.exemptions:read`       | n/a              | Read recommendation exemptions.                       |
+| `grafana‑adaptive‑metrics‑app.exemptions:write`      | n/a              | Create, update, and delete recommendation exemptions. |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -220,7 +220,7 @@ The following list contains role-based access control actions used by Grafana Ad
 | grafana-adaptive-metrics-app.rules:write           | n/a              | Create aggregation rules.                            |
 | grafana-adaptive-metrics-app.rules:delete          | n/a              | Delete aggregation rules.                            |
 | grafana-adaptive-metrics-app.exemptions:read       | n/a              | Read rule exemptions.                                |
-| grafana-adaptive-metrics-app.exemptions:write      | n/a              | Create rule exemptions.                              |
+| grafana-adaptive-metrics-app.exemptions:write      | n/a              | Create, update, and delete rule exemptions.                              |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -209,13 +209,13 @@ The following list contains role-based access control actions used by Grafana On
 
 The following list contains role-based access control actions used by Grafana Adaptive Metrics.
 
-| Action                                            | Applicable scope | Description |
-|---------------------------------------------------|------------------|-------------|
-| `grafana-adaptive-metrics-app.recommendations:read` | n/a              | Read aggregation recommendations.        |
-| `grafana-adaptive-metrics-app.rules:read`           | n/a              | Read aggregation rules.        |
-| `grafana-adaptive-metrics-app.exemptions:read`      | n/a              | Read rule exemptions.         |
-| `grafana-adaptive-metrics-app.plugin:access`        | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud.        |
-| `grafana-adaptive-metrics-app.config:read`          | n/a              | Read the Adaptive Metrics app configuration.        |
+| Action                                            | Applicable scope | Description                                          |
+|---------------------------------------------------|------------------|------------------------------------------------------|
+| grafana-adaptive-metrics-app.recommendations:read | n/a              | Read aggregation recommendations.                    |
+| grafana-adaptive-metrics-app.rules:read           | n/a              | Read aggregation rules.                              |
+| grafana-adaptive-metrics-app.exemptions:read      | n/a              | Read rule exemptions.                                |
+| grafana-adaptive-metrics-app.plugin:access        | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
+| grafana-adaptive-metrics-app.config:read          | n/a              | Read the Adaptive Metrics app configuration.         |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -205,6 +205,18 @@ The following list contains role-based access control actions used by Grafana On
 | `grafana-oncall-app.other-settings:read`         | n/a              | Read OnCall settings.                             |
 | `grafana-oncall-app.other-settings:write`        | n/a              | Edit OnCall settings.                             |
 
+### Grafana Adaptive Metrics action definitions
+
+The following list contains role-based access control actions used by Grafana Adaptive Metrics.
+
+| Action                                            | Applicable scope | Description |
+|---------------------------------------------------|------------------|-------------|
+| `grafana-adaptive-metrics-app.recommendations:read` | n/a              | lala        |
+| `grafana-adaptive-metrics-app.rules:read`           | n/a              | lala        |
+| `grafana-adaptive-metrics-app.exemptions:read`      | n/a              | lala        |
+| `grafana-adaptive-metrics-app.plugin:access`        | n/a              | lala        |
+| `grafana-adaptive-metrics-app.config:read`          | n/a              | lala        |
+
 ## Scope definitions
 
 The following list contains role-based access control scopes.

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -211,11 +211,11 @@ The following list contains role-based access control actions used by Grafana Ad
 
 | Action                                            | Applicable scope | Description |
 |---------------------------------------------------|------------------|-------------|
-| `grafana-adaptive-metrics-app.recommendations:read` | n/a              | lala        |
-| `grafana-adaptive-metrics-app.rules:read`           | n/a              | lala        |
-| `grafana-adaptive-metrics-app.exemptions:read`      | n/a              | lala        |
-| `grafana-adaptive-metrics-app.plugin:access`        | n/a              | lala        |
-| `grafana-adaptive-metrics-app.config:read`          | n/a              | lala        |
+| `grafana-adaptive-metrics-app.recommendations:read` | n/a              | Read aggregation recommendations.        |
+| `grafana-adaptive-metrics-app.rules:read`           | n/a              | Read aggregation rules.        |
+| `grafana-adaptive-metrics-app.exemptions:read`      | n/a              | Read rule exemptions.         |
+| `grafana-adaptive-metrics-app.plugin:access`        | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud.        |
+| `grafana-adaptive-metrics-app.config:read`          | n/a              | Read the Adaptive Metrics app configuration.        |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -209,13 +209,20 @@ The following list contains role-based access control actions used by Grafana On
 
 The following list contains role-based access control actions used by Grafana Adaptive Metrics.
 
-| Action                                            | Applicable scope | Description                                          |
-|---------------------------------------------------|------------------|------------------------------------------------------|
-| grafana-adaptive-metrics-app.recommendations:read | n/a              | Read aggregation recommendations.                    |
-| grafana-adaptive-metrics-app.rules:read           | n/a              | Read aggregation rules.                              |
-| grafana-adaptive-metrics-app.exemptions:read      | n/a              | Read rule exemptions.                                |
-| grafana-adaptive-metrics-app.plugin:access        | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
-| grafana-adaptive-metrics-app.config:read          | n/a              | Read the Adaptive Metrics app configuration.         |
+| Action                                             | Applicable scope | Description                                          |
+|----------------------------------------------------|------------------|------------------------------------------------------|
+| `grafana-adaptive-metrics-app.auto-apply:read`       | n/a              | Read                                                 |
+| `grafana-adaptive-metrics-app.auto-apply:write`      | n/a              | Create                                               |
+| `grafana-adaptive-metrics-app.exemptions:read`       | n/a              | Read rule exemptions.                                |
+| `grafana-adaptive-metrics-app.exemptions:write`      | n/a              | Create rule exemptions.                              |
+| `grafana-adaptive-metrics-app.plugin:access`         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
+| `grafana-adaptive-metrics-app.recommendations:read`  | n/a              | Read aggregation recommendations.                    |
+| `grafana-adaptive-metrics-app.recommendations:apply` | n/a              | Apply aggregation recommendations.                   |
+| `grafana-adaptive-metrics-app.rules:read`            | n/a              | Read aggregation rules.                              |
+| `grafana-adaptive-metrics-app.rules:write`           | n/a              | Create aggregation rules.                            |
+| `grafana-adaptive-metrics-app.rules:delete`          | n/a              | Delete aggregation rules.                            |
+| `grafana-adaptive-metrics-app.config:read`           | n/a              | Read the Adaptive Metrics app configuration.         |
+| `grafana-adaptive-metrics-app.config:write`          | n/a              | Update the Adaptive Metrics app configuration.       |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -220,7 +220,7 @@ The following list contains role-based access control actions used by Grafana Ad
 | grafana-adaptive-metrics-app.rules:write           | n/a              | Create aggregation rules.                            |
 | grafana-adaptive-metrics-app.rules:delete          | n/a              | Delete aggregation rules.                            |
 | grafana-adaptive-metrics-app.exemptions:read       | n/a              | Read rule exemptions.                                |
-| grafana-adaptive-metrics-app.exemptions:write      | n/a              | Create, update, and delete rule exemptions.                              |
+| grafana-adaptive-metrics-app.exemptions:write      | n/a              | Create, update, and delete rule exemptions.          |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -211,16 +211,16 @@ The following list contains role-based access control actions used by Grafana Ad
 
 | Action                                             | Applicable scope | Description                                          |
 | -------------------------------------------------- | ---------------- | ---------------------------------------------------- |
-| grafana-adaptive-metrics-app.plugin:access         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
-| grafana-adaptive-metrics-app.config:read           | n/a              | Read the Adaptive Metrics app configuration.         |
-| grafana-adaptive-metrics-app.config:write          | n/a              | Update the Adaptive Metrics app configuration.       |
-| grafana-adaptive-metrics-app.recommendations:read  | n/a              | Read aggregation recommendations.                    |
-| grafana-adaptive-metrics-app.recommendations:apply | n/a              | Apply aggregation recommendations.                   |
-| grafana-adaptive-metrics-app.rules:read            | n/a              | Read aggregation rules.                              |
-| grafana-adaptive-metrics-app.rules:write           | n/a              | Create aggregation rules.                            |
-| grafana-adaptive-metrics-app.rules:delete          | n/a              | Delete aggregation rules.                            |
-| grafana-adaptive-metrics-app.exemptions:read       | n/a              | Read rule exemptions.                                |
-| grafana-adaptive-metrics-app.exemptions:write      | n/a              | Create, update, and delete rule exemptions.          |
+| `grafana‑adaptive‑metrics‑app.plugin:access`         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
+| `grafana‑adaptive‑metrics‑app.config:read`           | n/a              | Read the Adaptive Metrics app configuration.         |
+| `grafana‑adaptive‑metrics‑app.config:write`          | n/a              | Update the Adaptive Metrics app configuration.       |
+| `grafana‑adaptive‑metrics‑app.recommendations:read`  | n/a              | Read aggregation recommendations.                    |
+| `grafana‑adaptive‑metrics‑app.recommendations:apply` | n/a              | Apply aggregation recommendations.                   |
+| `grafana‑adaptive‑metrics‑app.rules:read`            | n/a              | Read aggregation rules.                              |
+| `grafana‑adaptive‑metrics‑app.rules:write`           | n/a              | Create aggregation rules.                            |
+| `grafana‑adaptive‑metrics‑app.rules:delete`          | n/a              | Delete aggregation rules.                            |
+| `grafana‑adaptive‑metrics‑app.exemptions:read`       | n/a              | Read rule exemptions.                                |
+| `grafana‑adaptive‑metrics‑app.exemptions:write`      | n/a              | Create, update, and delete rule exemptions.          |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -211,18 +211,16 @@ The following list contains role-based access control actions used by Grafana Ad
 
 | Action                                             | Applicable scope | Description                                          |
 |----------------------------------------------------|------------------|------------------------------------------------------|
-| `grafana-adaptive-metrics-app.auto-apply:read`       | n/a              | Read                                                 |
-| `grafana-adaptive-metrics-app.auto-apply:write`      | n/a              | Create                                               |
-| `grafana-adaptive-metrics-app.exemptions:read`       | n/a              | Read rule exemptions.                                |
-| `grafana-adaptive-metrics-app.exemptions:write`      | n/a              | Create rule exemptions.                              |
-| `grafana-adaptive-metrics-app.plugin:access`         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
-| `grafana-adaptive-metrics-app.recommendations:read`  | n/a              | Read aggregation recommendations.                    |
-| `grafana-adaptive-metrics-app.recommendations:apply` | n/a              | Apply aggregation recommendations.                   |
-| `grafana-adaptive-metrics-app.rules:read`            | n/a              | Read aggregation rules.                              |
-| `grafana-adaptive-metrics-app.rules:write`           | n/a              | Create aggregation rules.                            |
-| `grafana-adaptive-metrics-app.rules:delete`          | n/a              | Delete aggregation rules.                            |
-| `grafana-adaptive-metrics-app.config:read`           | n/a              | Read the Adaptive Metrics app configuration.         |
-| `grafana-adaptive-metrics-app.config:write`          | n/a              | Update the Adaptive Metrics app configuration.       |
+| grafana-adaptive-metrics-app.plugin:access         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
+| grafana-adaptive-metrics-app.config:read           | n/a              | Read the Adaptive Metrics app configuration.         |
+| grafana-adaptive-metrics-app.config:write          | n/a              | Update the Adaptive Metrics app configuration.       |
+| grafana-adaptive-metrics-app.recommendations:read  | n/a              | Read aggregation recommendations.                    |
+| grafana-adaptive-metrics-app.recommendations:apply | n/a              | Apply aggregation recommendations.                   |
+| grafana-adaptive-metrics-app.rules:read            | n/a              | Read aggregation rules.                              |
+| grafana-adaptive-metrics-app.rules:write           | n/a              | Create aggregation rules.                            |
+| grafana-adaptive-metrics-app.rules:delete          | n/a              | Delete aggregation rules.                            |
+| grafana-adaptive-metrics-app.exemptions:read       | n/a              | Read rule exemptions.                                |
+| grafana-adaptive-metrics-app.exemptions:write      | n/a              | Create rule exemptions.                              |
 
 ## Scope definitions
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -210,7 +210,7 @@ The following list contains role-based access control actions used by Grafana On
 The following list contains role-based access control actions used by Grafana Adaptive Metrics.
 
 | Action                                             | Applicable scope | Description                                          |
-|----------------------------------------------------|------------------|------------------------------------------------------|
+| -------------------------------------------------- | ---------------- | ---------------------------------------------------- |
 | grafana-adaptive-metrics-app.plugin:access         | n/a              | Access the Adaptive Metrics plugin in Grafana Cloud. |
 | grafana-adaptive-metrics-app.config:read           | n/a              | Read the Adaptive Metrics app configuration.         |
 | grafana-adaptive-metrics-app.config:write          | n/a              | Update the Adaptive Metrics app configuration.       |


### PR DESCRIPTION
**What is this feature?**

This PR updates https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/ to include custom RBAC actions for Adaptive Metrics

**Why do we need this feature?**

Many Adaptive Metrics customers are unaware that they can use RBAC to manage permissions to Adaptive Metrics features.

**Who is this feature for?**

Adaptive Metrics customers.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana-adaptive-metrics-app/issues/520

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
