### PR TITLE
Plugins Catalog: Display Request data source and view roadmap links

### DIFF
--- a/packages/grafana-ui/src/components/Link/TextLink.tsx
+++ b/packages/grafana-ui/src/components/Link/TextLink.tsx
@@ -27,7 +27,7 @@ interface TextLinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 't
   weight?: 'light' | 'regular' | 'medium' | 'bold';
   /** Set the icon to be shown. An external link will show the 'external-link-alt' icon as default.*/
   icon?: IconName;
-  children: string;
+  children: React.ReactNode;
 }
 
 const svgSizes: {

--- a/public/app/features/connections/tabs/ConnectData/ConnectData.test.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.test.tsx
@@ -116,4 +116,11 @@ describe('Add new connection', () => {
     await userEvent.click(await screen.findByText('Sample data source'));
     expect(screen.queryByText(new RegExp(exampleSentenceInModal))).toBeInTheDocument();
   });
+
+  test('Show request data source and roadmap links', async () => {
+    renderPage([getCatalogPluginMock(), mockCatalogDataSourcePlugin]);
+
+    expect(await screen.findByText('Request a new data source')).toBeInTheDocument();
+    expect(await screen.findByText('View roadmap')).toBeInTheDocument();
+  });
 });

--- a/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
@@ -3,11 +3,11 @@ import { useMemo, useState } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2, PluginType } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
-import { useStyles2, LoadingPlaceholder, EmptyState, TextLink } from '@grafana/ui';
+import { useStyles2, LoadingPlaceholder, EmptyState } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { t } from 'app/core/internationalization';
+import { RoadmapLinks } from 'app/features/plugins/admin/components/RoadmapLinks';
 import { useGetAll } from 'app/features/plugins/admin/state/hooks';
 import { AccessControlAction } from 'app/types';
 
@@ -104,24 +104,7 @@ export function AddNewConnection() {
           message={t('connections.connect-data.empty-message', 'No results matching your query were found')}
         />
       )}
-      <div className={styles.spacer} />
-      <div>
-        <TextLink
-          href="https://github.com/grafana/grafana/issues/new?assignees=&labels=area%2Fdatasource%2Ctype%2Fnew-plugin-request&projects=&template=3-data_source_request.yaml&title=%5BNew+Data+Source%5D%3A+%3Cname-of-service%3E"
-          onClick={() => reportInteraction('connections_data_source_request_clicked')}
-          external
-        >
-          Request a new data source
-        </TextLink>
-        <br />
-        <TextLink
-          href="https://github.com/orgs/grafana/projects/619/views/1?pane=info"
-          onClick={() => reportInteraction('connections_data_source_roadmap_clicked')}
-          external
-        >
-          View roadmap
-        </TextLink>
-      </div>
+      <RoadmapLinks />
     </>
   );
 }

--- a/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
+++ b/public/app/features/connections/tabs/ConnectData/ConnectData.tsx
@@ -3,7 +3,8 @@ import { useMemo, useState } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2, PluginType } from '@grafana/data';
-import { useStyles2, LoadingPlaceholder, EmptyState } from '@grafana/ui';
+import { reportInteraction } from '@grafana/runtime';
+import { useStyles2, LoadingPlaceholder, EmptyState, TextLink } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { t } from 'app/core/internationalization';
@@ -103,6 +104,24 @@ export function AddNewConnection() {
           message={t('connections.connect-data.empty-message', 'No results matching your query were found')}
         />
       )}
+      <div className={styles.spacer} />
+      <div>
+        <TextLink
+          href="https://github.com/grafana/grafana/issues/new?assignees=&labels=area%2Fdatasource%2Ctype%2Fnew-plugin-request&projects=&template=3-data_source_request.yaml&title=%5BNew+Data+Source%5D%3A+%3Cname-of-service%3E"
+          onClick={() => reportInteraction('connections_data_source_request_clicked')}
+          external
+        >
+          Request a new data source
+        </TextLink>
+        <br />
+        <TextLink
+          href="https://github.com/orgs/grafana/projects/619/views/1?pane=info"
+          onClick={() => reportInteraction('connections_data_source_roadmap_clicked')}
+          external
+        >
+          View roadmap
+        </TextLink>
+      </div>
     </>
   );
 }

--- a/public/app/features/plugins/admin/components/RoadmapLinks.tsx
+++ b/public/app/features/plugins/admin/components/RoadmapLinks.tsx
@@ -1,21 +1,11 @@
-import { css } from '@emotion/css';
-
-import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { TextLink, useStyles2 } from '@grafana/ui';
+import { Space, TextLink } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  spacer: css({
-    height: theme.spacing(2),
-  }),
-});
-
 export const RoadmapLinks = () => {
-  const styles = useStyles2(getStyles);
   return (
     <div>
-      <div className={styles.spacer} />
+      <Space v={2} />
       <TextLink
         href="https://github.com/grafana/grafana/issues/new?assignees=&labels=area%2Fdatasource%2Ctype%2Fnew-plugin-request&projects=&template=3-data_source_request.yaml&title=%5BNew+Data+Source%5D%3A+%3Cname-of-service%3E"
         onClick={() => reportInteraction('connections_data_source_request_clicked')}

--- a/public/app/features/plugins/admin/components/RoadmapLinks.tsx
+++ b/public/app/features/plugins/admin/components/RoadmapLinks.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { TextLink, useStyles2 } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   spacer: css({
@@ -20,7 +21,7 @@ export const RoadmapLinks = () => {
         onClick={() => reportInteraction('connections_data_source_request_clicked')}
         external
       >
-        Request a new data source
+        <Trans i18nKey="connections.connect-data.request-data-source">Request a new data source</Trans>
       </TextLink>
       <br />
       <TextLink
@@ -28,7 +29,7 @@ export const RoadmapLinks = () => {
         onClick={() => reportInteraction('connections_data_source_roadmap_clicked')}
         external
       >
-        View roadmap
+        <Trans i18nKey="connections.connect-data.roadmap">View roadmap</Trans>
       </TextLink>
     </div>
   );

--- a/public/app/features/plugins/admin/components/RoadmapLinks.tsx
+++ b/public/app/features/plugins/admin/components/RoadmapLinks.tsx
@@ -1,0 +1,35 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
+import { TextLink, useStyles2 } from '@grafana/ui';
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  spacer: css({
+    height: theme.spacing(2),
+  }),
+});
+
+export const RoadmapLinks = () => {
+  const styles = useStyles2(getStyles);
+  return (
+    <div>
+      <div className={styles.spacer} />
+      <TextLink
+        href="https://github.com/grafana/grafana/issues/new?assignees=&labels=area%2Fdatasource%2Ctype%2Fnew-plugin-request&projects=&template=3-data_source_request.yaml&title=%5BNew+Data+Source%5D%3A+%3Cname-of-service%3E"
+        onClick={() => reportInteraction('connections_data_source_request_clicked')}
+        external
+      >
+        Request a new data source
+      </TextLink>
+      <br />
+      <TextLink
+        href="https://github.com/orgs/grafana/projects/619/views/1?pane=info"
+        onClick={() => reportInteraction('connections_data_source_roadmap_clicked')}
+        external
+      >
+        View roadmap
+      </TextLink>
+    </div>
+  );
+};

--- a/public/app/features/plugins/admin/pages/Browse.test.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.test.tsx
@@ -180,6 +180,17 @@ describe('Browse list of plugins', () => {
       expect(queryByText('Plugin 2')).not.toBeInTheDocument();
       expect(queryByText('Plugin 3')).not.toBeInTheDocument();
     });
+
+    test('Show request data source and roadmap links', async () => {
+      const { queryByText } = renderBrowse('/plugins', [
+        getCatalogPluginMock({ id: 'plugin-1', name: 'Plugin 1', type: PluginType.datasource }),
+        getCatalogPluginMock({ id: 'plugin-2', name: 'Plugin 2', type: PluginType.panel }),
+        getCatalogPluginMock({ id: 'plugin-3', name: 'Plugin 3', type: PluginType.datasource }),
+      ]);
+
+      expect(queryByText('Request a new data source')).toBeInTheDocument();
+      expect(queryByText('View roadmap')).toBeInTheDocument();
+    });
   });
 
   describe('when searching', () => {

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'app/types';
 
 import { HorizontalGroup } from '../components/HorizontalGroup';
 import { PluginList } from '../components/PluginList';
+import { RoadmapLinks } from '../components/RoadmapLinks';
 import { SearchField } from '../components/SearchField';
 import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
@@ -162,6 +163,7 @@ export default function Browse({ route }: GrafanaRouteComponentProps): ReactElem
         <div className={styles.listWrap}>
           <PluginList plugins={plugins} displayMode={displayMode} isLoading={isLoading} />
         </div>
+        <RoadmapLinks />
       </Page.Contents>
     </Page>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -302,7 +302,9 @@
   "connections": {
     "connect-data": {
       "category-header-label": "Data sources",
-      "empty-message": "No results matching your query were found"
+      "empty-message": "No results matching your query were found",
+      "request-data-source": "Request a new data source",
+      "roadmap": "View roadmap"
     },
     "search": {
       "placeholder": "Search all"

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -302,7 +302,9 @@
   "connections": {
     "connect-data": {
       "category-header-label": "Đäŧä şőūřčęş",
-      "empty-message": "Ńő řęşūľŧş mäŧčĥįŉģ yőūř qūęřy ŵęřę ƒőūŉđ"
+      "empty-message": "Ńő řęşūľŧş mäŧčĥįŉģ yőūř qūęřy ŵęřę ƒőūŉđ",
+      "request-data-source": "Ŗęqūęşŧ ä ŉęŵ đäŧä şőūřčę",
+      "roadmap": "Vįęŵ řőäđmäp"
     },
     "search": {
       "placeholder": "Ŝęäřčĥ äľľ"


### PR DESCRIPTION
**What is this feature?**

It adds two links to the connection tab: Roadmap and Roadmap Links.
It also adds the Roadmap Links to the catalog browse page.

Catalog and connections page: displayed at the end, always

![image](https://github.com/user-attachments/assets/e9424c4e-1296-4d34-b1e0-364cb76f66f5)


**Why do we need this feature?**

We want to make it easier for users to find the data source roadmap and request new ones.

**Who is this feature for?**

All admin users visiting the catalog and connections pages

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana/issues/90928
**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
