### PR TITLE
Vizards: Fix selecto for viz element

### DIFF
--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -89,13 +89,19 @@ const VisualizationDisplay = (props: CanvasElementProps<VizElementConfig, VizEle
   );
 
   return (
-    <div className={styles.container}>
-      <embeddedPanel.Component model={embeddedPanel} />
+    <div className={styles.outerContainer}>
+      <div className={styles.container}>
+        <embeddedPanel.Component model={embeddedPanel} />
+      </div>
     </div>
   );
 };
 
 const getStyles = stylesFactory((theme: GrafanaTheme2, data, scene) => ({
+  outerContainer: css({
+    height: '100%',
+    width: '100%',
+  }),
   container: css({
     position: 'absolute',
     height: '100%',


### PR DESCRIPTION
Add wrapper around viz element to prevent selecto from triggering when pointerEvents are set to none.

After:
![Aug-08-2024 10-37-48](https://github.com/user-attachments/assets/cbdcab8c-a774-4206-94b3-652b9bd841cc)

Fixes #91558