### PR TITLE
Vizards: Generate viz only for elements with fields

### DIFF
--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -98,7 +98,9 @@ export const CanvasContextMenu = ({ scene, panel, onVisibilityChange }: Props) =
         if (selectedElements.length === 1) {
           const element = findElementByTarget(selectedElements[0], scene.root.elements);
           skipVizMenuItem =
-            element?.options.type === 'visualization' || (element?.data.field && element?.data.field === '');
+            element?.options.type === 'visualization' ||
+            element?.data.field === undefined ||
+            element?.data.field === '';
         }
 
         if (!skipVizMenuItem) {

--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -93,11 +93,14 @@ export const CanvasContextMenu = ({ scene, panel, onVisibilityChange }: Props) =
 
     const generateVisualizationMenuItem = () => {
       if (selectedElements) {
-        const isVisualization =
-          selectedElements.length === 1 &&
-          findElementByTarget(selectedElements[0], scene.root.elements)?.options.type === 'visualization';
+        let skipVizMenuItem = false;
 
-        if (!isVisualization) {
+        if (selectedElements.length === 1) {
+          const element = findElementByTarget(selectedElements[0], scene.root.elements);
+          skipVizMenuItem = element?.options.type === 'visualization' || element?.data.field === '';
+        }
+
+        if (!skipVizMenuItem) {
           return (
             <MenuItem
               label="Generate visualization"

--- a/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx
@@ -97,7 +97,8 @@ export const CanvasContextMenu = ({ scene, panel, onVisibilityChange }: Props) =
 
         if (selectedElements.length === 1) {
           const element = findElementByTarget(selectedElements[0], scene.root.elements);
-          skipVizMenuItem = element?.options.type === 'visualization' || element?.data.field === '';
+          skipVizMenuItem =
+            element?.options.type === 'visualization' || (element?.data.field && element?.data.field === '');
         }
 
         if (!skipVizMenuItem) {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -172,7 +172,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
         )}
       </Stack>
       <Stack justifyContent="space-between" direction="row">
-        {selection.length > 1 && (
+        {selection.length > 0 && (
           <div className={styles.generateVizWrapper}>
             <Button size="sm" variant="secondary" onClick={onGenerateViz}>
               Generate visualization

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -133,6 +133,15 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     onGenerateVisualization(selectedElements, layer);
   };
 
+  const shouldShowGenerateVizButton = () => {
+    if (selection.length > 0) {
+      const onlyVizSelected = settings.selected.every((element) => element.options.type === 'visualization');
+      return !onlyVizSelected;
+    }
+
+    return false;
+  };
+
   const typeOptions = getElementTypes(settings.scene.shouldShowAdvancedTypes).options;
 
   return (
@@ -172,7 +181,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
         )}
       </Stack>
       <Stack justifyContent="space-between" direction="row">
-        {selection.length > 0 && (
+        {shouldShowGenerateVizButton() && (
           <div className={styles.generateVizWrapper}>
             <Button size="sm" variant="secondary" onClick={onGenerateViz}>
               Generate visualization


### PR DESCRIPTION

https://github.com/user-attachments/assets/2b246aa2-ba4b-4e3b-a44c-c6fb75807f06

![Screenshot 2024-08-08 at 2 35 59 PM](https://github.com/user-attachments/assets/36470f18-1219-4cdc-809b-60e54258318b)




Fixes https://github.com/grafana/grafana/issues/91708



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.
