### PR TITLE
CloudMigrations: Fix migration in docker

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -186,7 +186,7 @@ func (s *Service) buildSnapshot(ctx context.Context, signedInUser *user.SignedIn
 
 	s.log.Debug(fmt.Sprintf("buildSnapshot: generated keys in %d ms", time.Since(start).Milliseconds()))
 
-	// Use GMS public key + the grafana generated private private key to encrypt snapshot files.
+	// Use GMS public key + the grafana generated private key to encrypt snapshot files.
 	snapshotWriter, err := snapshot.NewSnapshotWriter(contracts.AssymetricKeys{
 		Public:  snapshotMeta.EncryptionKey,
 		Private: privateKey[:],

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -2,6 +2,7 @@ package setting
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -52,6 +53,6 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 
 	if cfg.CloudMigration.SnapshotFolder == "" {
 		homeDir, _ := os.UserHomeDir()
-		cfg.CloudMigration.SnapshotFolder = homeDir
+		cfg.CloudMigration.SnapshotFolder = filepath.Join(homeDir, "migration_snapshot")
 	}
 }

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -1,7 +1,6 @@
 package setting
 
 import (
-	"os"
 	"path/filepath"
 	"time"
 )
@@ -52,7 +51,6 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 	cfg.CloudMigration.FeedbackURL = cloudMigration.Key("feedback_url").MustString("")
 
 	if cfg.CloudMigration.SnapshotFolder == "" {
-		homeDir, _ := os.UserHomeDir()
-		cfg.CloudMigration.SnapshotFolder = filepath.Join(homeDir, "data/cloud_migration")
+		cfg.CloudMigration.SnapshotFolder = filepath.Join(cfg.DataPath, "cloud_migration")
 	}
 }

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -53,6 +53,6 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 
 	if cfg.CloudMigration.SnapshotFolder == "" {
 		homeDir, _ := os.UserHomeDir()
-		cfg.CloudMigration.SnapshotFolder = filepath.Join(homeDir, "migration_snapshot")
+		cfg.CloudMigration.SnapshotFolder = filepath.Join(homeDir, "data/cloud_migration")
 	}
 }


### PR DESCRIPTION
When a migration is run in a Grafana instance within Docker, it has some permissions issues when creating the folders and files.
This PR fixes the use the data folder which Grafana can write to. 
Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/900
