### PR TITLE
Alerting: use ErrResp when binding to model fails in autogenerated routes

### DIFF
--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -52,7 +52,7 @@ func (f *AlertmanagerApiHandler) RouteCreateGrafanaSilence(ctx *contextmodel.Req
 	// Parse Request Body
 	conf := apimodels.PostableSilence{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRouteCreateGrafanaSilence(ctx, conf)
 }
@@ -62,7 +62,7 @@ func (f *AlertmanagerApiHandler) RouteCreateSilence(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.PostableSilence{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRouteCreateSilence(ctx, conf, datasourceUIDParam)
 }
@@ -148,7 +148,7 @@ func (f *AlertmanagerApiHandler) RoutePostAMAlerts(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.PostableAlerts{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostAMAlerts(ctx, conf, datasourceUIDParam)
 }
@@ -158,7 +158,7 @@ func (f *AlertmanagerApiHandler) RoutePostAlertingConfig(ctx *contextmodel.ReqCo
 	// Parse Request Body
 	conf := apimodels.PostableUserConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostAlertingConfig(ctx, conf, datasourceUIDParam)
 }
@@ -166,7 +166,7 @@ func (f *AlertmanagerApiHandler) RoutePostGrafanaAlertingConfig(ctx *contextmode
 	// Parse Request Body
 	conf := apimodels.PostableUserConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostGrafanaAlertingConfig(ctx, conf)
 }
@@ -179,7 +179,7 @@ func (f *AlertmanagerApiHandler) RoutePostTestGrafanaReceivers(ctx *contextmodel
 	// Parse Request Body
 	conf := apimodels.TestReceiversConfigBodyParams{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostTestGrafanaReceivers(ctx, conf)
 }
@@ -187,7 +187,7 @@ func (f *AlertmanagerApiHandler) RoutePostTestGrafanaTemplates(ctx *contextmodel
 	// Parse Request Body
 	conf := apimodels.TestTemplatesConfigBodyParams{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostTestGrafanaTemplates(ctx, conf)
 }

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -43,7 +43,7 @@ func (f *ConfigurationApiHandler) RoutePostNGalertConfig(ctx *contextmodel.ReqCo
 	// Parse Request Body
 	conf := apimodels.PostableNGalertConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostNGalertConfig(ctx, conf)
 }

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -147,7 +147,7 @@ func (f *ProvisioningApiHandler) RoutePostAlertRule(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.ProvisionedAlertRule{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostAlertRule(ctx, conf)
 }
@@ -155,7 +155,7 @@ func (f *ProvisioningApiHandler) RoutePostContactpoints(ctx *contextmodel.ReqCon
 	// Parse Request Body
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostContactpoints(ctx, conf)
 }
@@ -163,7 +163,7 @@ func (f *ProvisioningApiHandler) RoutePostMuteTiming(ctx *contextmodel.ReqContex
 	// Parse Request Body
 	conf := apimodels.MuteTimeInterval{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostMuteTiming(ctx, conf)
 }
@@ -173,7 +173,7 @@ func (f *ProvisioningApiHandler) RoutePutAlertRule(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.ProvisionedAlertRule{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePutAlertRule(ctx, conf, uIDParam)
 }
@@ -184,7 +184,7 @@ func (f *ProvisioningApiHandler) RoutePutAlertRuleGroup(ctx *contextmodel.ReqCon
 	// Parse Request Body
 	conf := apimodels.AlertRuleGroup{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePutAlertRuleGroup(ctx, conf, folderUIDParam, groupParam)
 }
@@ -194,7 +194,7 @@ func (f *ProvisioningApiHandler) RoutePutContactpoint(ctx *contextmodel.ReqConte
 	// Parse Request Body
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePutContactpoint(ctx, conf, uIDParam)
 }
@@ -204,7 +204,7 @@ func (f *ProvisioningApiHandler) RoutePutMuteTiming(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.MuteTimeInterval{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePutMuteTiming(ctx, conf, nameParam)
 }
@@ -212,7 +212,7 @@ func (f *ProvisioningApiHandler) RoutePutPolicyTree(ctx *contextmodel.ReqContext
 	// Parse Request Body
 	conf := apimodels.Route{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePutPolicyTree(ctx, conf)
 }
@@ -222,7 +222,7 @@ func (f *ProvisioningApiHandler) RoutePutTemplate(ctx *contextmodel.ReqContext) 
 	// Parse Request Body
 	conf := apimodels.NotificationTemplateContent{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePutTemplate(ctx, conf, nameParam)
 }

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -107,7 +107,7 @@ func (f *RulerApiHandler) RoutePostNameGrafanaRulesConfig(ctx *contextmodel.ReqC
 	// Parse Request Body
 	conf := apimodels.PostableRuleGroupConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostNameGrafanaRulesConfig(ctx, conf, namespaceParam)
 }
@@ -118,7 +118,7 @@ func (f *RulerApiHandler) RoutePostNameRulesConfig(ctx *contextmodel.ReqContext)
 	// Parse Request Body
 	conf := apimodels.PostableRuleGroupConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostNameRulesConfig(ctx, conf, datasourceUIDParam, namespaceParam)
 }
@@ -128,7 +128,7 @@ func (f *RulerApiHandler) RoutePostRulesGroupForExport(ctx *contextmodel.ReqCont
 	// Parse Request Body
 	conf := apimodels.PostableRuleGroupConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRoutePostRulesGroupForExport(ctx, conf, namespaceParam)
 }

--- a/pkg/services/ngalert/api/generated_base_api_testing.go
+++ b/pkg/services/ngalert/api/generated_base_api_testing.go
@@ -30,7 +30,7 @@ func (f *TestingApiHandler) BacktestConfig(ctx *contextmodel.ReqContext) respons
 	// Parse Request Body
 	conf := apimodels.BacktestConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleBacktestConfig(ctx, conf)
 }
@@ -38,7 +38,7 @@ func (f *TestingApiHandler) RouteEvalQueries(ctx *contextmodel.ReqContext) respo
 	// Parse Request Body
 	conf := apimodels.EvalQueriesPayload{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRouteEvalQueries(ctx, conf)
 }
@@ -48,7 +48,7 @@ func (f *TestingApiHandler) RouteTestRuleConfig(ctx *contextmodel.ReqContext) re
 	// Parse Request Body
 	conf := apimodels.TestRulePayload{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRouteTestRuleConfig(ctx, conf, datasourceUIDParam)
 }
@@ -56,7 +56,7 @@ func (f *TestingApiHandler) RouteTestRuleGrafanaConfig(ctx *contextmodel.ReqCont
 	// Parse Request Body
 	conf := apimodels.PostableExtendedRuleNodeExtended{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	return f.handleRouteTestRuleGrafanaConfig(ctx, conf)
 }

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -27,7 +27,7 @@ func (f *{{classname}}Handler) {{nickname}}(ctx *contextmodel.ReqContext) respon
 	// Parse Request Body
 	conf := apimodels.{{dataType}}{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
+		return ErrResp(http.StatusBadRequest, err, "bad request data")
 	}
 	{{/bodyParams}}return f.handle{{nickname}}(ctx{{#bodyParams}}, conf{{/bodyParams}}{{#pathParams}}, {{paramName}}Param{{/pathParams}})
 }


### PR DESCRIPTION
**What is this feature?**
This PR proposes a change in API template to use the utility function `ErrResp` instead `response.Error`. The utility function appends the underlying error message to the response message, which makes clear all binding errors.
I think this is ok because we use this approach throughout the API handlers.

**Why do we need this feature?**
To return more information to user when the submitted model is not correct

**Who is this feature for?**
Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/89117

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
