### PR TITLE
Page/Body: Only show scrollbar lane gutter when needed

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -35,7 +35,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
         // Need type assertion here due to the use of !important
         // see https://github.com/frenic/csstype/issues/114#issuecomment-697201978
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        overflowY: 'scroll !important' as 'scroll',
+        overflowY: 'auto !important' as 'scroll',
         paddingRight: '0 !important',
         '@media print': {
           overflow: 'visible',

--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -35,7 +35,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
         // Need type assertion here due to the use of !important
         // see https://github.com/frenic/csstype/issues/114#issuecomment-697201978
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        overflowY: 'auto !important' as 'scroll',
+        overflowY: 'auto !important' as 'auto',
         paddingRight: '0 !important',
         '@media print': {
           overflow: 'visible',


### PR DESCRIPTION
The very soon the feature of body scrolling will be the default and only option. 

Currently this will force a scrollbar gutter (~16px) on ALL pages no matter if it's used or not. This scrollbar gutter will be shown on basically all windows, linux and OSX systems with a keyboard/mouse attached and default OS settings. 

on OSX in trackpad mode scrollbar gutters are not used and scrollbars are overlayed but this is by default disabled as soon as an external mouse & keyboard is attached. 

I am really unsure of what the best option is here, having the gutter there looks really ugly in panel edit for example that never has a page/body scrollbar and takes up valuable space. But having the gutter show up when needed makes some of the right side actions/buttons shift around bit when scrollbar is needed and when it's not. 

Before (Always show gutter): 

[always_gutter.webm](https://github.com/user-attachments/assets/8c9705cc-569e-4ae4-b8f1-097caeff4708)

After (Only when needed): 

[only_gutter_when_needed.webm](https://github.com/user-attachments/assets/1daaf6a2-e333-4559-8b81-90a0e9ba2fc0)
