### PR TITLE
AzureMonitor: Add errorsource

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -741,7 +741,7 @@ func Test_exemplarsFeatureToggle(t *testing.T) {
 			QueryType: string(dataquery.AzureQueryTypeTraceql),
 		}
 
-		_, err := ds.buildQueries(ctx, []backend.DataQuery{query}, dsInfo, false)
+		_, err := ds.buildQuery(ctx, query, dsInfo, false)
 
 		require.NoError(t, err)
 	})
@@ -761,7 +761,7 @@ func Test_exemplarsFeatureToggle(t *testing.T) {
 			QueryType: string(dataquery.AzureQueryTypeTraceql),
 		}
 
-		_, err := ds.buildQueries(ctx, []backend.DataQuery{query}, dsInfo, false)
+		_, err := ds.buildQuery(ctx, query, dsInfo, false)
 
 		require.Error(t, err, "query type unsupported as azureMonitorPrometheusExemplars feature toggle is not enabled")
 	})

--- a/pkg/tsdb/azuremonitor/loganalytics/utils.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/utils.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 )
 
@@ -45,14 +46,14 @@ func AddConfigLinks(frame data.Frame, dl string, title *string) data.Frame {
 // 4. number of selected resources is exactly one
 func meetsBasicLogsCriteria(resources []string, fromAlert bool) (bool, error) {
 	if fromAlert {
-		return false, fmt.Errorf("basic Logs queries cannot be used for alerts")
+		return false, errorsource.DownstreamError(fmt.Errorf("basic Logs queries cannot be used for alerts"), false)
 	}
 	if len(resources) != 1 {
-		return false, fmt.Errorf("basic logs queries cannot be run against multiple resources")
+		return false, errorsource.DownstreamError(fmt.Errorf("basic logs queries cannot be run against multiple resources"), false)
 	}
 
 	if !strings.Contains(strings.ToLower(resources[0]), "microsoft.operationalinsights/workspaces") {
-		return false, fmt.Errorf("basic Logs queries may only be run against Log Analytics workspaces")
+		return false, errorsource.DownstreamError(fmt.Errorf("basic Logs queries may only be run against Log Analytics workspaces"), false)
 	}
 
 	return true, nil

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -52,13 +52,13 @@ func (e *AzureMonitorDatasource) ResourceRequest(rw http.ResponseWriter, req *ht
 func (e *AzureMonitorDatasource) ExecuteTimeSeriesQuery(ctx context.Context, originalQueries []backend.DataQuery, dsInfo types.DatasourceInfo, client *http.Client, url string, fromAlert bool) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 
-	queries, err := e.buildQueries(originalQueries, dsInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, query := range queries {
-		res, err := e.executeQuery(ctx, query, dsInfo, client, url)
+	for _, query := range originalQueries {
+		azureQuery, err := e.buildQuery(query, dsInfo)
+		if err != nil {
+			errorsource.AddErrorToResponse(query.RefID, result, err)
+			continue
+		}
+		res, err := e.executeQuery(ctx, azureQuery, dsInfo, client, url)
 		if err != nil {
 			errorsource.AddErrorToResponse(query.RefID, result, err)
 			continue
@@ -69,151 +69,146 @@ func (e *AzureMonitorDatasource) ExecuteTimeSeriesQuery(ctx context.Context, ori
 	return result, nil
 }
 
-func (e *AzureMonitorDatasource) buildQueries(queries []backend.DataQuery, dsInfo types.DatasourceInfo) ([]*types.AzureMonitorQuery, error) {
-	azureMonitorQueries := []*types.AzureMonitorQuery{}
+func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo types.DatasourceInfo) (*types.AzureMonitorQuery, error) {
+	var target string
+	queryJSONModel := dataquery.AzureMonitorQuery{}
+	err := json.Unmarshal(query.JSON, &queryJSONModel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode the Azure Monitor query object from JSON: %w", err)
+	}
 
-	for _, query := range queries {
-		var target string
-		queryJSONModel := dataquery.AzureMonitorQuery{}
-		err := json.Unmarshal(query.JSON, &queryJSONModel)
+	azJSONModel := queryJSONModel.AzureMonitor
+	// Legacy: If only MetricDefinition is set, use it as namespace
+	if azJSONModel.MetricDefinition != nil && *azJSONModel.MetricDefinition != "" &&
+		azJSONModel.MetricNamespace != nil && *azJSONModel.MetricNamespace == "" {
+		azJSONModel.MetricNamespace = azJSONModel.MetricDefinition
+	}
+
+	azJSONModel.DimensionFilters = MigrateDimensionFilters(azJSONModel.DimensionFilters)
+
+	alias := ""
+	if azJSONModel.Alias != nil {
+		alias = *azJSONModel.Alias
+	}
+	azureURL := ""
+	if queryJSONModel.Subscription != nil {
+		azureURL = BuildSubscriptionMetricsURL(*queryJSONModel.Subscription)
+	}
+	filterInBody := true
+	resourceIDs := []string{}
+	resourceMap := map[string]dataquery.AzureMonitorResource{}
+	if hasOne, resourceGroup, resourceName := hasOneResource(queryJSONModel); hasOne {
+		ub := urlBuilder{
+			ResourceURI: azJSONModel.ResourceUri,
+			// Alternative, used to reconstruct resource URI if it's not present
+			DefaultSubscription: &dsInfo.Settings.SubscriptionId,
+			Subscription:        queryJSONModel.Subscription,
+			ResourceGroup:       resourceGroup,
+			MetricNamespace:     azJSONModel.MetricNamespace,
+			ResourceName:        resourceName,
+		}
+
+		// Construct the resourceURI (for legacy query objects pre Grafana 9)
+		resourceUri, err := ub.buildResourceURI()
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode the Azure Monitor query object from JSON: %w", err)
+			return nil, err
 		}
 
-		azJSONModel := queryJSONModel.AzureMonitor
-		// Legacy: If only MetricDefinition is set, use it as namespace
-		if azJSONModel.MetricDefinition != nil && *azJSONModel.MetricDefinition != "" &&
-			azJSONModel.MetricNamespace != nil && *azJSONModel.MetricNamespace == "" {
-			azJSONModel.MetricNamespace = azJSONModel.MetricDefinition
+		// POST requests are only supported at the subscription level
+		filterInBody = false
+		if resourceUri != nil {
+			azureURL = fmt.Sprintf("%s/providers/microsoft.insights/metrics", *resourceUri)
+			resourceMap[*resourceUri] = dataquery.AzureMonitorResource{ResourceGroup: resourceGroup, ResourceName: resourceName}
 		}
-
-		azJSONModel.DimensionFilters = MigrateDimensionFilters(azJSONModel.DimensionFilters)
-
-		alias := ""
-		if azJSONModel.Alias != nil {
-			alias = *azJSONModel.Alias
-		}
-		azureURL := ""
-		if queryJSONModel.Subscription != nil {
-			azureURL = BuildSubscriptionMetricsURL(*queryJSONModel.Subscription)
-		}
-		filterInBody := true
-		resourceIDs := []string{}
-		resourceMap := map[string]dataquery.AzureMonitorResource{}
-		if hasOne, resourceGroup, resourceName := hasOneResource(queryJSONModel); hasOne {
+	} else {
+		for _, r := range azJSONModel.Resources {
 			ub := urlBuilder{
-				ResourceURI: azJSONModel.ResourceUri,
-				// Alternative, used to reconstruct resource URI if it's not present
 				DefaultSubscription: &dsInfo.Settings.SubscriptionId,
 				Subscription:        queryJSONModel.Subscription,
-				ResourceGroup:       resourceGroup,
+				ResourceGroup:       r.ResourceGroup,
 				MetricNamespace:     azJSONModel.MetricNamespace,
-				ResourceName:        resourceName,
+				ResourceName:        r.ResourceName,
 			}
-
-			// Construct the resourceURI (for legacy query objects pre Grafana 9)
 			resourceUri, err := ub.buildResourceURI()
 			if err != nil {
 				return nil, err
 			}
 
-			// POST requests are only supported at the subscription level
-			filterInBody = false
 			if resourceUri != nil {
-				azureURL = fmt.Sprintf("%s/providers/microsoft.insights/metrics", *resourceUri)
-				resourceMap[*resourceUri] = dataquery.AzureMonitorResource{ResourceGroup: resourceGroup, ResourceName: resourceName}
+				resourceMap[*resourceUri] = r
 			}
-		} else {
-			for _, r := range azJSONModel.Resources {
-				ub := urlBuilder{
-					DefaultSubscription: &dsInfo.Settings.SubscriptionId,
-					Subscription:        queryJSONModel.Subscription,
-					ResourceGroup:       r.ResourceGroup,
-					MetricNamespace:     azJSONModel.MetricNamespace,
-					ResourceName:        r.ResourceName,
-				}
-				resourceUri, err := ub.buildResourceURI()
-				if err != nil {
-					return nil, err
-				}
-
-				if resourceUri != nil {
-					resourceMap[*resourceUri] = r
-				}
-				resourceIDs = append(resourceIDs, fmt.Sprintf("Microsoft.ResourceId eq '%s'", *resourceUri))
-			}
+			resourceIDs = append(resourceIDs, fmt.Sprintf("Microsoft.ResourceId eq '%s'", *resourceUri))
 		}
-
-		// old model
-		dimension := ""
-		if azJSONModel.Dimension != nil {
-			dimension = strings.TrimSpace(*azJSONModel.Dimension)
-		}
-		dimensionFilter := ""
-		if azJSONModel.DimensionFilter != nil {
-			dimensionFilter = strings.TrimSpace(*azJSONModel.DimensionFilter)
-		}
-
-		dimSB := strings.Builder{}
-
-		if dimension != "" && dimensionFilter != "" && dimension != "None" && len(azJSONModel.DimensionFilters) == 0 {
-			dimSB.WriteString(fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter))
-		} else {
-			for i, filter := range azJSONModel.DimensionFilters {
-				if len(filter.Filters) == 0 {
-					dimSB.WriteString(fmt.Sprintf("%s eq '*'", *filter.Dimension))
-				} else {
-					dimSB.WriteString(types.ConstructFiltersString(filter))
-				}
-				if i != len(azJSONModel.DimensionFilters)-1 {
-					dimSB.WriteString(" and ")
-				}
-			}
-		}
-
-		filterString := strings.Join(resourceIDs, " or ")
-
-		if dimSB.String() != "" {
-			if filterString != "" {
-				filterString = fmt.Sprintf("(%s) and (%s)", filterString, dimSB.String())
-			} else {
-				filterString = dimSB.String()
-			}
-		}
-
-		params, err := getParams(azJSONModel, query)
-		if err != nil {
-			return nil, err
-		}
-		target = params.Encode()
-
-		sub := ""
-		if queryJSONModel.Subscription != nil {
-			sub = *queryJSONModel.Subscription
-		}
-
-		query := &types.AzureMonitorQuery{
-			URL:          azureURL,
-			Target:       target,
-			Params:       params,
-			RefID:        query.RefID,
-			Alias:        alias,
-			TimeRange:    query.TimeRange,
-			Dimensions:   azJSONModel.DimensionFilters,
-			Resources:    resourceMap,
-			Subscription: sub,
-		}
-		if filterString != "" {
-			if filterInBody {
-				query.BodyFilter = filterString
-			} else {
-				query.Params.Add("$filter", filterString)
-			}
-		}
-		azureMonitorQueries = append(azureMonitorQueries, query)
 	}
 
-	return azureMonitorQueries, nil
+	// old model
+	dimension := ""
+	if azJSONModel.Dimension != nil {
+		dimension = strings.TrimSpace(*azJSONModel.Dimension)
+	}
+	dimensionFilter := ""
+	if azJSONModel.DimensionFilter != nil {
+		dimensionFilter = strings.TrimSpace(*azJSONModel.DimensionFilter)
+	}
+
+	dimSB := strings.Builder{}
+
+	if dimension != "" && dimensionFilter != "" && dimension != "None" && len(azJSONModel.DimensionFilters) == 0 {
+		dimSB.WriteString(fmt.Sprintf("%s eq '%s'", dimension, dimensionFilter))
+	} else {
+		for i, filter := range azJSONModel.DimensionFilters {
+			if len(filter.Filters) == 0 {
+				dimSB.WriteString(fmt.Sprintf("%s eq '*'", *filter.Dimension))
+			} else {
+				dimSB.WriteString(types.ConstructFiltersString(filter))
+			}
+			if i != len(azJSONModel.DimensionFilters)-1 {
+				dimSB.WriteString(" and ")
+			}
+		}
+	}
+
+	filterString := strings.Join(resourceIDs, " or ")
+
+	if dimSB.String() != "" {
+		if filterString != "" {
+			filterString = fmt.Sprintf("(%s) and (%s)", filterString, dimSB.String())
+		} else {
+			filterString = dimSB.String()
+		}
+	}
+
+	params, err := getParams(azJSONModel, query)
+	if err != nil {
+		return nil, err
+	}
+	target = params.Encode()
+
+	sub := ""
+	if queryJSONModel.Subscription != nil {
+		sub = *queryJSONModel.Subscription
+	}
+
+	azureQuery := &types.AzureMonitorQuery{
+		URL:          azureURL,
+		Target:       target,
+		Params:       params,
+		RefID:        query.RefID,
+		Alias:        alias,
+		TimeRange:    query.TimeRange,
+		Dimensions:   azJSONModel.DimensionFilters,
+		Resources:    resourceMap,
+		Subscription: sub,
+	}
+	if filterString != "" {
+		if filterInBody {
+			azureQuery.BodyFilter = filterString
+		} else {
+			azureQuery.Params.Add("$filter", filterString)
+		}
+	}
+
+	return azureQuery, nil
 }
 
 func getParams(azJSONModel *dataquery.AzureMetricQuery, query backend.DataQuery) (url.Values, error) {

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -294,7 +294,7 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 				},
 			}
 
-			queries, err := datasource.buildQueries(tsdbQuery, dsInfo)
+			query, err := datasource.buildQuery(tsdbQuery[0], dsInfo)
 			require.NoError(t, err)
 
 			resources := map[string]dataquery.AzureMonitorResource{}
@@ -321,12 +321,12 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 				Resources:    resources,
 			}
 
-			assert.Equal(t, tt.expectedParamFilter, queries[0].Params.Get("$filter"))
+			assert.Equal(t, tt.expectedParamFilter, query.Params.Get("$filter"))
 			if azureMonitorQuery.URL == "" {
 				azureMonitorQuery.URL = "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana/providers/microsoft.insights/metrics"
 			}
 
-			if diff := cmp.Diff(azureMonitorQuery, queries[0], cmpopts.IgnoreUnexported(struct{}{}), cmpopts.IgnoreFields(types.AzureMonitorQuery{}, "Params", "Dimensions")); diff != "" {
+			if diff := cmp.Diff(azureMonitorQuery, query, cmpopts.IgnoreUnexported(struct{}{}), cmpopts.IgnoreFields(types.AzureMonitorQuery{}, "Params", "Dimensions")); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
 			}
 
@@ -338,7 +338,7 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 				expectedPortalURL = *tt.expectedPortalURL
 			}
 
-			actual, err := getQueryUrl(queries[0], "http://ds", "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana", "grafana")
+			actual, err := getQueryUrl(query, "http://ds", "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana", "grafana")
 			require.NoError(t, err)
 			require.Equal(t, expectedPortalURL, actual)
 		})
@@ -359,10 +359,10 @@ func TestCustomNamespace(t *testing.T) {
 			},
 		}
 
-		result, err := datasource.buildQueries(q, types.DatasourceInfo{})
+		result, err := datasource.buildQuery(q[0], types.DatasourceInfo{})
 		require.NoError(t, err)
 		expected := "custom/namespace"
-		require.Equal(t, expected, result[0].Params.Get("metricnamespace"))
+		require.Equal(t, expected, result.Params.Get("metricnamespace"))
 	})
 }
 

--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"fmt"
 	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 // urlBuilder builds the URL for calling the Azure Monitor API
@@ -33,7 +35,7 @@ func (params *urlBuilder) buildResourceURI() (*string, error) {
 
 	if metricNamespace == nil || *metricNamespace == "" {
 		if params.MetricDefinition == nil || *params.MetricDefinition == "" {
-			return nil, fmt.Errorf("no metricNamespace or metricDefiniton value provided")
+			return nil, errorsource.DownstreamError(fmt.Errorf("no metricNamespace or metricDefiniton value provided"), false)
 		}
 		metricNamespace = params.MetricDefinition
 	}
@@ -45,7 +47,7 @@ func (params *urlBuilder) buildResourceURI() (*string, error) {
 		provider = metricNamespaceArray[0]
 		metricNamespaceArray = metricNamespaceArray[1:]
 	} else {
-		return nil, fmt.Errorf("metricNamespace is not in the correct format")
+		return nil, errorsource.DownstreamError(fmt.Errorf("metricNamespace is not in the correct format"), false)
 	}
 
 	var resourceNameArray []string
@@ -76,7 +78,7 @@ func (params *urlBuilder) buildResourceURI() (*string, error) {
 		if i < len(resourceNameArray) {
 			urlArray = append(urlArray, namespace, resourceNameArray[i])
 		} else {
-			return nil, fmt.Errorf("resourceNameArray does not have enough elements")
+			return nil, errorsource.DownstreamError(fmt.Errorf("resourceNameArray does not have enough elements"), false)
 		}
 	}
 

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource_test.go
@@ -25,11 +25,11 @@ func TestBuildingAzureResourceGraphQueries(t *testing.T) {
 	fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
 
 	tests := []struct {
-		name                      string
-		queryModel                []backend.DataQuery
-		timeRange                 backend.TimeRange
-		azureResourceGraphQueries []*AzureResourceGraphQuery
-		Err                       require.ErrorAssertionFunc
+		name                    string
+		queryModel              []backend.DataQuery
+		timeRange               backend.TimeRange
+		azureResourceGraphQuery AzureResourceGraphQuery
+		Err                     require.ErrorAssertionFunc
 	}{
 		{
 			name: "Query with macros should be interpolated",
@@ -49,20 +49,18 @@ func TestBuildingAzureResourceGraphQueries(t *testing.T) {
 					RefID: "A",
 				},
 			},
-			azureResourceGraphQueries: []*AzureResourceGraphQuery{
-				{
-					RefID:        "A",
-					ResultFormat: "table",
-					URL:          "",
-					JSON: []byte(`{
+			azureResourceGraphQuery: AzureResourceGraphQuery{
+				RefID:        "A",
+				ResultFormat: "table",
+				URL:          "",
+				JSON: []byte(`{
 						"queryType": "Azure Resource Graph",
 						"azureResourceGraph": {
 							"query":        "resources | where $__contains(name,'res1','res2')",
 							"resultFormat": "table"
 						}
 					}`),
-					InterpolatedQuery: "resources | where ['name'] in ('res1','res2')",
-				},
+				InterpolatedQuery: "resources | where ['name'] in ('res1','res2')",
 			},
 			Err: require.NoError,
 		},
@@ -70,9 +68,9 @@ func TestBuildingAzureResourceGraphQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			queries, err := datasource.buildQueries(tt.queryModel, types.DatasourceInfo{})
+			query, err := datasource.buildQuery(tt.queryModel[0], types.DatasourceInfo{})
 			tt.Err(t, err)
-			if diff := cmp.Diff(tt.azureResourceGraphQueries, queries, cmpopts.IgnoreUnexported(struct{}{})); diff != "" {
+			if diff := cmp.Diff(&tt.azureResourceGraphQuery, query, cmpopts.IgnoreUnexported(struct{}{})); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/tsdb/azuremonitor/time/time-grain.go
+++ b/pkg/tsdb/azuremonitor/time/time-grain.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 // TimeGrain handles conversions between
@@ -26,7 +27,7 @@ func CreateISO8601DurationFromIntervalMS(it int64) (string, error) {
 	timeValueString := formatted[0 : len(formatted)-1]
 	timeValue, err := strconv.Atoi(timeValueString)
 	if err != nil {
-		return "", fmt.Errorf("could not parse interval %q to an ISO 8061 duration: %w", it, err)
+		return "", errorsource.DownstreamError(fmt.Errorf("could not parse interval %q to an ISO 8061 duration: %w", it, err), false)
 	}
 
 	unit := formatted[len(formatted)-1:]


### PR DESCRIPTION
Add `errorsource` to any errors that are downstream and may be returned at some point in the `QueryData` endpoint. A downstream error is anything that is not due to the plugin directly.

I've also reworked all of the sub-datasources to individually build their queries. This will allow us to return any errors from the query building process in the frame but also we no longer prevent queries that can be successfully built from being executed.