### PR TITLE
Docs: Add cloud label to doc articles

### DIFF
--- a/docs/sources/administration/roles-and-permissions/_index.md
+++ b/docs/sources/administration/roles-and-permissions/_index.md
@@ -10,6 +10,7 @@ labels:
   products:
     - enterprise
     - oss
+    - cloud
 title: Roles and permissions
 weight: 300
 ---

--- a/docs/sources/administration/service-accounts/index.md
+++ b/docs/sources/administration/service-accounts/index.md
@@ -12,6 +12,7 @@ labels:
   products:
     - enterprise
     - oss
+    - cloud
 menuTitle: Service accounts
 title: Service accounts
 weight: 800


### PR DESCRIPTION
**What is this feature?**

Adding cloud label to some doc pages where it was missing.
