### PR TITLE
Docs: Introduce linkspector

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -1,0 +1,15 @@
+name: Linkspector
+on: [pull_request]
+jobs:
+  check-links:
+    name: runner / linkspector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          reporter: github-pr-review
+          fail_on_error: true

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - .
+modifiedFilesOnly: true
+# remove gitlab anchors to lines to prevent linkspector to write to stderr for github-action to work
+replacementPatterns:
+  - pattern: "^(.*)#(L\\d+)$"
+    replacement: '$1'

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,7 +1,11 @@
 dirs:
   - .
 modifiedFilesOnly: true
-# remove gitlab anchors to lines to prevent linkspector to write to stderr for github-action to work
+# Ignore links for setup dev environment
+ignorePatterns:
+  - pattern: '^http://localhost(.*)'
+  - pattern: '^(.*).loc/$'
+# Remove gitlab anchors to lines to prevent linkspector to write to stderr for github-action to work
 replacementPatterns:
   - pattern: "^(.*)#(L\\d+)$"
     replacement: '$1'


### PR DESCRIPTION
Introduce linkspector for checking mds for broken links.
Just checking broken links in changed mds of last commit for now. Be aware that therefor an empty commit would 'solve' any problems speaking from a ci perspective.


**What is this feature?**

Introduce linkspector to check for broken links in changed mds from last commit.

**Why do we need this feature?**

We have a couple of broken links, see e.g. #92102 and #91940

**Who is this feature for?**

Contributors to md-files

**Which issue(s) does this PR fix?**:

Fixes #92107

**Special notes for your reviewer:**



Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

If this PoC if of any interest please hint me if there are any docs regarding such CI-tasks we need to update.
