### PR TITLE
Alerting: Receiver API to use same logic for calculating UID as backend serivce

### DIFF
--- a/pkg/registry/apis/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/conversions.go
@@ -3,7 +3,6 @@ package receiver
 import (
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 
 	"github.com/prometheus/alertmanager/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,12 +12,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 )
 
 func getUID(t definitions.GettableApiReceiver) string {
-	sum := fnv.New64()
-	_, _ = sum.Write([]byte(t.Name))
-	return fmt.Sprintf("%016x", sum.Sum64())
+	return legacy_storage.NameToUid(t.Name)
 }
 
 func convertToK8sResources(orgID int64, receivers []definitions.GettableApiReceiver, namespacer request.NamespaceMapper) (*model.ReceiverList, error) {


### PR DESCRIPTION
**What is this feature?**
This fixes Receiver K8s API to use the same logic for calculating UID as the backend service. 

**Why do we need this feature?**
Because this UID is then used to delete receiver