### PR TITLE
CloudMigrations: Fix bugs found during local testing

### DIFF
--- a/devenv/bulk-folders/bulk-folders.yaml
+++ b/devenv/bulk-folders/bulk-folders.yaml
@@ -1,9 +1,9 @@
-# apiVersion: 1
+apiVersion: 1
 
-# providers:
-#  - name: 'Bulk folders'
-#    type: file
-#    updateIntervalSeconds: 3600
-#    options:
-#      foldersFromFilesStructure: true
-#      path: devenv/bulk-folders
+providers:
+ - name: 'Bulk folders'
+   type: file
+   updateIntervalSeconds: 3600
+   options:
+     foldersFromFilesStructure: true
+     path: devenv/bulk-folders

--- a/devenv/bulk-folders/bulk-folders.yaml
+++ b/devenv/bulk-folders/bulk-folders.yaml
@@ -1,9 +1,9 @@
-apiVersion: 1
+# apiVersion: 1
 
-providers:
- - name: 'Bulk folders'
-   type: file
-   updateIntervalSeconds: 3600
-   options:
-     foldersFromFilesStructure: true
-     path: devenv/bulk-folders
+# providers:
+#  - name: 'Bulk folders'
+#    type: file
+#    updateIntervalSeconds: 3600
+#    options:
+#      foldersFromFilesStructure: true
+#      path: devenv/bulk-folders

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -514,8 +514,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, signedInUser *user.SignedI
 
 	// Update status to "creating" to ensure the frontend polls from now on
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
-		UID:    uid,
-		Status: cloudmigration.SnapshotStatusCreating,
+		UID:       uid,
+		SessionID: sessionUid,
+		Status:    cloudmigration.SnapshotStatusCreating,
 	}); err != nil {
 		return nil, err
 	}
@@ -539,8 +540,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, signedInUser *user.SignedI
 			s.log.Error("building snapshot", "err", err.Error())
 			// Update status to error with retries
 			if err := s.updateSnapshotWithRetries(context.Background(), cloudmigration.UpdateSnapshotCmd{
-				UID:    snapshot.UID,
-				Status: cloudmigration.SnapshotStatusError,
+				UID:       snapshot.UID,
+				SessionID: sessionUid,
+				Status:    cloudmigration.SnapshotStatusError,
 			}); err != nil {
 				s.log.Error("critical failure during snapshot creation - please report any error logs")
 			}
@@ -659,8 +661,9 @@ func (s *Service) UploadSnapshot(ctx context.Context, sessionUid string, snapsho
 
 	// Update status to "creating" to ensure the frontend polls from now on
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
-		UID:    snapshotUid,
-		Status: cloudmigration.SnapshotStatusUploading,
+		UID:       snapshotUid,
+		SessionID: sessionUid,
+		Status:    cloudmigration.SnapshotStatusUploading,
 	}); err != nil {
 		return err
 	}
@@ -684,8 +687,9 @@ func (s *Service) UploadSnapshot(ctx context.Context, sessionUid string, snapsho
 			s.log.Error("uploading snapshot", "err", err.Error())
 			// Update status to error with retries
 			if err := s.updateSnapshotWithRetries(context.Background(), cloudmigration.UpdateSnapshotCmd{
-				UID:    snapshot.UID,
-				Status: cloudmigration.SnapshotStatusError,
+				UID:       snapshot.UID,
+				SessionID: sessionUid,
+				Status:    cloudmigration.SnapshotStatusError,
 			}); err != nil {
 				s.log.Error("critical failure during snapshot upload - please report any error logs")
 			}
@@ -713,8 +717,9 @@ func (s *Service) CancelSnapshot(ctx context.Context, sessionUid string, snapsho
 	s.cancelFunc = nil
 
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
-		UID:    snapshotUid,
-		Status: cloudmigration.SnapshotStatusCanceled,
+		UID:       snapshotUid,
+		SessionID: sessionUid,
+		Status:    cloudmigration.SnapshotStatusCanceled,
 	}); err != nil {
 		s.log.Error("critical failure during snapshot cancelation - please report any error logs")
 	}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -551,7 +551,7 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 	defer span.End()
 
 	sessionUid, snapshotUid := query.SessionUID, query.SnapshotUID
-	snapshot, err := s.store.GetSnapshotByUID(ctx, snapshotUid, query.ResultPage, query.ResultLimit)
+	snapshot, err := s.store.GetSnapshotByUID(ctx, sessionUid, snapshotUid, query.ResultPage, query.ResultLimit)
 	if err != nil {
 		return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
 	}
@@ -591,7 +591,7 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		}
 
 		// Refresh the snapshot after the update
-		snapshot, err = s.store.GetSnapshotByUID(ctx, snapshotUid, query.ResultPage, query.ResultLimit)
+		snapshot, err = s.store.GetSnapshotByUID(ctx, sessionUid, snapshotUid, query.ResultPage, query.ResultLimit)
 		if err != nil {
 			return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
 		}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -591,6 +591,7 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		// We need to update the snapshot in our db before reporting anything
 		if err := s.store.UpdateSnapshot(ctx, cloudmigration.UpdateSnapshotCmd{
 			UID:       snapshot.UID,
+			SessionID: sessionUid,
 			Status:    localStatus,
 			Resources: snapshotMeta.Results,
 		}); err != nil {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -659,7 +659,7 @@ func (s *Service) UploadSnapshot(ctx context.Context, sessionUid string, snapsho
 
 	s.log.Info("Uploading snapshot in local directory", "gmsSnapshotUID", snapshot.GMSSnapshotUID, "localDir", snapshot.LocalDir, "uploadURL", uploadUrl)
 
-	// Update status to "creating" to ensure the frontend polls from now on
+	// Update status to "uploading" to ensure the frontend polls from now on
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
 		UID:       snapshotUid,
 		SessionID: sessionUid,

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -589,8 +589,12 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		}); err != nil {
 			return nil, fmt.Errorf("error updating snapshot status: %w", err)
 		}
-		snapshot.Status = localStatus
-		snapshot.Resources = append(snapshot.Resources, snapshotMeta.Results...)
+
+		// Refresh the snapshot after the update
+		snapshot, err = s.store.GetSnapshotByUID(ctx, snapshotUid, query.ResultPage, query.ResultLimit)
+		if err != nil {
+			return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
+		}
 	}
 
 	return snapshot, nil

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -512,6 +512,9 @@ func (s *Service) CreateSnapshot(ctx context.Context, signedInUser *user.SignedI
 	}
 	snapshot.UID = uid
 
+	// ensure the client polls for status
+	s.report(ctx, session, gmsclient.EventStartBuildingSnapshot, 0, nil)
+
 	// start building the snapshot asynchronously while we return a success response to the client
 	go func() {
 		s.cancelMutex.Lock()
@@ -522,8 +525,6 @@ func (s *Service) CreateSnapshot(ctx context.Context, signedInUser *user.SignedI
 
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		s.cancelFunc = cancelFunc
-
-		s.report(ctx, session, gmsclient.EventStartBuildingSnapshot, 0, nil)
 
 		start := time.Now()
 		err := s.buildSnapshot(ctx, signedInUser, initResp.MaxItemsPerPartition, initResp.Metadata, snapshot)
@@ -644,6 +645,9 @@ func (s *Service) UploadSnapshot(ctx context.Context, sessionUid string, snapsho
 
 	s.log.Info("Uploading snapshot in local directory", "gmsSnapshotUID", snapshot.GMSSnapshotUID, "localDir", snapshot.LocalDir, "uploadURL", uploadUrl)
 
+	// ensure the client polls for status
+	s.report(ctx, session, gmsclient.EventStartUploadingSnapshot, 0, nil)
+
 	// start uploading the snapshot asynchronously while we return a success response to the client
 	go func() {
 		s.cancelMutex.Lock()
@@ -654,8 +658,6 @@ func (s *Service) UploadSnapshot(ctx context.Context, sessionUid string, snapsho
 
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		s.cancelFunc = cancelFunc
-
-		s.report(ctx, session, gmsclient.EventStartUploadingSnapshot, 0, nil)
 
 		start := time.Now()
 		err := s.uploadSnapshot(ctx, session, snapshot, uploadUrl)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -266,22 +266,10 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			},
 		}
 
-		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
-			SnapshotUID: uid,
-			SessionUID:  sess.UID,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusFinished, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
-		assert.Len(t, snapshot.Resources, 1)
-		assert.Equal(t, gmsClientMock.getSnapshotResponse.Results[0], snapshot.Resources[0])
-
 		// ensure it is persisted
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
-			ResultPage:  1,
-			ResultLimit: 100,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, cloudmigration.SnapshotStatusFinished, snapshot.Status)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -146,16 +146,18 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 
 	// Make the status pending processing and ensure GMS gets called
 	err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
-		UID:    uid,
-		Status: cloudmigration.SnapshotStatusPendingProcessing,
+		UID:       uid,
+		SessionID: sess.UID,
+		Status:    cloudmigration.SnapshotStatusPendingProcessing,
 	})
 	assert.NoError(t, err)
 
 	cleanupFunc := func() {
 		gmsClientMock.getStatusCalled = 0
 		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
-			UID:    uid,
-			Status: cloudmigration.SnapshotStatusPendingProcessing,
+			UID:       uid,
+			SessionID: sess.UID,
+			Status:    cloudmigration.SnapshotStatusPendingProcessing,
 		})
 		assert.NoError(t, err)
 	}
@@ -323,8 +325,9 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 		cloudmigration.SnapshotStatusError,
 	} {
 		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
-			UID:    uid,
-			Status: status,
+			UID:       uid,
+			SessionID: sess.UID,
+			Status:    status,
 		})
 		assert.NoError(t, err)
 		_, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -341,8 +344,9 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 		cloudmigration.SnapshotStatusProcessing,
 	} {
 		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
-			UID:    uid,
-			Status: status,
+			UID:       uid,
+			SessionID: sess.UID,
+			Status:    status,
 		})
 		assert.NoError(t, err)
 		_, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -254,6 +254,7 @@ func (s *Service) buildSnapshot(ctx context.Context, signedInUser *user.SignedIn
 	// update snapshot status to pending upload with retries
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
 		UID:       snapshotMeta.UID,
+		SessionID: snapshotMeta.SessionUID,
 		Status:    cloudmigration.SnapshotStatusPendingUpload,
 		Resources: localSnapshotResource,
 	}); err != nil {
@@ -323,8 +324,9 @@ func (s *Service) uploadSnapshot(ctx context.Context, session *cloudmigration.Cl
 
 	// update snapshot status to processing with retries
 	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
-		UID:    snapshotMeta.UID,
-		Status: cloudmigration.SnapshotStatusProcessing,
+		UID:       snapshotMeta.UID,
+		SessionID: snapshotMeta.SessionUID,
+		Status:    cloudmigration.SnapshotStatusProcessing,
 	}); err != nil {
 		return err
 	}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -144,7 +144,6 @@ func (s *Service) getDashboardAndFolderCommands(ctx context.Context, signedInUse
 			folderUids = append(folderUids, d.UID)
 		} else {
 			dashboardCmds = append(dashboardCmds, *d)
-			s.log.Info("dashboard cmd", "o", *d)
 		}
 	}
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -82,10 +82,6 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 		Items: migrationDataSlice,
 	}
 
-	for _, i := range migrationData.Items {
-		s.log.Info("migration data", "item", i)
-	}
-
 	return migrationData, nil
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -185,14 +185,6 @@ func (s *Service) buildSnapshot(ctx context.Context, signedInUser *user.SignedIn
 		s.log.Debug(fmt.Sprintf("buildSnapshot: method completed in %d ms", time.Since(start).Milliseconds()))
 	}()
 
-	// Update status to snapshot creating with retries
-	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
-		UID:    snapshotMeta.UID,
-		Status: cloudmigration.SnapshotStatusCreating,
-	}); err != nil {
-		return err
-	}
-
 	publicKey, privateKey, err := box.GenerateKey(cryptoRand.Reader)
 	if err != nil {
 		return fmt.Errorf("nacl: generating public and private key: %w", err)
@@ -286,14 +278,6 @@ func (s *Service) uploadSnapshot(ctx context.Context, session *cloudmigration.Cl
 	defer func() {
 		s.log.Debug(fmt.Sprintf("uploadSnapshot: method completed in %d ms", time.Since(start).Milliseconds()))
 	}()
-
-	// update snapshot status to uploading with retries
-	if err := s.updateSnapshotWithRetries(ctx, cloudmigration.UpdateSnapshotCmd{
-		UID:    snapshotMeta.UID,
-		Status: cloudmigration.SnapshotStatusUploading,
-	}); err != nil {
-		return err
-	}
 
 	indexFilePath := filepath.Join(snapshotMeta.LocalDir, "index.json")
 	// LocalDir can be set in the configuration, therefore the file path can be set to any path.

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -61,7 +61,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 			Data: dashboards.SaveDashboardCommand{
 				Dashboard: dashboard.Data,
 				Overwrite: true, // currently only intended to be a push, not a sync; revisit during the preview
-				Message:   fmt.Sprintf("Created via the Grafana Cloud Migration Assistant by on-prem user %s", signedInUser.Login),
+				Message:   fmt.Sprintf("Created via the Grafana Cloud Migration Assistant by on-prem user \"%s\"", signedInUser.Login),
 				IsFolder:  false,
 				FolderUID: dashboard.FolderUID,
 			},

--- a/pkg/services/cloudmigration/cloudmigrationimpl/store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/store.go
@@ -18,7 +18,7 @@ type store interface {
 
 	CreateSnapshot(ctx context.Context, snapshot cloudmigration.CloudMigrationSnapshot) (string, error)
 	UpdateSnapshot(ctx context.Context, snapshot cloudmigration.UpdateSnapshotCmd) error
-	GetSnapshotByUID(ctx context.Context, uid string, resultPage int, resultLimit int) (*cloudmigration.CloudMigrationSnapshot, error)
+	GetSnapshotByUID(ctx context.Context, sessUid, id string, resultPage int, resultLimit int) (*cloudmigration.CloudMigrationSnapshot, error)
 	GetSnapshotList(ctx context.Context, query cloudmigration.ListSnapshotsQuery) ([]cloudmigration.CloudMigrationSnapshot, error)
 
 	CreateUpdateSnapshotResources(ctx context.Context, snapshotUid string, resources []cloudmigration.CloudMigrationResource) error

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -331,10 +331,14 @@ func (ss *sqlStore) CreateUpdateSnapshotResources(ctx context.Context, snapshotU
 }
 
 func (ss *sqlStore) GetSnapshotResources(ctx context.Context, snapshotUid string, page int, limit int) ([]cloudmigration.CloudMigrationResource, error) {
-	var resources []cloudmigration.CloudMigrationResource
-	if limit == 0 {
-		return resources, nil
+	if page < 1 {
+		page = 1
 	}
+	if limit == 0 {
+		limit = 100
+	}
+
+	var resources []cloudmigration.CloudMigrationResource
 	err := ss.db.WithDbSession(ctx, func(sess *db.Session) error {
 		offset := (page - 1) * limit
 		sess.Limit(limit, offset)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -193,6 +193,9 @@ func (ss *sqlStore) UpdateSnapshot(ctx context.Context, update cloudmigration.Up
 	if update.UID == "" {
 		return fmt.Errorf("missing snapshot uid")
 	}
+	if update.SessionID == "" {
+		return fmt.Errorf("missing session uid")
+	}
 	err := ss.db.InTransaction(ctx, func(ctx context.Context) error {
 		// Update status if set
 		if update.Status != "" {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -187,7 +187,7 @@ func Test_SnapshotManagement(t *testing.T) {
 		require.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
 
 		// update its status
-		err = s.UpdateSnapshot(ctx, cloudmigration.UpdateSnapshotCmd{UID: snapshotUid, Status: cloudmigration.SnapshotStatusCreating})
+		err = s.UpdateSnapshot(ctx, cloudmigration.UpdateSnapshotCmd{UID: snapshotUid, Status: cloudmigration.SnapshotStatusCreating, SessionID: sessionUid})
 		require.NoError(t, err)
 
 		//retrieve it again

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -182,7 +182,7 @@ func Test_SnapshotManagement(t *testing.T) {
 		require.NotEmpty(t, snapshotUid)
 
 		//retrieve it from the db
-		snapshot, err := s.GetSnapshotByUID(ctx, snapshotUid, 0, 0)
+		snapshot, err := s.GetSnapshotByUID(ctx, sessionUid, snapshotUid, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
 
@@ -191,7 +191,7 @@ func Test_SnapshotManagement(t *testing.T) {
 		require.NoError(t, err)
 
 		//retrieve it again
-		snapshot, err = s.GetSnapshotByUID(ctx, snapshotUid, 0, 0)
+		snapshot, err = s.GetSnapshotByUID(ctx, sessionUid, snapshotUid, 0, 0)
 		require.NoError(t, err)
 		require.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
 

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -145,6 +145,7 @@ type ListSnapshotsQuery struct {
 
 type UpdateSnapshotCmd struct {
 	UID       string
+	SessionID string
 	Status    SnapshotStatus
 	Resources []CloudMigrationResource
 }


### PR DESCRIPTION
Fixes several bugs discovered over the last couple days of testing:

- Frontend not polling for updates when it should be. This was caused by the backend returning a success response for create/update snapshot before the state was persisted in the db.
- Snapshot operations now check for a valid sessionUid instead of just the snapshotUid
- Addresses an issue in which snapshots could return a `finished` status with `pending` results. This was caused by a poor job merging on-prem results with the latest GMS results, and is fixed by a refresh of the snapshot on the backend
- Fixes issue where dashboards weren't showing up under their parent folders. This was because we were saving the wrong JSON for dashboards in the snapshot

Please give this a try! I've given it a few rounds of testing and things looked good. I managed to migrate a large data set of 800 resources, including complex folder testing, although it took maybe two minutes for the processing to happen:
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/65953ed6-ba4a-4deb-8842-70fed82fff26">

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/899 and https://github.com/grafana/grafana-operator-experience-squad/issues/898