### PR TITLE
Heatmap: Skip null values instead of treating as 0

### DIFF
--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -597,7 +597,7 @@ export function heatmapPathsDense(opts: PathbuilderOpts) {
         );
 
         for (let i = 0; i < dlen; i++) {
-          if (counts[i] > hideLE && counts[i] < hideGE) {
+          if (counts[i] != null && counts[i] > hideLE && counts[i] < hideGE) {
             let cx = cxs[~~(i / yBinQty)];
             let cy = cys[i % yBinQty];
 
@@ -826,7 +826,7 @@ export const boundedMinMax = (
     minValue = Infinity;
 
     for (let i = 0; i < values.length; i++) {
-      if (values[i] > hideLE && values[i] < hideGE) {
+      if (values[i] != null && values[i] > hideLE && values[i] < hideGE) {
         minValue = Math.min(minValue, values[i]);
       }
     }
@@ -836,7 +836,7 @@ export const boundedMinMax = (
     maxValue = -Infinity;
 
     for (let i = 0; i < values.length; i++) {
-      if (values[i] > hideLE && values[i] < hideGE) {
+      if (values[i] != null && values[i] > hideLE && values[i] < hideGE) {
         maxValue = Math.max(maxValue, values[i]);
       }
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11693

before:

![image](https://github.com/user-attachments/assets/20ff415a-6f29-491e-b687-6ac023fe8890)

after:

![image](https://github.com/user-attachments/assets/37e4a055-8391-4d97-addf-b9c987acde7e)