### PR TITLE
Navigation: Fix `<Portal>` when `bodyScrolling` is enabled

### DIFF
--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,8 +1,11 @@
+import { css, cx } from '@emotion/css';
 import { PropsWithChildren, useLayoutEffect, useRef } from 'react';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 
-import { useTheme2 } from '../../themes';
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2, useTheme2 } from '../../themes';
 
 interface Props {
   className?: string;
@@ -47,8 +50,26 @@ export function getPortalContainer() {
 
 /** @internal */
 export function PortalContainer() {
-  return <div id="grafana-portal-container" />;
+  const styles = useStyles2(getStyles);
+  const isBodyScrolling = window.grafanaBootData?.settings.featureToggles.bodyScrolling;
+  return (
+    <div
+      id="grafana-portal-container"
+      className={cx({
+        [styles.grafanaPortalContainer]: isBodyScrolling,
+      })}
+    />
+  );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  grafanaPortalContainer: css({
+    position: 'fixed',
+    top: 0,
+    width: '100%',
+    zIndex: theme.zIndex.portal,
+  }),
+});
 
 export const RefForwardingPortal = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
   return <Portal {...props} forwardedRef={ref} />;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- changes `<PortalContainer>` to have a `fixed` position so it positions correctly
- this change is behind the `bodyScrolling` feature toggle
- what happens when `bodyScrolling` is disabled:
  - the `PortalContainer` sits at the top of the document since `grafana-app` is positioned absolutely and therefore takes no space
  - if the page is scrolled whilst the portalled element is visible, the portalled element becomes detached from its anchor
- what happens now when `bodyScrolling` is enabled:
  - the `PortalContainer` sits at the top of the document since it has a fixed position
  - if the page is scrolled whilst the portalled element is visible, the portalled element becomes detached from it's anchor
  
tl;dr: same behaviour as before. @joshhunt is right in the issue description, we don't even really need `<Portal>` anymore since we can utilise floating-ui. but i'm aiming for parity first here before refactoring. 

**Why do we need this feature?**

- so `<Portal>` behaves correctly when using `bodyScrolling`

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/90927

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
