### PR TITLE
AzureMonitor: Add authproxy as supported user auth method

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx
@@ -64,7 +64,9 @@ const QueryEditor = ({
     options: datasource.getVariables().map((v) => ({ label: v, value: v })),
   };
 
-  const isAzureAuthenticated = config.bootData.user.authenticatedBy === 'oauth_azuread';
+  // Allow authproxy as it may not be clear if an authproxy user is authenticated by Azure
+  const isAzureAuthenticated =
+    config.bootData.user.authenticatedBy === 'oauth_azuread' || config.bootData.user.authenticatedBy === 'authproxy';
   if (datasource.currentUserAuth) {
     if (
       app === CoreApp.UnifiedAlerting &&


### PR DESCRIPTION
This PR adds the `authproxy` as a supported auth method for user authentication as a Grafana admin may configure an auth proxy but the user may still be authenticating via Azure.