### PR TITLE
Alerting: Tidy up k8s utilities/constants

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
@@ -14,7 +14,7 @@ import {
 import { BaseAlertmanagerArgs, Skippable } from 'app/features/alerting/unified/types/hooks';
 import { cloudNotifierTypes } from 'app/features/alerting/unified/utils/cloud-alertmanager-notifier-types';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
-import { getNamespace, shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
+import { getK8sNamespace, shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
 import { onCallApi } from '../../api/onCallApi';
@@ -94,7 +94,7 @@ const useK8sContactPoints = (...[hookParams, queryOptions]: Parameters<typeof us
  * or the `/notifications/receivers` endpoint
  */
 const useFetchGrafanaContactPoints = ({ skip }: Skippable = {}) => {
-  const namespace = getNamespace();
+  const namespace = getK8sNamespace();
   const useK8sApi = shouldUseK8sApi(GRAFANA_RULES_SOURCE_NAME);
 
   const grafanaResponse = useGetContactPointsListQuery(undefined, { skip: skip || useK8sApi });

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx
@@ -11,7 +11,7 @@ import {
   useUpdateMuteTiming,
   useValidateMuteTiming,
 } from 'app/features/alerting/unified/components/mute-timings/useMuteTimings';
-import { shouldUseK8sApi } from 'app/features/alerting/unified/components/mute-timings/util';
+import { shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
 
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { MuteTimingFields } from '../../types/mute-timing-form';

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingsTable.tsx
@@ -9,6 +9,7 @@ import {
   ALL_MUTE_TIMINGS,
   useExportMuteTimingsDrawer,
 } from 'app/features/alerting/unified/components/mute-timings/useExportMuteTimingsDrawer';
+import { PROVENANCE_ANNOTATION } from 'app/features/alerting/unified/utils/k8s/constants';
 
 import { Authorize } from '../../components/Authorize';
 import { AlertmanagerAction, useAlertmanagerAbilities, useAlertmanagerAbility } from '../../hooks/useAbilities';
@@ -18,7 +19,7 @@ import { EmptyAreaWithCTA } from '../EmptyAreaWithCTA';
 import { ProvisioningBadge } from '../Provisioning';
 import { Spacer } from '../Spacer';
 
-import { MuteTiming, PROVENANCE_ANNOTATION, useMuteTimings } from './useMuteTimings';
+import { MuteTiming, useMuteTimings } from './useMuteTimings';
 import { renderTimeIntervals } from './util';
 
 interface MuteTimingsTableProps {

--- a/public/app/features/alerting/unified/components/mute-timings/useMuteTimings.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/useMuteTimings.tsx
@@ -3,11 +3,7 @@ import { useEffect } from 'react';
 
 import { alertmanagerApi } from 'app/features/alerting/unified/api/alertmanagerApi';
 import { timeIntervalsApi } from 'app/features/alerting/unified/api/timeIntervalsApi';
-import {
-  getK8sNamespace,
-  mergeTimeIntervals,
-  shouldUseK8sApi,
-} from 'app/features/alerting/unified/components/mute-timings/util';
+import { mergeTimeIntervals } from 'app/features/alerting/unified/components/mute-timings/util';
 import {
   ComGithubGrafanaGrafanaPkgApisAlertingNotificationsV0Alpha1TimeInterval,
   ReadNamespacedTimeIntervalApiResponse,
@@ -16,6 +12,8 @@ import { deleteMuteTimingAction, updateAlertManagerConfigAction } from 'app/feat
 import { BaseAlertmanagerArgs } from 'app/features/alerting/unified/types/hooks';
 import { renameMuteTimings } from 'app/features/alerting/unified/utils/alertmanager';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+import { PROVENANCE_ANNOTATION, PROVENANCE_NONE } from 'app/features/alerting/unified/utils/k8s/constants';
+import { getK8sNamespace, shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
 import { MuteTimeInterval } from 'app/plugins/datasource/alertmanager/types';
 import { useDispatch } from 'app/types';
 
@@ -36,12 +34,6 @@ export type MuteTiming = MuteTimeInterval & {
   id: string;
   metadata?: ReadNamespacedTimeIntervalApiResponse['metadata'];
 };
-
-/** Name of the custom annotation label used in k8s APIs for us to discern if a given entity was provisioned */
-export const PROVENANCE_ANNOTATION = 'grafana.com/provenance';
-
-/** Value of `PROVENANCE_ANNOTATION` given for non-provisioned intervals */
-export const PROVENANCE_NONE = 'none';
 
 /** Alias for generated kuberenetes Alerting API Server type */
 type TimeIntervalV0Alpha1 = ComGithubGrafanaGrafanaPkgApisAlertingNotificationsV0Alpha1TimeInterval;

--- a/public/app/features/alerting/unified/components/mute-timings/util.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/util.tsx
@@ -1,9 +1,7 @@
 import moment from 'moment';
 import { Fragment } from 'react';
 
-import { config } from '@grafana/runtime';
 import { Stack } from '@grafana/ui';
-import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 import { AlertmanagerConfig, MuteTimeInterval } from 'app/plugins/datasource/alertmanager/types';
 
 import {
@@ -84,19 +82,3 @@ export function renderTimeIntervals(muteTiming: MuteTimeInterval) {
     </Stack>
   );
 }
-
-/**
- * Get the correct namespace to use when using the K8S API.
- */
-export const getK8sNamespace = () => config.namespace;
-
-/**
- * Should we call the kubernetes-style API for managing the time intervals?
- *
- * Requires the alertmanager referenced being the Grafana AM,
- * and the `alertingApiServer` feature toggle being enabled
- */
-export const shouldUseK8sApi = (alertmanager?: string) => {
-  const featureToggleEnabled = config.featureToggles.alertingApiServer;
-  return featureToggleEnabled && alertmanager === GRAFANA_RULES_SOURCE_NAME;
-};

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s.ts
@@ -1,11 +1,8 @@
 import { HttpResponse, http } from 'msw';
 
-import {
-  PROVENANCE_ANNOTATION,
-  PROVENANCE_NONE,
-} from 'app/features/alerting/unified/components/mute-timings/useMuteTimings';
 import { ALERTING_API_SERVER_BASE_URL, getK8sResponse } from 'app/features/alerting/unified/mocks/server/utils';
 import { ComGithubGrafanaGrafanaPkgApisAlertingNotificationsV0Alpha1TimeInterval } from 'app/features/alerting/unified/openapi/timeIntervalsApi.gen';
+import { PROVENANCE_ANNOTATION, PROVENANCE_NONE } from 'app/features/alerting/unified/utils/k8s/constants';
 
 /** UID of a time interval that we expect to follow all happy paths within tests/mocks */
 export const TIME_INTERVAL_UID_HAPPY_PATH = 'f4eae7a4895fa786';

--- a/public/app/features/alerting/unified/utils/k8s/utils.ts
+++ b/public/app/features/alerting/unified/utils/k8s/utils.ts
@@ -4,7 +4,7 @@ import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/d
 /**
  * Get the correct namespace to use when using the K8S API.
  */
-export const getNamespace = () => config.namespace;
+export const getK8sNamespace = () => config.namespace;
 
 /**
  * Should we call the kubernetes-style API for managing alertmanager entities?


### PR DESCRIPTION
Tidies up some duplicated kubernetes utils/constants that were kept in the mute timings file(s) - now using the source of truth/single constants that we want to keep for these kind of things (at least within alerting)