### PR TITLE
Drawer: Fixes incorrect mask background and flickering

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -294,7 +294,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     // but we don't want the backdrop styling to apply over the top bar as it looks weird
     // instead have a child pseudo element to apply the backdrop styling below the top bar
     mask: css({
-      backgroundColor: 'transparent',
+      // The !important here is to override the default .rc-drawer-mask styles
+      backgroundColor: 'transparent !important',
       position: 'fixed',
 
       '&:before': {


### PR DESCRIPTION
Noticed strange flickering of the mask background when opening the Drawer 

Was caused by the default rc-drawer-mask styles overriding our emotion styles for the mask. 

[New-Features-in-v7-4---gdev-dashboards---Dashboards---Grafana (1).webm](https://github.com/user-attachments/assets/79f89463-cb30-4329-8e80-31cc5564b5f8)
