### PR TITLE
Tempo: Add migration to enable TraceQL streaming for Tempo datasources

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -126,9 +126,7 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 
 	ualert.AddStateResolvedAtColumns(mg)
 
-	if oss.features != nil && oss.features.IsEnabledGlobally(featuremgmt.FlagTraceQLStreaming) {
-		enableTraceQLStreaming(mg)
-	}
+	enableTraceQLStreaming(mg, oss.features != nil && oss.features.IsEnabledGlobally(featuremgmt.FlagTraceQLStreaming))
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -125,6 +125,10 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.AddRecordingRuleColumns(mg)
 
 	ualert.AddStateResolvedAtColumns(mg)
+
+	if oss.features != nil && oss.features.IsEnabledGlobally(featuremgmt.FlagTraceQLStreaming) {
+		enableTraceQLStreaming(mg)
+	}
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/tempo_datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/tempo_datasource_mig.go
@@ -9,7 +9,6 @@ import (
 )
 
 func enableTraceQLStreaming(mg *Migrator) {
-
 	mg.AddMigration("Enable traceQL streaming for all Tempo datasources", &AddTraceQLStreamingToJsonData{})
 }
 

--- a/pkg/services/sqlstore/migrations/tempo_datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/tempo_datasource_mig.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"xorm.io/xorm"
+
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+func enableTraceQLStreaming(mg *Migrator) {
+
+	mg.AddMigration("Enable traceQL streaming for all Tempo datasources", &AddTraceQLStreamingToJsonData{})
+}
+
+var _ CodeMigration = new(AddTraceQLStreamingToJsonData)
+
+type AddTraceQLStreamingToJsonData struct {
+	MigrationBase
+}
+
+func (m *AddTraceQLStreamingToJsonData) SQL(dialect Dialect) string {
+	return "code migration"
+}
+
+type TempoIdJsonDataDTO struct {
+	Id       int64
+	JsonData string
+}
+
+func (m *AddTraceQLStreamingToJsonData) Exec(sess *xorm.Session, mg *Migrator) error {
+	datasources := make([]*TempoIdJsonDataDTO, 0)
+
+	err := sess.SQL("SELECT id, json_data FROM data_source WHERE type = 'tempo'").Find(&datasources)
+
+	if err != nil {
+		return err
+	}
+
+	enabledStreamingMap := map[string]interface{}{
+		"search": true,
+	}
+
+	for _, ds := range datasources {
+		var parsedMap map[string]interface{}
+		if err := json.Unmarshal([]byte(ds.JsonData), &parsedMap); err != nil {
+			continue
+		}
+		// skip datasource if streamingEnabled is already set
+		if parsedMap["streamingEnabled"] != nil {
+			continue
+		}
+		parsedMap["streamingEnabled"] = enabledStreamingMap
+
+		newJsonData, err := json.Marshal(parsedMap)
+		if err != nil {
+			return err
+		}
+
+		_, err = sess.Exec("UPDATE data_source SET json_data = ? WHERE id = ?", newJsonData, ds.Id)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -277,10 +277,9 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
    */
   isStreamingSearchEnabled() {
     return (
-      config.featureToggles.traceQLStreaming &&
+      (config.featureToggles.traceQLStreaming || this.streamingEnabled?.search) &&
       this.isFeatureAvailable(FeatureName.streaming) &&
-      config.liveEnabled &&
-      this.streamingEnabled?.search
+      config.liveEnabled
     );
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As we plan to remove the `traceQLStreaming` feature toggle to replace it with a datasource config, we want to migrate the instances that have the feature toggle enabled to automatically enable the datasource config for all Tempo datasources available. 

Related to https://github.com/grafana/grafana/pull/88685

**Why do we need this feature?**

To automatically enable streaming if the feature toggle is enabled.

**Who is this feature for?**

Tempo datasource users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
