### PR TITLE
Alerting: Update contact points list and mute timings list on update

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -279,9 +279,11 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
     // TODO: Remove as part of migration to k8s API for receivers
     getContactPointsList: build.query<GrafanaManagedContactPoint[], void>({
       query: () => ({ url: '/api/v1/notifications/receivers' }),
+      providesTags: ['AlertmanagerConfiguration'],
     }),
     getMuteTimingList: build.query<MuteTimeInterval[], void>({
       query: () => ({ url: '/api/v1/notifications/time-intervals' }),
+      providesTags: ['AlertmanagerConfiguration'],
     }),
   }),
 });


### PR DESCRIPTION
**What is this feature?**

Prior to this PR adding, removing or renaming contact points and time intervals would not invalidate the existing cache.

This PR adds the `AlertmanagerConfiguration` tags to the separate endpoints for contact points and time intervals so those also get invalidated whenever we modify the Alertmanager configuration.

Ideally these would be separate tags but considering we still mutate everything via `updateAlertmanagerConfiguration` we should stick with the `AlertmanagerConfiguration`.

We could diff the changes in the `updateAlertmanagerConfiguration(...)` function and determine which tags to invalidate as a future enhancement.

**Special notes for your reviewer:**

Still needs a regression test added to this PR.