### PR TITLE
[DOC] Add canonical URL to Explore Metrics

### DIFF
--- a/docs/sources/explore/explore-metrics.md
+++ b/docs/sources/explore/explore-metrics.md
@@ -6,7 +6,8 @@ labels:
     - oss
 title: Explore Metrics
 aliases:
-description: This topic describes the Explore Metrics feature
+canonical: https://grafana.com/docs/grafana/latest/explore/explore-metrics/
+description: Explore Metrics lets you browse Prometheus-compatible metrics using an intuitive, queryless experience.
 weight: 200
 ---
 


### PR DESCRIPTION
**What is this feature?**

Adds a canonical URL for the Explore Metrics documentation. 

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/technical-documentation/issues/959
Fixes https://github.com/grafana/grafana/issues/90477

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
