### PR TITLE
RBAC: Fix folder move check when action sets are disabled

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -978,6 +978,12 @@ func (s *Service) canMove(ctx context.Context, cmd *folder.MoveFolderCommand) (b
 	var evaluators []accesscontrol.Evaluator
 	currentFolderScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(cmd.UID)
 	for action, scopes := range permissions {
+		// Skip unexpanded action sets - they have no impact if action sets are not enabled
+		if !s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
+			if action == "folders:view" || action == "folders:edit" || action == "folders:admin" {
+				continue
+			}
+		}
 		for _, scope := range newFolderAndParentUIDs {
 			if slices.Contains(scopes, scope) {
 				evaluators = append(evaluators, accesscontrol.EvalPermission(action, currentFolderScope))


### PR DESCRIPTION
**What is this feature?**

Fix folder move check that compares permissions on the current folder to permissions on the destination folder if action sets are disabled.

**Why do we need this feature?**

If action sets have been enabled, and then are disabled, folder move check can fail due to an unexpanded action set permission on the destination folder. Eg, user might have all folder editor permissions on folder A, and all editor permissions + `folders:edit` action set permission on folder B. This user wouldn't be able to move folder A to B, as they have an extra permission on B. This permission is ignored if action sets are not enabled, so it's safe to ignore it for folder move checks as well.