### PR TITLE
docs: added missing panel options to node graph docs

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -51,7 +51,7 @@ Defining arc sections overrides the automatic detection of `arc__*` and `color` 
 
 ## Edges options
 
-The Edges options section provides configurations to node edges behaviors.
+The **Edges** options section provides configurations for node edges behaviors.
 
 - **Main stat unit** choose which unit the main stat displays in the graph's edges.
 - **Secondary stat unit** choose which unit the secondary stat displays in the graph's edges.

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -53,8 +53,8 @@ Defining arc sections overrides the automatic detection of `arc__*` and `color` 
 
 The **Edges** options section provides configurations for node edges behaviors.
 
-- **Main stat unit** choose which unit the main stat displays in the graph's edges.
-- **Secondary stat unit** choose which unit the secondary stat displays in the graph's edges.
+- **Main stat unit** - Choose which unit the main stat displays in the graph's edges.
+- **Secondary stat unit** - Choose which unit the secondary stat displays in the graph's edges.
 
 ## Data requirements
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -39,7 +39,7 @@ The following video provides beginner steps for creating node panel visualizatio
 
 ## Nodes options
 
-The Nodes options section provides configurations to node behaviors.
+The **Nodes** options section provides configurations for node behaviors.
 
 - **Main stat unit** choose which unit the main stat displays in the graph's nodes.
 - **Secondary stat unit** choose which unit the secondary stat displays in the graph's nodes.

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -25,7 +25,7 @@ Node graphs can visualize directed graphs or networks. They use a directed force
 
 ![Node graph visualization](/static/img/docs/node-graph/node-graph-8-0.png 'Node graph')
 
-## Configure a pie chart visualization
+## Configure a node graph visualization
 
 The following video provides beginner steps for creating node panel visualizations. You'll learn the data requirements and caveats, special customizations, and much more:
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -43,7 +43,7 @@ The Nodes options section provides configurations to node behaviors.
 
 - **Main stat unit** choose which unit the main stat displays in the graph's nodes.
 - **Secondary stat unit** choose which unit the secondary stat displays in the graph's nodes.
-- **Arc sections** adds multiple configurations to what fields will provide the data field used to create the color circle around the node and define the color for each field. You can add multiple fields.
+- **Arc sections** configures what fields define the size of the colored circle around the node and to select a color for each. You can add multiple fields.
 
 {{% admonition type="note" %}}
 Defining Arc sections will override the automatic detection of `arc__*` and `color` fields described in the _Optional fields_ section of [Nodes data frame structure](#nodes-data-frame-structure).

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -173,7 +173,3 @@ Optional fields:
 | icon          | string        | Name of the icon to show inside the node instead of the default stats. Only Grafana built in icons are allowed (see the available icons [here](https://developers.grafana.com/ui/latest/index.html?path=/story/docs-overview-icon--icons-overview)).                                                                                                                      |
 | nodeRadius    | number        | Radius value in pixels. Used to manage node size.                                                                                                                                                                                                                                                                                                                         |
 | highlighted   | boolean       | Sets whether the node should be highlighted. Useful for example to represent a specific path in the graph by highlighting several nodes and edges. Default: `false`                                                                                                                                                                                                       |
-
-## Panel options
-
-{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -45,9 +45,9 @@ The **Nodes** options section provides configurations for node behaviors.
 - **Secondary stat unit** - Choose which unit the secondary stat displays in the graph's nodes.
 - **Arc sections** - Configure which fields define the size of the colored circle around the node and select a color for each. You can add multiple fields.
 
-{{% admonition type="note" %}}
-Defining Arc sections will override the automatic detection of `arc__*` and `color` fields described in the _Optional fields_ section of [Nodes data frame structure](#nodes-data-frame-structure).
-{{% /admonition %}}
+{{< admonition type="note" >}}
+Defining arc sections overrides the automatic detection of `arc__*` and `color` fields described in the **Optional fields** section of [Nodes data frame structure](#nodes-data-frame-structure).
+{{< /admonition >}}
 
 ## Edges options
 

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -41,9 +41,9 @@ The following video provides beginner steps for creating node panel visualizatio
 
 The **Nodes** options section provides configurations for node behaviors.
 
-- **Main stat unit** choose which unit the main stat displays in the graph's nodes.
-- **Secondary stat unit** choose which unit the secondary stat displays in the graph's nodes.
-- **Arc sections** configures what fields define the size of the colored circle around the node and to select a color for each. You can add multiple fields.
+- **Main stat unit** - Choose which unit the main stat displays in the graph's nodes.
+- **Secondary stat unit** - Choose which unit the secondary stat displays in the graph's nodes.
+- **Arc sections** - Configure which fields define the size of the colored circle around the node and select a color for each. You can add multiple fields.
 
 {{% admonition type="note" %}}
 Defining Arc sections will override the automatic detection of `arc__*` and `color` fields described in the _Optional fields_ section of [Nodes data frame structure](#nodes-data-frame-structure).

--- a/docs/sources/panels-visualizations/visualizations/node-graph/index.md
+++ b/docs/sources/panels-visualizations/visualizations/node-graph/index.md
@@ -25,11 +25,36 @@ Node graphs can visualize directed graphs or networks. They use a directed force
 
 ![Node graph visualization](/static/img/docs/node-graph/node-graph-8-0.png 'Node graph')
 
+## Configure a pie chart visualization
+
 The following video provides beginner steps for creating node panel visualizations. You'll learn the data requirements and caveats, special customizations, and much more:
 
 {{< youtube id="VrvsMkRwoKw" >}}
 
 {{< docs/play title="Node graph panel" url="https://play.grafana.org/d/bdodfbi3d57uoe/" >}}
+
+## Panel options
+
+{{< docs/shared lookup="visualizations/panel-options.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
+## Nodes options
+
+The Nodes options section provides configurations to node behaviors.
+
+- **Main stat unit** choose which unit the main stat displays in the graph's nodes.
+- **Secondary stat unit** choose which unit the secondary stat displays in the graph's nodes.
+- **Arc sections** adds multiple configurations to what fields will provide the data field used to create the color circle around the node and define the color for each field. You can add multiple fields.
+
+{{% admonition type="note" %}}
+Defining Arc sections will override the automatic detection of `arc__*` and `color` fields described in the _Optional fields_ section of [Nodes data frame structure](#nodes-data-frame-structure).
+{{% /admonition %}}
+
+## Edges options
+
+The Edges options section provides configurations to node edges behaviors.
+
+- **Main stat unit** choose which unit the main stat displays in the graph's edges.
+- **Secondary stat unit** choose which unit the secondary stat displays in the graph's edges.
 
 ## Data requirements
 


### PR DESCRIPTION
**What is this feature?**

Added the following missing sections adhering to the standards I noticed in other panel docs:
- Panel options
- Nodes options
   - Main stat unit
   - Secondary stat unit
   - Arc sections
- Edges options sections
   - Main stat unit
   - Secondary stat unit

_Note:_ I am undecided to have the sections together as the options repeat a bit. I felt separated have a better UX but I will defer to @imatwawana 's expert indications. :)

**Why do we need this feature?**

Indications to these panel options were completely missing in this doc.

**Who is this feature for?**

Anyone learning the Node graph panel visualization.

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
