### PR TITLE
RBAC: Fix an issue with server admins not being able to manage users in orgs that they don't belong to

### DIFF
--- a/pkg/services/accesscontrol/authorize_in_org_test.go
+++ b/pkg/services/accesscontrol/authorize_in_org_test.go
@@ -1,7 +1,6 @@
 package accesscontrol_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,6 @@ import (
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
@@ -22,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/team/teamtest"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -37,8 +34,8 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 		orgIDGetter          accesscontrol.OrgIDGetter
 		evaluator            accesscontrol.Evaluator
 		accessControl        accesscontrol.AccessControl
-		acService            accesscontrol.Service
-		userCache            user.Service
+		userIdentities       []*authn.Identity
+		authnErrors          []error
 		ctxSignedInUser      *user.SignedInUser
 		teamService          team.Service
 		expectedStatus       int
@@ -48,7 +45,6 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			targetOrgId:          accesscontrol.GlobalOrgID,
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{},
 			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
 			targerOrgPermissions: []accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
 			teamService:          &teamtest.FakeService{},
@@ -60,7 +56,6 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			targerOrgPermissions: []accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{},
 			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
 			teamService:          &teamtest.FakeService{},
 			expectedStatus:       http.StatusOK,
@@ -71,7 +66,6 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			targerOrgPermissions: []accesscontrol.Permission{},
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{},
 			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{}},
 			teamService:          &teamtest.FakeService{},
 			expectedStatus:       http.StatusForbidden,
@@ -82,7 +76,6 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			targerOrgPermissions: []accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{},
 			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
 			teamService:          &teamtest.FakeService{},
 			expectedStatus:       http.StatusOK,
@@ -93,30 +86,7 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			targerOrgPermissions: []accesscontrol.Permission{},
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{},
 			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
-			teamService:          &teamtest.FakeService{},
-			expectedStatus:       http.StatusForbidden,
-		},
-		{
-			name:                 "should return 403 when user org ID doesn't match and user does not exist in org 2",
-			targetOrgId:          2,
-			targerOrgPermissions: []accesscontrol.Permission{},
-			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
-			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{ExpectedError: fmt.Errorf("user not found")},
-			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
-			teamService:          &teamtest.FakeService{},
-			expectedStatus:       http.StatusForbidden,
-		},
-		{
-			name:                 "should return 403 early when api key org ID doesn't match",
-			targetOrgId:          2,
-			targerOrgPermissions: []accesscontrol.Permission{},
-			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
-			accessControl:        ac,
-			userCache:            &usertest.FakeUserService{},
-			ctxSignedInUser:      &user.SignedInUser{ApiKeyID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
 			teamService:          &teamtest.FakeService{},
 			expectedStatus:       http.StatusForbidden,
 		},
@@ -127,13 +97,8 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
 			teamService:          &teamtest.FakeService{},
-			userCache: &usertest.FakeUserService{
-				GetSignedInUserFn: func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
-					return &user.SignedInUser{UserID: 1, OrgID: 2, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}}, nil
-				},
-			},
-			ctxSignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:write": {"users:*"}}}},
-			expectedStatus:  http.StatusOK,
+			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:write": {"users:*"}}}},
+			expectedStatus:       http.StatusOK,
 		},
 		{
 			name:                 "fails to fetch user permissions when org ID doesn't match",
@@ -142,16 +107,9 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:        ac,
 			teamService:          &teamtest.FakeService{},
-			acService: &actest.FakeService{
-				ExpectedErr: fmt.Errorf("failed to get user permissions"),
-			},
-			userCache: &usertest.FakeUserService{
-				GetSignedInUserFn: func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
-					return &user.SignedInUser{UserID: 1, OrgID: 2, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}}, nil
-				},
-			},
-			ctxSignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
-			expectedStatus:  http.StatusForbidden,
+			authnErrors:          []error{fmt.Errorf("failed to get user permissions")},
+			ctxSignedInUser:      &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
+			expectedStatus:       http.StatusForbidden,
 		},
 		{
 			name: "unable to get target org",
@@ -160,24 +118,35 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 			},
 			evaluator:       accesscontrol.EvalPermission("users:read", "users:*"),
 			accessControl:   ac,
-			userCache:       &usertest.FakeUserService{},
 			ctxSignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:read": {"users:*"}}}},
 			teamService:     &teamtest.FakeService{},
 			expectedStatus:  http.StatusForbidden,
 		},
 		{
-			name:                 "should fetch global user permissions when user is not a member of the target org",
-			targetOrgId:          2,
-			targerOrgPermissions: []accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
-			evaluator:            accesscontrol.EvalPermission("users:read", "users:*"),
-			accessControl:        ac,
-			userCache: &usertest.FakeUserService{
-				GetSignedInUserFn: func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
-					return &user.SignedInUser{UserID: 1, OrgID: -1, Permissions: map[int64]map[string][]string{}}, nil
-				},
-			},
+			name:            "should fetch global user permissions when user is not a member of the target org",
+			targetOrgId:     2,
+			evaluator:       accesscontrol.EvalPermission("users:read", "users:*"),
+			accessControl:   ac,
 			ctxSignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:write": {"users:*"}}}},
-			expectedStatus:  http.StatusOK,
+			userIdentities: []*authn.Identity{
+				{ID: "1", OrgID: -1, Permissions: map[int64]map[string][]string{}},
+				{ID: "1", OrgID: accesscontrol.GlobalOrgID, Permissions: map[int64]map[string][]string{accesscontrol.GlobalOrgID: {"users:read": {"users:*"}}}},
+			},
+			authnErrors:    []error{nil, nil},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:            "should fail if user is not a member of the target org and doesn't have the right permissions globally",
+			targetOrgId:     2,
+			evaluator:       accesscontrol.EvalPermission("users:read", "users:*"),
+			accessControl:   ac,
+			ctxSignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{1: {"users:write": {"users:*"}}}},
+			userIdentities: []*authn.Identity{
+				{ID: "1", OrgID: -1, Permissions: map[int64]map[string][]string{}},
+				{ID: "1", OrgID: accesscontrol.GlobalOrgID, Permissions: map[int64]map[string][]string{accesscontrol.GlobalOrgID: {"folders:read": {"folders:*"}}}},
+			},
+			authnErrors:    []error{nil, nil},
+			expectedStatus: http.StatusForbidden,
 		},
 	}
 
@@ -194,9 +163,16 @@ func TestAuthorizeInOrgMiddleware(t *testing.T) {
 				Permissions: map[int64]map[string][]string{},
 			}
 			expectedIdentity.Permissions[tc.targetOrgId] = accesscontrol.GroupScopesByAction(tc.targerOrgPermissions)
+			var expectedErr error
+			if len(tc.authnErrors) > 0 {
+				expectedErr = tc.authnErrors[0]
+			}
 
 			authnService := &authntest.FakeService{
-				ExpectedIdentity: expectedIdentity,
+				ExpectedIdentity:   expectedIdentity,
+				ExpectedIdentities: tc.userIdentities,
+				ExpectedErr:        expectedErr,
+				ExpectedErrs:       tc.authnErrors,
 			}
 
 			var orgIDGetter accesscontrol.OrgIDGetter

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -193,7 +193,7 @@ func AuthorizeInOrgMiddleware(ac AccessControl, authnService authn.Service) func
 			var orgUser identity.Requester = c.SignedInUser
 			if targetOrgID != c.SignedInUser.GetOrgID() {
 				orgUser, err = authnService.ResolveIdentity(c.Req.Context(), targetOrgID, c.SignedInUser.GetID())
-				if err == nil && orgUser.GetOrgID() == -1 {
+				if err == nil && orgUser.GetOrgID() == NoOrgID {
 					// User is not a member of the target org, so only their global permissions are relevant
 					orgUser, err = authnService.ResolveIdentity(c.Req.Context(), GlobalOrgID, c.SignedInUser.GetID())
 				}

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -193,6 +193,10 @@ func AuthorizeInOrgMiddleware(ac AccessControl, authnService authn.Service) func
 			var orgUser identity.Requester = c.SignedInUser
 			if targetOrgID != c.SignedInUser.GetOrgID() {
 				orgUser, err = authnService.ResolveIdentity(c.Req.Context(), targetOrgID, c.SignedInUser.GetID())
+				if err == nil && orgUser.GetOrgID() == -1 {
+					// User is not a member of the target org, so only their global permissions are relevant
+					orgUser, err = authnService.ResolveIdentity(c.Req.Context(), GlobalOrgID, c.SignedInUser.GetID())
+				}
 				if err != nil {
 					deny(c, nil, fmt.Errorf("failed to authenticate user in target org: %w", err))
 					return


### PR DESCRIPTION
**What is this feature?**

Explicitly resolve user in the global org if the user is not found in the required org.

This allows server admins to carry out actions in orgs that they don't belong to (eg, add users to an org which they are not members of).

**Why do we need this feature?**

If a user is not a member of the target org, we set their org ID to `-1` ([here](https://github.com/grafana/grafana/blob/v11.1.4/pkg/services/user/userimpl/store.go#L333-L336)). This means that server admins who have some global permissions will still have these permissions, but they will be mapped to org `-1`. So when we do permission evaluation and check their global permissions ([here](https://github.com/grafana/grafana/blob/v11.1.4/pkg/services/accesscontrol/acimpl/accesscontrol.go#L41-L45)), we will return an empty permission list ([here](https://github.com/grafana/grafana/blob/v11.1.4/pkg/services/authn/identity.go#L168-L170)) and permission check will fail.

**Who is this feature for?**

On-prem Grafana users with several orgs

Related to https://github.com/grafana/grafana/issues/91787

**Special notes for your reviewer:**

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/7074

Note that there are some error pop-ups about server admin not being able to list user roles in orgs that they don't belong to. This is because for the role listing endpoint we don't use the `AuthorizeInOrgMiddleware` (instead, org is passed in through `targetOrgId` query parameter, and we use the regular authZ middleware for evaluation). We could extend the logic introduced in the current PR to always fetch user's global permissions, but this is a far larger change that could have other unwanted side-effects. So I'm opting for this change as a compromise until we implement https://github.com/grafana/grafana/issues/91339.

I've tested this pretty extensively, but would appreciate if you could also test this locally before approving. Some test scenarios:
* server admin can add other users to an org that they belong to;
* server admin can add other users to an org that they do not belong to;
* server admin can add themselves to an org that they do not belong to;
* test OSS and enterprise