### PR TITLE
Explore: Check for RBAC permissions when hitting query history endpoints

### DIFF
--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -49,7 +49,6 @@ func (s *QueryHistoryService) permissionsMiddleware(next CallbackHandler, errorM
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) createHandler(c *contextmodel.ReqContext) response.Response {
-
 	cmd := CreateQueryInQueryHistoryCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -76,7 +75,6 @@ func (s *QueryHistoryService) createHandler(c *contextmodel.ReqContext) response
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) searchHandler(c *contextmodel.ReqContext) response.Response {
-
 	timeRange := gtime.NewTimeRange(c.Query("from"), c.Query("to"))
 
 	query := SearchInQueryHistoryQuery{

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/util"
@@ -15,13 +16,25 @@ import (
 
 func (s *QueryHistoryService) registerAPIEndpoints() {
 	s.RouteRegister.Group("/api/query-history", func(entities routing.RouteRegister) {
-		entities.Post("/", middleware.ReqSignedIn, routing.Wrap(s.createHandler))
-		entities.Get("/", middleware.ReqSignedIn, routing.Wrap(s.searchHandler))
-		entities.Delete("/:uid", middleware.ReqSignedIn, routing.Wrap(s.deleteHandler))
-		entities.Post("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.starHandler))
-		entities.Delete("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.unstarHandler))
+		entities.Post("/", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.createHandler, "Failed to create query history")))
+		entities.Get("/", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.searchHandler, "Failed to get query history")))
+		entities.Delete("/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.deleteHandler, "Failed to delete query history")))
+		entities.Post("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.starHandler, "Failed to star query history")))
+		entities.Delete("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.unstarHandler, "Failed to unstar query history")))
 		entities.Patch("/:uid", middleware.ReqSignedIn, routing.Wrap(s.patchCommentHandler))
 	})
+}
+
+type CallbackHandler func(c *contextmodel.ReqContext) response.Response
+
+func (s *QueryHistoryService) permissionsMiddleware(next CallbackHandler, errorMessage string) CallbackHandler {
+	return func(c *contextmodel.ReqContext) response.Response {
+		hasAccess := ac.HasAccess(s.accessControl, c)
+		if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit && !hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
+			return response.Error(http.StatusUnauthorized, errorMessage, nil)
+		}
+		return next(c)
+	}
 }
 
 // swagger:route POST /query-history query_history createQuery
@@ -36,9 +49,6 @@ func (s *QueryHistoryService) registerAPIEndpoints() {
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) createHandler(c *contextmodel.ReqContext) response.Response {
-	if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit {
-		return response.Error(http.StatusUnauthorized, "Failed to create query history", nil)
-	}
 
 	cmd := CreateQueryInQueryHistoryCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
@@ -66,9 +76,6 @@ func (s *QueryHistoryService) createHandler(c *contextmodel.ReqContext) response
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) searchHandler(c *contextmodel.ReqContext) response.Response {
-	if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit {
-		return response.Error(http.StatusUnauthorized, "Failed to get query history", nil)
-	}
 
 	timeRange := gtime.NewTimeRange(c.Query("from"), c.Query("to"))
 
@@ -102,10 +109,6 @@ func (s *QueryHistoryService) searchHandler(c *contextmodel.ReqContext) response
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) deleteHandler(c *contextmodel.ReqContext) response.Response {
-	if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit {
-		return response.Error(http.StatusUnauthorized, "Failed to delete query history", nil)
-	}
-
 	queryUID := web.Params(c.Req)[":uid"]
 	if len(queryUID) > 0 && !util.IsValidShortUID(queryUID) {
 		return response.Error(http.StatusNotFound, "Query in query history not found", nil)
@@ -163,9 +166,6 @@ func (s *QueryHistoryService) patchCommentHandler(c *contextmodel.ReqContext) re
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) starHandler(c *contextmodel.ReqContext) response.Response {
-	if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit {
-		return response.Error(http.StatusUnauthorized, "Failed to star query history", nil)
-	}
 	queryUID := web.Params(c.Req)[":uid"]
 	if len(queryUID) > 0 && !util.IsValidShortUID(queryUID) {
 		return response.Error(http.StatusNotFound, "Query in query history not found", nil)
@@ -190,9 +190,6 @@ func (s *QueryHistoryService) starHandler(c *contextmodel.ReqContext) response.R
 // 401: unauthorisedError
 // 500: internalServerError
 func (s *QueryHistoryService) unstarHandler(c *contextmodel.ReqContext) response.Response {
-	if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit {
-		return response.Error(http.StatusUnauthorized, "Failed to unstar query history", nil)
-	}
 	queryUID := web.Params(c.Req)[":uid"]
 	if len(queryUID) > 0 && !util.IsValidShortUID(queryUID) {
 		return response.Error(http.StatusNotFound, "Query in query history not found", nil)

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -21,19 +21,19 @@ func (s *QueryHistoryService) registerAPIEndpoints() {
 		entities.Delete("/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.deleteHandler, "Failed to delete query history")))
 		entities.Post("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.starHandler, "Failed to star query history")))
 		entities.Delete("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.unstarHandler, "Failed to unstar query history")))
-		entities.Patch("/:uid", middleware.ReqSignedIn, routing.Wrap(s.patchCommentHandler))
+		entities.Patch("/:uid", middleware.ReqSignedIn, routing.Wrap(s.permissionsMiddleware(s.patchCommentHandler, "Failed to update comment of query in query history")))
 	})
 }
 
 type CallbackHandler func(c *contextmodel.ReqContext) response.Response
 
-func (s *QueryHistoryService) permissionsMiddleware(next CallbackHandler, errorMessage string) CallbackHandler {
+func (s *QueryHistoryService) permissionsMiddleware(handler CallbackHandler, errorMessage string) CallbackHandler {
 	return func(c *contextmodel.ReqContext) response.Response {
 		hasAccess := ac.HasAccess(s.accessControl, c)
 		if c.GetOrgRole() == org.RoleViewer && !s.Cfg.ViewersCanEdit && !hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)) {
 			return response.Error(http.StatusUnauthorized, errorMessage, nil)
 		}
-		return next(c)
+		return handler(c)
 	}
 }
 

--- a/pkg/services/queryhistory/queryhistory.go
+++ b/pkg/services/queryhistory/queryhistory.go
@@ -7,17 +7,19 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func ProvideService(cfg *setting.Cfg, sqlStore db.DB, routeRegister routing.RouteRegister) *QueryHistoryService {
+func ProvideService(cfg *setting.Cfg, sqlStore db.DB, routeRegister routing.RouteRegister, accessControl ac.AccessControl) *QueryHistoryService {
 	s := &QueryHistoryService{
 		store:         sqlStore,
 		Cfg:           cfg,
 		RouteRegister: routeRegister,
 		log:           log.New("query-history"),
 		now:           time.Now,
+		accessControl: accessControl,
 	}
 
 	// Register routes only when query history is enabled
@@ -45,6 +47,7 @@ type QueryHistoryService struct {
 	RouteRegister routing.RouteRegister
 	log           log.Logger
 	now           func() time.Time
+	accessControl ac.AccessControl
 }
 
 func (s QueryHistoryService) CreateQueryInQueryHistory(ctx context.Context, user *user.SignedInUser, cmd CreateQueryInQueryHistoryCommand) (QueryHistoryDTO, error) {

--- a/pkg/services/queryhistory/queryhistory_create_test.go
+++ b/pkg/services/queryhistory/queryhistory_create_test.go
@@ -42,5 +42,4 @@ func TestIntegrationCreateQueryInQueryHistory(t *testing.T) {
 			resp := permissionsMiddlewareCallback(sc.reqContext)
 			require.Equal(t, 401, resp.Status())
 		})
-
 }

--- a/pkg/services/queryhistory/queryhistory_create_test.go
+++ b/pkg/services/queryhistory/queryhistory_create_test.go
@@ -12,7 +12,7 @@ func TestIntegrationCreateQueryInQueryHistory(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	testScenario(t, "When users tries to create query in query history it should succeed", false,
+	testScenario(t, "When users tries to create query in query history it should succeed", true, true,
 		func(t *testing.T, sc scenarioContext) {
 			command := CreateQueryInQueryHistoryCommand{
 				DatasourceUID: "NCzh67i",
@@ -21,7 +21,26 @@ func TestIntegrationCreateQueryInQueryHistory(t *testing.T) {
 				}),
 			}
 			sc.reqContext.Req.Body = mockRequestBody(command)
-			resp := sc.service.createHandler(sc.reqContext)
+			permissionsMiddlewareCallback := sc.service.permissionsMiddleware(sc.service.createHandler, "Failed to create query history")
+
+			resp := permissionsMiddlewareCallback(sc.reqContext)
 			require.Equal(t, 200, resp.Status())
 		})
+
+	testScenario(t, "When users tries to create query in query history without permissions it should fail", true, false,
+		func(t *testing.T, sc scenarioContext) {
+			command := CreateQueryInQueryHistoryCommand{
+				DatasourceUID: "NCzh67i",
+				Queries: simplejson.NewFromAny(map[string]any{
+					"expr": "test",
+				}),
+			}
+
+			sc.reqContext.Req.Body = mockRequestBody(command)
+			permissionsMiddlewareCallback := sc.service.permissionsMiddleware(sc.service.createHandler, "Failed to create query history")
+
+			resp := permissionsMiddlewareCallback(sc.reqContext)
+			require.Equal(t, 401, resp.Status())
+		})
+
 }

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -262,10 +262,11 @@ func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 			require.Equal(t, 0, response.Result.TotalCount)
 		})
 
-	testScenario(t, "When user is viewer, return 401", true, false,
+	testScenario(t, "When user is viewer and has no RBAC permissions, return 401", true, false,
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "test")
-			resp := sc.service.searchHandler(sc.reqContext)
+			permissionsMiddlewareCallback := sc.service.permissionsMiddleware(sc.service.searchHandler, "Failed to get query history")
+			resp := permissionsMiddlewareCallback(sc.reqContext)
 			require.Equal(t, 401, resp.Status())
 		})
 

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -12,7 +12,7 @@ func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	testScenario(t, "When users tries to get query in empty query history, it should return empty result", false,
+	testScenario(t, "When users tries to get query in empty query history, it should return empty result", false, false,
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "test")
 			resp := sc.service.searchHandler(sc.reqContext)
@@ -262,7 +262,7 @@ func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 			require.Equal(t, 0, response.Result.TotalCount)
 		})
 
-	testScenario(t, "When user is viewer, return 401", true,
+	testScenario(t, "When user is viewer, return 401", true, false,
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "test")
 			resp := sc.service.searchHandler(sc.reqContext)


### PR DESCRIPTION
**What is this feature?**
PR https://github.com/grafana/grafana/pull/88735 added protection to query history endpoints by not returning results from the API for users with the viewer role. However, there are cases where customers should have access based on a custom permission set up with RBAC. 

We've had an [escalation ](https://github.com/grafana/support-escalations/issues/11700)where customer was not able to read/write query history in Explore despite having the role `datasources:explore` applied.

**Which issue(s) does this PR fix?**:

Fixes: https://github.com/grafana/support-escalations/issues/11700, Closes: #88722 

**Special notes for your reviewer:**
 - Make sure you are running grafana enterprise
 - Create a new user or update the existing one and set their role to `Viewer` and `Datasources:Explorer`:
![Screenshot 2024-07-29 at 2 17 07 PM](https://github.com/user-attachments/assets/a6af5e81-2aa7-4b67-97ea-22376be41c8e)
- The key piece of code that I added is `!hasAccess(ac.EvalPermission(ac.ActionDatasourcesExplore)` check from `permissionsMiddleware` in `pkg/services/queryhistory`. Removing this will reproduce the current error.

Please check that:
- [ ] It works as expected from a user's perspective.
