### PR TITLE
Snapshots: Fix panic when snapshot_remove_expired is true

### DIFF
--- a/pkg/services/dashboardsnapshots/database/database.go
+++ b/pkg/services/dashboardsnapshots/database/database.go
@@ -34,7 +34,7 @@ func NewStore(db db.DB, skipDeleteExpired bool) *DashboardSnapshotStore {
 	if skipDeleteExpired {
 		log.Warn("[Deprecated] The snapshot_remove_expired setting is outdated. Please remove from your config.")
 	}
-	return &DashboardSnapshotStore{store: db, skipDeleteExpired: skipDeleteExpired}
+	return &DashboardSnapshotStore{store: db, skipDeleteExpired: skipDeleteExpired, log: log}
 }
 
 // DeleteExpiredSnapshots removes snapshots with old expiry dates.


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/91217

In 11.2, the option is removed with https://github.com/grafana/grafana/pull/91231