### PR TITLE
VizTooltip: Fix positioning at bottom and right edges on mobile

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -313,8 +313,10 @@ export const TooltipPlugin2 = ({
           }
           // only pinnable tooltip is visible *and* is within proximity to series/point
           else if (_isHovering && closestSeriesIdx != null && !_isPinned) {
-            _isPinned = true;
-            scheduleRender(true);
+            setTimeout(() => {
+              _isPinned = true;
+              scheduleRender(true);
+            }, 0);
           }
         }
       });
@@ -608,14 +610,29 @@ export const TooltipPlugin2 = ({
       size.width = width;
       size.height = height;
 
-      const event = plot!.cursor.event;
+      let event = plot!.cursor.event;
 
       // if not viaSync, re-dispatch real event
       if (event != null) {
+        // we expect to re-dispatch mousemove, but on mobile we'll get mouseup or click
+        const isMobile = event.type !== 'mousemove';
+
+        if (isMobile) {
+          event = new MouseEvent('mousemove', {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            screenX: event.screenX,
+            screenY: event.screenY,
+          });
+        }
+
         // this works around the fact that uPlot does not unset cursor.event (for perf reasons)
         // so if the last real mouse event was mouseleave and you manually trigger u.setCursor()
         // it would end up re-dispatching mouseleave
-        const isStaleEvent = performance.now() - event.timeStamp > 16;
+        const isStaleEvent = isMobile ? false : performance.now() - event.timeStamp > 16;
 
         !isStaleEvent && plot!.over.dispatchEvent(event);
       } else {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/90413
Fixes https://github.com/grafana/grafana/issues/91452
Fixes https://github.com/grafana/grafana/issues/91740

we rely on re-emitting a `mousemove` event to re-position tooltips at the bottom and right edges of the viewport. but on mobile we end up re-emitting `mouseup` or `click` events during anchoring, which did not trigger the reposition logic.

this PR ensures we always emit a `mousemove`, regardless of what the original event was, we also delay the click-anchoring re-render to the next event loop.

![image](https://github.com/user-attachments/assets/29d482fa-8051-43fc-a01a-f82a1b7c4da7)