### PR TITLE
Bookmarks: Move building logic to the Frontend

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -169,14 +169,12 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 	}
 
 	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagPinNavItems) {
-		bookmarks := s.buildBookmarksNavLinks(prefs, treeRoot)
-
 		treeRoot.AddSection(&navtree.NavLink{
 			Text:           "Bookmarks",
 			Id:             navtree.NavIDBookmarks,
 			Icon:           "bookmark",
 			SortWeight:     navtree.WeightBookmarks,
-			Children:       bookmarks,
+			Children:       []*navtree.NavLink{},
 			EmptyMessageId: "bookmarks-empty",
 			Url:            s.cfg.AppSubURL + "/bookmarks",
 		})
@@ -334,39 +332,6 @@ func (s *ServiceImpl) buildStarredItemsNavLinks(c *contextmodel.ReqContext) ([]*
 	}
 
 	return starredItemsChildNavs, nil
-}
-func (s *ServiceImpl) buildBookmarksNavLinks(prefs *pref.Preference, treeRoot *navtree.NavTreeRoot) []*navtree.NavLink {
-	bookmarksChildNavs := []*navtree.NavLink{}
-
-	bookmarkUrls := prefs.JSONData.Navbar.BookmarkUrls
-
-	if len(bookmarkUrls) > 0 {
-		for _, url := range bookmarkUrls {
-			item := treeRoot.FindByURL(url)
-			if item != nil {
-				bookmarksChildNavs = append(bookmarksChildNavs, &navtree.NavLink{
-					Id:             item.Id,
-					Text:           item.Text,
-					SubTitle:       item.SubTitle,
-					Icon:           item.Icon,
-					Img:            item.Img,
-					Url:            item.Url,
-					Target:         item.Target,
-					HideFromTabs:   item.HideFromTabs,
-					RoundIcon:      item.RoundIcon,
-					IsSection:      item.IsSection,
-					HighlightText:  item.HighlightText,
-					HighlightID:    item.HighlightID,
-					PluginID:       item.PluginID,
-					IsCreateAction: item.IsCreateAction,
-					Keywords:       item.Keywords,
-					ParentItem:     &navtree.NavLink{Id: navtree.NavIDBookmarks},
-				})
-			}
-		}
-	}
-
-	return bookmarksChildNavs
 }
 
 func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navtree.NavLink {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -49,11 +49,9 @@ export const MegaMenu = memo(
             return acc;
           }
           acc.push({
-            ...item,
-            children: undefined,
-            sortWeight: 0,
-            emptyMessageId: '',
-            emptyMessage: '',
+            id: item.id,
+            text: item.text,
+            url: item.url,
             parentItem: { id: 'bookmarks', text: 'Bookmarks' },
           });
           return acc;

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -15,7 +15,7 @@ import { useDispatch, useSelector } from 'app/types';
 
 import { MegaMenuItem } from './MegaMenuItem';
 import { usePinnedItems } from './hooks';
-import { enrichWithInteractionTracking, getActiveItem } from './utils';
+import { enrichWithInteractionTracking, findByUrl, getActiveItem } from './utils';
 
 export const MENU_WIDTH = '300px';
 
@@ -38,6 +38,28 @@ export const MegaMenu = memo(
     const navItems = navTree
       .filter((item) => item.id !== 'profile' && item.id !== 'help')
       .map((item) => enrichWithInteractionTracking(item, state.megaMenuDocked));
+
+    if (config.featureToggles.pinNavItems) {
+      const bookmarksItem = findByUrl(navItems, '/bookmarks');
+      if (bookmarksItem) {
+        // Add children to the bookmarks section
+        bookmarksItem.children = pinnedItems.reduce((acc: NavModelItem[], url) => {
+          const item = findByUrl(navItems, url);
+          if (!item) {
+            return acc;
+          }
+          acc.push({
+            ...item,
+            children: undefined,
+            sortWeight: 0,
+            emptyMessageId: '',
+            emptyMessage: '',
+            parentItem: { id: 'bookmarks', text: 'Bookmarks' },
+          });
+          return acc;
+        }, []);
+      }
+    }
 
     const activeItem = getActiveItem(navItems, state.sectionNav.node, location.pathname);
 

--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -1,7 +1,50 @@
 import { NavModelItem } from '@grafana/data';
 import { ContextSrv, setContextSrv } from 'app/core/services/context_srv';
 
-import { enrichHelpItem, getActiveItem } from './utils';
+import { enrichHelpItem, getActiveItem, findByUrl } from './utils';
+
+const starredDashboardUid = 'foo';
+const mockNavTree: NavModelItem[] = [
+  {
+    text: 'Item',
+    url: '/item',
+    id: 'item',
+  },
+  {
+    text: 'Item with children',
+    url: '/itemWithChildren',
+    id: 'item-with-children',
+    children: [
+      {
+        text: 'Child',
+        url: '/child',
+        id: 'child',
+      },
+    ],
+  },
+  {
+    text: 'Base',
+    url: '/',
+    id: 'home',
+  },
+  {
+    text: 'Starred',
+    url: '/dashboards?starred',
+    id: 'starred',
+    children: [
+      {
+        id: `starred/${starredDashboardUid}`,
+        text: 'Lazy Loading',
+        url: `/d/${starredDashboardUid}/some-name`,
+      },
+    ],
+  },
+  {
+    text: 'Dashboards',
+    url: '/dashboards',
+    id: 'dashboards',
+  },
+];
 
 jest.mock('../../../app_events', () => ({
   publish: jest.fn(),
@@ -45,49 +88,6 @@ describe('enrichConfigItems', () => {
 });
 
 describe('getActiveItem', () => {
-  const starredDashboardUid = 'foo';
-  const mockNavTree: NavModelItem[] = [
-    {
-      text: 'Item',
-      url: '/item',
-      id: 'item',
-    },
-    {
-      text: 'Item with children',
-      url: '/itemWithChildren',
-      id: 'item-with-children',
-      children: [
-        {
-          text: 'Child',
-          url: '/child',
-          id: 'child',
-        },
-      ],
-    },
-    {
-      text: 'Base',
-      url: '/',
-      id: 'home',
-    },
-    {
-      text: 'Starred',
-      url: '/dashboards?starred',
-      id: 'starred',
-      children: [
-        {
-          id: `starred/${starredDashboardUid}`,
-          text: 'Lazy Loading',
-          url: `/d/${starredDashboardUid}/some-name`,
-        },
-      ],
-    },
-    {
-      text: 'Dashboards',
-      url: '/dashboards',
-      id: 'dashboards',
-    },
-  ];
-
   it('returns an exact match at the top level', () => {
     const mockPage: NavModelItem = {
       text: 'Some current page',
@@ -122,5 +122,27 @@ describe('getActiveItem', () => {
       id: 'not-home',
     };
     expect(getActiveItem(mockNavTree, mockPage, '/')?.id).toEqual('home');
+  });
+});
+
+describe('findByUrl', () => {
+  it('returns the correct item at the top level', () => {
+    expect(findByUrl(mockNavTree, '/item')).toEqual({
+      text: 'Item',
+      url: '/item',
+      id: 'item',
+    });
+  });
+
+  it('returns the correct child item', () => {
+    expect(findByUrl(mockNavTree, '/child')).toEqual({
+      text: 'Child',
+      url: '/child',
+      id: 'child',
+    });
+  });
+
+  it('returns null if no item found', () => {
+    expect(findByUrl(mockNavTree, '/no-item')).toBeNull();
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

There is currently a bug where enterprise navigation items cannot be bookmarked, this happens because we build the bookmarks section in the backend, before the enterprise items are added to the tree (see [bug](https://github.com/grafana/grafana/issues/91029) for more info).

This PR moves the logic of building the bookmarked items into the Frontend so that we already have all the navigation information accessible.

**Why do we need this feature?**

So users can also bookmark enterprise navigation items.

**Who is this feature for?**

Enterprise users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #91029

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
