### PR TITLE
Chore: Add diagnostics section to config

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -2,7 +2,7 @@
 init_cmds = [
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
-  ["./bin/grafana", "server", "-profile", "-profile-addr=0.0.0.0", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
+  ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]
 watch_all = true
 follow_symlinks = true
@@ -18,5 +18,5 @@ build_delay = 1500
 cmds = [
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
-  ["./bin/grafana", "server", "-profile", "-profile-addr=0.0.0.0", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
+  ["./bin/grafana", "server", "-packaging=dev", "cfg:app_mode=development"]
 ]

--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -77,13 +77,6 @@ func RunServer(opts ServerOptions) error {
 		}
 	}()
 
-	if err := setupProfiling(Profile, ProfileAddr, ProfilePort, ProfileBlockRate, ProfileMutexFraction); err != nil {
-		return err
-	}
-	if err := setupTracing(Tracing, TracingFile, logger); err != nil {
-		return err
-	}
-
 	defer func() {
 		// If we've managed to initialize them, this is the last place
 		// where we're able to log anything that'll end up in Grafana's
@@ -109,6 +102,13 @@ func RunServer(opts ServerOptions) error {
 		Args: append(configOptions, opts.Context.Args().Slice()...),
 	})
 	if err != nil {
+		return err
+	}
+
+	if err := setupProfiling(cfg, Profile, ProfileAddr, ProfilePort, ProfileBlockRate, ProfileMutexFraction); err != nil {
+		return err
+	}
+	if err := setupTracing(cfg, Tracing, TracingFile, logger); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/grafana-server/commands/diagnostics_test.go
+++ b/pkg/cmd/grafana-server/commands/diagnostics_test.go
@@ -15,6 +15,11 @@ func TestProfilingDiagnostics(t *testing.T) {
 		portEnv      string
 		blockRateEnv string
 		mutexRateEnv string
+		enabledArg   bool
+		addrArg      string
+		portArg      uint64
+		blockRateArg int
+		mutexRateArg int
 		expected     *profilingDiagnostics
 	}{
 		{defaults: newProfilingDiagnostics(false, "localhost", 6060, 0, 0), enabledEnv: "", addrEnv: "", portEnv: "", expected: newProfilingDiagnostics(false, "localhost", 6060, 0, 0)},
@@ -24,10 +29,14 @@ func TestProfilingDiagnostics(t *testing.T) {
 		{defaults: newProfilingDiagnostics(false, "127.0.0.1", 6060, 0, 0), enabledEnv: "true", addrEnv: "", portEnv: "", expected: newProfilingDiagnostics(true, "127.0.0.1", 6060, 0, 0)},
 		{defaults: newProfilingDiagnostics(true, "localhost", 6060, 0, 0), enabledEnv: "", addrEnv: "", portEnv: "", blockRateEnv: "3", mutexRateEnv: "4", expected: newProfilingDiagnostics(true, "localhost", 6060, 3, 4)},
 		{defaults: newProfilingDiagnostics(true, "localhost", 6060, 0, 0), enabledEnv: "", addrEnv: "", portEnv: "", expected: newProfilingDiagnostics(true, "localhost", 6060, 0, 0)},
+		{defaults: newProfilingDiagnostics(false, "localhost", 6060, 0, 0), enabledArg: true, addrArg: "0.0.0.0", portArg: 8080, blockRateArg: 1, mutexRateArg: 1, expected: newProfilingDiagnostics(true, "0.0.0.0", 8080, 1, 1)},
+		{defaults: newProfilingDiagnostics(true, "0.0.0.0", 8080, 1, 1), enabledArg: false, addrArg: "", portArg: 0, blockRateArg: 0, mutexRateArg: 0, expected: newProfilingDiagnostics(true, "0.0.0.0", 8080, 1, 1)},
+		{defaults: newProfilingDiagnostics(false, "localhost", 6060, 0, 0), enabledArg: false, addrArg: "1.1.1.1", portArg: 1111, blockRateArg: 1, mutexRateArg: 1, enabledEnv: "true", addrEnv: "2.2.2.2", portEnv: "2222", blockRateEnv: "2", mutexRateEnv: "2", expected: newProfilingDiagnostics(true, "2.2.2.2", 2222, 2, 2)},
 	}
 
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
+			tc.defaults.overrideWithArgs(tc.enabledArg, tc.addrArg, tc.portArg, tc.blockRateArg, tc.mutexRateArg)
 			if tc.enabledEnv != "" {
 				t.Setenv(profilingEnabledEnvName, tc.enabledEnv)
 			}
@@ -55,6 +64,8 @@ func TestTracingDiagnostics(t *testing.T) {
 		defaults   *tracingDiagnostics
 		enabledEnv string
 		fileEnv    string
+		enabledArg bool
+		fileArg    string
 		expected   *tracingDiagnostics
 	}{
 		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "", fileEnv: "", expected: newTracingDiagnostics(false, "trace.out")},
@@ -62,10 +73,14 @@ func TestTracingDiagnostics(t *testing.T) {
 		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "false", fileEnv: "/tmp/trace.out", expected: newTracingDiagnostics(false, "/tmp/trace.out")},
 		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "true", fileEnv: "/tmp/trace.out", expected: newTracingDiagnostics(true, "/tmp/trace.out")},
 		{defaults: newTracingDiagnostics(false, "trace.out"), enabledEnv: "true", fileEnv: "", expected: newTracingDiagnostics(true, "trace.out")},
+		{defaults: newTracingDiagnostics(false, "trace.out"), enabledArg: true, fileArg: "/tmp/trace.out", expected: newTracingDiagnostics(true, "/tmp/trace.out")},
+		{defaults: newTracingDiagnostics(true, "/tmp/trace.out"), enabledArg: false, fileArg: "", expected: newTracingDiagnostics(true, "/tmp/trace.out")},
+		{defaults: newTracingDiagnostics(false, "trace.out"), enabledArg: false, fileArg: "/tmp/trace.out", enabledEnv: "true", fileEnv: "/tmp/traceEnv.out", expected: newTracingDiagnostics(true, "/tmp/traceEnv.out")},
 	}
 
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
+			tc.defaults.overrideWithArgs(tc.enabledArg, tc.fileArg)
 			if tc.enabledEnv != "" {
 				t.Setenv(tracingEnabledEnvName, tc.enabledEnv)
 			}

--- a/pkg/cmd/grafana-server/commands/flags.go
+++ b/pkg/cmd/grafana-server/commands/flags.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"runtime"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -72,25 +70,25 @@ var commonFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "profile-addr",
-		Value:       "localhost",
+		Value:       "",
 		Usage:       "Define custom address for profiling",
 		Destination: &ProfileAddr,
 	},
 	&cli.Uint64Flag{
 		Name:        "profile-port",
-		Value:       6060,
+		Value:       0,
 		Usage:       "Define custom port for profiling",
 		Destination: &ProfilePort,
 	},
 	&cli.IntFlag{
 		Name:        "profile-block-rate",
-		Value:       1,
+		Value:       0,
 		Usage:       "Controls the fraction of goroutine blocking events that are reported in the blocking profile. The profiler aims to sample an average of one blocking event per rate nanoseconds spent blocked. To turn off profiling entirely, use 0",
 		Destination: &ProfileBlockRate,
 	},
 	&cli.IntFlag{
 		Name:        "profile-mutex-rate",
-		Value:       runtime.SetMutexProfileFraction(-1),
+		Value:       0,
 		Usage:       "Controls the fraction of mutex contention events that are reported in the mutex profile. On average 1/rate events are reported. To turn off mutex profiling entirely, use 0",
 		Destination: &ProfileMutexFraction,
 	},
@@ -102,7 +100,7 @@ var commonFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "tracing-file",
-		Value:       "trace.out",
+		Value:       "",
 		Usage:       "Define tracing output file",
 		Destination: &TracingFile,
 	},

--- a/pkg/cmd/grafana-server/commands/target.go
+++ b/pkg/cmd/grafana-server/commands/target.go
@@ -54,13 +54,6 @@ func RunTargetServer(opts ServerOptions) error {
 		}
 	}()
 
-	if err := setupProfiling(Profile, ProfileAddr, ProfilePort, ProfileBlockRate, ProfileMutexFraction); err != nil {
-		return err
-	}
-	if err := setupTracing(Tracing, TracingFile, logger); err != nil {
-		return err
-	}
-
 	defer func() {
 		// If we've managed to initialize them, this is the last place
 		// where we're able to log anything that'll end up in Grafana's
@@ -86,6 +79,13 @@ func RunTargetServer(opts ServerOptions) error {
 		Args: append(configOptions, opts.Context.Args().Slice()...),
 	})
 	if err != nil {
+		return err
+	}
+
+	if err := setupProfiling(cfg, Profile, ProfileAddr, ProfilePort, ProfileBlockRate, ProfileMutexFraction); err != nil {
+		return err
+	}
+	if err := setupTracing(cfg, Tracing, TracingFile, logger); err != nil {
 		return err
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -114,6 +114,9 @@ type Cfg struct {
 	EnforceDomain     bool
 	MinTLSVersion     string
 
+	// Diagnostics
+	Diagnostics DiagnosticsSettings
+
 	// Security settings
 	SecretKey             string
 	EmailCodeValidMinutes int
@@ -1072,6 +1075,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.BundledPluginsPath = makeAbsolute("plugins-bundled", cfg.HomePath)
 	provisioning := valueAsString(iniFile.Section("paths"), "provisioning", "")
 	cfg.ProvisioningPath = makeAbsolute(provisioning, cfg.HomePath)
+	cfg.readDiagnosticsSettings()
 
 	if err := cfg.readServerSettings(iniFile); err != nil {
 		return err

--- a/pkg/setting/setting_diagnostics.go
+++ b/pkg/setting/setting_diagnostics.go
@@ -1,0 +1,39 @@
+package setting
+
+import "runtime"
+
+type DiagnosticsSettings struct {
+	Profile              bool
+	ProfileAddr          string
+	ProfilePort          uint64
+	ProfileBlockRate     int
+	ProfileMutexFraction int
+	ProfileContention    bool
+	Tracing              bool
+	TracingFile          string
+}
+
+func (cfg *Cfg) readDiagnosticsSettings() {
+	diagnostics := cfg.Raw.Section("diagnostics")
+
+	cfg.Diagnostics.Profile = diagnostics.Key("profiling_enabled").MustBool(false)
+	cfg.Diagnostics.ProfileAddr = diagnostics.Key("profiling_addr").MustString("localhost")
+	cfg.Diagnostics.ProfilePort = diagnostics.Key("profiling_port").MustUint64(6060)
+	cfg.Diagnostics.ProfileBlockRate = diagnostics.Key("profiling_block_rate").MustInt(1)
+	cfg.Diagnostics.ProfileMutexFraction = diagnostics.Key("profiling_mutex_rate").MustInt(runtime.SetMutexProfileFraction(-1))
+	cfg.Diagnostics.ProfileContention = diagnostics.Key("profiling_contention").MustBool(false)
+
+	cfg.Diagnostics.Tracing = diagnostics.Key("tracing_enabled").MustBool(false)
+	cfg.Diagnostics.TracingFile = diagnostics.Key("tracing_file").MustString("trace.out")
+}
+
+func (cfg *Cfg) OverrideDiagnosticProfileSettings(profile bool, profileAddr string, profilePort uint64, profileBlockRate int, profileMutexFraction int, profileContention bool) {
+	if profile {
+		cfg.Diagnostics.Profile = profile
+	}
+	cfg.Diagnostics.ProfileAddr = profileAddr
+	cfg.Diagnostics.ProfilePort = profilePort
+	cfg.Diagnostics.ProfileBlockRate = profileBlockRate
+	cfg.Diagnostics.ProfileMutexFraction = profileMutexFraction
+	cfg.Diagnostics.ProfileContention = profileContention
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a diagnostics section to config. This is an alternate approach to https://github.com/grafana/grafana/pull/91916

**Why do we need this feature?**

via [this comment](https://github.com/grafana/grafana/pull/90866#issuecomment-2286495415):

> Mac OSX complains that you are opening a network connection everytime you start Grafana:
> 
> ![image](https://private-user-images.githubusercontent.com/4025665/357465069-2455181d-8276-4089-ab15-44f2186f2eb9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM2NDg0NzUsIm5iZiI6MTcyMzY0ODE3NSwicGF0aCI6Ii80MDI1NjY1LzM1NzQ2NTA2OS0yNDU1MTgxZC04Mjc2LTQwODktYWIxNS00NGYyMTg2ZjJlYjkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDgxNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA4MTRUMTUwOTM1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YTMwZjVhYTM0ZDMzZmJiYTJjMTNlNGU1ZDZiNjlhNTNmNGU5NGQ5YTRiZmViYWE3NTE4NTU4M2YyZWNhYmY0MCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.Zsxo5D6weZSTfI_8ZFfrPqVVcA4fiRWX-xgi7CsHygk)
> 
> This also happens if you don't set the Grafana `http_addr`, but that can be modified through configuration. Is there a way to configure this so devenv agent can still hit grafana but run it with `127.0.0.1` if you are just running `make run` locally?

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
