### PR TITLE
Table: Avoid rtl when using datalinks with units

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableCell.tsx
@@ -43,7 +43,7 @@ export const TableCell = ({
     cellProps.style.minWidth = cellProps.style.width;
     const justifyContent = (cell.column as any).justifyContent;
 
-    if (justifyContent === 'flex-end') {
+    if (justifyContent === 'flex-end' && !field.config.unit) {
       // justify-content flex-end is not compatible with cellLink overflow; use direction instead
       cellProps.style.textAlign = 'right';
       cellProps.style.direction = 'rtl';


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/91347, removing `!field.config.unit` is causing units to be rendered in front of the value when combined with a datalink. For now, let's re add that condition. The limitation here is that datalinks with units that overflow will not be rendered right align.

Before (with and without overflow):
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/e815d152-cda4-4311-8ae4-220fae871212">
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/7e201d75-f4d8-4a03-88ca-08e1f4b8a7ef">


After (with and without overflow):
<img width="1490" alt="image" src="https://github.com/user-attachments/assets/9a894859-3cc6-49f2-b298-d9db0cde9e07">
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/20289e7e-07ad-4a03-8df2-34f94699c58a">


A follow-up has ben created to go after all edge cases: https://github.com/grafana/grafana/issues/92037

Fixes https://github.com/grafana/support-escalations/issues/11986