### PR TITLE
Identity: remove GetIDClaims

### DIFF
--- a/pkg/apimachinery/identity/requester.go
+++ b/pkg/apimachinery/identity/requester.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	authnlib "github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/claims"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -76,8 +75,6 @@ type Requester interface {
 	// GetIDToken returns a signed token representing the identity that can be forwarded to plugins and external services.
 	// Will only be set when featuremgmt.FlagIdForwarding is enabled.
 	GetIDToken() string
-	// GetIDClaims returns the claims of the ID token.
-	GetIDClaims() *authnlib.Claims[authnlib.IDTokenClaims]
 }
 
 // IntIdentifier converts a typeID to an int64.

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -175,10 +175,6 @@ func (i *Identity) GetIDToken() string {
 	return i.IDToken
 }
 
-func (i *Identity) GetIDClaims() *authn.Claims[authn.IDTokenClaims] {
-	return i.IDTokenClaims
-}
-
 func (i *Identity) GetIsGrafanaAdmin() bool {
 	return i.IsGrafanaAdmin != nil && *i.IsGrafanaAdmin
 }

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -323,7 +323,3 @@ func (u *SignedInUser) GetDisplayName() string {
 func (u *SignedInUser) GetIDToken() string {
 	return u.IDToken
 }
-
-func (u *SignedInUser) GetIDClaims() *authnlib.Claims[authnlib.IDTokenClaims] {
-	return u.IDTokenClaims
-}


### PR DESCRIPTION
**What is this feature?**
Remove `GetIDClaims` from `Requester`. This is unused and we can already access id token specific claims by calling `GetIdentity` and using claims.IdentityClaims interface.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
