### PR TITLE
chore: add tracing to quote API and service methods with contexts

### DIFF
--- a/pkg/services/quota/quotaimpl/quota.go
+++ b/pkg/services/quota/quotaimpl/quota.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -12,6 +13,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/setting"
 )
+
+// tracer is the global tracer for the quota service. Tracer pulls the globally
+// initialized tracer from the opentelemetry package.
+var tracer = otel.Tracer("quota-service")
 
 type serviceDisabled struct {
 }
@@ -81,16 +86,20 @@ func (s *service) QuotaReached(c *contextmodel.ReqContext, targetSrv quota.Targe
 	if c == nil {
 		return false, nil
 	}
+	ctx, span := tracer.Start(c.Req.Context(), "quota-service.QuotaReached")
+	defer span.End()
 
 	params := &quota.ScopeParameters{}
 	if c.IsSignedIn {
 		params.OrgID = c.SignedInUser.GetOrgID()
 		params.UserID = c.UserID
 	}
-	return s.CheckQuotaReached(c.Req.Context(), targetSrv, params)
+	return s.CheckQuotaReached(ctx, targetSrv, params)
 }
 
 func (s *service) GetQuotasByScope(ctx context.Context, scope quota.Scope, id int64) ([]quota.QuotaDTO, error) {
+	ctx, span := tracer.Start(ctx, "quota-service.GetQuotasByScope")
+	defer span.End()
 	if err := scope.Validate(); err != nil {
 		return nil, err
 	}
@@ -104,10 +113,7 @@ func (s *service) GetQuotasByScope(ctx context.Context, scope quota.Scope, id in
 		scopeParams.UserID = id
 	}
 
-	c, err := s.getContext(ctx)
-	if err != nil {
-		return nil, err
-	}
+	c := quota.FromContext(ctx, s.targetToSrv)
 	customLimits, err := s.store.Get(c, &scopeParams)
 	if err != nil {
 		return nil, err
@@ -160,6 +166,8 @@ func (s *service) GetQuotasByScope(ctx context.Context, scope quota.Scope, id in
 }
 
 func (s *service) Update(ctx context.Context, cmd *quota.UpdateQuotaCmd) error {
+	ctx, span := tracer.Start(ctx, "quota-service.Update")
+	defer span.End()
 	targetFound := false
 	knownTargets, err := s.defaultLimits.Targets()
 	if err != nil {
@@ -175,16 +183,15 @@ func (s *service) Update(ctx context.Context, cmd *quota.UpdateQuotaCmd) error {
 		return quota.ErrInvalidTarget.Errorf("unknown quota target: %s", cmd.Target)
 	}
 
-	c, err := s.getContext(ctx)
-	if err != nil {
-		return err
-	}
+	c := quota.FromContext(ctx, s.targetToSrv)
 	return s.store.Update(c, cmd)
 }
 
 // CheckQuotaReached check that quota is reached for a target. If ScopeParameters are not defined, only global scope is checked
 func (s *service) CheckQuotaReached(ctx context.Context, targetSrv quota.TargetSrv, scopeParams *quota.ScopeParameters) (bool, error) {
-	targetSrvLimits, err := s.getOverridenLimits(ctx, targetSrv, scopeParams)
+	ctx, span := tracer.Start(ctx, "quota-service.CheckQuotaReached")
+	defer span.End()
+	targetSrvLimits, err := s.getOverriddenLimits(ctx, targetSrv, scopeParams)
 	if err != nil {
 		return false, err
 	}
@@ -233,10 +240,9 @@ func (s *service) CheckQuotaReached(ctx context.Context, targetSrv quota.TargetS
 }
 
 func (s *service) DeleteQuotaForUser(ctx context.Context, userID int64) error {
-	c, err := s.getContext(ctx)
-	if err != nil {
-		return err
-	}
+	ctx, span := tracer.Start(ctx, "quota-service.DeleteQuotaForUser")
+	defer span.End()
+	c := quota.FromContext(ctx, s.targetToSrv)
 	return s.store.DeleteByUser(c, userID)
 }
 
@@ -296,13 +302,12 @@ func (s *service) getReporters() <-chan reporter {
 	return ch
 }
 
-func (s *service) getOverridenLimits(ctx context.Context, targetSrv quota.TargetSrv, scopeParams *quota.ScopeParameters) (map[quota.Tag]int64, error) {
+func (s *service) getOverriddenLimits(ctx context.Context, targetSrv quota.TargetSrv, scopeParams *quota.ScopeParameters) (map[quota.Tag]int64, error) {
+	ctx, span := tracer.Start(ctx, "quota-service.getOverriddenLimits")
+	defer span.End()
 	targetSrvLimits := make(map[quota.Tag]int64)
 
-	c, err := s.getContext(ctx)
-	if err != nil {
-		return nil, err
-	}
+	c := quota.FromContext(ctx, s.targetToSrv)
 	customLimits, err := s.store.Get(c, scopeParams)
 	if err != nil {
 		return targetSrvLimits, err
@@ -331,6 +336,8 @@ func (s *service) getOverridenLimits(ctx context.Context, targetSrv quota.Target
 }
 
 func (s *service) getUsage(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
+	ctx, span := tracer.Start(ctx, "quota-service.getUsage")
+	defer span.End()
 	usage := &quota.Map{}
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -351,8 +358,4 @@ func (s *service) getUsage(ctx context.Context, scopeParams *quota.ScopeParamete
 	}
 
 	return usage, nil
-}
-
-func (s *service) getContext(ctx context.Context) (quota.Context, error) {
-	return quota.FromContext(ctx, s.targetToSrv), nil
 }

--- a/pkg/services/quota/quotaimpl/quota.go
+++ b/pkg/services/quota/quotaimpl/quota.go
@@ -16,7 +16,7 @@ import (
 
 // tracer is the global tracer for the quota service. Tracer pulls the globally
 // initialized tracer from the opentelemetry package.
-var tracer = otel.Tracer("quota-service")
+var tracer = otel.Tracer("github.com/grafana/grafana/pkg/services/quota/quotaimpl/service")
 
 type serviceDisabled struct {
 }


### PR DESCRIPTION
Add tracing to quota API and service methods (those with contexts)

I also fixed a typo (overriden -> overridden) and removed a method that wasn't adding anything. The method (s.getContext) called another method (quota.FromContext) and never returned an error, and so just added many lines of unnecessary error checking. 

As before, this is purposefully simplistic, but I'm happy to add to it!