### PR TITLE
Logs: Remove `grafana_explore_logs_log_details_clicked` event

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -115,13 +115,6 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       return;
     }
 
-    reportInteraction('grafana_explore_logs_log_details_clicked', {
-      datasourceType: this.props.row.datasourceType,
-      type: this.state.showDetails ? 'close' : 'open',
-      logRowUid: this.props.row.uid,
-      app: this.props.app,
-    });
-
     this.setState((state) => {
       return {
         showDetails: !state.showDetails,


### PR DESCRIPTION
**What is this feature?**

Removes the `grafana_explore_logs_log_details_clicked` event.

https://raintank-corp.slack.com/archives/C07CPR96GD8/p1721667284853379