### PR TITLE
Vizards: Don't generate viz for viz element

### DIFF
--- a/public/app/features/canvas/runtime/sceneElementManagement.ts
+++ b/public/app/features/canvas/runtime/sceneElementManagement.ts
@@ -169,6 +169,10 @@ const generateFrameContainer = (elements: ElementState[]): Placement => {
   };
 };
 
+/**
+ * Get selected elements from the scene, used in the context menu to generate a visualization
+ * @param scene
+ */
 export const getSelectedElements = (scene: Scene) => {
   const selectedElements = scene.selecto?.getSelectedTargets();
 
@@ -176,7 +180,7 @@ export const getSelectedElements = (scene: Scene) => {
 
   selectedElements?.forEach((element) => {
     const elementState = findElementByTarget(element, scene.root.elements);
-    if (elementState) {
+    if (elementState && elementState.options.type !== 'visualization') {
       elements.push(elementState);
     }
   });

--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -91,6 +91,29 @@ export const CanvasContextMenu = ({ scene, panel, onVisibilityChange }: Props) =
       />
     );
 
+    const generateVisualizationMenuItem = () => {
+      if (selectedElements) {
+        const isVisualization =
+          selectedElements.length === 1 &&
+          findElementByTarget(selectedElements[0], scene.root.elements)?.options.type === 'visualization';
+
+        if (!isVisualization) {
+          return (
+            <MenuItem
+              label="Generate visualization"
+              onClick={() => {
+                onGenerateVisualization(getSelectedElements(scene), scene.currentLayer!);
+                closeContextMenu();
+              }}
+              className={styles.menuItem}
+            />
+          );
+        }
+      }
+
+      return null;
+    };
+
     const editElementMenuItem = () => {
       if (selectedElements?.length === 1) {
         const onClickEditElementMenuItem = () => {
@@ -201,14 +224,7 @@ export const CanvasContextMenu = ({ scene, panel, onVisibilityChange }: Props) =
             className={styles.menuItem}
           />
           {openCloseEditorMenuItem}
-          <MenuItem
-            label="Generate visualization"
-            onClick={() => {
-              onGenerateVisualization(getSelectedElements(scene), scene.currentLayer!);
-              closeContextMenu();
-            }}
-            className={styles.menuItem}
-          />
+          {generateVisualizationMenuItem()}
         </>
       );
     } else {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -129,7 +129,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
   };
 
   const onGenerateViz = () => {
-    const selectedElements = [...settings.selected];
+    const selectedElements = [...settings.selected].filter((element) => element.options.type !== 'visualization');
     onGenerateVisualization(selectedElements, layer);
   };
 


### PR DESCRIPTION
- Excludes visualization type from viz generation
- Hides "Generate visualization" content menu item when a single visualization is selected

https://github.com/user-attachments/assets/ccaacd94-94a0-41d4-9b89-a954c70c2266





Fixes https://github.com/grafana/grafana/issues/91649


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
