### PR TITLE
Vizards: Wrap viz with display flex

### DIFF
--- a/public/app/features/canvas/elements/visualization.tsx
+++ b/public/app/features/canvas/elements/visualization.tsx
@@ -106,7 +106,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2, data, scene) => ({
     position: 'absolute',
     height: '100%',
     width: '100%',
-    display: 'table',
+    display: 'flex',
     pointerEvents: scene?.isEditingEnabled ? 'none' : 'auto',
   }),
 }));


### PR DESCRIPTION
In firefox, not wrapping the embedded viz inside of a display: flex div will cause it not to render.

