### PR TITLE
Grafana ui: Add new allowed color to badge component: gray

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -12,7 +12,7 @@ import { SkeletonComponent, attachSkeleton } from '../../utils/skeleton';
 import { Icon } from '../Icon/Icon';
 import { Tooltip } from '../Tooltip/Tooltip';
 
-export type BadgeColor = 'blue' | 'red' | 'green' | 'orange' | 'purple';
+export type BadgeColor = 'blue' | 'red' | 'green' | 'orange' | 'purple' | 'gray';
 
 export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   text: React.ReactNode;


### PR DESCRIPTION
**What is this feature?**

Add a new allowed color to the `Badge` component: `gray`.
<img width="190" alt="Screenshot 2024-08-12 at 12 15 51" src="https://github.com/user-attachments/assets/c472bcb2-42db-4d9d-bdb7-44f9f718674a">
<img width="145" alt="Screenshot 2024-08-12 at 12 15 57" src="https://github.com/user-attachments/assets/0e577287-b1ae-45db-b20b-d729128454c5">


**Why do we need this feature?**

We need it in order to display information as badges, but without conveying any sense of urgency or info through its color.

**Who is this feature for?**

This new color is needed for the application observability plugin to display as a badge information about the kind of service we're showing.

**Which issue(s) does this PR fix?**:

Fixes [#1161](https://github.com/grafana/app-observability-plugin/issues/1161)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
