### PR TITLE
search v2: pre-allocate dashboardQueryResult slice capacity for performance

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -846,14 +846,7 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 				attribute.Int64("lastID", lastID),
 			))
 
-			var rows []*dashboardQueryResult
-			if dashboardUID != "" { // only expecting a single result
-				// xorm will append if there is more than one
-				rows = make([]*dashboardQueryResult, 0, 1)
-			} else {
-				// start with an arbitrary but reasonable number of dashboards
-				rows = make([]*dashboardQueryResult, 0, 1000)
-			}
+			rows := make([]*dashboardQueryResult, 0, limit)
 			err := l.sql.WithDbSession(dashboardQueryCtx, func(sess *db.Session) error {
 				sess.Table("dashboard").
 					Where("org_id = ?", orgID).

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -846,7 +846,14 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 				attribute.Int64("lastID", lastID),
 			))
 
-			rows := make([]*dashboardQueryResult, 0)
+			var rows []*dashboardQueryResult
+			if dashboardUID != "" { // only expecting a single result
+				// xorm will append if there is more than one
+				rows = make([]*dashboardQueryResult, 0, 1)
+			} else {
+				// start with an arbitrary but reasonable number of dashboards
+				rows = make([]*dashboardQueryResult, 0, 1000)
+			}
 			err := l.sql.WithDbSession(dashboardQueryCtx, func(sess *db.Session) error {
 				sess.Table("dashboard").
 					Where("org_id = ?", orgID).


### PR DESCRIPTION
I noticed that the search v2 dashboard index function has o(1) performance, with xorm spending thirty minutes (in a loadtesting instance!) appending to a slice of dashboardQueryResult. 

This PR pre-allocates the slice with a larger capacity using the `limit` parameter. The previous caller (`LoadDashboards`) already sets limit to 1 if searching for a single dashboard and otherwise uses search settings `DashboardLoadingBatchSize` to set the limit (thanks @timlevett!). 


This is the current performance on a load testing instance with a very large number (100K? @jalevin?) of dashboards: 
<img width="832" alt="Screenshot 2024-08-05 at 9 58 22 AM" src="https://github.com/user-attachments/assets/7788c379-0e96-4b92-9a63-5b9d83ccd311">
