### PR TITLE
Vizards: Viz Element Styling

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2624,7 +2624,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/canvas/elements/visualization.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/canvas/runtime/ables.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],

--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { DataFrame } from '@grafana/data/';
 import { EmbeddedScene, PanelBuilders, SceneDataNode, SceneFlexItem, SceneFlexLayout } from '@grafana/scenes';
+import { TextDimensionMode } from '@grafana/schema/dist/esm/index';
 import { stylesFactory, usePanelContext } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { DimensionContext } from 'app/features/dimensions/context';
@@ -15,6 +16,8 @@ const panelTypes: Array<SelectableValue<string>> = Object.keys(PanelBuilders).ma
   return { label: type, value: type };
 });
 
+const defaultPanelTitle = 'New Visualization';
+
 const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizElementData>) => {
   const context = usePanelContext();
   const scene = context.instanceState?.scene;
@@ -22,7 +25,7 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   const { data, config: elementConfig } = props;
   const styles = getStyles(config.theme2, data, scene);
 
-  const panelTitle = data?.text ? data?.text : 'Visualization';
+  const panelTitle = data?.text ?? '';
   let panelToEmbed = PanelBuilders.timeseries().setTitle(panelTitle);
   if (data?.vizType) {
     // TODO make this better
@@ -94,6 +97,7 @@ export const visualizationItem: CanvasElementItem<VizElementConfig, VizElementDa
       },
       vizType: 'timeseries',
       fields: options?.fields ?? [],
+      text: { mode: TextDimensionMode.Fixed, fixed: defaultPanelTitle },
     },
     background: {
       color: {

--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -26,7 +26,7 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   const scene = context.instanceState?.scene;
 
   const { data, config: elementConfig } = props;
-  const styles = getStyles(config.theme2, data);
+  const styles = getStyles(config.theme2, data, scene);
 
   let panelToEmbed = PanelBuilders.timeseries().setTitle(data?.text ?? 'Visualization');
   if (data?.vizType) {
@@ -66,12 +66,13 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   );
 };
 
-const getStyles = stylesFactory((theme: GrafanaTheme2, data) => ({
+const getStyles = stylesFactory((theme: GrafanaTheme2, data, scene) => ({
   container: css({
     position: 'absolute',
     height: '100%',
     width: '100%',
     display: 'table',
+    pointerEvents: scene?.isEditingEnabled ? 'none' : 'auto',
   }),
 }));
 

--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -1,7 +1,7 @@
-import {css} from '@emotion/css';
+import { css } from '@emotion/css';
 
-import {GrafanaTheme2, SelectableValue} from '@grafana/data';
-import {DataFrame} from '@grafana/data/';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { DataFrame } from '@grafana/data/';
 import {
   EmbeddedScene,
   PanelBuilders,
@@ -10,11 +10,10 @@ import {
   SceneFlexLayout,
   SceneQueryRunner,
 } from '@grafana/scenes';
-import {stylesFactory, usePanelContext} from '@grafana/ui';
-import {config} from 'app/core/config';
-import {DimensionContext} from 'app/features/dimensions/context';
-import {ColorDimensionEditor} from 'app/features/dimensions/editors/ColorDimensionEditor';
-import {TextDimensionEditor} from 'app/features/dimensions/editors/TextDimensionEditor';
+import { stylesFactory, usePanelContext } from '@grafana/ui';
+import { config } from 'app/core/config';
+import { DimensionContext } from 'app/features/dimensions/context';
+import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';
 
 import {
   CanvasElementItem,
@@ -23,7 +22,7 @@ import {
   defaultBgColor,
   defaultTextColor,
 } from '../element';
-import {Align, VAlign, VizElementConfig, VizElementData} from '../types';
+import { Align, VAlign, VizElementConfig, VizElementData } from '../types';
 
 const panelTypes: Array<SelectableValue<string>> = Object.keys(PanelBuilders).map((type) => {
   return { label: type, value: type };
@@ -33,13 +32,13 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   const context = usePanelContext();
   const scene = context.instanceState?.scene;
 
-  const {data, config: elementConfig} = props;
+  const { data, config: elementConfig } = props;
   const styles = getStyles(config.theme2, data);
 
-  let panelToEmbed = PanelBuilders.timeseries().setTitle('Embedded Panel');
+  let panelToEmbed = PanelBuilders.timeseries().setTitle(data?.text ?? 'Visualization');
   if (data?.vizType) {
     // TODO make this better
-    panelToEmbed = PanelBuilders[data.vizType as keyof typeof PanelBuilders]().setTitle('Embedded Panel');
+    panelToEmbed = PanelBuilders[data.vizType as keyof typeof PanelBuilders]().setTitle(data?.text ?? 'Visualization');
   }
 
   // @TODO: Cleanup?
@@ -93,9 +92,7 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
 
   return (
     <div className={styles.container}>
-      <span className={styles.span}>
-        <embeddedPanel.Component model={embeddedPanel}/>
-      </span>
+      <embeddedPanel.Component model={embeddedPanel} />
     </div>
   );
 };
@@ -106,13 +103,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme2, data) => ({
     height: '100%',
     width: '100%',
     display: 'table',
-  }),
-  span: css({
-    display: 'table-cell',
-    verticalAlign: data?.valign,
-    textAlign: data?.align,
-    fontSize: `${data?.size}px`,
-    color: data?.color,
   }),
 }));
 
@@ -183,51 +173,8 @@ export const visualizationItem: CanvasElementItem<VizElementConfig, VizElementDa
         category,
         id: 'textSelector',
         path: 'config.text',
-        name: 'Text',
+        name: 'Panel Title',
         editor: TextDimensionEditor,
-      })
-      .addCustomEditor({
-        category,
-        id: 'config.color',
-        path: 'config.color',
-        name: 'Text color',
-        editor: ColorDimensionEditor,
-        settings: {},
-        defaultValue: {},
-      })
-      .addRadio({
-        category,
-        path: 'config.align',
-        name: 'Align text',
-        settings: {
-          options: [
-            { value: Align.Left, label: 'Left' },
-            { value: Align.Center, label: 'Center' },
-            { value: Align.Right, label: 'Right' },
-          ],
-        },
-        defaultValue: Align.Left,
-      })
-      .addRadio({
-        category,
-        path: 'config.valign',
-        name: 'Vertical align',
-        settings: {
-          options: [
-            { value: VAlign.Top, label: 'Top' },
-            { value: VAlign.Middle, label: 'Middle' },
-            { value: VAlign.Bottom, label: 'Bottom' },
-          ],
-        },
-        defaultValue: VAlign.Middle,
-      })
-      .addNumberInput({
-        category,
-        path: 'config.size',
-        name: 'Text size',
-        settings: {
-          placeholder: 'Auto',
-        },
       });
   },
 };

--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -8,13 +8,7 @@ import { config } from 'app/core/config';
 import { DimensionContext } from 'app/features/dimensions/context';
 import { TextDimensionEditor } from 'app/features/dimensions/editors/TextDimensionEditor';
 
-import {
-  CanvasElementItem,
-  CanvasElementOptions,
-  CanvasElementProps,
-  defaultBgColor,
-  defaultTextColor,
-} from '../element';
+import { CanvasElementItem, CanvasElementOptions, CanvasElementProps, defaultTextColor } from '../element';
 import { Align, VAlign, VizElementConfig, VizElementData } from '../types';
 
 const panelTypes: Array<SelectableValue<string>> = Object.keys(PanelBuilders).map((type) => {
@@ -46,6 +40,7 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   }));
 
   panelToEmbed.setData(new SceneDataNode({ data: data!.data }));
+  panelToEmbed.setDisplayMode('transparent');
   const panel = panelToEmbed.build();
 
   const embeddedPanel = new EmbeddedScene({
@@ -102,7 +97,7 @@ export const visualizationItem: CanvasElementItem<VizElementConfig, VizElementDa
     },
     background: {
       color: {
-        fixed: defaultBgColor,
+        fixed: config.theme2.colors.background.canvas,
       },
     },
     links: options?.links ?? [],

--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -28,10 +28,11 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   const { data, config: elementConfig } = props;
   const styles = getStyles(config.theme2, data, scene);
 
-  let panelToEmbed = PanelBuilders.timeseries().setTitle(data?.text ?? 'Visualization');
+  const panelTitle = data?.text ? data?.text : 'Visualization';
+  let panelToEmbed = PanelBuilders.timeseries().setTitle(panelTitle);
   if (data?.vizType) {
     // TODO make this better
-    panelToEmbed = PanelBuilders[data.vizType as keyof typeof PanelBuilders]().setTitle(data?.text ?? 'Visualization');
+    panelToEmbed = PanelBuilders[data.vizType as keyof typeof PanelBuilders]().setTitle(panelTitle);
   }
 
   // @TODO: Cleanup?


### PR DESCRIPTION
Improve styling for viz element.

- [x] Remove unused options
- [x] Remove span which was interfering with panel title font
- [x] Handle background color
- [x] Border radius
- [x] Lock pointer events during inline edit

After:
<img width="942" alt="image" src="https://github.com/user-attachments/assets/07aa5d46-99f0-4374-96a9-480540a9a009">
<img width="536" alt="image" src="https://github.com/user-attachments/assets/b39ad753-48f5-4548-ae56-528d9ff72ced">



Closes #91440, #91438