### PR TITLE
Alerting docs: separates doc on create alerts from panels

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-alerts-panels.md
+++ b/docs/sources/alerting/alerting-rules/create-alerts-panels.md
@@ -19,17 +19,23 @@ weight: 400
 
 ## Create alert rules from panels
 
-Create alert rules from any panel type. By doing so, you can reuse the queries in the panel and create alert rules based on them.
+Create alert rules from time series panels. By doing so, you can reuse the queries in the panel and create alert rules based on them.
 
 1. Navigate to a dashboard in the **Dashboards** section.
-2. Hover over the top-right corner of any panel and click the panel menu icon.
+2. Hover over the top-right corner of a time series panel and click the panel menu icon.
 3. From the dropdown menu, select **More...** > **New alert rule**.
 
 The New alert rule form opens where you can configure and create your alert rule based on the query used in the panel.
 
+{{% admonition type="note" %}}
+   At the moment, alert rules are only supported in [time series](ref:time-series) visualizations.
+   {{% /admonition %}}
+
+   {{< docs/play title="visualizations with linked alerts in Grafana" url="https://play.grafana.org/d/000000074/" >}}
+
 ## View alert rules from panels
 
-To view alert rules associated with a panel, complete the following steps.
+To view alert rules associated with a time series panel, complete the following steps.
 
 1. Ooen the panel editor by hovering over the top-right corner of any panel
 1. Click the panel menu icon that appears.

--- a/docs/sources/alerting/alerting-rules/create-alerts-panels.md
+++ b/docs/sources/alerting/alerting-rules/create-alerts-panels.md
@@ -28,10 +28,10 @@ Create alert rules from time series panels. By doing so, you can reuse the queri
 The New alert rule form opens where you can configure and create your alert rule based on the query used in the panel.
 
 {{% admonition type="note" %}}
-   At the moment, alert rules are only supported in [time series](ref:time-series) visualizations.
-   {{% /admonition %}}
+At the moment, alert rules are only supported in [time series](ref:time-series) visualizations.
+{{% /admonition %}}
 
-   {{< docs/play title="visualizations with linked alerts in Grafana" url="https://play.grafana.org/d/000000074/" >}}
+{{< docs/play title="visualizations with linked alerts in Grafana" url="https://play.grafana.org/d/000000074/" >}}
 
 ## View alert rules from panels
 

--- a/docs/sources/alerting/alerting-rules/create-alerts-panels.md
+++ b/docs/sources/alerting/alerting-rules/create-alerts-panels.md
@@ -37,7 +37,7 @@ At the moment, alert rules are only supported in [time series](ref:time-series) 
 
 To view alert rules associated with a time series panel, complete the following steps.
 
-1. Ooen the panel editor by hovering over the top-right corner of any panel
+1. Open the panel editor by hovering over the top-right corner of any panel
 1. Click the panel menu icon that appears.
 1. Click **Edit**.
 1. Click the **Alert** tab to view existing alert rules or create a new one.

--- a/docs/sources/alerting/alerting-rules/create-alerts-panels.md
+++ b/docs/sources/alerting/alerting-rules/create-alerts-panels.md
@@ -28,7 +28,9 @@ Create alert rules from time series panels. By doing so, you can reuse the queri
 The New alert rule form opens where you can configure and create your alert rule based on the query used in the panel.
 
 {{% admonition type="note" %}}
-At the moment, alert rules are only supported in [time series](ref:time-series) visualizations.
+Changes to the panel aren't reflected on the linked alert rules. If you change a query, you have to update it in both the panel and the alert rule.
+
+Alert rules are only supported in [time series](ref:time-series) visualizations.
 {{% /admonition %}}
 
 {{< docs/play title="visualizations with linked alerts in Grafana" url="https://play.grafana.org/d/000000074/" >}}

--- a/docs/sources/alerting/alerting-rules/create-alerts-panels.md
+++ b/docs/sources/alerting/alerting-rules/create-alerts-panels.md
@@ -1,0 +1,37 @@
+---
+canonical: https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-alerts-panels/
+description: Create alert rules from panels.  Reuse the queries in the panel and create alert rules based on them.
+keywords:
+  - grafana
+  - alerting
+  - panels
+  - create
+  - grafana-managed
+  - data source-managed
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Create alert rules from panels
+weight: 400
+---
+
+## Create alert rules from panels
+
+Create alert rules from any panel type. By doing so, you can reuse the queries in the panel and create alert rules based on them.
+
+1. Navigate to a dashboard in the **Dashboards** section.
+2. Hover over the top-right corner of any panel and click the panel menu icon.
+3. From the dropdown menu, select **More...** > **New alert rule**.
+
+The New alert rule form opens where you can configure and create your alert rule based on the query used in the panel.
+
+## View alert rules from panels
+
+To view alert rules associated with a panel, complete the following steps.
+
+1. Ooen the panel editor by hovering over the top-right corner of any panel
+1. Click the panel menu icon that appears.
+1. Click **Edit**.
+1. Click the **Alert** tab to view existing alert rules or create a new one.

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -270,13 +270,3 @@ You can also configure the alert instance state when its evaluation returns an e
 | Keep Last State     | Maintains the alert instance in its last state. Useful for mitigating temporary issues, refer to [Keep last state](ref:keep-last-state).                                                                                               |
 
 When you configure the No data or Error behavior to `Alerting` or `Normal`, Grafana will attempt to keep a stable set of fields under notification `Values`. If your query returns no data or an error, Grafana re-uses the latest known set of fields in `Values`, but will use `-1` in place of the measured value.
-
-## Create alerts from panels
-
-Create alerts from any panel type. This means you can reuse the queries in the panel and create alerts based on them.
-
-1. Navigate to a dashboard in the **Dashboards** section.
-2. In the top right corner of the panel, click on the three dots (ellipses).
-3. From the dropdown menu, select **More...** and then choose **New alert rule**.
-
-This will open the alert rule form, allowing you to configure and create your alert based on the current panel's query.

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -235,15 +235,13 @@ Annotations add metadata to provide more information on the alert in your alert 
 1. Optional: Add a custom annotation
 1. Optional: Add a **dashboard and panel link**.
 
-   Links alerts to panels in a dashboard.
+   Links alert rules to panels in a dashboard.
 
    {{% admonition type="note" %}}
-   At the moment, alerts are only supported in the [time series](ref:time-series) and [alert list](ref:alert-list) visualizations.
+   At the moment, alert rules are only supported in [time series](ref:time-series) and [alert list](ref:alert-list) visualizations.
    {{% /admonition %}}
 
-   {{< docs/play title="visualizations with linked alerts in Grafana" url="https://play.grafana.org/d/000000074/" >}}
-
-1. Click **Save rule**.
+2. Click **Save rule**.
 
 ## Configure no data and error handling
 

--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -241,7 +241,7 @@ Annotations add metadata to provide more information on the alert in your alert 
    At the moment, alert rules are only supported in [time series](ref:time-series) and [alert list](ref:alert-list) visualizations.
    {{% /admonition %}}
 
-2. Click **Save rule**.
+1. Click **Save rule**.
 
 ## Configure no data and error handling
 

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -145,9 +145,7 @@ Annotations add metadata to provide more information on the alert in your alert 
    Links alerts to panels in a dashboard.
 
    {{% admonition type="note" %}}
-   At the moment, alerts are only supported in the [time series](ref:time-series) and [alert list](ref:alert-list) visualizations.
+   At the moment, alert rules are only supported in [time series](ref:time-series) and [alert list](ref:alert-list) visualizations.
    {{% /admonition %}}
-
-   {{< docs/play title="visualizations with linked alerts in Grafana" url="https://play.grafana.org/d/000000074/" >}}
 
 1. Click **Save rule**.


### PR DESCRIPTION
separates out create alerts from panels from configure alert rules and adds some more info around viewing.