### PR TITLE
Alerting: Improve logging in scheduler and states

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -333,8 +333,10 @@ func ParseStateString(repr string) (State, error) {
 func buildDatasourceHeaders(ctx context.Context, metadata map[string]string) map[string]string {
 	headers := make(map[string]string, len(metadata)+3)
 
-	for key, value := range metadata {
-		headers[fmt.Sprintf("http_X-Rule-%s", key)] = url.QueryEscape(value)
+	if len(metadata) > 0 {
+		for key, value := range metadata {
+			headers[fmt.Sprintf("http_X-Rule-%s", key)] = url.QueryEscape(value)
+		}
 	}
 
 	// Many data sources check this in query method as sometimes alerting needs special considerations.

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -252,6 +252,7 @@ func (a *alertRule) Run() error {
 			}
 			f := ctx.Fingerprint()
 			logger := a.logger.New("version", ctx.rule.Version, "fingerprint", f, "now", ctx.scheduledAt)
+			logger.Debug("Processing tick")
 
 			func() {
 				orgID := fmt.Sprint(a.key.OrgID)
@@ -308,13 +309,13 @@ func (a *alertRule) Run() error {
 						logger.Error("Skip evaluation and updating the state because the context has been cancelled", "version", ctx.rule.Version, "fingerprint", f, "attempt", attempt, "now", ctx.scheduledAt)
 						return
 					}
-					logger.Debug("Start evaluating rule", "attempt", attempt)
 					retry := attempt < a.maxAttempts
 					err := a.evaluate(tracingCtx, ctx, span, retry, logger)
 					// This is extremely confusing - when we exhaust all retry attempts, or we have no retryable errors
 					// we return nil - so technically, this is meaningless to know whether the evaluation has errors or not.
 					span.End()
 					if err == nil {
+						logger.Debug("Tick processed", "attempt", attempt, "duration", a.clock.Now().Sub(evalStart))
 						return
 					}
 

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -353,7 +353,7 @@ func (a *alertRule) evaluate(ctx context.Context, f fingerprint, attempt int64, 
 	processDuration := a.metrics.ProcessDuration.WithLabelValues(orgID)
 	sendDuration := a.metrics.SendDuration.WithLabelValues(orgID)
 
-	logger := a.logger.FromContext(ctx).New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt).FromContext(ctx)
+	logger := a.logger.FromContext(ctx).New("version", e.rule.Version, "fingerprint", f, "attempt", attempt, "now", e.scheduledAt)
 	start := a.clock.Now()
 
 	evalCtx := eval.NewContextWithPreviousResults(ctx, SchedulerUserFor(e.rule.OrgID), a.newLoadedMetricsReader(e.rule))

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -309,7 +309,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 		}
 
 		if isReadyToRun {
-			logger.Debug("Rule is ready to run on the current tick", "tick", tickNum, "frequency", itemFrequency, "offset", offset)
+			logger.Debug("Rule is ready to run on the current tick", "tick", tick, "frequency", itemFrequency, "offset", offset)
 			readyToRun = append(readyToRun, readyToRunItem{ruleRoutine: ruleRoutine, Evaluation: Evaluation{
 				scheduledAt: tick,
 				rule:        item,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -358,7 +358,7 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 				return
 			}
 			if dropped != nil {
-				sch.log.Warn("Tick dropped because alert rule evaluation is too slow", append(key.LogContext(), "time", tick)...)
+				sch.log.Warn("Tick dropped because alert rule evaluation is too slow", append(key.LogContext(), "time", tick, "droppedTick", dropped.scheduledAt)...)
 				orgID := fmt.Sprint(key.OrgID)
 				sch.metrics.EvaluationMissed.WithLabelValues(orgID, item.rule.Title).Inc()
 			}

--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -95,8 +95,15 @@ func (h *AnnotationBackend) Record(ctx context.Context, rule history_model.RuleM
 		defer cancel()
 		defer close(errCh)
 		logger := h.log.FromContext(ctx)
+		logger.Debug("Saving state history batch", "samples", len(annotations))
 
-		errCh <- h.store.Save(ctx, panel, annotations, rule.OrgID, logger)
+		err := h.store.Save(ctx, panel, annotations, rule.OrgID, logger)
+		if err != nil {
+			logger.Error("Failed to save history batch", len(annotations), "err", err)
+			errCh <- err
+			return
+		}
+		logger.Debug("Done saving history batch", "samples", len(annotations))
 	}(writeCtx)
 	return errCh
 }

--- a/pkg/services/ngalert/state/historian/annotation_store.go
+++ b/pkg/services/ngalert/state/historian/annotation_store.go
@@ -47,13 +47,10 @@ func (s *AnnotationServiceStore) Save(ctx context.Context, panel *PanelKey, anno
 	s.metrics.WritesTotal.WithLabelValues(org, "annotations").Inc()
 	s.metrics.TransitionsTotal.WithLabelValues(org).Add(float64(len(annotations)))
 	if err := s.svc.SaveMany(ctx, annotations); err != nil {
-		logger.Error("Error saving alert annotation batch", "error", err)
 		s.metrics.WritesFailed.WithLabelValues(org, "annotations").Inc()
 		s.metrics.TransitionsFailed.WithLabelValues(org).Add(float64(len(annotations)))
 		return fmt.Errorf("error saving alert annotation batch: %w", err)
 	}
-
-	logger.Debug("Done saving alert annotation batch")
 	return nil
 }
 

--- a/pkg/services/ngalert/state/persister_sync.go
+++ b/pkg/services/ngalert/state/persister_sync.go
@@ -52,8 +52,8 @@ func (a *SyncStatePersister) deleteAlertStates(ctx context.Context, states []Sta
 	if a.store == nil || len(states) == 0 {
 		return
 	}
-
-	a.log.Debug("Deleting alert states", "count", len(states))
+	logger := a.log.FromContext(ctx)
+	logger.Debug("Deleting alert states", "count", len(states))
 	toDelete := make([]ngModels.AlertInstanceKey, 0, len(states))
 
 	for _, s := range states {
@@ -67,7 +67,7 @@ func (a *SyncStatePersister) deleteAlertStates(ctx context.Context, states []Sta
 
 	err := a.store.DeleteAlertInstances(ctx, toDelete...)
 	if err != nil {
-		a.log.Error("Failed to delete stale states", "error", err)
+		logger.Error("Failed to delete stale states", "error", err)
 	}
 }
 
@@ -75,7 +75,7 @@ func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...Stat
 	if a.store == nil || len(states) == 0 {
 		return
 	}
-
+	logger := a.log.FromContext(ctx)
 	saveState := func(ctx context.Context, idx int) error {
 		s := states[idx]
 
@@ -91,7 +91,7 @@ func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...Stat
 
 		key, err := s.GetAlertInstanceKey()
 		if err != nil {
-			a.log.Error("Failed to create a key for alert state to save it to database. The state will be ignored ", "cacheID", s.CacheID, "error", err, "labels", s.Labels.String())
+			logger.Error("Failed to create a key for alert state to save it to database. The state will be ignored ", "cacheID", s.CacheID, "error", err, "labels", s.Labels.String())
 			return nil
 		}
 		instance := ngModels.AlertInstance{
@@ -108,14 +108,14 @@ func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...Stat
 
 		err = a.store.SaveAlertInstance(ctx, instance)
 		if err != nil {
-			a.log.Error("Failed to save alert state", "labels", s.Labels.String(), "state", s.State, "error", err)
+			logger.Error("Failed to save alert state", "labels", s.Labels.String(), "state", s.State, "error", err)
 			return nil
 		}
 		return nil
 	}
 
 	start := time.Now()
-	a.log.Debug("Saving alert states", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency)
+	logger.Debug("Saving alert states", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency)
 	_ = concurrency.ForEachJob(ctx, len(states), a.maxStateSaveConcurrency, saveState)
-	a.log.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency, "duration", time.Since(start))
+	logger.Debug("Saving alert states done", "count", len(states), "max_state_save_concurrency", a.maxStateSaveConcurrency, "duration", time.Since(start))
 }


### PR DESCRIPTION
**What is this feature?**
- This PR cleans up usage of logging context in scheduler's alert rule evaluator.
- Adds a new log message "Processing tick" that indicates that the tick started to be processed.
- Adds a new log message "Tick processed" that includes duration of the operation.
- Adds a new log message "Sending transitions to notifier" that indicates the fact that state management was done and states are sent to notifier.

- Updates logging in persister to load info from context
- Updates historian implementations to log when operation starts and ends. Moved some logging from storage implementation to be consistent when storage is overridden.


Misc:
- buildDatasourceHeaders is updated to accept null map.

**Why do we need this feature?**
Avoid duplicated labels in log context