### PR TITLE
Alerting: Update Time Interval service to support renaming of resources

### DIFF
--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -10,6 +10,10 @@ const (
 	ProvenanceFile Provenance = "file"
 )
 
+var (
+	KnownProvenances = []Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile}
+)
+
 // Provisionable represents a resource that can be created through a provisioning mechanism, such as Terraform or config file.
 type Provisionable interface {
 	ResourceType() string

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -11,7 +11,7 @@ const (
 )
 
 var (
-	KnownProvenances = []Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile}
+	KnownProvenances = [...]Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile}
 )
 
 // Provisionable represents a resource that can be created through a provisioning mechanism, such as Terraform or config file.

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -11,7 +11,7 @@ const (
 )
 
 var (
-	KnownProvenances = [...]Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile}
+	KnownProvenances = []Provenance{ProvenanceNone, ProvenanceAPI, ProvenanceFile}
 )
 
 // Provisionable represents a resource that can be created through a provisioning mechanism, such as Terraform or config file.

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -25,6 +25,7 @@ import (
 
 type AlertRuleNotificationSettingsStore interface {
 	RenameReceiverInNotificationSettings(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
+	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error)
 	ListNotificationSettings(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -25,7 +25,7 @@ import (
 
 type AlertRuleNotificationSettingsStore interface {
 	RenameReceiverInNotificationSettings(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
+	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
 	ListNotificationSettings(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -25,7 +25,7 @@ import (
 
 type AlertRuleNotificationSettingsStore interface {
 	RenameReceiverInNotificationSettings(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error)
+	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
 	ListNotificationSettings(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -25,7 +25,7 @@ import (
 
 type AlertRuleNotificationSettingsStore interface {
 	RenameReceiverInNotificationSettings(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
+	RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, validateProvenance func(models.Provenance) bool, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
 	ListNotificationSettings(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -14,10 +14,10 @@ var ErrNotFound = fmt.Errorf("object not found")
 var (
 	ErrVersionConflict = errutil.Conflict("alerting.notifications.conflict")
 
-	ErrTimeIntervalNotFound = errutil.NotFound("alerting.notifications.time-intervals.notFound")
-	ErrTimeIntervalExists   = errutil.BadRequest("alerting.notifications.time-intervals.nameExists", errutil.WithPublicMessage("Time interval with this name already exists. Use a different name or update existing one."))
-	ErrTimeIntervalInvalid  = errutil.BadRequest("alerting.notifications.time-intervals.invalidFormat").MustTemplate("Invalid format of the submitted time interval", errutil.WithPublic("Time interval is in invalid format. Correct the payload and try again."))
-	ErrTimeIntervalInUse    = errutil.Conflict("alerting.notifications.time-intervals.used").MustTemplate("Time interval is used")
+	ErrTimeIntervalNotFound                     = errutil.NotFound("alerting.notifications.time-intervals.notFound")
+	ErrTimeIntervalExists                       = errutil.BadRequest("alerting.notifications.time-intervals.nameExists", errutil.WithPublicMessage("Time interval with this name already exists. Use a different name or update existing one."))
+	ErrTimeIntervalInvalid                      = errutil.BadRequest("alerting.notifications.time-intervals.invalidFormat").MustTemplate("Invalid format of the submitted time interval", errutil.WithPublic("Time interval is in invalid format. Correct the payload and try again."))
+	ErrTimeIntervalInUse                        = errutil.Conflict("alerting.notifications.time-intervals.used").MustTemplate("Time interval is used")
 	ErrTimeIntervalDependentResourcesProvenance = errutil.Conflict("alerting.notifications.time-intervals.usedProvisioned").MustTemplate(
 		"Time interval cannot be renamed because it is used by a provisioned {{.Private.Resource}}",
 		errutil.WithPublic("Time interval cannot be renamed because it is used by a provisioned {{.Private.Resource}}. You must update those resources first using the original provision method"),
@@ -73,12 +73,10 @@ func MakeErrTemplateInvalid(err error) error {
 	return ErrTemplateInvalid.Build(data)
 }
 
-func MakeErrTimeIntervalDependentResourcesProvenance(usedByRoutes bool, rules map[models.Provenance][]models.AlertRuleKey) error {
+func MakeErrTimeIntervalDependentResourcesProvenance(usedByRoutes bool, rules []models.AlertRuleKey) error {
 	uids := make([]string, 0, len(rules))
-	for _, keys := range rules {
-		for _, key := range keys {
-			uids = append(uids, key.UID)
-		}
+	for _, key := range rules {
+		uids = append(uids, key.UID)
 	}
 	data := make(map[string]any, 2)
 	resource := make([]string, 0, 2)

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -20,7 +20,7 @@ var (
 	ErrTimeIntervalInUse                        = errutil.Conflict("alerting.notifications.time-intervals.used").MustTemplate("Time interval is used")
 	ErrTimeIntervalDependentResourcesProvenance = errutil.Conflict("alerting.notifications.time-intervals.usedProvisioned").MustTemplate(
 		"Time interval cannot be renamed because it is used by a provisioned {{.Private.Resource}}",
-		errutil.WithPublic("Time interval cannot be renamed because it is used by a provisioned {{.Private.Resource}}. You must update those resources first using the original provision method"),
+		errutil.WithPublic("Time interval cannot be renamed because it is used by provisioned {{.Private.Resource}}. You must update those resources first using the original provision method"),
 	)
 
 	ErrTemplateNotFound = errutil.NotFound("alerting.notifications.templates.notFound")
@@ -89,7 +89,7 @@ func MakeErrTimeIntervalDependentResourcesProvenance(usedByRoutes bool, rules []
 		data["UsedByRoutes"] = true
 	}
 
-	return ErrTimeIntervalInUse.Build(errutil.TemplateData{
+	return ErrTimeIntervalDependentResourcesProvenance.Build(errutil.TemplateData{
 		Public: data,
 		Private: map[string]any{
 			"Resource": strings.Join(resource, " and "),

--- a/pkg/services/ngalert/provisioning/errors_test.go
+++ b/pkg/services/ngalert/provisioning/errors_test.go
@@ -1,9 +1,11 @@
 package provisioning
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -43,7 +45,8 @@ func TestMakeErrTimeIntervalDependentResourcesProvenance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := MakeErrTimeIntervalDependentResourcesProvenance(tt.usedByRoutes, tt.rules)
 			assert.Equal(t, tt.expectedPrivateMessage, err.Error())
-			e := err.(errutil.Error)
+			var e errutil.Error
+			require.True(t, errors.As(err, &e))
 			assert.Equal(t, tt.expectedPublicMessage, e.PublicMessage)
 		})
 	}

--- a/pkg/services/ngalert/provisioning/errors_test.go
+++ b/pkg/services/ngalert/provisioning/errors_test.go
@@ -1,0 +1,50 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestMakeErrTimeIntervalDependentResourcesProvenance(t *testing.T) {
+	tests := []struct {
+		name                   string
+		usedByRoutes           bool
+		rules                  []models.AlertRuleKey
+		expectedPrivateMessage string
+		expectedPublicMessage  string
+	}{
+		{
+			name:                   "both specified",
+			usedByRoutes:           true,
+			rules:                  []models.AlertRuleKey{models.GenerateRuleKey(1)},
+			expectedPrivateMessage: "[alerting.notifications.time-intervals.usedProvisioned] Time interval cannot be renamed because it is used by provisioned alert rules and notification policies",
+			expectedPublicMessage:  "Time interval cannot be renamed because it is used by provisioned alert rules and notification policies. You must update those resources first using the original provision method.",
+		},
+		{
+			name:                   "rules specified",
+			usedByRoutes:           false,
+			rules:                  []models.AlertRuleKey{models.GenerateRuleKey(1)},
+			expectedPrivateMessage: "[alerting.notifications.time-intervals.usedProvisioned] Time interval cannot be renamed because it is used by provisioned alert rules",
+			expectedPublicMessage:  "Time interval cannot be renamed because it is used by provisioned alert rules. You must update those resources first using the original provision method.",
+		},
+		{
+			name:                   "routes specified",
+			usedByRoutes:           true,
+			rules:                  nil,
+			expectedPrivateMessage: "[alerting.notifications.time-intervals.usedProvisioned] Time interval cannot be renamed because it is used by provisioned notification policies",
+			expectedPublicMessage:  "Time interval cannot be renamed because it is used by provisioned notification policies. You must update those resources first using the original provision method.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := MakeErrTimeIntervalDependentResourcesProvenance(tt.usedByRoutes, tt.rules)
+			assert.Equal(t, tt.expectedPrivateMessage, err.Error())
+			e := err.(errutil.Error)
+			assert.Equal(t, tt.expectedPublicMessage, e.PublicMessage)
+		})
+	}
+}

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -3,7 +3,6 @@ package provisioning
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"slices"
@@ -184,16 +183,24 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	// if the name of the time interval changed
-	if old.Name != mt.Name {
-		// TODO implement support for renaming.
-		return definitions.MuteTimeInterval{}, MakeErrTimeIntervalInvalid(errors.New("name change is not allowed"))
-	}
-
-	updateTimeInterval(revision, mt.MuteTimeInterval)
-
 	// TODO add diff and noop detection
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+		// if the name of the time interval changed
+		if old.Name != mt.Name {
+			deleteTimeInterval(revision, old)
+			revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, config.TimeInterval(mt.MuteTimeInterval))
+
+			err = svc.renameTimeIntervalInDependentResources(ctx, orgID, revision.Config.AlertmanagerConfig.Route, old.Name, mt.Name, models.Provenance(mt.Provenance))
+			if err != nil {
+				return err
+			}
+			err = svc.provenanceStore.DeleteProvenance(ctx, &definitions.MuteTimeInterval{MuteTimeInterval: old}, orgID)
+			if err != nil {
+				return err
+			}
+		} else {
+			updateTimeInterval(revision, mt.MuteTimeInterval)
+		}
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
@@ -393,4 +400,49 @@ func (svc *MuteTimingService) checkOptimisticConcurrency(current config.MuteTime
 		return ErrVersionConflict.Errorf("provided version %s of time interval %s does not match current version %s", desiredVersion, current.Name, currentVersion)
 	}
 	return nil
+}
+
+func (svc *MuteTimingService) renameTimeIntervalInDependentResources(ctx context.Context, orgID int64, route *definitions.Route, oldName, newName string, timeIntervalProvenance models.Provenance) error {
+	allowedProvenance := validation.GetAllowedProvenanceForDependentResources(timeIntervalProvenance)
+	// if there are no references to the old time interval, exit
+	var updatedRoutes int
+	if isMuteTimeInUseInRoutes(oldName, route) {
+		routeProvenance, err := svc.provenanceStore.GetProvenance(ctx, route, orgID)
+		if err != nil {
+			return err
+		}
+		if !slices.Contains(allowedProvenance, routeProvenance) {
+			return MakeErrTimeIntervalDependentResourcesProvenance(true, nil)
+		}
+		updatedRoutes = replaceMuteTiming(route, oldName, newName)
+	}
+
+	affected, invalidProvenance, err := svc.ruleNotificationsStore.RenameTimeIntervalInNotificationSettings(ctx, orgID, oldName, newName, allowedProvenance)
+	if err != nil {
+		return err
+	}
+	if len(invalidProvenance) > 0 {
+		return MakeErrTimeIntervalDependentResourcesProvenance(false, invalidProvenance)
+	}
+	if len(affected) > 0 || updatedRoutes > 0 {
+		svc.log.FromContext(ctx).Info("Updated rules and routes that use renamed time interval", "oldName", oldName, "newName", newName, "rules", len(affected), "routes", updatedRoutes)
+	}
+	return nil
+}
+
+func replaceMuteTiming(route *definitions.Route, oldName, newName string) int {
+	if route == nil {
+		return 0
+	}
+	updated := 0
+	for idx := range route.MuteTimeIntervals {
+		if route.MuteTimeIntervals[idx] == oldName {
+			route.MuteTimeIntervals[idx] = newName
+			updated++
+		}
+	}
+	for _, route := range route.Routes {
+		updated += replaceMuteTiming(route, oldName, newName)
+	}
+	return updated
 }

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -404,7 +404,7 @@ func (svc *MuteTimingService) checkOptimisticConcurrency(current config.MuteTime
 }
 
 func (svc *MuteTimingService) renameTimeIntervalInDependentResources(ctx context.Context, orgID int64, route *definitions.Route, oldName, newName string, timeIntervalProvenance models.Provenance) error {
-	allowedProvenance := validation.GetAllowedProvenanceForDependentResources(timeIntervalProvenance)
+	validate := validation.ValidateProvenanceOfDependentResources(timeIntervalProvenance)
 	// if there are no references to the old time interval, exit
 	updatedRoutes := replaceMuteTiming(route, oldName, newName)
 	canUpdate := true
@@ -413,10 +413,10 @@ func (svc *MuteTimingService) renameTimeIntervalInDependentResources(ctx context
 		if err != nil {
 			return err
 		}
-		canUpdate = slices.Contains(allowedProvenance, routeProvenance)
+		canUpdate = validate(routeProvenance)
 	}
 	dryRun := !canUpdate
-	affected, invalidProvenance, err := svc.ruleNotificationsStore.RenameTimeIntervalInNotificationSettings(ctx, orgID, oldName, newName, allowedProvenance, dryRun)
+	affected, invalidProvenance, err := svc.ruleNotificationsStore.RenameTimeIntervalInNotificationSettings(ctx, orgID, oldName, newName, validate, dryRun)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -524,28 +524,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		require.ErrorIs(t, err, expectedErr)
 	})
-
-	t.Run("rejects mute timings if provenance is not right", func(t *testing.T) {
-		sut, store, prov := createMuteTimingSvcSut()
-		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
-			return &legacy_storage.ConfigRevision{Config: initialConfig()}, nil
-		}
-		expectedErr := errors.New("test")
-		sut.validator = func(from, to models.Provenance) error {
-			return expectedErr
-		}
-		timing := definitions.MuteTimeInterval{
-			MuteTimeInterval: expected,
-			Provenance:       definitions.Provenance(models.ProvenanceFile),
-		}
-
-		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedProvenance, nil)
-
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
-
-		require.ErrorIs(t, err, expectedErr)
-	})
-
+	
 	t.Run("returns ErrVersionConflict if storage version does not match", func(t *testing.T) {
 		sut, store, prov := createMuteTimingSvcSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -738,7 +738,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			})
 
 		ruleStore := &fakeAlertRuleNotificationStore{
-			RenameTimeIntervalInNotificationSettingsFn: func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error) {
+			RenameTimeIntervalInNotificationSettingsFn: func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
 				assertInTransaction(t, ctx)
 				return nil, nil, nil
 			},
@@ -861,7 +861,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			expectedErr := errors.New("test-err")
 
 			ruleStore := &fakeAlertRuleNotificationStore{
-				RenameTimeIntervalInNotificationSettingsFn: func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error) {
+				RenameTimeIntervalInNotificationSettingsFn: func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
 					return nil, nil, expectedErr
 				},
 			}

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -524,7 +524,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		require.ErrorIs(t, err, expectedErr)
 	})
-	
+
 	t.Run("returns ErrVersionConflict if storage version does not match", func(t *testing.T) {
 		sut, store, prov := createMuteTimingSvcSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -169,8 +169,9 @@ func (s *fakeRuleAccessControlService) CanWriteAllRules(ctx context.Context, use
 type fakeAlertRuleNotificationStore struct {
 	Calls []call
 
-	RenameReceiverInNotificationSettingsFn func(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	ListNotificationSettingsFn             func(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
+	RenameReceiverInNotificationSettingsFn     func(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
+	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error)
+	ListNotificationSettingsFn                 func(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 
 func (f *fakeAlertRuleNotificationStore) RenameReceiverInNotificationSettings(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error) {
@@ -186,6 +187,21 @@ func (f *fakeAlertRuleNotificationStore) RenameReceiverInNotificationSettings(ct
 
 	// Default values when no function hook is provided
 	return 0, nil
+}
+
+func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error) {
+	call := call{
+		Method: "RenameTimeIntervalInNotificationSettings",
+		Args:   []interface{}{ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances},
+	}
+	f.Calls = append(f.Calls, call)
+
+	if f.RenameTimeIntervalInNotificationSettingsFn != nil {
+		return f.RenameTimeIntervalInNotificationSettingsFn(ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances)
+	}
+
+	// Default values when no function hook is provided
+	return nil, nil, nil
 }
 
 func (f *fakeAlertRuleNotificationStore) ListNotificationSettings(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error) {

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -170,7 +170,7 @@ type fakeAlertRuleNotificationStore struct {
 	Calls []call
 
 	RenameReceiverInNotificationSettingsFn     func(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
+	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
 	ListNotificationSettingsFn                 func(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 
@@ -189,15 +189,15 @@ func (f *fakeAlertRuleNotificationStore) RenameReceiverInNotificationSettings(ct
 	return 0, nil
 }
 
-func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
+func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
 	call := call{
 		Method: "RenameTimeIntervalInNotificationSettings",
-		Args:   []interface{}{ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances},
+		Args:   []interface{}{ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances, dryRun},
 	}
 	f.Calls = append(f.Calls, call)
 
 	if f.RenameTimeIntervalInNotificationSettingsFn != nil {
-		return f.RenameTimeIntervalInNotificationSettingsFn(ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances)
+		return f.RenameTimeIntervalInNotificationSettingsFn(ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances, dryRun)
 	}
 
 	// Default values when no function hook is provided

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -170,7 +170,7 @@ type fakeAlertRuleNotificationStore struct {
 	Calls []call
 
 	RenameReceiverInNotificationSettingsFn     func(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
+	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, validate func(models.Provenance) bool, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
 	ListNotificationSettingsFn                 func(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 
@@ -189,15 +189,15 @@ func (f *fakeAlertRuleNotificationStore) RenameReceiverInNotificationSettings(ct
 	return 0, nil
 }
 
-func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
+func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, validate func(models.Provenance) bool, dryRun bool) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
 	call := call{
 		Method: "RenameTimeIntervalInNotificationSettings",
-		Args:   []interface{}{ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances, dryRun},
+		Args:   []interface{}{ctx, orgID, oldTimeInterval, newTimeInterval, validate, dryRun},
 	}
 	f.Calls = append(f.Calls, call)
 
 	if f.RenameTimeIntervalInNotificationSettingsFn != nil {
-		return f.RenameTimeIntervalInNotificationSettingsFn(ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances, dryRun)
+		return f.RenameTimeIntervalInNotificationSettingsFn(ctx, orgID, oldTimeInterval, newTimeInterval, validate, dryRun)
 	}
 
 	// Default values when no function hook is provided

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -170,7 +170,7 @@ type fakeAlertRuleNotificationStore struct {
 	Calls []call
 
 	RenameReceiverInNotificationSettingsFn     func(ctx context.Context, orgID int64, oldReceiver, newReceiver string) (int, error)
-	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error)
+	RenameTimeIntervalInNotificationSettingsFn func(ctx context.Context, orgID int64, old, new string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error)
 	ListNotificationSettingsFn                 func(ctx context.Context, q models.ListNotificationSettingsQuery) (map[models.AlertRuleKey][]models.NotificationSettings, error)
 }
 
@@ -189,7 +189,7 @@ func (f *fakeAlertRuleNotificationStore) RenameReceiverInNotificationSettings(ct
 	return 0, nil
 }
 
-func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, map[models.Provenance][]models.AlertRuleKey, error) {
+func (f *fakeAlertRuleNotificationStore) RenameTimeIntervalInNotificationSettings(ctx context.Context, orgID int64, oldTimeInterval, newTimeInterval string, allowedProvenances []models.Provenance) ([]models.AlertRuleKey, []models.AlertRuleKey, error) {
 	call := call{
 		Method: "RenameTimeIntervalInNotificationSettings",
 		Args:   []interface{}{ctx, orgID, oldTimeInterval, newTimeInterval, allowedProvenances},

--- a/pkg/services/ngalert/provisioning/validation/provenance.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance.go
@@ -26,3 +26,12 @@ func ValidateProvenanceRelaxed(from, to models.Provenance) error {
 	}
 	return nil
 }
+
+// GetAllowedProvenanceForDependentResources returns a list of allowed provenance statuses for dependent resources
+// in the case when they need to be updated when the resource they depend on is changed.
+func GetAllowedProvenanceForDependentResources(parentProvenance models.Provenance) []models.Provenance {
+	if parentProvenance == models.ProvenanceNone {
+		return []models.Provenance{models.ProvenanceNone}
+	}
+	return []models.Provenance{parentProvenance, models.ProvenanceNone}
+}

--- a/pkg/services/ngalert/provisioning/validation/provenance.go
+++ b/pkg/services/ngalert/provisioning/validation/provenance.go
@@ -27,11 +27,10 @@ func ValidateProvenanceRelaxed(from, to models.Provenance) error {
 	return nil
 }
 
-// GetAllowedProvenanceForDependentResources returns a list of allowed provenance statuses for dependent resources
+// ValidateProvenanceOfDependentResources returns a list of allowed provenance statuses for dependent resources
 // in the case when they need to be updated when the resource they depend on is changed.
-func GetAllowedProvenanceForDependentResources(parentProvenance models.Provenance) []models.Provenance {
-	if parentProvenance == models.ProvenanceNone {
-		return []models.Provenance{models.ProvenanceNone}
+func ValidateProvenanceOfDependentResources(parentProvenance models.Provenance) func(childProvenance models.Provenance) bool {
+	return func(childProvenance models.Provenance) bool {
+		return parentProvenance == childProvenance || childProvenance == models.ProvenanceNone
 	}
-	return []models.Provenance{parentProvenance, models.ProvenanceNone}
 }

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -925,11 +925,11 @@ func TestIntegrationAlertRulesNotificationSettings(t *testing.T) {
 			allowedProvenance := []models.Provenance{models.ProvenanceNone}
 			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, allowedProvenance)
 
-			expected := map[models.Provenance][]models.AlertRuleKey{}
+			var expected []models.AlertRuleKey
 			for _, rule := range timeIntervalRules {
 				provenance := provenances[rule.GetKey()]
 				if provenance != models.ProvenanceNone {
-					expected[provenance] = append(expected[provenance], rule.GetKey())
+					expected = append(expected, rule.GetKey())
 				}
 			}
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -815,7 +815,7 @@ func TestIntegrationAlertRulesNotificationSettings(t *testing.T) {
 	for idx, rule := range append(timeIntervalRules, receiveRules...) {
 		p := models.KnownProvenances[idx%len(models.KnownProvenances)]
 		provenances[rule.GetKey()] = p
-		require.NoError(t, store.SetProvenance(context.Background(), rule, rule.OrgID, models.KnownProvenances[idx%len(models.KnownProvenances)]))
+		require.NoError(t, store.SetProvenance(context.Background(), rule, rule.OrgID, p))
 	}
 
 	_, err := store.InsertAlertRules(context.Background(), deref)
@@ -935,7 +935,7 @@ func TestIntegrationAlertRulesNotificationSettings(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Empty(t, affected)
-			require.Equal(t, expected, invalidProvenance)
+			require.ElementsMatch(t, expected, invalidProvenance)
 
 			actual, err := store.ListAlertRules(context.Background(), &models.ListAlertRulesQuery{
 				OrgID:            1,

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -914,28 +914,35 @@ func TestIntegrationAlertRulesNotificationSettings(t *testing.T) {
 	t.Run("RenameTimeIntervalInNotificationSettings", func(t *testing.T) {
 		newName := "new-time-interval"
 
+		alwaysTrue := func(p models.Provenance) bool {
+			return true
+		}
+
 		t.Run("should do nothing if no rules that match the filter", func(t *testing.T) {
-			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, "not-found", timeIntervalName, models.KnownProvenances, false)
+			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, "not-found", timeIntervalName, alwaysTrue, false)
 			require.NoError(t, err)
 			require.Empty(t, affected)
 			require.Empty(t, invalidProvenance)
 		})
 
 		t.Run("should do nothing if at least one rule has provenance that is not allowed", func(t *testing.T) {
-			allowedProvenance := []models.Provenance{models.ProvenanceNone}
-			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, allowedProvenance, false)
+			calledTimes := 0
+			alwaysFalse := func(p models.Provenance) bool {
+				calledTimes++
+				return false
+			}
+
+			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, alwaysFalse, false)
 
 			var expected []models.AlertRuleKey
 			for _, rule := range timeIntervalRules {
-				provenance := provenances[rule.GetKey()]
-				if provenance != models.ProvenanceNone {
-					expected = append(expected, rule.GetKey())
-				}
+				expected = append(expected, rule.GetKey())
 			}
 
 			require.NoError(t, err)
 			require.Empty(t, affected)
 			require.ElementsMatch(t, expected, invalidProvenance)
+			assert.Equal(t, len(expected), calledTimes)
 
 			actual, err := store.ListAlertRules(context.Background(), &models.ListAlertRulesQuery{
 				OrgID:            1,
@@ -946,7 +953,7 @@ func TestIntegrationAlertRulesNotificationSettings(t *testing.T) {
 		})
 
 		t.Run("should do nothing if dry run is set to true", func(t *testing.T) {
-			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, models.KnownProvenances, true)
+			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, alwaysTrue, true)
 			require.NoError(t, err)
 			require.Empty(t, invalidProvenance)
 			assert.Len(t, affected, len(timeIntervalRules))
@@ -964,7 +971,7 @@ func TestIntegrationAlertRulesNotificationSettings(t *testing.T) {
 		})
 
 		t.Run("should update all rules that refer to the old time interval", func(t *testing.T) {
-			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, models.KnownProvenances, false)
+			affected, invalidProvenance, err := store.RenameTimeIntervalInNotificationSettings(context.Background(), 1, timeIntervalName, newName, alwaysTrue, false)
 			require.NoError(t, err)
 			require.Empty(t, invalidProvenance)
 			assert.Len(t, affected, len(timeIntervalRules))

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -780,7 +780,7 @@ func TestMuteTimings(t *testing.T) {
 			},
 			MuteTimeIntervals: []string{anotherMuteTiming.Name},
 		})
-		status, response = apiClient.UpdateRouteWithStatus(t, route)
+		status, response = apiClient.UpdateRouteWithStatus(t, route, false)
 		requireStatusCode(t, http.StatusAccepted, status, response)
 
 		status, response = apiClient.DeleteMuteTimingWithStatus(t, anotherMuteTiming.Name)

--- a/pkg/tests/apis/alerting/notifications/timeinterval/test-data/notification-settings.json
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/test-data/notification-settings.json
@@ -14,7 +14,7 @@
             ]
           ],
           "mute_time_intervals": [
-            "test-interval"
+            "test-interval", "persisted-interval"
           ]
         }
       ]
@@ -22,6 +22,15 @@
     "mute_time_intervals": [
       {
         "name": "test-interval",
+        "time_intervals": [
+          {
+            "start_time": "06:00",
+            "end_time": "23:59"
+          }
+        ]
+      },
+      {
+        "name": "persisted-interval",
         "time_intervals": [
           {
             "start_time": "06:00",

--- a/pkg/tests/apis/alerting/notifications/timeinterval/test-data/rulegroup-1.json
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/test-data/rulegroup-1.json
@@ -28,7 +28,8 @@
         "notification_settings": {
           "receiver": "grafana-default-email",
           "mute_time_intervals": [
-            "test-interval"
+            "test-interval",
+            "persisted-interval"
           ]
         }
       }


### PR DESCRIPTION
**What is this feature?**
This PR updates MuteTimingService to support renaming time intervals: a situation when the UID of the incoming interval points to an interval with a different name. 
When interval is renamed all dependencies are updated, and operation fails if the provenance status of at least one dependency is not compatible with provenance status of the operation. 
For example, if the rename operation comes via a non-provisioning API, and there are rules that refer to the interval and are provisioned via either file or API, the update operation will be rejected. The same logic is applicable to the routes.

**Why do we need this feature?**
Currently, UI handles this but it does not fix the related rules but the UI that uses the new API does not support this. 

**Who is this feature for?**
UI users

**Special notes for your reviewer:**
Currently, provisioning does not support renaming because it does not use UIDs. It is only used by the new API.


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
