### PR TITLE
Alerting: Parse secret fields case-insensitively when creating or updating a contact point

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -550,15 +550,6 @@ func getCaseInsensitive(jsonObj *simplejson.Json, key string) (string, string, e
 	return key, "", nil
 }
 
-// handleWrappedError unwraps an error and wraps it with a new expected error type. If the error is not wrapped, it returns just the expected error.
-func handleWrappedError(err error, expected error) error {
-	err = errors.Unwrap(err)
-	if err == nil {
-		return expected
-	}
-	return fmt.Errorf("%w: %s", expected, err.Error())
-}
-
 // convertRecSvcErr converts errors from notifier.ReceiverService to errors expected from ContactPointService.
 func convertRecSvcErr(err error) error {
 	if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/alertmanager/config"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -516,11 +517,46 @@ func RemoveSecretsForContactPoint(e *apimodels.EmbeddedContactPoint) (map[string
 		return nil, err
 	}
 	for _, secretKey := range secretKeys {
-		secretValue := e.Settings.Get(secretKey).MustString()
-		e.Settings.Del(secretKey)
+		foundSecretKey, secretValue, err := getCaseInsensitive(e.Settings, secretKey)
+		if err != nil {
+			return nil, err
+		}
+		e.Settings.Del(foundSecretKey)
 		s[secretKey] = secretValue
 	}
 	return s, nil
+}
+
+// getCaseInsensitive returns the value of the specified key, preferring an exact match but accepting a case-insensitive match.
+// If no key matches, the second return value is an empty string.
+func getCaseInsensitive(jsonObj *simplejson.Json, key string) (string, string, error) {
+	// Check for an exact key match first.
+	if value, ok := jsonObj.CheckGet(key); ok {
+		return key, value.MustString(), nil
+	}
+
+	// If no exact match is found, look for a case-insensitive match.
+	settingsMap, err := jsonObj.Map()
+	if err != nil {
+		return "", "", err
+	}
+
+	for k, v := range settingsMap {
+		if strings.EqualFold(k, key) {
+			return k, v.(string), nil
+		}
+	}
+
+	return key, "", nil
+}
+
+// handleWrappedError unwraps an error and wraps it with a new expected error type. If the error is not wrapped, it returns just the expected error.
+func handleWrappedError(err error, expected error) error {
+	err = errors.Unwrap(err)
+	if err == nil {
+		return expected
+	}
+	return fmt.Errorf("%w: %s", expected, err.Error())
 }
 
 // convertRecSvcErr converts errors from notifier.ReceiverService to errors expected from ContactPointService.


### PR DESCRIPTION
**What is this feature?**

Ensure that secret field values are parsed correctly regardless of their case, preventing incorrect handling and storage of these fields.

For example, when a contact point is created with a `token` field passed with a different casing (e.g., `TOKEN`), the validation passes because Go's JSON Unmarshal and therefore our validation is case insensitive, but Grafana currently saves an empty string as the value because for the secrets it's looking for the exact match (`token`).

More details in the issue: https://github.com/grafana/grafana/issues/90903

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/90903

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
