### PR TITLE
Docs: Fix broken link in developers/contribute

### DIFF
--- a/docs/sources/developers/contribute.md
+++ b/docs/sources/developers/contribute.md
@@ -38,7 +38,7 @@ Our [style guides](https://github.com/grafana/grafana/tree/main/contribute/style
 
 - [Backend style guide](https://github.com/grafana/grafana/blob/main/contribute/style-guides/backend.md) explains how we want to write Go code in the future.
 
-- [Documentation style guide](https://github.com/grafana/grafana/blob/main/contribute/style-guides/documentation-style-guide.md) applies to all documentation created for Grafana products.
+- [Documentation style guide](https://grafana.com/docs/writers-toolkit/write/style-guide/) applies to all documentation created for Grafana products.
 
 - [End to end test framework](https://github.com/grafana/grafana/blob/main/contribute/style-guides/e2e.md) provides guidance for Grafana e2e tests.
 


### PR DESCRIPTION
Fixes broken link to doc style guide.

Fixes: https://github.com/grafana/grafana/issues/91541
