### PR TITLE
E2C: Reduce UI poll interval and make configurable

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1966,4 +1966,6 @@ domain = grafana.net
 snapshot_folder = ""
 # Link to form to give feedback on the feature
 feedback_url = https://docs.google.com/forms/d/e/1FAIpQLSeEE33vhbSpR8A8S1A1ocZ1ByVRRwiRl1GZr2FSrEer_tSa8w/viewform?usp=sf_link
+# How frequently should the frontend UI poll for changes while resources are migrating
+frontend_poll_interval = 2s
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1900,3 +1900,5 @@ timeout = 30s
 ;snapshot_folder = ""
 # Link to form to give feedback on the feature
 ;feedback_url = ""
+# How frequently should the frontend UI poll for changes while resources are migrating
+;frontend_poll_interval = 2s

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -182,6 +182,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   localFileSystemAvailable: boolean | undefined;
   cloudMigrationIsTarget: boolean | undefined;
   cloudMigrationFeedbackURL = '';
+  cloudMigrationPollIntervalMs = 2000;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset = '1h';
 

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -257,8 +257,9 @@ type FrontendSettingsDTO struct {
 	PublicDashboardAccessToken string `json:"publicDashboardAccessToken"`
 	PublicDashboardsEnabled    bool   `json:"publicDashboardsEnabled"`
 
-	CloudMigrationIsTarget    bool   `json:"cloudMigrationIsTarget"`
-	CloudMigrationFeedbackURL string `json:"cloudMigrationFeedbackURL"`
+	CloudMigrationIsTarget       bool   `json:"cloudMigrationIsTarget"`
+	CloudMigrationFeedbackURL    string `json:"cloudMigrationFeedbackURL"`
+	CloudMigrationPollIntervalMs int    `json:"cloudMigrationPollIntervalMs"`
 
 	DateFormats setting.DateFormats `json:"dateFormats,omitempty"`
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -224,6 +224,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		PublicDashboardsEnabled:             hs.Cfg.PublicDashboardsEnabled,
 		CloudMigrationIsTarget:              isCloudMigrationTarget,
 		CloudMigrationFeedbackURL:           hs.Cfg.CloudMigration.FeedbackURL,
+		CloudMigrationPollIntervalMs:        int(hs.Cfg.CloudMigration.FrontendPollInterval.Milliseconds()),
 		SharedWithMeFolderUID:               folder.SharedWithMeFolderUID,
 		RootFolderUID:                       accesscontrol.GeneralFolderUID,
 		LocalFileSystemAvailable:            hs.Cfg.LocalFileSystemAvailable,

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -50,7 +50,7 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 	cfg.CloudMigration.TokenExpiresAfter = cloudMigration.Key("token_expires_after").MustDuration(7 * 24 * time.Hour)
 	cfg.CloudMigration.IsDeveloperMode = cloudMigration.Key("developer_mode").MustBool(false)
 	cfg.CloudMigration.FeedbackURL = cloudMigration.Key("feedback_url").MustString("")
-	cfg.CloudMigration.FrontendPollInterval = cloudMigration.Key("frontend_poll_interval").MustDuration(5 * time.Second)
+	cfg.CloudMigration.FrontendPollInterval = cloudMigration.Key("frontend_poll_interval").MustDuration(2 * time.Second)
 
 	if cfg.CloudMigration.SnapshotFolder == "" {
 		cfg.CloudMigration.SnapshotFolder = filepath.Join(cfg.DataPath, "cloud_migration")

--- a/pkg/setting/setting_cloud_migration.go
+++ b/pkg/setting/setting_cloud_migration.go
@@ -24,6 +24,7 @@ type CloudMigrationSettings struct {
 	DeleteTokenTimeout          time.Duration
 	TokenExpiresAfter           time.Duration
 	FeedbackURL                 string
+	FrontendPollInterval        time.Duration
 
 	IsDeveloperMode bool
 }
@@ -49,6 +50,7 @@ func (cfg *Cfg) readCloudMigrationSettings() {
 	cfg.CloudMigration.TokenExpiresAfter = cloudMigration.Key("token_expires_after").MustDuration(7 * 24 * time.Hour)
 	cfg.CloudMigration.IsDeveloperMode = cloudMigration.Key("developer_mode").MustBool(false)
 	cfg.CloudMigration.FeedbackURL = cloudMigration.Key("feedback_url").MustString("")
+	cfg.CloudMigration.FrontendPollInterval = cloudMigration.Key("frontend_poll_interval").MustDuration(5 * time.Second)
 
 	if cfg.CloudMigration.SnapshotFolder == "" {
 		cfg.CloudMigration.SnapshotFolder = filepath.Join(cfg.DataPath, "cloud_migration")

--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -1,6 +1,7 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import { useCallback, useEffect, useState } from 'react';
 
+import { config } from '@grafana/runtime';
 import { AlertVariant, Box, Stack, Text } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
@@ -62,8 +63,6 @@ const SNAPSHOT_REBUILD_STATUSES: Array<SnapshotDto['status']> = ['PENDING_UPLOAD
 const SNAPSHOT_BUILDING_STATUSES: Array<SnapshotDto['status']> = ['INITIALIZING', 'CREATING'];
 const SNAPSHOT_UPLOADING_STATUSES: Array<SnapshotDto['status']> = ['UPLOADING', 'PENDING_PROCESSING', 'PROCESSING'];
 
-const STATUS_POLL_INTERVAL = 5 * 1000;
-
 const PAGE_SIZE = 50;
 
 function useGetLatestSnapshot(sessionUid?: string, page = 1) {
@@ -78,7 +77,7 @@ function useGetLatestSnapshot(sessionUid?: string, page = 1) {
       : skipToken;
 
   const snapshotResult = useGetSnapshotQuery(getSnapshotQueryArgs, {
-    pollingInterval: shouldPoll ? STATUS_POLL_INTERVAL : 0,
+    pollingInterval: shouldPoll ? config.cloudMigrationPollIntervalMs : 0,
     skipPollingIfUnfocused: true,
   });
 


### PR DESCRIPTION
The Cloud Migration frontend polls on an interval to updates to the migration status. Initially we started with a very conservative 5 second interval, but after testing this might be a bit too slow (especially as snapshot creation is often <1s).

This PR changes the default poll interval to 2 seconds, and adds a new a new `frontend_poll_interval` config value to allow server administrators to change this if they feel it's too frequent.