### PR TITLE
Team: Create permission type for team membership

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -261,7 +260,7 @@ func setupDB(b testing.TB) benchScenario {
 				UserID:     userID,
 				TeamID:     teamID,
 				OrgID:      orgID,
-				Permission: dashboardaccess.PERMISSION_VIEW,
+				Permission: team.PermissionTypeMember,
 				Created:    now,
 				Updated:    now,
 			})

--- a/pkg/services/accesscontrol/ossaccesscontrol/team.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/team.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/team"
@@ -83,9 +82,9 @@ func ProvideTeamPermissions(
 			}
 			switch permission {
 			case "Member":
-				return teamimpl.AddOrUpdateTeamMemberHook(session, user.ID, orgID, teamId, user.IsExternal, 0)
+				return teamimpl.AddOrUpdateTeamMemberHook(session, user.ID, orgID, teamId, user.IsExternal, team.PermissionTypeMember)
 			case "Admin":
-				return teamimpl.AddOrUpdateTeamMemberHook(session, user.ID, orgID, teamId, user.IsExternal, dashboardaccess.PERMISSION_ADMIN)
+				return teamimpl.AddOrUpdateTeamMemberHook(session, user.ID, orgID, teamId, user.IsExternal, team.PermissionTypeAdmin)
 			case "":
 				return teamimpl.RemoveTeamMemberHook(session, &team.RemoveTeamMemberCommand{
 					OrgID:  orgID,

--- a/pkg/services/sqlstore/migrations/accesscontrol/team_membership.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/team_membership.go
@@ -8,7 +8,6 @@ import (
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/team"
@@ -64,12 +63,12 @@ func (p *teamPermissionMigrator) setRolePermissions(roleID int64, permissions []
 }
 
 // mapPermissionToRBAC translates the legacy membership (Member or Admin) into RBAC permissions
-func (p *teamPermissionMigrator) mapPermissionToRBAC(permission dashboardaccess.PermissionType, teamID int64) []accesscontrol.Permission {
+func (p *teamPermissionMigrator) mapPermissionToRBAC(permission team.PermissionType, teamID int64) []accesscontrol.Permission {
 	teamIDScope := accesscontrol.Scope("teams", "id", strconv.FormatInt(teamID, 10))
 	switch permission {
-	case 0:
+	case team.PermissionTypeMember:
 		return []accesscontrol.Permission{{Action: "teams:read", Scope: teamIDScope}}
-	case dashboardaccess.PERMISSION_ADMIN:
+	case team.PermissionTypeAdmin:
 		return []accesscontrol.Permission{
 			{Action: "teams:delete", Scope: teamIDScope},
 			{Action: "teams:read", Scope: teamIDScope},
@@ -210,7 +209,7 @@ func (p *teamPermissionMigrator) generateAssociatedPermissions(teamMemberships [
 		// Downgrade team permissions if needed:
 		// only admins or editors (when editorsCanAdmin option is enabled)
 		// can access team administration endpoints
-		if m.Permission == dashboardaccess.PERMISSION_ADMIN {
+		if m.Permission == team.PermissionTypeAdmin {
 			if userRolesByOrg[m.OrgID][m.UserID] == string(org.RoleViewer) || (userRolesByOrg[m.OrgID][m.UserID] == string(org.RoleEditor) && !p.editorsCanAdmin) {
 				m.Permission = 0
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
@@ -328,7 +327,7 @@ func setupTeams(t *testing.T, x *xorm.Engine) {
 			TeamID:     1,
 			UserID:     1,
 			External:   false,
-			Permission: 0,
+			Permission: team.PermissionTypeMember,
 			Created:    now,
 			Updated:    now,
 		},
@@ -338,7 +337,7 @@ func setupTeams(t *testing.T, x *xorm.Engine) {
 			TeamID:     1,
 			UserID:     2,
 			External:   false,
-			Permission: dashboardaccess.PERMISSION_ADMIN,
+			Permission: team.PermissionTypeAdmin,
 			Created:    now,
 			Updated:    now,
 		},
@@ -348,7 +347,7 @@ func setupTeams(t *testing.T, x *xorm.Engine) {
 			TeamID:     1,
 			UserID:     3,
 			External:   false,
-			Permission: dashboardaccess.PERMISSION_ADMIN,
+			Permission: team.PermissionTypeAdmin,
 			Created:    now,
 			Updated:    now,
 		},
@@ -358,7 +357,7 @@ func setupTeams(t *testing.T, x *xorm.Engine) {
 			TeamID:     1,
 			UserID:     4,
 			External:   false,
-			Permission: dashboardaccess.PERMISSION_ADMIN,
+			Permission: team.PermissionTypeAdmin,
 			Created:    now,
 			Updated:    now,
 		},
@@ -368,7 +367,7 @@ func setupTeams(t *testing.T, x *xorm.Engine) {
 			TeamID:     2,
 			UserID:     5,
 			External:   false,
-			Permission: 0,
+			Permission: team.PermissionTypeMember,
 			Created:    now,
 			Updated:    now,
 		},

--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/search/model"
 )
 
@@ -20,9 +19,6 @@ var (
 
 	ErrTeamMemberAlreadyAdded = errors.New("user is already added to this team")
 )
-
-const MemberPermissionName = "Member"
-const AdminPermissionName = "Admin"
 
 // Team model
 type Team struct {
@@ -91,15 +87,29 @@ type SearchTeamsQuery struct {
 }
 
 type TeamDTO struct {
-	ID            int64                          `json:"id" xorm:"id"`
-	UID           string                         `json:"uid" xorm:"uid"`
-	OrgID         int64                          `json:"orgId" xorm:"org_id"`
-	Name          string                         `json:"name"`
-	Email         string                         `json:"email"`
-	AvatarURL     string                         `json:"avatarUrl"`
-	MemberCount   int64                          `json:"memberCount"`
-	Permission    dashboardaccess.PermissionType `json:"permission"`
-	AccessControl map[string]bool                `json:"accessControl"`
+	ID            int64           `json:"id" xorm:"id"`
+	UID           string          `json:"uid" xorm:"uid"`
+	OrgID         int64           `json:"orgId" xorm:"org_id"`
+	Name          string          `json:"name"`
+	Email         string          `json:"email"`
+	AvatarURL     string          `json:"avatarUrl"`
+	MemberCount   int64           `json:"memberCount"`
+	Permission    PermissionType  `json:"permission"`
+	AccessControl map[string]bool `json:"accessControl"`
+}
+
+type PermissionType int
+
+const (
+	PermissionTypeMember PermissionType = 0
+	PermissionTypeAdmin  PermissionType = 4
+)
+
+func (p PermissionType) String() string {
+	if p == PermissionTypeMember {
+		return "Member"
+	}
+	return "Admin"
 }
 
 type SearchTeamQueryResult struct {
@@ -116,7 +126,7 @@ type TeamMember struct {
 	TeamID     int64 `xorm:"team_id"`
 	UserID     int64 `xorm:"user_id"`
 	External   bool  // Signals that the membership has been created by an external systems, such as LDAP
-	Permission dashboardaccess.PermissionType
+	Permission PermissionType
 
 	Created time.Time
 	Updated time.Time
@@ -126,12 +136,12 @@ type TeamMember struct {
 // COMMANDS
 
 type AddTeamMemberCommand struct {
-	UserID     int64                          `json:"userId" binding:"Required"`
-	Permission dashboardaccess.PermissionType `json:"-"`
+	UserID     int64          `json:"userId" binding:"Required"`
+	Permission PermissionType `json:"-"`
 }
 
 type UpdateTeamMemberCommand struct {
-	Permission dashboardaccess.PermissionType `json:"permission"`
+	Permission PermissionType `json:"permission"`
 }
 
 type SetTeamMembershipsCommand struct {
@@ -161,16 +171,16 @@ type GetTeamMembersQuery struct {
 // Projections and DTOs
 
 type TeamMemberDTO struct {
-	OrgID      int64                          `json:"orgId" xorm:"org_id"`
-	TeamID     int64                          `json:"teamId" xorm:"team_id"`
-	TeamUID    string                         `json:"teamUID" xorm:"uid"`
-	UserID     int64                          `json:"userId" xorm:"user_id"`
-	External   bool                           `json:"-"`
-	AuthModule string                         `json:"auth_module"`
-	Email      string                         `json:"email"`
-	Name       string                         `json:"name"`
-	Login      string                         `json:"login"`
-	AvatarURL  string                         `json:"avatarUrl" xorm:"avatar_url"`
-	Labels     []string                       `json:"labels"`
-	Permission dashboardaccess.PermissionType `json:"permission"`
+	OrgID      int64          `json:"orgId" xorm:"org_id"`
+	TeamID     int64          `json:"teamId" xorm:"team_id"`
+	TeamUID    string         `json:"teamUID" xorm:"uid"`
+	UserID     int64          `json:"userId" xorm:"user_id"`
+	External   bool           `json:"-"`
+	AuthModule string         `json:"auth_module"`
+	Email      string         `json:"email"`
+	Name       string         `json:"name"`
+	Login      string         `json:"login"`
+	AvatarURL  string         `json:"avatarUrl" xorm:"avatar_url"`
+	Labels     []string       `json:"labels"`
+	Permission PermissionType `json:"permission"`
 }

--- a/pkg/services/team/model.go
+++ b/pkg/services/team/model.go
@@ -106,10 +106,10 @@ const (
 )
 
 func (p PermissionType) String() string {
-	if p == PermissionTypeMember {
-		return "Member"
+	if p == PermissionTypeAdmin {
+		return "Admin"
 	}
-	return "Admin"
+	return "Member"
 }
 
 type SearchTeamQueryResult struct {

--- a/pkg/services/team/teamapi/team_members_test.go
+++ b/pkg/services/team/teamapi/team_members_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -178,9 +177,9 @@ func Test_getTeamMembershipUpdates(t *testing.T) {
 				Admins:  []string{"user3"},
 			},
 			expectedUpdates: []accesscontrol.SetResourcePermissionCommand{
-				{UserID: 1, Permission: team.MemberPermissionName},
-				{UserID: 2, Permission: team.MemberPermissionName},
-				{UserID: 3, Permission: team.AdminPermissionName},
+				{UserID: 1, Permission: team.PermissionTypeMember.String()},
+				{UserID: 2, Permission: team.PermissionTypeMember.String()},
+				{UserID: 3, Permission: team.PermissionTypeAdmin.String()},
 			},
 		},
 		{
@@ -190,11 +189,11 @@ func Test_getTeamMembershipUpdates(t *testing.T) {
 				Admins:  []string{"user3"},
 			},
 			currentMembers: []*team.TeamMemberDTO{
-				{Email: "user1", Permission: 0},
-				{Email: "user3", Permission: dashboardaccess.PERMISSION_ADMIN},
+				{Email: "user1", Permission: team.PermissionTypeMember},
+				{Email: "user3", Permission: team.PermissionTypeAdmin},
 			},
 			expectedUpdates: []accesscontrol.SetResourcePermissionCommand{
-				{UserID: 2, Permission: team.MemberPermissionName},
+				{UserID: 2, Permission: team.PermissionTypeMember.String()},
 			},
 		},
 		{
@@ -204,13 +203,13 @@ func Test_getTeamMembershipUpdates(t *testing.T) {
 				Admins:  []string{"user3"},
 			},
 			currentMembers: []*team.TeamMemberDTO{
-				{Email: "user1", Permission: 0},
-				{Email: "user2", Permission: dashboardaccess.PERMISSION_ADMIN},
-				{Email: "user3", Permission: 0},
+				{Email: "user1", Permission: team.PermissionTypeMember},
+				{Email: "user2", Permission: team.PermissionTypeAdmin},
+				{Email: "user3", Permission: team.PermissionTypeMember},
 			},
 			expectedUpdates: []accesscontrol.SetResourcePermissionCommand{
-				{UserID: 2, Permission: team.MemberPermissionName},
-				{UserID: 3, Permission: team.AdminPermissionName},
+				{UserID: 2, Permission: team.PermissionTypeMember.String()},
+				{UserID: 3, Permission: team.PermissionTypeAdmin.String()},
 			},
 		},
 		{
@@ -220,10 +219,10 @@ func Test_getTeamMembershipUpdates(t *testing.T) {
 				Admins:  []string{"user3"},
 			},
 			currentMembers: []*team.TeamMemberDTO{
-				{Email: "user1", UserID: 1, Permission: 0},
-				{Email: "user2", UserID: 2, Permission: 0},
-				{Email: "user3", UserID: 3, Permission: dashboardaccess.PERMISSION_ADMIN},
-				{Email: "user4", UserID: 4, Permission: dashboardaccess.PERMISSION_ADMIN},
+				{Email: "user1", UserID: 1, Permission: team.PermissionTypeMember},
+				{Email: "user2", UserID: 2, Permission: team.PermissionTypeMember},
+				{Email: "user3", UserID: 3, Permission: team.PermissionTypeAdmin},
+				{Email: "user4", UserID: 4, Permission: team.PermissionTypeAdmin},
 			},
 			expectedUpdates: []accesscontrol.SetResourcePermissionCommand{
 				{UserID: 2, Permission: ""},

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -385,7 +384,7 @@ func isTeamMember(sess *db.Session, orgId int64, teamId int64, userId int64) (bo
 
 // AddOrUpdateTeamMemberHook is called from team resource permission service
 // it adds user to a team or updates user permissions in a team within the given transaction session
-func AddOrUpdateTeamMemberHook(sess *db.Session, userID, orgID, teamID int64, isExternal bool, permission dashboardaccess.PermissionType) error {
+func AddOrUpdateTeamMemberHook(sess *db.Session, userID, orgID, teamID int64, isExternal bool, permission team.PermissionType) error {
 	isMember, err := isTeamMember(sess, orgID, teamID, userID)
 	if err != nil {
 		return err
@@ -400,7 +399,7 @@ func AddOrUpdateTeamMemberHook(sess *db.Session, userID, orgID, teamID int64, is
 	return err
 }
 
-func addTeamMember(sess *db.Session, orgID, teamID, userID int64, isExternal bool, permission dashboardaccess.PermissionType) error {
+func addTeamMember(sess *db.Session, orgID, teamID, userID int64, isExternal bool, permission team.PermissionType) error {
 	if _, err := teamExists(orgID, teamID, sess); err != nil {
 		return err
 	}
@@ -419,14 +418,14 @@ func addTeamMember(sess *db.Session, orgID, teamID, userID int64, isExternal boo
 	return err
 }
 
-func updateTeamMember(sess *db.Session, orgID, teamID, userID int64, permission dashboardaccess.PermissionType) error {
+func updateTeamMember(sess *db.Session, orgID, teamID, userID int64, permission team.PermissionType) error {
 	member, err := getTeamMember(sess, orgID, teamID, userID)
 	if err != nil {
 		return err
 	}
 
-	if permission != dashboardaccess.PERMISSION_ADMIN {
-		permission = 0 // make sure we don't get invalid permission levels in store
+	if permission != team.PermissionTypeAdmin {
+		permission = team.PermissionTypeMember // make sure we don't get invalid permission levels in store
 	}
 
 	member.Permission = permission

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
 	"github.com/grafana/grafana/pkg/services/quota/quotaimpl"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
@@ -196,7 +195,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				qAfterUpdate := &team.GetTeamMembersQuery{OrgID: testOrgID, TeamID: team1.ID, SignedInUser: testUser}
 				qAfterUpdateResult, err := teamSvc.GetTeamMembers(context.Background(), qAfterUpdate)
 				require.NoError(t, err)
-				require.Equal(t, qAfterUpdateResult[0].Permission, dashboardaccess.PERMISSION_ADMIN)
+				require.Equal(t, qAfterUpdateResult[0].Permission, team.PermissionTypeAdmin)
 			})
 
 			t.Run("Should default to member permission level when updating a user with invalid permission level", func(t *testing.T) {

--- a/pkg/services/team/teamimpl/store_test.go
+++ b/pkg/services/team/teamimpl/store_test.go
@@ -189,7 +189,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.EqualValues(t, qBeforeUpdateResult[0].Permission, 0)
 
 				err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-					return AddOrUpdateTeamMemberHook(sess, userId, testOrgID, team1.ID, false, dashboardaccess.PERMISSION_ADMIN)
+					return AddOrUpdateTeamMemberHook(sess, userId, testOrgID, team1.ID, false, team.PermissionTypeAdmin)
 				})
 				require.NoError(t, err)
 
@@ -214,9 +214,9 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 				require.NoError(t, err)
 				require.EqualValues(t, qBeforeUpdateResult[0].Permission, 0)
 
-				invalidPermissionLevel := dashboardaccess.PERMISSION_EDIT
+				invalidPermissionLevel := 2
 				err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-					return AddOrUpdateTeamMemberHook(sess, userID, testOrgID, team1.ID, false, invalidPermissionLevel)
+					return AddOrUpdateTeamMemberHook(sess, userID, testOrgID, team1.ID, false, team.PermissionType(invalidPermissionLevel))
 				})
 				require.NoError(t, err)
 
@@ -356,7 +356,7 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 
 			t.Run("Should have empty teams", func(t *testing.T) {
 				err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-					return AddOrUpdateTeamMemberHook(sess, userIds[0], testOrgID, team1.ID, false, dashboardaccess.PERMISSION_ADMIN)
+					return AddOrUpdateTeamMemberHook(sess, userIds[0], testOrgID, team1.ID, false, team.PermissionTypeAdmin)
 				})
 				require.NoError(t, err)
 
@@ -379,11 +379,11 @@ func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 					setup()
 
 					err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
-						err := AddOrUpdateTeamMemberHook(sess, userIds[0], testOrgID, team1.ID, false, dashboardaccess.PERMISSION_ADMIN)
+						err := AddOrUpdateTeamMemberHook(sess, userIds[0], testOrgID, team1.ID, false, team.PermissionTypeAdmin)
 						if err != nil {
 							return err
 						}
-						return AddOrUpdateTeamMemberHook(sess, userIds[1], testOrgID, team1.ID, false, dashboardaccess.PERMISSION_ADMIN)
+						return AddOrUpdateTeamMemberHook(sess, userIds[1], testOrgID, team1.ID, false, team.PermissionTypeAdmin)
 					})
 					require.NoError(t, err)
 					err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {


### PR DESCRIPTION
**What is this feature?**
When working on https://github.com/grafana/grafana/pull/92204 I noticed that `dashboardaccess.PermissionType` was used for team memberships. This also includes some hacks to make it work because teams only have Member (0) and Admin (4). I have probably forgotten that it was this way but got annoyed enough to fix it now.

So instead of using `dashboardaccess.PermissionType` with these hacks I created a new type for team member permissions and map them correctly.

Some tests was using `dashboardaccess.PERMISSION_VIEW` when setting up team memberships. This is not a valid value but it is confusing using type for another model with hacks

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
