### PR TITLE
Pin Nav Items: Don't show icon for items without id

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
@@ -51,7 +51,7 @@ export function MegaMenuItemText({ children, isActive, onClick, target, url, id,
       >
         {linkContent}
       </LinkComponent>
-      {config.featureToggles.pinNavItems && (
+      {config.featureToggles.pinNavItems && id && (
         <IconButton
           name="bookmark"
           className={'pin-icon'}

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
@@ -51,7 +51,7 @@ export function MegaMenuItemText({ children, isActive, onClick, target, url, id,
       >
         {linkContent}
       </LinkComponent>
-      {config.featureToggles.pinNavItems && id && (
+      {config.featureToggles.pinNavItems && id && id !== 'bookmarks' && (
         <IconButton
           name="bookmark"
           className={'pin-icon'}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Some navigation items have no `id`, so it is not possible to bookmark. This PR removes the bookmark icon from next to these items.
This PR also hides the button for the "Bookmarks" section, as you shouldn't need to bookmark that.

**Why do we need this feature?**

So the bookmark button doesn't appear when it doesn't do anything.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
