### PR TITLE
[v11.1.x] Tooltip: Fix scrollbars 

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -1,14 +1,14 @@
-import {css, cx} from '@emotion/css';
-import React, {CSSProperties, ReactNode, useEffect, useRef, useState} from 'react';
+import { css, cx } from '@emotion/css';
+import React, { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
 
-import {GrafanaTheme2} from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 
-import {useStyles2} from '../../themes';
-import {InlineToast} from '../InlineToast/InlineToast';
-import {Tooltip} from '../Tooltip';
+import { useStyles2 } from '../../themes';
+import { InlineToast } from '../InlineToast/InlineToast';
+import { Tooltip } from '../Tooltip';
 
-import {ColorIndicatorPosition, VizTooltipColorIndicator} from './VizTooltipColorIndicator';
-import {ColorPlacement, VizTooltipItem} from './types';
+import { ColorIndicatorPosition, VizTooltipColorIndicator } from './VizTooltipColorIndicator';
+import { ColorPlacement, VizTooltipItem } from './types';
 
 interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   value: string | number | null | ReactNode;
@@ -47,7 +47,7 @@ export const VizTooltipRow = ({
         maxHeight: 55,
         whiteSpace: 'wrap',
         wordBreak: 'break-word',
-      overflowY: 'auto',
+        overflowY: 'auto',
       }
     : {
         whiteSpace: 'wrap',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -1,14 +1,14 @@
-import { css, cx } from '@emotion/css';
-import React, { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
+import {css, cx} from '@emotion/css';
+import React, {CSSProperties, ReactNode, useEffect, useRef, useState} from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import {GrafanaTheme2} from '@grafana/data';
 
-import { useStyles2 } from '../../themes';
-import { InlineToast } from '../InlineToast/InlineToast';
-import { Tooltip } from '../Tooltip';
+import {useStyles2} from '../../themes';
+import {InlineToast} from '../InlineToast/InlineToast';
+import {Tooltip} from '../Tooltip';
 
-import { ColorIndicatorPosition, VizTooltipColorIndicator } from './VizTooltipColorIndicator';
-import { ColorPlacement, VizTooltipItem } from './types';
+import {ColorIndicatorPosition, VizTooltipColorIndicator} from './VizTooltipColorIndicator';
+import {ColorPlacement, VizTooltipItem} from './types';
 
 interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   value: string | number | null | ReactNode;
@@ -47,7 +47,7 @@ export const VizTooltipRow = ({
         maxHeight: 55,
         whiteSpace: 'wrap',
         wordBreak: 'break-word',
-        overflowY: 'scroll',
+      overflowY: 'auto',
       }
     : {
         whiteSpace: 'wrap',


### PR DESCRIPTION
Backport PR to fix the tooltip scrollbars. 
The 11.2 PR that fixes the issue is https://github.com/grafana/grafana/pull/89196



Fixes https://github.com/grafana/support-escalations/issues/11795
Fixes https://github.com/grafana/grafana/issues/90697
Fixes https://github.com/grafana/grafana/issues/89975
Fixes https://github.com/grafana/grafana/issues/91100


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
