### PR TITLE
Alerting: Log rule evaluation error in scheduler

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -414,6 +414,7 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			err = results.Error()
 		}
 
+		logger.Debug("Alert rule evaluated", "error", err, "duration", dur)
 		span.SetStatus(codes.Error, "rule evaluation failed")
 		span.RecordError(err)
 	} else {


### PR DESCRIPTION
**What is this feature?**
Fixes rule evaluation routine to emit log message "Alert rule evaluated" in the case of a non-retryable error.

**Why do we need this feature?**
We do not log error results in that case.