### PR TITLE
Playlists: limit the total number of playlists

### DIFF
--- a/pkg/services/playlist/playlistimpl/xorm_store.go
+++ b/pkg/services/playlist/playlistimpl/xorm_store.go
@@ -31,7 +31,7 @@ func (s *sqlStore) Insert(ctx context.Context, cmd *playlist.CreatePlaylistComma
 	}
 
 	err := s.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		count, err := sess.SQL("SELECT COUNT(*) FROM playlist").Count()
+		count, err := sess.SQL("SELECT COUNT(*) FROM playlist WHERE playlist.org_id = ?", cmd.OrgId).Count()
 		if err != nil {
 			return err
 		}

--- a/pkg/services/playlist/playlistimpl/xorm_store.go
+++ b/pkg/services/playlist/playlistimpl/xorm_store.go
@@ -15,7 +15,7 @@ type sqlStore struct {
 	db db.DB
 }
 
-const MAX_PLAYLISTS = 250
+const MAX_PLAYLISTS = 1000
 
 var _ store = &sqlStore{}
 
@@ -176,6 +176,10 @@ func (s *sqlStore) List(ctx context.Context, query *playlist.GetPlaylistsQuery) 
 		return playlists, playlist.ErrCommandValidationFailed
 	}
 
+	if query.Limit > MAX_PLAYLISTS || query.Limit < 1 {
+		query.Limit = MAX_PLAYLISTS
+	}
+
 	err := s.db.WithDbSession(ctx, func(dbSess *db.Session) error {
 		sess := dbSess.Limit(query.Limit)
 
@@ -183,7 +187,7 @@ func (s *sqlStore) List(ctx context.Context, query *playlist.GetPlaylistsQuery) 
 			sess.Where("name LIKE ?", "%"+query.Name+"%")
 		}
 
-		sess.Where("org_id = ?", query.OrgId).Limit(MAX_PLAYLISTS)
+		sess.Where("org_id = ?", query.OrgId)
 		err := sess.Find(&playlists)
 
 		return err


### PR DESCRIPTION
The playlist API has always capped results beyond 1000 values -- this PR updates the CREATE function so it fails when you try to add more than 1000 values.

I don't think this represents a real breaking change because the errors were previously hidden now things fail on write