### PR TITLE
DashboardScenes: Default to first variable value when editing a repeated panel

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -812,7 +812,11 @@ describe('VizPanelManager', () => {
     const { scene, panel } = setupTest('panel-10');
 
     scene.setState({
-      $variables: new SceneVariableSet({ variables: [new CustomVariable({ name: 'custom', query: 'A,B,C' })] }),
+      $variables: new SceneVariableSet({
+        variables: [
+          new CustomVariable({ name: 'custom', query: 'A,B,C', value: ['A', 'B', 'C'], text: ['A', 'B', 'C'] }),
+        ],
+      }),
     });
 
     scene.setState({ editPanel: buildPanelEditScene(panel) });

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.test.tsx
@@ -4,7 +4,14 @@ import { DataQueryRequest, DataSourceApi, DataSourceInstanceSettings, LoadingSta
 import { calculateFieldTransformer } from '@grafana/data/src/transformations/transformers/calculateField';
 import { mockTransformationsRegistry } from '@grafana/data/src/utils/tests/mockTransformationsRegistry';
 import { config, locationService } from '@grafana/runtime';
-import { LocalValueVariable, SceneGridRow, SceneVariableSet, VizPanel, sceneGraph } from '@grafana/scenes';
+import {
+  CustomVariable,
+  LocalValueVariable,
+  SceneGridRow,
+  SceneVariableSet,
+  VizPanel,
+  sceneGraph,
+} from '@grafana/scenes';
 import { DataQuery, DataSourceJsonData, DataSourceRef } from '@grafana/schema';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { InspectTab } from 'app/features/inspector/types';
@@ -799,6 +806,22 @@ describe('VizPanelManager', () => {
 
     expect(vizPanelManager.state.datasource).toEqual(ds1Mock);
     expect(vizPanelManager.state.dsSettings).toEqual(instance1SettingsMock);
+  });
+
+  it('Should default to the first variable value if panel is repeated', async () => {
+    const { scene, panel } = setupTest('panel-10');
+
+    scene.setState({
+      $variables: new SceneVariableSet({ variables: [new CustomVariable({ name: 'custom', query: 'A,B,C' })] }),
+    });
+
+    scene.setState({ editPanel: buildPanelEditScene(panel) });
+
+    const vizPanelManager = scene.state.editPanel!.state.vizManager;
+    vizPanelManager.activate();
+
+    const variable = sceneGraph.lookupVariable('custom', vizPanelManager);
+    expect(variable?.getValue()).toBe('A');
   });
 
   describe('Given a panel inside repeated row', () => {

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -15,6 +15,7 @@ import {
 import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
 import {
   DeepPartial,
+  MultiValueVariable,
   PanelBuilders,
   SceneComponentProps,
   SceneDataTransformer,
@@ -23,8 +24,10 @@ import {
   SceneObjectState,
   SceneObjectStateChangedEvent,
   SceneQueryRunner,
+  SceneVariableSet,
   SceneVariables,
   VizPanel,
+  sceneGraph,
 } from '@grafana/scenes';
 import { DataQuery, DataTransformerConfig, Panel } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
@@ -95,6 +98,18 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
 
     if (gridItem.parent?.state.$variables) {
       variables = gridItem.parent.state.$variables.clone();
+    }
+
+    if (!variables && repeatOptions.repeat) {
+      const variable = sceneGraph.lookupVariable(repeatOptions.repeat, gridItem);
+
+      if (variable && variable instanceof MultiValueVariable) {
+        const clonedVar = variable.clone();
+
+        variables = new SceneVariableSet({
+          variables: [clonedVar],
+        });
+      }
     }
 
     return new VizPanelManager({
@@ -266,6 +281,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       queries,
     });
     if (defaultQueries) {
+      console.log('RUN QU 22');
       queryRunner.runQueries();
     }
 
@@ -316,6 +332,7 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     }
 
     dataObj.setState(dataObjStateUpdate);
+    console.log('RUN QUERIES');
     dataObj.runQueries();
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -112,13 +112,10 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           value: values[0],
           text: String(texts[0]),
         });
-        if (!variables) {
-          variables = new SceneVariableSet({
-            variables: [varWithDefaultValue],
-          });
-        } else {
-          variables.state.variables.push(varWithDefaultValue);
-        }
+
+        variables = new SceneVariableSet({
+          variables: [varWithDefaultValue],
+        });
       }
     }
 

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -113,9 +113,13 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
           text: String(texts[0]),
         });
 
-        variables = new SceneVariableSet({
-          variables: [varWithDefaultValue],
-        });
+        if (!variables) {
+          variables = new SceneVariableSet({
+            variables: [varWithDefaultValue],
+          });
+        } else {
+          variables.setState({ variables: [varWithDefaultValue] });
+        }
       }
     }
 

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -100,15 +100,17 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       variables = gridItem.parent.state.$variables.clone();
     }
 
-    if (!variables && repeatOptions.repeat) {
+    if (repeatOptions.repeat) {
       const variable = sceneGraph.lookupVariable(repeatOptions.repeat, gridItem);
 
-      if (variable && variable instanceof MultiValueVariable) {
-        const clonedVar = variable.clone();
-
-        variables = new SceneVariableSet({
-          variables: [clonedVar],
-        });
+      if (variable instanceof MultiValueVariable) {
+        if (!variables) {
+          variables = new SceneVariableSet({
+            variables: [variable.clone()],
+          });
+        } else {
+          variables.state.variables.push(variable.clone());
+        }
       }
     }
 

--- a/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/VizPanelManager.tsx
@@ -281,7 +281,6 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
       queries,
     });
     if (defaultQueries) {
-      console.log('RUN QU 22');
       queryRunner.runQueries();
     }
 
@@ -332,7 +331,6 @@ export class VizPanelManager extends SceneObjectBase<VizPanelManagerState> {
     }
 
     dataObj.setState(dataObjStateUpdate);
-    console.log('RUN QUERIES');
     dataObj.runQueries();
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/testfiles/testDashboard.ts
+++ b/public/app/features/dashboard-scene/panel-edit/testfiles/testDashboard.ts
@@ -91,6 +91,102 @@ export const panelWithQueriesOnly = {
   type: 'timeseries',
 };
 
+export const repeatedPanel = {
+  datasource: {
+    type: 'grafana-testdata-datasource',
+    uid: 'gdev-testdata',
+  },
+  repeat: 'custom',
+  repeatDirection: 'h',
+  maxPerRow: 4,
+  fieldConfig: {
+    defaults: {
+      color: {
+        mode: 'palette-classic',
+      },
+      custom: {
+        axisBorderShow: false,
+        axisCenteredZero: false,
+        axisColorMode: 'text',
+        axisLabel: '',
+        axisPlacement: 'auto',
+        barAlignment: 0,
+        drawStyle: 'line',
+        fillOpacity: 0,
+        gradientMode: 'none',
+        hideFrom: {
+          legend: false,
+          tooltip: false,
+          viz: false,
+        },
+        insertNulls: false,
+        lineInterpolation: 'linear',
+        lineWidth: 1,
+        pointSize: 5,
+        scaleDistribution: {
+          type: 'linear',
+        },
+        showPoints: 'auto',
+        spanNulls: false,
+        stacking: {
+          group: 'A',
+          mode: 'none',
+        },
+        thresholdsStyle: {
+          mode: 'off',
+        },
+      },
+      mappings: [],
+      thresholds: {
+        mode: 'absolute',
+        steps: [
+          {
+            color: 'green',
+            value: null,
+          },
+          {
+            color: 'red',
+            value: 80,
+          },
+        ],
+      },
+    },
+    overrides: [],
+  },
+  gridPos: {
+    h: 8,
+    w: 12,
+    x: 0,
+    y: 0,
+  },
+  id: 1,
+  options: {
+    legend: {
+      calcs: [],
+      displayMode: 'list',
+      placement: 'bottom',
+      showLegend: true,
+    },
+    tooltip: {
+      mode: 'single',
+      sort: 'none',
+    },
+  },
+  targets: [
+    {
+      datasource: {
+        type: 'grafana-testdata-datasource',
+        uid: 'gdev-testdata',
+      },
+      refId: 'A',
+      scenarioId: 'random_walk',
+      seriesCount: 1,
+    },
+  ],
+  title: 'Panel with just queries',
+  type: 'timeseries',
+};
+
 export const panelWithTransformations = {
   datasource: {
     type: 'grafana-testdata-datasource',
@@ -636,6 +732,7 @@ export const testDashboard = {
     panelWithQueriesAndMixedDatasource,
     row,
     rowChild,
+    repeatedPanel,
   ],
   refresh: '',
   schemaVersion: 39,


### PR DESCRIPTION
When using repeated panels, the queries are build properly in the dashboard, each repeated panel using the correct variable value in the query. But when editing the original panel the query is built using all variable values, causing it to return `No Data`. This PR fixes that by cloning the variable at the `VizPanelManager` level and defaulting to the first value so the query runs and shows the correct data for the original panel.

Closes https://github.com/grafana/grafana/issues/91188