### PR TITLE
unifiedStorage: name can be length 1

### DIFF
--- a/pkg/storage/unified/resource/validation.go
+++ b/pkg/storage/unified/resource/validation.go
@@ -9,7 +9,7 @@ var validNameCharPattern = `a-zA-Z0-9\-\_\.`
 var validNamePattern = regexp.MustCompile(`^[` + validNameCharPattern + `]*$`).MatchString
 
 func validateName(name string) error {
-	if len(name) < 1 {
+	if len(name) == 0 {
 		return fmt.Errorf("name is too short")
 	}
 	if len(name) > 64 {

--- a/pkg/storage/unified/resource/validation.go
+++ b/pkg/storage/unified/resource/validation.go
@@ -9,7 +9,7 @@ var validNameCharPattern = `a-zA-Z0-9\-\_\.`
 var validNamePattern = regexp.MustCompile(`^[` + validNameCharPattern + `]*$`).MatchString
 
 func validateName(name string) error {
-	if len(name) < 2 {
+	if len(name) < 1 {
 		return fmt.Errorf("name is too short")
 	}
 	if len(name) > 64 {

--- a/pkg/storage/unified/resource/validation_test.go
+++ b/pkg/storage/unified/resource/validation_test.go
@@ -13,6 +13,7 @@ func TestNameValidation(t *testing.T) {
 	))
 
 	// OK
+	require.NoError(t, validateName("a"))
 	require.NoError(t, validateName("hello-world"))
 	require.NoError(t, validateName("hello.world"))
 	require.NoError(t, validateName("hello_world"))


### PR DESCRIPTION
Allow single character object names to ensure we are backward compatible.
