### PR TITLE
AppChrome: Make side pane feature more generic and state owned by AppChromeService

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -31,7 +31,7 @@ export function AppChrome({ children }: Props) {
   const dockedMenuBreakpoint = theme.breakpoints.values.xl;
   const dockedMenuLocalStorageState = store.getBool(DOCKED_LOCAL_STORAGE_KEY, true);
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
-  const leftToolbarPaneOpen = state.sidePaneLeft !== undefined;
+  const sidePaneLeftOpen = state.sidePaneLeft !== undefined;
 
   useMediaQueryChange({
     breakpoint: dockedMenuBreakpoint,
@@ -120,9 +120,9 @@ export function AppChrome({ children }: Props) {
           <main
             className={cx(styles.pageContainer, {
               [styles.pageContainerMenuDocked]:
-                config.featureToggles.bodyScrolling && (menuDockedAndOpen || leftToolbarPaneOpen),
+                config.featureToggles.bodyScrolling && (menuDockedAndOpen || sidePaneLeftOpen),
               [styles.pageContainerMenuDockedScopes]:
-                config.featureToggles.bodyScrolling && menuDockedAndOpen && leftToolbarPaneOpen,
+                config.featureToggles.bodyScrolling && menuDockedAndOpen && sidePaneLeftOpen,
             })}
             id="pageContent"
           >

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -9,7 +9,6 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryChange } from 'app/core/hooks/useMediaQueryChange';
 import store from 'app/core/store';
 import { CommandPalette } from 'app/features/commandPalette/CommandPalette';
-import { ScopesDashboards } from 'app/features/scopes';
 import { KioskMode } from 'app/types';
 
 import { AppChromeMenu } from './AppChromeMenu';
@@ -32,8 +31,7 @@ export function AppChrome({ children }: Props) {
   const dockedMenuBreakpoint = theme.breakpoints.values.xl;
   const dockedMenuLocalStorageState = store.getBool(DOCKED_LOCAL_STORAGE_KEY, true);
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
-  // TODO how to get this state from the scene?
-  const scopeDashboardsState = true;
+  const leftToolbarPaneOpen = state.sidePaneLeft !== undefined;
 
   useMediaQueryChange({
     breakpoint: dockedMenuBreakpoint,
@@ -112,19 +110,19 @@ export function AppChrome({ children }: Props) {
           )}
           {!state.chromeless && (
             <div
-              className={cx(styles.scopedDashboardsContainer, {
-                [styles.dockedScopedDashboardsContainer]: menuDockedAndOpen,
+              className={cx(styles.sidePaneLeft, {
+                [styles.sidePaneLeftWithDockedMenu]: menuDockedAndOpen,
               })}
             >
-              <ScopesDashboards />
+              {state.sidePaneLeft}
             </div>
           )}
           <main
             className={cx(styles.pageContainer, {
               [styles.pageContainerMenuDocked]:
-                config.featureToggles.bodyScrolling && (menuDockedAndOpen || scopeDashboardsState),
+                config.featureToggles.bodyScrolling && (menuDockedAndOpen || leftToolbarPaneOpen),
               [styles.pageContainerMenuDockedScopes]:
-                config.featureToggles.bodyScrolling && menuDockedAndOpen && scopeDashboardsState,
+                config.featureToggles.bodyScrolling && menuDockedAndOpen && leftToolbarPaneOpen,
             })}
             id="pageContent"
           >
@@ -176,7 +174,7 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden: boolean) => {
             zIndex: theme.zIndex.navbarFixed,
           }
     ),
-    scopedDashboardsContainer: css(
+    sidePaneLeft: css(
       config.featureToggles.bodyScrolling
         ? {
             position: 'fixed',
@@ -187,7 +185,7 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden: boolean) => {
             zIndex: theme.zIndex.navbarFixed,
           }
     ),
-    dockedScopedDashboardsContainer: css({
+    sidePaneLeftWithDockedMenu: css({
       left: MENU_WIDTH,
     }),
     topNav: css({

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -14,7 +14,7 @@ import { KioskMode } from 'app/types';
 
 import { AppChromeMenu } from './AppChromeMenu';
 import { DOCKED_LOCAL_STORAGE_KEY, DOCKED_MENU_OPEN_LOCAL_STORAGE_KEY } from './AppChromeService';
-import { MegaMenu } from './MegaMenu/MegaMenu';
+import { MegaMenu, MENU_WIDTH } from './MegaMenu/MegaMenu';
 import { NavToolbar } from './NavToolbar/NavToolbar';
 import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
 import { TopSearchBar } from './TopBar/TopSearchBar';
@@ -32,6 +32,9 @@ export function AppChrome({ children }: Props) {
   const dockedMenuBreakpoint = theme.breakpoints.values.xl;
   const dockedMenuLocalStorageState = store.getBool(DOCKED_LOCAL_STORAGE_KEY, true);
   const menuDockedAndOpen = !state.chromeless && state.megaMenuDocked && state.megaMenuOpen;
+  // TODO how to get this state from the scene?
+  const scopeDashboardsState = true;
+
   useMediaQueryChange({
     breakpoint: dockedMenuBreakpoint,
     onChange: (e) => {
@@ -107,10 +110,21 @@ export function AppChrome({ children }: Props) {
           {menuDockedAndOpen && (
             <MegaMenu className={styles.dockedMegaMenu} onClose={() => chrome.setMegaMenuOpen(false)} />
           )}
-          {!state.chromeless && <ScopesDashboards />}
+          {!state.chromeless && (
+            <div
+              className={cx(styles.scopedDashboardsContainer, {
+                [styles.dockedScopedDashboardsContainer]: menuDockedAndOpen,
+              })}
+            >
+              <ScopesDashboards />
+            </div>
+          )}
           <main
             className={cx(styles.pageContainer, {
-              [styles.pageContainerMenuDocked]: config.featureToggles.bodyScrolling && menuDockedAndOpen,
+              [styles.pageContainerMenuDocked]:
+                config.featureToggles.bodyScrolling && (menuDockedAndOpen || scopeDashboardsState),
+              [styles.pageContainerMenuDockedScopes]:
+                config.featureToggles.bodyScrolling && menuDockedAndOpen && scopeDashboardsState,
             })}
             id="pageContent"
           >
@@ -156,12 +170,26 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden: boolean) => {
         ? {
             position: 'fixed',
             height: `calc(100% - ${searchBarHidden ? TOP_BAR_LEVEL_HEIGHT : TOP_BAR_LEVEL_HEIGHT * 2}px)`,
+            zIndex: 2,
+          }
+        : {
+            zIndex: theme.zIndex.navbarFixed,
+          }
+    ),
+    scopedDashboardsContainer: css(
+      config.featureToggles.bodyScrolling
+        ? {
+            position: 'fixed',
+            height: `calc(100% - ${searchBarHidden ? TOP_BAR_LEVEL_HEIGHT : TOP_BAR_LEVEL_HEIGHT * 2}px)`,
             zIndex: 1,
           }
         : {
             zIndex: theme.zIndex.navbarFixed,
           }
     ),
+    dockedScopedDashboardsContainer: css({
+      left: MENU_WIDTH,
+    }),
     topNav: css({
       display: 'flex',
       position: 'fixed',
@@ -188,7 +216,10 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden: boolean) => {
       }
     ),
     pageContainerMenuDocked: css({
-      paddingLeft: '300px',
+      paddingLeft: MENU_WIDTH,
+    }),
+    pageContainerMenuDockedScopes: css({
+      paddingLeft: `calc(${MENU_WIDTH} * 2)`,
     }),
     pageContainer: css(
       {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -23,6 +23,7 @@ export interface AppChromeState {
   megaMenuDocked: boolean;
   kioskMode: KioskMode | null;
   layout: PageLayoutType;
+  sidePaneLeft?: React.ReactNode;
   returnToPrevious?: {
     title: ReturnToPreviousProps['title'];
     href: ReturnToPreviousProps['href'];
@@ -72,6 +73,7 @@ export class AppChromeService {
     // when route change update props from route and clear fields
     if (!this.routeChangeHandled) {
       newState.actions = undefined;
+      newState.sidePaneLeft = undefined;
       newState.pageNav = undefined;
       newState.sectionNav = { node: { text: t('nav.home.title', 'Home') }, main: { text: '' } };
       newState.chromeless = this.currentRoute?.chromeless;

--- a/public/app/core/components/AppChrome/AppChromeSidePane.tsx
+++ b/public/app/core/components/AppChrome/AppChromeSidePane.tsx
@@ -1,0 +1,24 @@
+import { useLayoutEffect } from 'react';
+import * as React from 'react';
+
+import { useGrafana } from 'app/core/context/GrafanaContext';
+
+export interface AppChromeUpdateProps {
+  left?: React.ReactNode;
+}
+/**
+ * This needs to be moved to @grafana/ui or runtime.
+ * This is the way core pages and plugins update the breadcrumbs and page toolbar actions
+ */
+export const AppChromeSidePane = React.memo<AppChromeUpdateProps>(({ left }: AppChromeUpdateProps) => {
+  const { chrome } = useGrafana();
+
+  // We use useLayoutEffect here to make sure that the chrome is updated before the page is rendered
+  // This prevents flickering actions when going from one dashboard to another for example
+  useLayoutEffect(() => {
+    chrome.update({ sidePaneLeft: left });
+  });
+  return null;
+});
+
+AppChromeSidePane.displayName = 'AppChromeSidePane';

--- a/public/app/core/components/AppChrome/AppChromeUpdate.tsx
+++ b/public/app/core/components/AppChrome/AppChromeUpdate.tsx
@@ -5,20 +5,23 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 
 export interface AppChromeUpdateProps {
   actions?: React.ReactNode;
+  toolbarPaneLeft?: React.ReactNode;
 }
 /**
  * This needs to be moved to @grafana/ui or runtime.
  * This is the way core pages and plugins update the breadcrumbs and page toolbar actions
  */
-export const AppChromeUpdate = React.memo<AppChromeUpdateProps>(({ actions }: AppChromeUpdateProps) => {
-  const { chrome } = useGrafana();
+export const AppChromeUpdate = React.memo<AppChromeUpdateProps>(
+  ({ actions, toolbarPaneLeft }: AppChromeUpdateProps) => {
+    const { chrome } = useGrafana();
 
-  // We use useLayoutEffect here to make sure that the chrome is updated before the page is rendered
-  // This prevents flickering actions when going from one dashboard to another for example
-  useLayoutEffect(() => {
-    chrome.update({ actions });
-  });
-  return null;
-});
+    // We use useLayoutEffect here to make sure that the chrome is updated before the page is rendered
+    // This prevents flickering actions when going from one dashboard to another for example
+    useLayoutEffect(() => {
+      chrome.update({ actions, sidePaneLeft: toolbarPaneLeft });
+    });
+    return null;
+  }
+);
 
 AppChromeUpdate.displayName = 'TopNavUpdate';

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -15,6 +15,8 @@ import { useSelector } from 'app/types';
 
 import { DashboardScene } from './DashboardScene';
 import { NavToolbarActions } from './NavToolbarActions';
+import { AppChromeSidePane } from 'app/core/components/AppChrome/AppChromeSidePane';
+import { ScopesDashboards } from 'app/features/scopes';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {
   const { controls, overlay, editview, editPanel, isEmpty, meta } = model.useState();
@@ -61,6 +63,7 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
       {!editPanel && (
         <div className={cx(styles.pageContainer, hasControls && styles.pageContainerWithControls)}>
           <NavToolbarActions dashboard={model} />
+          <ScopesDashboards />
           {controls && (
             <div className={styles.controlsWrapper}>
               <controls.Component model={controls} />

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -15,7 +15,6 @@ import { useSelector } from 'app/types';
 
 import { DashboardScene } from './DashboardScene';
 import { NavToolbarActions } from './NavToolbarActions';
-import { AppChromeSidePane } from 'app/core/components/AppChrome/AppChromeSidePane';
 import { ScopesDashboards } from 'app/features/scopes';
 
 export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardScene>) {

--- a/public/app/features/scopes/internal/ScopesDashboardsScene.tsx
+++ b/public/app/features/scopes/internal/ScopesDashboardsScene.tsx
@@ -13,6 +13,8 @@ import { fetchSuggestedDashboards } from './api';
 import { DASHBOARDS_OPENED_KEY } from './const';
 import { SuggestedDashboard } from './types';
 import { getScopeNamesFromSelectedScopes } from './utils';
+import { AppChromeSidePane } from 'app/core/components/AppChrome/AppChromeSidePane';
+import React from 'react';
 
 export interface ScopesDashboardsSceneState extends SceneObjectState {
   selector: SceneObjectRef<ScopesSelectorScene> | null;
@@ -150,12 +152,14 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
   const [queryParams] = useQueryParams();
 
   if (!isEnabled || !isPanelOpened) {
-    return null;
+    return <AppChromeSidePane left={undefined} />;
   }
+
+  let paneContent: React.ReactNode;
 
   if (!isLoading) {
     if (!scopesSelected) {
-      return (
+      paneContent = (
         <div
           className={cx(styles.container, styles.noResultsContainer)}
           data-testid="scopes-dashboards-notFoundNoScopes"
@@ -164,7 +168,7 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
         </div>
       );
     } else if (dashboards.length === 0) {
-      return (
+      paneContent = (
         <div
           className={cx(styles.container, styles.noResultsContainer)}
           data-testid="scopes-dashboards-notFoundForScope"
@@ -175,7 +179,7 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
     }
   }
 
-  return (
+  paneContent = (
     <div className={styles.container} data-testid="scopes-dashboards-container">
       <div className={styles.searchInputContainer}>
         <FilterInput
@@ -221,6 +225,8 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
       )}
     </div>
   );
+
+  return <AppChromeSidePane left={paneContent} />;
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -233,6 +239,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       gap: theme.spacing(1),
       padding: theme.spacing(2),
       width: theme.spacing(37.5),
+      height: '100%',
     }),
     noResultsContainer: css({
       alignItems: 'center',


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/91892 runs into a messy issue of AppChrome having to depend on state inside the scope dashboards list component (if it's open or not). 

Not sure I like the fact that we always render ScopedDashboards on all pages (and that AppChrome has a dependency on it). Feels the wrong way around. esp since it's only shown on dashboard pages currently. currently it's rendered and activated on all pages even dashboards fetched no matter the page (if browser was closed with it opened )

This explores adding a concept of a side pane to AppChrome that can be added/rendered same way pages render the nav toolbar actions (via component that updates AppChromeService state). this is not ideal, best would be if this was all rendered inside the Page. 

