### PR TITLE
docs: Canvas updates adding why and how describing data needs

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -37,7 +37,7 @@ This lets you design custom visualizations and overlay data in ways that aren't 
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" alt="Canvas beta overview" >}}
 
 If you've used popular UI and web design tools, then designing canvases will feel very familiar.
-With all of these dynamic elements, there are few limits to what a canvas can display.
+With all of these dynamic elements, there's almost no limit to what a canvas can display.
 
 {{< admonition type="note" >}}
 We'd love your feedback on the canvas visualization. Please check out the [open Github issues](https://github.com/grafana/grafana/issues?page=1&q=is%3Aopen+is%3Aissue+label%3Aarea%2Fpanel%2Fcanvas) and [submit a new feature request](https://github.com/grafana/grafana/issues/new?assignees=&labels=type%2Ffeature-request,area%2Fpanel%2Fcanvas&title=Canvas:&projects=grafana-dataviz&template=1-feature_requests.md) as needed.
@@ -45,7 +45,7 @@ We'd love your feedback on the canvas visualization. Please check out the [open 
 
 ## Supported data formats
 
-The canvas visualization is unique in that it doesn't have any specific data requirements. You can even start drawing and configuring visual elements without providing any data. However, any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom elements.
+The canvas visualization is unique in that it doesn't have any specific data requirements. You can even start adding and configuring visual elements without providing any data. However, any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom elements.
 
 If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -36,7 +36,7 @@ This lets you design custom visualizations and overlay data in ways that aren't 
 
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" alt="Canvas beta overview" >}}
 
-Canvases support the use of HTML, CSS, and JavaScript to create visuals, and if you've used popular UI and web design tools, then designing canvases will feel very familiar.
+If you've used popular UI and web design tools, then designing canvases will feel very familiar.
 With all of these dynamic elements, there are few limits to what a canvas can display.
 
 {{< admonition type="note" >}}
@@ -45,7 +45,7 @@ We'd love your feedback on the canvas visualization. Please check out the [open 
 
 ## Supported data formats
 
-The canvas visualization is unique in that it doesn't have any specific data requirements. You can even start drawing and configuring visual elements without providing any data. However, any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom HTML, CSS, and JavaScript code.
+The canvas visualization is unique in that it doesn't have any specific data requirements. You can even start drawing and configuring visual elements without providing any data. However, any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom elements.
 
 If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -49,7 +49,7 @@ The canvas visualization is unique in that it doesn't have any specific data req
 
 If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
 
-You can provide data to the multiple _elements_ and _connections_ available in the canvas visualization to set options like text, colors, and background pattern images. These have different data requirements defined in the [Elements](#elements) and [Connections](#connections) sections.
+You can tie [Elements](#elements) and [Connections](#connections) to data through options like text, colors, and background pattern images, etc. available in the canvas visualization.
 
 ## Elements
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -49,7 +49,7 @@ The canvas visualization is unique in that it doesn't have any specific data req
 
 If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
 
-You can provide data to the multiple _elements_ and _connections_, like text, colors, and background pattern images, available in the canvas visualization. These have different data requirements defined in the [Elements](#elements) and [Connections](#connections) sections.
+You can provide data to the multiple _elements_ and _connections_ available in the canvas visualization to set options like text, colors, and background pattern images. These have different data requirements defined in the [Elements](#elements) and [Connections](#connections) sections.
 
 ## Elements
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -30,27 +30,26 @@ refs:
 
 # Canvas
 
-Canvases combine the power of Grafana with the flexibility of custom elements. Canvases are extensible form-built visualizations that allow you to explicitly place elements within static and dynamic layouts. This empowers you to design custom visualizations and overlay data in ways that aren't possible with standard Grafana panels, all within Grafana's UI. If you've used popular UI and web design tools, then designing canvases will feel very familiar.
+Canvases combine the power of Grafana with the flexibility of custom elements.
+They are extensible visualizations that allow you to add and arrange elements wherever you want within unstructured static and dynamic layouts.
+This lets you design custom visualizations and overlay data in ways that aren't possible with standard Grafana visualizations, all within the Grafana UI.
 
-> We would love your feedback on Canvas. Please check out the [open Github issues](https://github.com/grafana/grafana/issues?page=1&q=is%3Aopen+is%3Aissue+label%3Aarea%2Fpanel%2Fcanvas) and [submit a new feature request](https://github.com/grafana/grafana/issues/new?assignees=&labels=type%2Ffeature-request,area%2Fpanel%2Fcanvas&title=Canvas:&projects=grafana-dataviz&template=1-feature_requests.md) as needed.
+{{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" alt="Canvas beta overview" >}}
 
-A canvas is the most flexible visualization allowing you to create visualizations tailored to your specific needs. You can create visualizations based on any images you may need to use. If no other visualization type suits your needs, the canvas provides an unstructured space where you can design and script your own visuals using HTML, images, CSS, JavaScript and more.
+Canvases support the use of HTML, CSS, and JavaScript to create visuals, and if you've used popular UI and web design tools, then designing canvases will feel very familiar.
+With all of these dynamic elements, there are few limits to what a canvas can display.
 
-There are few limits to what a canvas can display with all the dynamic elements you can use to visualize values, text, icons, buttons, connections, and more.
-
-{{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" caption="Canvas beta overview" >}}
+{{< admonition type="note" >}}
+We'd love your feedback on the canvas visualization. Please check out the [open Github issues](https://github.com/grafana/grafana/issues?page=1&q=is%3Aopen+is%3Aissue+label%3Aarea%2Fpanel%2Fcanvas) and [submit a new feature request](https://github.com/grafana/grafana/issues/new?assignees=&labels=type%2Ffeature-request,area%2Fpanel%2Fcanvas&title=Canvas:&projects=grafana-dataviz&template=1-feature_requests.md) as needed.
+{{< /admonition >}}
 
 ## Supported data formats
 
-The canvas visualization is unique as it doesn't have any specific data requirements. You can even start drawing and configuring visual elements without any specific data provided.
-
-However, being so flexible, a canvas provides diverse data structuring and preparation options.
-
-Any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom HTML, CSS, and JavaScript code.
+The canvas visualization is unique in that it doesn't have any specific data requirements. You can even start drawing and configuring visual elements without providing any data. However, any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom HTML, CSS, and JavaScript code.
 
 If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
 
-You can provide data to the multiple **elements** and **connections** available in the canvas visualization, like text element values, colors, rotation, and background pattern images. Most of them have different data requirements defined in the [Elements](#elements) and [Connections](#connections) sections.
+You can provide data to the multiple _elements_ and _connections_, like text, colors, and background pattern images, available in the canvas visualization. These have different data requirements defined in the [Elements](#elements) and [Connections](#connections) sections.
 
 ## Elements
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -34,7 +34,23 @@ Canvases combine the power of Grafana with the flexibility of custom elements. C
 
 > We would love your feedback on Canvas. Please check out the [open Github issues](https://github.com/grafana/grafana/issues?page=1&q=is%3Aopen+is%3Aissue+label%3Aarea%2Fpanel%2Fcanvas) and [submit a new feature request](https://github.com/grafana/grafana/issues/new?assignees=&labels=type%2Ffeature-request,area%2Fpanel%2Fcanvas&title=Canvas:&projects=grafana-dataviz&template=1-feature_requests.md) as needed.
 
+A canvas is the most flexible visualization allowing you to create visualizations tailored to your specific needs. You can create visualizations based on any images you may need to use. If no other visualization type suits your needs, the canvas provides an unstructured space where you can design and script your own visuals using HTML, images, CSS, JavaScript and more.
+
+There are few limits to what a canvas can display with all the dynamic elements you can use to visualize values, text, icons, buttons, connections, and more.
+
 {{< video-embed src="/static/img/docs/canvas-panel/canvas-beta-overview-9-2-0.mp4" max-width="750px" caption="Canvas beta overview" >}}
+
+## Supported data formats
+
+The canvas visualization is unique as it doesn't have any specific data requirements. You can even start drawing and configuring visual elements without any specific data provided.
+
+However, being so flexible, a canvas provides diverse data structuring and preparation options.
+
+Any data you plan to consume should be accessible through supported Grafana data sources and structured in a way that ensures smooth integration with your custom HTML, CSS, and JavaScript code.
+
+If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
+
+You can provide data to the multiple elements and connections available in the canvas visualization, like text element values, colors, rotation, and background pattern images. Most of them has different data requirements defined in each item in the [Elements](#elements) and [Connections](#connections) sections.
 
 ## Elements
 

--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -50,7 +50,7 @@ Any data you plan to consume should be accessible through supported Grafana data
 
 If your canvas is going to update in real time, your data should support refreshes at your desired intervals without degrading the user experience.
 
-You can provide data to the multiple elements and connections available in the canvas visualization, like text element values, colors, rotation, and background pattern images. Most of them has different data requirements defined in each item in the [Elements](#elements) and [Connections](#connections) sections.
+You can provide data to the multiple **elements** and **connections** available in the canvas visualization, like text element values, colors, rotation, and background pattern images. Most of them have different data requirements defined in the [Elements](#elements) and [Connections](#connections) sections.
 
 ## Elements
 


### PR DESCRIPTION
**What is this feature?**

This PR does the following updates to the canvas documentation:
- Add descriptions of why a user may want to use a canvas panel
- Adds descriptions on how and data needs for the canvas panel

**Why do we need this feature?**

This helps users when they look for information on the canvas visualization

**Who is this feature for?**

Any user learning or improving the use of canvas panels

**Which issue(s) does this PR fix?**:

None

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
