### PR TITLE
Fix: add feature check in folderimpl

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -568,7 +568,8 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		dashFolder.FolderUID = cmd.ParentUID
 	}
 
-	if cmd.ParentUID == "" {
+	// we introduced folders:create to allow creating folders under the root level and subfolders
+	if s.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) && cmd.ParentUID == "" {
 		evaluator := accesscontrol.EvalPermission(dashboards.ActionFoldersCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
 		hasAccess, evalErr := s.accessControl.Evaluate(ctx, cmd.SignedInUser, evaluator)
 		if evalErr != nil {


### PR DESCRIPTION
# why

we introduced Allow folder editors and admins to create subfolders without any additional permissions
#91215

## what
We missed to add the feature toggle check for folderimpl when checking for rbac for plugins

- rbac integrations relaying on `folders:create` might have been affected

