### PR TITLE
Revert: Calcs: Update diff percent to be a percent

### DIFF
--- a/packages/grafana-data/src/transformations/fieldReducer.test.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.test.ts
@@ -55,14 +55,13 @@ describe('Stats Calculators', () => {
   it('should calculate basic stats', () => {
     const stats = reduceField({
       field: basicTable.fields[0],
-      reducers: [ReducerID.first, ReducerID.last, ReducerID.mean, ReducerID.count, ReducerID.diffperc],
+      reducers: [ReducerID.first, ReducerID.last, ReducerID.mean, ReducerID.count],
     });
 
     expect(stats.first).toEqual(10);
     expect(stats.last).toEqual(20);
     expect(stats.mean).toEqual(15);
     expect(stats.count).toEqual(2);
-    expect(stats.diffperc).toEqual(100);
   });
 
   it('should handle undefined field data without crashing', () => {

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -582,7 +582,7 @@ export function doStandardCalcs(field: Field, ignoreNulls: boolean, nullAsZero: 
   }
 
   if (isNumber(calcs.firstNotNull) && isNumber(calcs.diff)) {
-    calcs.diffperc = (calcs.diff / calcs.firstNotNull) * 100;
+    calcs.diffperc = calcs.diff / calcs.firstNotNull;
   }
   return calcs;
 }


### PR DESCRIPTION
Reverts grafana/grafana#90533

Context is that the PR caused a regression where stat percent change was no longer formatted as expected. Reverting these changes to fix the stat percent change regression to mitigate risk (these changes may of also caused additional issues we are currently unaware of).

Fixes https://github.com/grafana/grafana/issues/91553
Fixes https://github.com/grafana/support-escalations/issues/11818