### PR TITLE
Form: Fix key / value handling for radio / select form elements

### DIFF
--- a/public/app/features/canvas/elements/form/elements/RadioList.tsx
+++ b/public/app/features/canvas/elements/form/elements/RadioList.tsx
@@ -18,10 +18,10 @@ export const RadioList = ({ title, options, onChange, currentOption }: Props) =>
         <RadioButtonList
           name="default"
           value={selected}
-          options={options!.map((option) => ({ label: option[0], value: option[1] }))}
+          options={options!.map((option) => ({ label: option[1], value: option[0] }))}
           onChange={(value, label) => {
             setSelected(value);
-            onChange([label ?? '', value ?? '']);
+            onChange([value ?? '', label ?? '']);
           }}
         />
       </Stack>

--- a/public/app/features/canvas/elements/form/elements/Select.tsx
+++ b/public/app/features/canvas/elements/form/elements/Select.tsx
@@ -16,11 +16,11 @@ export const SelectDisplay = ({ options, currentOption, onChange, title }: Props
   return (
     <Field label={title} style={{ marginBottom: '2px' }}>
       <Select
-        options={options.map((option) => ({ label: option[0], value: option[1] }))}
+        options={options.map((option) => ({ label: option[1], value: option[0] }))}
         value={value}
         onChange={(option) => {
           setValue(option.value);
-          onChange([option.label ?? '', option.value ?? '']);
+          onChange([option.value ?? '', option.label ?? '']);
         }}
       />
     </Field>


### PR DESCRIPTION
Before key value were appearing seemingly backwards in select list (showing keys instead of values and persisting this backwards. Maybe I am wrong though 🤷‍♂️ 

Before
![image](https://github.com/user-attachments/assets/cda32b74-a46d-4709-9e3e-19da3767a884)

After

![Screenshot 2024-08-09 at 12 15 20 AM](https://github.com/user-attachments/assets/6c518ddb-82de-4b7f-a8c8-d426d608c7c5)
