### PR TITLE
RBAC: Actionsets add admin managed permissions on created folder and dashboard resources

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -212,6 +212,15 @@ func (hs *HTTPServer) setDefaultFolderPermissions(ctx context.Context, orgID int
 			{BuiltinRole: string(org.RoleEditor), Permission: dashboardaccess.PERMISSION_EDIT.String()},
 			{BuiltinRole: string(org.RoleViewer), Permission: dashboardaccess.PERMISSION_VIEW.String()},
 		}...)
+
+	}
+
+	// Add admin permission to the folder for action sets, as actionsets enable
+	// admin, editor, and viewer permissions to be dynamically set
+	if hs.Features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
+		permissions = append(permissions, []accesscontrol.SetResourcePermissionCommand{
+			{BuiltinRole: string(org.RoleAdmin), Permission: dashboardaccess.PERMISSION_ADMIN.String()},
+		}...)
 	}
 
 	_, err := hs.folderPermissionsService.SetPermissions(ctx, orgID, folder.UID, permissions...)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -507,6 +507,12 @@ func (dr *DashboardServiceImpl) setDefaultPermissions(ctx context.Context, dto *
 		}...)
 	}
 
+	if dr.features.IsEnabled(ctx, featuremgmt.FlagAccessActionSets) {
+		permissions = append(permissions, []accesscontrol.SetResourcePermissionCommand{
+			{BuiltinRole: string(org.RoleAdmin), Permission: dashboardaccess.PERMISSION_ADMIN.String()},
+		}...)
+	}
+
 	svc := dr.dashboardPermissions
 	if dash.IsFolder {
 		svc = dr.folderPermissions


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

followup on https://github.com/grafana/identity-access-team/issues/792

- This adds managed admin permissions on top of created folder and dashboard resources.
- We add the managed edit and view permissions for folder and dashboard created resources.

**Why do we need this feature?**

This is an additional feature on top of `actionsets` to plugin registration. where plugin registration can edit or modify the `folders:edit` for instance. 

https://github.com/user-attachments/assets/f42394a5-8a07-4599-a5bf-66f0341344e2


**Who is this feature for?**
anyone



