### PR TITLE
Identity: Remove id token from extra info

### DIFF
--- a/pkg/services/apiserver/auth/authenticator/signedinuser_test.go
+++ b/pkg/services/apiserver/auth/authenticator/signedinuser_test.go
@@ -47,7 +47,6 @@ func TestSignedInUser(t *testing.T) {
 		require.Equal(t, u.GetName(), res.User.GetName())
 		require.Equal(t, u.GetUID(), res.User.GetUID())
 		require.Equal(t, []string{"1", "2"}, res.User.GetGroups())
-		require.Empty(t, res.User.GetExtra()["id-token"])
 	})
 
 	t.Run("should set ID token when available", func(t *testing.T) {
@@ -72,7 +71,6 @@ func TestSignedInUser(t *testing.T) {
 		require.Equal(t, u.GetName(), res.User.GetName())
 		require.Equal(t, u.GetUID(), res.User.GetUID())
 		require.Equal(t, []string{"1", "2"}, res.User.GetGroups())
-		require.Equal(t, "test-id-token", res.User.GetExtra()["id-token"][0])
 	})
 }
 

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -89,14 +89,7 @@ func (i *Identity) GetIdentityType() identity.IdentityType {
 
 // GetExtra implements identity.Requester.
 func (i *Identity) GetExtra() map[string][]string {
-	extra := map[string][]string{}
-	if i.IDToken != "" {
-		extra["id-token"] = []string{i.IDToken}
-	}
-	if i.GetOrgRole().IsValid() {
-		extra["user-instance-role"] = []string{string(i.GetOrgRole())}
-	}
-	return extra
+	return map[string][]string{}
 }
 
 // GetGroups implements identity.Requester.

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -94,14 +94,7 @@ func (u *SignedInUser) GetName() string {
 
 // GetExtra implements Requester.
 func (u *SignedInUser) GetExtra() map[string][]string {
-	extra := map[string][]string{}
-	if u.IDToken != "" {
-		extra["id-token"] = []string{u.IDToken}
-	}
-	if u.OrgRole.IsValid() {
-		extra["user-instance-role"] = []string{string(u.GetOrgRole())}
-	}
-	return extra
+	return map[string][]string{}
 }
 
 // GetGroups implements Requester.


### PR DESCRIPTION
We used to include the id token in k8s extra -- I don't think this is necessary anymore, so lets remove it.