### PR TITLE
[DOC] Add Streaming doc for Tempo data source

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -103,6 +103,8 @@ To use streaming, you need to:
 
 For streaming to work for a particular Tempo data source, set your Grafana's `traceQLStreaming` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) to true and set **Streaming** to enabled in your Tempo data source configuration.
 
+![Streaming section in Tempo data source](/media/docs/grafana/data-sources/tempo-data-source-streaming-v11.2.png)
+
 If you are using Grafana Cloud, the `traceQLStreaming` feature toggle is already set to `true` by default.
 
 If the Tempo data source is set to allow streaming but the `traceQLStreaming` feature toggle is set to `false` in Grafana, no streaming will occur.

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -58,6 +58,8 @@ refs:
 
 # Configure the Tempo data source
 
+The Tempo data source sets how your Tempo data connects to Grafana and lets you configure features and integrations with other telemetry signals.
+
 To configure basic settings for the Tempo data source, complete the following steps:
 
 1.  Click **Connections** in the left-side menu.
@@ -81,6 +83,30 @@ You can also configure settings specific to the Tempo data source.
 This video explains how to add data sources, including Loki, Tempo, and Mimir, to Grafana and Grafana Cloud. Tempo data source set up starts at 4:58 in the video.
 
 {{< youtube id="cqHO0oYW6Ic" start="298" >}}
+
+## Streaming
+<!-- Streaming toggle will be deprecated in Grafana 11.2 and removed in 11.3. -->
+
+Streaming provides immediate visibility of incoming traces on the results table for a TraceQL query.
+
+The Streaming section is available in the Tempo data source settings for Grafana Cloud.
+This capability requires Tempo 2.2 and onwards.
+
+### Requirements
+
+To use this feature, you need to:
+
+* Use Tempo version 2.2 or newer. Grafana Cloud uses has the latest version of Tempo.
+* For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that does not supporting gRPC or HTTP2, streaming will probably not work and should be disabled.
+
+### Activate streaming
+
+To activate the Streaming section in your Tempo data source settings:
+
+1. Activate the `traceQLStreaming` feature toggle in your Grafana configuration file.
+  * If you are using Grafana Cloud, contact Customer Support to activate this feature toggle.
+1. Select the **Queries** toggle to activate streaming for queries.
+
 
 ## Trace to logs
 
@@ -208,7 +234,8 @@ To use custom queries with the configuration, follow these steps:
 
 ## Custom query variables
 
-To use a variable in your trace to logs, metrics or profiles you need to wrap it in `${}`. For example, `${__span.name}`.
+To use a variable in your trace to logs, metrics, or profiles, you need to wrap it in `${}`.
+For example, `${__span.name}`.
 
 | Variable name          | Description                                                                                                                                                                                                                                                                                                                              |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -98,9 +98,9 @@ This capability requires Tempo 2.2 and onwards.
 To use this feature, you need to:
 
 - Use Tempo version 2.2 or newer. Grafana Cloud uses has the latest version of Tempo.
-- For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that does not supporting gRPC or HTTP2, streaming will probably not work and should be disabled.
+- For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that doesn't supporting gRPC or HTTP2, streaming may not work and should be disabled.
 
-For streaming to work for a particular Tempo data source, both `traceQLStreaming` must be set to true for the Grafana and the data source must be set to allow streaming.
+For streaming to work for a particular Tempo data source, set both `traceQLStreaming` feature toggle to true and **Streaming** enabled in the the data source to allow streaming.
 
 If the data source allows streaming but `traceQLStreaming=false`, no streaming will occur.
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -85,6 +85,7 @@ This video explains how to add data sources, including Loki, Tempo, and Mimir, t
 {{< youtube id="cqHO0oYW6Ic" start="298" >}}
 
 ## Streaming
+
 <!-- Streaming toggle will be deprecated in Grafana 11.2 and removed in 11.3. -->
 
 Streaming provides immediate visibility of incoming traces on the results table for a TraceQL query.
@@ -96,17 +97,18 @@ This capability requires Tempo 2.2 and onwards.
 
 To use this feature, you need to:
 
-* Use Tempo version 2.2 or newer. Grafana Cloud uses has the latest version of Tempo.
-* For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that does not supporting gRPC or HTTP2, streaming will probably not work and should be disabled.
+- Use Tempo version 2.2 or newer. Grafana Cloud uses has the latest version of Tempo.
+- For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that does not supporting gRPC or HTTP2, streaming will probably not work and should be disabled.
 
 ### Activate streaming
 
 To activate the Streaming section in your Tempo data source settings:
 
 1. Activate the `traceQLStreaming` feature toggle in your Grafana configuration file.
-  * If you are using Grafana Cloud, contact Customer Support to activate this feature toggle.
-1. Select the **Queries** toggle to activate streaming for queries.
 
+- If you are using Grafana Cloud, contact Customer Support to activate this feature toggle.
+
+1. Select the **Queries** toggle to activate streaming for queries.
 
 ## Trace to logs
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -74,7 +74,7 @@ To configure basic settings for the Tempo data source, complete the following st
     | **Name**       | Sets the name you use to refer to the data source in panels and queries. |
     | **Default**    | Sets the data source that's pre-selected for new panels.                 |
     | **URL**        | Sets the URL of the Tempo instance, such as `http://tempo`.              |
-    | **Basic Auth** | Enables basic authentication to the Tempo data source.                   |
+    | **Basic Auth** | Enables authentication to the Tempo data source.                   |
     | **User**       | Sets the user name for basic authentication.                             |
     | **Password**   | Sets the password for basic authentication.                              |
 
@@ -88,14 +88,14 @@ This video explains how to add data sources, including Loki, Tempo, and Mimir, t
 
 <!-- The traceQLStreaming toggle will be deprecated in Grafana 11.2 and removed in 11.3. -->
 
-Streaming enables TraceQL query results to be displayed as they become available. Without streaming, no results are displayed until all results have returned. 
+Streaming enables TraceQL query results to be displayed as they become available. Without streaming, no results are displayed until all results have returned.
 
 
 ### Requirements
 
 To use streaming, you need to:
 
-- Be running Tempo version 2.2 or newer, or Grafana Enterprise Traces (GET) version 2.2 or newer, or be using Grafana Cloud Traces. 
+- Be running Tempo version 2.2 or newer, or Grafana Enterprise Traces (GET) version 2.2 or newer, or be using Grafana Cloud Traces.
 - For self-managed Tempo or GET instances: If your Tempo or GET instance is behind a load balancer or proxy that doesn't supporting gRPC or HTTP2, streaming may not work and should be disabled.
 
 For streaming to work for a particular Tempo data source, set your Grafana's `traceQLStreaming` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) to true and set **Streaming** to enabled in your Tempo data source configuration.
@@ -110,7 +110,7 @@ To enable streaming for a specific Tempo data source in your Grafana:
 
 1. Set the `traceQLStreaming` feature toggle to `true` in your Grafana configuration file.
 
-- If you are using Grafana Cloud, the `traceQLStreaming` feature toggle is already set to `true` by default. 
+- If you are using Grafana Cloud, the `traceQLStreaming` feature toggle is already set to `true` by default.
 
 1. Select the **Queries** toggle on your Tempo data source settings page.
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -74,7 +74,7 @@ To configure basic settings for the Tempo data source, complete the following st
     | **Name**       | Sets the name you use to refer to the data source in panels and queries. |
     | **Default**    | Sets the data source that's pre-selected for new panels.                 |
     | **URL**        | Sets the URL of the Tempo instance, such as `http://tempo`.              |
-    | **Basic Auth** | Enables authentication to the Tempo data source.                   |
+    | **Basic Auth** | Enables authentication to the Tempo data source.                         |
     | **User**       | Sets the user name for basic authentication.                             |
     | **Password**   | Sets the password for basic authentication.                              |
 
@@ -90,6 +90,7 @@ This video explains how to add data sources, including Loki, Tempo, and Mimir, t
 
 Streaming enables TraceQL query results to be displayed as they become available. Without streaming, no results are displayed until all results have returned.
 
+{{< docs/public-preview product="TraceQL streaming results" >}}
 
 ### Requirements
 
@@ -98,21 +99,15 @@ To use streaming, you need to:
 - Be running Tempo version 2.2 or newer, or Grafana Enterprise Traces (GET) version 2.2 or newer, or be using Grafana Cloud Traces.
 - For self-managed Tempo or GET instances: If your Tempo or GET instance is behind a load balancer or proxy that doesn't supporting gRPC or HTTP2, streaming may not work and should be disabled.
 
+### Activate streaming
+
 For streaming to work for a particular Tempo data source, set your Grafana's `traceQLStreaming` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) to true and set **Streaming** to enabled in your Tempo data source configuration.
+
+If you are using Grafana Cloud, the `traceQLStreaming` feature toggle is already set to `true` by default.
 
 If the Tempo data source is set to allow streaming but the `traceQLStreaming` feature toggle is set to `false` in Grafana, no streaming will occur.
 
 If the data source has streaming disabled and `traceQLStreaming` is set to `true`, no streaming will happen for that data source.
-
-### Activate streaming
-
-To enable streaming for a specific Tempo data source in your Grafana:
-
-1. Set the `traceQLStreaming` feature toggle to `true` in your Grafana configuration file.
-
-- If you are using Grafana Cloud, the `traceQLStreaming` feature toggle is already set to `true` by default.
-
-1. Select the **Queries** toggle on your Tempo data source settings page.
 
 ## Trace to logs
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -58,7 +58,7 @@ refs:
 
 # Configure the Tempo data source
 
-The Tempo data source sets how your Tempo data connects to Grafana and lets you configure features and integrations with other telemetry signals.
+The Tempo data source sets how Grafana connects to your Tempo database and lets you configure features and integrations with other telemetry signals.
 
 To configure basic settings for the Tempo data source, complete the following steps:
 
@@ -88,7 +88,7 @@ This video explains how to add data sources, including Loki, Tempo, and Mimir, t
 
 <!-- The traceQLStreaming toggle will be deprecated in Grafana 11.2 and removed in 11.3. -->
 
-Streaming provides immediate visibility of incoming traces on the results table for a TraceQL query.
+Streaming enables TraceQL query results to be displayed as they become available. Without streaming, no results are displayed until all results have returned. 
 
 
 ### Requirements

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -86,35 +86,33 @@ This video explains how to add data sources, including Loki, Tempo, and Mimir, t
 
 ## Streaming
 
-<!-- Streaming toggle will be deprecated in Grafana 11.2 and removed in 11.3. -->
+<!-- The traceQLStreaming toggle will be deprecated in Grafana 11.2 and removed in 11.3. -->
 
 Streaming provides immediate visibility of incoming traces on the results table for a TraceQL query.
 
-The Streaming section is available in the Tempo data source settings for Grafana Cloud.
-This capability requires Tempo 2.2 and onwards.
 
 ### Requirements
 
-To use this feature, you need to:
+To use streaming, you need to:
 
-- Use Tempo version 2.2 or newer. Grafana Cloud uses has the latest version of Tempo.
-- For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that doesn't supporting gRPC or HTTP2, streaming may not work and should be disabled.
+- Be running Tempo version 2.2 or newer, or Grafana Enterprise Traces (GET) version 2.2 or newer, or be using Grafana Cloud Traces. 
+- For self-managed Tempo or GET instances: If your Tempo or GET instance is behind a load balancer or proxy that doesn't supporting gRPC or HTTP2, streaming may not work and should be disabled.
 
-For streaming to work for a particular Tempo data source, set both `traceQLStreaming` feature toggle to true and **Streaming** enabled in the the data source to allow streaming.
+For streaming to work for a particular Tempo data source, set your Grafana's `traceQLStreaming` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) to true and set **Streaming** to enabled in your Tempo data source configuration.
 
-If the data source allows streaming but `traceQLStreaming=false`, no streaming will occur.
+If the Tempo data source is set to allow streaming but the `traceQLStreaming` feature toggle is set to `false` in Grafana, no streaming will occur.
 
-If the data source has streaming disabled and `traceQLStreaming=true`, no streaming wil happen for that data source.
+If the data source has streaming disabled and `traceQLStreaming` is set to `true`, no streaming will happen for that data source.
 
 ### Activate streaming
 
-To activate the Streaming section in your Tempo data source settings:
+To enable streaming for a specific Tempo data source in your Grafana:
 
-1. Activate the `traceQLStreaming` feature toggle in your Grafana configuration file.
+1. Set the `traceQLStreaming` feature toggle to `true` in your Grafana configuration file.
 
-- If you are using Grafana Cloud, contact Customer Support to activate this feature toggle.
+- If you are using Grafana Cloud, the `traceQLStreaming` feature toggle is already set to `true` by default. 
 
-1. Select the **Queries** toggle to activate streaming for queries.
+1. Select the **Queries** toggle on your Tempo data source settings page.
 
 ## Trace to logs
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -100,6 +100,12 @@ To use this feature, you need to:
 - Use Tempo version 2.2 or newer. Grafana Cloud uses has the latest version of Tempo.
 - For self-managed Tempo instances: If your Tempo instance is behind a load balancer or proxy that does not supporting gRPC or HTTP2, streaming will probably not work and should be disabled.
 
+For streaming to work for a particular Tempo data source, both `traceQLStreaming` must be set to true for the Grafana and the data source must be set to allow streaming.
+
+If the data source allows streaming but `traceQLStreaming=false`, no streaming will occur.
+
+If the data source has streaming disabled and `traceQLStreaming=true`, no streaming wil happen for that data source.
+
 ### Activate streaming
 
 To activate the Streaming section in your Tempo data source settings:

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -161,9 +161,12 @@ Queries can take a little while to return results. The results appear in a table
 The Tempo data source supports streaming responses to TraceQL queries so you can see partial query results as they come in without waiting for the whole query to finish.
 
 {{% admonition type="note" %}}
-To use this experimental feature, enable the `traceQLStreaming` feature toggle. If you’re using Grafana Cloud and would like to enable this feature, please contact customer support.
+To use this experimental feature, enable the `traceQLStreaming` feature toggle. When active, all configured Tempo data sources will attempt to use streaming.
+
+In Grafana Cloud, you can enable this capability in the **Streaming** section of the Tempo data source settings.
 {{% /admonition %}}
 
-Streaming is available for both the **Search** and **TraceQL** query types, and you'll get immediate visibility of incoming traces on the results table.
+Streaming is available for both the **Search** and **TraceQL** query types.
+You'll get immediate visibility of incoming traces on the results table.
 
 {{< video-embed src="/media/docs/grafana/data-sources/tempo-streaming-v2.mp4" >}}

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -161,9 +161,8 @@ Queries can take a little while to return results. The results appear in a table
 The Tempo data source supports streaming responses to TraceQL queries so you can see partial query results as they come in without waiting for the whole query to finish.
 
 {{% admonition type="note" %}}
-To use this experimental feature, enable the `traceQLStreaming` feature toggle. When active, all configured Tempo data sources will attempt to use streaming.
+To use this experimental feature, enable the `traceQLStreaming` feature toggle. When active, all configured Tempo data sources will attempt to use streaming. You can control which Tempo datasources do and don't attempt to stream results at the per-datasource level using the **Streaming** section of the Tempo datasource configuration. 
 
-In Grafana Cloud, you can enable this capability in the **Streaming** section of the Tempo data source settings.
 {{% /admonition %}}
 
 Streaming is available for both the **Search** and **TraceQL** query types.

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -161,7 +161,9 @@ Queries can take a little while to return results. The results appear in a table
 The Tempo data source supports streaming responses to TraceQL queries so you can see partial query results as they come in without waiting for the whole query to finish.
 
 {{% admonition type="note" %}}
-To use this experimental feature, enable the `traceQLStreaming` feature toggle. When active, all configured Tempo data sources will attempt to use streaming. You can control which Tempo datasources do and don't attempt to stream results at the per-datasource level using the **Streaming** section of the Tempo datasource configuration. 
+To use this public preview feature, enable the `traceQLStreaming` feature toggle.
+When active, all configured Tempo data sources will attempt to use streaming.
+You can control which Tempo data sources do and don't attempt to stream results at the per-data source level using the **Streaming** section of the Tempo data source configuration.
 
 {{% /admonition %}}
 


### PR DESCRIPTION
**What is this feature?**

Adds documentation for the Streaming feature in the Grafana Tempo data source documentation. 

This feature applies 11.2. The feature toggle used for streaming will be deprecated and removed, possibly in 11.3.

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/tempo-squad/issues/459

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
