### PR TITLE
E2C: Fix rebuild snapshot not showing while pending upload

### DIFF
--- a/public/app/features/migrate-to-cloud/onprem/MigrationSummary.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/MigrationSummary.tsx
@@ -101,32 +101,34 @@ export function MigrationSummary(props: MigrationSummaryProps) {
         </MigrationInfo>
       </Stack>
 
-      {showBuildSnapshot && (
-        <Button disabled={isBusy} onClick={onBuildSnapshot} icon={buildSnapshotIsLoading ? 'spinner' : undefined}>
-          <Trans i18nKey="migrate-to-cloud.summary.start-migration">Build snapshot</Trans>
-        </Button>
-      )}
+      <Stack gap={2}>
+        {showBuildSnapshot && (
+          <Button disabled={isBusy} onClick={onBuildSnapshot} icon={buildSnapshotIsLoading ? 'spinner' : undefined}>
+            <Trans i18nKey="migrate-to-cloud.summary.start-migration">Build snapshot</Trans>
+          </Button>
+        )}
 
-      {showRebuildSnapshot && (
-        <Button
-          disabled={isBusy}
-          onClick={onBuildSnapshot}
-          icon={buildSnapshotIsLoading ? 'spinner' : undefined}
-          variant="secondary"
-        >
-          <Trans i18nKey="migrate-to-cloud.summary.rebuild-snapshot">Rebuild snapshot</Trans>
-        </Button>
-      )}
+        {showRebuildSnapshot && (
+          <Button
+            disabled={isBusy}
+            onClick={onBuildSnapshot}
+            icon={buildSnapshotIsLoading ? 'spinner' : undefined}
+            variant="secondary"
+          >
+            <Trans i18nKey="migrate-to-cloud.summary.rebuild-snapshot">Rebuild snapshot</Trans>
+          </Button>
+        )}
 
-      {showUploadSnapshot && (
-        <Button
-          disabled={isBusy || uploadSnapshotIsLoading}
-          onClick={onUploadSnapshot}
-          icon={uploadSnapshotIsLoading ? 'spinner' : undefined}
-        >
-          <Trans i18nKey="migrate-to-cloud.summary.upload-migration">Upload snapshot</Trans>
-        </Button>
-      )}
+        {showUploadSnapshot && (
+          <Button
+            disabled={isBusy || uploadSnapshotIsLoading}
+            onClick={onUploadSnapshot}
+            icon={uploadSnapshotIsLoading ? 'spinner' : undefined}
+          >
+            <Trans i18nKey="migrate-to-cloud.summary.upload-migration">Upload snapshot</Trans>
+          </Button>
+        )}
+      </Stack>
     </Box>
   );
 }

--- a/public/app/features/migrate-to-cloud/onprem/MigrationSummary.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/MigrationSummary.tsx
@@ -63,7 +63,7 @@ export function MigrationSummary(props: MigrationSummaryProps) {
       alignItems="center"
       justifyContent="space-between"
     >
-      <Stack gap={4} wrap="wrap">
+      <Stack gap={4} wrap>
         <MigrationInfo title={t('migrate-to-cloud.summary.snapshot-date', 'Snapshot timestamp')}>
           {snapshot?.created ? (
             formatDate(snapshot.created, DATE_FORMAT)
@@ -101,7 +101,7 @@ export function MigrationSummary(props: MigrationSummaryProps) {
         </MigrationInfo>
       </Stack>
 
-      <Stack gap={2}>
+      <Stack gap={2} wrap justifyContent="flex-end">
         {showBuildSnapshot && (
           <Button disabled={isBusy} onClick={onBuildSnapshot} icon={buildSnapshotIsLoading ? 'spinner' : undefined}>
             <Trans i18nKey="migrate-to-cloud.summary.start-migration">Build snapshot</Trans>

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -81,11 +81,6 @@ function useGetLatestSnapshot(sessionUid?: string, page = 1) {
     skipPollingIfUnfocused: true,
   });
 
-  // If the GetSnapshot query is still returning cached data for a snapshot that's no longer the latest,
-  // consider it as 'stale' and don't show it
-  const snapshotIsStale = snapshotResult.data?.uid !== lastItem?.uid;
-  const snapshotData = snapshotIsStale ? undefined : snapshotResult.data;
-
   useEffect(() => {
     const shouldPoll = SHOULD_POLL_STATUSES.includes(snapshotResult.data?.status);
     setShouldPoll(shouldPoll);
@@ -93,14 +88,13 @@ function useGetLatestSnapshot(sessionUid?: string, page = 1) {
 
   return {
     ...snapshotResult,
-    data: snapshotData,
 
     error: listResult.error || snapshotResult.error,
 
     // isSuccess and isUninitialised should always be from snapshotResult
     // as only the 'final' values from those are important
     isError: listResult.isError || snapshotResult.isError,
-    isLoading: listResult.isLoading || snapshotResult.isLoading || snapshotIsStale,
+    isLoading: listResult.isLoading || snapshotResult.isLoading,
     isFetching: listResult.isFetching || snapshotResult.isFetching,
   };
 }


### PR DESCRIPTION
Fixes an issue where the rebuild snapshot button was not showing when it's pending upload. I had meant for this to work, but I included the wrong status (PENDING_PROCESSING instead of PENDING_UPLOAD).

The loading state while the snapshot is rebuilding isn't ideal - I think the old resources table shows for too long - but fiddling with all the various statuses was just too much for me today 😌. ~~Settled on hiding the table one request earlier (when we know from the ListSnapshots request that the GetSnapshot is invalid)~~. Nope, this was buggy, and didn't even get us much :/

Also improved the layout of the MigrationSummary bar when there's multiple action buttons.

![image](https://github.com/user-attachments/assets/d3203d12-f7f3-4fe9-a20a-5896cd947df3)

Part of https://github.com/grafana/grafana/issues/86861