### PR TITLE
Alerting: Extend scheduler user with datasources:read

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -514,6 +514,9 @@ func SchedulerUserFor(orgID int64) *user.SignedInUser {
 				datasources.ActionQuery: []string{
 					datasources.ScopeAll,
 				},
+				datasources.ActionRead: []string{
+					datasources.ScopeAll,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What is this feature?**

This is in preparation for a future change which disambiguates datasources:read from datasources:query.

This has no effect right now - just updating our client to be compliant ahead of any changes.

**Why do we need this feature?**

Updating clients ahead of breaking change.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
