### PR TITLE
Canvas: Fix selection box glitch when adding certain elements

### DIFF
--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -33,6 +33,37 @@ const enableCustomables = (moveable: Moveable) => {
   };
 };
 
+/* 
+  Helper function that determines if the selected target is currently selected
+
+  For context canvas elements each have a different level of nesting.
+  Given this, we need to traverse up the DOM tree from the selected target to find
+  the element's selecto div to determine if the selected target is already selected in selecto state.
+*/
+const isTargetAlreadySelected = (selectedTarget: HTMLElement, scene: Scene) => {
+  let selectedTargetParent = selectedTarget.parentElement;
+  let isTargetAlreadySelected = false;
+
+  // Traverse up the DOM tree to check if the selected target is already selected
+  while (selectedTargetParent) {
+    // If the selected target is the scene's root element div, break the loop
+    if (selectedTargetParent === scene.root.div) {
+      break;
+    }
+
+    // Check if the selected target is already selected
+    isTargetAlreadySelected = scene.selecto?.getSelectedTargets().includes(selectedTargetParent) ?? false;
+    if (isTargetAlreadySelected) {
+      break;
+    }
+
+    // Move up the DOM tree to the next parent element to check
+    selectedTargetParent = selectedTargetParent.parentElement;
+  }
+
+  return isTargetAlreadySelected;
+};
+
 // Generate HTML element divs for every canvas element to configure selecto / moveable
 const generateTargetElements = (rootElements: ElementState[]): HTMLDivElement[] => {
   let targetElements: HTMLDivElement[] = [];
@@ -335,9 +366,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
         scene.moveable!.isMoveableElement(selectedTarget) ||
         targets.some((target) => target === selectedTarget || target.contains(selectedTarget));
 
-      const isTargetAlreadySelected = scene.selecto
-        ?.getSelectedTargets()
-        .includes(selectedTarget.parentElement.parentElement);
+      const isElementSelected = isTargetAlreadySelected(selectedTarget, scene);
 
       // Apply grabbing cursor while dragging, applyLayoutStylesToDiv() resets it to grab when done
       if (
@@ -349,7 +378,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
         scene.selecto.getSelectedTargets()[0].style.cursor = 'grabbing';
       }
 
-      if (isTargetMoveableElement || isTargetAlreadySelected || !scene.isEditingEnabled) {
+      if (isTargetMoveableElement || isElementSelected || !scene.isEditingEnabled) {
         // Prevent drawing selection box when selected target is a moveable element or already selected
         event.stop();
       }

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -34,11 +34,12 @@ const enableCustomables = (moveable: Moveable) => {
 };
 
 /* 
-  Helper function that determines if the selected target is currently selected
+  Helper function that determines if the selected DOM target is currently selected in selecto state.
 
   For context canvas elements each have a different level of nesting.
   Given this, we need to traverse up the DOM tree from the selected target to find
-  the element's selecto div to determine if the selected target is already selected in selecto state.
+  the element's registered selecto div to determine if the selected target is already selected in selecto state.
+  See `initMoveable` and `generateTargetElements` for more context.
 */
 const isTargetAlreadySelected = (selectedTarget: HTMLElement, scene: Scene) => {
   let selectedTargetParent = selectedTarget.parentElement;


### PR DESCRIPTION
Fixes issue where selecto selection box would be drawn when moving certain newly added elements to the canvas. This issue was impacting: 
- `Ellipse`
- `Server`
- `Triangle`
- `Cloud`
- `Parallelogram`
- `Button`
- `Wind turbine`
- `All drone elements`

Before

https://github.com/user-attachments/assets/95f5fd71-8178-4b17-accb-9dcafd882475


After

https://github.com/user-attachments/assets/718f99ff-f298-40b3-bfaa-8bc10e8b408a



The way we were calculating whether or not a element was already selected was contingent on having a consistent DOM structure which is no longer the case.

Fixes https://github.com/grafana/grafana/issues/91558