### PR TITLE
RestoreDashboards: Make confirmation text consistent

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -370,7 +370,7 @@ func (hs *HTTPServer) SoftDeleteDashboard(c *contextmodel.ReqContext) response.R
 
 	return response.JSON(http.StatusOK, util.DynMap{
 		"title":   dash.Title,
-		"message": fmt.Sprintf("Dashboard %s moved to trash", dash.Title),
+		"message": fmt.Sprintf("Dashboard %s moved to Recently deleted", dash.Title),
 		"uid":     dash.UID,
 	})
 }

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -6,9 +6,9 @@ import { locationService, config, reportInteraction } from '@grafana/runtime';
 import { Modal, ConfirmModal, Button, Text, Space, TextLink } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { cleanUpDashboardAndVariables } from 'app/features/dashboard/state/actions';
-import { deleteDashboard } from 'app/features/manage-dashboards/state/actions';
 
 import { Trans, t } from '../../../../core/internationalization';
+import { useDeleteItemsMutation } from '../../../browse-dashboards/api/browseDashboardsAPI';
 
 type DeleteDashboardModalProps = {
   hideModal(): void;
@@ -25,6 +25,7 @@ type Props = DeleteDashboardModalProps & ConnectedProps<typeof connector>;
 
 const DeleteDashboardModalUnconnected = ({ hideModal, cleanUpDashboardAndVariables, dashboard }: Props) => {
   const isProvisioned = dashboard.meta.provisioned;
+  const [deleteItems] = useDeleteItemsMutation();
 
   const [, onConfirm] = useAsyncFn(async () => {
     reportInteraction('grafana_manage_dashboards_delete_clicked', {
@@ -34,7 +35,15 @@ const DeleteDashboardModalUnconnected = ({ hideModal, cleanUpDashboardAndVariabl
       source: 'dashboard_settings',
       restore_enabled: config.featureToggles.dashboardRestoreUI,
     });
-    await deleteDashboard(dashboard.uid, true);
+    // await deleteDashboard(dashboard.uid, true);
+    await deleteItems({
+      selectedItems: {
+        dashboard: {
+          [dashboard.uid]: true,
+        },
+        folder: {},
+      },
+    });
     cleanUpDashboardAndVariables();
     hideModal();
     locationService.replace('/');

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -35,7 +35,6 @@ const DeleteDashboardModalUnconnected = ({ hideModal, cleanUpDashboardAndVariabl
       source: 'dashboard_settings',
       restore_enabled: config.featureToggles.dashboardRestoreUI,
     });
-    // await deleteDashboard(dashboard.uid, true);
     await deleteItems({
       selectedItems: {
         dashboard: {


### PR DESCRIPTION
**What is this feature?**
While testing we found an inconsistency in the wording of the confirmation toast when a user deletes a dashboard. This PR changes the wording for it so the toast's wording is the same no matter from where the user deletes their dashboard. 

**Which issue(s) does this PR fix?**:
Fixes #92363 

**Special notes for your reviewer:**

`For testing: delete a dashboard from its settings page`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
