### PR TITLE
Chore: Remove depguard rule skip in apiserver

### DIFF
--- a/pkg/apiserver/rest/dualwriter.go
+++ b/pkg/apiserver/rest/dualwriter.go
@@ -240,6 +240,7 @@ func removeMeta(obj runtime.Object) []byte {
 	}
 	// we don't want to compare meta fields
 	delete(unstObj, "metadata")
+	delete(unstObj, "objectMeta")
 
 	jsonObj, err := json.Marshal(unstObj)
 	if err != nil {

--- a/pkg/apiserver/rest/dualwriter_test.go
+++ b/pkg/apiserver/rest/dualwriter_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	// nolint:depguard
-	playlist "github.com/grafana/grafana/pkg/apis/playlist/v0alpha1"
+	"k8s.io/apiserver/pkg/apis/example"
 )
 
 func TestSetDualWritingMode(t *testing.T) {
@@ -63,9 +62,9 @@ func TestSetDualWritingMode(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
-	var examplePlaylistGen1 = &playlist.Playlist{ObjectMeta: metav1.ObjectMeta{Generation: 1}, Spec: playlist.Spec{Title: "Example Playlist"}}
-	var examplePlaylistGen2 = &playlist.Playlist{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Spec: playlist.Spec{Title: "Example Playlist"}}
-	var anotherPlaylist = &playlist.Playlist{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Spec: playlist.Spec{Title: "Another Playlist"}}
+	var exampleObjGen1 = &example.Pod{ObjectMeta: metav1.ObjectMeta{Generation: 1}, Spec: example.PodSpec{Hostname: "one"}, Status: example.PodStatus{StartTime: &metav1.Time{Time: time.Unix(0, 0)}}}
+	var exampleObjGen2 = &example.Pod{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Spec: example.PodSpec{Hostname: "one"}, Status: example.PodStatus{StartTime: &metav1.Time{Time: time.Unix(0, 0)}}}
+	var exampleObjDifferentTitle = &example.Pod{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Spec: example.PodSpec{Hostname: "two"}, Status: example.PodStatus{StartTime: &metav1.Time{Time: time.Unix(0, 0)}}}
 
 	testCase := []struct {
 		name     string
@@ -80,21 +79,15 @@ func TestCompare(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "should return false when objects are different",
-			input1:   exampleObj,
-			input2:   anotherObj,
-			expected: false,
-		},
-		{
-			name:     "should return true when Playlists are the same, but different metadata (generation)",
-			input1:   examplePlaylistGen1,
-			input2:   examplePlaylistGen2,
+			name:     "should return true when objects are the same, but different metadata (generation)",
+			input1:   exampleObjGen1,
+			input2:   exampleObjGen2,
 			expected: true,
 		},
 		{
-			name:     "should return false when Playlists different",
-			input1:   examplePlaylistGen1,
-			input2:   anotherPlaylist,
+			name:     "should return false when objects are different",
+			input1:   exampleObjGen1,
+			input2:   exampleObjDifferentTitle,
 			expected: false,
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates tests to remove `grafana/grafana` import in `pkg/apiserver/rest`.

**Why do we need this feature?**

A `// nolint:depguard` comment was added in https://github.com/grafana/grafana/pull/90455, which breaks `go mod tidy` in the `pkg/apiserver` submodule.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
