### PR TITLE
Add test-go-unit-pretty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,14 @@ test-go-unit: ## Run unit tests for backend with flags.
 	go list -f '{{.Dir}}/...' -m | xargs \
 	$(GO) test $(GO_RACE_FLAG) -short -covermode=atomic -timeout=30m
 
+.PHONY: test-go-unit-pretty
+test-go-unit-pretty: check-tparse
+	@if [ -z "$(FILES)" ]; then \
+		echo "Notice: FILES variable is not set. Try \"make test-go-unit-pretty FILES=./pkg/services/mysvc\""; \
+		exit 1; \
+	fi
+	$(GO) test $(GO_RACE_FLAG) -timeout=10s $(FILES) -json | tparse -all
+
 .PHONY: test-go-integration
 test-go-integration: ## Run integration tests for backend with flags.
 	@echo "test backend integration tests"
@@ -431,6 +439,12 @@ go-race-is-enabled:
 .PHONY: enable-go-race
 enable-go-race:
 	@touch .go-race-enabled-locally
+
+check-tparse:
+	@command -v tparse >/dev/null 2>&1 || { \
+		echo >&2 "Error: tparse is not installed. Refer to https://github.com/mfridman/tparse"; \
+		exit 1; \
+	}
 
 .PHONY: help
 help: ## Display this help.


### PR DESCRIPTION
This adds a make task for running go unit tests through [tparse](https://github.com/mfridman/tparse). Additionally, it's a more convenient way of executing tests using a custom set of packages, rather than having to execute the entire test suite to test a single change.

## Example

```
➜  grafana git:(makefile-test-go-unit-pretty) make test-go-unit-pretty FILES=./pkg/extensions/accesscontrol
...
go test  -timeout=10s ./pkg/extensions/accesscontrol -json | tparse -all
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                                        TEST                                        │                         PACKAGE                          │
│─────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────│
│  PASS   │    0.11 │ TestResourcePermissions                                                            │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.11 │ TestResourcePermissions/should_not_allow_to_create_data_source_with_UID_*          │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.01 │ TestResourcePermissions/should_allow_to_create_data_source_with_valid_UID          │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestTranslateDeprecatedRoleName                                                    │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestTranslateDeprecatedRoleName/expect_deprecated_name_to_be_translated_to_new_one │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestTranslateDeprecatedRoleName/expect_name_to_not_be_translated                   │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestRoleMarshalRoleDtoRoundTrip                                                    │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestRoleMarshalRoleDtoCompare                                                      │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestRoleMarshalRoleRoundTrip                                                       │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestRoleMarshalRoleCompare                                                         │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
│  PASS   │    0.00 │ TestRoleMarshalRoleGlobalOff                                                       │ github.com/grafana/grafana/pkg/extensions/accesscontrol  │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                         PACKAGE                         │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼─────────────────────────────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  0.87s  │ github.com/grafana/grafana/pkg/extensions/accesscontrol │  --   │  11  │  0   │  0    │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```