### PR TITLE
Explore metrics: Fix long metrics and labels in landing page

### DIFF
--- a/public/app/features/trails/DataTrailCard.tsx
+++ b/public/app/features/trails/DataTrailCard.tsx
@@ -55,7 +55,7 @@ export function DataTrailCard(props: Props) {
       <div className={styles.description}>
         <Stack gap={1.5} wrap="wrap">
           {filters.map((f) => (
-            <Tag key={f.key} name={`${f.key}: ${f.value}`} colorIndex={12} />
+            <Tag key={f.key} name={truncateLongLabels(f)} colorIndex={12} />
           ))}
         </Stack>
       </div>
@@ -115,4 +115,13 @@ function getStyles(theme: GrafanaTheme2) {
       overflowWrap: 'anywhere',
     }),
   };
+}
+
+function truncateLongLabels(filter: { key: string; value: string }, maxlength?: number, suffix?: string) {
+  suffix = suffix ?? '...';
+  maxlength = maxlength ?? 80;
+
+  const label = `${filter.key}: ${filter.value}`;
+
+  return label.slice(0, maxlength) + suffix;
 }

--- a/public/app/features/trails/DataTrailCard.tsx
+++ b/public/app/features/trails/DataTrailCard.tsx
@@ -55,7 +55,7 @@ export function DataTrailCard(props: Props) {
       <div className={styles.description}>
         <Stack gap={1.5} wrap="wrap">
           {filters.map((f) => (
-            <Tag key={f.key} name={truncateLongLabels(f)} colorIndex={12} />
+            <Tag key={f.key} name={`${f.key}: ${f.value}`} colorIndex={12} />
           ))}
         </Stack>
       </div>
@@ -106,6 +106,9 @@ function getStyles(theme: GrafanaTheme2) {
       margin: theme.spacing(1, 0, 0),
       color: theme.colors.text.secondary,
       lineHeight: theme.typography.body.lineHeight,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
     }),
     actions: css({
       marginRight: theme.spacing(1),
@@ -115,13 +118,4 @@ function getStyles(theme: GrafanaTheme2) {
       overflowWrap: 'anywhere',
     }),
   };
-}
-
-function truncateLongLabels(filter: { key: string; value: string }, maxlength?: number, suffix?: string) {
-  suffix = suffix ?? '...';
-  maxlength = maxlength ?? 80;
-
-  const label = `${filter.key}: ${filter.value}`;
-
-  return label.slice(0, maxlength) + suffix;
 }

--- a/public/app/features/trails/DataTrailCard.tsx
+++ b/public/app/features/trails/DataTrailCard.tsx
@@ -51,7 +51,7 @@ export function DataTrailCard(props: Props) {
 
   return (
     <Card onClick={onSelect} className={styles.card}>
-      <Card.Heading>{getMetricName(metric)}</Card.Heading>
+      <Card.Heading className={styles.wordwrap}>{getMetricName(metric)}</Card.Heading>
       <div className={styles.description}>
         <Stack gap={1.5} wrap="wrap">
           {filters.map((f) => (
@@ -109,6 +109,10 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     actions: css({
       marginRight: theme.spacing(1),
+    }),
+    wordwrap: css({
+      overflow: 'hidden',
+      overflowWrap: 'anywhere',
     }),
   };
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/92411

What is this?

This is a bug fix for long metric names and labels in the landing page for Explore metrics.

Why?

Long metric names and labels break the Card components and for the UI to extend off the page, which allows the user to scroll outside the landing page window. This is a bad experience.

Previously

https://github.com/user-attachments/assets/984aaf7b-9a74-4436-bc9d-30f3b3fe9b9d


Now we word wrap long metrics and hide longer labels to prevent flowing beyond the page.

![Screenshot 2024-09-04 at 9 01 48 AM](https://github.com/user-attachments/assets/3927f973-0e02-405a-b601-f135cd304a47)





Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
