### PR TITLE
Logs: Remove `grafana_explore_logs_result_displayed` event

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -22,9 +22,8 @@ import {
   toLegacyResponseData,
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
-import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import store from 'app/core/store';
 import {
   buildQueryTransaction,
   ensureQueries,
@@ -55,7 +54,6 @@ import { ExploreState, QueryOptions, SupplementaryQueries } from 'app/types/expl
 import { notifyApp } from '../../../core/actions';
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { runRequest } from '../../query/state/runRequest';
-import { visualisationTypeKey } from '../Logs/utils/logs';
 import { decorateData, decorateWithLogsResult } from '../utils/decorators';
 import {
   getSupplementaryQueryProvider,
@@ -656,15 +654,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
       newQuerySubscription = newQuerySource.subscribe({
         next(data) {
           const exploreState = getState().explore.panes[exploreId];
-          if (data.logsResult !== null && data.state === LoadingState.Done) {
-            reportInteraction('grafana_explore_logs_result_displayed', {
-              datasourceType: datasourceInstance.type,
-              visualisationType:
-                exploreState?.panelsState?.logs?.visualisationType ?? store.get(visualisationTypeKey) ?? 'N/A',
-              length: data.logsResult.rows.length,
-              defaultVisualisationType: config.featureToggles.logsExploreTableDefaultVisualization ? 'table' : 'logs',
-            });
-          }
           dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
 
           // Keep scanning for results if this was the last scanning transaction


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/80219

**What is this feature?**

Removes the `grafana_explore_logs_result_displayed` event.

**Why do we need this feature?**

https://raintank-corp.slack.com/archives/C07CPR96GD8/p1721667274533709
