### PR TITLE
Canvas Form: Number input bug fix

### DIFF
--- a/public/app/features/canvas/elements/form/elements/NumberInput.tsx
+++ b/public/app/features/canvas/elements/form/elements/NumberInput.tsx
@@ -12,8 +12,8 @@ interface NumberInputProps extends Omit<FormChild, 'id' | 'type'> {
 }
 
 export const NumberInput = ({ title, onChange, min, max, placeholder, currentOption }: NumberInputProps) => {
-  const key = Object.keys(currentOption?.[1] ?? {})[0];
-  const [value, setValue] = useState(currentOption?.[1][key]);
+  const key = Object.keys(currentOption?.[0] ?? {})[0];
+  const [value, setValue] = useState(currentOption?.[0][key]);
 
   return (
     <Field label={title}>

--- a/public/app/features/canvas/elements/form/elements/NumberInputEditor.tsx
+++ b/public/app/features/canvas/elements/form/elements/NumberInputEditor.tsx
@@ -14,7 +14,7 @@ export const NumberInputEditor = ({ onChange, currentOption }: TextInputProps) =
         defaultValue={value}
         onBlur={(event) => {
           setValue(event.currentTarget.value);
-          onChange(event.currentTarget.value);
+          onChange(event.currentTarget.value === '' ? key : event.currentTarget.value);
         }}
       />
     </Field>


### PR DESCRIPTION
- Fix number input where it was looking for non-existing element in the array (number input always has only one key-value pair as currentOption)
- Make sure number input title is never empty because we need it as a key