### PR TITLE
Vizards: Overflow form element

### DIFF
--- a/public/app/features/canvas/elements/form/form.tsx
+++ b/public/app/features/canvas/elements/form/form.tsx
@@ -179,6 +179,7 @@ const getStyles = (data: FormData | undefined) => (theme: GrafanaTheme2) => ({
     display: 'flex',
     border: `1px solid ${theme.colors.border.strong}`,
     flexDirection: 'column',
+    overflow: 'auto',
   }),
   itemsContainer: css({
     display: 'flex',


### PR DESCRIPTION
Before:
![Aug-08-2024 13-59-06](https://github.com/user-attachments/assets/582ddc4d-8887-4879-82ae-d4b06753171c)

After:
![Aug-08-2024 13-57-40](https://github.com/user-attachments/assets/c3abba22-2a56-4e4c-b351-2654deffbdaf)
