### PR TITLE
Prometheus: Add group function to aggregations

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/aggregations.ts
+++ b/packages/grafana-prometheus/src/querybuilder/aggregations.ts
@@ -16,6 +16,7 @@ export function getAggregationOperations(): QueryBuilderOperationDef[] {
     ...createAggregationOperation(PromOperationId.Min),
     ...createAggregationOperation(PromOperationId.Max),
     ...createAggregationOperation(PromOperationId.Count),
+    ...createAggregationOperation(PromOperationId.Group),
     ...createAggregationOperationWithParam(PromOperationId.TopK, {
       params: [{ name: 'K-value', type: 'number' }],
       defaultParams: [5],

--- a/packages/grafana-prometheus/src/querybuilder/operations.ts
+++ b/packages/grafana-prometheus/src/querybuilder/operations.ts
@@ -195,7 +195,6 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
     //
     createFunction({ id: PromOperationId.Exp }),
     createFunction({ id: PromOperationId.Floor }),
-    createFunction({ id: PromOperationId.Group }),
     createFunction({ id: PromOperationId.Hour }),
     createFunction({
       id: PromOperationId.LabelJoin,

--- a/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.test.ts
@@ -783,6 +783,21 @@ describe('buildVisualQueryFromString', () => {
       })
     );
   });
+
+  it('parses the group function as an aggregation', () => {
+    expect(buildVisualQueryFromString('group by (job) (go_goroutines)')).toEqual(
+      noErrors({
+        metric: 'go_goroutines',
+        labels: [],
+        operations: [
+          {
+            id: '__group_by',
+            params: ['job'],
+          },
+        ],
+      })
+    );
+  });
 });
 
 function noErrors(query: PromVisualQuery) {


### PR DESCRIPTION
**What is this?**

This is a bug fix for the `group` function in the Prometheus query builder. The bug is that when switching from the code editor to the query builder the following query gets an error:

```
group by (job) (go_goroutines)
```

This is because the query builder does not define the `group` function as an aggregator. 

https://github.com/user-attachments/assets/55e7691e-5519-4962-9fcc-3a196c45e349




Fixes https://github.com/grafana/grafana/issues/91362

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
