### PR TITLE
Chore: Update imports from RTKQ

### DIFF
--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -1,6 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { QueryDefinition, BaseQueryFn } from '@reduxjs/toolkit/dist/query';
-import { QueryActionCreatorResult } from '@reduxjs/toolkit/dist/query/core/buildInitiate';
+import { QueryDefinition, BaseQueryFn, QueryActionCreatorResult } from '@reduxjs/toolkit/query';
 import { RequestOptions } from 'http';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 

--- a/public/app/features/alerting/unified/api/timeIntervalsApi.ts
+++ b/public/app/features/alerting/unified/api/timeIntervalsApi.ts
@@ -7,7 +7,7 @@
 // which may help alleviate this when it lands:
 // https://github.com/reduxjs/redux-toolkit/pull/3485
 
-import { DefinitionsFromApi, OverrideResultType } from '@reduxjs/toolkit/dist/query/endpointDefinitions';
+import { DefinitionsFromApi, OverrideResultType } from '@reduxjs/toolkit/query';
 
 import {
   ListTimeIntervalForAllNamespacesApiResponse,


### PR DESCRIPTION
**What is this feature?**

As per https://github.com/grafana/grafana/pull/91177#issuecomment-2257956941, some imports from RTKQ are broken on upgrade to a newer version. Fixes the two offending files
