### PR TITLE
Chore: Fix Crowdin Download action failing consistently

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -19,7 +19,6 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Generate token
-        if: steps.crowdin-download.outputs.pull_request_url
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
         with:
@@ -110,7 +109,6 @@ jobs:
                 }
               }
             }
-
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/89605 we changed the crowdin download action to use the generated token from GRAFANA_PR_AUTOMATION_APP, but as we copy-pasted we left in a `if:` that prevented the token from actually being created.

This PR removes the check so the token always gets made 😌 