### PR TITLE
RestoreDashboards: Set preselected folder in folder picker for restoring several dashboards from the same folder

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -29,11 +29,11 @@ export function RecentlyDeletedActions() {
       .map(([uid]) => uid);
   }, [selectedItemsState.dashboard]);
 
-  const dashboardOrigin: Record<string, string> = {};
+  const selectedDashboardOrigin: string[] = [];
   if (searchState.result) {
     for (const selectedDashboard of selectedDashboards) {
       const index = searchState.result.view.fields.uid.values.findIndex((e) => e === selectedDashboard);
-      dashboardOrigin[selectedDashboard] = searchState.result.view.fields.location.values[index];
+      selectedDashboardOrigin.push(searchState.result.view.fields.location.values[index]);
     }
   }
 
@@ -90,7 +90,7 @@ export function RecentlyDeletedActions() {
         component: RestoreModal,
         props: {
           selectedDashboards,
-          dashboardOrigin,
+          dashboardOrigin: selectedDashboardOrigin,
           onConfirm: onRestore,
           isLoading: isRestoreLoading,
         },

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -11,7 +11,7 @@ export interface RestoreModalProps {
   onConfirm: (restoreTarget: string) => Promise<void>;
   onDismiss: () => void;
   selectedDashboards: string[];
-  dashboardOrigin: { [key: string]: string };
+  dashboardOrigin: string[];
   isLoading: boolean;
 }
 
@@ -27,14 +27,14 @@ export const RestoreModal = ({
   const numberOfDashboards = selectedDashboards.length;
 
   useEffect(() => {
-    const origins = Object.values(dashboardOrigin);
     // restoreTarget is used by the folder picker to preselect a folder and therefore unblock the confirm button
     // if there is only one dashboard selected or all selected dashboards come from the same folder
     if (
-      origins.length === 1 ||
-      (origins.length > 1 && origins.every((originalLocation) => originalLocation === origins[0]))
+      dashboardOrigin.length === 1 ||
+      (dashboardOrigin.length > 1 &&
+        dashboardOrigin.every((originalLocation) => originalLocation === dashboardOrigin[0]))
     ) {
-      setRestoreTarget(origins[0]);
+      setRestoreTarget(dashboardOrigin[0]);
     }
   }, [dashboardOrigin, selectedDashboards]);
 

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -27,12 +27,11 @@ export const RestoreModal = ({
   const numberOfDashboards = selectedDashboards.length;
 
   useEffect(() => {
-    // restoreTarget is used by the folder picker to preselect a folder and therefore unblock the confirm button
+    // restoreTarget is used by the folder picker to preselect a folder and therefore enable the confirm button
     // if there is only one dashboard selected or all selected dashboards come from the same folder
     if (
-      dashboardOrigin.length === 1 ||
-      (dashboardOrigin.length > 1 &&
-        dashboardOrigin.every((originalLocation) => originalLocation === dashboardOrigin[0]))
+      dashboardOrigin.length > 0 &&
+      dashboardOrigin.every((originalLocation) => originalLocation === dashboardOrigin[0])
     ) {
       setRestoreTarget(dashboardOrigin[0]);
     }

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -28,11 +28,11 @@ export const RestoreModal = ({
 
   useEffect(() => {
     const origins = Object.values(dashboardOrigin);
-    if (origins.length === 1 && dashboardOrigin[selectedDashboards[0]] !== 'general') {
-      setRestoreTarget(dashboardOrigin[selectedDashboards[0]]);
+    if (origins.length === 1) {
+      setRestoreTarget(origins[0]);
     } else if (origins.length > 1) {
       if (origins.filter((originalLocation) => originalLocation !== origins[0]).length === 0) {
-        setRestoreTarget(dashboardOrigin[selectedDashboards[0]]);
+        setRestoreTarget(origins[0]);
       }
     }
   }, [dashboardOrigin, selectedDashboards]);

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -28,12 +28,13 @@ export const RestoreModal = ({
 
   useEffect(() => {
     const origins = Object.values(dashboardOrigin);
-    if (origins.length === 1) {
+    // restoreTarget is used by the folder picker to preselect a folder and therefore unblock the confirm button
+    // if there is only one dashboard selected or all selected dashboards come from the same folder
+    if (
+      origins.length === 1 ||
+      (origins.length > 1 && origins.every((originalLocation) => originalLocation === origins[0]))
+    ) {
       setRestoreTarget(origins[0]);
-    } else if (origins.length > 1) {
-      if (origins.filter((originalLocation) => originalLocation !== origins[0]).length === 0) {
-        setRestoreTarget(origins[0]);
-      }
     }
   }, [dashboardOrigin, selectedDashboards]);
 

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -27,8 +27,13 @@ export const RestoreModal = ({
   const numberOfDashboards = selectedDashboards.length;
 
   useEffect(() => {
-    if (Object.entries(dashboardOrigin).length === 1 && dashboardOrigin[selectedDashboards[0]] !== 'general') {
+    const origins = Object.values(dashboardOrigin);
+    if (origins.length === 1 && dashboardOrigin[selectedDashboards[0]] !== 'general') {
       setRestoreTarget(dashboardOrigin[selectedDashboards[0]]);
+    } else if (origins.length > 1) {
+      if (origins.filter((originalLocation) => originalLocation !== origins[0]).length === 0) {
+        setRestoreTarget(dashboardOrigin[selectedDashboards[0]]);
+      }
     }
   }, [dashboardOrigin, selectedDashboards]);
 


### PR DESCRIPTION
**What is this feature?**
The folder picker in RestoreModal showed a preselected folder when only one dashboard was selected. The preselection gets expanded to several dashboards from the same folder in this PR.

**Which issue(s) does this PR fix?**:
Fixes #92366

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
