### PR TITLE
DataLinks: Fix long datalinks to fit in panel options editor

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksListItem.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksListItem.tsx
@@ -88,6 +88,7 @@ const getDataLinkListItemStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexDirection: 'column',
       flexGrow: 1,
+      maxWidth: '80%',
     }),
     errored: css({
       color: theme.colors.error.text,
@@ -107,7 +108,6 @@ const getDataLinkListItemStyles = (theme: GrafanaTheme2) => {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      maxWidth: '90%',
     }),
     dragRow: css({
       position: 'relative',


### PR DESCRIPTION
Fixes an issue, where long datalinks scroll beyond panel options, by setting a max width for the url so everything fits inside the draggable item.

Before:

https://github.com/user-attachments/assets/129321a8-67fd-44e8-bc99-7bd3d625be2b





After:

https://github.com/user-attachments/assets/47450fd8-281d-4a0f-93f4-2e9a1f4ca76f


