### PR TITLE
Alerting: Introduce useProduceNewAlertmanagerConfiguration

### DIFF
--- a/package.json
+++ b/package.json
@@ -382,6 +382,7 @@
     "react-window": "1.8.10",
     "react-window-infinite-loader": "1.0.9",
     "react-zoom-pan-pinch": "^3.3.0",
+    "reduce-reducers": "^1.0.4",
     "redux": "5.0.1",
     "redux-thunk": "3.1.0",
     "regenerator-runtime": "0.14.1",

--- a/public/app/features/alerting/unified/hooks/mergeRequestStates.ts
+++ b/public/app/features/alerting/unified/hooks/mergeRequestStates.ts
@@ -1,0 +1,19 @@
+interface RequestState {
+  error?: unknown;
+
+  isUninitialized: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  isLoading: boolean;
+}
+
+// @TODO what to do with the other props that we get from RTKQ's state such as originalArgs, etc?
+export function mergeRequestStates(...states: RequestState[]): RequestState {
+  return {
+    error: states.find((s) => s.error),
+    isUninitialized: states.every((s) => s.isUninitialized),
+    isSuccess: states.every((s) => s.isSuccess),
+    isError: states.some((s) => s.isError),
+    isLoading: states.some((s) => s.isLoading),
+  };
+}

--- a/public/app/features/alerting/unified/hooks/useProduceNewAlertmanagerConfig.ts
+++ b/public/app/features/alerting/unified/hooks/useProduceNewAlertmanagerConfig.ts
@@ -1,0 +1,64 @@
+import { Action } from '@reduxjs/toolkit';
+import reduceReducers from 'reduce-reducers';
+
+import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
+
+import { alertmanagerApi } from '../api/alertmanagerApi';
+import { useAlertmanager } from '../state/AlertmanagerContext';
+
+import { mergeRequestStates } from './mergeRequestStates';
+
+const ERR_NO_ACTIVE_AM = new Error('no active Alertmanager');
+
+const { useLazyGetAlertmanagerConfigurationQuery, useUpdateAlertmanagerConfigurationMutation } = alertmanagerApi;
+
+export const initialAlertmanagerConfiguration: AlertManagerCortexConfig = {
+  alertmanager_config: {
+    receivers: [],
+    route: {},
+    time_intervals: [],
+    mute_time_intervals: [],
+    inhibit_rules: [],
+    templates: [],
+  },
+  template_files: {},
+};
+
+const configurationReducer = reduceReducers(initialAlertmanagerConfiguration);
+
+/**
+ * This hook will make sure we are always applying actions that mutate the Alertmanager configuration
+ * on top of the latest Alertmanager configuration object.
+ */
+export function useProduceNewAlertmanagerConfiguration() {
+  const { selectedAlertmanager } = useAlertmanager();
+
+  const [fetchAlertmanagerConfig, fetchAlertmanagerState] = useLazyGetAlertmanagerConfigurationQuery();
+  const [updateAlertManager, updateAlertmanagerState] = useUpdateAlertmanagerConfigurationMutation();
+
+  const newConfigurationState = mergeRequestStates(fetchAlertmanagerState, updateAlertmanagerState);
+
+  if (!selectedAlertmanager) {
+    throw ERR_NO_ACTIVE_AM;
+  }
+
+  /**
+   * This function will fetch the latest Alertmanager configuration, apply a diff to it via a reducer and
+   * returns the result.
+   *
+   * ┌────────────────────────────┐  ┌───────────────┐  ┌───────────────────┐
+   * │ fetch latest configuration │─▶│ apply reducer │─▶│  new rule config  │
+   * └────────────────────────────┘  └───────────────┘  └───────────────────┘
+   */
+  const produceNewAlertmanagerConfiguration = async (action: Action) => {
+    const currentAlertmanagerConfiguration = await fetchAlertmanagerConfig(selectedAlertmanager).unwrap();
+    const newConfig = configurationReducer(currentAlertmanagerConfiguration, action);
+
+    return updateAlertManager({
+      selectedAlertmanager,
+      config: newConfig,
+    }).unwrap();
+  };
+
+  return [produceNewAlertmanagerConfiguration, newConfigurationState] as const;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17761,6 +17761,7 @@ __metadata:
     react-window: "npm:1.8.10"
     react-window-infinite-loader: "npm:1.0.9"
     react-zoom-pan-pinch: "npm:^3.3.0"
+    reduce-reducers: "npm:^1.0.4"
     redux: "npm:5.0.1"
     redux-mock-store: "npm:1.5.4"
     redux-thunk: "npm:3.1.0"
@@ -26511,6 +26512,13 @@ __metadata:
     indent-string: "npm:^4.0.0"
     strip-indent: "npm:^3.0.0"
   checksum: 10/fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
+  languageName: node
+  linkType: hard
+
+"reduce-reducers@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "reduce-reducers@npm:1.0.4"
+  checksum: 10/9b3648fa505a3ac7834cd8150ec98f9915e4020c8df0e9a4eddb5d3615814067943913f2582d0be4763ad6583209c0cf7ad3cc1021745b9b8e6ace768d49f6a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

The proposal of this PR is to add the following abstractions / hooks to interface or modify the Alertmanager configuration. Below is an example for "delete receiver (contact point)" and what that looks like.

```mermaid
flowchart TD

%% Nodes
    subgraph hooks
        useDeleteReceiver("useDeleteReceiver()")
        --> DeleteAction(["action = DeleteReceiverAction"])
        --> produce("produceNewConfig(action)")
    end
    
    subgraph produceNewAlertmanagerConfiguration
        fetchConfig("fetchAlertmanagerConfig()")
        -.- GET>"GET /config/api/v1/alerts"] 
        -.-> state(["latest configuration"])
    end
    
    subgraph reducer
        reduce("reduce(config, action)")
        -.-> newState(["new state"])
    end

    subgraph produceNewAlertmanagerConfiguration
        apply("updateAlertManager(state)")
        -.- POST>"POST /config/api/v1/alerts"] 
        -.-> invalidate(["invalidate cache"])
    end

    hooks --> fetchConfig
    state --> reduce
    newState --> apply
```

Prior to the changes in the PR it would reject one user with "another user has modified the AM config, reload" but with this PR the edits will both be applied provided they aren't one of the following scenarios.

1. they do not conflict on the same entity – ie. user 1 edits receiver :a: and user 2 edits receiver :a: then the last write wins
2. edits are not sent while another edit is in progress – ie. user 1 adds contact point :a: and user 2 adds contact point :b: while the first user's update is still in-flight then the last write wins

There's no good solution to those scenarios from the front-end but these scenarios will hopefully be quite rare.
The next steps are to

**Special notes for your reviewer:**

This PR includes isolated components from https://github.com/grafana/grafana/pull/88456 and https://github.com/grafana/grafana/pull/91404 so it makes reviewing easier.

I plan to rebase those PRs to use the update patterns included in this PR.