### PR TITLE
Logs panel: Enable displayedFields in dashboards and apps

### DIFF
--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -14,6 +14,7 @@ export const pluginVersion = "11.2.0-pre";
 
 export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
+  displayedFields?: Array<string>;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
   /**
@@ -31,3 +32,7 @@ export interface Options {
   sortOrder: common.LogsSortOrder;
   wrapLogMessage: boolean;
 }
+
+export const defaultOptions: Partial<Options> = {
+  displayedFields: [],
+};

--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -24,6 +24,8 @@ export interface Options {
   onClickFilterOutLabel?: unknown;
   onClickFilterOutString?: unknown;
   onClickFilterString?: unknown;
+  onClickHideField?: unknown;
+  onClickShowField?: unknown;
   prettifyLogMessage: boolean;
   showCommonLabels: boolean;
   showLabels: boolean;

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -449,34 +449,7 @@ describe('LogsPanel', () => {
       }),
     ];
 
-    it('does not show the button if the callbacks and fields are not passed', async () => {
-      setup({
-        data: {
-          series,
-        },
-        options: {
-          showLabels: false,
-          showTime: false,
-          wrapLogMessage: false,
-          showCommonLabels: false,
-          prettifyLogMessage: false,
-          sortOrder: LogsSortOrder.Descending,
-          dedupStrategy: LogsDedupStrategy.none,
-          enableLogDetails: true,
-          displayedFields: undefined,
-          onClickHideField: undefined,
-          onClickShowField: undefined,
-        },
-      });
-
-      expect(await screen.findByRole('row')).toBeInTheDocument();
-
-      await userEvent.click(screen.getByText('logline text'));
-
-      expect(screen.queryByLabelText('Show this field instead of the message')).not.toBeInTheDocument();
-    });
-
-    it('shows the button if an array of fields is passed', async () => {
+    it('displays the provided fields instead of the log line', async () => {
       setup({
         data: {
           series,
@@ -508,7 +481,7 @@ describe('LogsPanel', () => {
       expect(screen.getByText('logline text')).toBeInTheDocument();
     });
 
-    it('enables the behavior with a default implementation when passing an empty array', async () => {
+    it('enables the behavior with a default implementation', async () => {
       setup({
         data: {
           series,
@@ -540,7 +513,7 @@ describe('LogsPanel', () => {
       expect(screen.getByText('logline text')).toBeInTheDocument();
     });
 
-    it('enables the behavior when the callbacks are passed', async () => {
+    it('overrides the default implementation when the callbacks are provided', async () => {
       const onClickShowFieldMock = jest.fn();
 
       setup({

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -426,6 +426,149 @@ describe('LogsPanel', () => {
       });
     });
   });
+
+  describe.only('Show/hide fields', () => {
+    const series = [
+      createDataFrame({
+        refId: 'A',
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            values: ['2019-04-26T09:28:11.352440161Z'],
+          },
+          {
+            name: 'message',
+            type: FieldType.string,
+            values: ['logline text'],
+            labels: {
+              app: 'common_app',
+            },
+          },
+        ],
+      }),
+    ];
+
+    it('does not show the button if the callbacks and fields are not passed', async () => {
+      setup({
+        data: {
+          series,
+        },
+        options: {
+          showLabels: false,
+          showTime: false,
+          wrapLogMessage: false,
+          showCommonLabels: false,
+          prettifyLogMessage: false,
+          sortOrder: LogsSortOrder.Descending,
+          dedupStrategy: LogsDedupStrategy.none,
+          enableLogDetails: true,
+          displayedFields: undefined,
+          onClickHideField: undefined,
+          onClickShowField: undefined,
+        },
+      });
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('logline text'));
+
+      expect(screen.queryByLabelText('Show this field instead of the message')).not.toBeInTheDocument();
+    });
+
+    it('shows the button if an array of fields is passed', async () => {
+      setup({
+        data: {
+          series,
+        },
+        options: {
+          showLabels: false,
+          showTime: false,
+          wrapLogMessage: false,
+          showCommonLabels: false,
+          prettifyLogMessage: false,
+          sortOrder: LogsSortOrder.Descending,
+          dedupStrategy: LogsDedupStrategy.none,
+          enableLogDetails: true,
+          displayedFields: ['app'],
+          onClickHideField: undefined,
+          onClickShowField: undefined,
+        },
+      });
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+      expect(screen.queryByText('logline text')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('app=common_app'));
+
+      expect(screen.getByLabelText('Hide this field')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText('Hide this field'));
+
+      expect(screen.getByText('logline text')).toBeInTheDocument();
+    });
+
+    it('enables the behavior with a default implementation when passing an empty array', async () => {
+      setup({
+        data: {
+          series,
+        },
+        options: {
+          showLabels: false,
+          showTime: false,
+          wrapLogMessage: false,
+          showCommonLabels: false,
+          prettifyLogMessage: false,
+          sortOrder: LogsSortOrder.Descending,
+          dedupStrategy: LogsDedupStrategy.none,
+          enableLogDetails: true,
+          displayedFields: [],
+          onClickHideField: undefined,
+          onClickShowField: undefined,
+        },
+      });
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('logline text'));
+      await userEvent.click(screen.getByLabelText('Show this field instead of the message'));
+
+      expect(screen.getByText('app=common_app')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText('Hide this field'));
+
+      expect(screen.getByText('logline text')).toBeInTheDocument();
+    });
+
+    it('enables the behavior when the callbacks are passed', async () => {
+      const onClickShowFieldMock = jest.fn();
+
+      setup({
+        data: {
+          series,
+        },
+        options: {
+          showLabels: false,
+          showTime: false,
+          wrapLogMessage: false,
+          showCommonLabels: false,
+          prettifyLogMessage: false,
+          sortOrder: LogsSortOrder.Descending,
+          dedupStrategy: LogsDedupStrategy.none,
+          enableLogDetails: true,
+          onClickHideField: jest.fn(),
+          onClickShowField: onClickShowFieldMock,
+        },
+      });
+
+      expect(await screen.findByRole('row')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('logline text'));
+      await userEvent.click(screen.getByLabelText('Show this field instead of the message'));
+
+      expect(onClickShowFieldMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 const setup = (propsOverrides?: {}) => {

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -427,7 +427,7 @@ describe('LogsPanel', () => {
     });
   });
 
-  describe.only('Show/hide fields', () => {
+  describe('Show/hide fields', () => {
     const series = [
       createDataFrame({
         refId: 'A',

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -56,6 +56,9 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Determines if a given key => value filter is active in a given query. Used by Log details.
    * isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
+   * 
+   * Array of field names to display instead of the log line. Used, for example, by the "eye" icon in Explore's Log Details.
+   * displayedFields?: string[]
    */
 }
 interface LogsPermalinkUrlState {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -85,6 +85,7 @@ export const LogsPanel = ({
     onClickFilterOutString,
     onClickFilterString,
     isFilterLabelActive,
+    displayedFields,
   },
   id,
 }: LogsPanelProps) => {
@@ -342,6 +343,7 @@ export const LogsPanel = ({
               isOnClickFilterOutString(onClickFilterOutString) ? onClickFilterOutString : undefined
             }
             isFilterLabelActive={isIsFilterLabelActive(isFilterLabelActive) ? isFilterLabelActive : undefined}
+            displayedFields={displayedFields}
           />
           {showCommonLabels && isAscending && renderCommonLabels()}
         </div>

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -58,9 +58,15 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Determines if a given key => value filter is active in a given query. Used by Log details.
    * isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
-   * 
-   * Array of field names to display instead of the log line. Used, for example, by the "eye" icon in Explore's Log Details.
+   *
+   * Array of field names to display instead of the log line. Pass a list of fields or an empty array to enable hide/show fields in Log Details.
    * displayedFields?: string[]
+   *
+   * Called from the "eye" icon in Log Details to request showing the displayed field. If ommited, a default implementation is used.
+   * onClickShowField?: (key: string) => void;
+   *
+   * Called from the "eye" icon in Log Details to request hiding the displayed field. If ommited, a default implementation is used.
+   * onClickHideField?: (key: string) => void;
    */
 }
 interface LogsPermalinkUrlState {
@@ -103,7 +109,9 @@ export const LogsPanel = ({
   const dataSourcesMap = useDatasourcesFromTargets(data.request?.targets);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   const defaultDisplayedFields = options.displayedFields !== undefined ? options.displayedFields : [];
-  const [displayedFields, setDisplayedFields] = useState<string[] | undefined>((options.onClickHideField || options.onClickShowField) ? defaultDisplayedFields : options.displayedFields)
+  const [displayedFields, setDisplayedFields] = useState<string[] | undefined>(
+    options.onClickHideField || options.onClickShowField ? defaultDisplayedFields : options.displayedFields
+  );
   let closeCallback = useRef<() => void>();
 
   const { eventBus, onAddAdHocFilter } = usePanelContext();

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -108,10 +108,7 @@ export const LogsPanel = ({
   const timeRange = data.timeRange;
   const dataSourcesMap = useDatasourcesFromTargets(data.request?.targets);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
-  const defaultDisplayedFields = options.displayedFields !== undefined ? options.displayedFields : [];
-  const [displayedFields, setDisplayedFields] = useState<string[] | undefined>(
-    options.onClickHideField || options.onClickShowField ? defaultDisplayedFields : options.displayedFields
-  );
+  const [displayedFields, setDisplayedFields] = useState<string[]>(options.displayedFields ?? []);
   let closeCallback = useRef<() => void>();
 
   const { eventBus, onAddAdHocFilter } = usePanelContext();

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -41,6 +41,7 @@ composableKinds: PanelCfg: {
 					isFilterLabelActive?:    _
 					onClickFilterString?:    _
 					onClickFilterOutString?: _
+					displayedFields?: [...string]
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -41,6 +41,8 @@ composableKinds: PanelCfg: {
 					isFilterLabelActive?:    _
 					onClickFilterString?:    _
 					onClickFilterOutString?: _
+					onClickShowField?: _
+					onClickHideField?: _
 					displayedFields?: [...string]
 				} @cuetsy(kind="interface")
 			}

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -12,6 +12,7 @@ import * as common from '@grafana/schema';
 
 export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
+  displayedFields?: Array<string>;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
   /**
@@ -29,3 +30,7 @@ export interface Options {
   sortOrder: common.LogsSortOrder;
   wrapLogMessage: boolean;
 }
+
+export const defaultOptions: Partial<Options> = {
+  displayedFields: [],
+};

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -22,6 +22,8 @@ export interface Options {
   onClickFilterOutLabel?: unknown;
   onClickFilterOutString?: unknown;
   onClickFilterString?: unknown;
+  onClickHideField?: unknown;
+  onClickShowField?: unknown;
   prettifyLogMessage: boolean;
   showCommonLabels: boolean;
   showLabels: boolean;

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -7,6 +7,8 @@ type onClickFilterOutLabelType = (key: string, value: string, frame?: DataFrame)
 type onClickFilterValueType = (value: string, refId?: string) => void;
 type onClickFilterOutStringType = (value: string, refId?: string) => void;
 type isFilterLabelActiveType = (key: string, value: string, refId?: string) => Promise<boolean>;
+type isOnClickShowFieldType = (value: string) => void;
+type isOnClickHideFieldType = (value: string) => void;
 
 export function isOnClickFilterLabel(callback: unknown): callback is onClickFilterLabelType {
   return typeof callback === 'function';
@@ -25,5 +27,13 @@ export function isOnClickFilterOutString(callback: unknown): callback is onClick
 }
 
 export function isIsFilterLabelActive(callback: unknown): callback is isFilterLabelActiveType {
+  return typeof callback === 'function';
+}
+
+export function isOnClickShowField(callback: unknown): callback is isOnClickShowFieldType {
+  return typeof callback === 'function';
+}
+
+export function isOnClickHideField(callback: unknown): callback is isOnClickHideFieldType {
   return typeof callback === 'function';
 }


### PR DESCRIPTION
This PR exposes new props through the external LogsPanel API, so that users of this visualization can externally control the hide/show field options from Log Details and the Log Row. Additionally, it provides a default implementation to provide the show/hide fields in both Grafana Dashboards and apps.

New props:

- displayedFields: an array of fields to be displayed instead of the log line. Pass an empty array to enable the feature with a default implementation for show and hide.
- onClickShowField: optional callback to be called from log details to request showing a given field instead of the log line.
- onClickHideField: optional callback to be called from log details to request hiding a showed field.

Before these changes, this API was only available in Explore through the "show field" or "eye icon" feature of Log Details:

![imagen](https://github.com/user-attachments/assets/70101ae1-78cb-473c-a68a-bc34caab1d19)

For example, if `['app']` is passed, and it's present in the log response, it will be shown instead of the log line:

![imagen](https://github.com/user-attachments/assets/7879ae74-ba8a-45c4-8744-cc4036faec6f)

Demo:

https://github.com/user-attachments/assets/53822c88-5c3a-447d-acc8-36d68afd848f

Part of https://github.com/grafana/explore-logs/issues/677
Closes https://github.com/grafana/grafana/issues/77552
Persistence of the selection will be addressed by https://github.com/grafana/grafana/issues/89168

**Special notes for your reviewer:**

No visual or breaking changes.