### PR TITLE
Navigation: fix `bodyScrolling` in safari for browseDashboards/scenes dashboards

### DIFF
--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -117,10 +117,19 @@ const getStyles = (theme: GrafanaTheme2) => {
             minHeight: 0,
           }
     ),
-    pageContent: css({
-      label: 'page-content',
-      flexGrow: 1,
-    }),
+    pageContent: css(
+      config.featureToggles.bodyScrolling
+        ? {
+            display: 'flex',
+            flexDirection: 'column',
+            label: 'page-content',
+            flexGrow: 1,
+          }
+        : {
+            label: 'page-content',
+            flexGrow: 1,
+          }
+    ),
     primaryBg: css({
       background: theme.colors.background.primary,
     }),

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -100,35 +100,30 @@ Page.Contents = PageContents;
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrapper: css(
+      {
+        label: 'page-wrapper',
+        display: 'flex',
+        flex: '1 1 0',
+        flexDirection: 'column',
+      },
       config.featureToggles.bodyScrolling
         ? {
-            label: 'page-wrapper',
-            display: 'flex',
-            flex: '1 1 0',
-            flexDirection: 'column',
             position: 'relative',
           }
         : {
-            label: 'page-wrapper',
             height: '100%',
-            display: 'flex',
-            flex: '1 1 0',
-            flexDirection: 'column',
             minHeight: 0,
           }
     ),
     pageContent: css(
-      config.featureToggles.bodyScrolling
-        ? {
-            display: 'flex',
-            flexDirection: 'column',
-            label: 'page-content',
-            flexGrow: 1,
-          }
-        : {
-            label: 'page-content',
-            flexGrow: 1,
-          }
+      {
+        label: 'page-content',
+        flexGrow: 1,
+      },
+      config.featureToggles.bodyScrolling && {
+        display: 'flex',
+        flexDirection: 'column',
+      }
     ),
     primaryBg: css({
       background: theme.colors.background.primary,

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -171,17 +171,16 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   pageContents: css(
+    {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
     config.featureToggles.bodyScrolling
       ? {
-          display: 'flex',
-          flexDirection: 'column',
           flex: 1,
-          gap: theme.spacing(1),
         }
       : {
-          display: 'flex',
-          flexDirection: 'column',
-          gap: theme.spacing(1),
           height: '100%',
         }
   ),

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
@@ -170,17 +170,32 @@ const BrowseDashboardsPage = memo(({ match }: Props) => {
 });
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  pageContents: css({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(1),
-    height: '100%',
-  }),
+  pageContents: css(
+    config.featureToggles.bodyScrolling
+      ? {
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          gap: theme.spacing(1),
+        }
+      : {
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing(1),
+          height: '100%',
+        }
+  ),
 
   // AutoSizer needs an element to measure the full height available
-  subView: css({
-    height: '100%',
-  }),
+  subView: css(
+    config.featureToggles.bodyScrolling
+      ? {
+          flex: 1,
+        }
+      : {
+          height: '100%',
+        }
+  ),
 
   filters: css({
     display: 'none',

--- a/public/app/features/browse-dashboards/RecentlyDeletedPage.tsx
+++ b/public/app/features/browse-dashboards/RecentlyDeletedPage.tsx
@@ -3,6 +3,7 @@ import { memo, useEffect } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { t } from 'app/core/internationalization';
@@ -91,17 +92,31 @@ const RecentlyDeletedPage = memo(() => {
 });
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  pageContents: css({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(1),
-    height: '100%',
-  }),
+  pageContents: css(
+    {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
+    config.featureToggles.bodyScrolling
+      ? {
+          flex: 1,
+        }
+      : {
+          height: '100%',
+        }
+  ),
 
   // AutoSizer needs an element to measure the full height available
-  subView: css({
-    height: '100%',
-  }),
+  subView: css(
+    config.featureToggles.bodyScrolling
+      ? {
+          flex: 1,
+        }
+      : {
+          height: '100%',
+        }
+  ),
 
   filters: css({
     display: 'none',

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -4,6 +4,7 @@ import { useMedia } from 'react-use';
 
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { SceneComponentProps } from '@grafana/scenes';
 import { CustomScrollbar, useStyles2, useTheme2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -93,18 +94,35 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    pageContainer: css({
-      display: 'grid',
-      gridTemplateAreas: `
+    pageContainer: css(
+      config.featureToggles.bodyScrolling
+        ? {
+            display: 'grid',
+            gridTemplateAreas: `
         "panels"`,
-      gridTemplateColumns: `1fr`,
-      gridTemplateRows: '1fr',
-      height: '100%',
-      [theme.breakpoints.down('sm')]: {
-        display: 'flex',
-        flexDirection: 'column',
-      },
-    }),
+            gridTemplateColumns: `1fr`,
+            gridTemplateRows: '1fr',
+            height: '100%',
+            position: 'absolute',
+            width: '100%',
+            [theme.breakpoints.down('sm')]: {
+              display: 'flex',
+              flexDirection: 'column',
+            },
+          }
+        : {
+            display: 'grid',
+            gridTemplateAreas: `
+        "panels"`,
+            gridTemplateColumns: `1fr`,
+            gridTemplateRows: '1fr',
+            height: '100%',
+            [theme.breakpoints.down('sm')]: {
+              display: 'flex',
+              flexDirection: 'column',
+            },
+          }
+    ),
     pageContainerWithControls: css({
       gridTemplateAreas: `
         "controls"
@@ -123,9 +141,16 @@ function getStyles(theme: GrafanaTheme2) {
         "scopes controls"
         "scopes panels"`,
     }),
-    panelsContainer: css({
-      gridArea: 'panels',
-    }),
+    panelsContainer: css(
+      config.featureToggles.bodyScrolling
+        ? {
+            gridArea: 'panels',
+            minHeight: 'unset !important',
+          }
+        : {
+            gridArea: 'panels',
+          }
+    ),
     controlsWrapper: css({
       display: 'flex',
       flexDirection: 'column',

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -95,33 +95,22 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
 function getStyles(theme: GrafanaTheme2) {
   return {
     pageContainer: css(
-      config.featureToggles.bodyScrolling
-        ? {
-            display: 'grid',
-            gridTemplateAreas: `
-        "panels"`,
-            gridTemplateColumns: `1fr`,
-            gridTemplateRows: '1fr',
-            height: '100%',
-            position: 'absolute',
-            width: '100%',
-            [theme.breakpoints.down('sm')]: {
-              display: 'flex',
-              flexDirection: 'column',
-            },
-          }
-        : {
-            display: 'grid',
-            gridTemplateAreas: `
-        "panels"`,
-            gridTemplateColumns: `1fr`,
-            gridTemplateRows: '1fr',
-            height: '100%',
-            [theme.breakpoints.down('sm')]: {
-              display: 'flex',
-              flexDirection: 'column',
-            },
-          }
+      {
+        display: 'grid',
+        gridTemplateAreas: `
+  "panels"`,
+        gridTemplateColumns: `1fr`,
+        gridTemplateRows: '1fr',
+        height: '100%',
+        [theme.breakpoints.down('sm')]: {
+          display: 'flex',
+          flexDirection: 'column',
+        },
+      },
+      config.featureToggles.bodyScrolling && {
+        position: 'absolute',
+        width: '100%',
+      }
     ),
     pageContainerWithControls: css({
       gridTemplateAreas: `
@@ -142,14 +131,12 @@ function getStyles(theme: GrafanaTheme2) {
         "scopes panels"`,
     }),
     panelsContainer: css(
-      config.featureToggles.bodyScrolling
-        ? {
-            gridArea: 'panels',
-            minHeight: 'unset !important',
-          }
-        : {
-            gridArea: 'panels',
-          }
+      {
+        gridArea: 'panels',
+      },
+      config.featureToggles.bodyScrolling && {
+        minHeight: 'unset !important',
+      }
     ),
     controlsWrapper: css({
       display: 'flex',

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -6,7 +6,7 @@ import { Subscription } from 'rxjs';
 
 import { FieldConfigSource, GrafanaTheme2, NavModel, NavModelItem, PageLayoutType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import {
   Button,
   HorizontalGroup,
@@ -495,20 +495,33 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, props: Props) => {
   const paneSpacing = theme.spacing(2);
 
   return {
-    wrapper: css({
-      width: '100%',
-      flexGrow: 1,
-      minHeight: 0,
-      display: 'flex',
-      paddingTop: theme.spacing(2),
-    }),
-    verticalSplitPanesWrapper: css({
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-      width: '100%',
-      position: 'relative',
-    }),
+    wrapper: css(
+      {
+        width: '100%',
+        flexGrow: 1,
+        minHeight: 0,
+        display: 'flex',
+        paddingTop: theme.spacing(2),
+      },
+      config.featureToggles.bodyScrolling && {
+        flexDirection: 'column',
+      }
+    ),
+    verticalSplitPanesWrapper: css(
+      {
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+      },
+      config.featureToggles.bodyScrolling
+        ? {
+            flex: 1,
+          }
+        : {
+            height: '100%',
+            width: '100%',
+          }
+    ),
     mainPaneWrapper: css({
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- correctly flexes pages in safari

**Why do we need this feature?**

- so pages appear correctly in safari when `bodyScrolling` is enabled

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/90930
Fixes https://github.com/grafana/grafana/issues/90929

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
