### PR TITLE
Angular deprecation: Disable dynamic angular inspector if CheckForPluginUpdates is false

### DIFF
--- a/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic.go
+++ b/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/plugins/log"
 	"github.com/grafana/grafana/pkg/plugins/manager/loader/angular/angulardetector"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/angularpatternsstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -332,3 +333,10 @@ func makeHttpClient() http.Client {
 		Transport: tr,
 	}
 }
+
+// static checks
+
+var (
+	_ registry.BackgroundService = (*Dynamic)(nil)
+	_ registry.CanBeDisabled     = (*Dynamic)(nil)
+)

--- a/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic.go
+++ b/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic.go
@@ -35,6 +35,7 @@ type Dynamic struct {
 
 	httpClient http.Client
 	baseURL    string
+	disabled   bool
 
 	// store is the underlying angular patterns store used as a cache.
 	store angularpatternsstore.Service
@@ -64,6 +65,9 @@ func ProvideDynamic(cfg *setting.Cfg, store angularpatternsstore.Service) (*Dyna
 		httpClient:            makeHttpClient(),
 		baseURL:               cfg.GrafanaComAPIURL,
 		backgroundJobInterval: backgroundJobInterval,
+		// Disable the background service if the user has opted out of plugin updates.
+		// (useful for air-gapped installations)
+		disabled: !cfg.CheckForPluginUpdates,
 	}
 	d.log.Debug("Providing dynamic angular detection patterns", "baseURL", d.baseURL, "interval", d.backgroundJobInterval)
 
@@ -294,6 +298,11 @@ func (d *Dynamic) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// IsDisabled returns whether the dynamic detectors provider background service is disabled.
+func (d *Dynamic) IsDisabled() bool {
+	return d.disabled
 }
 
 // ProvideDetectors returns the cached detectors. It returns an empty slice if there's no value.

--- a/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic_test.go
+++ b/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic_test.go
@@ -421,6 +421,24 @@ func TestDynamicAngularDetectorsProviderBackgroundService(t *testing.T) {
 			require.True(t, jobCalls.calledX(tcRuns), "should have the correct number of job calls")
 			require.True(t, gcom.httpCalls.calledX(tcRuns), "should have the correct number of gcom api calls")
 		})
+
+		t.Run("IsDisabled", func(t *testing.T) {
+			for _, tc := range []struct {
+				name                  string
+				checkForPluginUpdates bool
+				expIsDisabled         bool
+			}{
+				{name: "true", checkForPluginUpdates: true, expIsDisabled: false},
+				{name: "false", checkForPluginUpdates: false, expIsDisabled: true},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					cfg := setting.NewCfg()
+					cfg.CheckForPluginUpdates = tc.checkForPluginUpdates
+					svc := provideDynamic(t, srv.URL, provideDynamicOpts{cfg: cfg})
+					require.Equal(t, tc.expIsDisabled, svc.IsDisabled(), "IsDisabled should return correct value")
+				})
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disables the dynamic angular detectors provider background service (which contacts grafana.com) when `[analytics].check_for_plugin_updates` is set to false.

**Why do we need this feature?**

To allow disabling network requests for air-gapped installations.

**Who is this feature for?**

Grafana users with air-gapped installations.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #90168

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
