### PR TITLE
TextPanel: Allow iframes (after sanitization)

### DIFF
--- a/packages/grafana-data/src/text/sanitize.test.ts
+++ b/packages/grafana-data/src/text/sanitize.test.ts
@@ -23,7 +23,7 @@ describe('sanitizeIframe', () => {
   it('should sanitize iframe tags', () => {
     const html = '<iframe src="javascript:alert(document.domain)"></iframe>';
     const str = sanitizeTextPanelContent(html);
-    expect(str).toBe('<iframe src="about:blank" sandbox credentialless=true referrerpolicy=no-referrer></iframe>');
+    expect(str).toBe('<iframe src="about:blank" sandbox credentialless referrerpolicy=no-referrer></iframe>');
   });
 });
 

--- a/packages/grafana-data/src/text/sanitize.test.ts
+++ b/packages/grafana-data/src/text/sanitize.test.ts
@@ -23,7 +23,7 @@ describe('sanitizeIframe', () => {
   it('should sanitize iframe tags', () => {
     const html = '<iframe src="javascript:alert(document.domain)"></iframe>';
     const str = sanitizeTextPanelContent(html);
-    expect(str).toBe('<iframe src="about:blank" sandbox></iframe>');
+    expect(str).toBe('<iframe src="about:blank" sandbox credentialless=true referrerpolicy=no-referrer></iframe>');
   });
 });
 

--- a/packages/grafana-data/src/text/sanitize.test.ts
+++ b/packages/grafana-data/src/text/sanitize.test.ts
@@ -19,7 +19,14 @@ describe('sanitizeUrl', () => {
   });
 });
 
-// write test to sanitize xss payloads using the sanitize function
+describe('sanitizeIframe', () => {
+  it('should sanitize iframe tags', () => {
+    const html = '<iframe src="javascript:alert(document.domain)"></iframe>';
+    const str = sanitizeTextPanelContent(html);
+    expect(str).toBe('<iframe src="about:blank" sandbox></iframe>');
+  });
+});
+
 describe('sanitize', () => {
   it('should sanitize xss payload', () => {
     const html = '<script>alert(1)</script>';

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -7,7 +7,17 @@ const XSSWL = Object.keys(xss.whiteList).reduce<xss.IWhiteList>((acc, element) =
   return acc;
 }, {});
 
+// Add iframe tags to XSSWL.
+// We don't allow the sandbox attribute, since it can be overridden, instead we add it below.
+XSSWL.iframe = ['src', 'width', 'height'];
+
 const sanitizeTextPanelWhitelist = new xss.FilterXSS({
+  // Add sandbox attribute to iframe tags if an attribute is allowed.
+  onTagAttr: function (tag, name, value, isWhiteAttr) {
+    if (tag === 'iframe') {
+      return isWhiteAttr ? ` ${name}="${xss.escapeAttrValue(sanitizeUrl(value))}" sandbox` : '';
+    }
+  },
   whiteList: XSSWL,
   css: {
     whiteList: {

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -16,7 +16,7 @@ const sanitizeTextPanelWhitelist = new xss.FilterXSS({
   onTagAttr: function (tag, name, value, isWhiteAttr) {
     if (tag === 'iframe') {
       return isWhiteAttr
-        ? ` ${name}="${xss.escapeAttrValue(sanitizeUrl(value))}" sandbox credentialless=true referrerpolicy=no-referrer`
+        ? ` ${name}="${xss.escapeAttrValue(sanitizeUrl(value))}" sandbox credentialless referrerpolicy=no-referrer`
         : '';
     }
     return;

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -15,8 +15,11 @@ const sanitizeTextPanelWhitelist = new xss.FilterXSS({
   // Add sandbox attribute to iframe tags if an attribute is allowed.
   onTagAttr: function (tag, name, value, isWhiteAttr) {
     if (tag === 'iframe') {
-      return isWhiteAttr ? ` ${name}="${xss.escapeAttrValue(sanitizeUrl(value))}" sandbox` : '';
+      return isWhiteAttr
+        ? ` ${name}="${xss.escapeAttrValue(sanitizeUrl(value))}" sandbox credentialless=true referrerpolicy=no-referrer`
+        : '';
     }
+    return;
   },
   whiteList: XSSWL,
   css: {


### PR DESCRIPTION
**What is this feature?**

This features allows the `<iframe>` tag in Text Panel. I've added appropriate security considerations by automatically adding the `sandbox`, `referrerpolicy` and `credentialless` attributes to all iframes, which locks down what's possible within the iframe. For more information about the attributes, please see: 
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#credentialless (Chromium only)
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#referrerpolicy

The `src` value is also sanitized with `sanitizeUrl` function. 

![Screenshot from 2024-08-22 15-08-57](https://github.com/user-attachments/assets/413af343-2636-40ce-bf62-2e6c1e498bcd)

**Why do we need this feature?**
Adding iframes in text panel enriches the panel by embedding websites with dynamic content, such as a status page.

**Who is this feature for?**
Users that build dashboards.

**Which issue(s) does this PR fix?**:
none

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
