### PR TITLE
PanelInspect: Handle field type frame for csv export

### DIFF
--- a/packages/grafana-data/src/utils/csv.test.ts
+++ b/packages/grafana-data/src/utils/csv.test.ts
@@ -5,6 +5,7 @@ import { MutableDataFrame } from '../dataframe/MutableDataFrame';
 import { getDataFrameRow, toDataFrameDTO } from '../dataframe/processDataFrame';
 import { getDisplayProcessor } from '../field/displayProcessor';
 import { createTheme } from '../themes/createTheme';
+import { FieldType } from '../types/dataFrame';
 
 import { CSVHeaderStyle, readCSV, toCSV } from './csv';
 
@@ -157,6 +158,25 @@ describe('DataFrame to CSV', () => {
     expect(csv).toMatchInlineSnapshot(`
       ""Time","Value"
       1589455688623,2020-05-14 11:28:08"
+    `);
+  });
+
+  it('should handle field type frame', () => {
+    const dataFrame = new MutableDataFrame({
+      fields: [
+        { name: 'Time', values: [1589455688623] },
+        {
+          name: 'Value',
+          type: FieldType.frame,
+          values: [{ value: '1234' }],
+        },
+      ],
+    });
+
+    const csv = toCSV([dataFrame]);
+    expect(csv).toMatchInlineSnapshot(`
+      ""Time","Value"
+      1589455688623,1234"
     `);
   });
 });

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -309,7 +309,11 @@ export function toCSV(data: DataFrame[], config?: CSVConfig): string {
             csv = csv + config.delimiter;
           }
 
-          const v = fields[j].values[i];
+          let v = fields[j].values[i];
+          // For FieldType frame, use value if it exists to prevent exporting [object object]
+          if (fields[j].type === FieldType.frame && fields[j].values[i].value) {
+            v = fields[j].values[i].value;
+          }
           if (v !== null) {
             csv = csv + writers[j](v);
           }


### PR DESCRIPTION
For panel inspect, csv export was outputting [object] [object] for fields of type frame. This handles that field type.

Fixes https://github.com/grafana/support-escalations/issues/11685