### PR TITLE
K8s identity api server fix mysql quotes

### DIFF
--- a/pkg/registry/apis/identity/legacy/legacy_sql.go
+++ b/pkg/registry/apis/identity/legacy/legacy_sql.go
@@ -66,10 +66,14 @@ func (s *legacySQLStore) ListTeams(ctx context.Context, ns claims.NamespaceInfo,
 		var lastID int64
 		for rows.Next() {
 			t := team.Team{}
-			err = rows.Scan(&t.ID, &t.UID, &t.Name, &t.Email, &t.Created, &t.Updated)
+			// TODO: fix this
+			createdAt := []uint8{}
+			updatedAt := []uint8{}
+			err = rows.Scan(&t.ID, &t.UID, &t.Name, &t.Email, &createdAt, &updatedAt)
 			if err != nil {
 				return res, err
 			}
+			fmt.Printf("createdAt: %v, updatedAt: %v\n", createdAt, updatedAt)
 			lastID = t.ID
 			res.Teams = append(res.Teams, t)
 			if len(res.Teams) > limit {

--- a/pkg/registry/apis/identity/legacy/queries.go
+++ b/pkg/registry/apis/identity/legacy/queries.go
@@ -34,6 +34,7 @@ var (
 type sqlQueryListUsers struct {
 	sqltemplate.SQLTemplate
 	Query        *ListUserQuery
+	SchemaName   string
 	UserTable    string
 	OrgUserTable string
 }
@@ -41,6 +42,7 @@ type sqlQueryListUsers struct {
 func newListUser(sql *legacysql.LegacyDatabaseHelper, q *ListUserQuery) sqlQueryListUsers {
 	return sqlQueryListUsers{
 		SQLTemplate:  sqltemplate.New(sql.DialectForDriver()),
+		SchemaName:   sql.SchemaName(),
 		UserTable:    sql.Table("user"),
 		OrgUserTable: sql.Table("org_user"),
 		Query:        q,
@@ -53,13 +55,15 @@ func (r sqlQueryListUsers) Validate() error {
 
 type sqlQueryListTeams struct {
 	sqltemplate.SQLTemplate
-	Query     *ListTeamQuery
-	TeamTable string
+	Query      *ListTeamQuery
+	SchemaName string
+	TeamTable  string
 }
 
 func newListTeams(sql *legacysql.LegacyDatabaseHelper, q *ListTeamQuery) sqlQueryListTeams {
 	return sqlQueryListTeams{
 		SQLTemplate: sqltemplate.New(sql.DialectForDriver()),
+		SchemaName:  sql.SchemaName(),
 		TeamTable:   sql.Table("team"),
 		Query:       q,
 	}
@@ -72,6 +76,7 @@ func (r sqlQueryListTeams) Validate() error {
 type sqlQueryGetDisplay struct {
 	sqltemplate.SQLTemplate
 	Query        *GetUserDisplayQuery
+	SchemaName   string
 	UserTable    string
 	OrgUserTable string
 }
@@ -79,6 +84,7 @@ type sqlQueryGetDisplay struct {
 func newGetDisplay(sql *legacysql.LegacyDatabaseHelper, q *GetUserDisplayQuery) sqlQueryGetDisplay {
 	return sqlQueryGetDisplay{
 		SQLTemplate:  sqltemplate.New(sql.DialectForDriver()),
+		SchemaName:   sql.SchemaName(),
 		UserTable:    sql.Table("user"),
 		OrgUserTable: sql.Table("org_user"),
 		Query:        q,

--- a/pkg/registry/apis/identity/legacy/queries_test.go
+++ b/pkg/registry/apis/identity/legacy/queries_test.go
@@ -12,9 +12,8 @@ import (
 func TestQueries(t *testing.T) {
 	// prefix tables with grafana
 	nodb := &legacysql.LegacyDatabaseHelper{
-		Table: func(n string) string {
-			return "grafana." + n
-		},
+		SchemaName: func() string { return "grafana" },
+		Table:      func(n string) string { return n },
 	}
 
 	getDisplay := func(q *GetUserDisplayQuery) sqltemplate.SQLTemplate {

--- a/pkg/registry/apis/identity/legacy/query_display.sql
+++ b/pkg/registry/apis/identity/legacy/query_display.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM {{ .Ident .UserTable }} as u JOIN {{ .Ident .OrgUserTable }} as o ON u.id = o.user_id
+  FROM {{ if .SchemaName }}{{ .Ident .SchemaName }}.{{ end }}{{ .Ident .UserTable }} as u JOIN {{ if .SchemaName }}{{ .Ident .SchemaName }}.{{ end }}{{ .Ident .OrgUserTable }} as o ON u.id = o.user_id
  WHERE o.org_id = {{ .Arg .Query.OrgID }} AND ( 1=2
 {{ if .Query.UIDs }}
    OR uid IN ({{ .ArgList .Query.UIDs }})

--- a/pkg/registry/apis/identity/legacy/query_teams.sql
+++ b/pkg/registry/apis/identity/legacy/query_teams.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM {{ .Ident .TeamTable }}
+  FROM {{ if .SchemaName }}{{ .Ident .SchemaName }}.{{ end }}{{ .Ident .TeamTable }}
  WHERE org_id = {{ .Arg .Query.OrgID }}
 {{ if .Query.UID }}
    AND uid = {{ .Arg .Query.UID }}

--- a/pkg/registry/apis/identity/legacy/query_users.sql
+++ b/pkg/registry/apis/identity/legacy/query_users.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM {{ .Ident .UserTable }} as u JOIN {{ .Ident .OrgUserTable }} as o ON u.id = o.user_id
+  FROM {{ if .SchemaName }}{{ .Ident .SchemaName }}.{{ end }}{{ .Ident .UserTable }} as u JOIN {{ if .SchemaName }}{{ .Ident .SchemaName }}.{{ end }}{{ .Ident .OrgUserTable }} as o ON u.id = o.user_id
  WHERE o.org_id = {{ .Arg .Query.OrgID }}
    AND u.is_service_account = {{ .Arg .Query.IsServiceAccount }}
 {{ if .Query.UID }}

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_display-display_ids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_display-display_ids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR u.id IN (1, 2)
  )

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_display-display_ids_uids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_display-display_ids_uids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR uid IN ('a', 'b')
    OR u.id IN (1, 2)

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_display-display_uids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_display-display_uids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR uid IN ('a', 'b')
  )

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_teams-teams_page_1.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_teams-teams_page_1.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM `grafana`.`team`
  WHERE org_id = 0
  ORDER BY id asc
  LIMIT 5

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_teams-teams_page_2.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_teams-teams_page_2.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM `grafana`.`team`
  WHERE org_id = 0
    AND id > 1
  ORDER BY id asc

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_teams-teams_uid.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_teams-teams_uid.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM `grafana`.`team`
  WHERE org_id = 0
    AND uid = 'abc'
  ORDER BY id asc

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_users-users_page_1.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_users-users_page_1.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
  ORDER BY u.id asc

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_users-users_page_2.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_users-users_page_2.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
    AND id > 1

--- a/pkg/registry/apis/identity/legacy/testdata/mysql--query_users-users_uid.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/mysql--query_users-users_uid.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM `grafana`.`user` as u JOIN `grafana`.`org_user` as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
    AND uid = 'abc'

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_display-display_ids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_display-display_ids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR u.id IN (1, 2)
  )

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_display-display_ids_uids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_display-display_ids_uids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR uid IN ('a', 'b')
    OR u.id IN (1, 2)

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_display-display_uids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_display-display_uids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR uid IN ('a', 'b')
  )

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_teams-teams_page_1.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_teams-teams_page_1.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM "grafana"."team"
  WHERE org_id = 0
  ORDER BY id asc
  LIMIT 5

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_teams-teams_page_2.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_teams-teams_page_2.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM "grafana"."team"
  WHERE org_id = 0
    AND id > 1
  ORDER BY id asc

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_teams-teams_uid.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_teams-teams_uid.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM "grafana"."team"
  WHERE org_id = 0
    AND uid = 'abc'
  ORDER BY id asc

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_users-users_page_1.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_users-users_page_1.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
  ORDER BY u.id asc

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_users-users_page_2.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_users-users_page_2.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
    AND id > 1

--- a/pkg/registry/apis/identity/legacy/testdata/postgres--query_users-users_uid.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/postgres--query_users-users_uid.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
    AND uid = 'abc'

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_display-display_ids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_display-display_ids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR u.id IN (1, 2)
  )

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_display-display_ids_uids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_display-display_ids_uids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR uid IN ('a', 'b')
    OR u.id IN (1, 2)

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_display-display_uids.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_display-display_uids.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name, 
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 2 AND ( 1=2
    OR uid IN ('a', 'b')
  )

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_teams-teams_page_1.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_teams-teams_page_1.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM "grafana"."team"
  WHERE org_id = 0
  ORDER BY id asc
  LIMIT 5

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_teams-teams_page_2.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_teams-teams_page_2.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM "grafana"."team"
  WHERE org_id = 0
    AND id > 1
  ORDER BY id asc

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_teams-teams_uid.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_teams-teams_uid.sql
@@ -1,5 +1,5 @@
 SELECT id, uid, name, email, created, updated
-  FROM "grafana.team"
+  FROM "grafana"."team"
  WHERE org_id = 0
    AND uid = 'abc'
  ORDER BY id asc

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_users-users_page_1.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_users-users_page_1.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
  ORDER BY u.id asc

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_users-users_page_2.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_users-users_page_2.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
    AND id > 1

--- a/pkg/registry/apis/identity/legacy/testdata/sqlite--query_users-users_uid.sql
+++ b/pkg/registry/apis/identity/legacy/testdata/sqlite--query_users-users_uid.sql
@@ -1,6 +1,6 @@
 SELECT o.org_id, u.id, u.uid, u.login, u.email, u.name,
   u.created, u.updated, u.is_service_account, u.is_disabled, u.is_admin
-  FROM "grafana.user" as u JOIN "grafana.org_user" as o ON u.id = o.user_id
+  FROM "grafana"."user" as u JOIN "grafana"."org_user" as o ON u.id = o.user_id
  WHERE o.org_id = 0
    AND u.is_service_account = FALSE
    AND uid = 'abc'

--- a/pkg/storage/legacysql/db.go
+++ b/pkg/storage/legacysql/db.go
@@ -16,6 +16,9 @@ type LegacyDatabaseProvider func(ctx context.Context) (*LegacyDatabaseHelper, er
 func NewDatabaseProvider(db db.DB) LegacyDatabaseProvider {
 	helper := &LegacyDatabaseHelper{
 		DB: db,
+		SchemaName: func() string {
+			return ""
+		},
 		Table: func(n string) string {
 			return n
 		},
@@ -28,6 +31,9 @@ func NewDatabaseProvider(db db.DB) LegacyDatabaseProvider {
 type LegacyDatabaseHelper struct {
 	// The database connection
 	DB db.DB
+
+	// schema locator
+	SchemaName func() string
 
 	// table name locator
 	Table func(n string) string

--- a/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
@@ -27,12 +27,9 @@ var standardFallback = standardIdent{}
 
 func (backtickIdent) Ident(s string) (string, error) {
 	switch s {
-	// Internal identifiers require backticks to work properly
-	case "user":
-		return "`" + s + "`", nil
 	case "":
 		return "", ErrEmptyIdent
 	}
 	// standard
-	return standardFallback.Ident(s)
+	return "`" + s + "`", nil
 }


### PR DESCRIPTION
**What is this feature?**

This PR changes the MySQL dialect to quote with backticks, rather than double quotes, and quotes the schema & table individually.

from:
```
SELECT id, uid, name, email, created, updated
  FROM "hg_foo.team"
 WHERE org_id = ?
 ORDER BY id asc
 LIMIT ?
```
to
```
SELECT id, uid, name, email, created, updated
  FROM `hg_foo`.`team`
 WHERE org_id = ?
 ORDER BY id asc
 LIMIT ?
```

**Why do we need this feature?**

Currently, the MySQL dialect is adding double quotes, which is resulting in syntax errors:
```
Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '\"hg_foo.team\"\n WHERE org_id = ?\n\n\n ORDER BY id asc\n LIMIT ?' at line 2
```

It also fails if we just switch the double quotes to backticks. Instead the schema and table need to be individually done.

**Supporting info:**
![Screenshot 2024-08-23 at 3 17 14 PM](https://github.com/user-attachments/assets/553f656e-87b9-4f1c-beb3-751d9b7f560c)
![Screenshot 2024-08-23 at 3 17 29 PM](https://github.com/user-attachments/assets/e64ad7f0-0884-4c66-a647-3a0d51bf27ca)
![Screenshot 2024-08-23 at 3 17 39 PM](https://github.com/user-attachments/assets/c47483ad-25b6-427f-bf7c-69c357138cbe)
![Screenshot 2024-08-23 at 3 18 00 PM](https://github.com/user-attachments/assets/2d9d23ba-175b-49f3-9b65-0681912d783d)

**Note**: While testing, I also found an issue with the datetime conversion. Still looking into this. Getting the error:
```
sql: Scan error on column index 5, name \"updated\": unsupported Scan, storing driver.Value type []uint8 into type *time.Time
```