### PR TITLE
Plugins: Hide GetStartedWithDataSource when cloud plugin is not fully installed

### DIFF
--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithPlugin.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithPlugin.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react';
 
 import { PluginType } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { CatalogPlugin } from '../../types';
 
@@ -12,7 +13,9 @@ type Props = {
 };
 
 export function GetStartedWithPlugin({ plugin }: Props): ReactElement | null {
-  if (!plugin.isInstalled || plugin.isDisabled) {
+  const isInstalled = config.featureToggles.managedPluginsInstall && config.pluginAdminExternalManageEnabled ? plugin.isFullyInstalled : plugin.isInstalled;
+
+  if (isInstalled || plugin.isDisabled) {
     return null;
   }
 

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithPlugin.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithPlugin.tsx
@@ -15,7 +15,7 @@ type Props = {
 export function GetStartedWithPlugin({ plugin }: Props): ReactElement | null {
   const isInstalled = config.featureToggles.managedPluginsInstall && config.pluginAdminExternalManageEnabled ? plugin.isFullyInstalled : plugin.isInstalled;
 
-  if (isInstalled || plugin.isDisabled) {
+  if (!isInstalled || plugin.isDisabled) {
     return null;
   }
 

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithPlugin.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithPlugin.tsx
@@ -13,7 +13,10 @@ type Props = {
 };
 
 export function GetStartedWithPlugin({ plugin }: Props): ReactElement | null {
-  const isInstalled = config.featureToggles.managedPluginsInstall && config.pluginAdminExternalManageEnabled ? plugin.isFullyInstalled : plugin.isInstalled;
+  const isInstalled =
+    config.featureToggles.managedPluginsInstall && config.pluginAdminExternalManageEnabled
+      ? plugin.isFullyInstalled
+      : plugin.isInstalled;
 
   if (!isInstalled || plugin.isDisabled) {
     return null;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Avoid get started with datasource controls to show when plugin isn't fully installed.

**Why do we need this feature?**

This is necessary to avoid a user to add a datasource before it's fully installed.

**Who is this feature for?**

Plugin catalog users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
