### PR TITLE
Alerting: Fixes incorrect cache invalidation for silences when no silences exist

### DIFF
--- a/public/app/features/alerting/unified/api/alertSilencesApi.ts
+++ b/public/app/features/alerting/unified/api/alertSilencesApi.ts
@@ -26,8 +26,14 @@ export const alertSilencesApi = alertingApi.injectEndpoints({
           accesscontrol: accessControl,
         },
       }),
-      providesTags: (result) =>
-        result ? result.map(({ id }) => ({ type: 'AlertmanagerSilences', id })) : ['AlertmanagerSilences'],
+      providesTags: (result) => {
+        return result
+          ? [
+              ...result.map(({ id }) => ({ type: 'AlertmanagerSilences' as const, id })),
+              { type: 'AlertmanagerSilences' },
+            ]
+          : [{ type: 'AlertmanagerSilences' }];
+      },
     }),
 
     getSilence: build.query<


### PR DESCRIPTION
**What is this feature?**

Prior to this PR a user would have had to manually refresh the page after creating their first silence.