### PR TITLE
Prometheus: Histogram table format should keep `le` values as strings

### DIFF
--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -202,11 +202,10 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
         .forEach((label) => {
           // If we don't have label in labelFields, add it
           if (!labelFields.some((l) => l.name === label)) {
-            const numberField = label === HISTOGRAM_QUANTILE_LABEL_NAME;
             labelFields.push({
               name: label,
               config: { filterable: true },
-              type: numberField ? FieldType.number : FieldType.string,
+              type: FieldType.string,
               values: [],
             });
           }
@@ -280,9 +279,6 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
 
 function getLabelValue(metric: PromMetric, label: string): string | number {
   if (metric.hasOwnProperty(label)) {
-    if (label === HISTOGRAM_QUANTILE_LABEL_NAME) {
-      return parseSampleValue(metric[label]);
-    }
     return metric[label];
   }
   return '';


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11162

**What is this?**
This keeps `le` values as strings when selecting the table format in Explore. Prometheus sends them as strings.

**Why?**
This is a bug fix.

When querying a histogram in table format in Prometheus, Prometheus sends the `le` labels values as strings but these strings were being parsed as numbers in `transformV2. This broke the Explore table result filter for the `le` label.

To test this,

1. Got to Explore.
2. Query a prometheus metric that ends in `bucket`.
3. Select the table format.
4. Find the le column in the table result.
5. Mouse hover on a value in the le column of the table.
6. Choose the `+` or `-` to filter the le label value.
7. See that the query is updated as it filters the value you selected.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
