### PR TITLE
Unified Storage: Records grafana database metrics

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 
 	"github.com/dlmiddlecote/sqlstats"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.opentelemetry.io/otel/trace"
 	"xorm.io/xorm"
 
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
@@ -23,7 +23,7 @@ const (
 	dbTypePostgres = "postgres"
 )
 
-func ProvideResourceDB(grafanaDB infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer trace.Tracer) (db.DBProvider, error) {
+func ProvideResourceDB(grafanaDB infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (db.DBProvider, error) {
 	p, err := newResourceDBProvider(grafanaDB, cfg, features, tracer)
 	if err != nil {
 		return nil, fmt.Errorf("provide Resource DB: %w", err)
@@ -54,7 +54,7 @@ type resourceDBProvider struct {
 	logQueries      bool
 }
 
-func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer trace.Tracer) (p *resourceDBProvider, err error) {
+func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (p *resourceDBProvider, err error) {
 	// TODO: This should be renamed resource_api
 	getter := &sectionGetter{
 		DynamicSection: cfg.SectionWithEnvOverrides("resource_api"),

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -1,9 +1,8 @@
 package sql
 
 import (
-	"go.opentelemetry.io/otel/trace"
-
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -11,7 +10,7 @@ import (
 )
 
 // Creates a ResourceServer
-func ProvideResourceServer(db infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer trace.Tracer) (resource.ResourceServer, error) {
+func ProvideResourceServer(db infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (resource.ResourceServer, error) {
 	opts := resource.ResourceServerOptions{
 		Tracer: tracer,
 	}

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -33,15 +32,13 @@ func newServer(t *testing.T) (sql.Backend, resource.ResourceServer) {
 	dbstore := infraDB.InitTestDB(t)
 	cfg := setting.NewCfg()
 	features := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorage)
-	tr := noop.NewTracerProvider().Tracer("integrationtests")
 
-	eDB, err := dbimpl.ProvideResourceDB(dbstore, cfg, features, tr)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, cfg, features, nil)
 	require.NoError(t, err)
 	require.NotNil(t, eDB)
 
 	ret, err := sql.NewBackend(sql.BackendOptions{
 		DBProvider: eDB,
-		Tracer:     tr,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, ret)


### PR DESCRIPTION
Noticed the `Queries per second` panel on our US dashboard has no data. Looks like the `grafana_grpc_request_duration_seconds` histogram got lost when we moved to the resource store. Original PR [here](https://github.com/grafana/grafana/pull/87781/files). This adds it back 👍 