### PR TITLE
Docs: edit e2e style guides (part 10 of doc improvement project)

### DIFF
--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -10,7 +10,7 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
 
 1. Add a new directory with the same name as your plugin at [`https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e). This is where your plugin tests are kept.
 
-1. In the [Playwright configuration file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` subdirectory matches the name of the directory that contains your plugin tests.
+1. In the [Playwright configuration file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` subdirectory match the name of the directory that contains your plugin tests.
 
 1. Add `'authenticate'` to the list of dependencies and specifying `'playwright/.auth/admin.json'` as a storage state to ensure that all tests in your project start already authenticated as an admin user. 
 

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -1,6 +1,6 @@
 # E2E tests for plugins
 
-Grafana provides the [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) tool for testing end-to-end Grafana plugins. The `@grafana/plugin-e2e` tool extends [`@playwright/test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers to simplify plugin development. 
+Grafana provides the [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) tool for testing end-to-end Grafana plugins. The `@grafana/plugin-e2e` tool extends [`@playwright/test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers to simplify plugin development.
 
 You can use the tool to enable comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. For information on how to get started with plugin end-to-end testing and Playwright, refer to the [E2E Get started](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/get-started) guide.
 
@@ -12,7 +12,7 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
 
 1. In the [Playwright configuration file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` subdirectory match the name of the directory that contains your plugin tests.
 
-1. Add `'authenticate'` to the list of dependencies and specify `'playwright/.auth/admin.json'` as a storage state to ensure that all tests in your project start already authenticated as an admin user. 
+1. Add `'authenticate'` to the list of dependencies and specify `'playwright/.auth/admin.json'` as a storage state to ensure that all tests in your project start already authenticated as an admin user.
 
    ```ts
    {
@@ -26,7 +26,7 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
     },
    ```
 
-    > **Note:** If you want to use a different role or test RBAC for some of your tests, refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
+   > **Note:** If you want to use a different role or test RBAC for some of your tests, refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
 
 1. Update the [`CODEOWNERS`](https://github.com/grafana/grafana/blob/main/.github/CODEOWNERS/#L315) file so that your team is specified as the owner of the tests in the directory you previously added in step 1.
 
@@ -38,4 +38,4 @@ The `yarn e2e:playwright` script assumes that you have Grafana running on `local
 
 - `HOST=127.0.0.1 PORT=3001 yarn e2e:playwright`
 
-The `yarn e2e:playwright:server` command  starts a Grafana [development server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) on port `3001` and runs the Playwright tests. This development server is provisioned with the [devenv](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#add-data-sources) dashboards, data sources, and apps.
+The `yarn e2e:playwright:server` command starts a Grafana [development server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) on port `3001` and runs the Playwright tests. This development server is provisioned with the [devenv](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#add-data-sources) dashboards, data sources, and apps.

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -26,7 +26,7 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
     },
    ```
 
-    > **Note:** If you want to use a different role for and perhaps test RBAC for some of your tests, refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
+    > **Note:** If you want to use a different role or test RBAC for some of your tests, refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
 
 1. Update the [`CODEOWNERS`](https://github.com/grafana/grafana/blob/main/.github/CODEOWNERS/#L315) file so that your team is specified as the owner of the tests in the directory you previously added in step 1.
 

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -12,7 +12,7 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
 
 1. In the [Playwright configuration file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` subdirectory match the name of the directory that contains your plugin tests.
 
-1. Add `'authenticate'` to the list of dependencies and specifying `'playwright/.auth/admin.json'` as a storage state to ensure that all tests in your project start already authenticated as an admin user. 
+1. Add `'authenticate'` to the list of dependencies and specify `'playwright/.auth/admin.json'` as a storage state to ensure that all tests in your project start already authenticated as an admin user. 
 
    ```ts
    {

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -1,16 +1,18 @@
-# end-to-end tests for plugins
+# E2E tests for plugins
 
-When end-to-end testing Grafana plugins, it's recommended to use the [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) testing tool. `@grafana/plugin-e2e` extends [`@playwright/test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers; enabling comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. For information on how to get started with Plugin end-to-end testing and Playwright, checkout the [Get started](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/get-started) guide.
+Grafana provides the [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) tool for testing end-to-end Grafana plugins. The `@grafana/plugin-e2e` tool extends [`@playwright/test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers to simplify plugin development. 
 
-## Adding end-to-end tests for a core plugin
+You can use the tool to enable comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. For information on how to get started with plugin end-to-end testing and Playwright, refer to the [E2E Get started](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/get-started) guide.
 
-Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e) directory.
+## Add end-to-end tests for a core plugin
 
-1. Add a new directory that has the name as your plugin [`here`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e). This is where your plugin tests will be kept.
+Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e) directory in a specific _project_. In Playwright's terminology, [projects](https://playwright.dev/docs/test-projects) are logical groupings of tests. All tests in a Playwright project share the same configuration.
 
-2. Playwright uses [projects](https://playwright.dev/docs/test-projects) to logically group tests together. All tests in a project share the same configuration.
-   In the [Playwright config file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` sub directory matches the name of the directory that contains your plugin tests.
-   Adding `'authenticate'` to the list of dependencies and specifying `'playwright/.auth/admin.json'` as storage state will ensure all tests in your project will start already authenticated as an admin user. If you wish to use a different role for and perhaps test RBAC for some of your tests, please refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
+1. Add a new directory with the same name as your plugin at [`https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e`](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e). This is where your plugin tests are kept.
+
+1. In the [Playwright configuration file](https://github.com/grafana/grafana/blob/main/playwright.config.ts), add a new project item. Make sure the `name` and the `testDir` subdirectory matches the name of the directory that contains your plugin tests.
+
+1. Add `'authenticate'` to the list of dependencies and specifying `'playwright/.auth/admin.json'` as a storage state to ensure that all tests in your project start already authenticated as an admin user. 
 
    ```ts
    {
@@ -24,14 +26,16 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
     },
    ```
 
-3. Update the [CODEOWNERS](https://github.com/grafana/grafana/blob/main/.github/CODEOWNERS/#L315) file so that your team is owner of the tests in the directory you added in step 1.
+    > **Note:** If you want to use a different role for and perhaps test RBAC for some of your tests, refer to the plugin-e2e [documentation](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication).
 
-## Commands
+1. Update the [`CODEOWNERS`](https://github.com/grafana/grafana/blob/main/.github/CODEOWNERS/#L315) file so that your team is specified as the owner of the tests in the directory you previously added in step 1.
 
-- `yarn e2e:playwright` will run all Playwright tests. Optionally, you can provide the `--project mysql` argument to run tests in a certain project.
+## E2E test commands
 
-The script above assumes you have Grafana running on `localhost:3000`. You may change this by providing environment variables.
+The `yarn e2e:playwright` command runs all Playwright tests. Optionally, you can provide the `--project mysql` argument to run tests in a specific project.
 
-`HOST=127.0.0.1 PORT=3001 yarn e2e:playwright`
+The `yarn e2e:playwright` script assumes that you have Grafana running on `localhost:3000`. You may change the host by supplying environment variables. For example:
 
-- `yarn e2e:playwright:server` will start a Grafana [development server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) on port 3001 and run the Playwright tests. The development server is provisioned with the [devenv](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#add-data-sources) dashboards, data sources and apps.
+- `HOST=127.0.0.1 PORT=3001 yarn e2e:playwright`
+
+The `yarn e2e:playwright:server` command  starts a Grafana [development server](https://github.com/grafana/grafana/blob/main/scripts/grafana-server/start-server) on port `3001` and runs the Playwright tests. This development server is provisioned with the [devenv](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#add-data-sources) dashboards, data sources, and apps.

--- a/contribute/style-guides/e2e-plugins.md
+++ b/contribute/style-guides/e2e-plugins.md
@@ -34,7 +34,7 @@ Playwright end-to-end tests for plugins should be added to the [`e2e/plugin-e2e`
 
 The `yarn e2e:playwright` command runs all Playwright tests. Optionally, you can provide the `--project mysql` argument to run tests in a specific project.
 
-The `yarn e2e:playwright` script assumes that you have Grafana running on `localhost:3000`. You may change the host by supplying environment variables. For example:
+The `yarn e2e:playwright` script assumes that you have Grafana running on `localhost:3000`. You can change the host by supplying environment variables. For example:
 
 - `HOST=127.0.0.1 PORT=3001 yarn e2e:playwright`
 

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -6,7 +6,7 @@ Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built
 
 ## Framework structure
 
-Grafana end-to-end tests generally store all element identifiers ([CSS selectors](https://mdn.io/docs/Web/CSS/CSS_Selectors)) within the test framework for reuse and maintainability.
+Grafana end-to-end tests generally store all element identifiers ([CSS selectors](https://mdn.io/docs/Web/CSS/CSS_Selectors)) in the test framework for reuse and maintainability.
 
 We use a framework structure inspired by https://martinfowler.com/bliki/PageObject.html. The key features of this structure include:
 

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -1,74 +1,69 @@
-# End-to-End tests
+# E2E tests
 
-Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests.
+Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests. 
 
-Important notes:
-
-- We generally store all element identifiers ([CSS selectors](https://mdn.io/docs/Web/CSS/CSS_Selectors)) within the framework for reuse and maintainability.
-- We generally do not use stubs or mocks as to fully simulate a real user.
-- Cypress' promises [do not behave as you'd expect](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Mixing-Async-and-Sync-code).
-- [Testing core Grafana](e2e-core.md) is different than [testing plugins](e2e-plugins.md) - core Grafana uses Cypress whereas plugins use [Playwright test](https://playwright.dev/).
+> **Note:** Grafana plugins are tested differently. Plugins should be tested with a different [solution](e2e-plugins.md) that uses [Playwright](https://playwright.dev/).
 
 ## Framework structure
 
-Inspired by https://martinfowler.com/bliki/PageObject.html
+Grafana end-to-end tests generally store all element identifiers ([CSS selectors](https://mdn.io/docs/Web/CSS/CSS_Selectors)) within the test framework for reuse and maintainability.
 
-- `Selector`: A unique identifier that is used from the E2E framework to retrieve an element from the Browser
-- `Page`: An abstraction for an object that contains one or more `Selectors` with `visit` function to navigate to the page.
-- `Component`: An abstraction for an object that contains one or more `Selectors` but without `visit` function
-- `Flow`: An abstraction that contains a sequence of actions on one or more `Pages` that can be reused and shared between tests
+We use a framework structure inspired by https://martinfowler.com/bliki/PageObject.html. The key features of this structure include:
 
-## Basic example
+- `Selector`: A unique identifier that is used from the end-to-end framework to retrieve an element from the browser.
+- `Page`: An abstraction for an object that contains one or more `Selectors` with a `visit` function to navigate to the page.
+- `Component`: An abstraction for an object that contains one or more `Selectors` but without the `visit` function.
+- `Flow`: An abstraction that contains a sequence of actions on one or more `Pages` that can be reused and shared between tests.
 
-Let's start with a simple [JSX](https://reactjs.org/docs/introducing-jsx.html) example containing a single input field that we want to populate during our E2E test:
+## Basic JSX example
+
+Let's start with a simple [JSX](https://reactjs.org/docs/introducing-jsx.html) example with a single input field that we want to populate during our end-to-end test:
 
 ```jsx
 <input className="gf-form-input login-form-input" type="text" />
 ```
 
-We _could_ target the field with a CSS selector like `.gf-form-input.login-form-input` but that would be brittle as style changes occur frequently. Furthermore there is nothing that signals to future developers that this input is part of an E2E test. At Grafana, we use `data-testid` attributes as our preferred way of defining selectors. See [Aria-Labels vs data-testid](#aria-labels-vs-data-testid) for more details.
+You can target the field with a CSS selector like `.gf-form-input.login-form-input`, but that is a brittle solution because style changes occur frequently. Furthermore, there is nothing that signals to future developers that this input is part of an E2E test. Accordingly, it is a best practice to use `data-testid` attributes as the preferred way to define selectors. Refer to [Aria-Labels vs `data-testid`](#aria-labels-vs-data-testid) for more details.
 
-```jsx
-<input data-testid="Username input field" className="gf-form-input login-form-input" type="text" />
-```
+1. Use the`data-testid` attribute to define the CSS selectors:
 
-The next step is to create a `Page` representation in our E2E framework to glue the test with the real implementation using the `pageFactory` function. For that function we can supply a `url` and `selectors` like in the example below:
+    ```jsx
+    <input data-testid="Username input field" className="gf-form-input login-form-input" type="text" />
+    ```
 
-```typescript
-export const Login = {
-  // Called via `Login.visit()`
-  url: '/login',
-  // Called via `Login.username()`
-  username: 'data-testid Username input field',
-};
-```
+1. Create a `Page` representation in our E2E framework to glue the test with the real implementation using the `pageFactory` function. For that function, we can supply a `url` and `selectors` like in the example below:
 
-Note that the selector is prefixed with `data-testid` - this is a signal to the framework to look for the selector in the `data-testid` attribute.
+    ```typescript
+    export const Login = {
+      // Call via `Login.visit()`
+      url: '/login',
+      // Call via `Login.username()`
+      username: 'data-testid Username input field',
+    };
+    ```
 
-The next step is to add the `Login` page to the `Pages` export within [_\<repo-root>/packages/grafana-e2e-selectors/src/selectors/pages.ts_](../../packages/grafana-e2e-selectors/src/selectors/pages.ts) so that it appears when we type `e2e.pages` in our IDE.
+    > **Note:** the selector is prefixed with `data-testid`. This attribute is a signal to the framework to look for the selector in `data-testid`.
 
-```typescript
-export const Pages = {
-  Login,
-  …,
-  …,
-  …,
-};
-```
+1. Add the `Login` page to the `Pages` export within [_\<repo-root>/packages/grafana-e2e-selectors/src/selectors/pages.ts_](../../packages/grafana-e2e-selectors/src/selectors/pages.ts) so that it appears when we type `e2e.pages` in our IDE. For example:
 
-Now that we have a `Page` called `Login` in our `Pages` const we can use that to add a selector in our html like shown below and now this really signals to future developers that it is part of an E2E test.
+    ```typescript
+    export const Pages = {
+      Login,
+      …,
+      …,
+      …,
+    };
+    ```
 
-```jsx
-import { selectors } from '@grafana/e2e-selectors';
+1. Now that we have a `Page` called `Login` in our `Pages` const, you can use that page to add a selector in our HTML like the code shown below. This code now signals to future developers that it is part of an E2E test.
 
-<input data-testid={selectors.pages.Login.username} className="gf-form-input login-form-input" type="text" />;
-```
+    ```jsx
+    import { selectors } from '@grafana/e2e-selectors';
 
-The last step in our example is to use our `Login` page as part of a test.
+    <input data-testid={selectors.pages.Login.username} className="gf-form-input login-form-input" type="text" />;
+    ```
 
-- The `url` property is used whenever we call the `visit` function and is equivalent to the Cypress' [`cy.visit()`](https://docs.cypress.io/api/commands/visit.html#Syntax).
-
-- Any defined selector can be accessed from the `Login` page by invoking it. This is equivalent to the result of the Cypress function [`cy.get(…)`](https://docs.cypress.io/api/commands/get.html#Syntax).
+1. Finally, use our `Login` page as part of a test. Use code similar to the following:
 
 ```typescript
 describe('Login test', () => {
@@ -81,9 +76,11 @@ describe('Login test', () => {
 });
 ```
 
-## Advanced example
+In this example, the `url` property is used whenever we call the `visit` function and is equivalent to the Cypress' [`cy.visit()`](https://docs.cypress.io/api/commands/visit.html#Syntax). Furthermore, you can access any defined selector from the `Login` page by invoking it. This is equivalent to the result of the Cypress function [`cy.get(…)`](https://docs.cypress.io/api/commands/get.html#Syntax).
 
-Let's take a look at an example that uses the same `selector` for multiple items in a list for instance. In this example app we have a list of data sources that we want to click on during an E2E test.
+## Advanced JSX example
+
+Let's take a look at an example app that uses the same `selector` for multiple items in a list. In this example, we have a list of data sources that we want to click on during an E2E test:
 
 ```jsx
 <ul>
@@ -97,97 +94,98 @@ Let's take a look at an example that uses the same `selector` for multiple items
 </ul>
 ```
 
-Just as before in the basic example we'll start by creating a page abstraction using the `pageFactory` function:
+1. Just as before in the basic example, begin by creating a page abstraction using the `pageFactory` function:
 
-```typescript
-export const DataSources = {
-  url: '/datasources',
-  dataSources: (dataSourceName: string) => `data-testid Data source list item ${dataSourceName}`,
-};
-```
+    ```typescript
+    export const DataSources = {
+      url: '/datasources',
+      dataSources: (dataSourceName: string) => `data-testid Data source list item ${dataSourceName}`,
+    };
+    ```
 
-You might have noticed that instead of a simple `string` as the `selector`, we're using a `function` that takes a string parameter as an argument and returns a formatted string using the argument.
+    You might have noticed that instead of a simple string as the selector, we're using a function that takes a string parameter as an argument and returns a formatted string using the argument.
 
-Just as before we need to add the `DataSources` page to the exported const `Pages` in `packages/grafana-e2e-selectors/src/selectors/pages.ts`.
+1. Just as before, add the `DataSources` page to the exported const `Pages` in `packages/grafana-e2e-selectors/src/selectors/pages.ts`.
 
-The next step is to use the `dataSources` selector function as in our example below:
+1. Use the `dataSources` selector function as shown in the following example:
 
-```jsx
-<ul>
-  {dataSources.map(({ id, name }) => (
-    <li className="card-item-wrapper" key={id}>
-      <a className="card-item" href={`datasources/edit/${id}`}>
-        <div className="card-item-name" data-testid={selectors.pages.DataSources.dataSources(name)}>
-          {name}
-        </div>
-      </a>
-    </li>
-  ))}
-</ul>
-```
+    ```jsx
+    <ul>
+      {dataSources.map(({ id, name }) => (
+        <li className="card-item-wrapper" key={id}>
+          <a className="card-item" href={`datasources/edit/${id}`}>
+            <div className="card-item-name" data-testid={selectors.pages.DataSources.dataSources(name)}>
+              {name}
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+    ```
 
-When this list is rendered with the data sources with names `A`, `B` and `C` ,the resulting HTML would look like:
+    When this list is rendered with the data sources names of `A`, `B` and `C`, the resulting HTML looks like this:
 
-```html
-<div class="card-item-name" data-testid="data-testid Data source list item A">A</div>
-<div class="card-item-name" data-testid="data-testid Data source list item B">B</div>
-<div class="card-item-name" data-testid="data-testid Data source list item C">C</div>
-```
+    ```html
+    <div class="card-item-name" data-testid="data-testid Data source list item A">A</div>
+    <div class="card-item-name" data-testid="data-testid Data source list item B">B</div>
+    <div class="card-item-name" data-testid="data-testid Data source list item C">C</div>
+    ```
 
-Now we can write our test. The one thing that differs from the [basic example](#basic-example) above is that we pass in which data source we want to click on as an argument to the selector function:
+1. Pass in the name of the data source we want to select as an argument to the selector function:
 
-```typescript
-describe('List test', () => {
-  it('clicks on data source named B', () => {
-    e2e.pages.DataSources.visit();
-    // To prevent flaky tests, always do a .should on any selector that you expect to be in the DOM.
-    // Read more here: https://docs.cypress.io/guides/core-concepts/retry-ability.html#Commands-vs-assertions
-    e2e.pages.DataSources.dataSources('B').should('be.visible').click();
-  });
-});
-```
+    ```typescript
+    describe('List test', () => {
+      it('clicks on data source named B', () => {
+        e2e.pages.DataSources.visit();
+        // To prevent flaky tests, always do a .should on any selector that you expect to be in the DOM.
+        // Read more here: https://docs.cypress.io/guides/core-concepts/retry-ability.html#Commands-vs-assertions
+        e2e.pages.DataSources.dataSources('B').should('be.visible').click();
+      });
+    });
+    ```
 
-## Aria-Labels vs data-testid
+## The aria-label attribute vs. data-testid attribute
 
-Our selectors are set up to work with both aria-labels and data-testid attributes. Aria-labels help assistive technologies such as screenreaders identify interactive elements of a page for our users.
+Our selectors are set up to work with both `aria-label` attributes and `data-testid` attributes. An `aria-label` helps assistive technologies such as screen readers identify interactive elements of a page for users.
 
-A good example of a time to use an aria-label might be if you have a button with an X to close:
+A good example of a time to use an aria-label is if you have a button with an "X" to close:
 
 ```
 <button aria-label="close">X<button>
 ```
 
-It might be clear visually that the X closes the modal, but audibly it would not be clear for example.
+Although it might be clear visually that the "X" closes the modal, audibly it may not be clear. For example.
 
 ```
 <button aria-label="close">Close<button>
 ```
 
-The example might read aloud to a user as "Close, Close" or something similar.
+In this example, the label might be read aloud to a user as "Close, Close" or something similar.
 
-However adding aria-labels to elements that are already clearly labeled or not interactive can be confusing and redundant for users with assistive technologies.
+However, adding an `aria-label` to elements that are already clearly labeled or not interactive can be confusing and redundant for users with assistive technologies.
 
-In such cases rather than adding unnecessary aria-labels to components so as to make them selectable for testing, it is preferable to use a data attribute that would not be read aloud with an assistive technology for example:
+In such cases, don't add an unnecessary `aria-label` to components so as to make them selectable for testing. Instead, use a `data-testid` attribute that is not read aloud with an assistive technology. For example:
 
-```
-<button data-testid="modal-close-button">Close<button>
-```
+    ```typescript
+    <button data-testid="modal-close-button">Close<button>
+    ```
 
-We have added support for this in our selectors, to use:
+1. Prefix your selector string with `data-testid`:
 
-Prefix your selector string with "data-testid":
+    ```typescript
+    export const Components = {
+      Login: {
+        openButton: 'open-button', // this looks for an aria-label
+        closeButton: 'data-testid modal-close-button', // this looks for a data-testid
+      },
+    };
+    ```
 
-```typescript
-export const Components = {
-  Login: {
-    openButton: 'open-button', // this would look for an aria-label
-    closeButton: 'data-testid modal-close-button', // this would look for a data-testid
-  },
-};
-```
+1. In your component, import the selectors and add the `data-testid`:
 
-and in your component, import the selectors and add the data test id:
+    ```
+    <button data-testid={Selectors.Components.Login.closeButton}>
+    ```
+## See also
 
-```
-<button data-testid={Selectors.Components.Login.closeButton}>
-```
+If you are unfamiliar with the use of promises in Cypress, refer to [Cypress' documentation](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Mixing-Async-and-Sync-code). They don't work as you would probably expect.

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -1,6 +1,6 @@
 # E2E tests
 
-Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests. 
+Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests.
 
 > **Note:** Grafana plugins are tested differently. Test them with a different [solution](e2e-plugins.md) that uses [Playwright](https://playwright.dev/).
 
@@ -27,41 +27,41 @@ You can target the field with a CSS selector like `.gf-form-input.login-form-inp
 
 1. Use the`data-testid` attribute to define the CSS selectors:
 
-    ```jsx
-    <input data-testid="Username input field" className="gf-form-input login-form-input" type="text" />
-    ```
+   ```jsx
+   <input data-testid="Username input field" className="gf-form-input login-form-input" type="text" />
+   ```
 
 1. Create a `Page` representation in our E2E framework to glue the test with the real implementation using the `pageFactory` function. For that function, we can supply a `url` and `selectors` like in the example below:
 
-    ```typescript
-    export const Login = {
-      // Call via `Login.visit()`
-      url: '/login',
-      // Call via `Login.username()`
-      username: 'data-testid Username input field',
-    };
-    ```
+   ```typescript
+   export const Login = {
+     // Call via `Login.visit()`
+     url: '/login',
+     // Call via `Login.username()`
+     username: 'data-testid Username input field',
+   };
+   ```
 
-    > **Note:** the selector is prefixed with `data-testid`. This attribute is a signal to the framework to look for the selector in `data-testid`.
+   > **Note:** the selector is prefixed with `data-testid`. This attribute is a signal to the framework to look for the selector in `data-testid`.
 
 1. Add the `Login` page to the `Pages` export within [_\<repo-root>/packages/grafana-e2e-selectors/src/selectors/pages.ts_](../../packages/grafana-e2e-selectors/src/selectors/pages.ts) so that it appears when we type `e2e.pages` in our IDE. For example:
 
-    ```typescript
-    export const Pages = {
-      Login,
-      …,
-      …,
-      …,
-    };
-    ```
+   ```typescript
+   export const Pages = {
+     Login,
+     …,
+     …,
+     …,
+   };
+   ```
 
 1. Now that we have a `Page` called `Login` in our `Pages` const, you can use that page to add a selector in our HTML like the code shown below. This code now signals to future developers that it is part of an E2E test.
 
-    ```jsx
-    import { selectors } from '@grafana/e2e-selectors';
+   ```jsx
+   import { selectors } from '@grafana/e2e-selectors';
 
-    <input data-testid={selectors.pages.Login.username} className="gf-form-input login-form-input" type="text" />;
-    ```
+   <input data-testid={selectors.pages.Login.username} className="gf-form-input login-form-input" type="text" />;
+   ```
 
 1. Finally, use our `Login` page as part of a test. Use code similar to the following:
 
@@ -96,53 +96,53 @@ Let's take a look at an example app that uses the same `selector` for multiple i
 
 1. Just as before in the basic example, begin by creating a page abstraction using the `pageFactory` function:
 
-    ```typescript
-    export const DataSources = {
-      url: '/datasources',
-      dataSources: (dataSourceName: string) => `data-testid Data source list item ${dataSourceName}`,
-    };
-    ```
+   ```typescript
+   export const DataSources = {
+     url: '/datasources',
+     dataSources: (dataSourceName: string) => `data-testid Data source list item ${dataSourceName}`,
+   };
+   ```
 
-    You might have noticed that instead of a simple string as the selector, we're using a function that takes a string parameter as an argument and returns a formatted string using the argument.
+   You might have noticed that instead of a simple string as the selector, we're using a function that takes a string parameter as an argument and returns a formatted string using the argument.
 
 1. Just as before, add the `DataSources` page to the exported const `Pages` in `packages/grafana-e2e-selectors/src/selectors/pages.ts`.
 
 1. Use the `dataSources` selector function as shown in the following example:
 
-    ```jsx
-    <ul>
-      {dataSources.map(({ id, name }) => (
-        <li className="card-item-wrapper" key={id}>
-          <a className="card-item" href={`datasources/edit/${id}`}>
-            <div className="card-item-name" data-testid={selectors.pages.DataSources.dataSources(name)}>
-              {name}
-            </div>
-          </a>
-        </li>
-      ))}
-    </ul>
-    ```
+   ```jsx
+   <ul>
+     {dataSources.map(({ id, name }) => (
+       <li className="card-item-wrapper" key={id}>
+         <a className="card-item" href={`datasources/edit/${id}`}>
+           <div className="card-item-name" data-testid={selectors.pages.DataSources.dataSources(name)}>
+             {name}
+           </div>
+         </a>
+       </li>
+     ))}
+   </ul>
+   ```
 
-    When this list is rendered with the data sources names of `A`, `B` and `C`, the resulting HTML looks like this:
+   When this list is rendered with the data sources names of `A`, `B` and `C`, the resulting HTML looks like this:
 
-    ```html
-    <div class="card-item-name" data-testid="data-testid Data source list item A">A</div>
-    <div class="card-item-name" data-testid="data-testid Data source list item B">B</div>
-    <div class="card-item-name" data-testid="data-testid Data source list item C">C</div>
-    ```
+   ```html
+   <div class="card-item-name" data-testid="data-testid Data source list item A">A</div>
+   <div class="card-item-name" data-testid="data-testid Data source list item B">B</div>
+   <div class="card-item-name" data-testid="data-testid Data source list item C">C</div>
+   ```
 
 1. Pass in the name of the data source we want to select as an argument to the selector function:
 
-    ```typescript
-    describe('List test', () => {
-      it('clicks on data source named B', () => {
-        e2e.pages.DataSources.visit();
-        // To prevent flaky tests, always do a .should on any selector that you expect to be in the DOM.
-        // Read more here: https://docs.cypress.io/guides/core-concepts/retry-ability.html#Commands-vs-assertions
-        e2e.pages.DataSources.dataSources('B').should('be.visible').click();
-      });
-    });
-    ```
+   ```typescript
+   describe('List test', () => {
+     it('clicks on data source named B', () => {
+       e2e.pages.DataSources.visit();
+       // To prevent flaky tests, always do a .should on any selector that you expect to be in the DOM.
+       // Read more here: https://docs.cypress.io/guides/core-concepts/retry-ability.html#Commands-vs-assertions
+       e2e.pages.DataSources.dataSources('B').should('be.visible').click();
+     });
+   });
+   ```
 
 ## The aria-label attribute vs. data-testid attribute
 
@@ -172,20 +172,21 @@ In such cases, don't add an unnecessary `aria-label` to components so as to make
 
 1. Prefix your selector string with `data-testid`:
 
-    ```typescript
-    export const Components = {
-      Login: {
-        openButton: 'open-button', // this looks for an aria-label
-        closeButton: 'data-testid modal-close-button', // this looks for a data-testid
-      },
-    };
-    ```
+   ```typescript
+   export const Components = {
+     Login: {
+       openButton: 'open-button', // this looks for an aria-label
+       closeButton: 'data-testid modal-close-button', // this looks for a data-testid
+     },
+   };
+   ```
 
 1. In your component, import the selectors and add the `data-testid`:
 
-    ```
-    <button data-testid={Selectors.Components.Login.closeButton}>
-    ```
+   ```
+   <button data-testid={Selectors.Components.Login.closeButton}>
+   ```
+
 ## See also
 
 If you are unfamiliar with the use of promises in Cypress, refer to [Cypress' documentation](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Mixing-Async-and-Sync-code). They don't work as you would probably expect.

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -188,4 +188,4 @@ In such cases, don't add an unnecessary `aria-label` to components so as to make
     ```
 ## See also
 
-If you are unfamiliar with the use of promises in Cypress, refer to [Cypress' documentation](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Mixing-Async-and-Sync-code). They don't work as you would probably expect.
+If you are unfamiliar with the use of promises in Cypress, refer to [Cypress' documentation](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Mixing-Async-and-Sync-code). 

--- a/contribute/style-guides/e2e.md
+++ b/contribute/style-guides/e2e.md
@@ -2,7 +2,7 @@
 
 Grafana Labs uses a minimal [homegrown solution](../../e2e/utils/index.ts) built on top of [Cypress](https://cypress.io) for its end-to-end (E2E) tests. 
 
-> **Note:** Grafana plugins are tested differently. Plugins should be tested with a different [solution](e2e-plugins.md) that uses [Playwright](https://playwright.dev/).
+> **Note:** Grafana plugins are tested differently. Test them with a different [solution](e2e-plugins.md) that uses [Playwright](https://playwright.dev/).
 
 ## Framework structure
 


### PR DESCRIPTION
What is this feature?

Edit of 2 files sin grafana/contribute for style (Writers' Toolkit guidelines), grammar, and clarity:

- contribute/style-guides/e2e.md
- contribute/style-guides/e2e-plugins.md

Who is this feature for?

All Grafana contributors.

Which issue(s) does this PR fix?:

Fixes https://github.com/grafana/grafana/issues/74629 in part (more PRs to follow)
