### PR TITLE
Snapshots: Remove deprecated option snapshot_remove_expired

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -428,9 +428,6 @@ external_snapshot_name = Publish to snapshots.raintank.io
 # creating and deleting snapshots.
 public_mode = false
 
-# remove expired snapshot
-snapshot_remove_expired = true
-
 #################################### Dashboards ##################
 
 [dashboards]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -431,9 +431,6 @@
 # creating and deleting snapshots.
 ;public_mode = false
 
-# remove expired snapshot
-;snapshot_remove_expired = true
-
 #################################### Dashboards ##################
 [dashboards]
 # Number dashboard versions to keep (per dashboard). Default: 20, Minimum: 1

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -754,10 +754,6 @@ Set name for external snapshot button. Defaults to `Publish to snapshots.raintan
 
 Set to true to enable this Grafana instance to act as an external snapshot server and allow unauthenticated requests for creating and deleting snapshots. Default is `false`.
 
-### snapshot_remove_expired
-
-Enable this to automatically remove expired snapshots. Default is `true`.
-
 <hr />
 
 ## [dashboards]

--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/setting"
@@ -15,10 +14,6 @@ import (
 
 type DashboardSnapshotStore struct {
 	store db.DB
-	log   log.Logger
-
-	// deprecated behavior
-	skipDeleteExpired bool
 }
 
 // DashboardStore implements the Store interface
@@ -26,25 +21,17 @@ var _ dashboardsnapshots.Store = (*DashboardSnapshotStore)(nil)
 
 func ProvideStore(db db.DB, cfg *setting.Cfg) *DashboardSnapshotStore {
 	// nolint:staticcheck
-	return NewStore(db, !cfg.SnapShotRemoveExpired)
+	return NewStore(db)
 }
 
-func NewStore(db db.DB, skipDeleteExpired bool) *DashboardSnapshotStore {
-	log := log.New("dashboardsnapshot.store")
-	if skipDeleteExpired {
-		log.Warn("[Deprecated] The snapshot_remove_expired setting is outdated. Please remove from your config.")
-	}
-	return &DashboardSnapshotStore{store: db, skipDeleteExpired: skipDeleteExpired}
+func NewStore(db db.DB) *DashboardSnapshotStore {
+	return &DashboardSnapshotStore{store: db}
 }
 
 // DeleteExpiredSnapshots removes snapshots with old expiry dates.
 // SnapShotRemoveExpired is deprecated and should be removed in the future.
 // Snapshot expiry is decided by the user when they share the snapshot.
 func (d *DashboardSnapshotStore) DeleteExpiredSnapshots(ctx context.Context, cmd *dashboardsnapshots.DeleteExpiredSnapshotsCommand) error {
-	if d.skipDeleteExpired {
-		d.log.Warn("[Deprecated] The snapshot_remove_expired setting is outdated. Please remove from your config.")
-		return nil
-	}
 	return d.store.WithDbSession(ctx, func(sess *db.Session) error {
 		deleteExpiredSQL := "DELETE FROM dashboard_snapshot WHERE expires < ?"
 		expiredResponse, err := sess.Exec(deleteExpiredSQL, time.Now())

--- a/pkg/services/dashboardsnapshots/database/database_test.go
+++ b/pkg/services/dashboardsnapshots/database/database_test.go
@@ -164,7 +164,7 @@ func TestIntegrationDeleteExpiredSnapshots(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	sqlstore := db.InitTestDB(t)
-	dashStore := NewStore(sqlstore, false)
+	dashStore := NewStore(sqlstore)
 
 	t.Run("Testing dashboard snapshots clean up", func(t *testing.T) {
 		nonExpiredSnapshot := createTestSnapshot(t, dashStore, "key1", 48000)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -342,8 +342,6 @@ type Cfg struct {
 	ExternalSnapshotUrl  string
 	ExternalSnapshotName string
 	ExternalEnabled      bool
-	// Deprecated: setting this to false adds deprecation warnings at runtime
-	SnapShotRemoveExpired bool
 
 	// Only used in https://snapshots.raintank.io/
 	SnapshotPublicMode bool
@@ -1851,7 +1849,6 @@ func readSnapshotsSettings(cfg *Cfg, iniFile *ini.File) error {
 	cfg.ExternalSnapshotName = valueAsString(snapshots, "external_snapshot_name", "")
 
 	cfg.ExternalEnabled = snapshots.Key("external_enabled").MustBool(true)
-	cfg.SnapShotRemoveExpired = snapshots.Key("snapshot_remove_expired").MustBool(true)
 	cfg.SnapshotPublicMode = snapshots.Key("public_mode").MustBool(false)
 
 	return nil


### PR DESCRIPTION
This removes the option to avoid removing expired snapshots.  