### PR TITLE
chore: preallocate slices where we have a good idea of requirements

### DIFF
--- a/pkg/services/ngalert/sender/notifier.go
+++ b/pkg/services/ngalert/sender/notifier.go
@@ -540,7 +540,7 @@ func postPath(pre string, v config.AlertmanagerAPIVersion) string {
 // AlertmanagerFromGroup extracts a list of alertmanagers from a target group
 // and an associated AlertmanagerConfig.
 func AlertmanagerFromGroup(tg *targetgroup.Group, cfg *config.AlertmanagerConfig) ([]alertmanager, []alertmanager, error) {
-	var res []alertmanager
+	res := make([]alertmanager, 0, len(tg.Targets))
 	var droppedAlertManagers []alertmanager
 
 	for _, tlset := range tg.Targets {

--- a/pkg/util/xorm/dialect_postgres.go
+++ b/pkg/util/xorm/dialect_postgres.go
@@ -1097,8 +1097,9 @@ func (db *postgres) GetTables() ([]*core.Table, error) {
 
 func getIndexColName(indexdef string) []string {
 	cs := strings.Split(indexdef, "(")
-	colNames := make([]string, 0, len(strings.Split(strings.Split(cs[1], ")")[0], ",")))
-	for _, v := range strings.Split(strings.Split(cs[1], ")")[0], ",") {
+	splitNames := strings.Split(strings.Split(cs[1], ")")[0], ",")
+	colNames := make([]string, 0, len(splitNames))
+	for _, v := range splitNames {
 		colNames = append(colNames, strings.Split(strings.TrimLeft(v, " "), " ")[0])
 	}
 

--- a/pkg/util/xorm/dialect_postgres.go
+++ b/pkg/util/xorm/dialect_postgres.go
@@ -1096,9 +1096,8 @@ func (db *postgres) GetTables() ([]*core.Table, error) {
 }
 
 func getIndexColName(indexdef string) []string {
-	var colNames []string
-
 	cs := strings.Split(indexdef, "(")
+	colNames := make([]string, 0, len(strings.Split(strings.Split(cs[1], ")")[0], ",")))
 	for _, v := range strings.Split(strings.Split(cs[1], ")")[0], ",") {
 		colNames = append(colNames, strings.Split(strings.TrimLeft(v, " "), " ")[0])
 	}

--- a/pkg/util/xorm/helpers.go
+++ b/pkg/util/xorm/helpers.go
@@ -191,7 +191,7 @@ func eraseAny(value string, strToErase ...string) string {
 	if len(strToErase) == 0 {
 		return value
 	}
-	var replaceSeq []string
+	replaceSeq := make([]string, 0, len(strToErase)*2)
 	for _, s := range strToErase {
 		replaceSeq = append(replaceSeq, s, "")
 	}

--- a/pkg/util/xorm/statement.go
+++ b/pkg/util/xorm/statement.go
@@ -866,7 +866,7 @@ func (statement *Statement) genUniqueSQL() []string {
 }
 
 func (statement *Statement) genDelIndexSQL() []string {
-	var sqls []string
+	sqls := make([]string, 0, len(statement.RefTable.Indexes))
 	tbName := statement.TableName()
 	idxPrefixName := strings.Replace(tbName, `"`, "", -1)
 	idxPrefixName = strings.Replace(idxPrefixName, `.`, "_", -1)


### PR DESCRIPTION
Cleanup based on running `prealloc` locally and selecting the slices where we know the size. 
