### PR TITLE
ElasticSearch: Neaten up vars/consts

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Used in logging to mark a stage
-var (
+const (
 	StagePrepareRequest  = "prepareRequest"
 	StageDatabaseRequest = "databaseRequest"
 	StageParseResponse   = "parseResponse"

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -18,6 +18,57 @@ const (
 	intervalYearly  = "yearly"
 )
 
+var datePatternRegex = regexp.MustCompile("(LT|LL?L?L?|l{1,4}|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|SS?S?|X|zz?|ZZ?|Q)")
+
+var datePatternReplacements = map[string]string{
+	"M":    "1",                       // stdNumMonth 1 2 ... 11 12
+	"MM":   "01",                      // stdZeroMonth 01 02 ... 11 12
+	"MMM":  "Jan",                     // stdMonth Jan Feb ... Nov Dec
+	"MMMM": "January",                 // stdLongMonth January February ... November December
+	"D":    "2",                       // stdDay 1 2 ... 30 30
+	"DD":   "02",                      // stdZeroDay 01 02 ... 30 31
+	"DDD":  "<stdDayOfYear>",          // Day of the year 1 2 ... 364 365
+	"DDDD": "<stdDayOfYearZero>",      // Day of the year 001 002 ... 364 365 @todo****
+	"d":    "<stdDayOfWeek>",          // Numeric representation of day of the week 0 1 ... 5 6
+	"dd":   "Mon",                     // ***Su Mo ... Fr Sa @todo
+	"ddd":  "Mon",                     // Sun Mon ... Fri Sat
+	"dddd": "Monday",                  // stdLongWeekDay Sunday Monday ... Friday Saturday
+	"e":    "<stdDayOfWeek>",          // Numeric representation of day of the week 0 1 ... 5 6 @todo
+	"E":    "<stdDayOfWeekISO>",       // ISO-8601 numeric representation of the day of the week (added in PHP 5.1.0) 1 2 ... 6 7 @todo
+	"w":    "<stdWeekOfYear>",         // 1 2 ... 52 53
+	"ww":   "<stdWeekOfYear>",         // ***01 02 ... 52 53 @todo
+	"W":    "<stdWeekOfYear>",         // 1 2 ... 52 53
+	"WW":   "<stdWeekOfYear>",         // ***01 02 ... 52 53 @todo
+	"YY":   "06",                      // stdYear 70 71 ... 29 30
+	"YYYY": "2006",                    // stdLongYear 1970 1971 ... 2029 2030
+	"gg":   "<stdIsoYearShort>",       // ISO-8601 year number 70 71 ... 29 30
+	"gggg": "<stdIsoYear>",            // ***1970 1971 ... 2029 2030
+	"GG":   "<stdIsoYearShort>",       // 70 71 ... 29 30
+	"GGGG": "<stdIsoYear>",            // ***1970 1971 ... 2029 2030
+	"Q":    "<stdQuarter>",            // 1, 2, 3, 4
+	"A":    "PM",                      // stdPM AM PM
+	"a":    "pm",                      // stdpm am pm
+	"H":    "<stdHourNoZero>",         // stdHour 0 1 ... 22 23
+	"HH":   "15",                      // 00 01 ... 22 23
+	"h":    "3",                       // stdHour12 1 2 ... 11 12
+	"hh":   "03",                      // stdZeroHour12 01 02 ... 11 12
+	"m":    "4",                       // stdZeroMinute 0 1 ... 58 59
+	"mm":   "04",                      // stdZeroMinute 00 01 ... 58 59
+	"s":    "5",                       // stdSecond 0 1 ... 58 59
+	"ss":   "05",                      // stdZeroSecond ***00 01 ... 58 59
+	"z":    "MST",                     // EST CST ... MST PST
+	"zz":   "MST",                     // EST CST ... MST PST
+	"Z":    "Z07:00",                  // stdNumColonTZ -07:00 -06:00 ... +06:00 +07:00
+	"ZZ":   "-0700",                   // stdNumTZ -0700 -0600 ... +0600 +0700
+	"X":    "<stdUnix>",               // Seconds since unix epoch 1360013296
+	"LT":   "3:04 PM",                 // 8:30 PM
+	"L":    "01/02/2006",              // 09/04/1986
+	"l":    "1/2/2006",                // 9/4/1986
+	"ll":   "Jan 2 2006",              // Sep 4 1986
+	"lll":  "Jan 2 2006 3:04 PM",      // Sep 4 1986 8:30 PM
+	"llll": "Mon, Jan 2 2006 3:04 PM", // Thu, Sep 4 1986 8:30 PM
+}
+
 type IndexPattern interface {
 	GetIndices(timeRange backend.TimeRange) ([]string, error)
 }
@@ -198,57 +249,6 @@ func (i *yearlyInterval) Generate(from, to time.Time) []time.Time {
 	}
 
 	return intervals
-}
-
-var datePatternRegex = regexp.MustCompile("(LT|LL?L?L?|l{1,4}|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|SS?S?|X|zz?|ZZ?|Q)")
-
-var datePatternReplacements = map[string]string{
-	"M":    "1",                       // stdNumMonth 1 2 ... 11 12
-	"MM":   "01",                      // stdZeroMonth 01 02 ... 11 12
-	"MMM":  "Jan",                     // stdMonth Jan Feb ... Nov Dec
-	"MMMM": "January",                 // stdLongMonth January February ... November December
-	"D":    "2",                       // stdDay 1 2 ... 30 30
-	"DD":   "02",                      // stdZeroDay 01 02 ... 30 31
-	"DDD":  "<stdDayOfYear>",          // Day of the year 1 2 ... 364 365
-	"DDDD": "<stdDayOfYearZero>",      // Day of the year 001 002 ... 364 365 @todo****
-	"d":    "<stdDayOfWeek>",          // Numeric representation of day of the week 0 1 ... 5 6
-	"dd":   "Mon",                     // ***Su Mo ... Fr Sa @todo
-	"ddd":  "Mon",                     // Sun Mon ... Fri Sat
-	"dddd": "Monday",                  // stdLongWeekDay Sunday Monday ... Friday Saturday
-	"e":    "<stdDayOfWeek>",          // Numeric representation of day of the week 0 1 ... 5 6 @todo
-	"E":    "<stdDayOfWeekISO>",       // ISO-8601 numeric representation of the day of the week (added in PHP 5.1.0) 1 2 ... 6 7 @todo
-	"w":    "<stdWeekOfYear>",         // 1 2 ... 52 53
-	"ww":   "<stdWeekOfYear>",         // ***01 02 ... 52 53 @todo
-	"W":    "<stdWeekOfYear>",         // 1 2 ... 52 53
-	"WW":   "<stdWeekOfYear>",         // ***01 02 ... 52 53 @todo
-	"YY":   "06",                      // stdYear 70 71 ... 29 30
-	"YYYY": "2006",                    // stdLongYear 1970 1971 ... 2029 2030
-	"gg":   "<stdIsoYearShort>",       // ISO-8601 year number 70 71 ... 29 30
-	"gggg": "<stdIsoYear>",            // ***1970 1971 ... 2029 2030
-	"GG":   "<stdIsoYearShort>",       // 70 71 ... 29 30
-	"GGGG": "<stdIsoYear>",            // ***1970 1971 ... 2029 2030
-	"Q":    "<stdQuarter>",            // 1, 2, 3, 4
-	"A":    "PM",                      // stdPM AM PM
-	"a":    "pm",                      // stdpm am pm
-	"H":    "<stdHourNoZero>",         // stdHour 0 1 ... 22 23
-	"HH":   "15",                      // 00 01 ... 22 23
-	"h":    "3",                       // stdHour12 1 2 ... 11 12
-	"hh":   "03",                      // stdZeroHour12 01 02 ... 11 12
-	"m":    "4",                       // stdZeroMinute 0 1 ... 58 59
-	"mm":   "04",                      // stdZeroMinute 00 01 ... 58 59
-	"s":    "5",                       // stdSecond 0 1 ... 58 59
-	"ss":   "05",                      // stdZeroSecond ***00 01 ... 58 59
-	"z":    "MST",                     // EST CST ... MST PST
-	"zz":   "MST",                     // EST CST ... MST PST
-	"Z":    "Z07:00",                  // stdNumColonTZ -07:00 -06:00 ... +06:00 +07:00
-	"ZZ":   "-0700",                   // stdNumTZ -0700 -0600 ... +0600 +0700
-	"X":    "<stdUnix>",               // Seconds since unix epoch 1360013296
-	"LT":   "3:04 PM",                 // 8:30 PM
-	"L":    "01/02/2006",              // 09/04/1986
-	"l":    "1/2/2006",                // 9/4/1986
-	"ll":   "Jan 2 2006",              // Sep 4 1986
-	"lll":  "Jan 2 2006 3:04 PM",      // Sep 4 1986 8:30 PM
-	"llll": "Mon, Jan 2 2006 3:04 PM", // Thu, Sep 4 1986 8:30 PM
 }
 
 func formatDate(t time.Time, pattern string) string {

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -7,6 +7,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+// DateFormatEpochMS represents a date format of epoch milliseconds (epoch_millis)
+const DateFormatEpochMS = "epoch_millis"
+
 // SearchRequest represents a search request
 type SearchRequest struct {
 	Index       string
@@ -118,9 +121,6 @@ type RangeFilter struct {
 	Lte    int64
 	Format string
 }
-
-// DateFormatEpochMS represents a date format of epoch milliseconds (epoch_millis)
-const DateFormatEpochMS = "epoch_millis"
 
 // MarshalJSON returns the JSON encoding of the query string filter.
 func (f *RangeFilter) MarshalJSON() ([]byte, error) {

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -12,6 +12,15 @@ const (
 	HighlightPostTagsString = "@/HIGHLIGHT@"
 	HighlightFragmentSize   = 2147483647
 	DefaultGeoHashPrecision = 3
+
+	termsOrderTerm = "_term"
+)
+
+type SortOrder string
+
+const (
+	SortOrderAsc  SortOrder = "asc"
+	SortOrderDesc SortOrder = "desc"
 )
 
 // SearchRequestBuilder represents a builder which can build a search request
@@ -78,13 +87,6 @@ func (b *SearchRequestBuilder) Size(size int) *SearchRequestBuilder {
 	b.size = size
 	return b
 }
-
-type SortOrder string
-
-const (
-	SortOrderAsc  SortOrder = "asc"
-	SortOrderDesc SortOrder = "desc"
-)
 
 // Sort adds a "asc" | "desc" sort to the search request
 func (b *SearchRequestBuilder) Sort(order SortOrder, field string, unmappedType string) *SearchRequestBuilder {
@@ -385,8 +387,6 @@ func (b *aggBuilderImpl) DateHistogram(key, field string, fn func(a *DateHistogr
 
 	return b
 }
-
-const termsOrderTerm = "_term"
 
 func (b *aggBuilderImpl) Terms(key, field string, fn func(a *TermsAggregation, b AggBuilder)) AggBuilder {
 	innerAgg := &TermsAggregation{

--- a/pkg/tsdb/elasticsearch/response_parser.go
+++ b/pkg/tsdb/elasticsearch/response_parser.go
@@ -46,6 +46,7 @@ const (
 )
 
 var searchWordsRegex = regexp.MustCompile(regexp.QuoteMeta(es.HighlightPreTagsString) + `(.*?)` + regexp.QuoteMeta(es.HighlightPostTagsString))
+var aliasPatternRegex = regexp.MustCompile(`\{\{([\s\S]+?)\}\}`)
 
 func parseResponse(ctx context.Context, responses []*es.SearchResponse, targets []*Query, configuredFields es.ConfiguredFields, keepLabelsInResponse bool, logger log.Logger) (*backend.QueryDataResponse, error) {
 	result := backend.QueryDataResponse{
@@ -922,8 +923,6 @@ func nameFields(queryResult backend.DataResponse, target *Query, keepLabelsInRes
 		}
 	}
 }
-
-var aliasPatternRegex = regexp.MustCompile(`\{\{([\s\S]+?)\}\}`)
 
 func getFieldName(dataField data.Field, target *Query, metricTypeCount int) string {
 	metricType := dataField.Labels["metric"]


### PR DESCRIPTION
Evaluated the ElasticSearch plugin for multitenancy.
There was nothing to fix, I just cleaned up some of the consts and moved all of them to the top of the file to make them easier to find in the future.

We are using the `os` package to read files for tests in response_bench_test.go and snapshot_test.go , but those are test files so it should be fine.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/oss-plugin-partnerships/issues/1033
