### PR TITLE
Table: Fix edge case where text wrapping crashes on undefined header widths

### DIFF
--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -645,7 +645,7 @@ export function guessTextBoundingBox(
   lineHeight: number,
   defaultRowHeight: number
 ) {
-  const width = Number(headerGroup.width ?? 300);
+  const width = Number(headerGroup?.width ?? 300);
   const LINE_SCALE_FACTOR = 1.17;
   const LOW_LINE_PAD = 42;
 


### PR DESCRIPTION
It's possible under certain circumstances for the header groups provided by `react-table` to be undefined. This causes text wrapping to crash the panel when enabled. This fixes that issue, by checking for undefined values in this case and allows the pre-existing width check to function appropriately.
