### PR TITLE
Alerting: Fix long Alertmanager names overflowing the window

### DIFF
--- a/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
+++ b/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
-import { useMemo } from 'react';
+import { useMemo, ComponentProps } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { InlineField, Select, useStyles2 } from '@grafana/ui';
+import { InlineField, Select, SelectMenuOptions, useStyles2 } from '@grafana/ui';
 
 import { useAlertmanager } from '../state/AlertmanagerContext';
 import { AlertManagerDataSource, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
@@ -12,15 +12,15 @@ interface Props {
 }
 
 function getAlertManagerLabel(alertManager: AlertManagerDataSource) {
-  return alertManager.name === GRAFANA_RULES_SOURCE_NAME ? 'Grafana' : alertManager.name.slice(0, 37);
+  return alertManager.name === GRAFANA_RULES_SOURCE_NAME ? 'Grafana' : alertManager.name;
 }
 
 export const AlertManagerPicker = ({ disabled = false }: Props) => {
   const styles = useStyles2(getStyles);
   const { selectedAlertmanager, availableAlertManagers, setSelectedAlertmanager } = useAlertmanager();
 
-  const options: Array<SelectableValue<string>> = useMemo(() => {
-    return availableAlertManagers.map((ds) => ({
+  const options = useMemo(() => {
+    return availableAlertManagers.map<SelectableValue<string>>((ds) => ({
       label: getAlertManagerLabel(ds),
       value: ds.name,
       imgUrl: ds.imgUrl,
@@ -44,10 +44,10 @@ export const AlertManagerPicker = ({ disabled = false }: Props) => {
           }
         }}
         options={options}
-        maxMenuHeight={500}
         noOptionsMessage="No datasources found"
         value={selectedAlertmanager}
         getOptionLabel={(o) => o.label}
+        components={{ Option: CustomOption }}
       />
     </InlineField>
   );
@@ -58,3 +58,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin: 0,
   }),
 });
+
+// custom option that overwrites the default "white-space: nowrap" for Alertmanager names that are really long
+const CustomOption = (props: ComponentProps<typeof SelectMenuOptions>) => (
+  <SelectMenuOptions
+    {...props}
+    renderOptionLabel={({ label }) => <div style={{ whiteSpace: 'pre-line' }}>{label}</div>}
+  />
+);


### PR DESCRIPTION
**What is this feature?**

Prior to this PR, long Alertmanager names would overflow the window and be illegible.

This PR introduces a custom `Option` component that overrides the default `white-space: nowrap` by rendering the label on more than one line.

**Before**
<img width="331" alt="image" src="https://github.com/user-attachments/assets/db04647e-68e6-44a2-abcd-0a116cace733">


**After**
<img width="489" alt="image" src="https://github.com/user-attachments/assets/14c122fc-baa8-49bc-b514-4428cbb09ac1">


**Special notes for your reviewer:**

Using `formatOptionLabel` doesn't work as a solution here unfortunately because it also wraps the selected value which makes it look weird.

<img width="404" alt="image" src="https://github.com/user-attachments/assets/8af3d587-e7e3-4ca6-9c83-f0f51d6558fc">
