### PR TITLE
Alerting docs: include `Grafana Alerting API` as one option to manage…

### DIFF
--- a/docs/sources/shared/alerts/alerting_provisioning.md
+++ b/docs/sources/shared/alerts/alerting_provisioning.md
@@ -390,6 +390,10 @@ The Alerting Provisioning HTTP API can only be used to manage Grafana-managed al
 - [cortex-tools](https://github.com/grafana/cortex-tools#cortextool): to interact with the Cortex alertmanager and ruler configuration.
 - [lokitool](https://grafana.com/docs/loki/<GRAFANA_VERSION>/alert/#lokitool): to configure the Loki Ruler.
 
+Alternatively, the [Grafana Alerting API](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/pkg/services/ngalert/api/tooling/post.json) can be used to access data from data source-managed alerts. This API is primarily intended for internal usage, with the exception of the `/api/v1/provisioning/` endpoints. It's important to note that internal APIs may undergo changes without prior notice and are not officially supported for user consumption.
+
+For Prometheus, `amtool` can also be used to interact with the [AlertManager API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/prometheus/alertmanager/main/api/v2/openapi.yaml#/).
+
 ## Paths
 
 ### <span id="route-delete-alert-rule"></span> Delete a specific alert rule by UID. (_RouteDeleteAlertRule_)


### PR DESCRIPTION
Include the `Grafana Alerting API` as one option to interact with [Data source-managed alerting resources](https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/http-api/alerting_provisioning/#data-source-managed-resources).

This is a follow-up PR of https://github.com/grafana/grafana/pull/91493. 

Both PRs aimed to document the distinct APIs and tools to manage Data source-managed resources.

The `Grafana Alerting API` is an internal API so this addition may not be desired. It needs a review from product/engineering. 

cc @JacobsonMT as previously discussed in Slack. 








