### PR TITLE
Anon: Add ability to search with anonymous typedid for permissions

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -81,13 +81,14 @@ type Options struct {
 }
 
 type SearchOptions struct {
-	ActionPrefix string // Needed for the PoC v1, it's probably going to be removed.
-	Action       string
-	ActionSets   []string
-	Scope        string
-	TypedID      string    // ID of the identity (ex: user:3, service-account:4)
-	wildcards    Wildcards // private field computed based on the Scope
-	RolePrefixes []string
+	AllowAnonymous bool
+	ActionPrefix   string // Needed for the PoC v1, it's probably going to be removed.
+	Action         string
+	ActionSets     []string
+	Scope          string
+	TypedID        string    // ID of the identity (ex: user:3, service-account:4)
+	wildcards      Wildcards // private field computed based on the Scope
+	RolePrefixes   []string
 }
 
 // Wildcards computes the wildcard scopes that include the scope
@@ -111,6 +112,10 @@ func (s *SearchOptions) ComputeUserID() (int64, error) {
 		return 0, err
 	}
 
+	if s.AllowAnonymous && claims.IsIdentityType(typ, claims.TypeAnonymous) {
+		// their userID is 0 as they don't exist. Their permissions matches only their basic role
+		return 0, nil
+	}
 	if !claims.IsIdentityType(typ, claims.TypeUser, claims.TypeServiceAccount) {
 		return 0, fmt.Errorf("invalid type: %s", typ)
 	}

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -56,7 +56,7 @@ func ProvideService(
 ) (*Service, error) {
 	service := ProvideOSSService(cfg, database.ProvideService(db), actionResolver, cache, features, tracer, zclient, db.DB(), permRegistry)
 
-	api.NewAccessControlAPI(routeRegister, accessControl, service, features).RegisterAPIEndpoints()
+	api.NewAccessControlAPI(routeRegister, accessControl, service, features, cfg).RegisterAPIEndpoints()
 	if err := accesscontrol.DeclareFixedRoles(service, cfg); err != nil {
 		return nil, err
 	}
@@ -494,7 +494,9 @@ func (s *Service) SearchUsersPermissions(ctx context.Context, usr identity.Reque
 	// Limit roles to available in OSS
 	options.RolePrefixes = OSSRolesPrefixes
 	if options.TypedID != "" {
-		userID, err := options.ComputeUserID()
+		var err error
+		var userID int64
+		userID, err = options.ComputeUserID()
 		if err != nil {
 			s.log.Error("Failed to resolve user ID", "error", err)
 			return nil, err

--- a/pkg/services/accesscontrol/api/api.go
+++ b/pkg/services/accesscontrol/api/api.go
@@ -10,11 +10,13 @@ import (
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func NewAccessControlAPI(router routing.RouteRegister, accesscontrol ac.AccessControl, service ac.Service,
-	features featuremgmt.FeatureToggles) *AccessControlAPI {
+	features featuremgmt.FeatureToggles, cfg *setting.Cfg) *AccessControlAPI {
 	return &AccessControlAPI{
+		Cfg:           cfg,
 		RouteRegister: router,
 		Service:       service,
 		AccessControl: accesscontrol,
@@ -23,6 +25,7 @@ func NewAccessControlAPI(router routing.RouteRegister, accesscontrol ac.AccessCo
 }
 
 type AccessControlAPI struct {
+	Cfg           *setting.Cfg
 	Service       ac.Service
 	AccessControl ac.AccessControl
 	RouteRegister routing.RouteRegister
@@ -68,10 +71,11 @@ func (api *AccessControlAPI) getUserPermissions(c *contextmodel.ReqContext) resp
 // GET /api/access-control/users/permissions/search
 func (api *AccessControlAPI) searchUsersPermissions(c *contextmodel.ReqContext) response.Response {
 	searchOptions := ac.SearchOptions{
-		ActionPrefix: c.Query("actionPrefix"),
-		Action:       c.Query("action"),
-		Scope:        c.Query("scope"),
-		TypedID:      c.Query("namespacedId"),
+		AllowAnonymous: api.Cfg.AnonymousEnabled,
+		ActionPrefix:   c.Query("actionPrefix"),
+		Action:         c.Query("action"),
+		Scope:          c.Query("scope"),
+		TypedID:        c.Query("namespacedId"),
 	}
 
 	// Validate inputs

--- a/pkg/services/accesscontrol/api/api_test.go
+++ b/pkg/services/accesscontrol/api/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
@@ -40,7 +41,7 @@ func TestAPI_getUserActions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			acSvc := actest.FakeService{ExpectedPermissions: tt.permissions}
-			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, featuremgmt.WithFeatures())
+			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, featuremgmt.WithFeatures(), setting.NewCfg())
 			api.RegisterAPIEndpoints()
 
 			server := webtest.NewServer(t, api.RouteRegister)
@@ -93,7 +94,7 @@ func TestAPI_getUserPermissions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			acSvc := actest.FakeService{ExpectedPermissions: tt.permissions}
-			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, featuremgmt.WithFeatures())
+			api := NewAccessControlAPI(routing.NewRouteRegister(), actest.FakeAccessControl{}, acSvc, featuremgmt.WithFeatures(), setting.NewCfg())
 			api.RegisterAPIEndpoints()
 
 			server := webtest.NewServer(t, api.RouteRegister)
@@ -174,7 +175,7 @@ func TestAccessControlAPI_searchUsersPermissions(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			acSvc := actest.FakeService{ExpectedUsersPermissions: tt.permissions}
 			accessControl := actest.FakeAccessControl{ExpectedEvaluate: true} // Always allow access to the endpoint
-			api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, featuremgmt.WithFeatures(featuremgmt.FlagAccessControlOnCall))
+			api := NewAccessControlAPI(routing.NewRouteRegister(), accessControl, acSvc, featuremgmt.WithFeatures(featuremgmt.FlagAccessControlOnCall), setting.NewCfg())
 			api.RegisterAPIEndpoints()
 
 			server := webtest.NewServer(t, api.RouteRegister)

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
@@ -278,12 +277,7 @@ func (s *AccessControlStore) SearchUsersPermissions(ctx context.Context, orgID i
 }
 
 // GetUsersBasicRoles returns the list of user basic roles (Admin, Editor, Viewer, Grafana Admin) indexed by UserID
-// Special case for anonymous users, they don't have a user ID, we return the basic roles for them
 func (s *AccessControlStore) GetUsersBasicRoles(ctx context.Context, userIDFilter []int64, orgID int64) (map[int64][]string, error) {
-	// Special case for anonymous users, they don't have a user ID
-	if len(userIDFilter) == 1 && userIDFilter[0] == 0 {
-		return map[int64][]string{0: []string{string(identity.RoleAdmin), string(identity.RoleEditor), string(identity.RoleViewer)}}, nil
-	}
 	type UserOrgRole struct {
 		UserID  int64  `xorm:"id"`
 		OrgRole string `xorm:"role"`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
- adds the abiity for anonymous users to use the /users/search/permissions endpoint

The anonymous user becomes `userID=0, basicRoles` only.

to test this out:
```bash
$ curl -X GET http://localhost:3000/api/access-control/users/permissions/search?actionPrefix=teams&namespacedId=anonymous:2
```

**Why do we need this feature?**

anonymous users being able to search the permissions.

**Who is this feature for?**
anyone wanting to use anony

**Which issue(s) does this PR fix?**:
https://github.com/grafana/authlib/issues/62
