### PR TITLE
Provisioning: Allow startup when there are dashboard provisioning failures

### DIFF
--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -185,7 +185,7 @@ func (ps *ProvisioningServiceImpl) Run(ctx context.Context) error {
 	err := ps.ProvisionDashboards(ctx)
 	if err != nil {
 		ps.log.Error("Failed to provision dashboard", "error", err)
-		return err
+		return nil
 	}
 	if ps.dashboardProvisioner.HasDashboardSources() {
 		ps.searchService.TriggerReIndex()

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -122,6 +122,7 @@ func newProvisioningServiceImpl(
 	newDashboardProvisioner dashboards.DashboardProvisionerFactory,
 	provisionDatasources func(context.Context, string, datasources.BaseDataSourceService, datasources.CorrelationsStore, org.Service) error,
 	provisionPlugins func(context.Context, string, pluginstore.Store, pluginsettings.Service, org.Service) error,
+	searchService searchV2.SearchService,
 ) *ProvisioningServiceImpl {
 	return &ProvisioningServiceImpl{
 		log:                     log.New("provisioning"),
@@ -129,6 +130,7 @@ func newProvisioningServiceImpl(
 		provisionDatasources:    provisionDatasources,
 		provisionPlugins:        provisionPlugins,
 		Cfg:                     setting.NewCfg(),
+		searchService:           searchService,
 	}
 }
 
@@ -185,7 +187,6 @@ func (ps *ProvisioningServiceImpl) Run(ctx context.Context) error {
 	err := ps.ProvisionDashboards(ctx)
 	if err != nil {
 		ps.log.Error("Failed to provision dashboard", "error", err)
-		return nil
 	}
 	if ps.dashboardProvisioner.HasDashboardSources() {
 		ps.searchService.TriggerReIndex()

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -75,7 +75,8 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		serviceTest.mock.ProvisionFunc = func(ctx context.Context) error {
 			return provisioningErr
 		}
-		serviceTest.service.ProvisionDashboards(context.Background())
+		err := serviceTest.service.ProvisionDashboards(context.Background())
+		assert.NotNil(t, err)
 		serviceTest.startService()
 
 		serviceTest.waitForPollChanges()
@@ -88,7 +89,6 @@ func TestProvisioningServiceImpl(t *testing.T) {
 		fmt.Println("serviceTest.serviceError", serviceTest.serviceError)
 		assert.Equal(t, context.Canceled, serviceTest.serviceError)
 	})
-
 }
 
 type serviceTestStruct struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Log dashboard provisioning issues instead of preventing startup.

**Why do we need this feature?**

Issues restarting Grafana because a folder with provisioned dashboards was deleted and then recreated via UI.

**Who is this feature for?**

Users who rely on provisioning

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/support-escalations/issues/10964

**Special notes for your reviewer:**

* Need to read about backport policies but thinking we should backport to the same versions that https://github.com/grafana/grafana/pull/87465 does: v9.5.x, v10.4.x and v11.0.x. This was a fix for a similar issue.
* See doc [[Azure escalation] Provisioning when the target folder is deleted](https://docs.google.com/document/d/190kiLZVl4_0CI4MNR4M0nqUkIslK2W85ARvS39CozXw/edit). This PR implements proposal 6.
* We're going to need frontend changes for this as well: "I wonder whether we could use something similar to the alerts for license expiration to throw up a visible warning inside grafana itself for admins" ([source](https://raintank-corp.slack.com/archives/C05FYAPEPKP/p1719415987229529?thread_ts=1719401988.624259&cid=C05FYAPEPKP)). IMO this could be done in a separate PR. We can prioritise alleviating the current bug and then make the change clearer in the UI. --> created ticket: https://github.com/grafana/grafana/issues/92280
* This PR is not instead of https://github.com/grafana/grafana/pull/92022 but in addition to.
* Dashboards aren't the only question when it comes to provisioning. Alert rules can also be provisioned to specific folders. So far I haven't found any reference to folder UIDs when it comes to alert rule provisioning just folder names (example [doc](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/file-provisioning/) I looked at). Therefore, we shouldn't be running into similar issues when it comes to them. I'll double check with the alerting team though.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
