### PR TITLE
[v9.5.x] CI: set dry-run if `release/dry-run` label is set on `release-comms.yml` and set latest on github release if `latest` is set

### DIFF
--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -38,8 +38,8 @@ jobs:
         echo "LATEST=${{ inputs.latest }}" >> $GITHUB_ENV
     - if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') }}
       run: |
-        echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\///g')" >> $GITHUB_ENV
-        echo "DRY_RUN=true" >> $GITHUB_ENV
+        echo "VERSION=$(echo ${{ github.head_ref }} | sed -e 's/release\/.*\///g')" >> $GITHUB_ENV
+        echo "DRY_RUN=${{ contains(github.event.pull_request.labels.*.name, 'release/dry-run') }}" >> $GITHUB_ENV
         echo "LATEST=${{ contains(github.event.pull_request.labels.*.name, 'release/latest') }}" >> $GITHUB_ENV
     - id: output
       run: |
@@ -68,6 +68,7 @@ jobs:
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+      latest: ${{ needs.setup.outputs.latest }}
   post_on_slack:
     needs: setup
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport 4e84234424ae7d2bef5d52a238ce0c46f21956aa from #91089