### PR TITLE
Alerting docs: fixes alt text errors

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/annotation-label.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/annotation-label.md
@@ -68,7 +68,7 @@ Examples of labels are `server=server1` or `team=backend`. Each alert rule can h
 
 For example, an alert instance might have the label set `{alertname="High CPU usage",server="server1"}` while another alert instance might have the label set `{alertname="High CPU usage",server="server2"}`. These are two separate alert instances because although their `alertname` labels are the same, their `server` labels are different.
 
-{{< figure alt="Image shows an example of an alert instance and its labels" src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" >}}
+{{< figure alt="Image shows an example of an alert instance and the labels used on the alert instance." src="/static/img/docs/alerting/unified/multi-dimensional-alert.png" >}}
 
 Labels are a fundamental component of alerting:
 

--- a/docs/sources/alerting/manage-notifications/view-state-health.md
+++ b/docs/sources/alerting/manage-notifications/view-state-health.md
@@ -111,5 +111,3 @@ To access the State history view, complete the following steps.
    The value shown for each instance is for each part of the expression that was evaluated.
 
 1. Click the labels to filter and narrow down the results.
-
-   {{< figure src="/media/docs/alerting/state-history.png" max-width="750px" >}}


### PR DESCRIPTION
deletes a screenshot and updates text for the other to get rid of alt text errors