### PR TITLE
Canvas: Fix form API editor payload bug

### DIFF
--- a/packages/grafana-ui/src/components/TextArea/TextArea.tsx
+++ b/packages/grafana-ui/src/components/TextArea/TextArea.tsx
@@ -15,6 +15,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(({ invalid, class
   const styles = useStyles2(getTextAreaStyle, invalid);
 
   //TODO; hack to make sure the payload field in API Editor updates when canvas form values update
+  // using value props instead of defaultValue because updating defaultValue will not trigger a re-render
   return <textarea {...props} value={props.defaultValue} className={cx(styles.textarea, className)} ref={ref} />;
 });
 

--- a/packages/grafana-ui/src/components/TextArea/TextArea.tsx
+++ b/packages/grafana-ui/src/components/TextArea/TextArea.tsx
@@ -14,7 +14,8 @@ export interface Props extends Omit<HTMLProps<HTMLTextAreaElement>, 'size'> {
 export const TextArea = forwardRef<HTMLTextAreaElement, Props>(({ invalid, className, ...props }, ref) => {
   const styles = useStyles2(getTextAreaStyle, invalid);
 
-  return <textarea {...props} className={cx(styles.textarea, className)} ref={ref} />;
+  //TODO; hack to make sure the payload field in API Editor updates when canvas form values update
+  return <textarea {...props} value={props.defaultValue} className={cx(styles.textarea, className)} ref={ref} />;
 });
 
 const getTextAreaStyle = (theme: GrafanaTheme2, invalid = false) => ({

--- a/public/app/features/canvas/elements/form/elements/FormElementTypeEditor.tsx
+++ b/public/app/features/canvas/elements/form/elements/FormElementTypeEditor.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
 import { uniqueId } from 'lodash';
 import { useCallback } from 'react';
+import { useObservable } from 'react-use';
+import { Subject } from 'rxjs';
 
 import { GrafanaTheme2, SelectableValue, StandardEditorProps } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
@@ -38,6 +40,11 @@ export const FormElementTypeEditor = ({ value, context, onChange, item }: Props)
     { value: FormElementType.NumberInput, label: 'Number input' },
     { value: FormElementType.Submit, label: 'Submit' },
   ];
+
+  const scene = context.instanceState?.scene;
+
+  // Will force a rerender whenever the subject changes
+  useObservable(scene ? scene.moved : new Subject());
 
   const styles = useStyles2(getStyles);
 
@@ -91,9 +98,9 @@ export const FormElementTypeEditor = ({ value, context, onChange, item }: Props)
         return child;
       });
       onChange(newElements);
-      updateAPIPayload(newElements);
+      updateAPIPayload(newElements, scene);
     },
-    [onChange, value]
+    [onChange, value, scene]
   );
 
   const onTextInputOptionsChange = useCallback(
@@ -106,9 +113,9 @@ export const FormElementTypeEditor = ({ value, context, onChange, item }: Props)
         return child;
       });
       onChange(newElements);
-      updateAPIPayload(newElements);
+      updateAPIPayload(newElements, scene);
     },
-    [onChange, value]
+    [onChange, value, scene]
   );
 
   const onSelectionItemTitleChange = useCallback(
@@ -136,9 +143,9 @@ export const FormElementTypeEditor = ({ value, context, onChange, item }: Props)
       });
 
       onChange(newElements);
-      updateAPIPayload(newElements);
+      updateAPIPayload(newElements, scene);
     },
-    [onChange, value]
+    [onChange, value, scene]
   );
 
   const onCheckboxParamsChange = useCallback(
@@ -154,9 +161,9 @@ export const FormElementTypeEditor = ({ value, context, onChange, item }: Props)
         return child;
       });
       onChange(newElements);
-      updateAPIPayload(newElements);
+      updateAPIPayload(newElements, scene);
     },
-    [onChange, value]
+    [onChange, value, scene]
   );
 
   const onCheckBoxTitleChange = useCallback(

--- a/public/app/features/canvas/elements/form/elements/utils.ts
+++ b/public/app/features/canvas/elements/form/elements/utils.ts
@@ -1,6 +1,6 @@
 import { FormChild } from './FormElementTypeEditor';
 
-export const updateAPIPayload = (formElements: FormChild[]) => {
+export const updateAPIPayload = (formElements: FormChild[], scene: any) => {
   const submitElement = formElements?.find((child) => {
     if (child.type === 'Submit') {
       return true;
@@ -25,4 +25,6 @@ export const updateAPIPayload = (formElements: FormChild[]) => {
   }, {});
 
   submitElement.api!.data = JSON.stringify(payload);
+  // need so the FormElementTypeEditor rerenders and payload
+  scene.moved.next(Date.now());
 };

--- a/public/app/features/canvas/elements/form/form.tsx
+++ b/public/app/features/canvas/elements/form/form.tsx
@@ -76,11 +76,7 @@ const Form = (props: CanvasElementProps<FormConfig, FormData>) => {
       child.currentOption = [{ [newParams[0]]: newParams[1] }];
     }
 
-    updateAPIPayload(config.formElements!);
-    // TODO: figure out why this is not updating the editor
-    // it's updating the save model but
-    // see layoutEditor
-    scene.moved.next(Date.now());
+    updateAPIPayload(config.formElements!, scene);
   };
 
   const onTextInputChange = (value: string, id: string) => {
@@ -90,7 +86,7 @@ const Form = (props: CanvasElementProps<FormConfig, FormData>) => {
       child.currentOption = [{ [child.title]: value }];
     }
 
-    updateAPIPayload(config.formElements!);
+    updateAPIPayload(config.formElements!, scene);
   };
 
   const onNumberInputChange = (value: string, id: string) => {
@@ -100,7 +96,7 @@ const Form = (props: CanvasElementProps<FormConfig, FormData>) => {
       child.currentOption = [{ [child.title]: value }];
     }
 
-    updateAPIPayload(config.formElements!);
+    updateAPIPayload(config.formElements!, scene);
   };
 
   const onCheckboxOptionsChange = (value: [string, string], index: number, id: string) => {
@@ -119,7 +115,7 @@ const Form = (props: CanvasElementProps<FormConfig, FormData>) => {
       child.currentOption = updatedCheckboxes;
     }
 
-    updateAPIPayload(config.formElements!);
+    updateAPIPayload(config.formElements!, scene);
   };
 
   const children = config.formElements?.map((child) => {


### PR DESCRIPTION
Fixes the bug where payload field wouldn't update on changes in the form element. 
Using a hack in TextArea for now. 