### PR TITLE
OpenAPI: Fix alerting DeleteMuteTiming errors

### DIFF
--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1315,14 +1315,6 @@
    "title": "Frames is a slice of Frame pointers.",
    "type": "array"
   },
-  "GenericPublicError": {
-   "properties": {
-    "body": {
-     "$ref": "#/definitions/PublicError"
-    }
-   },
-   "type": "object"
-  },
   "GettableAlertmanagers": {
    "properties": {
     "data": {
@@ -4581,7 +4573,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup",
     "type": "object"
@@ -5919,9 +5910,9 @@
       "description": " The mute timing was deleted successfully."
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -5997,9 +5988,9 @@
       }
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -6211,9 +6202,9 @@
       "description": " The template was deleted successfully."
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -6241,9 +6232,9 @@
       }
      },
      "404": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -6286,15 +6277,15 @@
       }
      },
      "400": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -70,7 +70,7 @@ import (
 //     Responses:
 //       202: MuteTimeInterval
 //       400: ValidationError
-//       409: GenericPublicError
+//       409: PublicError
 
 // swagger:route DELETE /v1/provisioning/mute-timings/{name} provisioning stable RouteDeleteMuteTiming
 //
@@ -78,7 +78,7 @@ import (
 //
 //     Responses:
 //       204: description: The mute timing was deleted successfully.
-//       409: GenericPublicError
+//       409: PublicError
 
 // swagger:route
 

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -13,7 +13,7 @@ package definitions
 //
 //     Responses:
 //       200: NotificationTemplate
-//       404: GenericPublicError
+//       404: PublicError
 
 // swagger:route PUT /v1/provisioning/templates/{name} provisioning stable RoutePutTemplate
 //
@@ -24,8 +24,8 @@ package definitions
 //
 //     Responses:
 //       202: NotificationTemplate
-//       400: GenericPublicError
-//       409: GenericPublicError
+//       400: PublicError
+//       409: PublicError
 
 // swagger:route DELETE /v1/provisioning/templates/{name} provisioning stable RouteDeleteTemplate
 //
@@ -33,7 +33,7 @@ package definitions
 //
 //     Responses:
 //       204: description: The template was deleted successfully.
-//       409: GenericPublicError
+//       409: PublicError
 
 // swagger:parameters RouteGetTemplate RoutePutTemplate RouteDeleteTemplate
 type RouteGetTemplateParam struct {

--- a/pkg/services/ngalert/api/tooling/definitions/shared.go
+++ b/pkg/services/ngalert/api/tooling/definitions/shared.go
@@ -20,10 +20,3 @@ type ForbiddenError struct {
 	// in: body
 	Body errutil.PublicError `json:"body"`
 }
-
-// swagger:model
-type GenericPublicError struct {
-	// The response message
-	// in: body
-	Body errutil.PublicError `json:"body"`
-}

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1315,14 +1315,6 @@
    "title": "Frames is a slice of Frame pointers.",
    "type": "array"
   },
-  "GenericPublicError": {
-   "properties": {
-    "body": {
-     "$ref": "#/definitions/PublicError"
-    }
-   },
-   "type": "object"
-  },
   "GettableAlertmanagers": {
    "properties": {
     "data": {
@@ -4316,7 +4308,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -4352,7 +4343,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "UpdateRuleGroupResponse": {
@@ -8130,9 +8121,9 @@
       "description": " The mute timing was deleted successfully."
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -8208,9 +8199,9 @@
       }
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -8422,9 +8413,9 @@
       "description": " The template was deleted successfully."
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -8452,9 +8443,9 @@
       }
      },
      "404": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },
@@ -8497,15 +8488,15 @@
       }
      },
      "400": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      },
      "409": {
-      "description": "GenericPublicError",
+      "description": "PublicError",
       "schema": {
-       "$ref": "#/definitions/GenericPublicError"
+       "$ref": "#/definitions/PublicError"
       }
      }
     },

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3086,9 +3086,9 @@
             }
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -3125,9 +3125,9 @@
             "description": " The mute timing was deleted successfully."
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -3343,9 +3343,9 @@
             }
           },
           "404": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -3389,15 +3389,15 @@
             }
           },
           "400": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -3429,9 +3429,9 @@
             "description": " The template was deleted successfully."
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -4945,14 +4945,6 @@
       "title": "Frames is a slice of Frame pointers.",
       "items": {
         "$ref": "#/definitions/Frame"
-      }
-    },
-    "GenericPublicError": {
-      "type": "object",
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/PublicError"
-        }
       }
     },
     "GettableAlertmanagers": {
@@ -7949,9 +7941,8 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nThe Host field contains the host and port subcomponents of the URL.\nWhen the port is present, it is separated from the host with a colon.\nWhen the host is an IPv6 address, it must be enclosed in square brackets:\n\"[fe80::1]:80\". The [net.JoinHostPort] function combines a host and port\ninto a string suitable for the Host field, adding square brackets to\nthe host when necessary.\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use the [URL.EscapedPath] method, which preserves\nthe original encoding of Path.\n\nThe RawPath field is an optional field which is only set when the default\nencoding of Path is different from the escaped path. See the EscapedPath method\nfor more details.\n\nURL's String method uses the EscapedPath method to obtain the path.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -11498,9 +11498,9 @@
             }
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -11536,9 +11536,9 @@
             "description": " The mute timing was deleted successfully."
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -11747,9 +11747,9 @@
             }
           },
           "404": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -11792,15 +11792,15 @@
             }
           },
           "400": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -11831,9 +11831,9 @@
             "description": " The template was deleted successfully."
           },
           "409": {
-            "description": "GenericPublicError",
+            "description": "PublicError",
             "schema": {
-              "$ref": "#/definitions/GenericPublicError"
+              "$ref": "#/definitions/PublicError"
             }
           }
         }
@@ -15552,14 +15552,6 @@
       "title": "Frames is a slice of Frame pointers.",
       "items": {
         "$ref": "#/definitions/Frame"
-      }
-    },
-    "GenericPublicError": {
-      "type": "object",
-      "properties": {
-        "body": {
-          "$ref": "#/definitions/PublicError"
-        }
       }
     },
     "GetAccessTokenResponseDTO": {
@@ -22165,7 +22157,6 @@
       }
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "type": "object",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -5614,14 +5614,6 @@
         "title": "Frames is a slice of Frame pointers.",
         "type": "array"
       },
-      "GenericPublicError": {
-        "properties": {
-          "body": {
-            "$ref": "#/components/schemas/PublicError"
-          }
-        },
-        "type": "object"
-      },
       "GetAccessTokenResponseDTO": {
         "properties": {
           "createdAt": {
@@ -12224,7 +12216,6 @@
         "type": "object"
       },
       "alertGroups": {
-        "description": "AlertGroups alert groups",
         "items": {
           "$ref": "#/components/schemas/alertGroup"
         },
@@ -25445,11 +25436,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenericPublicError"
+                  "$ref": "#/components/schemas/PublicError"
                 }
               }
             },
-            "description": "GenericPublicError"
+            "description": "PublicError"
           }
         },
         "summary": "Delete a mute timing.",
@@ -25545,11 +25536,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenericPublicError"
+                  "$ref": "#/components/schemas/PublicError"
                 }
               }
             },
-            "description": "GenericPublicError"
+            "description": "PublicError"
           }
         },
         "summary": "Replace an existing mute timing.",
@@ -25874,11 +25865,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenericPublicError"
+                  "$ref": "#/components/schemas/PublicError"
                 }
               }
             },
-            "description": "GenericPublicError"
+            "description": "PublicError"
           }
         },
         "summary": "Delete a template.",
@@ -25914,11 +25905,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenericPublicError"
+                  "$ref": "#/components/schemas/PublicError"
                 }
               }
             },
-            "description": "GenericPublicError"
+            "description": "PublicError"
           }
         },
         "summary": "Get a notification template.",
@@ -25971,21 +25962,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenericPublicError"
+                  "$ref": "#/components/schemas/PublicError"
                 }
               }
             },
-            "description": "GenericPublicError"
+            "description": "PublicError"
           },
           "409": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenericPublicError"
+                  "$ref": "#/components/schemas/PublicError"
                 }
               }
             },
-            "description": "GenericPublicError"
+            "description": "PublicError"
           }
         },
         "summary": "Updates an existing notification template.",


### PR DESCRIPTION
The `GenericPublicError` is not what is actually returned by the API. Using `PublicError` describes the API correctly
