### PR TITLE
Storage: remove sqlstore.WrapDatabaseDriverWithHooks

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"xorm.io/xorm"
 )
@@ -107,8 +106,7 @@ func getEnginePostgres(getter *sectionGetter, tracer tracing.Tracer) (*xorm.Engi
 	}
 
 	// FIXME: get rid of xorm
-	driverName := sqlstore.WrapDatabaseDriverWithHooks(db.DriverPostgres, tracer)
-	engine, err := xorm.NewEngine(driverName, dsn)
+	engine, err := xorm.NewEngine(db.DriverPostgres, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}


### PR DESCRIPTION
**What is this feature?**

Remove sqlstore.WrapDatabaseDriverWithHooks since it prevents usage of transaction options.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
