### PR TITLE
GCM: Add errorsource

### DIFF
--- a/pkg/tsdb/cloud-monitoring/promql_query.go
+++ b/pkg/tsdb/cloud-monitoring/promql_query.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/grafana/grafana/pkg/tsdb/cloud-monitoring/converter"
 	jsoniter "github.com/json-iterator/go"
 )
@@ -22,8 +23,7 @@ func (promQLQ *cloudMonitoringProm) run(ctx context.Context, req *backend.QueryD
 	dr := &backend.DataResponse{}
 	projectName, err := s.ensureProject(ctx, dsInfo, promQLQ.parameters.ProjectName)
 	if err != nil {
-		dr.Error = err
-		return dr, backend.DataResponse{}, "", nil
+		return dr, backend.DataResponse{}, "", err
 	}
 	r, err := createRequest(ctx, &dsInfo, path.Join("/v1/projects", projectName, "location/global/prometheus/api/v1/query_range"), nil)
 	if err != nil {
@@ -43,8 +43,7 @@ func (promQLQ *cloudMonitoringProm) run(ctx context.Context, req *backend.QueryD
 
 	res, err := doRequestProm(r, dsInfo, requestBody)
 	if err != nil {
-		dr.Error = err
-		return dr, backend.DataResponse{}, "", nil
+		return dr, backend.DataResponse{}, "", err
 	}
 
 	defer func() {
@@ -67,7 +66,7 @@ func doRequestProm(r *http.Request, dsInfo datasourceInfo, body map[string]any) 
 	}
 	res, err := dsInfo.services[cloudMonitor].client.Do(r)
 	if err != nil {
-		return res, err
+		return res, errorsource.DownstreamError(err, false)
 	}
 
 	return res, nil

--- a/pkg/tsdb/cloud-monitoring/promql_query_test.go
+++ b/pkg/tsdb/cloud-monitoring/promql_query_test.go
@@ -58,11 +58,11 @@ func TestPromqlQuery(t *testing.T) {
 			},
 		}
 
-		dr, parsedProm, _, _ := query.run(context.Background(), &backend.QueryDataRequest{}, service, dsInfo, service.logger)
-		require.Error(t, dr.Error)
-		require.Equal(t, "not found!", dr.Error.Error())
+		dr, parsedProm, _, err := query.run(context.Background(), &backend.QueryDataRequest{}, service, dsInfo, service.logger)
+		require.Error(t, err)
+		require.Equal(t, "not found!", err.Error())
 
-		err := query.parseResponse(dr, parsedProm, "", service.logger)
+		err = query.parseResponse(dr, parsedProm, "", service.logger)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/tsdb/cloud-monitoring/time_series_filter.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_filter.go
@@ -21,7 +21,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesList) run(ctx context.Context, 
 }
 
 func parseTimeSeriesResponse(queryRes *backend.DataResponse,
-	response cloudMonitoringResponse, executedQueryString string, query cloudMonitoringQueryExecutor, params url.Values, groupBys []string, logger log.Logger) error {
+	response cloudMonitoringResponse, executedQueryString string, query cloudMonitoringQueryExecutor, params url.Values, groupBys []string, _ log.Logger) error {
 	frames := data.Frames{}
 
 	for _, series := range response.TimeSeries {

--- a/pkg/tsdb/cloud-monitoring/utils.go
+++ b/pkg/tsdb/cloud-monitoring/utils.go
@@ -29,15 +29,15 @@ func addInterval(period string, field *data.Field) error {
 	if err != nil {
 		return err
 	}
-	if err == nil {
-		if field.Config != nil {
-			field.Config.Interval = float64(p.Milliseconds())
-		} else {
-			field.SetConfig(&data.FieldConfig{
-				Interval: float64(p.Milliseconds()),
-			})
-		}
+
+	if field.Config != nil {
+		field.Config.Interval = float64(p.Milliseconds())
+	} else {
+		field.SetConfig(&data.FieldConfig{
+			Interval: float64(p.Milliseconds()),
+		})
 	}
+
 	return nil
 }
 
@@ -71,7 +71,7 @@ func createRequest(ctx context.Context, dsInfo *datasourceInfo, proxyPass string
 	return req, nil
 }
 
-func doRequestPage(ctx context.Context, r *http.Request, dsInfo datasourceInfo, params url.Values, body map[string]any, logger log.Logger) (cloudMonitoringResponse, error) {
+func doRequestPage(_ context.Context, r *http.Request, dsInfo datasourceInfo, params url.Values, body map[string]any, logger log.Logger) (cloudMonitoringResponse, error) {
 	if params != nil {
 		r.URL.RawQuery = params.Encode()
 	}
@@ -125,7 +125,7 @@ func doRequestWithPagination(ctx context.Context, r *http.Request, dsInfo dataso
 	return d, nil
 }
 
-func traceReq(ctx context.Context, req *backend.QueryDataRequest, dsInfo datasourceInfo, r *http.Request, target string) trace.Span {
+func traceReq(ctx context.Context, req *backend.QueryDataRequest, dsInfo datasourceInfo, _ *http.Request, target string) trace.Span {
 	_, span := tracing.DefaultTracer().Start(ctx, "cloudMonitoring query", trace.WithAttributes(
 		attribute.String("target", target),
 		attribute.String("from", req.Queries[0].TimeRange.From.String()),


### PR DESCRIPTION
Add `errorsource` to any errors that are downstream and may be returned at some point in the `QueryData` endpoint. A downstream error is anything that is not due to the plugin directly.

Also fixed some minor lint issues.