### PR TITLE
[v11.0.x] TemplateSrv: Backportable version of 90808 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4506,6 +4506,9 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/plugins/datasource/dashboard/datasource.ts:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/plugins/datasource/dashboard/runSharedRequest.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -15,7 +15,7 @@ import {
   TemplateSrv as BaseTemplateSrv,
   VariableInterpolation,
 } from '@grafana/runtime';
-import { sceneGraph, VariableCustomFormatterFn } from '@grafana/scenes';
+import { sceneGraph, VariableCustomFormatterFn, SceneObject } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 
 import { getVariablesCompatibility } from '../dashboard-scene/utils/getVariablesCompatibility';
@@ -249,8 +249,10 @@ export class TemplateSrv implements BaseTemplateSrv {
   ): string {
     // Scenes compatability (primary method) is via SceneObject inside scopedVars. This way we get a much more accurate "local" scope for the evaluation
     if (scopedVars && scopedVars.__sceneObject) {
+      // We are using valueOf here as __sceneObject can be after scenes 5.6.0 a SafeSerializableSceneObject that overrides valueOf to return the underlying SceneObject
+      const sceneObject: SceneObject = scopedVars.__sceneObject.value.valueOf();
       return sceneGraph.interpolate(
-        scopedVars.__sceneObject.value,
+        sceneObject,
         target,
         scopedVars,
         format as string | VariableCustomFormatterFn | undefined

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -6,6 +6,7 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   TestDataSourceResponse,
+  ScopedVar,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
@@ -25,7 +26,8 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   }
 
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
-    const scene: SceneObject | undefined = options.scopedVars?.__sceneObject?.value;
+    const sceneScopedVar: ScopedVar | undefined = options.scopedVars?.__sceneObject;
+    let scene: SceneObject | undefined = sceneScopedVar ? (sceneScopedVar.value.valueOf() as SceneObject) : undefined;
 
     if (options.requestId.indexOf('mixed') > -1) {
       throw new Error('Dashboard data source cannot be used with Mixed data source.');


### PR DESCRIPTION
Backport 2e5b41cbcb403d7dee6ecdfacb94a6bc52cd6e90 from #90833

---

This is the same thing as https://github.com/grafana/grafana/pull/90808, but without tests case that requires scenes 5.6.x. It's created to backport this to 11.1.x so that scenes apps using scenes 5.6.x can be run agains Grafana 11.0.x
