### PR TITLE
DashboardGridItem - increase timeout in flaky panel repeat test

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -47,7 +47,7 @@ describe('PanelRepeaterGridItem', () => {
 
     expect(repeater.state.repeatedPanels?.length).toBe(0);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 100));
 
     expect(repeater.state.repeatedPanels?.length).toBe(1);
   });


### PR DESCRIPTION
Attempt to fix flaky test with timeout

Fail eg:
[drone](https://drone.grafana.net/grafana/grafana/191235/1/5)
[drone](https://drone.grafana.net/grafana/grafana/191813/1/6)