### PR TITLE
Storage: always use transactions and make them readonly when possible

### DIFF
--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -79,6 +79,7 @@ func (r *historyPollResponse) Results() (*historyPollResponse, error) {
 }
 
 type groupResourceRV map[string]map[string]int64
+
 type sqlResourceHistoryPollRequest struct {
 	sqltemplate.SQLTemplate
 	Resource             string
@@ -87,8 +88,13 @@ type sqlResourceHistoryPollRequest struct {
 	Response             *historyPollResponse
 }
 
-func (r sqlResourceHistoryPollRequest) Validate() error {
+func (r *sqlResourceHistoryPollRequest) Validate() error {
 	return nil // TODO
+}
+
+func (r *sqlResourceHistoryPollRequest) Results() (*historyPollResponse, error) {
+	res := *r.Response
+	return &res, nil
 }
 
 // sqlResourceReadRequest can be used to retrieve a row fromthe "resource" tables.
@@ -107,8 +113,13 @@ type sqlResourceReadRequest struct {
 	*readResponse
 }
 
-func (r sqlResourceReadRequest) Validate() error {
+func (r *sqlResourceReadRequest) Validate() error {
 	return nil // TODO
+}
+
+func (r *sqlResourceReadRequest) Results() (*readResponse, error) {
+	x := *r.readResponse
+	return &x, nil
 }
 
 // List
@@ -189,6 +200,11 @@ type sqlResourceVersionListRequest struct {
 	*groupResourceVersion
 }
 
-func (r sqlResourceVersionListRequest) Validate() error {
+func (r *sqlResourceVersionListRequest) Validate() error {
 	return nil // TODO
+}
+
+func (r *sqlResourceVersionListRequest) Results() (*groupResourceVersion, error) {
+	x := *r.groupResourceVersion
+	return &x, nil
 }

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -95,10 +95,10 @@ func (r *sqlResourceHistoryPollRequest) Validate() error {
 func (r *sqlResourceHistoryPollRequest) Results() (*historyPollResponse, error) {
 	return &historyPollResponse{
 		Key: resource.ResourceKey{
-			Namespace: r.Response.Namespace,
-			Group:     r.Response.Group,
-			Resource:  r.Response.Resource,
-			Name:      r.Response.Name,
+			Namespace: r.Response.Key.Namespace,
+			Group:     r.Response.Key.Group,
+			Resource:  r.Response.Key.Resource,
+			Name:      r.Response.Key.Name,
 		},
 		ResourceVersion: r.Response.ResourceVersion,
 		Value:           r.Response.Value,
@@ -128,9 +128,11 @@ func (r *sqlResourceReadRequest) Validate() error {
 
 func (r *sqlResourceReadRequest) Results() (*readResponse, error) {
 	return &readResponse{
-		Error:           r.readResponse.Error,
-		ResourceVersion: r.readResponse.ResourceVersion,
-		Value:           r.readResponse.Value,
+		ReadResponse: resource.ReadResponse{
+			Error:           r.ReadResponse.Error,
+			ResourceVersion: r.ReadResponse.ResourceVersion,
+			Value:           r.ReadResponse.Value,
+		},
 	}, nil
 }
 

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -93,8 +93,17 @@ func (r *sqlResourceHistoryPollRequest) Validate() error {
 }
 
 func (r *sqlResourceHistoryPollRequest) Results() (*historyPollResponse, error) {
-	res := *r.Response
-	return &res, nil
+	return &historyPollResponse{
+		Key: resource.ResourceKey{
+			Namespace: r.Response.Namespace,
+			Group:     r.Response.Group,
+			Resource:  r.Response.Resource,
+			Name:      r.Response.Name,
+		},
+		ResourceVersion: r.Response.ResourceVersion,
+		Value:           r.Response.Value,
+		Action:          r.Response.Action,
+	}, nil
 }
 
 // sqlResourceReadRequest can be used to retrieve a row fromthe "resource" tables.
@@ -118,8 +127,11 @@ func (r *sqlResourceReadRequest) Validate() error {
 }
 
 func (r *sqlResourceReadRequest) Results() (*readResponse, error) {
-	x := *r.readResponse
-	return &x, nil
+	return &readResponse{
+		Error:           r.readResponse.Error,
+		ResourceVersion: r.readResponse.ResourceVersion,
+		Value:           r.readResponse.Value,
+	}, nil
 }
 
 // List


### PR DESCRIPTION
**What is this feature?**

- Improves error reporting by including SQL executed (without data, i.e. with placeholders)
- Removes some lower-level operations on rows
- Prevent potential future misuse of low-level database operations

**Why do we need this feature?**

To improve logging and reduce the chances of future bugs.

**Who is this feature for?**

Operators and developers.

None

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
