### PR TITLE
RemoteCache: remove count method

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -122,22 +122,6 @@ func (dc *databaseCache) Delete(ctx context.Context, key string) error {
 	})
 }
 
-func (dc *databaseCache) Count(ctx context.Context, prefix string) (int64, error) {
-	res := int64(0)
-	err := dc.SQLStore.WithDbSession(ctx, func(session *db.Session) error {
-		sql := "SELECT COUNT(*) FROM cache_data WHERE cache_key LIKE ?"
-
-		_, err := session.SQL(sql, prefix+"%").Get(&res)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-
-	return res, err
-}
-
 // CacheData is the struct representing the table in the database
 type CacheData struct {
 	CacheKey  string

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -75,43 +74,4 @@ func TestSecondSet(t *testing.T) {
 
 	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
-}
-
-func TestDatabaseStorageCount(t *testing.T) {
-	sqlstore := db.InitTestDB(t)
-
-	db := &databaseCache{
-		SQLStore: sqlstore,
-		log:      log.New("remotecache.database"),
-	}
-
-	obj := []byte("foolbar")
-
-	// set time.now to 2 weeks ago
-	var err error
-	getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
-	err = db.Set(context.Background(), "pref-key1", obj, 1000*time.Second)
-	require.NoError(t, err)
-
-	err = db.Set(context.Background(), "pref-key2", obj, 1000*time.Second)
-	require.NoError(t, err)
-
-	err = db.Set(context.Background(), "pref-key3", obj, 1000*time.Second)
-	require.NoError(t, err)
-
-	// insert object that should never expire
-	err = db.Set(context.Background(), "pref-key4", obj, 0)
-	require.NoError(t, err)
-
-	getTime = time.Now
-	err = db.Set(context.Background(), "pref-key5", obj, 1000*time.Second)
-	require.NoError(t, err)
-
-	// run GC
-	db.internalRunGC()
-
-	// try to read values
-	n, errC := db.Count(context.Background(), "pref-")
-	require.NoError(t, errC)
-	assert.Equal(t, int64(2), n)
 }

--- a/pkg/infra/remotecache/memcached_storage.go
+++ b/pkg/infra/remotecache/memcached_storage.go
@@ -57,10 +57,6 @@ func (s *memcachedStorage) Get(ctx context.Context, key string) ([]byte, error) 
 	return memcachedItem.Value, nil
 }
 
-func (s *memcachedStorage) Count(ctx context.Context, prefix string) (int64, error) {
-	return 0, ErrNotImplemented
-}
-
 // Delete delete a key from the cache
 func (s *memcachedStorage) Delete(ctx context.Context, key string) error {
 	return s.c.Delete(key)

--- a/pkg/infra/remotecache/memcached_storage_integration_test.go
+++ b/pkg/infra/remotecache/memcached_storage_integration_test.go
@@ -20,5 +20,4 @@ func TestIntegrationMemcachedCacheStorage(t *testing.T) {
 	opts := &setting.RemoteCacheOptions{Name: memcachedCacheType, ConnStr: u}
 	client := createTestClient(t, opts, nil)
 	runTestsForClient(t, client)
-	runCountTestsForClient(t, opts, nil)
 }

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -110,12 +110,3 @@ func (s *redisStorage) Delete(ctx context.Context, key string) error {
 	cmd := s.c.Del(ctx, key)
 	return cmd.Err()
 }
-
-func (s *redisStorage) Count(ctx context.Context, prefix string) (int64, error) {
-	cmd := s.c.Keys(ctx, prefix+"*")
-	if cmd.Err() != nil {
-		return 0, cmd.Err()
-	}
-
-	return int64(len(cmd.Val())), nil
-}

--- a/pkg/infra/remotecache/redis_storage_integration_test.go
+++ b/pkg/infra/remotecache/redis_storage_integration_test.go
@@ -37,5 +37,4 @@ func TestIntegrationRedisCacheStorage(t *testing.T) {
 	opts := &setting.RemoteCacheOptions{Name: redisCacheType, ConnStr: b.String()}
 	client := createTestClient(t, opts, nil)
 	runTestsForClient(t, client)
-	runCountTestsForClient(t, opts, nil)
 }

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -69,11 +69,6 @@ type CacheStorage interface {
 
 	// Delete object from cache
 	Delete(ctx context.Context, key string) error
-
-	// Count returns the number of items in the cache.
-	// Optionaly a prefix can be provided to only count items with that prefix
-	// DO NOT USE. Not available for memcached.
-	Count(ctx context.Context, prefix string) (int64, error)
 }
 
 // RemoteCache allows Grafana to cache data outside its own process
@@ -100,11 +95,6 @@ func (ds *RemoteCache) Set(ctx context.Context, key string, value []byte, expire
 // Delete object from cache
 func (ds *RemoteCache) Delete(ctx context.Context, key string) error {
 	return ds.client.Delete(ctx, key)
-}
-
-// Count returns the number of items in the cache.
-func (ds *RemoteCache) Count(ctx context.Context, prefix string) (int64, error) {
-	return ds.client.Count(ctx, prefix)
 }
 
 // Run starts the backend processes for cache clients.

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -163,10 +163,6 @@ func (pcs *encryptedCacheStorage) Delete(ctx context.Context, key string) error 
 	return pcs.cache.Delete(ctx, key)
 }
 
-func (pcs *encryptedCacheStorage) Count(ctx context.Context, prefix string) (int64, error) {
-	return pcs.cache.Count(ctx, prefix)
-}
-
 type prefixCacheStorage struct {
 	cache  CacheStorage
 	prefix string
@@ -180,8 +176,4 @@ func (pcs *prefixCacheStorage) Set(ctx context.Context, key string, value []byte
 }
 func (pcs *prefixCacheStorage) Delete(ctx context.Context, key string) error {
 	return pcs.cache.Delete(ctx, pcs.prefix+key)
-}
-
-func (pcs *prefixCacheStorage) Count(ctx context.Context, prefix string) (int64, error) {
-	return pcs.cache.Count(ctx, pcs.prefix+prefix)
 }

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -42,7 +42,6 @@ func TestCachedBasedOnConfig(t *testing.T) {
 
 	client := createTestClient(t, cfg.RemoteCacheOptions, db)
 	runTestsForClient(t, client)
-	runCountTestsForClient(t, cfg.RemoteCacheOptions, db)
 }
 
 func TestInvalidCacheTypeReturnsError(t *testing.T) {
@@ -53,37 +52,6 @@ func TestInvalidCacheTypeReturnsError(t *testing.T) {
 func runTestsForClient(t *testing.T, client CacheStorage) {
 	canPutGetAndDeleteCachedObjects(t, client)
 	canNotFetchExpiredItems(t, client)
-}
-
-func runCountTestsForClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore db.DB) {
-	client := createTestClient(t, opts, sqlstore)
-	expectError := false
-	if opts.Name == memcachedCacheType {
-		expectError = true
-	}
-
-	t.Run("can count items", func(t *testing.T) {
-		cacheableValue := []byte("hej hej")
-
-		err := client.Set(context.Background(), "pref-key1", cacheableValue, 0)
-		require.NoError(t, err)
-
-		err = client.Set(context.Background(), "pref-key2", cacheableValue, 0)
-		require.NoError(t, err)
-
-		err = client.Set(context.Background(), "key3-not-pref", cacheableValue, 0)
-		require.NoError(t, err)
-
-		n, errC := client.Count(context.Background(), "pref-")
-		if expectError {
-			require.ErrorIs(t, ErrNotImplemented, errC)
-			assert.Equal(t, int64(0), n)
-			return
-		}
-
-		require.NoError(t, errC)
-		assert.Equal(t, int64(2), n)
-	})
 }
 
 func canPutGetAndDeleteCachedObjects(t *testing.T, client CacheStorage) {

--- a/pkg/infra/remotecache/test_utils.go
+++ b/pkg/infra/remotecache/test_utils.go
@@ -28,10 +28,6 @@ func (fcs FakeCacheStorage) Delete(_ context.Context, key string) error {
 	return nil
 }
 
-func (fcs FakeCacheStorage) Count(_ context.Context, prefix string) (int64, error) {
-	return int64(len(fcs.Storage)), nil
-}
-
 func NewFakeCacheStorage() FakeCacheStorage {
 	return FakeCacheStorage{
 		Storage: map[string][]byte{},


### PR DESCRIPTION
**What is this feature?**
It is not used and can't be implemented for e.g. memcache. Was added for anonymous counting but is not used anymore

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
