### PR TITLE
Provisioning: Fix admin reloading of dashboard configuration

### DIFF
--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -235,13 +235,18 @@ func (ps *ProvisioningServiceImpl) ProvisionPlugins(ctx context.Context) error {
 }
 
 func (ps *ProvisioningServiceImpl) ProvisionDashboards(ctx context.Context) error {
+	err := ps.setDashboardProvisioner()
+	if err != nil {
+		return fmt.Errorf("%v: %w", "Failed to create provisioner", err)
+	}
+
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 
 	ps.cancelPolling()
 	ps.dashboardProvisioner.CleanUpOrphanedDashboards(ctx)
 
-	err := ps.dashboardProvisioner.Provision(ctx)
+	err = ps.dashboardProvisioner.Provision(ctx)
 	if err != nil {
 		// If we fail to provision with the new provisioner, the mutex will unlock and the polling will restart with the
 		// old provisioner as we did not switch them yet.

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -108,6 +108,19 @@ func TestProvisioningServiceImpl(t *testing.T) {
 
 		assert.True(t, errors.Is(serviceTest.serviceError, provisioningErr))
 	})
+	t.Run("Should set dashboard provisioner when provisioning dashboards", func(t *testing.T) {
+		// The first dashboard provisioner instantiation takes place when
+		// setDashboardProvisioner() is called in setup(t).
+		serviceTest := setup(t)
+		// The second dashboard provisioner instantiation takes place when
+		// Run(ctx) is executed.
+		serviceTest.startService()
+
+		serviceTest.cancel()
+		serviceTest.waitForStop()
+
+		assert.Equal(t, 2, serviceTest.dashboardProvisionerInstantiations)
+	})
 }
 
 type serviceTestStruct struct {
@@ -120,6 +133,8 @@ type serviceTestStruct struct {
 
 	startService func()
 	cancel       func()
+
+	dashboardProvisionerInstantiations int
 
 	mock    *dashboards.ProvisionerMock
 	service *ProvisioningServiceImpl
@@ -141,6 +156,7 @@ func setup(t *testing.T) *serviceTestStruct {
 
 	service, err := newProvisioningServiceImpl(
 		func(context.Context, string, dashboardstore.DashboardProvisioningService, org.Service, utils.DashboardStore, folder.Service) (dashboards.DashboardProvisioner, error) {
+			serviceTest.dashboardProvisionerInstantiations++
 			return serviceTest.mock, nil
 		},
 		nil,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Set new provisioner before provisioning dashboards as was the case before https://github.com/grafana/grafana/pull/85011

**Why do we need this feature?**

Dashboards aren't being properly reloaded because the provisioner being used is out of date.

**Who is this feature for?**

Provisioning admins. 

~~[EDIT: this next part is on hold. Not sure yet if it will be necessary actually] Grafana developers. The plan is to merge and backport this fix to v9.5.x, v10.4.x and v11.0.x. This will then allow us to backport https://github.com/grafana/grafana/pull/85011 to v9.5.x and v10.4.x (currently only to v11.0.x). The latter change will allow me to easily fix the manual backport PRs of https://github.com/grafana/grafana/pull/92201.~~

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/grafana/issues/92319

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
