### PR TITLE
docs: add play link to explore metrics to demonstrate

### DIFF
--- a/docs/sources/explore/explore-metrics/index.md
+++ b/docs/sources/explore/explore-metrics/index.md
@@ -28,6 +28,8 @@ With Explore Metrics, you can:
 - view a history of user steps when navigating through metrics and their filters
 <!-- - easily pivot to other related telemetry, including logs or traces -->
 
+{{< docs/play title="Explore Metrics" url="https://play.grafana.org/explore/metrics/trail?from=now-1h&to=now&var-ds=grafanacloud-demoinfra-prom&var-filters=&refresh=&metricPrefix=all" >}}
+
 You can access Explore Metrics either as a standalone experience or as part of Grafana dashboards.
 
 ## Standalone experience


### PR DESCRIPTION
Part of a series of PRs, adds an example where users can directly play with the product described

I could use backport labeling advice on this due to the age of the product; normally I'd backport docs PRs several versions, on this one not sure.