### PR TITLE
AutoSizeInput: add safeguard when converting value to string

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -20,14 +20,14 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
   const [inputWidth, setInputWidth] = React.useState(minWidth);
 
   useEffect(() => {
-    setInputWidth(getWidthFor(value.toString(), minWidth, maxWidth));
+    setInputWidth(getWidthFor(value?.toString(), minWidth, maxWidth));
   }, [value, maxWidth, minWidth]);
 
   return (
     <Input
       {...restProps}
       ref={ref}
-      value={value.toString()}
+      value={value?.toString()}
       onChange={(event) => {
         setValue(event.currentTarget.value);
       }}
@@ -51,7 +51,7 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
   );
 });
 
-function getWidthFor(value: string, minWidth: number, maxWidth: number | undefined): number {
+function getWidthFor(value: Props['defaultValue'], minWidth: number, maxWidth: number | undefined): number {
   if (!value) {
     return minWidth;
   }


### PR DESCRIPTION
Related to [this](https://github.com/grafana/support-escalations/issues/11556) escalation. when scenes are enabled `null` can reach `value` prop and break `value.toString()` in AutoSizeInput.

Fixes # https://github.com/grafana/support-escalations/issues/11556

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
