### PR TITLE
Canvas: Viz time range sync and bug fix

### DIFF
--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -3,7 +3,14 @@ import { useCallback, useMemo } from 'react';
 
 import { Field, GrafanaTheme2, SelectableValue, StandardEditorProps } from '@grafana/data';
 import { DataFrame } from '@grafana/data/';
-import { EmbeddedScene, PanelBuilders, SceneDataNode, SceneFlexItem, SceneFlexLayout } from '@grafana/scenes';
+import {
+  EmbeddedScene,
+  PanelBuilders,
+  SceneDataNode,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneTimeRange,
+} from '@grafana/scenes';
 import { TextDimensionMode } from '@grafana/schema/dist/esm/index';
 import { MultiSelect, stylesFactory, usePanelContext } from '@grafana/ui';
 import { frameHasName, useFieldDisplayNames, useSelectOptions } from '@grafana/ui/src/components/MatchersUI/utils';
@@ -19,6 +26,8 @@ const panelTypes: Array<SelectableValue<string>> = Object.keys(PanelBuilders).ma
 });
 
 const defaultPanelTitle = 'New Visualization';
+
+export const CANVAS_EMBEDDED_SCENE_KEY = 'canvas-embedded-scene';
 
 const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizElementData>) => {
   const context = usePanelContext();
@@ -43,7 +52,14 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
       panelToEmbed.setColor({ mode: 'palette-classic' });
       const panel = panelToEmbed.build();
 
+      // const timeRange = new SceneTimeRange({
+      //   from: context.timeRange.from,
+      //   to: context.timeRange.to,
+      // });
+
       return new EmbeddedScene({
+        key: CANVAS_EMBEDDED_SCENE_KEY,
+        // $timeRange: context.timeRange,
         body: new SceneFlexLayout({
           children: [
             new SceneFlexItem({

--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -52,14 +52,15 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
       panelToEmbed.setColor({ mode: 'palette-classic' });
       const panel = panelToEmbed.build();
 
-      // const timeRange = new SceneTimeRange({
-      //   from: context.timeRange.from,
-      //   to: context.timeRange.to,
-      // });
+      const timeRange = data?.data?.timeRange;
+      const sceneTimeRange = new SceneTimeRange({
+        from: timeRange?.raw.from.toString(),
+        to: timeRange?.raw.to.toString(),
+      });
 
       return new EmbeddedScene({
+        $timeRange: sceneTimeRange,
         key: CANVAS_EMBEDDED_SCENE_KEY,
-        // $timeRange: context.timeRange,
         body: new SceneFlexLayout({
           children: [
             new SceneFlexItem({

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -20,6 +20,7 @@ import appEvents from 'app/core/app_events';
 import { config } from 'app/core/config';
 import { AutoRefreshInterval, contextSrv, ContextSrv } from 'app/core/services/context_srv';
 import { getCopiedTimeRange, getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePicker';
+import { CANVAS_EMBEDDED_SCENE_KEY } from 'app/features/canvas/elements/visualization';
 import { getTimeRange } from 'app/features/dashboard/utils/timeRange';
 
 import {
@@ -344,7 +345,13 @@ export class TimeSrv {
   timeRange(): TimeRange {
     // Scenes can set this global object to the current time range.
     // This is a patch to support data sources that rely on TimeSrv.getTimeRange()
-    if (window.__grafanaSceneContext && window.__grafanaSceneContext.isActive) {
+    console.log('window.__grafanaSceneContext', window.__grafanaSceneContext);
+
+    if (
+      window.__grafanaSceneContext &&
+      window.__grafanaSceneContext.isActive &&
+      window.__grafanaSceneContext.key !== CANVAS_EMBEDDED_SCENE_KEY
+    ) {
       return sceneGraph.getTimeRange(window.__grafanaSceneContext).state.value;
     }
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -345,12 +345,11 @@ export class TimeSrv {
   timeRange(): TimeRange {
     // Scenes can set this global object to the current time range.
     // This is a patch to support data sources that rely on TimeSrv.getTimeRange()
-    console.log('window.__grafanaSceneContext', window.__grafanaSceneContext);
-
     if (
       window.__grafanaSceneContext &&
       window.__grafanaSceneContext.isActive &&
-      window.__grafanaSceneContext.key !== CANVAS_EMBEDDED_SCENE_KEY
+      // Canvas is using EmbdeddedScene but we don't want to modify dashboard core's time range
+      window.__grafanaSceneContext.state.key !== CANVAS_EMBEDDED_SCENE_KEY
     ) {
       return sceneGraph.getTimeRange(window.__grafanaSceneContext).state.value;
     }


### PR DESCRIPTION

- Fixed the bug where the time range picker was frozen and always set to 6h. 
- Synchronized time ranges with the canvas viz

The culprit is this logic here 
https://github.com/grafana/grafana/blob/5917e1c6d66cabed7f780b279b6a1a434590e325/public/app/features/dashboard/services/TimeSrv.ts#L347-L349

Since we are using `EmbeddedScene` for the visualization element in canvas and we don't pass a value to the `$timerange` field, time range will default to `6h` and then the above logic will use that scene object's time range to set the time range. 

When using dashboard scenes, this is not the issue because we can just rely on dashboard scene object. 

To support this in the dashboard core, I think the best solution is to rely on sceneObject's state.key, which we can then use to ignore the time range from the EmbeddedScene. 

Fixes: #91592 
Fixes: #91436 

Demo:

https://github.com/user-attachments/assets/33c4ad7d-c627-4eca-820b-508f314e93c8


