### PR TITLE
chore (replstore): fix registration with multiple sql drivers, again

### DIFF
--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -61,7 +61,7 @@ func WrapDatabaseDriverWithHooks(dbType string, tracer tracing.Tracer) string {
 // WrapDatabaseDriverWithHooks creates a fake database driver that
 // executes pre and post functions which we use to gather metrics about
 // database queries. It also registers the metrics.
-func WrapDatabaseReplDriverWithHooks(dbType string, index int, tracer tracing.Tracer) string {
+func WrapDatabaseReplDriverWithHooks(dbType string, index uint, tracer tracing.Tracer) string {
 	drivers := map[string]driver.Driver{
 		migrator.SQLite:   &sqlite3.SQLiteDriver{},
 		migrator.MySQL:    &mysql.MySQLDriver{},

--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -61,7 +61,7 @@ func WrapDatabaseDriverWithHooks(dbType string, tracer tracing.Tracer) string {
 // WrapDatabaseDriverWithHooks creates a fake database driver that
 // executes pre and post functions which we use to gather metrics about
 // database queries. It also registers the metrics.
-func WrapDatabaseReplDriverWithHooks(dbType string, tracer tracing.Tracer) string {
+func WrapDatabaseReplDriverWithHooks(dbType string, index int, tracer tracing.Tracer) string {
 	drivers := map[string]driver.Driver{
 		migrator.SQLite:   &sqlite3.SQLiteDriver{},
 		migrator.MySQL:    &mysql.MySQLDriver{},
@@ -73,7 +73,7 @@ func WrapDatabaseReplDriverWithHooks(dbType string, tracer tracing.Tracer) strin
 		return dbType
 	}
 
-	driverWithHooks := dbType + "ReplicaWithHooks"
+	driverWithHooks := dbType + fmt.Sprintf("ReplicaWithHooks%d", index)
 	sql.Register(driverWithHooks, sqlhooks.Wrap(d, &databaseQueryWrapper{log: log.New("sqlstore.metrics"), tracer: tracer}))
 	core.RegisterDriver(driverWithHooks, &databaseQueryWrapperDriver{dbType: dbType})
 	return driverWithHooks

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -107,13 +107,14 @@ type LockCfg struct {
 type dialectFunc func() Dialect
 
 var supportedDialects = map[string]dialectFunc{
-	MySQL:                      NewMysqlDialect,
-	SQLite:                     NewSQLite3Dialect,
-	Postgres:                   NewPostgresDialect,
-	MySQL + "WithHooks":        NewMysqlDialect,
-	MySQL + "ReplicaWithHooks": NewMysqlDialect,
-	SQLite + "WithHooks":       NewSQLite3Dialect,
-	Postgres + "WithHooks":     NewPostgresDialect,
+	MySQL:                         NewMysqlDialect,
+	SQLite:                        NewSQLite3Dialect,
+	Postgres:                      NewPostgresDialect,
+	MySQL + "WithHooks":           NewMysqlDialect,
+	MySQL + "ReplicaWithHooks":    NewMysqlDialect,
+	SQLite + "WithHooks":          NewSQLite3Dialect,
+	Postgres + "WithHooks":        NewPostgresDialect,
+	Postgres + "ReplicaWithHooks": NewPostgresDialect,
 }
 
 func NewDialect(driverName string) Dialect {

--- a/pkg/services/sqlstore/replstore.go
+++ b/pkg/services/sqlstore/replstore.go
@@ -55,7 +55,6 @@ func (rs *ReplStore) nextRepl() *SQLStore {
 	// then increment the index for the next call
 	atomic.AddUint64(&rs.next, 1)
 
-	rs.log.Debug("Using ReadReplica")
 	return selected
 }
 
@@ -92,7 +91,7 @@ func ProvideServiceWithReadReplica(primary *SQLStore, cfg *setting.Cfg,
 	for i, replCfg := range replCfgs {
 		// If the database_instrument_queries feature is enabled, wrap the driver with hooks.
 		if cfg.DatabaseInstrumentQueries {
-			replCfg.Type = WrapDatabaseReplDriverWithHooks(replCfg.Type, i, tracer)
+			replCfg.Type = WrapDatabaseReplDriverWithHooks(replCfg.Type, uint(i), tracer)
 		}
 
 		s, err := newReadOnlySQLStore(cfg, replCfg, features, bus, tracer)

--- a/pkg/services/sqlstore/replstore.go
+++ b/pkg/services/sqlstore/replstore.go
@@ -133,12 +133,14 @@ func newReadOnlySQLStore(cfg *setting.Cfg, dbCfg *DatabaseConfig, features featu
 
 	// When there are multiple read replicas, we append an index to the driver name (ex: mysqlWithHooks11).
 	// Remove the index from the end of the driver name to get the original driver name that xorm and other libraries recognize.
-	reg := regexp.MustCompile("[0-9]+") // any number of digits
-	driverName := reg.ReplaceAllString(s.engine.DriverName(), "")
+	driverName := digitsRegexp.ReplaceAllString(s.engine.DriverName(), "")
 
 	s.dialect = migrator.NewDialect(driverName)
 	return s, nil
 }
+
+// digitsRegexp is used to remove the index from the end of the driver name.
+var digitsRegexp = regexp.MustCompile("[0-9]+")
 
 // initReadOnlyEngine initializes ss.engine for read-only operations. The database must be a fully-populated read replica.
 func (ss *SQLStore) initReadOnlyEngine(engine *xorm.Engine) error {


### PR DESCRIPTION
The driver name ( mysql, mysqlWithHooks) is used both as a unique name for metrics, and the key to the map of supported driver types. This was weird enough when I added the read replica, and needed to add a "Repl" version of each driver to the map, and it got messier when I tried to add support for multiple replicas. Instead of continually adding to a map, I added a replica number to the end of the driver name, and - in the replstore's `initReadOnlyEngine` only - added a regex to strip the numbers out of the driver name when using it to look up what driver type should be used. 