### PR TITLE
Alerting Docs: Monitor your high availability setup

### DIFF
--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -155,7 +155,7 @@ For a demo, see this [example of alerting high availability using Redis and Dock
 
 When running multiple Grafana instances, all alert rules are evaluated on every instance. This multiple evaluation of alert rules is visible in the [state history](ref:state-history) and provides a straightforward way to verify that your high availability configuration is working correctly.
 
-You can also confirm your high availability setup by monitoring alertmanager metrics exposed by Grafana:
+You can also confirm your high availability setup by monitoring Alertmanager metrics exposed by Grafana.
 
 | Metric                                               | Description                                                                                                    |
 | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -67,7 +67,7 @@ Since gossiping of notifications and silences uses both TCP and UDP port `9094`,
    By default, it is set to listen to all interfaces (`0.0.0.0`).
 1. Set `[ha_peer_timeout]` in the `[unified_alerting]` section of the custom.ini to specify the time to wait for an instance to send a notification via the Alertmanager. The default value is 15s, but it may increase if Grafana servers are located in different geographic regions or if the network latency between them is high.
 
-For a demo, see this [example](https://github.com/grafana/alerting-ha-docker-examples/tree/main/memberlist) of alerting high availability using Memberlist and Docker Compose.
+For a demo, see this [example using Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/tree/main/memberlist).
 
 ## Enable alerting high availability using Redis
 
@@ -81,7 +81,7 @@ database for HA and cannot support the meshing of all Grafana servers.
 1. Optional: Set `ha_redis_prefix` to something unique if you plan to share the Redis server with multiple Grafana instances.
 1. Optional: Set `ha_redis_tls_enabled` to `true` and configure the corresponding `ha_redis_tls_*` fields to secure communications between Grafana and Redis with Transport Layer Security (TLS).
 
-For a demo, see this [example of alerting high availability using Redis and Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/tree/main/redis).
+For a demo, see this [example using Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/tree/main/redis).
 
 ## Enable alerting high availability using Kubernetes
 

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -160,17 +160,17 @@ The HA settings (`ha_peers`, etc.) apply only to communication between alertmana
 
 You can also confirm your high availability setup by monitoring Alertmanager metrics exposed by Grafana.
 
-| Metric                                               | Description                                                                                                    |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| alertmanager_cluster_members                         | Number indicating current number of members in cluster.                                                        |
-| alertmanager_cluster_messages_received_total         | Total number of cluster messages received.                                                                     |
-| alertmanager_cluster_messages_received_size_total    | Total size of cluster messages received.                                                                       |
-| alertmanager_cluster_messages_sent_total             | Total number of cluster messages sent.                                                                         |
-| alertmanager_cluster_messages_sent_size_total        | Total number of cluster messages received.                                                                     |
-| alertmanager_cluster_messages_publish_failures_total | Total number of messages that failed to be published.                                                          |
-| alertmanager_cluster_pings_seconds                   | Histogram of latencies for ping messages.                                                                      |
-| alertmanager_cluster_pings_failures_total            | Total number of failed pings.                                                                                  |
-| alertmanager_peer_position                           | Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster. |
+| Metric                                               | Description                                                                                                                                                |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| alertmanager_cluster_members                         | Number indicating current number of members in cluster.                                                                                                    |
+| alertmanager_cluster_messages_received_total         | Total number of cluster messages received.                                                                                                                 |
+| alertmanager_cluster_messages_received_size_total    | Total size of cluster messages received.                                                                                                                   |
+| alertmanager_cluster_messages_sent_total             | Total number of cluster messages sent.                                                                                                                     |
+| alertmanager_cluster_messages_sent_size_total        | Total number of cluster messages received.                                                                                                                 |
+| alertmanager_cluster_messages_publish_failures_total | Total number of messages that failed to be published.                                                                                                      |
+| alertmanager_cluster_pings_seconds                   | Histogram of latencies for ping messages.                                                                                                                  |
+| alertmanager_cluster_pings_failures_total            | Total number of failed pings.                                                                                                                              |
+| alertmanager_peer_position                           | The position an Alertmanager instance believes it holds, which defines its role in the cluster. Peers should be numbered sequentially, starting from zero. |
 
 You can confirm the number of Grafana instances in your alerting high availability setup by querying the `alertmanager_cluster_members` and `alertmanager_peer_position` metrics.
 

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -171,7 +171,7 @@ You can also confirm your high availability setup by monitoring Alertmanager met
 
 You can confirm the number of Grafana instances in your alerting high availability setup by querying the `alertmanager_cluster_members` and `alertmanager_peer_position` metrics.
 
-But note that these alerting high availability metrics are exposed via the `/metrics` endpoint in Grafana, and are not automatically collected or displayed. If you have a Prometheus instance connected to Grafana, you can add a `scrape_config` to scrape Grafana metrics and then query these metrics in Explore.
+Note that these alerting high availability metrics are exposed via the `/metrics` endpoint in Grafana, and are not automatically collected or displayed. If you have a Prometheus instance connected to Grafana, add a `scrape_config` to scrape Grafana metrics and then query these metrics in Explore.
 
 ```yaml
 - job_name: grafana

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -67,7 +67,7 @@ Since gossiping of notifications and silences uses both TCP and UDP port `9094`,
    By default, it is set to listen to all interfaces (`0.0.0.0`).
 1. Set `[ha_peer_timeout]` in the `[unified_alerting]` section of the custom.ini to specify the time to wait for an instance to send a notification via the Alertmanager. The default value is 15s, but it may increase if Grafana servers are located in different geographic regions or if the network latency between them is high.
 
-For a demo, see this [example of alerting high availability using Memberlist and Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/tree/main/memberlist).
+For a demo, see this [example](https://github.com/grafana/alerting-ha-docker-examples/tree/main/memberlist) of alerting high availability using Memberlist and Docker Compose.
 
 ## Enable alerting high availability using Redis
 

--- a/docs/sources/alerting/set-up/configure-high-availability/_index.md
+++ b/docs/sources/alerting/set-up/configure-high-availability/_index.md
@@ -186,4 +186,4 @@ Note that these alerting high availability metrics are exposed via the `/metrics
         - grafana:3000
 ```
 
-For more details about monitoring alerting metrics, refer to [Alerting meta-monitoring](ref:meta-monitoring). For a demo, see the [alerting high availability examples using Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/).
+For more information on monitoring alerting metrics, refer to [Alerting meta-monitoring](ref:meta-monitoring). For a demo, see [alerting high availability examples using Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/).


### PR DESCRIPTION
Document how to verify that Alertmanger HA gossip is working. Closes https://github.com/grafana/grafana/issues/85913 

Also, refer to [new alerting high availability examples using Docker Compose](https://github.com/grafana/alerting-ha-docker-examples/) - it would be ideal to also review these examples.


