### PR TITLE
Plugins: Update CLI check if plugin is already installed

### DIFF
--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -117,8 +117,13 @@ func doInstallPlugin(ctx context.Context, pluginID, version string, o pluginInst
 
 	// If a version is specified, check if it is already installed
 	if version != "" {
-		if services.PluginVersionInstalled(pluginID, version, o.pluginDir) {
+		if p, ok := services.PluginVersionInstalled(pluginID, version, o.pluginDir); ok {
 			services.Logger.Successf("Plugin %s v%s already installed.", pluginID, version)
+			for _, depP := range p.JSONData.Dependencies.Plugins {
+				if err := doInstallPlugin(ctx, depP.ID, depP.Version, o, installing); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 	}
@@ -144,8 +149,13 @@ func doInstallPlugin(ctx context.Context, pluginID, version string, o pluginInst
 			return err
 		}
 
-		if services.PluginVersionInstalled(pluginID, archiveInfo.Version, o.pluginDir) {
+		if p, ok := services.PluginVersionInstalled(pluginID, archiveInfo.Version, o.pluginDir); ok {
 			services.Logger.Successf("Plugin %s v%s already installed.", pluginID, archiveInfo.Version)
+			for _, depP := range p.JSONData.Dependencies.Plugins {
+				if err = doInstallPlugin(ctx, depP.ID, depP.Version, o, installing); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
 

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -115,6 +115,14 @@ func doInstallPlugin(ctx context.Context, pluginID, version string, o pluginInst
 		installing[pluginID] = false
 	}()
 
+	// If a version is specified, check if it is already installed
+	if version != "" {
+		if services.PluginVersionInstalled(pluginID, version, o.pluginDir) {
+			services.Logger.Successf("Plugin %s v%s already installed.", pluginID, version)
+			return nil
+		}
+	}
+
 	repository := repo.NewManager(repo.ManagerCfg{
 		SkipTLSVerify: o.insecure,
 		BaseURL:       o.repoURL,

--- a/pkg/cmd/grafana-cli/services/services.go
+++ b/pkg/cmd/grafana-cli/services/services.go
@@ -88,14 +88,14 @@ func GetLocalPlugins(pluginDir string) []*plugins.FoundBundle {
 	return res
 }
 
-func PluginVersionInstalled(pluginID, version, pluginDir string) bool {
+func PluginVersionInstalled(pluginID, version, pluginDir string) (plugins.FoundPlugin, bool) {
 	for _, bundle := range GetLocalPlugins(pluginDir) {
 		pJSON := bundle.Primary.JSONData
 		if pJSON.ID == pluginID {
 			if pJSON.Info.Version == version {
-				return true
+				return bundle.Primary, true
 			}
 		}
 	}
-	return false
+	return plugins.FoundPlugin{}, false
 }

--- a/pkg/plugins/storage/fs.go
+++ b/pkg/plugins/storage/fs.go
@@ -237,7 +237,7 @@ func readPluginJSON(pluginDir string) (plugins.JSONData, error) {
 		// nolint:gosec
 		data, err = os.ReadFile(pluginPath)
 		if err != nil {
-			return plugins.JSONData{}, fmt.Errorf("could not find plugin.json or dist/plugin.json for in %s", pluginDir)
+			return plugins.JSONData{}, fmt.Errorf("could not find plugin.json or dist/plugin.json in %s", pluginDir)
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

Improves the Grafana CLI plugin installation flow by checking if a plugin is already installed on disk prior to fetching from the remote repository.

```
➜ grafana cli --debug plugins install grafana-metrics-enterprise-app
✔ Plugin grafana-metrics-enterprise-app v4.1.2 already installed.

✔ Plugin marcusolsson-treemap-panel v2.0.1 already installed.

Please restart Grafana after installing or removing plugins. Refer to Grafana documentation for instructions if necessary.
```
```
➜ grafana cli --debug plugins install alexanderzobnin-zabbix-app    
✔ Plugin alexanderzobnin-zabbix-app v4.5.2 already installed.

Please restart Grafana after installing or removing plugins. Refer to Grafana documentation for instructions if necessary.
```
```
➜ grafana cli --debug plugins install grafana-metrics-enterprise-app
✔ Plugin grafana-metrics-enterprise-app v4.1.2 already installed.

Installing plugin from https://grafana.com/api/plugins/marcusolsson-treemap-panel/versions/2.0.1/download

✔ Downloaded and extracted marcusolsson-treemap-panel v2.0.1 zip successfully to /Users/wbrowne/dev/grafana/data/plugins/marcusolsson-treemap-panel

Please restart Grafana after installing or removing plugins. Refer to Grafana documentation for instructions if necessary.
```

**Why do we need this feature?**

General improvement.

**Who is this feature for?**

Those who use Grafana CLI to manage plugin installations.

**Which issue(s) does this PR fix?**:

Fixes #90633
