### PR TITLE
Vizards: Add background color opacity slider

### DIFF
--- a/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/canvas/panelcfg/x/CanvasPanelCfg_types.gen.ts
@@ -54,6 +54,7 @@ export enum BackgroundImageSize {
 export interface BackgroundConfig {
   color?: ui.ColorDimensionConfig;
   image?: ui.ResourceDimensionConfig;
+  opacity?: number;
   size?: BackgroundImageSize;
 }
 

--- a/public/app/features/canvas/elements/cloud.tsx
+++ b/public/app/features/canvas/elements/cloud.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import tinycolor from 'tinycolor2';
 import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2, OneClickMode } from '@grafana/data';
@@ -120,7 +121,16 @@ export const cloudItem: CanvasElementItem = {
     }
 
     const { background, border } = elementOptions;
-    data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    // TODO consolidate these calcs at the element level
+    if (background?.color?.field) {
+      const color = dimensionContext.getColor(background.color);
+      const alphaAdjustedColor = tinycolor(color.value())
+        .setAlpha(background.opacity ?? 1)
+        .toString();
+      data.backgroundColor = background?.color ? alphaAdjustedColor : defaultBgColor;
+    } else {
+      data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    }
     data.borderColor = border?.color ? dimensionContext.getColor(border.color).value() : defaultBgColor;
     data.borderWidth = border?.width ?? 0;
 

--- a/public/app/features/canvas/elements/ellipse.tsx
+++ b/public/app/features/canvas/elements/ellipse.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import tinycolor from 'tinycolor2';
 import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2, OneClickMode } from '@grafana/data';
@@ -126,7 +127,17 @@ export const ellipseItem: CanvasElementItem<CanvasElementConfig, CanvasElementDa
     }
 
     const { background, border } = elementOptions;
-    data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    // TODO consolidate these calcs at the element level
+    if (background?.color?.field) {
+      const color = dimensionContext.getColor(background.color);
+      const alphaAdjustedColor = tinycolor(color.value())
+        .setAlpha(background.opacity ?? 1)
+        .toString();
+      data.backgroundColor = background?.color ? alphaAdjustedColor : defaultBgColor;
+    } else {
+      data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    }
+
     data.borderColor = border?.color ? dimensionContext.getColor(border.color).value() : defaultBgColor;
     data.borderWidth = border?.width ?? 0;
 

--- a/public/app/features/canvas/elements/parallelogram.tsx
+++ b/public/app/features/canvas/elements/parallelogram.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import tinycolor from 'tinycolor2';
 import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2, OneClickMode } from '@grafana/data';
@@ -120,7 +121,16 @@ export const parallelogramItem: CanvasElementItem = {
     }
 
     const { background, border } = elementOptions;
-    data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    // TODO consolidate these calcs at the element level
+    if (background?.color?.field) {
+      const color = dimensionContext.getColor(background.color);
+      const alphaAdjustedColor = tinycolor(color.value())
+        .setAlpha(background.opacity ?? 1)
+        .toString();
+      data.backgroundColor = background?.color ? alphaAdjustedColor : defaultBgColor;
+    } else {
+      data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    }
     data.borderColor = border?.color ? dimensionContext.getColor(border.color).value() : defaultBgColor;
     data.borderWidth = border?.width ?? 0;
 

--- a/public/app/features/canvas/elements/triangle.tsx
+++ b/public/app/features/canvas/elements/triangle.tsx
@@ -122,7 +122,6 @@ export const triangleItem: CanvasElementItem = {
     }
 
     const { background, border } = elementOptions;
-    data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
     // TODO consolidate these calcs at the element level
     if (background?.color?.field) {
       const color = dimensionContext.getColor(background.color);
@@ -133,6 +132,7 @@ export const triangleItem: CanvasElementItem = {
     } else {
       data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
     }
+    data.borderColor = border?.color ? dimensionContext.getColor(border.color).value() : defaultBgColor;
     data.borderWidth = border?.width ?? 0;
 
     data.backgroundImage = background?.image ? dimensionContext.getResource(background.image).value() : undefined;

--- a/public/app/features/canvas/elements/triangle.tsx
+++ b/public/app/features/canvas/elements/triangle.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import tinycolor from 'tinycolor2';
 import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2, OneClickMode } from '@grafana/data';
@@ -122,7 +123,16 @@ export const triangleItem: CanvasElementItem = {
 
     const { background, border } = elementOptions;
     data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
-    data.borderColor = border?.color ? dimensionContext.getColor(border.color).value() : defaultBgColor;
+    // TODO consolidate these calcs at the element level
+    if (background?.color?.field) {
+      const color = dimensionContext.getColor(background.color);
+      const alphaAdjustedColor = tinycolor(color.value())
+        .setAlpha(background.opacity ?? 1)
+        .toString();
+      data.backgroundColor = background?.color ? alphaAdjustedColor : defaultBgColor;
+    } else {
+      data.backgroundColor = background?.color ? dimensionContext.getColor(background.color).value() : defaultBgColor;
+    }
     data.borderWidth = border?.width ?? 0;
 
     data.backgroundImage = background?.image ? dimensionContext.getResource(background.image).value() : undefined;

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
 import { OnDrag, OnResize, OnRotate } from 'react-moveable/declaration/types';
+import tinycolor from 'tinycolor2';
 
 import { FieldType, getLinksSupplier, LinkModel, OneClickMode, ValueLinkConfig } from '@grafana/data';
 import { LayerElement } from 'app/core/components/Layers/types';
@@ -403,7 +404,14 @@ export class ElementState implements LayerElement {
     if (background) {
       if (background.color) {
         const color = ctx.getColor(background.color);
-        css.backgroundColor = color.value();
+        // If a field driven background color is present, apply alpha
+        if (background.color.field) {
+          css.backgroundColor = tinycolor(color.value())
+            .setAlpha(background.opacity ?? 1)
+            .toString();
+        } else {
+          css.backgroundColor = color.value();
+        }
       }
       if (background.image) {
         const image = ctx.getResource(background.image);

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -47,6 +47,23 @@ export const optionBuilder: OptionSuppliers = {
           fixed: '',
         },
       })
+      .addSliderInput({
+        category,
+        path: 'background.opacity',
+        name: 'Opacity',
+        defaultValue: 1,
+        settings: {
+          min: 0,
+          max: 1,
+          step: 0.1,
+        },
+        showIf: () => {
+          if (context.options?.background?.color?.field) {
+            return true;
+          }
+          return false;
+        },
+      })
       .addCustomEditor({
         category,
         id: 'background.image',

--- a/public/app/plugins/panel/canvas/panelcfg.cue
+++ b/public/app/plugins/panel/canvas/panelcfg.cue
@@ -48,9 +48,10 @@ composableKinds: PanelCfg: {
 
 				BackgroundImageSize: "original" | "contain" | "cover" | "fill" | "tile" @cuetsy(kind="enum", memberNames="Original|Contain|Cover|Fill|Tile")
 				BackgroundConfig: {
-					color?: ui.ColorDimensionConfig
-					image?: ui.ResourceDimensionConfig
-					size?:  BackgroundImageSize
+					color?:   ui.ColorDimensionConfig
+					image?:   ui.ResourceDimensionConfig
+					size?:    BackgroundImageSize
+					opacity?: float64
 				} @cuetsy(kind="interface")
 
 				LineConfig: {

--- a/public/app/plugins/panel/canvas/panelcfg.gen.ts
+++ b/public/app/plugins/panel/canvas/panelcfg.gen.ts
@@ -52,6 +52,7 @@ export enum BackgroundImageSize {
 export interface BackgroundConfig {
   color?: ui.ColorDimensionConfig;
   image?: ui.ResourceDimensionConfig;
+  opacity?: number;
   size?: BackgroundImageSize;
 }
 


### PR DESCRIPTION
Add opacity slider when background color is field driven.

After:
![Aug-07-2024 16-24-34](https://github.com/user-attachments/assets/3fb97bea-2e11-4eae-80c3-77dea86e43c0)

Closes #91656