### PR TITLE
chore: create mock for @bsull/augurs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -55,7 +55,7 @@ module.exports = {
     '^@grafana/schema/dist/esm/(.*)$': '<rootDir>/packages/grafana-schema/src/$1',
     // prevent systemjs amd extra from breaking tests.
     'systemjs/dist/extras/amd': '<rootDir>/public/test/mocks/systemjsAMDExtra.ts',
-    '@bsull/augurs': '@bsull/augurs/augurs.js',
+    '@bsull/augurs': '<rootDir>/public/test/mocks/augurs.ts',
   },
   // Log the test results with dynamic Loki tags. Drone CI only
   reporters: ['default', ['<rootDir>/public/test/log-reporter.js', { enable: process.env.DRONE === 'true' }]],

--- a/public/test/mocks/augurs.ts
+++ b/public/test/mocks/augurs.ts
@@ -1,0 +1,32 @@
+import type {
+  LoadedOutlierDetector as AugursLoadedOutlierDetector,
+  OutlierDetector as AugursOutlierDetector,
+  OutlierDetectorOptions,
+  OutlierOutput,
+} from '@bsull/augurs';
+
+export default function init() {}
+
+const dummyOutliers: OutlierOutput = {
+  outlyingSeries: [],
+  clusterBand: { min: [], max: [] },
+  seriesResults: [],
+};
+
+export class OutlierDetector implements AugursOutlierDetector {
+  free(): void {}
+  detect(): OutlierOutput {
+    return dummyOutliers;
+  }
+  preprocess(y: Float64Array, nTimestamps: number): AugursLoadedOutlierDetector {
+    return new LoadedOutlierDetector();
+  }
+}
+
+export class LoadedOutlierDetector implements AugursLoadedOutlierDetector {
+  detect(): OutlierOutput {
+    return dummyOutliers;
+  }
+  free(): void {}
+  updateDetector(options: OutlierDetectorOptions): void {}
+}


### PR DESCRIPTION
@bsull/augurs assumes it will be running as an ESM, not a CommonJS module, so can't be loaded by Jest (specifically because it contains a reference to import.meta.url).

This PR provides a mock implementation which gets tests passing again.

Ideally we'd be able to load the actual @bsull/augurs module in tests so this is just a stopgap really, until a better solution appears.
