### PR TITLE
feat(alerting): add support for query service instant vectors

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/expr/classic"
@@ -648,6 +647,9 @@ func datasourceUIDsToRefIDs(refIDsToDatasourceUIDs map[string]string) map[string
 // Each non-empty Frame must be a single Field of type []*float64 and of length 1.
 // Also, each Frame must be uniquely identified by its Field.Labels or a single Error result will be returned.
 //
+// An exception to this is data that is returned by the query service, which might have a timestamp and single value.
+// Those are handled with the appropriated logic.
+//
 // Per Frame, data becomes a State based on the following rules:
 //
 // If no value is set:
@@ -702,6 +704,14 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 			continue
 		}
 
+		// The query service returns instant vectors from prometheus as scalars. We need to handle them accordingly.
+		if isScalarInstantVector(f) {
+			val := f.Fields[1].At(0).(*float64)
+			r := buildResult(f, val, ts)
+			evalResults = append(evalResults, r)
+			continue
+		}
+
 		if len(f.TypeIndices(data.FieldTypeTime, data.FieldTypeNullableTime)) > 0 {
 			appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: "looks like time series data, only reduced data can be alerted on."})
 			continue
@@ -734,23 +744,7 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 		}
 
 		val := f.Fields[0].At(0).(*float64) // type checked by data.FieldTypeNullableFloat64 above
-
-		r := Result{
-			Instance:           f.Fields[0].Labels,
-			EvaluatedAt:        ts,
-			EvaluationDuration: time.Since(ts),
-			EvaluationString:   extractEvalString(f),
-			Values:             extractValues(f),
-		}
-
-		switch {
-		case val == nil:
-			r.State = NoData
-		case *val == 0:
-			r.State = Normal
-		default:
-			r.State = Alerting
-		}
+		r := buildResult(f, val, ts)
 
 		evalResults = append(evalResults, r)
 	}
@@ -774,6 +768,38 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 	}
 
 	return evalResults
+}
+
+func buildResult(f *data.Frame, val *float64, ts time.Time) Result {
+	r := Result{
+		Instance:           f.Fields[0].Labels,
+		EvaluatedAt:        ts,
+		EvaluationDuration: time.Since(ts),
+		EvaluationString:   extractEvalString(f),
+		Values:             extractValues(f),
+	}
+	switch {
+	case val == nil:
+		r.State = NoData
+	case *val == 0:
+		r.State = Normal
+	default:
+		r.State = Alerting
+	}
+	return r
+}
+
+func isScalarInstantVector(f *data.Frame) bool {
+	if len(f.Fields) != 2 {
+		return false
+	}
+	if f.Fields[0].Len() > 1 || f.Fields[0].Type() != data.FieldTypeNullableTime {
+		return false
+	}
+	if f.Fields[1].Len() > 1 || f.Fields[1].Type() != data.FieldTypeNullableFloat64 {
+		return false
+	}
+	return true
 }
 
 // AsDataFrame forms the EvalResults in Frame suitable for displaying in the table panel of the front end.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -793,7 +793,7 @@ func isScalarInstantVector(f *data.Frame) bool {
 	if len(f.Fields) != 2 {
 		return false
 	}
-	if f.Fields[0].Len() > 1 || f.Fields[0].Type() != data.FieldTypeNullableTime {
+	if f.Fields[0].Len() > 1 || (f.Fields[0].Type() != data.FieldTypeNullableTime && f.Fields[0].Type() != data.FieldTypeTime) {
 		return false
 	}
 	if f.Fields[1].Len() > 1 || f.Fields[1].Type() != data.FieldTypeNullableFloat64 {

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -63,6 +63,52 @@ func TestEvaluateExecutionResult(t *testing.T) {
 			},
 		},
 		{
+			desc: "query service dataframe works as instant vector",
+			execResults: ExecutionResults{
+				Condition: func() []*data.Frame {
+					f := data.NewFrame("",
+						data.NewField("", nil, []*time.Time{util.Pointer(time.Now())}),
+						data.NewField("", nil, []*float64{util.Pointer(0.0)}),
+					)
+					f.Meta = &data.FrameMeta{
+						Custom: map[string]any{
+							"resultType": "scalar",
+						},
+					}
+					return []*data.Frame{f}
+				}(),
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: Normal,
+				},
+			},
+		},
+		{
+			desc: "query service dataframe works as instant vector when alerting",
+			execResults: ExecutionResults{
+				Condition: func() []*data.Frame {
+					f := data.NewFrame("",
+						data.NewField("", nil, []*time.Time{util.Pointer(time.Now())}),
+						data.NewField("", nil, []*float64{util.Pointer(1.0)}),
+					)
+					f.Meta = &data.FrameMeta{
+						Custom: map[string]any{
+							"resultType": "scalar",
+						},
+					}
+					return []*data.Frame{f}
+				}(),
+			},
+			expectResultLength: 1,
+			expectResults: Results{
+				{
+					State: Alerting,
+				},
+			},
+		},
+		{
 			desc: "nil value single instance is single a NoData state result",
 			execResults: ExecutionResults{
 				Condition: []*data.Frame{


### PR DESCRIPTION
This PR adds support to use instant vectors that come from the query service directly in alerting. Instant vectors from the `/ds/query` API have a different form than instant vectors that come from the expression engine. 

Example `/ds/query`
```json
[
  [
    1725979627897
  ],
  [
    1
  ]
]
```

Example `eval`
```json
[
  [
    1
  ]
]
```

The eval API does not return a timestamp with the instant vectors result, where as the query API does. This result in this part of the code to be triggered:

```golang
if len(f.TypeIndices(data.FieldTypeTime, data.FieldTypeNullableTime)) > 0 {
    appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: "looks like time series data, only reduced data can be alerted on."})
    continue
}
```

With the changes we are able to correctly detect those instant vectors that come from the query API and apply the same logic to them as we would do in the eval API. 

I also considered using the eval API everywhere, the problem is that we need the `/ds/query` semantics in the API as it will also be used by things like dashboards etc.