### PR TITLE
unifiedStorage: fix flaky integration test

### DIFF
--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -58,7 +58,7 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 	ctx := testutil.NewDefaultTestContext(t)
 	store := newServer(t)
 
-	stream, err := store.WatchWriteEvents(ctx)
+	stream, err := store.WatchWriteEvents(context.Background()) // Using a different context to avoid canceling the stream after the DefaultContextTimeout
 	require.NoError(t, err)
 
 	t.Run("Add 3 resources", func(t *testing.T) {
@@ -161,7 +161,7 @@ func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start the watch
-	stream, err := store.WatchWriteEvents(ctx)
+	stream, err := store.WatchWriteEvents(context.Background()) // Using a different context to avoid canceling the stream after the DefaultContextTimeout
 	require.NoError(t, err)
 
 	// Create one more event


### PR DESCRIPTION
Do not use a context relying on DefaultContextTimeout for Watch.

[Example Build](https://drone.grafana.net/grafana/grafana-enterprise/73918/2/9)
 
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
