### PR TITLE
Combobox: Add clear and reset onBlur

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { Chance } from 'chance';
-import { ComponentProps, useState } from 'react';
+import { ComponentProps, useEffect, useState } from 'react';
 
 import { Combobox, Option, Value } from './Combobox';
 
@@ -55,7 +55,7 @@ type Story = StoryObj<typeof Combobox>;
 
 export const Basic: Story = {};
 
-function generateOptions(amount: number): Option[] {
+async function generateOptions(amount: number): Promise<Option[]> {
   return Array.from({ length: amount }, () => ({
     label: chance.name(),
     value: chance.guid(),
@@ -63,15 +63,27 @@ function generateOptions(amount: number): Option[] {
   }));
 }
 
-const manyOptions = generateOptions(1e5);
-manyOptions.push({ label: 'Banana', value: 'banana', description: 'A yellow fruit' });
-
 const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...args }) => {
-  const [value, setValue] = useState<Value | null>(manyOptions[5].value);
+  const [value, setValue] = useState<Value | null>(null);
+  const [options, setOptions] = useState<Option[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      generateOptions(numberOfOptions).then((options) => {
+        setIsLoading(false);
+        setOptions(options);
+        setValue(options[5].value);
+        console.log("I've set stuff");
+      });
+    }, 1000);
+  }, [numberOfOptions]);
+
   return (
     <Combobox
       {...args}
-      options={manyOptions}
+      loading={isLoading}
+      options={options}
       value={value}
       onChange={(val) => {
         setValue(val?.value || null);

--- a/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
@@ -44,7 +44,7 @@ const BasicWithState: StoryFn<typeof Combobox> = (args) => {
       {...args}
       value={value}
       onChange={(val) => {
-        setValue(val?.value || '');
+        setValue(val?.value || null);
         action('onChange')(val);
       }}
     />

--- a/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
@@ -44,7 +44,7 @@ const BasicWithState: StoryFn<typeof Combobox> = (args) => {
       {...args}
       value={value}
       onChange={(val) => {
-        setValue(val?.value || null);
+        setValue(val?.value || '');
         action('onChange')(val);
       }}
     />
@@ -66,18 +66,16 @@ function generateOptions(amount: number): Option[] {
 const manyOptions = generateOptions(1e5);
 manyOptions.push({ label: 'Banana', value: 'banana', description: 'A yellow fruit' });
 
-const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions }) => {
-  const [value, setValue] = useState<Value>(manyOptions[5].value);
-  const options = useMemo(() => generateOptions(numberOfOptions), [numberOfOptions]);
+const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...args }) => {
+  const [value, setValue] = useState<Value | null>(manyOptions[5].value);
+  //const options = useMemo(() => generateOptions(numberOfOptions), [numberOfOptions]);
   return (
     <Combobox
-      options={options}
+      {...args}
+      options={manyOptions}
       value={value}
       onChange={(val) => {
-        if (!val) {
-          return;
-        }
-        setValue(val.value);
+        setValue(val?.value || null);
         action('onChange')(val);
       }}
     />

--- a/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
@@ -44,10 +44,7 @@ const BasicWithState: StoryFn<typeof Combobox> = (args) => {
       {...args}
       value={value}
       onChange={(val) => {
-        if (!val) {
-          return;
-        }
-        setValue(val.value);
+        setValue(val?.value || null);
         action('onChange')(val);
       }}
     />

--- a/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.internal.story.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { Chance } from 'chance';
-import { ComponentProps, useMemo, useState } from 'react';
+import { ComponentProps, useState } from 'react';
 
 import { Combobox, Option, Value } from './Combobox';
 
@@ -68,7 +68,6 @@ manyOptions.push({ label: 'Banana', value: 'banana', description: 'A yellow frui
 
 const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...args }) => {
   const [value, setValue] = useState<Value | null>(manyOptions[5].value);
-  //const options = useMemo(() => generateOptions(numberOfOptions), [numberOfOptions]);
   return (
     <Combobox
       {...args}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -8,6 +8,7 @@ import { useStyles2 } from '../../themes';
 import { t } from '../../utils/i18n';
 import { Icon } from '../Icon/Icon';
 import { Input, Props as InputProps } from '../Input/Input';
+import { Spinner } from '../Spinner/Spinner';
 
 import { getComboboxStyles } from './getComboboxStyles';
 
@@ -49,9 +50,7 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
   const MIN_WIDTH = 400;
   const [items, setItems] = useState(options);
   const selectedItem = useMemo(() => options.find((option) => option.value === value) || null, [options, value]);
-  console.log('selectedItem', selectedItem);
-  console.log(value);
-  console.log(options);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const floatingRef = useRef(null);
   const styles = useStyles2(getComboboxStyles);
@@ -71,7 +70,8 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
       scrollIntoView: () => {},
       onInputValueChange: (changes) => {
         // Ignore this internal state change, as it does not work when clearing input
-        if (changes.type === useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem) {
+        // Check value instead of selectedItem, as selectedItem is incorrect
+        if (changes.type === useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem && value === null) {
           setInputValue('');
           return;
         }

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -5,6 +5,7 @@ import { useCombobox } from 'downshift';
 import { useMemo, useRef, useState } from 'react';
 
 import { useStyles2 } from '../../themes';
+import { t } from '../../utils/i18n';
 import { Icon } from '../Icon/Icon';
 import { Input, Props as InputProps } from '../Input/Input';
 
@@ -59,15 +60,24 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
     overscan: 2,
   });
 
-  const { getInputProps, getMenuProps, getItemProps, isOpen, highlightedIndex } = useCombobox({
+  const { getInputProps, getMenuProps, getItemProps, isOpen, highlightedIndex, setInputValue } = useCombobox({
     items,
     itemToString,
     selectedItem,
     scrollIntoView: () => {},
     onInputValueChange: ({ inputValue }) => {
+      if (inputValue === '' || inputValue === selectedItem?.label) {
+        setItems(options);
+        return;
+      }
       setItems(options.filter(itemFilter(inputValue)));
     },
-    onSelectedItemChange: ({ selectedItem }) => onChange(selectedItem),
+    onSelectedItemChange: ({ selectedItem }) => {
+      console.log(selectedItem);
+      console.log(options);
+      onChange(selectedItem);
+      setItems(options);
+    },
     onHighlightedIndexChange: ({ highlightedIndex, type }) => {
       if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {
         rowVirtualizer.scrollToIndex(highlightedIndex);
@@ -98,7 +108,23 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
   return (
     <div>
       <Input
-        suffix={<Icon name={isOpen ? 'search' : 'angle-down'} />}
+        suffix={
+          <>
+            {!!value && (
+              <Icon
+                name="times"
+                className={styles.clear}
+                title={t('combobox.clear.title', 'Clear value')}
+                tabIndex={0}
+                onClick={() => {
+                  console.log('clear');
+                  onChange(null);
+                }}
+              />
+            )}
+            <Icon name={isOpen ? 'search' : 'angle-down'} />
+          </>
+        }
         {...restProps}
         {...getInputProps({
           ref: inputRef,
@@ -108,6 +134,7 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
            */
           onChange: () => {},
         })}
+        onBlur={() => (selectedItem ? setInputValue(selectedItem.label) : setInputValue(''))}
       />
       <div
         className={cx(styles.menu, hasMinHeight && styles.menuHeight)}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -60,30 +60,31 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
     overscan: 2,
   });
 
-  const { getInputProps, getMenuProps, getItemProps, isOpen, highlightedIndex, setInputValue } = useCombobox({
-    items,
-    itemToString,
-    selectedItem,
-    scrollIntoView: () => {},
-    onInputValueChange: ({ inputValue }) => {
-      if (inputValue === '' || inputValue === selectedItem?.label) {
+  const { getInputProps, getMenuProps, getItemProps, isOpen, highlightedIndex, setInputValue, selectItem } =
+    useCombobox({
+      items,
+      itemToString,
+      selectedItem,
+      scrollIntoView: () => {},
+      onInputValueChange: ({ inputValue }) => {
+        if (inputValue === '' || inputValue === selectedItem?.label) {
+          setItems(options);
+          return;
+        }
+        setItems(options.filter(itemFilter(inputValue)));
+      },
+      onSelectedItemChange: ({ selectedItem }) => {
+        console.log(selectedItem);
+        console.log(options);
+        onChange(selectedItem);
         setItems(options);
-        return;
-      }
-      setItems(options.filter(itemFilter(inputValue)));
-    },
-    onSelectedItemChange: ({ selectedItem }) => {
-      console.log(selectedItem);
-      console.log(options);
-      onChange(selectedItem);
-      setItems(options);
-    },
-    onHighlightedIndexChange: ({ highlightedIndex, type }) => {
-      if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {
-        rowVirtualizer.scrollToIndex(highlightedIndex);
-      }
-    },
-  });
+      },
+      onHighlightedIndexChange: ({ highlightedIndex, type }) => {
+        if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {
+          rowVirtualizer.scrollToIndex(highlightedIndex);
+        }
+      },
+    });
 
   // the order of middleware is important!
   const middleware = [
@@ -117,8 +118,7 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
                 title={t('combobox.clear.title', 'Clear value')}
                 tabIndex={0}
                 onClick={() => {
-                  console.log('clear');
-                  onChange(null);
+                  selectItem(null);
                 }}
               />
             )}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -8,7 +8,6 @@ import { useStyles2 } from '../../themes';
 import { t } from '../../utils/i18n';
 import { Icon } from '../Icon/Icon';
 import { Input, Props as InputProps } from '../Input/Input';
-import { Spinner } from '../Spinner/Spinner';
 
 import { getComboboxStyles } from './getComboboxStyles';
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -67,17 +67,22 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
       selectedItem,
       scrollIntoView: () => {},
       onInputValueChange: ({ inputValue }) => {
-        if (inputValue === '' || inputValue === selectedItem?.label) {
+        console.log(inputValue);
+        setItems(options.filter(itemFilter(inputValue)));
+      },
+      onIsOpenChange: ({ isOpen, selectedItem }) => {
+        // Basically onBlur handler
+        if (isOpen) {
           setItems(options);
           return;
         }
-        setItems(options.filter(itemFilter(inputValue)));
+        console.log(selectedItem);
+        selectedItem ? setInputValue(selectedItem.label) : setInputValue('');
       },
       onSelectedItemChange: ({ selectedItem }) => {
         console.log(selectedItem);
-        console.log(options);
+        selectedItem ? setInputValue(selectedItem.label) : setInputValue('');
         onChange(selectedItem);
-        setItems(options);
       },
       onHighlightedIndexChange: ({ highlightedIndex, type }) => {
         if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {
@@ -134,7 +139,6 @@ export const Combobox = ({ options, onChange, value, ...restProps }: ComboboxPro
            */
           onChange: () => {},
         })}
-        onBlur={() => (selectedItem ? setInputValue(selectedItem.label) : setInputValue(''))}
       />
       <div
         className={cx(styles.menu, hasMinHeight && styles.menuHeight)}

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -77,5 +77,12 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
         top: 0,
       },
     }),
+    clear: css({
+      label: 'grafana-select-clear',
+      cursor: 'pointer',
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
   };
 };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -260,6 +260,11 @@
       "success": "Copied"
     }
   },
+  "combobox": {
+    "clear": {
+      "title": "Clear value"
+    }
+  },
   "command-palette": {
     "action": {
       "change-theme": "Change theme...",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -260,6 +260,11 @@
       "success": "Cőpįęđ"
     }
   },
+  "combobox": {
+    "clear": {
+      "title": "Cľęäř väľūę"
+    }
+  },
   "command-palette": {
     "action": {
       "change-theme": "Cĥäŉģę ŧĥęmę...",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Enables clearing value
- Sets input value to whichever is the selected value when blurring

**Why do we need this feature?**

UX

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes [#90646](https://github.com/grafana/grafana/issues/90646)

**Special notes for your reviewer:**

There is some lag when actually selecting the value. It might have to do with the way we use Downshift, as the search itself is very quick.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
