### PR TITLE
Profile: Add tooltip to revoke session button

### DIFF
--- a/public/app/features/profile/UserSessions.tsx
+++ b/public/app/features/profile/UserSessions.tsx
@@ -60,7 +60,7 @@ class UserSessions extends PureComponent<Props> {
                       <Button
                         size="sm"
                         variant="destructive"
-                        tooltip={'Revoke user session'}
+                        tooltip={t('user-session.revoke', 'Revoke user session')}
                         onClick={() => revokeUserSession(session.id)}
                         aria-label={t('user-session.revoke', 'Revoke user session')}
                       >

--- a/public/app/features/profile/UserSessions.tsx
+++ b/public/app/features/profile/UserSessions.tsx
@@ -60,6 +60,7 @@ class UserSessions extends PureComponent<Props> {
                       <Button
                         size="sm"
                         variant="destructive"
+                        tooltip={'Revoke user session'}
                         onClick={() => revokeUserSession(session.id)}
                         aria-label={t('user-session.revoke', 'Revoke user session')}
                       >


### PR DESCRIPTION
What is this feature?
This feature adds a tooltip to a specific button in the sessions section of the application. The tooltip provides additional context for the button, enhancing its accessibility and usability.

Why do we need this feature?
Improving accessibility (A11y) is a priority for our application. By adding a tooltip to this button, we make the function of the button clearer, especially for users relying on assistive technologies, contributing to a more inclusive user experience.

Which issue(s) does this PR fix?
This PR addresses the lack of a tooltip on one specific button in the sessions section, ensuring that its purpose is easily understood by all users.

Fixes [#91836](https://github.com/grafana/grafana/issues/91836)