### PR TITLE
Docs: remove aliases from incorrect files

### DIFF
--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -1,7 +1,4 @@
 ---
-aliases:
-  - ../features/dashboard/dashboards/
-  - dashboard-manage/
 labels:
   products:
     - cloud

--- a/docs/sources/dashboards/manage-dashboards/index.md
+++ b/docs/sources/dashboards/manage-dashboards/index.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - ../features/dashboard/dashboards/
   - ../panels/working-with-panels/organize-dashboard/
   - ../reference/dashboard_folders/
   - dashboard-folders/

--- a/docs/sources/dashboards/use-dashboards/index.md
+++ b/docs/sources/dashboards/use-dashboards/index.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - ../features/dashboard/dashboards/
   - ../reference/search/
   - dashboard-ui/
   - dashboard-ui/dashboard-header/

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -2,7 +2,6 @@
 aliases:
   - ../dashboards/add-organize-panels/
   - ../dashboards/dashboard-create/
-  - ../features/dashboard/dashboards/
   - ../panels/add-panels-dynamically/about-repeating-panels-rows/
   - ../panels/add-panels-dynamically/configure-repeating-panels/
   - ../panels/add-panels-dynamically/configure-repeating-rows/


### PR DESCRIPTION
Remove aliases from files they shouldn't be in.

`/docs/grafana/latest/dashboards/dashboard-manage/ `redirects to `/docs/grafana/latest/dashboards/manage-dashboards/`

`/docs/grafana/latest/features/dashboard/dashboards/` redirects to `/docs/grafana/latest/dashboards/`

@jdbaldry - I made the change for the public dashboards page here even though it's also in [PR 90630](https://github.com/grafana/grafana/pull/90630), because that won't be merged for a while and the page has been moved and renamed in that PR.