### PR TITLE
E2C: Post success toast when migration finishes

### DIFF
--- a/public/app/features/migrate-to-cloud/onprem/Page.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/Page.tsx
@@ -24,6 +24,7 @@ import { MigrationSummary } from './MigrationSummary';
 import { ResourcesTable } from './ResourcesTable';
 import { BuildSnapshotCTA, CreatingSnapshotCTA } from './SnapshotCTAs';
 import { SupportedTypesDisclosure } from './SupportedTypesDisclosure';
+import { useNotifySuccessful } from './useNotifyOnSuccess';
 
 /**
  * Here's how migrations work:
@@ -118,6 +119,8 @@ export const Page = () => {
   const [performUploadSnapshot, uploadSnapshotResult] = useUploadSnapshotMutation();
   const [performCancelSnapshot, cancelSnapshotResult] = useCancelSnapshotMutation();
   const [performDisconnect, disconnectResult] = useDeleteSessionMutation();
+
+  useNotifySuccessful(snapshot.data);
 
   const sessionUid = session.data?.uid;
   const snapshotUid = snapshot.data?.uid;

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -1,0 +1,60 @@
+import { t } from 'i18next';
+import { useRef, useEffect } from 'react';
+
+import { useAppNotification } from 'app/core/copy/appNotification';
+
+import { GetSnapshotResponseDto, SnapshotDto } from '../api';
+
+export function useNotifySuccessful(snapshot: GetSnapshotResponseDto | undefined) {
+  const previousStatusRef = useRef<SnapshotDto['status']>(undefined);
+  const notifyApp = useAppNotification();
+
+  useEffect(() => {
+    const status = snapshot?.status;
+    const didJustFinish =
+      previousStatusRef.current !== 'FINISHED' && previousStatusRef.current !== undefined && status === 'FINISHED';
+
+    previousStatusRef.current = status; // must be AFTER the check above
+
+    if (!didJustFinish) {
+      return;
+    }
+
+    if (snapshot) {
+      const title = t('migrate-to-cloud.onprem.success-title', 'Migration completed!');
+      const message = getTranslatedMessage(snapshot);
+
+      notifyApp.success(title, message);
+    }
+  }, [notifyApp, snapshot]);
+}
+
+function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
+  const types: string[] = [];
+
+  for (const [type, count] of Object.entries(snapshot.stats?.types ?? {})) {
+    if (count <= 0) {
+      continue;
+    }
+
+    // We don't have per-resource status counts, so there's no way to accurately pluralize these
+    // so we just don't :)
+    if (type === 'DASHBOARD') {
+      types.push(t('migrate-to-cloud.migrated-counts.dashboards', 'dashboards'));
+    } else if (type === 'DATASOURCE') {
+      types.push(t('migrate-to-cloud.migrated-counts.datasources', 'data sources'));
+    } else if (type === 'FOLDER') {
+      types.push(t('migrate-to-cloud.migrated-counts.folders', 'folders'));
+    }
+  }
+
+  const successCount = snapshot?.stats?.statuses?.['OK'] ?? 0;
+
+  const message = t(
+    'migrate-to-cloud.onprem.success-message',
+    'Successfully migrated {{successCount}} {{types, list}} to your Grafana Cloud instance.',
+    { successCount, types }
+  );
+
+  return message;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1089,6 +1089,11 @@
       "link-title": "View the full migration guide",
       "title": "Let us help you migrate to this stack"
     },
+    "migrated-counts": {
+      "dashboards": "dashboards",
+      "datasources": "data sources",
+      "folders": "folders"
+    },
     "migration-token": {
       "delete-button": "Delete token",
       "delete-modal-body": "If you've already used this token with a self-managed installation, that installation will no longer be able to upload content.",
@@ -1120,6 +1125,8 @@
       "migration-finished-with-warnings-body": "The migration has completed with some warnings. Check individual resources for more details",
       "snapshot-error-status-body": "There was an error creating the snapshot or starting the migration process. See the Grafana server logs for more details",
       "snapshot-error-status-title": "Error migrating resources",
+      "success-message": "Successfully migrated {{successCount}} {{types, list}} to your Grafana Cloud instance.",
+      "success-title": "Migration completed!",
       "upload-snapshot-error-title": "Error uploading snapshot"
     },
     "pdc": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1089,6 +1089,11 @@
       "link-title": "Vįęŵ ŧĥę ƒūľľ mįģřäŧįőŉ ģūįđę",
       "title": "Ŀęŧ ūş ĥęľp yőū mįģřäŧę ŧő ŧĥįş şŧäčĸ"
     },
+    "migrated-counts": {
+      "dashboards": "đäşĥþőäřđş",
+      "datasources": "đäŧä şőūřčęş",
+      "folders": "ƒőľđęřş"
+    },
     "migration-token": {
       "delete-button": "Đęľęŧę ŧőĸęŉ",
       "delete-modal-body": "Ĩƒ yőū'vę äľřęäđy ūşęđ ŧĥįş ŧőĸęŉ ŵįŧĥ ä şęľƒ-mäŉäģęđ įŉşŧäľľäŧįőŉ, ŧĥäŧ įŉşŧäľľäŧįőŉ ŵįľľ ŉő ľőŉģęř þę äþľę ŧő ūpľőäđ čőŉŧęŉŧ.",
@@ -1120,6 +1125,8 @@
       "migration-finished-with-warnings-body": "Ŧĥę mįģřäŧįőŉ ĥäş čőmpľęŧęđ ŵįŧĥ şőmę ŵäřŉįŉģş. Cĥęčĸ įŉđįvįđūäľ řęşőūřčęş ƒőř mőřę đęŧäįľş",
       "snapshot-error-status-body": "Ŧĥęřę ŵäş äŉ ęřřőř čřęäŧįŉģ ŧĥę şŉäpşĥőŧ őř şŧäřŧįŉģ ŧĥę mįģřäŧįőŉ přőčęşş. Ŝęę ŧĥę Ğřäƒäŉä şęřvęř ľőģş ƒőř mőřę đęŧäįľş",
       "snapshot-error-status-title": "Ēřřőř mįģřäŧįŉģ řęşőūřčęş",
+      "success-message": "Ŝūččęşşƒūľľy mįģřäŧęđ {{successCount}} {{types, list}} ŧő yőūř Ğřäƒäŉä Cľőūđ įŉşŧäŉčę.",
+      "success-title": "Mįģřäŧįőŉ čőmpľęŧęđ!",
       "upload-snapshot-error-title": "Ēřřőř ūpľőäđįŉģ şŉäpşĥőŧ"
     },
     "pdc": {


### PR DESCRIPTION
**What is this feature?**

Displays a success notification when a migration finishes. It only gets displayed the the status transitions to FINISHED while the user has the page open, and not if they load an already finished migration.

![7993_2024-08-07-16-31_firefox](https://github.com/user-attachments/assets/07e3a082-8480-4b4a-a042-13100207f57e)

**Why do we need this feature?**

A finished migration is something worth celebrating

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/912 