### PR TITLE
Search: Fix a bug when searching folders under the general folder

### DIFF
--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -103,10 +103,15 @@ func (f FolderUIDFilter) Where() (string, []any) {
 	if includeGeneral {
 		if q == "" {
 			q = "dashboard.folder_id = ? "
+			if f.NestedFoldersEnabled {
+				q = "dashboard.folder_uid IS NULL "
+			}
 		} else {
 			q = "(" + q + " OR dashboard.folder_id = ?)"
+			if f.NestedFoldersEnabled {
+				q = "(" + q + " OR dashboard.folder_uid IS NULL)"
+			}
 		}
-		params = append(params, 0)
 	}
 
 	return q, params

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -102,14 +102,18 @@ func (f FolderUIDFilter) Where() (string, []any) {
 
 	if includeGeneral {
 		if q == "" {
-			q = "dashboard.folder_id = ? "
 			if f.NestedFoldersEnabled {
 				q = "dashboard.folder_uid IS NULL "
+			} else {
+				q = "dashboard.folder_id = ? "
+				params = append(params, 0)
 			}
 		} else {
-			q = "(" + q + " OR dashboard.folder_id = ?)"
 			if f.NestedFoldersEnabled {
 				q = "(" + q + " OR dashboard.folder_uid IS NULL)"
+			} else {
+				q = "(" + q + " OR dashboard.folder_id = ?)"
+				params = append(params, 0)
 			}
 		}
 	}

--- a/pkg/services/sqlstore/searchstore/filters_test.go
+++ b/pkg/services/sqlstore/searchstore/filters_test.go
@@ -57,3 +57,55 @@ func TestFolderUIDFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestFolderUIDFilterWithNestedFoldersEnabled(t *testing.T) {
+	testCases := []struct {
+		description    string
+		uids           []string
+		expectedSql    string
+		expectedParams []any
+	}{
+		{
+			description:    "searching general folder",
+			uids:           []string{"general"},
+			expectedSql:    "dashboard.folder_uid IS NULL ",
+			expectedParams: []any{},
+		},
+		{
+			description:    "searching a specific folder",
+			uids:           []string{"abc-123"},
+			expectedSql:    "dashboard.org_id = ? AND dashboard.folder_uid = ?",
+			expectedParams: []any{int64(1), "abc-123"},
+		},
+		{
+			description:    "searching a specific folders",
+			uids:           []string{"abc-123", "def-456"},
+			expectedSql:    "dashboard.org_id = ? AND dashboard.folder_uid IN (?,?)",
+			expectedParams: []any{int64(1), "abc-123", "def-456"},
+		},
+		{
+			description:    "searching a specific folders or general",
+			uids:           []string{"general", "abc-123", "def-456"},
+			expectedSql:    "(dashboard.org_id = ? AND dashboard.folder_uid IN (?,?) OR dashboard.folder_uid IS NULL)",
+			expectedParams: []any{int64(1), "abc-123", "def-456"},
+		},
+	}
+
+	store := setupTestEnvironment(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			f := searchstore.FolderUIDFilter{
+				Dialect:              store.GetDialect(),
+				OrgID:                1,
+				UIDs:                 tc.uids,
+				NestedFoldersEnabled: true,
+			}
+
+			sql, params := f.Where()
+
+			assert.Equal(t, tc.expectedSql, sql)
+			assert.Equal(t, tc.expectedParams, params)
+		})
+	}
+}

--- a/pkg/services/sqlstore/searchstore/filters_test.go
+++ b/pkg/services/sqlstore/searchstore/filters_test.go
@@ -9,85 +9,67 @@ import (
 
 func TestFolderUIDFilter(t *testing.T) {
 	testCases := []struct {
-		description    string
-		uids           []string
-		expectedSql    string
-		expectedParams []any
+		description          string
+		uids                 []string
+		expectedSql          string
+		expectedParams       []any
+		nestedFoldersEnabled bool
 	}{
 		{
-			description:    "searching general folder",
-			uids:           []string{"general"},
-			expectedSql:    "dashboard.folder_id = ? ",
-			expectedParams: []any{0},
+			description:          "searching general folder",
+			uids:                 []string{"general"},
+			expectedSql:          "dashboard.folder_id = ? ",
+			expectedParams:       []any{0},
+			nestedFoldersEnabled: false,
 		},
 		{
-			description:    "searching a specific folder",
-			uids:           []string{"abc-123"},
-			expectedSql:    "dashboard.folder_id IN (SELECT id FROM dashboard WHERE org_id = ? AND uid = ?)",
-			expectedParams: []any{int64(1), "abc-123"},
+			description:          "searching a specific folder",
+			uids:                 []string{"abc-123"},
+			expectedSql:          "dashboard.folder_id IN (SELECT id FROM dashboard WHERE org_id = ? AND uid = ?)",
+			expectedParams:       []any{int64(1), "abc-123"},
+			nestedFoldersEnabled: false,
 		},
 		{
-			description:    "searching a specific folders",
-			uids:           []string{"abc-123", "def-456"},
-			expectedSql:    "dashboard.folder_id IN (SELECT id FROM dashboard WHERE org_id = ? AND uid IN (?,?))",
-			expectedParams: []any{int64(1), "abc-123", "def-456"},
+			description:          "searching a specific folders",
+			uids:                 []string{"abc-123", "def-456"},
+			expectedSql:          "dashboard.folder_id IN (SELECT id FROM dashboard WHERE org_id = ? AND uid IN (?,?))",
+			expectedParams:       []any{int64(1), "abc-123", "def-456"},
+			nestedFoldersEnabled: false,
 		},
 		{
-			description:    "searching a specific folders or general",
-			uids:           []string{"general", "abc-123", "def-456"},
-			expectedSql:    "(dashboard.folder_id IN (SELECT id FROM dashboard WHERE org_id = ? AND uid IN (?,?)) OR dashboard.folder_id = ?)",
-			expectedParams: []any{int64(1), "abc-123", "def-456", 0},
-		},
-	}
-
-	store := setupTestEnvironment(t)
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			f := searchstore.FolderUIDFilter{
-				Dialect: store.GetDialect(),
-				OrgID:   1,
-				UIDs:    tc.uids,
-			}
-
-			sql, params := f.Where()
-
-			assert.Equal(t, tc.expectedSql, sql)
-			assert.Equal(t, tc.expectedParams, params)
-		})
-	}
-}
-
-func TestFolderUIDFilterWithNestedFoldersEnabled(t *testing.T) {
-	testCases := []struct {
-		description    string
-		uids           []string
-		expectedSql    string
-		expectedParams []any
-	}{
-		{
-			description:    "searching general folder",
-			uids:           []string{"general"},
-			expectedSql:    "dashboard.folder_uid IS NULL ",
-			expectedParams: []any{},
+			description:          "searching a specific folders or general",
+			uids:                 []string{"general", "abc-123", "def-456"},
+			expectedSql:          "(dashboard.folder_id IN (SELECT id FROM dashboard WHERE org_id = ? AND uid IN (?,?)) OR dashboard.folder_id = ?)",
+			expectedParams:       []any{int64(1), "abc-123", "def-456", 0},
+			nestedFoldersEnabled: false,
 		},
 		{
-			description:    "searching a specific folder",
-			uids:           []string{"abc-123"},
-			expectedSql:    "dashboard.org_id = ? AND dashboard.folder_uid = ?",
-			expectedParams: []any{int64(1), "abc-123"},
+			description:          "searching general folder with nestedFoldersEnabled",
+			uids:                 []string{"general"},
+			expectedSql:          "dashboard.folder_uid IS NULL ",
+			expectedParams:       []any{},
+			nestedFoldersEnabled: true,
 		},
 		{
-			description:    "searching a specific folders",
-			uids:           []string{"abc-123", "def-456"},
-			expectedSql:    "dashboard.org_id = ? AND dashboard.folder_uid IN (?,?)",
-			expectedParams: []any{int64(1), "abc-123", "def-456"},
+			description:          "searching a specific folder with nestedFoldersEnabled",
+			uids:                 []string{"abc-123"},
+			expectedSql:          "dashboard.org_id = ? AND dashboard.folder_uid = ?",
+			expectedParams:       []any{int64(1), "abc-123"},
+			nestedFoldersEnabled: true,
 		},
 		{
-			description:    "searching a specific folders or general",
-			uids:           []string{"general", "abc-123", "def-456"},
-			expectedSql:    "(dashboard.org_id = ? AND dashboard.folder_uid IN (?,?) OR dashboard.folder_uid IS NULL)",
-			expectedParams: []any{int64(1), "abc-123", "def-456"},
+			description:          "searching a specific folders with nestedFoldersEnabled",
+			uids:                 []string{"abc-123", "def-456"},
+			expectedSql:          "dashboard.org_id = ? AND dashboard.folder_uid IN (?,?)",
+			expectedParams:       []any{int64(1), "abc-123", "def-456"},
+			nestedFoldersEnabled: true,
+		},
+		{
+			description:          "searching a specific folders or general with nestedFoldersEnabled",
+			uids:                 []string{"general", "abc-123", "def-456"},
+			expectedSql:          "(dashboard.org_id = ? AND dashboard.folder_uid IN (?,?) OR dashboard.folder_uid IS NULL)",
+			expectedParams:       []any{int64(1), "abc-123", "def-456"},
+			nestedFoldersEnabled: true,
 		},
 	}
 
@@ -99,7 +81,7 @@ func TestFolderUIDFilterWithNestedFoldersEnabled(t *testing.T) {
 				Dialect:              store.GetDialect(),
 				OrgID:                1,
 				UIDs:                 tc.uids,
-				NestedFoldersEnabled: true,
+				NestedFoldersEnabled: tc.nestedFoldersEnabled,
 			}
 
 			sql, params := f.Where()


### PR DESCRIPTION
**What is this feature?**

This PR is to fix a bug that will return all matched nested folders when searching folders only under the general folder.

In Grafana v11, I create a few nested folders like the below image: 
<img width="331" alt="image" src="https://github.com/user-attachments/assets/97601f94-6224-493a-b95d-e35ecdfa82ca">


When using the search API to search the folders named 'b' under the general folder, it returns all the folders named 'b', including the folder `b` under the folder `a`. But it should only return one folder under the general folder.
`http://localhost:3000/api/search?query=b&dash=dash-folder&folderUIDs=general`. The result:

```
[
    {
        "id": 2021,
        "uid": "ddswszjpzzoxse",
        "title": "b",
        "uri": "db/b",
        "url": "/dashboards/f/ddswszjpzzoxse/b",
        "slug": "",
        "type": "dash-folder",
        "tags": [],
        "isStarred": false,
        "folderUid": "ddswszbukighsc",
        "folderTitle": "a",
        "sortMeta": 0
    },
    {
        "id": 2022,
        "uid": "adswt078w2dc0d",
        "title": "b",
        "uri": "db/b",
        "url": "/dashboards/f/adswt078w2dc0d/b",
        "slug": "",
        "type": "dash-folder",
        "tags": [],
        "isStarred": false,
        "sortMeta": 0
    }
]
```

I fixed this issue by using the SQL `dashboard.folder_uid is NULL ` when `NestedFoldersEnabled` is enabled in `FolderUIDFilter`, rather than using `dashboard.folder_id = 0`

Please see the `dashboard` table below. When `NestedFoldersEnabled` is enabled, the folder_uid of a nested folder is not null, but its folder_id is still 0.
Thus, it will return all matched nested folders if we use `dashboard.folder_id = 0` to match folders under the general folder.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/f69d5114-6783-4420-9914-a0991bbccab3">


**Why do we need this feature?**

To fix a bug that will return all matched nested folders when searching folders under the general folder.

**Who is this feature for?**

All users using Search API

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
