### PR TITLE
RolePicker: Reload org users after role update

### DIFF
--- a/public/app/features/users/UsersListPage.tsx
+++ b/public/app/features/users/UsersListPage.tsx
@@ -81,6 +81,10 @@ export const UsersListPageUnconnected = ({
     setShowInvites(!showInvites);
   };
 
+  const onUserRolesChange = () => {
+    loadUsers();
+  };
+
   const renderTable = () => {
     if (showInvites) {
       return <InviteesTable invitees={invitees} />;
@@ -92,6 +96,7 @@ export const UsersListPageUnconnected = ({
           rolesLoading={rolesLoading}
           onRoleChange={onRoleChange}
           onRemoveUser={onRemoveUser}
+          onUserRolesChange={onUserRolesChange}
           fetchData={changeSort}
           changePage={changePage}
           page={page}


### PR DESCRIPTION
**What is this feature?**

This PR fixes issue with user role picker not showing updated roles until page reload.

**Why do we need this feature?**

Roles picker should reflect changes made by user.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-adaptive-metrics-app/issues/513

**Special notes for your reviewer:**

This is a quick-fix, however, there's still another small issue left. When you apply changes, role picker first shows updated roles, then switches back to original one, and then roles are updated again after fetching user information. That happens due to state override by the parent component. This requires some additional work to fix.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
