### PR TITLE
Alerting: Update remote Alertmanager config marshalling in test

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -767,7 +767,6 @@ global:
     http_config:
         follow_redirects: true
         enable_http2: true
-        http_headers: null
     smtp_hello: localhost
     smtp_require_tls: true
     pagerduty_url: https://events.pagerduty.com/v2/enqueue


### PR DESCRIPTION
A `omitempty` was added in the `GlobalConfig.HTTPConfig.HTTPHeaders` field ([permalink](https://github.com/prometheus/common/blob/1dade5bb9242eab4c1c23baa09becd561389c47c/config/http_config.go#L326)). Instead of a `null` map, the field is omitted. We need to remove this field in our tests.