### PR TITLE
Release Pipeline: [RPM pkg verification] Fix linefeeds converted to literal backslash-n sequences

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3308,7 +3308,7 @@ steps:
   - rpm --import https://rpm.grafana.com/gpg.key
   - 'echo "Step 4: Configuring Grafana repository..."'
   - |-
-    echo '[grafana]
+    echo -e '[grafana]
     name=grafana
     baseurl=https://rpm.grafana.com
     repo_gpgcheck=0
@@ -3486,7 +3486,7 @@ steps:
   - rpm --import https://rpm.grafana.com/gpg.key
   - 'echo "Step 4: Configuring Grafana repository..."'
   - |-
-    echo '[grafana]
+    echo -e '[grafana]
     name=grafana
     baseurl=https://rpm.grafana.com
     repo_gpgcheck=0
@@ -5514,6 +5514,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 2478fec0f251bc9f1eeaa692cdc5b150e7d6f93f143c1b8e6a149fada98cd097
+hmac: 1a6176686248c5751036eef67b3972b3ea002aa82226dfc28bd565febf17cb19
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1318,7 +1318,7 @@ def verify_linux_RPM_packages_step(depends_on = []):
             'echo "Step 3: Adding Grafana GPG key..."',
             "rpm --import https://rpm.grafana.com/gpg.key",
             'echo "Step 4: Configuring Grafana repository..."',
-            "echo '" + repo_config + "' > /etc/yum.repos.d/grafana.repo",
+            "echo -e '" + repo_config + "' > /etc/yum.repos.d/grafana.repo",
             'echo "Step 5: Checking RPM repository..."',
             "dnf list available grafana-${TAG}",
             "if [ $? -eq 0 ]; then",


### PR DESCRIPTION
**What is this feature?**

Fix linefeeds converted to literal backslash-n sequences in RPM package verification. Locally tested in docker.

**Why do we need this feature?**

To fix pipelines from incorrectly failing. Examples:

- [9.5.29 Enterprise Promotion](https://drone.grafana.net/grafana/grafana-enterprise/73702/5/8)
- [9.5.29 OSS Promotion](https://drone.grafana.net/grafana/grafana/188696/4/6)

**Who is this feature for?**

Release team.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
