### PR TITLE
Alerting: Swap useAsync return signature params

### DIFF
--- a/public/app/features/alerting/unified/components/MenuItemPauseRule.tsx
+++ b/public/app/features/alerting/unified/components/MenuItemPauseRule.tsx
@@ -25,7 +25,7 @@ interface Props {
  */
 const MenuItemPauseRule = ({ rule, onPauseChange }: Props) => {
   const notifyApp = useAppNotification();
-  const [updateState, pauseRule] = usePauseRuleInGroup();
+  const [pauseRule, updateState] = usePauseRuleInGroup();
 
   const isPaused = isGrafanaRulerRule(rule.rulerRule) && isGrafanaRulerRulePaused(rule.rulerRule);
   const icon = isPaused ? 'play' : 'pause';

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -66,7 +66,7 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
   const [queryParams] = useQueryParams();
   const [showEditYaml, setShowEditYaml] = useState(false);
   const [evaluateEvery, setEvaluateEvery] = useState(existing?.group.interval ?? DEFAULT_GROUP_EVALUATION_INTERVAL);
-  const [_deleteRuleState, deleteRuleFromGroup] = useDeleteRuleFromGroup();
+  const [deleteRuleFromGroup] = useDeleteRuleFromGroup();
 
   const routeParams = useParams<{ type: string; id: string }>();
   const ruleType = translateRouteParamToRuleType(routeParams.type);

--- a/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
@@ -13,7 +13,7 @@ type DeleteModalHook = [JSX.Element, (rule: CombinedRule) => void, () => void];
 
 export const useDeleteModal = (redirectToListView = false): DeleteModalHook => {
   const [ruleToDelete, setRuleToDelete] = useState<CombinedRule | undefined>();
-  const [_deleteState, deleteRuleFromGroup] = useDeleteRuleFromGroup();
+  const [deleteRuleFromGroup] = useDeleteRuleFromGroup();
 
   const dismissModal = useCallback(() => {
     setRuleToDelete(undefined);

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -192,9 +192,9 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
    *  2. rename the rule group, but keeping it in the same namespace
    *  3. move the rule group to a new namespace, optionally with a different group name
    */
-  const [updateRuleGroupState, updateRuleGroup] = useUpdateRuleGroupConfiguration();
-  const [renameRuleGroupState, renameRuleGroup] = useRenameRuleGroup();
-  const [moveRuleGroupState, moveRuleGroup] = useMoveRuleGroup();
+  const [updateRuleGroup, updateRuleGroupState] = useUpdateRuleGroupConfiguration();
+  const [renameRuleGroup, renameRuleGroupState] = useRenameRuleGroup();
+  const [moveRuleGroup, moveRuleGroupState] = useMoveRuleGroup();
 
   const { loading, error } = anyOfRequestState(updateRuleGroupState, moveRuleGroupState, renameRuleGroupState);
 

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.test.tsx
@@ -132,7 +132,7 @@ type DeleteTestComponentProps = {
   rule: CombinedRule;
 };
 const DeleteTestComponent = ({ rule }: DeleteTestComponentProps) => {
-  const [requestState, deleteRuleFromGroup] = useDeleteRuleFromGroup();
+  const [deleteRuleFromGroup, requestState] = useDeleteRuleFromGroup();
 
   // always handle your errors!
   const ruleGroupID = getRuleGroupLocationFromCombinedRule(rule);

--- a/public/app/features/alerting/unified/hooks/ruleGroup/usePauseAlertRule.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/usePauseAlertRule.test.tsx
@@ -76,7 +76,7 @@ describe('pause rule', () => {
 
 // this test component will cycle through the loading states
 const PauseTestComponent = (options: { rulerRule?: RulerGrafanaRuleDTO }) => {
-  const [requestState, pauseRule] = usePauseRuleInGroup();
+  const [pauseRule, requestState] = usePauseRuleInGroup();
 
   const rulerRule = options.rulerRule ?? grafanaRulerRule;
   const rule = mockCombinedRule({

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleGroup.test.tsx
@@ -85,7 +85,7 @@ describe('useUpdateRuleGroupConfiguration', () => {
 });
 
 const UpdateRuleGroupComponent = () => {
-  const [requestState, updateRuleGroup] = useUpdateRuleGroupConfiguration();
+  const [updateRuleGroup, requestState] = useUpdateRuleGroupConfiguration();
 
   const ruleGroupID: RuleGroupIdentifier = {
     dataSourceName: GRAFANA_RULES_SOURCE_NAME,
@@ -102,7 +102,7 @@ const UpdateRuleGroupComponent = () => {
 };
 
 const RenameRuleGroupComponent = ({ group = 'another-group-name' }: { group?: string }) => {
-  const [requestState, renameRuleGroup] = useRenameRuleGroup();
+  const [renameRuleGroup, requestState] = useRenameRuleGroup();
 
   const ruleGroupID: RuleGroupIdentifier = {
     dataSourceName: GRAFANA_RULES_SOURCE_NAME,
@@ -119,7 +119,7 @@ const RenameRuleGroupComponent = ({ group = 'another-group-name' }: { group?: st
 };
 
 const MoveGrafanaManagedRuleGroupComponent = () => {
-  const [requestState, moveRuleGroup] = useMoveRuleGroup();
+  const [moveRuleGroup, requestState] = useMoveRuleGroup();
 
   const ruleGroupID: RuleGroupIdentifier = {
     dataSourceName: GRAFANA_RULES_SOURCE_NAME,
@@ -146,7 +146,7 @@ const MoveDataSourceManagedRuleGroupComponent = ({
   group,
   interval,
 }: MoveDataSourceManagedRuleGroupComponentProps) => {
-  const [requestState, moveRuleGroup] = useMoveRuleGroup();
+  const [moveRuleGroup, requestState] = useMoveRuleGroup();
 
   const ruleGroupID: RuleGroupIdentifier = {
     dataSourceName: MIMIR_DATASOURCE_UID,

--- a/public/app/features/alerting/unified/hooks/useAsync.tsx
+++ b/public/app/features/alerting/unified/hooks/useAsync.tsx
@@ -54,11 +54,11 @@ export type UseAsyncMeta<Result, Args extends unknown[] = unknown[]> = {
 export function useAsync<Result, Args extends unknown[] = unknown[]>(
   asyncFn: (...params: Args) => Promise<Result>,
   initialValue: Result
-): [AsyncState<Result>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>];
+): [UseAsyncActions<Result, Args>, AsyncState<Result>, UseAsyncMeta<Result, Args>];
 export function useAsync<Result, Args extends unknown[] = unknown[]>(
   asyncFn: (...params: Args) => Promise<Result>,
   initialValue?: Result
-): [AsyncState<Result | undefined>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>];
+): [UseAsyncActions<Result, Args>, AsyncState<Result | undefined>, UseAsyncMeta<Result, Args>];
 
 /**
  * Tracks the result and errors of the provided async function and provides handles to control its execution.
@@ -70,7 +70,7 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
 export function useAsync<Result, Args extends unknown[] = unknown[]>(
   asyncFn: (...params: Args) => Promise<Result>,
   initialValue?: Result
-): [AsyncState<Result | undefined>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>] {
+): [UseAsyncActions<Result, Args>, AsyncState<Result | undefined>, UseAsyncMeta<Result, Args>] {
   const [state, setState] = useState<AsyncState<Result | undefined>>({
     status: 'not-executed',
     error: undefined,
@@ -119,7 +119,6 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
   });
 
   return [
-    state,
     useMemo(
       () => ({
         reset() {
@@ -130,6 +129,7 @@ export function useAsync<Result, Args extends unknown[] = unknown[]>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
       []
     ),
+    state,
     { promise: promiseRef.current, lastArgs: argsRef.current },
   ];
 }


### PR DESCRIPTION
This PR swaps the return signature of `useAsync` to more closely resemble the return signature of `RTKQ`.


**Before**
```tsx
const [requestState, makeRequest] = useCreateMuteTiming(); 
```

**After**
```tsx
const [makeRequest, requestState] = useCreateMuteTiming(); 
```