### PR TITLE
BarChart: Prevent label clipping at top

### DIFF
--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -436,6 +436,11 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
             xAdjust = value < 0 ? textMetrics.width * scaleFactor : 0;
           }
 
+          // Force label bounding box y position to not be negative
+          if (y - yAdjust < 0) {
+            y = yAdjust;
+          }
+
           // Construct final bounding box for the label text
           labels[dataIdx][seriesIdx].x = x;
           labels[dataIdx][seriesIdx].y = y;

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -399,7 +399,7 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
           // Calculate final co-ordinates for text position
           const x =
             u.bbox.left + (isXHorizontal ? lft + wid / 2 : value < 0 ? lft - labelOffset : lft + wid + labelOffset);
-          const y =
+          let y =
             u.bbox.top +
             (isXHorizontal ? (value < 0 ? top + hgt + labelOffset : top - labelOffset) : top + hgt / 2 - middleShift);
 


### PR DESCRIPTION
Before:
![Aug-15-2024 17-46-12](https://github.com/user-attachments/assets/36d4e6c9-4cfb-4d8a-8beb-5a405580c8e5)

After:
![Aug-15-2024 17-46-36](https://github.com/user-attachments/assets/4c78af09-3dce-43db-a6d9-1f309dbdb597)

Fixes https://github.com/grafana/support-escalations/issues/11975