### PR TITLE
Alerting: Use stable identifier of a group,contact point,mute timing when export to HCL

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -595,7 +595,6 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 				Name: fmt.Sprintf("rule_group_%016x", hash),
 				Body: &gr,
 			})
-
 		}
 		for _, cp := range body.ContactPoints {
 			upd, err := ContactPointFromContactPointExport(cp)

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -612,7 +612,6 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 
 		for idx, cp := range body.Policies {
 			policy := cp.RouteExport
-			hash := getHash([]string{policy.})
 			resources = append(resources, hcl.Resource{
 				Type: "grafana_notification_policy",
 				Name: fmt.Sprintf("notification_policy_%d", idx+1),
@@ -620,14 +619,15 @@ func exportHcl(download bool, body definitions.AlertingFileExport) response.Resp
 			})
 		}
 
-		for idx, mt := range body.MuteTimings {
+		for _, mt := range body.MuteTimings {
 			mthcl, err := MuteTimingIntervalToMuteTimeIntervalHclExport(mt)
 			if err != nil {
 				return fmt.Errorf("failed to convert mute timing [%s] to HCL:%w", mt.Name, err)
 			}
+			hash := getHash([]string{mthcl.Name})
 			resources = append(resources, hcl.Resource{
 				Type: "grafana_mute_timing",
-				Name: fmt.Sprintf("mute_timing_%d", idx+1),
+				Name: fmt.Sprintf("mute_timing_%016x", hash),
 				Body: mthcl,
 			})
 		}

--- a/pkg/services/ngalert/api/test-data/alertmanager_default_mutetimings-export.hcl
+++ b/pkg/services/ngalert/api/test-data/alertmanager_default_mutetimings-export.hcl
@@ -1,7 +1,7 @@
-resource "grafana_mute_timing" "mute_timing_1" {
+resource "grafana_mute_timing" "mute_timing_9e85e7a27b8f12ca" {
   name = "interval"
 }
-resource "grafana_mute_timing" "mute_timing_2" {
+resource "grafana_mute_timing" "mute_timing_b469bb50150a4298" {
   name = "full-interval"
 
   intervals {

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"net/http"
 	"net/url"
@@ -229,4 +230,13 @@ func containsProvisionedAlerts(provenances map[string]ngmodels.Provenance, rules
 		}
 	}
 	return false
+}
+
+func getHash(hashSlice []string) uint64 {
+	sum := fnv.New64()
+	for _, str := range hashSlice {
+		sum.Write([]byte(str))
+	}
+	hash := sum.Sum64()
+	return hash
 }

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -235,7 +235,7 @@ func containsProvisionedAlerts(provenances map[string]ngmodels.Provenance, rules
 func getHash(hashSlice []string) uint64 {
 	sum := fnv.New64()
 	for _, str := range hashSlice {
-		sum.Write([]byte(str))
+		_, _ = sum.Write([]byte(str))
 	}
 	hash := sum.Sum64()
 	return hash


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

when exporting to HCL, we now use a fnv-1 hash to create the resource name for contact point,mute-timing and rule_grpup

**Why do we need this feature?**

to make the HCL resource identifiner stable and uniqe

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

-->

Fixes #88714 

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
