### PR TITLE
Dashboard: Fixes closing share modal

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareModal.tsx
@@ -88,7 +88,12 @@ export class ShareModal extends SceneObjectBase<ShareModalState> implements Moda
   }
 
   onDismiss = () => {
-    locationService.partial({ shareView: null });
+    if (this.state.panelRef) {
+      const dashboard = getDashboardSceneFor(this);
+      dashboard.closeModal();
+    } else {
+      locationService.partial({ shareView: null });
+    }
   };
 
   onChangeTab: ComponentProps<typeof ModalTabsHeader>['onChangeTab'] = (tab) => {


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/92020 merged a few days ago made it impossible to close panel share modals. 

I first looked at fixing this more cleanly by making panel modal also be controlled via query param (with the panel key), but since this modal will be soon replaced with the coming share drawer I felt that would be wasted effort 