### PR TITLE
SQL Store: Fix parse time setup

### DIFF
--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -166,10 +166,6 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 			cnnstr += fmt.Sprintf("&transaction_isolation=%s", val)
 		}
 
-		if features != nil && features.IsEnabledGlobally(featuremgmt.FlagMysqlParseTime) {
-			cnnstr += "&parseTime=true"
-		}
-
 		if features != nil && features.IsEnabledGlobally(featuremgmt.FlagMysqlAnsiQuotes) {
 			cnnstr += "&sql_mode='ANSI_QUOTES'"
 		}

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -8,8 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestMain(m *testing.M) {
@@ -63,6 +67,71 @@ func TestIntegrationIsUniqueConstraintViolation(t *testing.T) {
 			})
 			require.Error(t, err)
 			assert.True(t, store.dialect.IsUniqueConstraintViolation(err))
+		})
+	}
+}
+
+func TestInitEngine_ParseTimeInConnectionString(t *testing.T) {
+	tests := []struct {
+		name               string
+		connectionString   string
+		dbType             string
+		featureEnabled     bool
+		expectedConnection string
+	}{
+		{
+			name:               "MySQL with parseTime already present",
+			connectionString:   "mysql://user:password@localhost:3306/alreadypresent?parseTime=false",
+			dbType:             "mysql",
+			featureEnabled:     true,
+			expectedConnection: "user:password@tcp(localhost:3306)/alreadypresent?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=false",
+		},
+		{
+			name:               "MySQL with feature enabled",
+			connectionString:   "mysql://user:password@localhost:3306/existingparams?charset=utf8",
+			dbType:             "mysql",
+			featureEnabled:     true,
+			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&charset=utf8&parseTime=true",
+		},
+		{
+			name:               "MySQL with feature disabled",
+			connectionString:   "mysql://user:password@localhost:3306/disabled",
+			dbType:             "mysql",
+			featureEnabled:     false,
+			expectedConnection: "user:password@tcp(localhost:3306)/disabled?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
+		},
+		{
+			name:               "Postgres",
+			connectionString:   "postgres://username:password@localhost:5432/mydatabase",
+			dbType:             "postgres",
+			featureEnabled:     true,
+			expectedConnection: "user=username host=localhost port=5432 dbname=mydatabase sslmode='' sslcert='' sslkey='' sslrootcert='' password=password",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := ini.Load([]byte(`
+				[database]
+				url = ` + tt.connectionString))
+			require.NoError(t, err)
+
+			ftMgr := featuremgmt.WithFeatures()
+			if tt.featureEnabled {
+				ftMgr = featuremgmt.WithFeatures(featuremgmt.FlagMysqlParseTime)
+			}
+
+			ss := &SQLStore{
+				cfg: &setting.Cfg{
+					Raw: raw,
+				},
+				features: ftMgr,
+				log:      log.New(),
+			}
+
+			err = ss.initEngine(nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedConnection, ss.dbCfg.ConnectionString)
 		})
 	}
 }

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -129,8 +129,8 @@ func TestInitEngine_ParseTimeInConnectionString(t *testing.T) {
 				log:      log.New(),
 			}
 
-			ss.initEngine(nil)
 			// don't check the error, the db isn't running. Just check the connection string is okay
+			_ = ss.initEngine(nil)
 			assert.Equal(t, tt.expectedConnection, ss.dbCfg.ConnectionString)
 		})
 	}

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -129,8 +129,8 @@ func TestInitEngine_ParseTimeInConnectionString(t *testing.T) {
 				log:      log.New(),
 			}
 
-			err = ss.initEngine(nil)
-			require.NoError(t, err)
+			ss.initEngine(nil)
+			// don't check the error, the db isn't running. Just check the connection string is okay
 			assert.Equal(t, tt.expectedConnection, ss.dbCfg.ConnectionString)
 		})
 	}


### PR DESCRIPTION
**What is this feature?**

This PR fixes the addition of the parseTime parameter, specifically it now:
- Double checks if there are already url parameters. If so, it uses the `&` vs the `?`.
- Removes the addition of the `parseTime` in the database_config (it was adding parseTime=true even when the user sets it to false)

It also adds a unit test around the connection strings