### PR TITLE
Loki language provider: don't cache empty array while querying

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -268,6 +268,23 @@ describe('Language completion provider', () => {
         end: expect.any(Number),
       });
     });
+
+    it.only('should use a single promise to resolve values', async () => {
+      const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+      const provider = await getLanguageProvider(datasource);
+      const requestSpy = jest.spyOn(provider, 'request');
+      const promise1 = provider.fetchLabelValues('testkey');
+      const promise2 = provider.fetchLabelValues('testkey');
+      const promise3 = provider.fetchLabelValues('testkeyNOPE');
+      expect(requestSpy).toHaveBeenCalledTimes(2);
+      
+      const values1 = await promise1;
+      const values2 = await promise2;
+      const values3 = await promise3;
+
+      expect(values1).toStrictEqual(values2);
+      expect(values2).not.toStrictEqual(values3);
+    });
   });
 
   describe('fetchLabels', () => {

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -284,6 +284,7 @@ describe('Language completion provider', () => {
 
       expect(values1).toStrictEqual(values2);
       expect(values2).not.toStrictEqual(values3);
+      expect(requestSpy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -269,7 +269,7 @@ describe('Language completion provider', () => {
       });
     });
 
-    it.only('should use a single promise to resolve values', async () => {
+    it('should use a single promise to resolve values', async () => {
       const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const requestSpy = jest.spyOn(provider, 'request');

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -277,7 +277,7 @@ describe('Language completion provider', () => {
       const promise2 = provider.fetchLabelValues('testkey');
       const promise3 = provider.fetchLabelValues('testkeyNOPE');
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      
+
       const values1 = await promise1;
       const values2 = await promise2;
       const values3 = await promise3;


### PR DESCRIPTION
Found while working on https://github.com/grafana/explore-logs/issues/690 , where I needed to have the label values before running other queries. I experienced a situation where I would receive an initial empty array, while successive requests correctly received the label values.

Before these changes, if the values were not in cache, while the request was being made, an incorrect empty string was set in the cache to prevent further API calls. This worked, but had the side effect of returning empty arrays while the actual values were being resolved.

![debug](https://github.com/user-attachments/assets/c0f1b248-4df4-48d8-914d-2964eec6769e)

It can be seen in the capture that, after the first call, it set the cache to `[]` and returned it to any call made before the actual API was resolved.

This PR changes the implementation to, instead of returning an empty cached array, it returns a promise that will be resolved with the received values. We need this because otherwise we can easily pile up repeated value calls:

![reason](https://github.com/user-attachments/assets/a2759caa-c2b8-4e2e-87a7-6e26ee3bdd0d)

**What is this feature?**

Bug fix

**Why do we need this feature?**

Feture correctness and for Explore Logs request sharding.


**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/explore-logs/issues/690

**Special notes for your reviewer:**

Please check that:
- Can be tested using the Loki query builder in Explore, when populating label values
- Can be tested in Explore Logs with this branch: https://github.com/grafana/explore-logs/compare/matyax%2Fshard-splitting