### PR TITLE
Table: Fix negative numbers during rtl styling

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -43,8 +43,7 @@ export const TableCell = ({
     cellProps.style.minWidth = cellProps.style.width;
     const justifyContent = (cell.column as any).justifyContent;
 
-    // If cell has a unit we should avoid setting direction to rtl
-    if (justifyContent === 'flex-end' && !field.config.unit) {
+    if (justifyContent === 'flex-end') {
       // justify-content flex-end is not compatible with cellLink overflow; use direction instead
       cellProps.style.textAlign = 'right';
       cellProps.style.direction = 'rtl';

--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -48,6 +48,7 @@ export const TableCell = ({
       // justify-content flex-end is not compatible with cellLink overflow; use direction instead
       cellProps.style.textAlign = 'right';
       cellProps.style.direction = 'rtl';
+      cellProps.style.unicodeBidi = 'plaintext';
     } else {
       cellProps.style.justifyContent = justifyContent;
     }


### PR DESCRIPTION
When rtl styling is applied to table cells, we need to make sure negative numbers are rendered properly. To do this, we can use bidirectional styling (unicodeBidi) option 'plaintext'.

Before:
![image](https://github.com/user-attachments/assets/0b5ba66e-1bdd-49b8-9876-94234664a529)
![image](https://github.com/user-attachments/assets/d7cd64d0-a0ec-459f-b940-fe055e5ed33b)

After:
![image](https://github.com/user-attachments/assets/d59d842e-f117-4b6a-a5c6-e292211cac35)
![image](https://github.com/user-attachments/assets/a4aff64d-014f-4da4-8f51-c44e87777171)

Fixes https://github.com/grafana/support-escalations/issues/11664