### PR TITLE
Alerting: Integration test for testing template via remote alertmanager

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -954,7 +954,7 @@ services:
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
-  image: grafana/mimir-alpine:r295-a23e559
+  image: grafana/mimir-alpine:r304-3872ccb
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -1402,7 +1402,7 @@ services:
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
-  image: grafana/mimir-alpine:r295-a23e559
+  image: grafana/mimir-alpine:r304-3872ccb
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -2480,7 +2480,7 @@ services:
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
-  image: grafana/mimir-alpine:r295-a23e559
+  image: grafana/mimir-alpine:r304-3872ccb
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -3112,7 +3112,7 @@ services:
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
-  image: grafana/mimir-alpine:r295-a23e559
+  image: grafana/mimir-alpine:r304-3872ccb
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -5271,7 +5271,7 @@ services:
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
   environment: {}
-  image: grafana/mimir-alpine:r295-a23e559
+  image: grafana/mimir-alpine:r304-3872ccb
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -5792,7 +5792,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM python:3.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir-alpine:r295-a23e559
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir-alpine:r304-3872ccb
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:8.0.32
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM redis:6.2.11-alpine
@@ -5829,7 +5829,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL python:3.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir-alpine:r295-a23e559
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir-alpine:r304-3872ccb
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:8.0.32
   - trivy --exit-code 1 --severity HIGH,CRITICAL redis:6.2.11-alpine

--- a/.drone.yml
+++ b/.drone.yml
@@ -6074,6 +6074,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: d35eadf9a166f68973ffd6df85f165bbda468d422d5debe416ec6a5af6ead84a
+hmac: 39565be86e2be3f42728062ce9c4e4b28d5f386e5f48cf3c765fd443c44d9e0e
 
 ...

--- a/devenv/docker/blocks/mimir_backend/docker-compose.yaml
+++ b/devenv/docker/blocks/mimir_backend/docker-compose.yaml
@@ -1,5 +1,5 @@
   mimir_backend:
-    image: grafana/mimir-alpine:r295-a23e559
+    image: grafana/mimir-alpine:r304-3872ccb
     container_name: mimir_backend
     command:
       - -target=backend

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/grafana/alerting/definition"
 	alertingModels "github.com/grafana/alerting/models"
+	"github.com/grafana/alerting/notify"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -737,6 +738,66 @@ func TestIntegrationRemoteAlertmanagerReceivers(t *testing.T) {
 			Integrations: []apimodels.Integration{},
 		},
 	}, rcvs)
+}
+
+func TestIntegrationRemoteAlertmanagerTestTemplates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	amURL, ok := os.LookupEnv("AM_URL")
+	if !ok {
+		t.Skip("No Alertmanager URL provided")
+	}
+
+	tenantID := os.Getenv("AM_TENANT_ID")
+	password := os.Getenv("AM_PASSWORD")
+
+	cfg := AlertmanagerConfig{
+		OrgID:             1,
+		URL:               amURL,
+		TenantID:          tenantID,
+		BasicAuthPassword: password,
+		DefaultConfig:     defaultGrafanaConfig,
+	}
+
+	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+	m := metrics.NewRemoteAlertmanagerMetrics(prometheus.NewRegistry())
+	am, err := NewAlertmanager(cfg, nil, secretsService.Decrypt, NoopAutogenFn, m, tracing.InitializeTracerForTest())
+	require.NoError(t, err)
+
+	// Valid template
+	c := apimodels.TestTemplatesConfigBodyParams{
+		Alerts: []*amv2.PostableAlert{
+			{
+				Annotations: amv2.LabelSet{
+					"annotations_label": "annotations_value",
+				},
+				Alert: amv2.Alert{
+					Labels: amv2.LabelSet{
+						"labels_label:": "labels_value",
+					},
+				},
+			},
+		},
+		Template: `{{ define "test" }} {{ index .Alerts 0 }} {{ end }}`,
+		Name:     "test",
+	}
+	res, err := am.TestTemplate(context.Background(), c)
+
+	require.NoError(t, err)
+	require.Len(t, res.Errors, 0)
+	require.Len(t, res.Results, 1)
+	require.Equal(t, "test", res.Results[0].Name)
+
+	// Invalid template
+	c.Template = `{{ define "test" }} {{ index 0 .Alerts }} {{ end }}`
+	res, err = am.TestTemplate(context.Background(), c)
+
+	require.NoError(t, err)
+	require.Len(t, res.Results, 0)
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, notify.ExecutionError, res.Errors[0].Kind)
 }
 
 func genAlert(active bool, labels map[string]string) amv2.PostableAlert {

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -22,7 +22,7 @@ images = {
     "plugins_slack": "plugins/slack",
     "python": "python:3.8",
     "postgres_alpine": "postgres:12.3-alpine",
-    "mimir": "grafana/mimir-alpine:r295-a23e559",
+    "mimir": "grafana/mimir-alpine:r304-3872ccb",
     "mysql5": "mysql:5.7.39",
     "mysql8": "mysql:8.0.32",
     "redis_alpine": "redis:6.2.11-alpine",


### PR DESCRIPTION
Adds an integration test to test template via the remote alertmanager and updates the mimir-alpine image to `mimir-alpine:r304-3872ccb`.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
