### PR TITLE
Alerting: Fix permissions for prometheus rule endpoints

### DIFF
--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -38,31 +38,31 @@
       "method": "GET",
       "path": "/rules",
       "reqRole": "Viewer",
-      "reqAction": "datasources:query"
+      "reqAction": "alert.rules.external:read"
     },
     {
       "method": "POST",
       "path": "/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "alert.rules.external:write"
     },
     {
       "method": "DELETE",
       "path": "/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "alert.rules.external:write"
     },
     {
       "method": "DELETE",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "alert.rules.external:write"
     },
     {
       "method": "POST",
       "path": "/config/v1/rules",
       "reqRole": "Editor",
-      "reqAction": "datasources:write"
+      "reqAction": "alert.rules.external:write"
     }
   ],
   "includes": [


### PR DESCRIPTION
**What is this feature?**
This PR fixes the action that is required for managing external Prometheus rules. 


** Notes for reviewer **

This can only be tested with feature flag `accessControlOnCall` enabled because of https://github.com/grafana/grafana/blob/c326d865c58b410cd118fd363c7713ba23e99aeb/pkg/api/pluginproxy/ds_proxy.go#L342