### PR TITLE
Typo fix in Templates documentation

### DIFF
--- a/docs/sources/alerting/fundamentals/notifications/templates.md
+++ b/docs/sources/alerting/fundamentals/notifications/templates.md
@@ -131,7 +131,7 @@ Notification templates represent the alternative approach to templating designed
 Here is an example of a notification template:
 
 ```go
-{ define "alerts.message" -}}
+{{ define "alerts.message" -}}
 {{ if .Alerts.Firing -}}
 {{ len .Alerts.Firing }} firing alert(s)
 {{ template "alerts.summarize" .Alerts.Firing }}


### PR DESCRIPTION
**What is this feature?**

This is a minor documentation update to fix a typo in the Grafana Templates documentation.

**Why do we need this feature?**

This fix improves the experience while going through the examples in the Templates documentation.

**Who is this feature for?**

Removes frustrations for those who deal with Go templates for the first time.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.

