### PR TITLE
Chore: Refactor explore metrics layout switcher and breakdown scene 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5457,9 +5457,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/trails/MetricScene.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/trails/MetricSelect/MetricSelectScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],

--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -324,7 +324,6 @@ export function buildAllLayout(
       { value: 'grid', label: 'Grid' },
       { value: 'rows', label: 'Rows' },
     ],
-    activeBreakdownLayout: 'grid',
     onBreakdownLayoutChange,
     breakdownLayouts: [
       new SceneCSSGridLayout({
@@ -386,7 +385,6 @@ function buildNormalLayout(queryDef: AutoQueryDef, onBreakdownLayoutChange: Brea
       { value: 'grid', label: 'Grid' },
       { value: 'rows', label: 'Rows' },
     ],
-    activeBreakdownLayout: 'grid',
     onBreakdownLayoutChange,
     breakdownLayouts: [
       new SceneFlexLayout({

--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -35,7 +35,7 @@ import { getColorByIndex, getTrailFor } from '../utils';
 
 import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
 import { ByFrameRepeater } from './ByFrameRepeater';
-import { LayoutSwitcher } from './LayoutSwitcher';
+import { BreakdownLayoutChange, LayoutSwitcher } from './LayoutSwitcher';
 import { breakdownPanelOptions } from './panelConfigs';
 import { getLabelOptions } from './utils';
 import { BreakdownAxisChangeEvent, yAxisSyncBehavior } from './yAxisSyncBehavior';
@@ -97,12 +97,7 @@ export class BreakdownScene extends SceneObjectBase<BreakdownSceneState> {
       this.clearBreakdownPanelAxisValues();
     });
 
-    metricScene.subscribeToState(({ layout }, old) => {
-      if (layout !== old.layout) {
-        // Change in layout will set up a different set of panel objects that haven't received the current yaxis range
-        this.clearBreakdownPanelAxisValues();
-      }
-    });
+    this._subs.add(this.subscribeToEvent(BreakdownLayoutChange, () => this.clearBreakdownPanelAxisValues));
 
     this.updateBody(variable);
   }
@@ -154,6 +149,7 @@ export class BreakdownScene extends SceneObjectBase<BreakdownSceneState> {
   }, 1000);
 
   private clearBreakdownPanelAxisValues() {
+    console.log('I am triggered because layout has changed');
     this.breakdownPanelMaxValue = undefined;
     this.breakdownPanelMinValue = undefined;
   }
@@ -322,6 +318,7 @@ export function buildAllLayout(options: Array<SelectableValue<string>>, queryDef
       { value: 'grid', label: 'Grid' },
       { value: 'rows', label: 'Rows' },
     ],
+    active: 'grid',
     layouts: [
       new SceneCSSGridLayout({
         templateColumns: GRID_TEMPLATE_COLUMNS,
@@ -382,6 +379,7 @@ function buildNormalLayout(queryDef: AutoQueryDef) {
       { value: 'grid', label: 'Grid' },
       { value: 'rows', label: 'Rows' },
     ],
+    active: 'grid',
     layouts: [
       new SceneFlexLayout({
         direction: 'column',

--- a/public/app/features/trails/ActionTabs/BreakdownScene.tsx
+++ b/public/app/features/trails/ActionTabs/BreakdownScene.tsx
@@ -37,7 +37,7 @@ import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
 import { ByFrameRepeater } from './ByFrameRepeater';
 import { LayoutSwitcher } from './LayoutSwitcher';
 import { breakdownPanelOptions } from './panelConfigs';
-import { LayoutChangeCallback, LayoutType } from './types';
+import { BreakdownLayoutChangeCallback, BreakdownLayoutType } from './types';
 import { getLabelOptions } from './utils';
 import { BreakdownAxisChangeEvent, yAxisSyncBehavior } from './yAxisSyncBehavior';
 
@@ -180,8 +180,8 @@ export class BreakdownScene extends SceneObjectBase<BreakdownSceneState> {
 
     if (!variable.state.loading && variable.state.options.length) {
       stateUpdate.body = variable.hasAllValue()
-        ? buildAllLayout(options, this._query!, this.onLayoutChanged)
-        : buildNormalLayout(this._query!, this.onLayoutChanged);
+        ? buildAllLayout(options, this._query!, this.onBreakdownLayoutChange)
+        : buildNormalLayout(this._query!, this.onBreakdownLayoutChange);
     } else if (!variable.state.loading) {
       stateUpdate.body = undefined;
       stateUpdate.blockingMessage = 'Unable to retrieve label options for currently selected metric.';
@@ -192,7 +192,7 @@ export class BreakdownScene extends SceneObjectBase<BreakdownSceneState> {
     this.setState(stateUpdate);
   }
 
-  public onLayoutChanged = (newLayout: LayoutType) => {
+  public onBreakdownLayoutChange = (_: BreakdownLayoutType) => {
     this.clearBreakdownPanelAxisValues();
   };
 
@@ -272,7 +272,7 @@ function getStyles(theme: GrafanaTheme2) {
 export function buildAllLayout(
   options: Array<SelectableValue<string>>,
   queryDef: AutoQueryDef,
-  onLayoutChange: LayoutChangeCallback
+  onBreakdownLayoutChange: BreakdownLayoutChangeCallback
 ) {
   const children: SceneFlexItemLike[] = [];
 
@@ -320,13 +320,13 @@ export function buildAllLayout(
     );
   }
   return new LayoutSwitcher({
-    options: [
+    breakdownLayoutOptions: [
       { value: 'grid', label: 'Grid' },
       { value: 'rows', label: 'Rows' },
     ],
-    active: 'grid',
-    onLayoutChange,
-    layouts: [
+    activeBreakdownLayout: 'grid',
+    onBreakdownLayoutChange,
+    breakdownLayouts: [
       new SceneCSSGridLayout({
         templateColumns: GRID_TEMPLATE_COLUMNS,
         autoRows: '200px',
@@ -346,7 +346,7 @@ export function buildAllLayout(
 
 const GRID_TEMPLATE_COLUMNS = 'repeat(auto-fit, minmax(400px, 1fr))';
 
-function buildNormalLayout(queryDef: AutoQueryDef, onLayoutChange: LayoutChangeCallback) {
+function buildNormalLayout(queryDef: AutoQueryDef, onBreakdownLayoutChange: BreakdownLayoutChangeCallback) {
   const unit = queryDef.unit;
 
   function getLayoutChild(data: PanelData, frame: DataFrame, frameIndex: number): SceneFlexItem {
@@ -381,14 +381,14 @@ function buildNormalLayout(queryDef: AutoQueryDef, onLayoutChange: LayoutChangeC
       maxDataPoints: 300,
       queries: queryDef.queries,
     }),
-    options: [
+    breakdownLayoutOptions: [
       { value: 'single', label: 'Single' },
       { value: 'grid', label: 'Grid' },
       { value: 'rows', label: 'Rows' },
     ],
-    active: 'grid',
-    onLayoutChange,
-    layouts: [
+    activeBreakdownLayout: 'grid',
+    onBreakdownLayoutChange,
+    breakdownLayouts: [
       new SceneFlexLayout({
         direction: 'column',
         children: [

--- a/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
+++ b/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
@@ -38,10 +38,10 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> impleme
   }
 
   updateFromUrl(values: SceneObjectUrlValues) {
-    if (typeof values.breakdownLayout === 'string') {
-      const newBreakdownLayoutLayout = values.breakdownLayout as BreakdownLayoutType;
-      if (this.state.activeBreakdownLayout !== newBreakdownLayoutLayout) {
-        this.setState({ activeBreakdownLayout: newBreakdownLayoutLayout });
+    const newBreakdownLayout = values.breakdownLayout;
+    if (newBreakdownLayout === 'string' && isBreakdownLayoutType(newBreakdownLayout)) {
+      if (this.state.activeBreakdownLayout !== newBreakdownLayout) {
+        this.setState({ activeBreakdownLayout: newBreakdownLayout });
       }
     }
   }

--- a/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
+++ b/public/app/features/trails/ActionTabs/LayoutSwitcher.tsx
@@ -13,20 +13,13 @@ import { Field, RadioButtonGroup } from '@grafana/ui';
 import { reportExploreMetrics } from '../interactions';
 import { MakeOptional, TRAIL_BREAKDOWN_VIEW_KEY } from '../shared';
 
-import { isLayoutType, LayoutType } from './types';
-
-export class BreakdownLayoutChange extends BusEventBase {
-  constructor(public layout: LayoutType) {
-    super();
-  }
-
-  public static type = 'breakdown-layout-change';
-}
+import { isLayoutType, LayoutChangeCallback, LayoutType } from './types';
 
 export interface LayoutSwitcherState extends SceneObjectState {
   active: LayoutType;
   layouts: SceneObject[];
   options: Array<SelectableValue<LayoutType>>;
+  onLayoutChange: LayoutChangeCallback;
 }
 
 export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> implements SceneObjectWithUrlSync {
@@ -71,7 +64,7 @@ export class LayoutSwitcher extends SceneObjectBase<LayoutSwitcherState> impleme
     reportExploreMetrics('breakdown_layout_changed', { layout: active });
     localStorage.setItem(TRAIL_BREAKDOWN_VIEW_KEY, active);
     this.setState({ active });
-    this.publishEvent(new BreakdownLayoutChange(active));
+    this.state.onLayoutChange(active);
   };
 
   public static Component = ({ model }: SceneComponentProps<LayoutSwitcher>) => {

--- a/public/app/features/trails/ActionTabs/types.ts
+++ b/public/app/features/trails/ActionTabs/types.ts
@@ -5,3 +5,5 @@ export type LayoutType = (typeof LAYOUT_TYPES)[number];
 export function isLayoutType(layoutType: string | null | undefined): layoutType is LayoutType {
   return !!layoutType && layoutType in LAYOUT_TYPES;
 }
+
+export type LayoutChangeCallback = (newLayout: LayoutType) => void;

--- a/public/app/features/trails/ActionTabs/types.ts
+++ b/public/app/features/trails/ActionTabs/types.ts
@@ -1,9 +1,11 @@
-const LAYOUT_TYPES = ['single', 'grid', 'rows'] as const;
+const BREAKDOWN_LAYOUT_TYPES = ['single', 'grid', 'rows'] as const;
 
-export type LayoutType = (typeof LAYOUT_TYPES)[number];
+export type BreakdownLayoutType = (typeof BREAKDOWN_LAYOUT_TYPES)[number];
 
-export function isLayoutType(layoutType: string | null | undefined): layoutType is LayoutType {
-  return !!layoutType && layoutType in LAYOUT_TYPES;
+export function isBreakdownLayoutType(
+  breakdownLayoutType: string | null | undefined
+): breakdownLayoutType is BreakdownLayoutType {
+  return !!breakdownLayoutType && breakdownLayoutType in BREAKDOWN_LAYOUT_TYPES;
 }
 
-export type LayoutChangeCallback = (newLayout: LayoutType) => void;
+export type BreakdownLayoutChangeCallback = (newBreakdownLayout: BreakdownLayoutType) => void;

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -3,23 +3,22 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
-  SceneObjectState,
-  SceneObjectBase,
+  QueryVariable,
   SceneComponentProps,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectState,
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
-  sceneGraph,
   SceneVariableSet,
-  QueryVariable,
 } from '@grafana/scenes';
-import { ToolbarButton, Box, Stack, Icon, TabsBar, Tab, useStyles2, LinkButton, Tooltip } from '@grafana/ui';
+import { Box, Icon, LinkButton, Stack, Tab, TabsBar, ToolbarButton, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { getExploreUrl } from '../../core/utils/explore';
 
 import { buildBreakdownActionScene } from './ActionTabs/BreakdownScene';
 import { buildMetricOverviewScene } from './ActionTabs/MetricOverviewScene';
 import { buildRelatedMetricsScene } from './ActionTabs/RelatedMetricsScene';
-import { isLayoutType, LayoutType } from './ActionTabs/types';
 import { getAutoQueriesForMetric } from './AutomaticMetricQueries/AutoQueryEngine';
 import { AutoQueryDef, AutoQueryInfo } from './AutomaticMetricQueries/types';
 import { MAIN_PANEL_MAX_HEIGHT, MAIN_PANEL_MIN_HEIGHT, MetricGraphScene } from './MetricGraphScene';
@@ -32,7 +31,6 @@ import {
   getVariablesWithMetricConstant,
   MakeOptional,
   MetricSelectedEvent,
-  TRAIL_BREAKDOWN_VIEW_KEY,
   trailDS,
   VAR_GROUP_BY,
   VAR_METRIC_EXPR,
@@ -43,24 +41,21 @@ export interface MetricSceneState extends SceneObjectState {
   body: MetricGraphScene;
   metric: string;
   actionView?: string;
-  layout: LayoutType;
 
   autoQuery: AutoQueryInfo;
   queryDef?: AutoQueryDef;
 }
 
 export class MetricScene extends SceneObjectBase<MetricSceneState> {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['actionView', 'layout'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['actionView'] });
 
-  public constructor(state: MakeOptional<MetricSceneState, 'body' | 'autoQuery' | 'layout'>) {
+  public constructor(state: MakeOptional<MetricSceneState, 'body' | 'autoQuery'>) {
     const autoQuery = state.autoQuery ?? getAutoQueriesForMetric(state.metric);
-    const layout = localStorage.getItem(TRAIL_BREAKDOWN_VIEW_KEY);
     super({
       $variables: state.$variables ?? getVariableSet(state.metric),
       body: state.body ?? new MetricGraphScene({}),
       autoQuery,
       queryDef: state.queryDef ?? autoQuery.main,
-      layout: isLayoutType(layout) ? layout : 'grid',
       ...state,
     });
 
@@ -74,7 +69,7 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
   }
 
   getUrlState() {
-    return { actionView: this.state.actionView, layout: this.state.layout };
+    return { actionView: this.state.actionView };
   }
 
   updateFromUrl(values: SceneObjectUrlValues) {
@@ -87,13 +82,6 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
       }
     } else if (values.actionView === null) {
       this.setActionView(undefined);
-    }
-
-    if (typeof values.layout === 'string') {
-      const newLayout = values.layout as LayoutType;
-      if (this.state.layout !== newLayout) {
-        this.setState({ layout: newLayout });
-      }
     }
   }
 

--- a/public/app/features/trails/interactions.ts
+++ b/public/app/features/trails/interactions.ts
@@ -1,7 +1,7 @@
 import { AdHocVariableFilter } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 
-import { LayoutType } from './ActionTabs/types';
+import { BreakdownLayoutType } from './ActionTabs/types';
 import { TrailStepType } from './DataTrailsHistory';
 import { ActionViewType } from './shared';
 
@@ -26,7 +26,7 @@ type Interactions = {
     cause: 'breakdown' | 'adhoc_filter';
   };
   // User changed the breakdown layout
-  breakdown_layout_changed: { layout: LayoutType };
+  breakdown_layout_changed: { layout: BreakdownLayoutType };
   // A metric exploration has started due to one of the following causes
   exploration_started: {
     cause: (


### PR DESCRIPTION
**What is this feature?**

The `LayoutSwitcher` was mutating the `MetricScene` state. And `MetricScene` syncs the URL. `BreakdownScene` was listening `MetricScene` state changes to run one function. This was quite confusing in the beginning as `layout` was used everywhere. At first glance you might think this is `MetricScene` layout. As it is confusing I decided to move `urlSync` of `layout` in `LayoutSwitcher` where it is actually being changed. And added a callback so `BreakdownScene` can be notified with the layout change. Finally I changed the name of the variable to a more self-explanatory one: `breakdownLayout`. 

This way the top scene, `MetricScene`,  will be decoupled from `BreakdownScene` and `LayoutSwitcher`. `LayoutSwitcher` will have less confusing logic.

In Summary:

- Move the urlSync of the layout in `LayoutSwitcher`
- Trigger a callback to inform BreakdownScene
- A little more clear approach to switch breakdown layout
- Rename layout as `breakdownLayout` to prevent confusion

**Why do we need this feature?**

To prepare the breakdown scene for future improvements

**Special notes for your reviewer:**
Previous work: https://github.com/grafana/grafana/pull/90429

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
