### PR TITLE
add spans to search v2

### DIFF
--- a/pkg/services/searchV2/usage.go
+++ b/pkg/services/searchV2/usage.go
@@ -45,7 +45,7 @@ var (
 )
 
 func updateUsageStats(ctx context.Context, reader *bluge.Reader, logger log.Logger, tracer tracing.Tracer) {
-	ctx, span := tracer.Start(ctx, "searchV2 updateUsageStats")
+	ctx, span := tracer.Start(ctx, "searchV2.updateUsageStats")
 	defer span.End()
 	req := bluge.NewAllMatches(bluge.NewTermQuery("panel").SetField(documentFieldKind))
 	for _, usage := range panelUsage {


### PR DESCRIPTION
Searchv1 and the SearchIndex service (in searchv2) already have (some) tracing set, so this is just for search v2's main paths. 