### PR TITLE
Chore: Switch dev profiling address to 127.0.0.1:6000

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -2,7 +2,7 @@
 init_cmds = [
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
-  ["./bin/grafana", "server", "-profile", "-profile-addr=0.0.0.0", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
+  ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]
 watch_all = true
 follow_symlinks = true
@@ -18,5 +18,5 @@ build_delay = 1500
 cmds = [
   ["GO_BUILD_DEV=1", "make", "build-go"],
   ["make", "gen-jsonnet"],
-  ["./bin/grafana", "server", "-profile", "-profile-addr=0.0.0.0", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
+  ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is an alternate approach to https://github.com/grafana/grafana/pull/91914

This moves the profiling address to `127.0.0.1:6000` when using `make run`.

When using `make devenv sources=self-instrumentation`, you can set the IP address using an environment variable:

```
export GF_DIAGNOSTICS_PROFILING_ADDR=0.0.0.0
make run
```

**Why do we need this feature?**

via [this comment](https://github.com/grafana/grafana/pull/90866#issuecomment-2286495415):

> Mac OSX complains that you are opening a network connection everytime you start Grafana:
> 
> ![image](https://private-user-images.githubusercontent.com/4025665/357465069-2455181d-8276-4089-ab15-44f2186f2eb9.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjM2NDg0NzUsIm5iZiI6MTcyMzY0ODE3NSwicGF0aCI6Ii80MDI1NjY1LzM1NzQ2NTA2OS0yNDU1MTgxZC04Mjc2LTQwODktYWIxNS00NGYyMTg2ZjJlYjkucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDgxNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA4MTRUMTUwOTM1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YTMwZjVhYTM0ZDMzZmJiYTJjMTNlNGU1ZDZiNjlhNTNmNGU5NGQ5YTRiZmViYWE3NTE4NTU4M2YyZWNhYmY0MCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.Zsxo5D6weZSTfI_8ZFfrPqVVcA4fiRWX-xgi7CsHygk)
> 
> This also happens if you don't set the Grafana `http_addr`, but that can be modified through configuration. Is there a way to configure this so devenv agent can still hit grafana but run it with `127.0.0.1` if you are just running `make run` locally?

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
