### PR TITLE
Correlations: Migrate config type to root

### DIFF
--- a/docs/sources/developers/http_api/correlations.md
+++ b/docs/sources/developers/http_api/correlations.md
@@ -38,8 +38,8 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 	"targetUID": "PDDA8E780A17E7EF1",
 	"label": "My Label",
 	"description": "Logs to Traces",
+  "type": "query",
   "config": {
-    "type": "query",
     "field": "message",
     "target": {},
   }
@@ -65,8 +65,8 @@ Content-Type: application/json
     "sourceUID": "uyBf2637k",
     "targetUID": "PDDA8E780A17E7EF1",
     "uid": "50xhMlg9k",
+    "type": "query",
     "config": {
-      "type": "query",
       "field": "message",
       "target": {},
     }
@@ -153,8 +153,8 @@ Content-Type: application/json
     "sourceUID": "uyBf2637k",
     "targetUID": "PDDA8E780A17E7EF1",
     "uid": "J6gn7d31L",
+    "type": "query",
     "config": {
-			"type": "query",
 			"field": "message",
 			"target": {}
 		}
@@ -197,8 +197,8 @@ Content-Type: application/json
   "targetUID": "PDDA8E780A17E7EF1",
   "uid": "J6gn7d31L",
   "provisioned": false,
+  "type": "query",
   "config": {
-    "type": "query",
     "field": "message",
     "target": {},
   }
@@ -239,8 +239,8 @@ Content-Type: application/json
     "targetUID": "PDDA8E780A17E7EF1",
     "uid": "J6gn7d31L",
     "provisioned": false,
+    "type": "query",
     "config": {
-      "type": "query",
       "field": "message",
       "target": {},
     }
@@ -252,8 +252,8 @@ Content-Type: application/json
     "targetUID": "P15396BDD62B2BE29",
     "uid": "uWCpURgVk",
     "provisioned": false,
+    "type": "query",
     "config": {
-      "type": "query",
       "field": "message",
       "target": {},
     }
@@ -301,8 +301,8 @@ Content-Type: application/json
     "targetUID": "PDDA8E780A17E7EF1",
     "uid": "J6gn7d31L",
     "provisioned": false,
+    "type": "query",
     "config": {
-      "type": "query",
       "field": "message",
       "target": {},
     }
@@ -314,8 +314,8 @@ Content-Type: application/json
     "targetUID": "P15396BDD62B2BE29",
     "uid": "uWCpURgVk",
     "provisioned": false,
+    "type": "query",
     "config": {
-      "type": "query",
       "field": "message",
       "target": {},
     }

--- a/pkg/services/correlations/database.go
+++ b/pkg/services/correlations/database.go
@@ -22,6 +22,7 @@ func (s CorrelationsService) createCorrelation(ctx context.Context, cmd CreateCo
 		Description: cmd.Description,
 		Config:      cmd.Config,
 		Provisioned: cmd.Provisioned,
+		Type:		 cmd.Type,
 	}
 
 	err := s.SQLStore.WithTransactionalDbSession(ctx, func(session *db.Session) error {

--- a/pkg/services/correlations/database.go
+++ b/pkg/services/correlations/database.go
@@ -131,13 +131,13 @@ func (s CorrelationsService) updateCorrelation(ctx context.Context, cmd UpdateCo
 			correlation.Description = *cmd.Description
 			session.MustCols("description")
 		}
+		if cmd.Type != nil {
+			correlation.Type = *cmd.Type
+		}
 		if cmd.Config != nil {
 			session.MustCols("config")
 			if cmd.Config.Field != nil {
 				correlation.Config.Field = *cmd.Config.Field
-			}
-			if cmd.Config.Type != nil {
-				correlation.Config.Type = *cmd.Config.Type
 			}
 			if cmd.Config.Target != nil {
 				correlation.Config.Target = *cmd.Config.Target

--- a/pkg/services/correlations/database.go
+++ b/pkg/services/correlations/database.go
@@ -22,7 +22,7 @@ func (s CorrelationsService) createCorrelation(ctx context.Context, cmd CreateCo
 		Description: cmd.Description,
 		Config:      cmd.Config,
 		Provisioned: cmd.Provisioned,
-		Type:		 cmd.Type,
+		Type:        cmd.Type,
 	}
 
 	err := s.SQLStore.WithTransactionalDbSession(ctx, func(session *db.Session) error {

--- a/pkg/services/correlations/models.go
+++ b/pkg/services/correlations/models.go
@@ -27,7 +27,7 @@ const (
 	QuotaTarget    quota.Target    = "correlations"
 )
 
-type CorrelationConfigType string
+type CorrelationType string
 
 type Transformation struct {
 	//Enum: regex,logfmt
@@ -38,11 +38,11 @@ type Transformation struct {
 }
 
 const (
-	ConfigTypeQuery CorrelationConfigType = "query"
+	TypeQuery CorrelationType = "query"
 )
 
-func (t CorrelationConfigType) Validate() error {
-	if t != ConfigTypeQuery {
+func (t CorrelationType) Validate() error {
+	if t != TypeQuery {
 		return fmt.Errorf("%s: \"%s\"", ErrInvalidConfigType, t)
 	}
 	return nil
@@ -68,8 +68,9 @@ type CorrelationConfig struct {
 	// example: message
 	Field string `json:"field" binding:"Required"`
 	// Target type
-	// required:true
-	Type CorrelationConfigType `json:"type" binding:"Required"`
+	// This is deprecated: use the type property outside of config
+	// deprecated:true
+	Type CorrelationType `json:"type"`
 	// Target data query
 	// required:true
 	// example: {"prop1":"value1","prop2":"value"}
@@ -87,12 +88,10 @@ func (c CorrelationConfig) MarshalJSON() ([]byte, error) {
 		target = map[string]any{}
 	}
 	return json.Marshal(struct {
-		Type            CorrelationConfigType `json:"type"`
 		Field           string                `json:"field"`
 		Target          map[string]any        `json:"target"`
 		Transformations Transformations       `json:"transformations,omitempty"`
 	}{
-		Type:            ConfigTypeQuery,
 		Field:           c.Field,
 		Target:          target,
 		Transformations: transformations,
@@ -124,6 +123,8 @@ type Correlation struct {
 	Config CorrelationConfig `json:"config" xorm:"jsonb config"`
 	// Provisioned True if the correlation was created during provisioning
 	Provisioned bool `json:"provisioned"`
+	// The type of correlation. Currently, only valid value is "query"
+	Type CorrelationType `json:"type" binding:"Required"`
 }
 
 type GetCorrelationsResponseBody struct {
@@ -160,14 +161,16 @@ type CreateCorrelationCommand struct {
 	Config CorrelationConfig `json:"config" binding:"Required"`
 	// True if correlation was created with provisioning. This makes it read-only.
 	Provisioned bool `json:"provisioned"`
+	// correlation type, currently only valid value is "query"
+	Type CorrelationType `json:"type" binding:"Required"`
 }
 
 func (c CreateCorrelationCommand) Validate() error {
 	if err := c.Config.Type.Validate(); err != nil {
 		return err
 	}
-	if c.TargetUID == nil && c.Config.Type == ConfigTypeQuery {
-		return fmt.Errorf("correlations of type \"%s\" must have a targetUID", ConfigTypeQuery)
+	if c.TargetUID == nil && c.Config.Type == TypeQuery {
+		return fmt.Errorf("correlations of type \"%s\" must have a targetUID", TypeQuery)
 	}
 
 	if err := c.Config.Transformations.Validate(); err != nil {
@@ -202,24 +205,12 @@ type CorrelationConfigUpdateDTO struct {
 	// Field used to attach the correlation link
 	// example: message
 	Field *string `json:"field"`
-	// Target type
-	Type *CorrelationConfigType `json:"type"`
 	// Target data query
 	// example: {"prop1":"value1","prop2":"value"}
 	Target *map[string]any `json:"target"`
 	// Source data transformations
 	// example: [{"type": "logfmt"},{"type":"regex","expression":"(Superman|Batman)", "variable":"name"}]
 	Transformations []Transformation `json:"transformations"`
-}
-
-func (c CorrelationConfigUpdateDTO) Validate() error {
-	if c.Type != nil {
-		if err := c.Type.Validate(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // UpdateCorrelationCommand is the command for updating a correlation
@@ -238,16 +229,12 @@ type UpdateCorrelationCommand struct {
 	Description *string `json:"description"`
 	// Correlation Configuration
 	Config *CorrelationConfigUpdateDTO `json:"config"`
+	// correlation type
+	Type *CorrelationType `json:"type"`
 }
 
 func (c UpdateCorrelationCommand) Validate() error {
-	if c.Config != nil {
-		if err := c.Config.Validate(); err != nil {
-			return err
-		}
-	}
-
-	if c.Label == nil && c.Description == nil && (c.Config == nil || (c.Config.Field == nil && c.Config.Type == nil && c.Config.Target == nil)) {
+	if c.Label == nil && c.Description == nil && c.Type == nil && (c.Config == nil || (c.Config.Field == nil && c.Config.Target == nil)) {
 		return ErrUpdateCorrelationEmptyParams
 	}
 

--- a/pkg/services/correlations/models.go
+++ b/pkg/services/correlations/models.go
@@ -166,7 +166,7 @@ type CreateCorrelationCommand struct {
 }
 
 func (c CreateCorrelationCommand) Validate() error {
-	if err := c.Config.Type.Validate(); err != nil {
+	if err := c.Type.Validate(); err != nil {
 		return err
 	}
 	if c.TargetUID == nil && c.Config.Type == TypeQuery {

--- a/pkg/services/correlations/models.go
+++ b/pkg/services/correlations/models.go
@@ -88,9 +88,9 @@ func (c CorrelationConfig) MarshalJSON() ([]byte, error) {
 		target = map[string]any{}
 	}
 	return json.Marshal(struct {
-		Field           string                `json:"field"`
-		Target          map[string]any        `json:"target"`
-		Transformations Transformations       `json:"transformations,omitempty"`
+		Field           string          `json:"field"`
+		Target          map[string]any  `json:"target"`
+		Transformations Transformations `json:"transformations,omitempty"`
 	}{
 		Field:           c.Field,
 		Target:          target,

--- a/pkg/services/correlations/models.go
+++ b/pkg/services/correlations/models.go
@@ -148,7 +148,7 @@ type CreateCorrelationCommand struct {
 	// UID of the data source for which correlation is created.
 	SourceUID string `json:"-"`
 	OrgId     int64  `json:"-"`
-	// Target data source UID to which the correlation is created. required if config.type = query
+	// Target data source UID to which the correlation is created. required if type = query
 	// example: PE1C5CBDA0504A6A3
 	TargetUID *string `json:"targetUID"`
 	// Optional label identifying the correlation
@@ -169,7 +169,7 @@ func (c CreateCorrelationCommand) Validate() error {
 	if err := c.Type.Validate(); err != nil {
 		return err
 	}
-	if c.TargetUID == nil && c.Config.Type == TypeQuery {
+	if c.TargetUID == nil && c.Type == TypeQuery {
 		return fmt.Errorf("correlations of type \"%s\" must have a targetUID", TypeQuery)
 	}
 

--- a/pkg/services/correlations/models_test.go
+++ b/pkg/services/correlations/models_test.go
@@ -79,13 +79,12 @@ func TestCorrelationModels(t *testing.T) {
 		t.Run("Applies a default empty object if target is not defined", func(t *testing.T) {
 			config := CorrelationConfig{
 				Field: "field",
-				Type:  TypeQuery,
 			}
 
 			data, err := json.Marshal(config)
 			require.NoError(t, err)
 
-			require.Equal(t, `{"type":"query","field":"field","target":{}}`, string(data))
+			require.Equal(t, `{"field":"field","target":{}}`, string(data))
 		})
 	})
 }

--- a/pkg/services/correlations/models_test.go
+++ b/pkg/services/correlations/models_test.go
@@ -14,13 +14,13 @@ func TestCorrelationModels(t *testing.T) {
 			config := &CorrelationConfig{
 				Field:  "field",
 				Target: map[string]any{},
-				Type:   ConfigTypeQuery,
 			}
 			cmd := &CreateCorrelationCommand{
 				SourceUID: "some-uid",
 				OrgId:     1,
 				TargetUID: &targetUid,
 				Config:    *config,
+				Type:		TypeQuery,
 			}
 
 			require.NoError(t, cmd.Validate())
@@ -30,7 +30,7 @@ func TestCorrelationModels(t *testing.T) {
 			config := &CorrelationConfig{
 				Field:  "field",
 				Target: map[string]any{},
-				Type:   ConfigTypeQuery,
+				Type:   TypeQuery,
 			}
 			cmd := &CreateCorrelationCommand{
 				SourceUID: "some-uid",
@@ -60,7 +60,7 @@ func TestCorrelationModels(t *testing.T) {
 	t.Run("CorrelationConfigType Validate", func(t *testing.T) {
 		t.Run("Successfully validates a correct type", func(t *testing.T) {
 			type test struct {
-				input     CorrelationConfigType
+				input     CorrelationType
 				assertion require.ErrorAssertionFunc
 			}
 
@@ -79,7 +79,7 @@ func TestCorrelationModels(t *testing.T) {
 		t.Run("Applies a default empty object if target is not defined", func(t *testing.T) {
 			config := CorrelationConfig{
 				Field: "field",
-				Type:  ConfigTypeQuery,
+				Type:  TypeQuery,
 			}
 
 			data, err := json.Marshal(config)

--- a/pkg/services/correlations/models_test.go
+++ b/pkg/services/correlations/models_test.go
@@ -20,7 +20,7 @@ func TestCorrelationModels(t *testing.T) {
 				OrgId:     1,
 				TargetUID: &targetUid,
 				Config:    *config,
-				Type:		TypeQuery,
+				Type:      TypeQuery,
 			}
 
 			require.NoError(t, cmd.Validate())

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -195,7 +195,7 @@ func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, 
 	// we look for a correlation type at the root if it is defined, if not use default
 	// we ignore the legacy config.type value - the only valid value at that version was "query"
 	var corrType = correlation["type"]
-	if (corrType == nil || corrType == "") {
+	if corrType == nil || corrType == "" {
 		corrType = correlations.TypeQuery
 	}
 
@@ -206,7 +206,7 @@ func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, 
 		Description: correlation["description"].(string),
 		OrgId:       OrgId,
 		Provisioned: true,
-		Type: corrType.(correlations.CorrelationType),
+		Type:        corrType.(correlations.CorrelationType),
 	}
 
 	targetUID, ok := correlation["targetUID"].(string)
@@ -230,7 +230,7 @@ func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, 
 		}
 
 		createCommand.Config = config
-	} 
+	}
 	if err := createCommand.Validate(); err != nil {
 		return correlations.CreateCorrelationCommand{}, err
 	}

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -199,6 +199,7 @@ func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, 
 		Description: correlation["description"].(string),
 		OrgId:       OrgId,
 		Provisioned: true,
+		Type: correlation["type"].(correlations.CorrelationType) ,
 	}
 
 	targetUID, ok := correlation["targetUID"].(string)
@@ -221,13 +222,15 @@ func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, 
 			return correlations.CreateCorrelationCommand{}, err
 		}
 
-		createCommand.Config = config
-	} else {
-		// when provisioning correlations without config we default to type="query"
-		createCommand.Config = correlations.CorrelationConfig{
-			Type: correlations.ConfigTypeQuery,
+		if (correlation["type"] == nil && config.Type != nil) {
+			createCommand.Type = config.Type
+		} else if (correlation["type"] == nil && config.Type == nil) {
+						createCommand.Type = correlations.TypeQuery
 		}
-	}
+
+
+		createCommand.Config = config
+	} 
 	if err := createCommand.Validate(); err != nil {
 		return correlations.CreateCorrelationCommand{}, err
 	}

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -192,6 +192,8 @@ func (dc *DatasourceProvisioner) applyChanges(ctx context.Context, configPath st
 }
 
 func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, OrgId int64) (correlations.CreateCorrelationCommand, error) {
+	// we look for a correlation type at the root if it is defined, if not use default
+	// we ignore the legacy config.type value - the only valid value at that version was "query"
 	var corrType = correlation["type"]
 	if (corrType == nil || corrType == "") {
 		corrType = correlations.TypeQuery
@@ -225,13 +227,6 @@ func makeCreateCorrelationCommand(correlation map[string]any, SourceUID string, 
 		config := correlations.CorrelationConfig{}
 		if err := json.Unmarshal(jsonbody, &config); err != nil {
 			return correlations.CreateCorrelationCommand{}, err
-		}
-
-		// if type is not defined at root but is defined in the config, use that
-		if (correlation["type"] == nil && config.Type == correlations.TypeQuery) {
-			createCommand.Type = config.Type
-		} else if (correlation["type"] == nil && config.Type != correlations.TypeQuery) { // if it is not defined in either, use default
-			createCommand.Type = correlations.TypeQuery
 		}
 
 		createCommand.Config = config

--- a/pkg/services/sqlstore/migrations/correlations_mig.go
+++ b/pkg/services/sqlstore/migrations/correlations_mig.go
@@ -64,6 +64,6 @@ func addCorrelationsMigrations(mg *Migrator) {
 	}))
 
 	mg.AddMigration("add type column", NewAddColumnMigration(correlationsV2, &Column{
-		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: true,
+		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: false, Default: "`query`",
 	}))
 }

--- a/pkg/services/sqlstore/migrations/correlations_mig.go
+++ b/pkg/services/sqlstore/migrations/correlations_mig.go
@@ -38,7 +38,6 @@ func addCorrelationsMigrations(mg *Migrator) {
 			// All existing records will have '0' assigned
 			{Name: "org_id", Type: DB_BigInt, IsPrimaryKey: true, Default: "0"},
 			{Name: "source_uid", Type: DB_NVarchar, Length: 40, Nullable: false, IsPrimaryKey: true},
-			// Nullable because in the future we want to have correlations to external resources
 			{Name: "target_uid", Type: DB_NVarchar, Length: 40, Nullable: true},
 			{Name: "label", Type: DB_Text, Nullable: false},
 			{Name: "description", Type: DB_Text, Nullable: false},
@@ -62,5 +61,9 @@ func addCorrelationsMigrations(mg *Migrator) {
 
 	mg.AddMigration("add provisioning column", NewAddColumnMigration(correlationsV2, &Column{
 		Name: "provisioned", Type: DB_Bool, Nullable: false, Default: "0",
+	}))
+
+	mg.AddMigration("add type column", NewAddColumnMigration(correlationsV2, &Column{
+		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: false, Default: "query",
 	}))
 }

--- a/pkg/services/sqlstore/migrations/correlations_mig.go
+++ b/pkg/services/sqlstore/migrations/correlations_mig.go
@@ -64,6 +64,6 @@ func addCorrelationsMigrations(mg *Migrator) {
 	}))
 
 	mg.AddMigration("add type column", NewAddColumnMigration(correlationsV2, &Column{
-		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: false, Default: "query",
+		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: true,
 	}))
 }

--- a/pkg/services/sqlstore/migrations/correlations_mig.go
+++ b/pkg/services/sqlstore/migrations/correlations_mig.go
@@ -64,6 +64,6 @@ func addCorrelationsMigrations(mg *Migrator) {
 	}))
 
 	mg.AddMigration("add type column", NewAddColumnMigration(correlationsV2, &Column{
-		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: false, Default: "`query`",
+		Name: "type", Type: DB_NVarchar, Length: 40, Nullable: false, Default: "'query'",
 	}))
 }

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -163,7 +163,7 @@ func (b *BaseDialect) Default(col *Column) string {
 		}
 		return b.dialect.BooleanStr(bl)
 	}
-	return col.Default
+	return b.dialect.Quote(col.Default)
 }
 
 func (b *BaseDialect) DateTimeFunc(value string) string {

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -163,7 +163,6 @@ func (b *BaseDialect) Default(col *Column) string {
 		}
 		return b.dialect.BooleanStr(bl)
 	}
-
 	return col.Default
 }
 

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -164,12 +164,7 @@ func (b *BaseDialect) Default(col *Column) string {
 		return b.dialect.BooleanStr(bl)
 	}
 
-	// if default is a number, do not quote. Otherwise add quotes to escape reserved words
-	if _, err := strconv.Atoi(col.Default); err == nil {
-		return col.Default
-	} else {
-		return b.dialect.Quote(col.Default)
-	}
+	return col.Default
 }
 
 func (b *BaseDialect) DateTimeFunc(value string) string {

--- a/pkg/services/sqlstore/migrator/dialect.go
+++ b/pkg/services/sqlstore/migrator/dialect.go
@@ -163,7 +163,13 @@ func (b *BaseDialect) Default(col *Column) string {
 		}
 		return b.dialect.BooleanStr(bl)
 	}
-	return b.dialect.Quote(col.Default)
+
+	// if default is a number, do not quote. Otherwise add quotes to escape reserved words
+	if _, err := strconv.Atoi(col.Default); err == nil {
+		return col.Default
+	} else {
+		return b.dialect.Quote(col.Default)
+	}
 }
 
 func (b *BaseDialect) DateTimeFunc(value string) string {

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -238,7 +238,7 @@ func (mg *Migrator) run() (err error) {
 			return err
 		})
 		if err != nil {
-			return fmt.Errorf("%v: %w", fmt.Sprintf("migration failed (id = %s)", m.Id()), err)
+			return fmt.Errorf("%v: %w %s", fmt.Sprintf("migration failed (id = %s)", m.Id()), err, sql)
 		}
 	}
 

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -238,7 +238,7 @@ func (mg *Migrator) run() (err error) {
 			return err
 		})
 		if err != nil {
-			return fmt.Errorf("%v: %w %s", fmt.Sprintf("migration failed (id = %s)", m.Id()), err, sql)
+			return fmt.Errorf("%v: %w", fmt.Sprintf("migration failed (id = %s)", m.Id()), err)
 		}
 	}
 

--- a/pkg/services/stats/statsimpl/stats_test.go
+++ b/pkg/services/stats/statsimpl/stats_test.go
@@ -104,7 +104,7 @@ func populateDB(t *testing.T, db db.DB, cfg *setting.Cfg) {
 			Config: correlations.CorrelationConfig{
 				Field:  "field",
 				Target: map[string]any{},
-				Type:   correlations.ConfigTypeQuery,
+				Type:   correlations.TypeQuery,
 			},
 		}
 		correlation, err := correlationsSvc.CreateCorrelation(context.Background(), cmd)

--- a/pkg/tests/api/correlations/correlations_create_test.go
+++ b/pkg/tests/api/correlations/correlations_create_test.go
@@ -115,8 +115,8 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 			url: fmt.Sprintf("/api/datasources/uid/%s/correlations", "nonexistent-ds-uid"),
 			body: fmt.Sprintf(`{
 					"targetUID": "%s",
+					"type": "query",
 					"config": {
-						"type": "query",
 						"field": "message",
 						"target": {}
 					}
@@ -142,8 +142,8 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 			url: fmt.Sprintf("/api/datasources/uid/%s/correlations", writableDs),
 			body: `{
 					"targetUID": "nonexistent-uid-uid",
+					"type": "query",
 					"config": {
-						"type": "query",
 						"field": "message",
 						"target": {}
 					}
@@ -169,8 +169,8 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 			url: fmt.Sprintf("/api/datasources/uid/%s/correlations", readOnlyDS),
 			body: fmt.Sprintf(`{
 					"targetUID": "%s",
+					"type": "query",
 					"config": {
-						"type": "query",
 						"field": "message",
 						"target": {}
 					}
@@ -200,8 +200,8 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 			url: fmt.Sprintf("/api/datasources/uid/%s/correlations", writableDs),
 			body: fmt.Sprintf(`{
 					"targetUID": "%s",
+					"type": "query",
 					"config": {
-						"type": "query",
 						"field": "message",
 						"target": {}
 					}
@@ -230,7 +230,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 		description := "a description"
 		label := "a label"
 		fieldName := "fieldName"
-		configType := correlations.ConfigTypeQuery
+		corrType := correlations.TypeQuery
 		transformation := correlations.Transformation{Type: "logfmt"}
 		transformation2 := correlations.Transformation{Type: "regex", Expression: "testExpression", MapValue: "testVar"}
 		res := ctx.Post(PostParams{
@@ -239,8 +239,8 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 					"targetUID": "%s",
 					"description": "%s",
 					"label": "%s",
+					"type": "%s",
 					"config": {
-						"type": "%s",
 						"field": "%s",
 						"target": { "expr": "foo" },
 						"transformations": [
@@ -248,7 +248,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 							{"type": "regex", "expression": "testExpression", "mapValue": "testVar"}
 						]
 					}
-				}`, writableDs, description, label, configType, fieldName),
+				}`, writableDs, description, label, corrType, fieldName),
 			user: adminUser,
 		})
 		require.Equal(t, http.StatusOK, res.StatusCode)
@@ -265,7 +265,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 		require.Equal(t, writableDs, *response.Result.TargetUID)
 		require.Equal(t, description, response.Result.Description)
 		require.Equal(t, label, response.Result.Label)
-		require.Equal(t, configType, response.Result.Config.Type)
+		require.Equal(t, corrType, response.Result.Config.Type)
 		require.Equal(t, fieldName, response.Result.Config.Field)
 		require.Equal(t, map[string]any{"expr": "foo"}, response.Result.Config.Target)
 		require.Equal(t, transformation, response.Result.Config.Transformations[0])

--- a/pkg/tests/api/correlations/correlations_create_test.go
+++ b/pkg/tests/api/correlations/correlations_create_test.go
@@ -265,7 +265,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 		require.Equal(t, writableDs, *response.Result.TargetUID)
 		require.Equal(t, description, response.Result.Description)
 		require.Equal(t, label, response.Result.Label)
-		require.Equal(t, corrType, response.Result.Config.Type)
+		require.Equal(t, corrType, response.Result.Type)
 		require.Equal(t, fieldName, response.Result.Config.Field)
 		require.Equal(t, map[string]any{"expr": "foo"}, response.Result.Config.Target)
 		require.Equal(t, transformation, response.Result.Config.Transformations[0])

--- a/pkg/tests/api/correlations/correlations_create_test.go
+++ b/pkg/tests/api/correlations/correlations_create_test.go
@@ -137,7 +137,7 @@ func TestIntegrationCreateCorrelation(t *testing.T) {
 		require.NoError(t, res.Body.Close())
 	})
 
-	t.Run("inexistent target data source should result in a 404 if config.type=query", func(t *testing.T) {
+	t.Run("inexistent target data source should result in a 404 if type=query", func(t *testing.T) {
 		res := ctx.Post(PostParams{
 			url: fmt.Sprintf("/api/datasources/uid/%s/correlations", writableDs),
 			body: `{

--- a/pkg/tests/api/correlations/correlations_provisioning_api_test.go
+++ b/pkg/tests/api/correlations/correlations_provisioning_api_test.go
@@ -39,7 +39,7 @@ func TestIntegrationCreateOrUpdateCorrelation(t *testing.T) {
 		OrgId:     dataSource.OrgID,
 		Label:     "needs migration",
 		Config: correlations.CorrelationConfig{
-			Type:   correlations.ConfigTypeQuery,
+			Type:   correlations.TypeQuery,
 			Field:  "foo",
 			Target: map[string]any{},
 			Transformations: []correlations.Transformation{
@@ -55,7 +55,7 @@ func TestIntegrationCreateOrUpdateCorrelation(t *testing.T) {
 		OrgId:     dataSource.OrgID,
 		Label:     "existing",
 		Config: correlations.CorrelationConfig{
-			Type:   correlations.ConfigTypeQuery,
+			Type:   correlations.TypeQuery,
 			Field:  "foo",
 			Target: map[string]any{},
 			Transformations: []correlations.Transformation{

--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -78,7 +78,7 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 		TargetUID: &dsWithCorrelations.UID,
 		OrgId:     dsWithCorrelations.OrgID,
 		Config: correlations.CorrelationConfig{
-			Type:   correlations.ConfigTypeQuery,
+			Type:   correlations.TypeQuery,
 			Field:  "foo",
 			Target: map[string]any{},
 			Transformations: []correlations.Transformation{

--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -77,7 +77,7 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 		SourceUID: dsWithCorrelations.UID,
 		TargetUID: &dsWithCorrelations.UID,
 		OrgId:     dsWithCorrelations.OrgID,
-		Type:   correlations.TypeQuery,
+		Type:      correlations.TypeQuery,
 		Config: correlations.CorrelationConfig{
 			Field:  "foo",
 			Target: map[string]any{},

--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -77,8 +77,8 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 		SourceUID: dsWithCorrelations.UID,
 		TargetUID: &dsWithCorrelations.UID,
 		OrgId:     dsWithCorrelations.OrgID,
+		Type:   correlations.TypeQuery,
 		Config: correlations.CorrelationConfig{
-			Type:   correlations.TypeQuery,
 			Field:  "foo",
 			Target: map[string]any{},
 			Transformations: []correlations.Transformation{

--- a/pkg/tests/api/correlations/correlations_update_test.go
+++ b/pkg/tests/api/correlations/correlations_update_test.go
@@ -263,9 +263,9 @@ func TestIntegrationUpdateCorrelation(t *testing.T) {
 			body: `{
 				"label": "1",
 				"description": "1",
+				"type": "query",
 				"config": {
 					"field": "field",
-					"type": "query",
 					"target": { "expr": "bar" },
 					"transformations": [ {"type": "logfmt"} ]
 				}

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -3330,14 +3330,8 @@
         },
         "transformations": {
           "$ref": "#/definitions/Transformations"
-        },
-        "type": {
-          "$ref": "#/definitions/CorrelationConfigType"
         }
       }
-    },
-    "CorrelationConfigType": {
-      "type": "string"
     },
     "CorrelationConfigUpdateDTO": {
       "type": "object",
@@ -3372,9 +3366,6 @@
               "variable": "name"
             }
           ]
-        },
-        "type": {
-          "$ref": "#/definitions/CorrelationConfigType"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13878,9 +13878,6 @@
         }
       }
     },
-    "CorrelationConfigType": {
-      "type": "string"
-    },
     "CorrelationConfigUpdateDTO": {
       "type": "object",
       "properties": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -13839,6 +13839,9 @@
           "type": "string",
           "example": "PE1C5CBDA0504A6A3"
         },
+        "type": {
+          "$ref": "#/definitions/CorrelationType"
+        },
         "uid": {
           "description": "Unique identifier of the correlation",
           "type": "string",
@@ -13850,7 +13853,6 @@
       "type": "object",
       "required": [
         "field",
-        "type",
         "target"
       ],
       "properties": {
@@ -13872,7 +13874,7 @@
           "$ref": "#/definitions/Transformations"
         },
         "type": {
-          "$ref": "#/definitions/CorrelationConfigType"
+          "$ref": "#/definitions/CorrelationType"
         }
       }
     },
@@ -13912,11 +13914,11 @@
               "variable": "name"
             }
           ]
-        },
-        "type": {
-          "$ref": "#/definitions/CorrelationConfigType"
         }
       }
+    },
+    "CorrelationType": {
+      "type": "string"
     },
     "CounterResetHint": {
       "description": "or alternatively that we are dealing with a gauge histogram, where counter resets do not apply.",
@@ -13954,9 +13956,12 @@
           "type": "boolean"
         },
         "targetUID": {
-          "description": "Target data source UID to which the correlation is created. required if config.type = query",
+          "description": "Target data source UID to which the correlation is created. required if type = query",
           "type": "string",
           "example": "PE1C5CBDA0504A6A3"
+        },
+        "type": {
+          "$ref": "#/definitions/CorrelationType"
         }
       }
     },
@@ -21419,6 +21424,9 @@
           "description": "Optional label identifying the correlation",
           "type": "string",
           "example": "My label"
+        },
+        "type": {
+          "$ref": "#/definitions/CorrelationType"
         }
       }
     },

--- a/public/app/features/correlations/CorrelationsPage.test.tsx
+++ b/public/app/features/correlations/CorrelationsPage.test.tsx
@@ -361,10 +361,10 @@ describe('CorrelationsPage', () => {
             uid: '1',
             label: 'Some label',
             provisioned: false,
+            type: 'query',
             config: {
               field: 'line',
               target: {},
-              type: 'query',
               transformations: [
                 { type: SupportedTransformationType.Regex, expression: 'url=http[s]?://(S*)', mapValue: 'path' },
               ],
@@ -375,7 +375,8 @@ describe('CorrelationsPage', () => {
             targetUID: 'loki',
             uid: '2',
             label: 'Prometheus to Loki',
-            config: { field: 'label', target: {}, type: 'query' },
+            type: 'query',
+            config: { field: 'label', target: {} },
             provisioned: false,
           },
         ]
@@ -598,10 +599,10 @@ describe('CorrelationsPage', () => {
             uid: '1',
             label: 'Loki to Loki',
             provisioned: false,
+            type: 'query',
             config: {
               field: 'line',
               target: {},
-              type: 'query',
               transformations: [
                 { type: SupportedTransformationType.Regex, expression: 'url=http[s]?://(S*)', mapValue: 'path' },
               ],
@@ -613,10 +614,10 @@ describe('CorrelationsPage', () => {
             uid: '2',
             label: 'Loki to Prometheus',
             provisioned: false,
+            type: 'query',
             config: {
               field: 'line',
               target: {},
-              type: 'query',
               transformations: [
                 { type: SupportedTransformationType.Regex, expression: 'url=http[s]?://(S*)', mapValue: 'path' },
               ],
@@ -627,7 +628,8 @@ describe('CorrelationsPage', () => {
             targetUID: 'loki',
             uid: '3',
             label: 'Prometheus to Loki',
-            config: { field: 'label', target: {}, type: 'query' },
+            type: 'query',
+            config: { field: 'label', target: {} },
             provisioned: false,
           },
           {
@@ -635,7 +637,8 @@ describe('CorrelationsPage', () => {
             targetUID: 'prometheus',
             uid: '4',
             label: 'Prometheus to Prometheus',
-            config: { field: 'label', target: {}, type: 'query' },
+            type: 'query',
+            config: { field: 'label', target: {} },
             provisioned: false,
           },
         ]
@@ -660,10 +663,10 @@ describe('CorrelationsPage', () => {
         uid: '1',
         label: 'Some label',
         provisioned: true,
+        type: 'query',
         config: {
           field: 'line',
           target: {},
-          type: 'query',
           transformations: [{ type: SupportedTransformationType.Regex, expression: '(?:msg)=' }],
         },
       },

--- a/public/app/features/correlations/Forms/AddCorrelationForm.tsx
+++ b/public/app/features/correlations/Forms/AddCorrelationForm.tsx
@@ -44,7 +44,7 @@ export const AddCorrelationForm = ({ onClose, onCreated }: Props) => {
     }
   }, [error, loading, value, onCreated]);
 
-  const defaultValues: Partial<FormDTO> = { config: { type: 'query', target: {}, field: '' } };
+  const defaultValues: Partial<FormDTO> = { type: 'query', config: { target: {}, field: '' } };
 
   return (
     <PanelContainer className={styles.panelContainer}>

--- a/public/app/features/correlations/Forms/ConfigureCorrelationBasicInfoForm.tsx
+++ b/public/app/features/correlations/Forms/ConfigureCorrelationBasicInfoForm.tsx
@@ -29,7 +29,7 @@ export const ConfigureCorrelationBasicInfoForm = () => {
         <Trans i18nKey="correlations.basic-info-form.sub-text">
           <p>Define text that will describe the correlation.</p>
         </Trans>
-        <input type="hidden" {...register('config.type')} />
+        <input type="hidden" {...register('type')} />
         <Field
           label={t('correlations.basic-info-form.label-label', 'Label')}
           description={t(

--- a/public/app/features/correlations/Forms/types.ts
+++ b/public/app/features/correlations/Forms/types.ts
@@ -1,13 +1,14 @@
 import { SupportedTransformationType } from '@grafana/data';
 import { t } from 'app/core/internationalization';
 
-import { CorrelationConfig } from '../types';
+import { CorrelationConfig, CorrelationType } from '../types';
 
 export interface FormDTO {
   sourceUID: string;
   targetUID: string;
   label: string;
   description: string;
+  type: CorrelationType;
   config: CorrelationConfig;
 }
 

--- a/public/app/features/correlations/types.ts
+++ b/public/app/features/correlations/types.ts
@@ -26,12 +26,11 @@ export interface RemoveCorrelationResponse {
   message: string;
 }
 
-type CorrelationConfigType = 'query';
+export type CorrelationType = 'query';
 
 export interface CorrelationConfig {
   field: string;
   target: object; // this contains anything that would go in the query editor, so any extension off DataQuery a datasource would have, and needs to be generic
-  type: CorrelationConfigType;
   transformations?: DataLinkTransformationConfig[];
 }
 
@@ -44,6 +43,7 @@ export interface Correlation {
   provisioned: boolean;
   orgId?: number;
   config: CorrelationConfig;
+  type: CorrelationType;
 }
 
 export type GetCorrelationsParams = {

--- a/public/app/features/correlations/utils.test.ts
+++ b/public/app/features/correlations/utils.test.ts
@@ -111,7 +111,8 @@ function setup() {
       label: 'logs to metrics',
       source: loki,
       target: prometheus,
-      config: { type: 'query', field: 'traceId', target: { expr: 'target Prometheus query' } },
+      type: 'query',
+      config: { field: 'traceId', target: { expr: 'target Prometheus query' } },
       provisioned: false,
     },
     // Test multiple correlations attached to the same field
@@ -120,7 +121,8 @@ function setup() {
       label: 'logs to logs',
       source: loki,
       target: elastic,
-      config: { type: 'query', field: 'traceId', target: { expr: 'target Elastic query' } },
+      type: 'query',
+      config: { field: 'traceId', target: { expr: 'target Elastic query' } },
       provisioned: false,
     },
     {
@@ -128,7 +130,8 @@ function setup() {
       label: 'metrics to logs',
       source: prometheus,
       target: elastic,
-      config: { type: 'query', field: 'value', target: { expr: 'target Elastic query' } },
+      type: 'query',
+      config: { field: 'value', target: { expr: 'target Elastic query' } },
       provisioned: false,
     },
   ];

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -81,10 +81,10 @@ export function saveCurrentCorrelation(
         targetUID: targetDatasource.uid,
         label: label || (await generateDefaultLabel(sourcePane, targetPane)),
         description,
+        type: 'query',
         config: {
           field: targetPane.correlationEditorHelperData.resultField,
           target: targetPane.queries[0],
-          type: 'query',
           transformations: transformations,
         },
       };

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3938,9 +3938,6 @@
         ],
         "type": "object"
       },
-      "CorrelationConfigType": {
-        "type": "string"
-      },
       "CorrelationConfigUpdateDTO": {
         "properties": {
           "field": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -3898,6 +3898,9 @@
             "example": "PE1C5CBDA0504A6A3",
             "type": "string"
           },
+          "type": {
+            "$ref": "#/components/schemas/CorrelationType"
+          },
           "uid": {
             "description": "Unique identifier of the correlation",
             "example": "50xhMlg9k",
@@ -3926,12 +3929,11 @@
             "$ref": "#/components/schemas/Transformations"
           },
           "type": {
-            "$ref": "#/components/schemas/CorrelationConfigType"
+            "$ref": "#/components/schemas/CorrelationType"
           }
         },
         "required": [
           "field",
-          "type",
           "target"
         ],
         "type": "object"
@@ -3971,12 +3973,12 @@
               "$ref": "#/components/schemas/Transformation"
             },
             "type": "array"
-          },
-          "type": {
-            "$ref": "#/components/schemas/CorrelationConfigType"
           }
         },
         "type": "object"
+      },
+      "CorrelationType": {
+        "type": "string"
       },
       "CounterResetHint": {
         "description": "or alternatively that we are dealing with a gauge histogram, where counter resets do not apply.",
@@ -4013,9 +4015,12 @@
             "type": "boolean"
           },
           "targetUID": {
-            "description": "Target data source UID to which the correlation is created. required if config.type = query",
+            "description": "Target data source UID to which the correlation is created. required if type = query",
             "example": "PE1C5CBDA0504A6A3",
             "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CorrelationType"
           }
         },
         "type": "object"
@@ -11477,6 +11482,9 @@
             "description": "Optional label identifying the correlation",
             "example": "My label",
             "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CorrelationType"
           }
         },
         "type": "object"


### PR DESCRIPTION
**What is this feature?**

In doing #89844, we recognized the need to do filtering at the SQL level to support a new scenario - when the correlation type is `external`, there will not be a target datasource. This is a valid correlation that should display.

The target datasource when the correlation type is `query` can be missing for various reasons that make the correlation invalid - such as the user not having permissions to the target datasource, or the target datasource no longer existing. In that case, the correlation should not display.

The correlation type is where the logic branches. However, we put this value in the `config` column of correlations, where it is stored with other values in JSON. It is not a simple matter to extract it while keeping support for various database dialects, so we are deprecating the value from the JSON and moving it to its own column, which will be in the main Correlations object.

The `external` type will be future work, so we are not putting anything in this PR for that. The only valid type is `query`, which is why we can just assume at this point that if the type is not defined in the root, it is `query`.

**Which issue(s) does this PR fix?**:

Fixes #91643 

**Special notes for your reviewer:**

Tested by creating a correlation in both editors and verifying it works. Cleared out the correlations table and created new from provisioning works as well.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
