### PR TITLE
Alerting docs: Update `Alerting provisioning  HTTP API`

### DIFF
--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -14,7 +14,7 @@ For details about the differences between Grafana-managed and data source-manage
 
 ## Grafana-managed endpoints
 
-Note that the JSON format from most of the following endpoints is not fully compatible with [provisioning via configuration files](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/).
+Note that the JSON format from most of the following endpoints is not fully compatible with [provisioning via configuration JSON files](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/).
 
 ### Alert rules
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -10,12 +10,6 @@ The Alerting provisioning API can be used to create, modify, and delete resource
 
 To manage resources related to [data source-managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}), including recording rules, use the [Mimir tool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/) and [Cortex tool](https://github.com/grafana/cortex-tools#cortextool).
 
-## Information
-
-### Version
-
-1.1.0
-
 ## All endpoints
 
 ### Alert rules

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -10,7 +10,7 @@ The Alerting Provisioning HTTP API can be used to create, modify, and delete res
 
 For more information on the differences between Grafana-managed and data source-managed alerts, refer to [Introduction to alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
+> If you are running Grafana Enterprise, you need to add specific permissions for some endpoints. For more information, refer to [Role-based access control permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/).
 
 ## Grafana-managed endpoints
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -31,7 +31,7 @@ Note that the JSON format from most of the following endpoints is not fully comp
 | GET    | /api/v1/provisioning/alert-rules                                 | [route get alert rules](#route-get-alert-rules)                         | Get all the alert rules.                                              |
 | GET    | /api/v1/provisioning/alert-rules/export                          | [route get alert rules export](#route-get-alert-rules-export)           | Export all alert rules in provisioning file format.                   |
 
-**Example Request for new alert rule:**
+**Example request for new alert rule:**
 
 ```http
 POST /api/v1/provisioning/alert-rules

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -18,10 +18,6 @@ To manage resources related to [data source-managed alerts]({{< relref "/docs/gr
 
 ## Content negotiation
 
-### Consumes
-
-- application/json
-
 ### Produces
 
 - application/json
@@ -215,10 +211,6 @@ Status: No Content
 ```
 DELETE /api/v1/provisioning/contact-points/:uid
 ```
-
-#### Consumes
-
-- application/json
 
 #### Parameters
 
@@ -884,10 +876,6 @@ Status: Not Found
 POST /api/v1/provisioning/alert-rules
 ```
 
-#### Consumes
-
-- application/json
-
 #### Parameters
 
 {{% responsive-table %}}
@@ -929,10 +917,6 @@ Status: Bad Request
 ```
 POST /api/v1/provisioning/contact-points
 ```
-
-#### Consumes
-
-- application/json
 
 #### Parameters
 
@@ -976,10 +960,6 @@ Status: Bad Request
 POST /api/v1/provisioning/mute-timings
 ```
 
-#### Consumes
-
-- application/json
-
 #### Parameters
 
 {{% responsive-table %}}
@@ -1021,10 +1001,6 @@ Status: Bad Request
 ```
 PUT /api/v1/provisioning/alert-rules/:uid
 ```
-
-#### Consumes
-
-- application/json
 
 #### Parameters
 
@@ -1068,10 +1044,6 @@ Status: Bad Request
 ```
 PUT /api/v1/provisioning/folder/:folderUid/rule-groups/:group
 ```
-
-#### Consumes
-
-- application/json
 
 #### Parameters
 
@@ -1117,10 +1089,6 @@ Status: Bad Request
 PUT /api/v1/provisioning/contact-points/:uid
 ```
 
-#### Consumes
-
-- application/json
-
 #### Parameters
 
 {{% responsive-table %}}
@@ -1163,10 +1131,6 @@ Status: Bad Request
 ```
 PUT /api/v1/provisioning/mute-timings/:name
 ```
-
-#### Consumes
-
-- application/json
 
 #### Parameters
 
@@ -1211,10 +1175,6 @@ Status: Bad Request
 PUT /api/v1/provisioning/policies
 ```
 
-#### Consumes
-
-- application/json
-
 #### Parameters
 
 {{% responsive-table %}}
@@ -1256,10 +1216,6 @@ Status: Bad Request
 ```
 PUT /api/v1/provisioning/templates/:name
 ```
-
-#### Consumes
-
-- application/json
 
 {{% responsive-table %}}
 
@@ -1303,10 +1259,6 @@ Status: Bad Request
 ```
 DELETE /api/v1/provisioning/policies
 ```
-
-#### Consumes
-
-- application/json
 
 #### All responses
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -16,14 +16,6 @@ To manage resources related to [data source-managed alerts]({{< relref "/docs/gr
 
 1.1.0
 
-## Content negotiation
-
-### Produces
-
-- application/json
-- text/yaml
-- application/yaml
-
 ## All endpoints
 
 ### Alert rules

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -8,7 +8,7 @@ title: 'Alerting Provisioning HTTP API '
 
 The Alerting Provisioning HTTP API can be used to create, modify, and delete resources relevant to Grafana-managed alerts. This API is the one used by our [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 
-For details about the differences between Grafana-managed and data source-managed alerts, refer to the [Introduction to alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/).
+For more information on the differences between Grafana-managed and data source-managed alerts, refer to [Introduction to alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/).
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -31,13 +31,18 @@ Note that the JSON format from most of the following endpoints is not fully comp
 | GET    | /api/v1/provisioning/alert-rules                                 | [route get alert rules](#route-get-alert-rules)                         | Get all the alert rules.                                              |
 | GET    | /api/v1/provisioning/alert-rules/export                          | [route get alert rules export](#route-get-alert-rules-export)           | Export all alert rules in provisioning file format.                   |
 
-#### Example alert rules template
+**Example Request for new alert rule:**
 
-```json
+```http
+POST /api/v1/provisioning/alert-rules
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+
 {
   "title": "TEST-API_1",
   "ruleGroup": "API",
-  "folderUID": "FOLDER",
+  "folderUID": "SET_FOLDER_UID",
   "noDataState": "OK",
   "execErrState": "OK",
   "for": "5m",
@@ -58,7 +63,7 @@ Note that the JSON format from most of the following endpoints is not fully comp
         "from": 600,
         "to": 0
       },
-      "datasourceUid": " XXXXXXXXX-XXXXXXXXX-XXXXXXXXXX",
+      "datasourceUid": "XXXXXXXXX-XXXXXXXXX-XXXXXXXXXX",
       "model": {
         "expr": "up",
         "hide": false,
@@ -108,6 +113,99 @@ Note that the JSON format from most of the following endpoints is not fully comp
     }
   ]
 }
+
+```
+
+#### Example Response:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": 1,
+  "uid": "XXXXXXXXX",
+  "orgID": 1,
+  "folderUID": "SET_FOLDER_UID",
+  "ruleGroup": "API3",
+  "title": "TEST-API_1",
+  "condition": "B",
+  "data": [
+    {
+      "refId": "A",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 600,
+        "to": 0
+      },
+      "datasourceUid": "XXXXXXXXX-XXXXXXXXX-XXXXXXXXXX",
+      "model": {
+        "expr": "up",
+        "hide": false,
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "datasourceUid": "-100",
+      "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                6
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "last"
+            },
+            "type": "query"
+          }
+        ],
+        "datasource": {
+          "type": "__expr__",
+          "uid": "-100"
+        },
+        "hide": false,
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "refId": "B",
+        "type": "classic_conditions"
+      }
+    }
+  ],
+  "updated": "2024-08-02T13:19:32.609640048Z",
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "for": "5m",
+  "annotations": {
+    "summary": "test_api_1"
+  },
+  "labels": {
+    "API": "test1"
+  },
+  "provenance": "api",
+  "isPaused": false,
+  "notification_settings": null,
+  "record": null
+}
 ```
 
 ### Contact points
@@ -120,6 +218,34 @@ Note that the JSON format from most of the following endpoints is not fully comp
 | PUT    | /api/v1/provisioning/contact-points/:uid   | [route put contactpoint](#route-put-contactpoint)                 | Update an existing contact point.                      |
 | GET    | /api/v1/provisioning/contact-points/export | [route get contactpoints export](#route-get-contactpoints-export) | Export all contact points in provisioning file format. |
 
+**Example Request for all the contact points:**
+
+```http
+GET /api/v1/provisioning/contact-points
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+**Example Response:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "uid": "",
+    "name": "email receiver",
+    "type": "email",
+    "settings": {
+      "addresses": "<example@email.com>"
+    },
+    "disableResolveMessage": false
+  }
+]
+```
+
 ### Notification policies
 
 | Method | URI                                  | Name                                                          | Summary                                                          |
@@ -128,6 +254,38 @@ Note that the JSON format from most of the following endpoints is not fully comp
 | GET    | /api/v1/provisioning/policies        | [route get policy tree](#route-get-policy-tree)               | Get the notification policy tree.                                |
 | PUT    | /api/v1/provisioning/policies        | [route put policy tree](#route-put-policy-tree)               | Sets the notification policy tree.                               |
 | GET    | /api/v1/provisioning/policies/export | [route get policy tree export](#route-get-policy-tree-export) | Export the notification policy tree in provisioning file format. |
+
+**Example Request for exporting the notification policy tree in YAML format:**
+
+```http
+GET /api/v1/provisioning/policies/export?format=yaml
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+**Example Response:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/yaml
+
+apiVersion: 1
+policies:
+    - orgId: 1
+      receiver: My Contact Email Point
+      group_by:
+        - grafana_folder
+        - alertname
+      routes:
+        - receiver: My Contact Email Point
+          object_matchers:
+            - - monitor
+              - =
+              - testdata
+          mute_time_intervals:
+            - weekends
+```
 
 ### Mute timings
 
@@ -141,6 +299,38 @@ Note that the JSON format from most of the following endpoints is not fully comp
 | GET    | /api/v1/provisioning/mute-timings/export       | [route get mute timings export](#route-get-mute-timings-export) | Export all mute timings in provisioning file format. |
 | GET    | /api/v1/provisioning/mute-timings/:name/export | [route get mute timing export](#route-get-mute-timing-export)   | Export a mute timing in provisioning file format.    |
 
+**Example Request for all mute timings:**
+
+```http
+GET /api/v1/provisioning/mute-timings
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+**Example Response:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "name": "weekends",
+    "time_intervals": [
+      {
+        "weekdays": [
+          "saturday",
+          "sunday"
+        ]
+      }
+    ],
+    "version": "",
+    "provenance": "file"
+  }
+]
+```
+
 ### Templates
 
 | Method | URI                                  | Name                                            | Summary                                   |
@@ -149,6 +339,35 @@ Note that the JSON format from most of the following endpoints is not fully comp
 | GET    | /api/v1/provisioning/templates/:name | [route get template](#route-get-template)       | Get a notification template.              |
 | GET    | /api/v1/provisioning/templates       | [route get templates](#route-get-templates)     | Get all notification templates.           |
 | PUT    | /api/v1/provisioning/templates/:name | [route put template](#route-put-template)       | Create or update a notification template. |
+
+**Example Request for all notification templates:**
+
+```http
+GET /api/v1/provisioning/templates
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+**Example Response:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "name": "custom_email.message",
+    "template": "{{ define \"custom_email.message\" }}\n  Custom alert!\n{{ end }}",
+    "provenance": "file"
+  },
+  {
+    "name": "custom_email.subject",
+    "template": "{{ define \"custom_email.subject\" }}\n{{ len .Alerts.Firing }} firing alert(s), {{ len .Alerts.Resolved }} resolved alert(s)\n{{ end }}",
+    "provenance": "file"
+  }
+]
+```
 
 ### Edit resources in the Grafana UI
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -10,6 +10,8 @@ The Alerting Provisioning HTTP API can be used to create, modify, and delete res
 
 For details about the differences between Grafana-managed and data source-managed alerts, refer to the [Introduction to alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/).
 
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/) for more information.
+
 ## Grafana-managed endpoints
 
 ### Alert rules

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -6,11 +6,11 @@ labels:
 title: 'Alerting Provisioning HTTP API '
 ---
 
-The Alerting provisioning API can be used to create, modify, and delete resources relevant to [Grafana-managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}). It is the one used by our [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
+The Alerting Provisioning HTTP API can be used to create, modify, and delete resources relevant to Grafana-managed alerts. This API is the one used by our [Grafana Terraform provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs).
 
-To manage resources related to [data source-managed alerts]({{< relref "/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule" >}}), including recording rules, use the [Mimir tool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/) and [Cortex tool](https://github.com/grafana/cortex-tools#cortextool).
+For details about the differences between Grafana-managed and data source-managed alerts, refer to the [Introduction to alert rules](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/).
 
-## All endpoints
+## Grafana-managed endpoints
 
 ### Alert rules
 
@@ -146,7 +146,7 @@ To manage resources related to [data source-managed alerts]({{< relref "/docs/gr
 | GET    | /api/v1/provisioning/templates       | [route get templates](#route-get-templates)     | Get all notification templates.           |
 | PUT    | /api/v1/provisioning/templates/:name | [route put template](#route-put-template)       | Create or update a notification template. |
 
-## Edit resources in the Grafana UI
+### Edit resources in the Grafana UI
 
 By default, you cannot edit API-provisioned alerting resources in Grafana. To enable editing these resources in the Grafana UI, add the `X-Disable-Provenance` header to the following requests in the API:
 
@@ -158,6 +158,14 @@ By default, you cannot edit API-provisioned alerting resources in Grafana. To en
 - `PUT /api/v1/provisioning/templates/{name}`
 
 To reset the notification policy tree to the default and unlock it for editing in the Grafana UI, use the `DELETE /api/v1/provisioning/policies` endpoint.
+
+## Data source-managed resources
+
+To manage resources related to [data source-managed alerts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule/), you can use:
+
+- [mimirtool](https://grafana.com/docs/mimir/<GRAFANA_VERSION>/manage/tools/mimirtool/): to interact with the Mimir alertmanager and ruler configuration.
+- [cortex-tools](https://github.com/grafana/cortex-tools#cortextool): to interact with the Cortex alertmanager and ruler configuration.
+- [lokitool](https://grafana.com/docs/loki/<GRAFANA_VERSION>/alert/#lokitool): to interact with the Loki Ruler.
 
 ## Paths
 

--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -14,6 +14,8 @@ For details about the differences between Grafana-managed and data source-manage
 
 ## Grafana-managed endpoints
 
+Note that the JSON format from most of the following endpoints is not fully compatible with [provisioning via configuration files](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/).
+
 ### Alert rules
 
 | Method | URI                                                              | Name                                                                    | Summary                                                               |
@@ -163,11 +165,11 @@ To reset the notification policy tree to the default and unlock it for editing i
 
 ## Data source-managed resources
 
-To manage resources related to [data source-managed alerts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule/), you can use:
+The Alerting Provisioning HTTP API can only be used to manage Grafana-managed alert resources. To manage resources related to [data source-managed alerts](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-mimir-loki-managed-rule/), consider the following tools:
 
 - [mimirtool](https://grafana.com/docs/mimir/<GRAFANA_VERSION>/manage/tools/mimirtool/): to interact with the Mimir alertmanager and ruler configuration.
 - [cortex-tools](https://github.com/grafana/cortex-tools#cortextool): to interact with the Cortex alertmanager and ruler configuration.
-- [lokitool](https://grafana.com/docs/loki/<GRAFANA_VERSION>/alert/#lokitool): to interact with the Loki Ruler.
+- [lokitool](https://grafana.com/docs/loki/<GRAFANA_VERSION>/alert/#lokitool): to configure the Loki Ruler.
 
 ## Paths
 


### PR DESCRIPTION
This PR adds a few minor content changes to the [Alerting provisioning  HTTP API documentation](https://grafana.com/docs/grafana/latest/developers/http_api/alerting_provisioning/). 

1 - Adapted a bit the Table of Content to try to follow a similar structure to other HTTP API documentation pages, such as the [Admin API](https://grafana.com/docs/grafana/latest/developers/http_api/admin/) or [Dashboard API](https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/), as suggested by @jasuade. 
- Added one example for each alerting resource below the corresponding table of endpoints.
- Added a note about the Enterprise RBAC permissions. 


2 - Included a new section and updated some headings to distinguish more clearly between Grafana-managed endpoints and the available data source-managed options.




### Preview


![Screenshot 2024-08-02 at 16 12 48](https://github.com/user-attachments/assets/fc9a6ef8-f22b-43e7-8f31-8b73bb22208e)



### Follow-ups

 There are related issues we could address in separate discussions:

- Include **(RBAC) Required permissions** section for each API endpoint like other HTTP API docs
- The **Data source-managed resources** section could reference other options: 
   - The unstable [Grafana Alerting API ](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/pkg/services/ngalert/api/tooling/post.json)- these APIs might be modified or deprecated at any time without breaking change notice.
   - [amtool](https://github.com/prometheus/alertmanager?tab=readme-ov-file#amtool) 
   - [Prometheus AlertManager API]( https://petstore.swagger.io/?url=https://raw.githubusercontent.com/prometheus/alertmanager/main/api/v2/openapi.yaml#/alertgroup/getAlertGroups)
   - ...




