### PR TITLE
Alerting: Use remote Alertmanager to test templates and receivers when enabled

### DIFF
--- a/pkg/services/ngalert/notifier/templates.go
+++ b/pkg/services/ngalert/notifier/templates.go
@@ -31,7 +31,7 @@ var (
 // If an existing template of the same filename as the one being tested is found, it will not be used as context.
 func (am *alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*TestTemplatesResults, error) {
 	for _, alert := range c.Alerts {
-		addDefaultLabelsAndAnnotations(alert)
+		AddDefaultLabelsAndAnnotations(alert)
 	}
 
 	return am.Base.TestTemplate(ctx, alertingNotify.TestTemplatesConfigBodyParams{
@@ -42,7 +42,7 @@ func (am *alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTempla
 }
 
 // addDefaultLabelsAndAnnotations is a slimmed down version of state.StateToPostableAlert and state.GetRuleExtraLabels using default values.
-func addDefaultLabelsAndAnnotations(alert *amv2.PostableAlert) {
+func AddDefaultLabelsAndAnnotations(alert *amv2.PostableAlert) {
 	if alert.Labels == nil {
 		alert.Labels = make(map[string]string)
 	}

--- a/pkg/services/ngalert/notifier/templates.go
+++ b/pkg/services/ngalert/notifier/templates.go
@@ -41,7 +41,7 @@ func (am *alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTempla
 	})
 }
 
-// addDefaultLabelsAndAnnotations is a slimmed down version of state.StateToPostableAlert and state.GetRuleExtraLabels using default values.
+// AddDefaultLabelsAndAnnotations is a slimmed down version of state.StateToPostableAlert and state.GetRuleExtraLabels using default values.
 func AddDefaultLabelsAndAnnotations(alert *amv2.PostableAlert) {
 	if alert.Labels == nil {
 		alert.Labels = make(map[string]string)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -569,7 +569,15 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 }
 
 func (am *Alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {
-	return &notifier.TestTemplatesResults{}, nil
+	for _, alert := range c.Alerts {
+		notifier.AddDefaultLabelsAndAnnotations(alert)
+	}
+
+	return am.mimirClient.TestTemplate(ctx, alertingNotify.TestTemplatesConfigBodyParams{
+		Alerts:   c.Alerts,
+		Template: c.Template,
+		Name:     c.Name,
+	})
 }
 
 // StopAndWait is called when the grafana server is instructed to shut down or an org is deleted.

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -539,7 +539,6 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 		Alert:     alert,
 		Receivers: receivers,
 	})
-
 }
 
 func (am *Alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -535,37 +535,11 @@ func (am *Alertmanager) TestReceivers(ctx context.Context, c apimodels.TestRecei
 		alert = &alertingNotify.TestReceiversConfigAlertParams{Annotations: c.Alert.Annotations, Labels: c.Alert.Labels}
 	}
 
-	result, err := am.mimirClient.TestReceivers(ctx, alertingNotify.TestReceiversConfigBodyParams{
+	return am.mimirClient.TestReceivers(ctx, alertingNotify.TestReceiversConfigBodyParams{
 		Alert:     alert,
 		Receivers: receivers,
 	})
 
-	if err != nil {
-		return nil, err
-	}
-
-	resultReceivers := make([]notifier.TestReceiverResult, 0, len(result.Receivers))
-	for _, resultReceiver := range result.Receivers {
-		configs := make([]notifier.TestReceiverConfigResult, 0, len(resultReceiver.Configs))
-		for _, c := range resultReceiver.Configs {
-			configs = append(configs, notifier.TestReceiverConfigResult{
-				Name:   c.Name,
-				UID:    c.UID,
-				Status: c.Status,
-				Error:  c.Error,
-			})
-		}
-		resultReceivers = append(resultReceivers, notifier.TestReceiverResult{
-			Name:    resultReceiver.Name,
-			Configs: configs,
-		})
-	}
-
-	return &notifier.TestReceiversResult{
-		Alert:     result.Alert,
-		Receivers: resultReceivers,
-		NotifedAt: result.NotifedAt,
-	}, err
 }
 
 func (am *Alertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -208,6 +208,8 @@ func (mc *Mimir) TestReceivers(ctx context.Context, c alertingNotify.TestReceive
 
 	trResult := &alertingNotify.TestReceiversResult{}
 
+	// nolint:bodyclose
+	// closed within `do`
 	_, err = mc.do(ctx, "api/v1/grafana/receivers/test", http.MethodPost, bytes.NewBuffer(payload), &trResult)
 	if err != nil {
 		return nil, err
@@ -224,6 +226,8 @@ func (mc *Mimir) TestTemplate(ctx context.Context, c alertingNotify.TestTemplate
 
 	ttResult := &alertingNotify.TestTemplatesResults{}
 
+	// nolint:bodyclose
+	// closed within `do`
 	_, err = mc.do(ctx, "api/v1/grafana/templates/test", http.MethodPost, bytes.NewBuffer(payload), &ttResult)
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -31,7 +31,7 @@ type MimirClient interface {
 	DeleteGrafanaAlertmanagerConfig(ctx context.Context) error
 
 	TestTemplate(ctx context.Context, c alertingNotify.TestTemplatesConfigBodyParams) (*alertingNotify.TestTemplatesResults, error)
-	TestReceivers(ctx context.Context, c alertingNotify.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, error)
+	TestReceivers(ctx context.Context, c alertingNotify.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error)
 
 	ShouldPromoteConfig() bool
 
@@ -200,10 +200,10 @@ func (mc *Mimir) doOK(ctx context.Context, p, method string, payload io.Reader) 
 	}
 }
 
-func (mc *Mimir) TestReceivers(ctx context.Context, c alertingNotify.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, error) {
+func (mc *Mimir) TestReceivers(ctx context.Context, c alertingNotify.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error) {
 	payload, err := json.Marshal(c)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	trResult := &alertingNotify.TestReceiversResult{}
@@ -212,10 +212,10 @@ func (mc *Mimir) TestReceivers(ctx context.Context, c alertingNotify.TestReceive
 	// closed within `do`
 	_, err = mc.do(ctx, "api/v1/grafana/receivers/test", http.MethodPost, bytes.NewBuffer(payload), &trResult)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return trResult, nil
+	return trResult, http.StatusOK, nil
 }
 
 func (mc *Mimir) TestTemplate(ctx context.Context, c alertingNotify.TestTemplatesConfigBodyParams) (*alertingNotify.TestTemplatesResults, error) {

--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -626,30 +626,28 @@ func TestForkedAlertmanager_ModeRemotePrimary(t *testing.T) {
 
 	t.Run("TestReceivers", func(tt *testing.T) {
 		// TestReceivers should be called only in the remote Alertmanager.
-		// TODO: change to remote AM once it's implemented there.
-		internal, _, forked := genTestAlertmanagers(tt, modeRemotePrimary)
-		internal.EXPECT().TestReceivers(mock.Anything, mock.Anything).Return(nil, 0, nil).Once()
+		_, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().TestReceivers(mock.Anything, mock.Anything).Return(nil, 0, nil).Once()
 		_, _, err := forked.TestReceivers(ctx, apimodels.TestReceiversConfigBodyParams{})
 		require.NoError(tt, err)
 
 		// If there's an error in the remote Alertmanager, it should be returned.
-		internal, _, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		internal.EXPECT().TestReceivers(mock.Anything, mock.Anything).Return(nil, 0, expErr).Once()
+		_, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().TestReceivers(mock.Anything, mock.Anything).Return(nil, 0, expErr).Once()
 		_, _, err = forked.TestReceivers(ctx, apimodels.TestReceiversConfigBodyParams{})
 		require.ErrorIs(tt, expErr, err)
 	})
 
 	t.Run("TestTemplate", func(tt *testing.T) {
 		// TestTemplate should be called only in the internal Alertmanager.
-		// TODO: change to remote AM once it's implemented there.
-		internal, _, forked := genTestAlertmanagers(tt, modeRemotePrimary)
-		internal.EXPECT().TestTemplate(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		_, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().TestTemplate(mock.Anything, mock.Anything).Return(nil, nil).Once()
 		_, err := forked.TestTemplate(ctx, apimodels.TestTemplatesConfigBodyParams{})
 		require.NoError(tt, err)
 
 		// If there's an error in the internal Alertmanager, it should be returned.
-		internal, _, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		internal.EXPECT().TestTemplate(mock.Anything, mock.Anything).Return(nil, expErr).Once()
+		_, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
+		remote.EXPECT().TestTemplate(mock.Anything, mock.Anything).Return(nil, expErr).Once()
 		_, err = forked.TestTemplate(ctx, apimodels.TestTemplatesConfigBodyParams{})
 		require.ErrorIs(tt, expErr, err)
 	})

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -119,13 +119,11 @@ func (fam *RemotePrimaryForkedAlertmanager) GetReceivers(ctx context.Context) ([
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error) {
-	// TODO: change to remote AM once it's implemented there.
-	return fam.internal.TestReceivers(ctx, c)
+	return fam.remote.TestReceivers(ctx, c)
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*notifier.TestTemplatesResults, error) {
-	// TODO: change to remote AM once it's implemented there.
-	return fam.internal.TestTemplate(ctx, c)
+	return fam.remote.TestTemplate(ctx, c)
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) SilenceState(ctx context.Context) (alertingNotify.SilenceState, error) {


### PR DESCRIPTION
**What is this feature?**
When `alertmanagerRemotePrimary` is enabled, Grafana will now call out to the configured remote alertmanager to test templates (`api/v1/grafana/receivers/test`) and receivers (`api/v1/grafana/templates/test`)

Also updates the Mimir image used in Drone to https://github.com/grafana/mimir/commit/853a1baea8f7d90111a41cb02902b4c50a96c0f6

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
