### PR TITLE
Alerting: Fix bug where patching recording rule queries wouldn't apply

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -768,7 +768,7 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	if ruleToPatch.Title == "" {
 		ruleToPatch.Title = existingRule.Title
 	}
-	if ruleToPatch.Condition == "" || len(ruleToPatch.Data) == 0 {
+	if !hasAnyCondition(ruleToPatch) || len(ruleToPatch.Data) == 0 {
 		ruleToPatch.Condition = existingRule.Condition
 		ruleToPatch.Data = existingRule.Data
 	}
@@ -872,4 +872,8 @@ func (r *Record) Fingerprint() data.Fingerprint {
 	writeString(r.Metric)
 	writeString(r.From)
 	return data.Fingerprint(h.Sum64())
+}
+
+func hasAnyCondition(rule *AlertRuleWithOptionals) bool {
+	return rule.Condition != "" || (rule.Record != nil && rule.Record.From != "")
 }


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where updating a recording rule query seems to do nothing.

This is because the patch logic only looked at `Condition` like for alert rules, and would skip the update if condition was blank, even if there was data. Condition is blank on all recording rules.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
