### PR TITLE
Loki: Add option to issue forward queries

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -30,11 +30,11 @@ export const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
 ];
 
 export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
-  { value: LokiQueryDirection.Backward, label: 'Backward', description: 'Search in backwards direction.' },
+  { value: LokiQueryDirection.Backward, label: 'Backward', description: 'Search in backward direction.' },
   {
     value: LokiQueryDirection.Forward,
     label: 'Forward',
-    description: 'Search in forwards direction.',
+    description: 'Search in forward direction.',
   },
 ];
 

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -9,7 +9,7 @@ import { config } from '@grafana/runtime';
 import { InlineFormLabel, RadioButtonGroup, InlineField, Input, Select, Stack } from '@grafana/ui';
 
 import { getLokiQueryType } from '../queryUtils';
-import { LokiQuery, LokiQueryType } from '../types';
+import { LokiQuery, LokiQueryDirection, LokiQueryType } from '../types';
 
 export interface LokiOptionFieldsProps {
   lineLimitValue: string;
@@ -26,6 +26,15 @@ export const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
     value: LokiQueryType.Instant,
     label: 'Instant',
     description: 'Run query against a single point in time. For this query, the "To" time is used.',
+  },
+];
+
+export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
+  { value: LokiQueryDirection.Backward, label: 'Backward', description: 'Search in backwards direction.' },
+  {
+    value: LokiQueryDirection.Forward,
+    label: 'Forward',
+    description: 'Search in forwards direction.',
   },
 ];
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -7,9 +7,14 @@ import { EditorField, EditorRow, QueryOptionGroup } from '@grafana/experimental'
 import { config, reportInteraction } from '@grafana/runtime';
 import { Alert, AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
 
-import { preprocessMaxLines, queryTypeOptions, RESOLUTION_OPTIONS } from '../../components/LokiOptionFields';
+import {
+  preprocessMaxLines,
+  queryDirections,
+  queryTypeOptions,
+  RESOLUTION_OPTIONS,
+} from '../../components/LokiOptionFields';
 import { getLokiQueryType, isLogsQuery } from '../../queryUtils';
-import { LokiQuery, LokiQueryType, QueryStats } from '../../types';
+import { LokiQuery, LokiQueryDirection, LokiQueryType, QueryStats } from '../../types';
 
 export interface Props {
   query: LokiQuery;
@@ -26,6 +31,11 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
 
     const onQueryTypeChange = (value: LokiQueryType) => {
       onChange({ ...query, queryType: value });
+      onRunQuery();
+    };
+
+    const onQueryDirectionChange = (value: LokiQueryDirection) => {
+      onChange({ ...query, direction: value });
       onRunQuery();
     };
 
@@ -73,6 +83,8 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
       ? queryTypeOptions.filter((o) => o.value !== LokiQueryType.Instant)
       : queryTypeOptions;
 
+    const queryDirection = query.direction ?? LokiQueryDirection.Backward;
+
     // if the state's queryType is still Instant, trigger a change to range for log queries
     if (isLogQuery && queryType === LokiQueryType.Instant) {
       onChange({ ...query, queryType: LokiQueryType.Range });
@@ -111,16 +123,21 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
             </EditorField>
           )}
           {isLogQuery && (
-            <EditorField label="Line limit" tooltip="Upper limit for number of log lines returned by query.">
-              <AutoSizeInput
-                className="width-4"
-                placeholder={maxLines.toString()}
-                type="number"
-                min={0}
-                defaultValue={query.maxLines?.toString() ?? ''}
-                onCommitChange={onMaxLinesChange}
-              />
-            </EditorField>
+            <>
+              <EditorField label="Line limit" tooltip="Upper limit for number of log lines returned by query.">
+                <AutoSizeInput
+                  className="width-4"
+                  placeholder={maxLines.toString()}
+                  type="number"
+                  min={0}
+                  defaultValue={query.maxLines?.toString() ?? ''}
+                  onCommitChange={onMaxLinesChange}
+                />
+              </EditorField>
+              <EditorField label="Direction" tooltip="Direction to search for logs.">
+                <RadioButtonGroup options={queryDirections} value={queryDirection} onChange={onQueryDirectionChange} />
+              </EditorField>
+            </>
           )}
           {!isLogQuery && (
             <>


### PR DESCRIPTION
**What is this feature?**

This PR adds a Loki query option wether the query should be performed as a "backwards" or "forwards" query:
![image](https://github.com/user-attachments/assets/a5d0053c-8161-4a17-8869-d287544e09b5)

Currently we default to only execute "backwards" queries. Imagine the following example:
1. User wants to only see 1 log line. (line limit: 1)
2. User wants to see "newest first".
3. Query executes with "backwards" direction, so Loki will start at the newest lines going "backwards" in time.
4. Query returns after 1 newest log line is found. The user is happy, because they wanted to see the "newest" log line.
5. User wants to see the "oldest first" - or the oldest log line.
6. Query executes again with "backwards" direction, because there is no way to change the direction. 
7. User will not really be able to find the 1 oldest log line.

With this PR, they would need to change the "direction" query option and they will be able to see the "oldest" 1 log line.

This PR does not contain binding the query direction to the log sort order of the logs panel!