### PR TITLE
Canvas: Support template variables in base URL of actions

### DIFF
--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -12,7 +12,8 @@ type IsLoadingCallback = (loading: boolean) => void;
 export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoadingCallback) => {
   if (api && api.endpoint) {
     // If API endpoint origin matches Grafana origin, don't call it.
-    if (requestMatchesGrafanaOrigin(api.endpoint)) {
+    const interpolatedUrl = interpolateVariables(api.endpoint);
+    if (requestMatchesGrafanaOrigin(interpolatedUrl)) {
       appEvents.emit(AppEvents.alertError, ['Cannot call API at Grafana origin.']);
       updateLoadingStateCallback && updateLoadingStateCallback(false);
       return;


### PR DESCRIPTION
Support variable interpolation for the base URL in a canvas action. 

Before


https://github.com/user-attachments/assets/575f92a7-8eb5-4009-be0f-0df68b1dafe3



After (note the CORS issue but the request is going through)


https://github.com/user-attachments/assets/f6059709-020f-442b-b9c9-a0b36577bd49

