### PR TITLE
DashboardScene: Fix issue where panels are lost from dashboard

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -194,6 +194,62 @@ describe('transformSaveModelToScene', () => {
   });
 
   describe('when organizing panels as scene children', () => {
+    it('should leave panels outside second row if it is collapsed', () => {
+      const panel1 = createPanelSaveModel({
+        title: 'test1',
+        gridPos: { x: 0, y: 1, w: 12, h: 8 },
+      }) as Panel;
+
+      const panel2 = createPanelSaveModel({
+        title: 'test2',
+        gridPos: { x: 0, y: 10, w: 12, h: 8 },
+      }) as Panel;
+
+      const row1 = createPanelSaveModel({
+        title: 'test row 1',
+        type: 'row',
+        gridPos: { x: 0, y: 0, w: 12, h: 1 },
+        collapsed: false,
+        panels: [],
+      }) as unknown as RowPanel;
+
+      const row2 = createPanelSaveModel({
+        title: 'test row 2',
+        type: 'row',
+        gridPos: { x: 0, y: 9, w: 12, h: 1 },
+        collapsed: true,
+        panels: [],
+      }) as unknown as RowPanel;
+
+      const dashboard = {
+        ...defaultDashboard,
+        title: 'Test dashboard',
+        uid: 'test-uid',
+        panels: [row1, panel1, row2, panel2],
+      };
+
+      const oldModel = new DashboardModel(dashboard);
+
+      const scene = createDashboardSceneFromDashboardModel(oldModel, dashboard);
+      const body = scene.state.body as SceneGridLayout;
+
+      expect(body.state.children).toHaveLength(3);
+      const rowScene1 = body.state.children[0] as SceneGridRow;
+      expect(rowScene1).toBeInstanceOf(SceneGridRow);
+      expect(rowScene1.state.title).toEqual(row1.title);
+      expect(rowScene1.state.isCollapsed).toEqual(row1.collapsed);
+      expect(rowScene1.state.children).toHaveLength(1);
+      expect(rowScene1.state.children[0]).toBeInstanceOf(DashboardGridItem);
+
+      const rowScene2 = body.state.children[1] as SceneGridRow;
+      expect(rowScene2).toBeInstanceOf(SceneGridRow);
+      expect(rowScene2.state.title).toEqual(row2.title);
+      expect(rowScene2.state.isCollapsed).toEqual(row2.collapsed);
+      expect(rowScene2.state.children).toHaveLength(0);
+
+      expect(body.state.children[2]).toBeInstanceOf(DashboardGridItem);
+    });
+
     it('should create panels within collapsed rows', () => {
       const panel = createPanelSaveModel({
         title: 'test',

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -108,7 +108,15 @@ export function createSceneObjectsForPanels(oldPanels: PanelModel[]): SceneGridI
           // commit previous row panels
           panels.push(createRowFromPanelModel(currentRow, currentRowPanels));
 
-          currentRow = panel;
+          if (Boolean(panel.collapsed)) {
+            // collapsed rows contain their panels within the row model
+            panels.push(createRowFromPanelModel(panel, []));
+            currentRow = null;
+          } else {
+            // indicate new row to be processed
+            currentRow = panel;
+          }
+
           currentRowPanels = [];
         }
       }
@@ -151,7 +159,7 @@ export function createSceneObjectsForPanels(oldPanels: PanelModel[]): SceneGridI
 
 function createRowFromPanelModel(row: PanelModel, content: SceneGridItemLike[]): SceneGridItemLike {
   if (Boolean(row.collapsed)) {
-    if (row.panels && row.panels.length) {
+    if (row.panels) {
       content = row.panels.map((saveModel) => {
         // Collapsed panels are not actually PanelModel instances
         if (!(saveModel instanceof PanelModel)) {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -151,7 +151,7 @@ export function createSceneObjectsForPanels(oldPanels: PanelModel[]): SceneGridI
 
 function createRowFromPanelModel(row: PanelModel, content: SceneGridItemLike[]): SceneGridItemLike {
   if (Boolean(row.collapsed)) {
-    if (row.panels) {
+    if (row.panels && row.panels.length) {
       content = row.panels.map((saveModel) => {
         // Collapsed panels are not actually PanelModel instances
         if (!(saveModel instanceof PanelModel)) {


### PR DESCRIPTION
Fixes a bug where the old panel model was not properly updated to a scene grid layout with multiple rows.

E.g.: In a dashboard with an uncollapsed row containing one panel, a collapsed row with no panels, and a panel after the second collapsed row, the last panel is lost due to the `currentRow` not resetting properly. Thus, when it reaches `createRowFromPanelModel` the content, which contains said panel, is overwritten to empty array because the row `PanelModel` does not contain any panels and so that panel is lost.

Before:

https://github.com/user-attachments/assets/1fb2b2e8-77ff-4d84-97b4-33f60aec6ff6




After:


https://github.com/user-attachments/assets/9e44d3ae-0ec8-4cae-8dac-1f05075da192




