### PR TITLE
Annotations: only set userID if caller is a user or service account

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -141,11 +141,7 @@ func (hs *HTTPServer) PostAnnotation(c *contextmodel.ReqContext) response.Respon
 	}
 
 	// nolint:staticcheck
-	userID, err := c.SignedInUser.GetInternalID()
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to save annotation", err)
-	}
-
+	userID, _ := c.SignedInUser.GetInternalID()
 	item := annotations.Item{
 		OrgID:       c.SignedInUser.GetOrgID(),
 		UserID:      userID,
@@ -229,11 +225,7 @@ func (hs *HTTPServer) PostGraphiteAnnotation(c *contextmodel.ReqContext) respons
 	}
 
 	// nolint:staticcheck
-	userID, err := c.SignedInUser.GetInternalID()
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to save Graphite annotation", err)
-	}
-
+	userID, _ := c.SignedInUser.GetInternalID()
 	item := annotations.Item{
 		OrgID:  c.SignedInUser.GetOrgID(),
 		UserID: userID,
@@ -287,11 +279,7 @@ func (hs *HTTPServer) UpdateAnnotation(c *contextmodel.ReqContext) response.Resp
 	}
 
 	// nolint:staticcheck
-	userID, err := c.SignedInUser.GetInternalID()
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to update annotation", err)
-	}
-
+	userID, _ := c.SignedInUser.GetInternalID()
 	item := annotations.Item{
 		OrgID:    c.SignedInUser.GetOrgID(),
 		UserID:   userID,
@@ -350,11 +338,7 @@ func (hs *HTTPServer) PatchAnnotation(c *contextmodel.ReqContext) response.Respo
 	}
 
 	// nolint:staticcheck
-	userID, err := c.SignedInUser.GetInternalID()
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to update annotation", err)
-	}
-
+	userID, _ := c.SignedInUser.GetInternalID()
 	existing := annotations.Item{
 		OrgID:    c.SignedInUser.GetOrgID(),
 		UserID:   userID,

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -335,12 +335,7 @@ func (hs *HTTPServer) PatchAnnotation(c *contextmodel.ReqContext) response.Respo
 		}
 	}
 
-	// nolint:staticcheck
-	userID, err := c.SignedInUser.GetInternalID()
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Failed to update annotation", err)
-	}
-
+	userID, _ := identity.UserIdentifier(c.GetID())
 	existing := annotations.Item{
 		OrgID:    c.SignedInUser.GetOrgID(),
 		UserID:   userID,

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -140,8 +141,7 @@ func (hs *HTTPServer) PostAnnotation(c *contextmodel.ReqContext) response.Respon
 		return response.Error(http.StatusBadRequest, "Failed to save annotation", err)
 	}
 
-	// nolint:staticcheck
-	userID, _ := c.SignedInUser.GetInternalID()
+	userID, _ := identity.UserIdentifier(c.GetID())
 	item := annotations.Item{
 		OrgID:       c.SignedInUser.GetOrgID(),
 		UserID:      userID,
@@ -224,8 +224,7 @@ func (hs *HTTPServer) PostGraphiteAnnotation(c *contextmodel.ReqContext) respons
 		return response.Error(http.StatusBadRequest, "Failed to save Graphite annotation", err)
 	}
 
-	// nolint:staticcheck
-	userID, _ := c.SignedInUser.GetInternalID()
+	userID, _ := identity.UserIdentifier(c.GetID())
 	item := annotations.Item{
 		OrgID:  c.SignedInUser.GetOrgID(),
 		UserID: userID,
@@ -278,8 +277,7 @@ func (hs *HTTPServer) UpdateAnnotation(c *contextmodel.ReqContext) response.Resp
 		}
 	}
 
-	// nolint:staticcheck
-	userID, _ := c.SignedInUser.GetInternalID()
+	userID, _ := identity.UserIdentifier(c.GetID())
 	item := annotations.Item{
 		OrgID:    c.SignedInUser.GetOrgID(),
 		UserID:   userID,
@@ -338,7 +336,11 @@ func (hs *HTTPServer) PatchAnnotation(c *contextmodel.ReqContext) response.Respo
 	}
 
 	// nolint:staticcheck
-	userID, _ := c.SignedInUser.GetInternalID()
+	userID, err := c.SignedInUser.GetInternalID()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to update annotation", err)
+	}
+
 	existing := annotations.Item{
 		OrgID:    c.SignedInUser.GetOrgID(),
 		UserID:   userID,


### PR DESCRIPTION
**What is this feature?**
After https://github.com/grafana/grafana/pull/91801 we now return errors when calling `GetInternalID()`. Before this we did not.

I started to look through all paths we called this function and this is the only place that is slightly incorrect. We should only set userID if caller is either service-account or user. But right now if these are called with an api-key that id will be used.

Another issue is that right now anonymous users with access to e.g. create annotations will be prevented to do so because they do not have an internal id.

I changed these to user `identity.UserIdentifier`. This function will only return an valid id if caller is a user or a service-account. We ignore the error because 0 is return if they do not match. E.g. we don't record who created them 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
