### PR TITLE
UI Extensions: Share the registries using a React context

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -19,6 +19,7 @@ import { sidecarService } from './core/services/SidecarService';
 import { contextSrv } from './core/services/context_srv';
 import { ThemeProvider } from './core/utils/ConfigProvider';
 import { LiveConnectionWarning } from './features/live/LiveConnectionWarning';
+import { ExtensionRegistriesProvider } from './features/plugins/extensions/ExtensionRegistriesContext';
 import { ExperimentalSplitPaneRouterWrapper, RouterWrapper } from './routes/RoutesWrapper';
 
 interface AppWrapperProps {
@@ -110,15 +111,17 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
               >
                 <GlobalStyles />
                 <SidecarContext.Provider value={sidecarService}>
-                  <div className="grafana-app">
-                    {config.featureToggles.appSidecar ? (
-                      <ExperimentalSplitPaneRouterWrapper {...routerWrapperProps} />
-                    ) : (
-                      <RouterWrapper {...routerWrapperProps} />
-                    )}
-                    <LiveConnectionWarning />
-                    <PortalContainer />
-                  </div>
+                  <ExtensionRegistriesProvider registries={app.extensionRegistries}>
+                    <div className="grafana-app">
+                      {config.featureToggles.appSidecar ? (
+                        <ExperimentalSplitPaneRouterWrapper {...routerWrapperProps} />
+                      ) : (
+                        <RouterWrapper {...routerWrapperProps} />
+                      )}
+                      <LiveConnectionWarning />
+                      <PortalContainer />
+                    </div>
+                  </ExtensionRegistriesProvider>
                 </SidecarContext.Provider>
               </KBarProvider>
             </ThemeProvider>

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -111,7 +111,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
               >
                 <GlobalStyles />
                 <SidecarContext.Provider value={sidecarService}>
-                  <ExtensionRegistriesProvider registries={app.extensionRegistries}>
+                  <ExtensionRegistriesProvider registries={app.pluginExtensionsRegistries}>
                     <div className="grafana-app">
                       {config.featureToggles.appSidecar ? (
                         <ExperimentalSplitPaneRouterWrapper {...routerWrapperProps} />

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -83,6 +83,9 @@ import { PanelDataErrorView } from './features/panel/components/PanelDataErrorVi
 import { PanelRenderer } from './features/panel/components/PanelRenderer';
 import { DatasourceSrv } from './features/plugins/datasource_srv';
 import { createPluginExtensionsGetter } from './features/plugins/extensions/getPluginExtensions';
+import { AddedComponentsRegistry } from './features/plugins/extensions/registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from './features/plugins/extensions/registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from './features/plugins/extensions/registry/ExposedComponentsRegistry';
 import { setupPluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
 import { createUsePluginComponent } from './features/plugins/extensions/usePluginComponent';
 import { createUsePluginComponents } from './features/plugins/extensions/usePluginComponents';
@@ -124,6 +127,11 @@ if (process.env.NODE_ENV === 'development') {
 
 export class GrafanaApp {
   context!: GrafanaContextType;
+  extensionRegistries!: {
+    addedLinks: AddedLinksRegistry;
+    addedComponents: AddedComponentsRegistry;
+    exposedComponents: ExposedComponentsRegistry;
+  };
 
   async init() {
     try {
@@ -228,6 +236,12 @@ export class GrafanaApp {
       setPluginExtensionsHook(createUsePluginExtensions(pluginExtensionsRegistries));
       setPluginComponentHook(createUsePluginComponent(pluginExtensionsRegistries.exposedComponentsRegistry));
       setPluginComponentsHook(createUsePluginComponents(pluginExtensionsRegistries.addedComponentsRegistry));
+
+      this.extensionRegistries = {
+        addedLinks: pluginExtensionsRegistries.addedLinksRegistry,
+        addedComponents: pluginExtensionsRegistries.addedComponentsRegistry,
+        exposedComponents: pluginExtensionsRegistries.exposedComponentsRegistry,
+      };
 
       // initialize chrome service
       const queryParams = locationService.getSearchObject();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -87,7 +87,7 @@ import { AddedComponentsRegistry } from './features/plugins/extensions/registry/
 import { AddedLinksRegistry } from './features/plugins/extensions/registry/AddedLinksRegistry';
 import { ExposedComponentsRegistry } from './features/plugins/extensions/registry/ExposedComponentsRegistry';
 import { setupPluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
-import { createUsePluginComponent } from './features/plugins/extensions/usePluginComponent';
+import { usePluginComponent } from './features/plugins/extensions/usePluginComponent';
 import { createUsePluginComponents } from './features/plugins/extensions/usePluginComponents';
 import { createUsePluginExtensions } from './features/plugins/extensions/usePluginExtensions';
 import { createUsePluginLinks } from './features/plugins/extensions/usePluginLinks';
@@ -234,7 +234,7 @@ export class GrafanaApp {
       setPluginLinksHook(createUsePluginLinks(pluginExtensionsRegistries.addedLinksRegistry));
       setPluginExtensionGetter(createPluginExtensionsGetter(pluginExtensionsRegistries));
       setPluginExtensionsHook(createUsePluginExtensions(pluginExtensionsRegistries));
-      setPluginComponentHook(createUsePluginComponent(pluginExtensionsRegistries.exposedComponentsRegistry));
+      setPluginComponentHook(usePluginComponent);
       setPluginComponentsHook(createUsePluginComponents(pluginExtensionsRegistries.addedComponentsRegistry));
 
       this.extensionRegistries = {

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -83,14 +83,12 @@ import { PanelDataErrorView } from './features/panel/components/PanelDataErrorVi
 import { PanelRenderer } from './features/panel/components/PanelRenderer';
 import { DatasourceSrv } from './features/plugins/datasource_srv';
 import { createPluginExtensionsGetter } from './features/plugins/extensions/getPluginExtensions';
-import { AddedComponentsRegistry } from './features/plugins/extensions/registry/AddedComponentsRegistry';
-import { AddedLinksRegistry } from './features/plugins/extensions/registry/AddedLinksRegistry';
-import { ExposedComponentsRegistry } from './features/plugins/extensions/registry/ExposedComponentsRegistry';
 import { setupPluginExtensionRegistries } from './features/plugins/extensions/registry/setup';
+import { PluginExtensionRegistries } from './features/plugins/extensions/registry/types';
 import { usePluginComponent } from './features/plugins/extensions/usePluginComponent';
-import { createUsePluginComponents } from './features/plugins/extensions/usePluginComponents';
+import { usePluginComponents } from './features/plugins/extensions/usePluginComponents';
 import { createUsePluginExtensions } from './features/plugins/extensions/usePluginExtensions';
-import { createUsePluginLinks } from './features/plugins/extensions/usePluginLinks';
+import { usePluginLinks } from './features/plugins/extensions/usePluginLinks';
 import { importPanelPlugin, syncGetPanelPlugin } from './features/plugins/importPanelPlugin';
 import { preloadPlugins } from './features/plugins/pluginPreloader';
 import { QueryRunner } from './features/query/state/QueryRunner';
@@ -127,11 +125,7 @@ if (process.env.NODE_ENV === 'development') {
 
 export class GrafanaApp {
   context!: GrafanaContextType;
-  extensionRegistries!: {
-    addedLinks: AddedLinksRegistry;
-    addedComponents: AddedComponentsRegistry;
-    exposedComponents: ExposedComponentsRegistry;
-  };
+  pluginExtensionsRegistries!: PluginExtensionRegistries;
 
   async init() {
     try {
@@ -218,7 +212,7 @@ export class GrafanaApp {
       initWindowRuntime();
 
       // Initialize plugin extensions
-      const pluginExtensionsRegistries = setupPluginExtensionRegistries();
+      this.pluginExtensionsRegistries = setupPluginExtensionRegistries();
 
       if (contextSrv.user.orgRole !== '') {
         // The "cloud-home-app" is registering banners once it's loaded, and this can cause a rerender in the AppChrome if it's loaded after the Grafana app init.
@@ -227,21 +221,15 @@ export class GrafanaApp {
         const awaitedAppPlugins = Object.values(config.apps).filter((app) => awaitedAppPluginIds.includes(app.id));
         const appPlugins = Object.values(config.apps).filter((app) => !awaitedAppPluginIds.includes(app.id));
 
-        preloadPlugins(appPlugins, pluginExtensionsRegistries);
-        await preloadPlugins(awaitedAppPlugins, pluginExtensionsRegistries, 'frontend_awaited_plugins_preload');
+        preloadPlugins(appPlugins, this.pluginExtensionsRegistries);
+        await preloadPlugins(awaitedAppPlugins, this.pluginExtensionsRegistries, 'frontend_awaited_plugins_preload');
       }
 
-      setPluginLinksHook(createUsePluginLinks(pluginExtensionsRegistries.addedLinksRegistry));
-      setPluginExtensionGetter(createPluginExtensionsGetter(pluginExtensionsRegistries));
-      setPluginExtensionsHook(createUsePluginExtensions(pluginExtensionsRegistries));
+      setPluginExtensionGetter(createPluginExtensionsGetter(this.pluginExtensionsRegistries));
+      setPluginExtensionsHook(createUsePluginExtensions(this.pluginExtensionsRegistries));
+      setPluginLinksHook(usePluginLinks);
       setPluginComponentHook(usePluginComponent);
-      setPluginComponentsHook(createUsePluginComponents(pluginExtensionsRegistries.addedComponentsRegistry));
-
-      this.extensionRegistries = {
-        addedLinks: pluginExtensionsRegistries.addedLinksRegistry,
-        addedComponents: pluginExtensionsRegistries.addedComponentsRegistry,
-        exposedComponents: pluginExtensionsRegistries.exposedComponentsRegistry,
-      };
+      setPluginComponentsHook(usePluginComponents);
 
       // initialize chrome service
       const queryParams = locationService.getSearchObject();

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -11,6 +11,8 @@ import { RouteDescriptor } from 'app/core/navigation/types';
 import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
 
+import { ExtensionRegistriesProvider } from '../extensions/ExtensionRegistriesContext';
+import { setupPluginExtensionRegistries } from '../extensions/registry/setup';
 import { getPluginSettings } from '../pluginSettings';
 import { importAppPlugin } from '../plugin_loader';
 
@@ -85,6 +87,7 @@ async function renderUnderRouter(page = '') {
 
   appPluginNavItem.parentItem = appsSection;
 
+  const registries = setupPluginExtensionRegistries();
   const pagePath = page ? `/${page}` : '';
   const route = {
     component: () => <AppRootPage pluginId="my-awesome-plugin" pluginNavSection={appsSection} />,
@@ -96,7 +99,9 @@ async function renderUnderRouter(page = '') {
 
   render(
     <Router history={locationService.getHistory()}>
-      <Route path={`/a/:pluginId${pagePath}`} exact render={(props) => <GrafanaRoute {...props} route={route} />} />
+      <ExtensionRegistriesProvider registries={registries}>
+        <Route path={`/a/:pluginId${pagePath}`} exact render={(props) => <GrafanaRoute {...props} route={route} />} />
+      </ExtensionRegistriesProvider>
     </Router>
   );
 }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -55,9 +55,9 @@ interface State {
 const initialState: State = { loading: true, loadingError: false, pluginNav: null, plugin: null };
 
 export function AppRootPage({ pluginId, pluginNavSection }: Props) {
-  const addedLinks = useAddedLinksRegistry();
-  const addedComponents = useAddedComponentsRegistry();
-  const exposedComponents = useExposedComponentsRegistry();
+  const addedLinksRegistry = useAddedLinksRegistry();
+  const addedComponentsRegistry = useAddedComponentsRegistry();
+  const exposedComponentsRegistry = useExposedComponentsRegistry();
   const match = useRouteMatch();
   const location = useLocation();
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState);
@@ -98,7 +98,13 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
 
   const pluginRoot = plugin.root && (
     <PluginContextProvider meta={plugin.meta}>
-      <ExtensionRegistriesProvider registries={{ addedLinks, addedComponents, exposedComponents }}>
+      <ExtensionRegistriesProvider
+        registries={{
+          addedLinksRegistry: addedLinksRegistry.readOnly(),
+          addedComponentsRegistry: addedComponentsRegistry.readOnly(),
+          exposedComponentsRegistry: exposedComponentsRegistry.readOnly(),
+        }}
+      >
         <plugin.root
           meta={plugin.meta}
           basename={match.url}

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -24,6 +24,12 @@ import { appEvents, contextSrv } from 'app/core/core';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/navigation/errorModels';
 import { getMessageFromError } from 'app/core/utils/errors';
 
+import {
+  ExtensionRegistriesProvider,
+  useAddedLinksRegistry,
+  useAddedComponentsRegistry,
+  useExposedComponentsRegistry,
+} from '../extensions/ExtensionRegistriesContext';
 import { getPluginSettings } from '../pluginSettings';
 import { importAppPlugin } from '../plugin_loader';
 import { buildPluginSectionNav, pluginsLogger } from '../utils';
@@ -49,6 +55,9 @@ interface State {
 const initialState: State = { loading: true, loadingError: false, pluginNav: null, plugin: null };
 
 export function AppRootPage({ pluginId, pluginNavSection }: Props) {
+  const addedLinks = useAddedLinksRegistry();
+  const addedComponents = useAddedComponentsRegistry();
+  const exposedComponents = useExposedComponentsRegistry();
   const match = useRouteMatch();
   const location = useLocation();
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState);
@@ -89,13 +98,15 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
 
   const pluginRoot = plugin.root && (
     <PluginContextProvider meta={plugin.meta}>
-      <plugin.root
-        meta={plugin.meta}
-        basename={match.url}
-        onNavChanged={onNavChanged}
-        query={queryParams}
-        path={location.pathname}
-      />
+      <ExtensionRegistriesProvider registries={{ addedLinks, addedComponents, exposedComponents }}>
+        <plugin.root
+          meta={plugin.meta}
+          basename={match.url}
+          onNavChanged={onNavChanged}
+          query={queryParams}
+          path={location.pathname}
+        />
+      </ExtensionRegistriesProvider>
     </PluginContextProvider>
   );
 

--- a/public/app/features/plugins/extensions/ExtensionRegistriesContext.tsx
+++ b/public/app/features/plugins/extensions/ExtensionRegistriesContext.tsx
@@ -4,12 +4,10 @@ import { AddedComponentsRegistry } from 'app/features/plugins/extensions/registr
 import { AddedLinksRegistry } from 'app/features/plugins/extensions/registry/AddedLinksRegistry';
 import { ExposedComponentsRegistry } from 'app/features/plugins/extensions/registry/ExposedComponentsRegistry';
 
+import { PluginExtensionRegistries } from './registry/types';
+
 export interface ExtensionRegistriesContextType {
-  registries: {
-    addedLinks: AddedLinksRegistry;
-    addedComponents: AddedComponentsRegistry;
-    exposedComponents: ExposedComponentsRegistry;
-  };
+  registries: PluginExtensionRegistries;
 }
 
 // Using a different context for each registry to avoid unnecessary re-renders
@@ -46,9 +44,9 @@ export const ExtensionRegistriesProvider = ({
   children,
 }: PropsWithChildren<ExtensionRegistriesContextType>) => {
   return (
-    <AddedLinksRegistryContext.Provider value={registries.addedLinks}>
-      <AddedComponentsRegistryContext.Provider value={registries.addedComponents}>
-        <ExposedComponentsRegistryContext.Provider value={registries.exposedComponents}>
+    <AddedLinksRegistryContext.Provider value={registries.addedLinksRegistry}>
+      <AddedComponentsRegistryContext.Provider value={registries.addedComponentsRegistry}>
+        <ExposedComponentsRegistryContext.Provider value={registries.exposedComponentsRegistry}>
           {children}
         </ExposedComponentsRegistryContext.Provider>
       </AddedComponentsRegistryContext.Provider>

--- a/public/app/features/plugins/extensions/ExtensionRegistriesContext.tsx
+++ b/public/app/features/plugins/extensions/ExtensionRegistriesContext.tsx
@@ -1,0 +1,57 @@
+import { PropsWithChildren, createContext, useContext } from 'react';
+
+import { AddedComponentsRegistry } from 'app/features/plugins/extensions/registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from 'app/features/plugins/extensions/registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from 'app/features/plugins/extensions/registry/ExposedComponentsRegistry';
+
+export interface ExtensionRegistriesContextType {
+  registries: {
+    addedLinks: AddedLinksRegistry;
+    addedComponents: AddedComponentsRegistry;
+    exposedComponents: ExposedComponentsRegistry;
+  };
+}
+
+// Using a different context for each registry to avoid unnecessary re-renders
+export const AddedLinksRegistryContext = createContext<AddedLinksRegistry | undefined>(undefined);
+export const AddedComponentsRegistryContext = createContext<AddedComponentsRegistry | undefined>(undefined);
+export const ExposedComponentsRegistryContext = createContext<ExposedComponentsRegistry | undefined>(undefined);
+
+export function useAddedLinksRegistry(): AddedLinksRegistry {
+  const context = useContext(AddedLinksRegistryContext);
+  if (!context) {
+    throw new Error('No `AddedLinksRegistryContext` found.');
+  }
+  return context;
+}
+
+export function useAddedComponentsRegistry(): AddedComponentsRegistry {
+  const context = useContext(AddedComponentsRegistryContext);
+  if (!context) {
+    throw new Error('No `AddedComponentsRegistryContext` found.');
+  }
+  return context;
+}
+
+export function useExposedComponentsRegistry(): ExposedComponentsRegistry {
+  const context = useContext(ExposedComponentsRegistryContext);
+  if (!context) {
+    throw new Error('No `ExposedComponentsRegistryContext` found.');
+  }
+  return context;
+}
+
+export const ExtensionRegistriesProvider = ({
+  registries,
+  children,
+}: PropsWithChildren<ExtensionRegistriesContextType>) => {
+  return (
+    <AddedLinksRegistryContext.Provider value={registries.addedLinks}>
+      <AddedComponentsRegistryContext.Provider value={registries.addedComponents}>
+        <ExposedComponentsRegistryContext.Provider value={registries.exposedComponents}>
+          {children}
+        </ExposedComponentsRegistryContext.Provider>
+      </AddedComponentsRegistryContext.Provider>
+    </AddedLinksRegistryContext.Provider>
+  );
+};

--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
@@ -1,3 +1,5 @@
+import { ReplaySubject } from 'rxjs';
+
 import { PluginExtensionAddedComponentConfig } from '@grafana/data';
 
 import { logWarning, wrapWithPluginContext } from '../utils';
@@ -21,10 +23,13 @@ export class AddedComponentsRegistry extends Registry<
   AddedComponentRegistryItem[],
   PluginExtensionAddedComponentConfig
 > {
-  constructor(initialState: RegistryType<AddedComponentRegistryItem[]> = {}) {
-    super({
-      initialState,
-    });
+  constructor(
+    options: {
+      registrySubject?: ReplaySubject<RegistryType<AddedComponentRegistryItem[]>>;
+      initialState?: RegistryType<AddedComponentRegistryItem[]>;
+    } = {}
+  ) {
+    super(options);
   }
 
   mapToRegistry(
@@ -82,5 +87,12 @@ export class AddedComponentsRegistry extends Registry<
     }
 
     return registry;
+  }
+
+  // Returns a read-only version of the registry.
+  readOnly() {
+    return new AddedComponentsRegistry({
+      registrySubject: this.registrySubject,
+    });
   }
 }

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -1,3 +1,5 @@
+import { ReplaySubject } from 'rxjs';
+
 import { IconName, PluginExtensionAddedLinkConfig } from '@grafana/data';
 import { PluginAddedLinksConfigureFunc, PluginExtensionEventHelpers } from '@grafana/data/src/types/pluginExtensions';
 
@@ -25,10 +27,13 @@ export type AddedLinkRegistryItem<Context extends object = object> = {
 };
 
 export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], PluginExtensionAddedLinkConfig> {
-  constructor(initialState: RegistryType<AddedLinkRegistryItem[]> = {}) {
-    super({
-      initialState,
-    });
+  constructor(
+    options: {
+      registrySubject?: ReplaySubject<RegistryType<AddedLinkRegistryItem[]>>;
+      initialState?: RegistryType<AddedLinkRegistryItem[]>;
+    } = {}
+  ) {
+    super(options);
   }
 
   mapToRegistry(
@@ -94,5 +99,12 @@ export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], Plugin
     }
 
     return registry;
+  }
+
+  // Returns a read-only version of the registry.
+  readOnly() {
+    return new AddedLinksRegistry({
+      registrySubject: this.registrySubject,
+    });
   }
 }

--- a/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
@@ -1,3 +1,5 @@
+import { ReplaySubject } from 'rxjs';
+
 import { PluginExtensionExposedComponentConfig } from '@grafana/data';
 
 import { logWarning } from '../utils';
@@ -16,10 +18,13 @@ export class ExposedComponentsRegistry extends Registry<
   ExposedComponentRegistryItem,
   PluginExtensionExposedComponentConfig
 > {
-  constructor(initialState: RegistryType<ExposedComponentRegistryItem> = {}) {
-    super({
-      initialState,
-    });
+  constructor(
+    options: {
+      registrySubject?: ReplaySubject<RegistryType<ExposedComponentRegistryItem>>;
+      initialState?: RegistryType<ExposedComponentRegistryItem>;
+    } = {}
+  ) {
+    super(options);
   }
 
   mapToRegistry(

--- a/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
@@ -73,4 +73,11 @@ export class ExposedComponentsRegistry extends Registry<
 
     return registry;
   }
+
+  // Returns a read-only version of the registry.
+  readOnly() {
+    return new ExposedComponentsRegistry({
+      registrySubject: this.registrySubject,
+    });
+  }
 }

--- a/public/app/features/plugins/extensions/registry/Registry.ts
+++ b/public/app/features/plugins/extensions/registry/Registry.ts
@@ -9,43 +9,39 @@ export type PluginExtensionConfigs<T> = {
 
 export type RegistryType<T> = Record<string | symbol, T>;
 
-type ConstructorOptions<T> = {
-  initialState: RegistryType<T>;
-};
-
-export class ReadOnlyRegistry<T> {
-  private registryObservable: ReplaySubject<RegistryType<T>>;
-
-  constructor(registryObservable: ReplaySubject<RegistryType<T>>) {
-    this.registryObservable = registryObservable;
-  }
-
-  asObservable(): Observable<RegistryType<T>> {
-    return this.registryObservable.asObservable();
-  }
-
-  getState(): Promise<RegistryType<T>> {
-    return firstValueFrom(this.asObservable());
-  }
-}
-
 // This is the base-class used by the separate specific registries.
 export abstract class Registry<TRegistryValue, TMapType> {
+  // Used in cases when we would like to pass a read-only registry to plugin.
+  // In these cases we are passing in the `registrySubject` to the constructor.
+  // (If TRUE `initialState` is ignored.)
+  private isReadOnly: boolean;
+  // This is the subject that receives extension configs for a loaded plugin.
   private resultSubject: Subject<PluginExtensionConfigs<TMapType>>;
+  // This is the subject that we expose.
+  // (It will buffer the last value on the stream - the registry - and emit it to new subscribers immediately.)
   private registrySubject: ReplaySubject<RegistryType<TRegistryValue>>;
 
-  constructor(options: ConstructorOptions<TRegistryValue>) {
-    const { initialState } = options;
+  constructor(options: {
+    registrySubject?: ReplaySubject<RegistryType<TRegistryValue>>;
+    initialState?: RegistryType<TRegistryValue>;
+  }) {
     this.resultSubject = new Subject<PluginExtensionConfigs<TMapType>>();
-    // This is the subject that we expose.
-    // (It will buffer the last value on the stream - the registry - and emit it to new subscribers immediately.)
-    this.registrySubject = new ReplaySubject<RegistryType<TRegistryValue>>(1);
+    this.isReadOnly = false;
 
+    // If the registry subject (observable) is provided, it means that all the registry updates are taken care of outside of this class -> it is read-only.
+    if (options.registrySubject) {
+      this.registrySubject = options.registrySubject;
+      this.isReadOnly = true;
+
+      return;
+    }
+
+    this.registrySubject = new ReplaySubject<RegistryType<TRegistryValue>>(1);
     this.resultSubject
       .pipe(
-        scan(this.mapToRegistry, initialState),
+        scan(this.mapToRegistry, options.initialState ?? {}),
         // Emit an empty registry to start the stream (it is only going to do it once during construction, and then just passes down the values)
-        startWith(initialState),
+        startWith(options.initialState ?? {}),
         map((registry) => deepFreeze(registry))
       )
       // Emitting the new registry to `this.registrySubject`
@@ -58,6 +54,10 @@ export abstract class Registry<TRegistryValue, TMapType> {
   ): RegistryType<TRegistryValue>;
 
   register(result: PluginExtensionConfigs<TMapType>): void {
+    if (this.isReadOnly) {
+      throw new Error('Cannot register to a read-only registry');
+    }
+
     this.resultSubject.next(result);
   }
 
@@ -70,7 +70,11 @@ export abstract class Registry<TRegistryValue, TMapType> {
   }
 
   // Returns a read-only version of the registry.
-  readOnly(): ReadOnlyRegistry<TRegistryValue> {
-    return new ReadOnlyRegistry(this.registrySubject);
+  readOnly() {
+    return new (this.constructor as new (options: {
+      registrySubject: ReplaySubject<RegistryType<TRegistryValue>>;
+    }) => this)({
+      registrySubject: this.registrySubject,
+    });
   }
 }

--- a/public/app/features/plugins/extensions/registry/Registry.ts
+++ b/public/app/features/plugins/extensions/registry/Registry.ts
@@ -13,6 +13,22 @@ type ConstructorOptions<T> = {
   initialState: RegistryType<T>;
 };
 
+export class ReadOnlyRegistry<T> {
+  private registryObservable: ReplaySubject<RegistryType<T>>;
+
+  constructor(registryObservable: ReplaySubject<RegistryType<T>>) {
+    this.registryObservable = registryObservable;
+  }
+
+  asObservable(): Observable<RegistryType<T>> {
+    return this.registryObservable.asObservable();
+  }
+
+  getState(): Promise<RegistryType<T>> {
+    return firstValueFrom(this.asObservable());
+  }
+}
+
 // This is the base-class used by the separate specific registries.
 export abstract class Registry<TRegistryValue, TMapType> {
   private resultSubject: Subject<PluginExtensionConfigs<TMapType>>;
@@ -51,5 +67,10 @@ export abstract class Registry<TRegistryValue, TMapType> {
 
   getState(): Promise<RegistryType<TRegistryValue>> {
     return firstValueFrom(this.asObservable());
+  }
+
+  // Returns a read-only version of the registry.
+  readOnly(): ReadOnlyRegistry<TRegistryValue> {
+    return new ReadOnlyRegistry(this.registrySubject);
   }
 }

--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -19,13 +19,13 @@ jest.mock('app/features/plugins/pluginSettings', () => ({
 }));
 
 describe('usePluginComponent()', () => {
-  let registry: ExposedComponentsRegistry;
+  let exposedComponents: ExposedComponentsRegistry;
   let wrapper: ({ children }: { children: React.ReactNode }) => JSX.Element;
 
   beforeEach(() => {
+    exposedComponents = new ExposedComponentsRegistry();
     const addedLinks = new AddedLinksRegistry();
     const addedComponents = new AddedComponentsRegistry();
-    const exposedComponents = new ExposedComponentsRegistry();
 
     wrapper = ({ children }: { children: React.ReactNode }) => (
       <ExtensionRegistriesProvider
@@ -51,7 +51,7 @@ describe('usePluginComponent()', () => {
     const id = 'my-app-plugin/foo/bar/v1';
     const pluginId = 'my-app-plugin';
 
-    registry.register({
+    exposedComponents.register({
       pluginId,
       configs: [{ id, title: 'not important', description: 'not important', component: () => <div>Hello World</div> }],
     });
@@ -79,7 +79,7 @@ describe('usePluginComponent()', () => {
 
     // Add extensions to the registry
     act(() => {
-      registry.register({
+      exposedComponents.register({
         pluginId,
         configs: [
           {
@@ -107,7 +107,7 @@ describe('usePluginComponent()', () => {
   });
 
   it('should only render the hook once', () => {
-    const spy = jest.spyOn(registry, 'asObservable');
+    const spy = jest.spyOn(exposedComponents, 'asObservable');
     const id = 'my-app-plugin/foo/bar';
 
     renderHook(() => usePluginComponent(id), { wrapper });

--- a/public/app/features/plugins/extensions/usePluginComponent.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.tsx
@@ -3,31 +3,28 @@ import { useObservable } from 'react-use';
 
 import { UsePluginComponentResult } from '@grafana/runtime';
 
-import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
+import { useExposedComponentsRegistry } from './ExtensionRegistriesContext';
 import { wrapWithPluginContext } from './utils';
 
 // Returns a component exposed by a plugin.
 // (Exposed components can be defined in plugins by calling .exposeComponent() on the AppPlugin instance.)
-export function createUsePluginComponent(registry: ExposedComponentsRegistry) {
-  const observableRegistry = registry.asObservable();
+export function usePluginComponent<Props extends object = {}>(id: string): UsePluginComponentResult<Props> {
+  const registry = useExposedComponentsRegistry();
+  const registryState = useObservable(registry.asObservable());
 
-  return function usePluginComponent<Props extends object = {}>(id: string): UsePluginComponentResult<Props> {
-    const registry = useObservable(observableRegistry);
-
-    return useMemo(() => {
-      if (!registry?.[id]) {
-        return {
-          isLoading: false,
-          component: null,
-        };
-      }
-
-      const registryItem = registry[id];
-
+  return useMemo(() => {
+    if (!registryState?.[id]) {
       return {
         isLoading: false,
-        component: wrapWithPluginContext(registryItem.pluginId, registryItem.component),
+        component: null,
       };
-    }, [id, registry]);
-  };
-}
+    }
+
+    const registryItem = registryState[id];
+
+    return {
+      isLoading: false,
+      component: wrapWithPluginContext(registryItem.pluginId, registryItem.component),
+    };
+  }, [id, registryState]);
+};

--- a/public/app/features/plugins/extensions/usePluginComponent.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.tsx
@@ -27,4 +27,4 @@ export function usePluginComponent<Props extends object = {}>(id: string): UsePl
       component: wrapWithPluginContext(registryItem.pluginId, registryItem.component),
     };
   }, [id, registryState]);
-};
+}

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -1,8 +1,11 @@
 import { act, render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 
+import { ExtensionRegistriesProvider } from './ExtensionRegistriesContext';
 import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
-import { createUsePluginComponents } from './usePluginComponents';
+import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from './registry/ExposedComponentsRegistry';
+import { usePluginComponents } from './usePluginComponents';
 
 jest.mock('app/features/plugins/pluginSettings', () => ({
   getPluginSettings: jest.fn().mockResolvedValue({
@@ -16,18 +19,34 @@ jest.mock('app/features/plugins/pluginSettings', () => ({
 }));
 
 describe('usePluginComponents()', () => {
-  let registry: AddedComponentsRegistry;
+  let addedComponents: AddedComponentsRegistry;
+  let wrapper: ({ children }: { children: React.ReactNode }) => JSX.Element;
 
   beforeEach(() => {
-    registry = new AddedComponentsRegistry();
+    addedComponents = new AddedComponentsRegistry();
+    const addedLinks = new AddedLinksRegistry();
+    const exposedComponents = new ExposedComponentsRegistry();
+
+    wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ExtensionRegistriesProvider
+        registries={{
+          addedComponents,
+          addedLinks,
+          exposedComponents,
+        }}
+      >
+        {children}
+      </ExtensionRegistriesProvider>
+    );
   });
 
   it('should return an empty array if there are no extensions registered for the extension point', () => {
-    const usePluginComponents = createUsePluginComponents(registry);
-    const { result } = renderHook(() =>
-      usePluginComponents({
-        extensionPointId: 'foo/bar',
-      })
+    const { result } = renderHook(
+      () =>
+        usePluginComponents({
+          extensionPointId: 'foo/bar',
+        }),
+      { wrapper }
     );
 
     expect(result.current.components).toEqual([]);
@@ -37,7 +56,7 @@ describe('usePluginComponents()', () => {
     const extensionPointId = 'plugins/foo/bar/v1';
     const pluginId = 'my-app-plugin';
 
-    registry.register({
+    addedComponents.register({
       pluginId,
       configs: [
         {
@@ -61,8 +80,7 @@ describe('usePluginComponents()', () => {
       ],
     });
 
-    const usePluginComponents = createUsePluginComponents(registry);
-    const { result } = renderHook(() => usePluginComponents({ extensionPointId }));
+    const { result } = renderHook(() => usePluginComponents({ extensionPointId }), { wrapper });
 
     expect(result.current.components.length).toBe(2);
 
@@ -77,15 +95,14 @@ describe('usePluginComponents()', () => {
   it('should dynamically update the extensions registered for a certain extension point', () => {
     const extensionPointId = 'plugins/foo/bar/v1';
     const pluginId = 'my-app-plugin';
-    const usePluginComponents = createUsePluginComponents(registry);
-    let { result, rerender } = renderHook(() => usePluginComponents({ extensionPointId }));
+    let { result, rerender } = renderHook(() => usePluginComponents({ extensionPointId }), { wrapper });
 
     // No extensions yet
     expect(result.current.components.length).toBe(0);
 
     // Add extensions to the registry
     act(() => {
-      registry.register({
+      addedComponents.register({
         pluginId,
         configs: [
           {
@@ -117,19 +134,19 @@ describe('usePluginComponents()', () => {
   });
 
   it('should only render the hook once', () => {
-    const spy = jest.spyOn(registry, 'asObservable');
+    const spy = jest.spyOn(addedComponents, 'asObservable');
     const extensionPointId = 'plugins/foo/bar';
-    const usePluginComponents = createUsePluginComponents(registry);
 
-    renderHook(() => usePluginComponents({ extensionPointId }));
+    renderHook(() => usePluginComponents({ extensionPointId }), { wrapper });
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should honour the limitPerPlugin arg if its set', () => {
     const extensionPointId = 'plugins/foo/bar/v1';
     const plugins = ['my-app-plugin1', 'my-app-plugin2', 'my-app-plugin3'];
-    const usePluginComponents = createUsePluginComponents(registry);
-    let { result, rerender } = renderHook(() => usePluginComponents({ extensionPointId, limitPerPlugin: 2 }));
+    let { result, rerender } = renderHook(() => usePluginComponents({ extensionPointId, limitPerPlugin: 2 }), {
+      wrapper,
+    });
 
     // No extensions yet
     expect(result.current.components.length).toBe(0);
@@ -137,7 +154,7 @@ describe('usePluginComponents()', () => {
     // Add extensions to the registry
     act(() => {
       for (let pluginId of plugins) {
-        registry.register({
+        addedComponents.register({
           pluginId,
           configs: [
             {

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -6,42 +6,39 @@ import {
   UsePluginComponentsResult,
 } from '@grafana/runtime/src/services/pluginExtensions/getPluginExtensions';
 
-import { AddedComponentsRegistry } from './registry/AddedComponentsRegistry';
+import { useAddedComponentsRegistry } from './ExtensionRegistriesContext';
 
 // Returns an array of component extensions for the given extension point
-export function createUsePluginComponents(registry: AddedComponentsRegistry) {
-  const observableRegistry = registry.asObservable();
+export function usePluginComponents<Props extends object = {}>({
+  limitPerPlugin,
+  extensionPointId,
+}: UsePluginComponentOptions): UsePluginComponentsResult<Props> {
+  const registry = useAddedComponentsRegistry();
+  const registryState = useObservable(registry.asObservable());
 
-  return function usePluginComponents<Props extends object = {}>({
-    limitPerPlugin,
-    extensionPointId,
-  }: UsePluginComponentOptions): UsePluginComponentsResult<Props> {
-    const registry = useObservable(observableRegistry);
+  return useMemo(() => {
+    const components: Array<React.ComponentType<Props>> = [];
+    const extensionsByPlugin: Record<string, number> = {};
 
-    return useMemo(() => {
-      const components: Array<React.ComponentType<Props>> = [];
-      const extensionsByPlugin: Record<string, number> = {};
+    for (const registryItem of registryState?.[extensionPointId] ?? []) {
+      const { pluginId } = registryItem;
 
-      for (const registryItem of registry?.[extensionPointId] ?? []) {
-        const { pluginId } = registryItem;
-
-        // Only limit if the `limitPerPlugin` is set
-        if (limitPerPlugin && extensionsByPlugin[pluginId] >= limitPerPlugin) {
-          continue;
-        }
-
-        if (extensionsByPlugin[pluginId] === undefined) {
-          extensionsByPlugin[pluginId] = 0;
-        }
-
-        components.push(registryItem.component as React.ComponentType<Props>);
-        extensionsByPlugin[pluginId] += 1;
+      // Only limit if the `limitPerPlugin` is set
+      if (limitPerPlugin && extensionsByPlugin[pluginId] >= limitPerPlugin) {
+        continue;
       }
 
-      return {
-        isLoading: false,
-        components,
-      };
-    }, [extensionPointId, limitPerPlugin, registry]);
-  };
+      if (extensionsByPlugin[pluginId] === undefined) {
+        extensionsByPlugin[pluginId] = 0;
+      }
+
+      components.push(registryItem.component as React.ComponentType<Props>);
+      extensionsByPlugin[pluginId] += 1;
+    }
+
+    return {
+      isLoading: false,
+      components,
+    };
+  }, [extensionPointId, limitPerPlugin, registryState]);
 }

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -8,7 +8,7 @@ import {
   UsePluginLinksResult,
 } from '@grafana/runtime/src/services/pluginExtensions/getPluginExtensions';
 
-import { AddedLinksRegistry } from './registry/AddedLinksRegistry';
+import { useAddedLinksRegistry } from './ExtensionRegistriesContext';
 import {
   generateExtensionId,
   getLinkExtensionOnClick,
@@ -18,69 +18,67 @@ import {
 } from './utils';
 
 // Returns an array of component extensions for the given extension point
-export function createUsePluginLinks(registry: AddedLinksRegistry) {
-  const observableRegistry = registry.asObservable();
+export function usePluginLinks({
+  limitPerPlugin,
+  extensionPointId,
+  context,
+}: UsePluginLinksOptions): UsePluginLinksResult {
+  const registry = useAddedLinksRegistry();
+  const registryState = useObservable(registry.asObservable());
 
-  return function usePluginLinks({
-    limitPerPlugin,
-    extensionPointId,
-    context,
-  }: UsePluginLinksOptions): UsePluginLinksResult {
-    const registry = useObservable(observableRegistry);
-
-    return useMemo(() => {
-      if (!registry || !registry[extensionPointId]) {
-        return {
-          isLoading: false,
-          links: [],
-        };
-      }
-      const frozenContext = context ? getReadOnlyProxy(context) : {};
-      const extensions: PluginExtensionLink[] = [];
-      const extensionsByPlugin: Record<string, number> = {};
-
-      for (const addedLink of registry[extensionPointId] ?? []) {
-        const { pluginId } = addedLink;
-        // Only limit if the `limitPerPlugin` is set
-        if (limitPerPlugin && extensionsByPlugin[pluginId] >= limitPerPlugin) {
-          continue;
-        }
-
-        if (extensionsByPlugin[pluginId] === undefined) {
-          extensionsByPlugin[pluginId] = 0;
-        }
-
-        // Run the configure() function with the current context, and apply the ovverides
-        const overrides = getLinkExtensionOverrides(pluginId, addedLink, frozenContext);
-
-        // configure() returned an `undefined` -> hide the extension
-        if (addedLink.configure && overrides === undefined) {
-          continue;
-        }
-
-        const path = overrides?.path || addedLink.path;
-        const extension: PluginExtensionLink = {
-          id: generateExtensionId(pluginId, extensionPointId, addedLink.title),
-          type: PluginExtensionTypes.link,
-          pluginId: pluginId,
-          onClick: getLinkExtensionOnClick(pluginId, extensionPointId, addedLink, frozenContext),
-
-          // Configurable properties
-          icon: overrides?.icon || addedLink.icon,
-          title: overrides?.title || addedLink.title,
-          description: overrides?.description || addedLink.description,
-          path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
-          category: overrides?.category || addedLink.category,
-        };
-
-        extensions.push(extension);
-        extensionsByPlugin[pluginId] += 1;
-      }
-
+  return useMemo(() => {
+    if (!registryState || !registryState[extensionPointId]) {
       return {
         isLoading: false,
-        links: extensions,
+        links: [],
       };
-    }, [context, extensionPointId, limitPerPlugin, registry]);
-  };
+    }
+
+    const frozenContext = context ? getReadOnlyProxy(context) : {};
+    const extensions: PluginExtensionLink[] = [];
+    const extensionsByPlugin: Record<string, number> = {};
+
+    for (const addedLink of registryState[extensionPointId] ?? []) {
+      const { pluginId } = addedLink;
+      // Only limit if the `limitPerPlugin` is set
+      if (limitPerPlugin && extensionsByPlugin[pluginId] >= limitPerPlugin) {
+        continue;
+      }
+
+      if (extensionsByPlugin[pluginId] === undefined) {
+        extensionsByPlugin[pluginId] = 0;
+      }
+
+      // Run the configure() function with the current context, and apply the ovverides
+      const overrides = getLinkExtensionOverrides(pluginId, addedLink, frozenContext);
+
+      // configure() returned an `undefined` -> hide the extension
+      if (addedLink.configure && overrides === undefined) {
+        continue;
+      }
+
+      const path = overrides?.path || addedLink.path;
+      const extension: PluginExtensionLink = {
+        id: generateExtensionId(pluginId, extensionPointId, addedLink.title),
+        type: PluginExtensionTypes.link,
+        pluginId: pluginId,
+        onClick: getLinkExtensionOnClick(pluginId, extensionPointId, addedLink, frozenContext),
+
+        // Configurable properties
+        icon: overrides?.icon || addedLink.icon,
+        title: overrides?.title || addedLink.title,
+        description: overrides?.description || addedLink.description,
+        path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
+        category: overrides?.category || addedLink.category,
+      };
+
+      extensions.push(extension);
+      extensionsByPlugin[pluginId] += 1;
+    }
+
+    return {
+      isLoading: false,
+      links: extensions,
+    };
+  }, [context, extensionPointId, limitPerPlugin, registryState]);
 }


### PR DESCRIPTION
**Related PR(s):** https://github.com/grafana/grafana/pull/91648

### Background
Currently we are sharing the registry by wrapping the public API functions (`getPluginExtensions()`, `usePluginExtensions()`, etc.) with the internal registry singleton, so they have access to this internally during runtime. Although this works, in certain situations we would like to pass a "different" registry to certain plugins (e.g. the Extensions Admin page), which isn't really possible with this solution.

(The intent is that by default every plugin would receive a read-only version of the registry, however using the Grafana INI it would possible to specify plugin ids - e.g. the Extensions Admin App - that would receive a writable version, so it can edit the registry during runtime.)

### What changed?
- [x] Introduces a read-only registry
- [x] Shares the registry for _**exposed components**_ using context
- [x] Shares the registry for _**component extensions**_ using context
- [x] Shares the registry for _**link extensions**_ using context

**The main intent of this PR is to share the underlying registries using a React context.** To keep the implementation simple, the functions in `@grafana/runtime` are kept to be singletons that are set from grafana core (during boot time), as like this we can keep most of the business logic in core, while making the "state" (registry) overridable by nesting the context providers in the react tree.

<img width="847" alt="Screenshot 2024-08-19 at 6 31 30" src="https://github.com/user-attachments/assets/9c6b231c-51e8-4bdf-bfb0-54e772b2afb7">

### Testing

https://github.com/user-attachments/assets/84415296-5e94-4e59-8dc9-d60315c1c1ad


