### PR TITLE
ResourceStore: Fix sql List

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -350,7 +350,8 @@ func (b *backend) listLatest(ctx context.Context, req *resource.ListRequest) (*r
 		ResourceVersion: 0,
 	}
 
-	err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
+	// This transaction is ReadCommitted to ensure we call SELECT .. FOR UPDATE
+	err := b.db.WithTx(ctx, ReadCommitted, func(ctx context.Context, tx db.Tx) error {
 		var err error
 
 		out.ResourceVersion, err = fetchLatestRV(ctx, tx, b.dialect, req.Options.Key.Group, req.Options.Key.Resource)

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -350,8 +350,7 @@ func (b *backend) listLatest(ctx context.Context, req *resource.ListRequest) (*r
 		ResourceVersion: 0,
 	}
 
-	// This transaction is ReadCommitted to ensure we call SELECT .. FOR UPDATE
-	err := b.db.WithTx(ctx, ReadCommitted, func(ctx context.Context, tx db.Tx) error {
+	err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
 		var err error
 
 		out.ResourceVersion, err = fetchLatestRV(ctx, tx, b.dialect, req.Options.Key.Group, req.Options.Key.Resource)
@@ -542,6 +541,7 @@ func fetchLatestRV(ctx context.Context, x db.ContextExecer, d sqltemplate.Dialec
 		SQLTemplate:     sqltemplate.New(d),
 		Group:           group,
 		Resource:        resource,
+		ReadOnly:        true,
 		resourceVersion: new(resourceVersion),
 	})
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/storage/unified/sql/data/resource_version_get.sql
+++ b/pkg/storage/unified/sql/data/resource_version_get.sql
@@ -4,5 +4,7 @@ SELECT
     WHERE 1 = 1
         AND {{ .Ident "group" }}    = {{ .Arg .Group }}
         AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
+    {{ if not .ReadOnly }}
     {{ .SelectFor "UPDATE" }}
+    {{ end}}
 ;

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -189,6 +189,7 @@ func (r *resourceVersion) Results() (*resourceVersion, error) {
 type sqlResourceVersionRequest struct {
 	*sqltemplate.SQLTemplate
 	Group, Resource string
+	ReadOnly        bool
 	*resourceVersion
 }
 

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -268,6 +268,7 @@ func TestQueries(t *testing.T) {
 				Data: &sqlResourceVersionRequest{
 					SQLTemplate:     new(sqltemplate.SQLTemplate),
 					resourceVersion: new(resourceVersion),
+					ReadOnly:        false,
 				},
 				Expected: expected{
 					"resource_version_get_mysql.sql": dialects{


### PR DESCRIPTION
Seeing the following error with RDS. 

> Error 1792 (25006): Cannot execute statement in a READ ONLY transaction.; query: SELECT \"resource_version\"\n    FROM \"resource_version\"\n    WHERE 1 = 1 AND \"group\" = ? AND \"resource\" = ? FOR UPDATE

This happens because we are using "FOR UPDATE" in a read only transaction.