### PR TITLE
Unified Storage: Wrapping the mysql driver with hooks causes issues

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
@@ -51,8 +51,9 @@ func getEngineMySQL(getter *sectionGetter, tracer tracing.Tracer) (*xorm.Engine,
 	}
 
 	// FIXME: get rid of xorm
-	driverName := sqlstore.WrapDatabaseDriverWithHooks(db.DriverMySQL, tracer)
-	engine, err := xorm.NewEngine(driverName, config.FormatDSN())
+	// TODO figure out why wrapping the db driver with hooks causes mysql errors when writing
+	//driverName := sqlstore.WrapDatabaseDriverWithHooks(db.DriverMySQL, tracer)
+	engine, err := xorm.NewEngine(db.DriverMySQL, config.FormatDSN())
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}


### PR DESCRIPTION
Using ` sqlstore.WrapDatabaseDriverWithHooks()` causes us to get the error:

> begin tx: sql: driver does not support non-default isolation level 

Not sure why yet. This was code we had before we moved to the resource store. PR that introduced this issue is [here](https://github.com/grafana/grafana/pull/91932).