### PR TITLE
CloudMigrations: Add a default feedback url

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1967,3 +1967,6 @@ delete_access_policy_timeout = 5s
 domain = grafana.net
 # Folder used to store snapshot files. Defaults to the home dir
 snapshot_folder = ""
+# Link to form to give feedback on the feature
+feedback_url = https://docs.google.com/forms/d/e/1FAIpQLSeEE33vhbSpR8A8S1A1ocZ1ByVRRwiRl1GZr2FSrEer_tSa8w/viewform?usp=sf_link
+

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1898,3 +1898,5 @@ timeout = 30s
 ;domain = grafana-dev.net
 # Folder used to store snapshot files. Defaults to the home dir
 ;snapshot_folder = ""
+# Link to form to give feedback on the feature
+;feedback_url = ""


### PR DESCRIPTION
Sets the default feedback url for the cloud migration feature. Form is currently set to not accept responses.