### PR TITLE
unifiedStorage: sort by namespace/name ASC

### DIFF
--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -359,9 +359,9 @@ func buildTree(ctx context.Context, s *cdkBackend, key *ResourceKey) (*cdkListIt
 		resources = append(resources, *res)
 	}
 	sort.Slice(resources, func(i, j int) bool {
-		a := resources[i].versions[0].rv
-		b := resources[j].versions[0].rv
-		return a > b
+		a := resources[i].prefix
+		b := resources[j].prefix
+		return a < b
 	})
 
 	return &cdkListIterator{

--- a/pkg/storage/unified/sql/data/resource_history_list.sql
+++ b/pkg/storage/unified/sql/data/resource_history_list.sql
@@ -46,7 +46,7 @@ SELECT
         AND kv.{{ .Ident "name" }}      = {{ .Arg .Request.Options.Key.Name }}
         {{ end }}
     {{ end }}
-    ORDER BY kv.{{ .Ident "resource_version" }} DESC
+    ORDER BY kv.{{ .Ident "namespace" }} ASC, kv.{{ .Ident "name" }} ASC
     {{ if (gt .Request.Limit 0) }}
     LIMIT {{ .Arg .Request.Limit }} OFFSET {{ .Arg .Request.Offset }}
     {{ end }}

--- a/pkg/storage/unified/sql/data/resource_list.sql
+++ b/pkg/storage/unified/sql/data/resource_list.sql
@@ -19,5 +19,5 @@ SELECT
             AND {{ .Ident "name" }}      = {{ .Arg .Request.Options.Key.Name }}
             {{ end }}
         {{ end }}
-    ORDER BY {{ .Ident "resource_version" }} DESC
+    ORDER BY {{ .Ident "namespace" }} ASC, {{ .Ident "name" }} ASC
 ;

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -60,7 +60,7 @@ func newServer(t *testing.T) (sql.Backend, resource.ResourceServer) {
 }
 
 func TestIntegrationBackendHappyPath(t *testing.T) {
-	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -168,7 +168,7 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 }
 
 func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
-	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -191,7 +191,7 @@ func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
 }
 
 func TestIntegrationBackendList(t *testing.T) {
-	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -325,7 +325,7 @@ func TestIntegrationBackendList(t *testing.T) {
 	})
 }
 func TestClientServer(t *testing.T) {
-	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 	dbstore := infraDB.InitTestDB(t)
 

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -60,7 +60,7 @@ func newServer(t *testing.T) (sql.Backend, resource.ResourceServer) {
 }
 
 func TestIntegrationBackendHappyPath(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -168,7 +168,7 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 }
 
 func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -191,7 +191,7 @@ func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
 }
 
 func TestIntegrationBackendList(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -220,12 +220,12 @@ func TestIntegrationBackendList(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 5)
-		// should be sorted by resource version DESC
-		require.Equal(t, "item6 ADDED", string(res.Items[0].Value))
+		// should be sorted by key ASC
+		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
 		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
-		require.Equal(t, "item5 ADDED", string(res.Items[2].Value))
-		require.Equal(t, "item4 ADDED", string(res.Items[3].Value))
-		require.Equal(t, "item1 ADDED", string(res.Items[4].Value))
+		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
+		require.Equal(t, "item5 ADDED", string(res.Items[3].Value))
+		require.Equal(t, "item6 ADDED", string(res.Items[4].Value))
 
 		require.Empty(t, res.NextPageToken)
 	})
@@ -245,9 +245,9 @@ func TestIntegrationBackendList(t *testing.T) {
 		require.Len(t, res.Items, 3)
 		continueToken, err := sql.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
-		require.Equal(t, "item6 ADDED", string(res.Items[0].Value))
+		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
 		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
-		require.Equal(t, "item5 ADDED", string(res.Items[2].Value))
+		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
 		require.Equal(t, int64(8), continueToken.ResourceVersion)
 	})
 
@@ -264,10 +264,10 @@ func TestIntegrationBackendList(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 4)
-		require.Equal(t, "item4 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item3 ADDED", string(res.Items[1].Value))
-		require.Equal(t, "item2 ADDED", string(res.Items[2].Value))
-		require.Equal(t, "item1 ADDED", string(res.Items[3].Value))
+		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
+		require.Equal(t, "item2 ADDED", string(res.Items[1].Value))
+		require.Equal(t, "item3 ADDED", string(res.Items[2].Value))
+		require.Equal(t, "item4 ADDED", string(res.Items[3].Value))
 		require.Empty(t, res.NextPageToken)
 	})
 
@@ -287,8 +287,8 @@ func TestIntegrationBackendList(t *testing.T) {
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 3)
 		t.Log(res.Items)
-		require.Equal(t, "item2 MODIFIED", string(res.Items[0].Value))
-		require.Equal(t, "item5 ADDED", string(res.Items[1].Value))
+		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
+		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
 		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
 
 		continueToken, err := sql.GetContinueToken(res.NextPageToken)
@@ -315,8 +315,8 @@ func TestIntegrationBackendList(t *testing.T) {
 		require.Nil(t, res.Error)
 		require.Len(t, res.Items, 2)
 		t.Log(res.Items)
-		require.Equal(t, "item5 ADDED", string(res.Items[0].Value))
-		require.Equal(t, "item4 ADDED", string(res.Items[1].Value))
+		require.Equal(t, "item4 ADDED", string(res.Items[0].Value))
+		require.Equal(t, "item5 ADDED", string(res.Items[1].Value))
 
 		continueToken, err = sql.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
@@ -325,7 +325,7 @@ func TestIntegrationBackendList(t *testing.T) {
 	})
 }
 func TestClientServer(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 	dbstore := infraDB.InitTestDB(t)
 

--- a/pkg/storage/unified/sql/testdata/resource_history_list_mysql_sqlite.sql
+++ b/pkg/storage/unified/sql/testdata/resource_history_list_mysql_sqlite.sql
@@ -8,6 +8,6 @@ INNER JOIN (
 ) AS maxkv
 ON maxkv."resource_version" = kv."resource_version" AND maxkv."namespace" = kv."namespace" AND maxkv."group" = kv."group" AND maxkv."resource" = kv."resource" AND maxkv."name" = kv."name"
 WHERE kv."action" != 3 AND kv."namespace" = ?
-ORDER BY kv."resource_version" DESC
+ORDER BY kv."namespace" ASC, kv."name" ASC
 LIMIT ? OFFSET ?
 ;

--- a/pkg/storage/unified/sql/testdata/resource_list_mysql_sqlite.sql
+++ b/pkg/storage/unified/sql/testdata/resource_list_mysql_sqlite.sql
@@ -1,5 +1,5 @@
 SELECT "resource_version", "namespace", "name", "value"
     FROM "resource"
     WHERE 1 = 1 AND "namespace" = ?
-    ORDER BY "resource_version" DESC
+    ORDER BY "namespace" ASC, "name" ASC
 ;


### PR DESCRIPTION
**What is this feature?**
Ensure unified storage sorts resources by key instead of by resource version. We want the default implementation to match as much as possible.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
