### PR TITLE
Alerting: Update starting version for central ash (OSS users)

### DIFF
--- a/docs/sources/alerting/manage-notifications/view-state-health.md
+++ b/docs/sources/alerting/manage-notifications/view-state-health.md
@@ -57,7 +57,7 @@ An alert event is displayed each time an alert instance changes its state over a
 
 {{% admonition type="note" %}}
 For Grafana Enterprise and OSS users:
-
+The feature will be available starting with Grafana 12.
 To try out the new alert history page, enable the `alertingCentralAlertHistory` feature toggle and configure [Loki annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/).
 
 Users can only see the history and transitions of alert rules they have access to (RBAC).

--- a/docs/sources/alerting/manage-notifications/view-state-health.md
+++ b/docs/sources/alerting/manage-notifications/view-state-health.md
@@ -57,7 +57,7 @@ An alert event is displayed each time an alert instance changes its state over a
 
 {{% admonition type="note" %}}
 For Grafana Enterprise and OSS users:
-The feature will be available starting with Grafana 12.
+The feature is available starting with Grafana 11.2.
 To try out the new alert history page, enable the `alertingCentralAlertHistory` feature toggle and configure [Loki annotations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/).
 
 Users can only see the history and transitions of alert rules they have access to (RBAC).


### PR DESCRIPTION

**What is this feature?**

This PR adds the starting version in docs for the central alert state history on OSS.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
