### PR TITLE
[authz]: set authzv1.ReadResponse.Found

### DIFF
--- a/pkg/services/authz/server.go
+++ b/pkg/services/authz/server.go
@@ -48,6 +48,8 @@ func (s *legacyServer) Read(ctx context.Context, req *authzv1.ReadRequest) (*aut
 	ctx, span := s.tracer.Start(ctx, "authz.grpc.Read")
 	defer span.End()
 
+	// FIXME: once we have access tokens, we need to do namespace validation here
+
 	action := req.GetAction()
 	subject := req.GetSubject()
 	stackID := req.GetStackId() // TODO can we consider the stackID as the orgID?
@@ -74,5 +76,8 @@ func (s *legacyServer) Read(ctx context.Context, req *authzv1.ReadRequest) (*aut
 	for _, perm := range permissions {
 		data = append(data, &authzv1.ReadResponse_Data{Object: perm.Scope})
 	}
-	return &authzv1.ReadResponse{Data: data}, nil
+	return &authzv1.ReadResponse{
+		Data:  data,
+		Found: len(data) > 0,
+	}, nil
 }


### PR DESCRIPTION
**What is this feature?**

Setting `authzv1.ReadResponse.Found` in Read handler.
Catch up with https://github.com/grafana/authlib/pull/43

**Why do we need this feature?**

n/a

**Who is this feature for?**

n/a

**Which issue(s) does this PR fix?**:

Fixes #n/a

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
