### PR TITLE
Cloudwatch: Clear cached PDC transport when PDC is disabled

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -337,6 +337,10 @@ func (ds *DataSource) newSession(region string) (*session.Session, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error configuring Secure Socks proxy for Transport: %w", err)
 		}
+	} else if sess.Config.HTTPClient != nil {
+		// Workaround for https://github.com/grafana/grafana/issues/91356 - PDC transport set above
+		// stays on the cached session after PDC is disabled
+		sess.Config.HTTPClient.Transport = nil
 	}
 	return sess, nil
 }


### PR DESCRIPTION
**What is this feature?**
This fixes an issue where disabling PDC on a Cloudwatch datasource doesn't take effect until the cached session expires.

**Why do we need this feature?**
Fixes #91356
