### PR TITLE
Alerting: Don't show success message after updating AM config

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -242,11 +242,11 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
       void,
       { selectedAlertmanager: string; config: AlertManagerCortexConfig }
     >({
-      query: ({ selectedAlertmanager, config, ...rest }) => ({
+      query: ({ selectedAlertmanager, config }) => ({
         url: `/api/alertmanager/${getDatasourceAPIUid(selectedAlertmanager)}/config/api/v1/alerts`,
         method: 'POST',
         data: config,
-        ...rest,
+        showSuccessAlert: false,
       }),
       invalidatesTags: ['AlertmanagerConfiguration'],
     }),


### PR DESCRIPTION
**What is this feature?**

Hide the success message shown after updating alertmanager configuration (specifically, when deleting a contact point)

**Why do we need this feature?**

After deleting a contact point, we were showing a message saying "configuration created", from the API response. We don't really need to show this, and it's a little misleading. Other pieces of concurrent work will be improving the behaviour in this area anyway, so we can address further in that work

**Who is this feature for?**

Alerting users
