### PR TITLE
Performance: Lazy load built in panel plugins

### DIFF
--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -21,33 +21,49 @@ const alertmanagerPlugin = async () =>
   await import(/* webpackChunkName: "alertmanagerPlugin" */ 'app/plugins/datasource/alertmanager/module');
 
 import { config } from '@grafana/runtime';
-import * as alertListPanel from 'app/plugins/panel/alertlist/module';
-import * as annoListPanel from 'app/plugins/panel/annolist/module';
-import * as barChartPanel from 'app/plugins/panel/barchart/module';
-import * as barGaugePanel from 'app/plugins/panel/bargauge/module';
-import * as candlestickPanel from 'app/plugins/panel/candlestick/module';
-import * as dashListPanel from 'app/plugins/panel/dashlist/module';
-import * as dataGridPanel from 'app/plugins/panel/datagrid/module';
-import * as debugPanel from 'app/plugins/panel/debug/module';
-import * as flamegraphPanel from 'app/plugins/panel/flamegraph/module';
-import * as gaugePanel from 'app/plugins/panel/gauge/module';
-import * as gettingStartedPanel from 'app/plugins/panel/gettingstarted/module';
-import * as histogramPanel from 'app/plugins/panel/histogram/module';
-import * as livePanel from 'app/plugins/panel/live/module';
-import * as logsPanel from 'app/plugins/panel/logs/module';
-import * as newsPanel from 'app/plugins/panel/news/module';
-import * as pieChartPanel from 'app/plugins/panel/piechart/module';
-import * as statPanel from 'app/plugins/panel/stat/module';
-import * as stateTimelinePanel from 'app/plugins/panel/state-timeline/module';
-import * as statusHistoryPanel from 'app/plugins/panel/status-history/module';
-import * as tablePanel from 'app/plugins/panel/table/module';
-import * as textPanel from 'app/plugins/panel/text/module';
-import * as timeseriesPanel from 'app/plugins/panel/timeseries/module';
-import * as tracesPanel from 'app/plugins/panel/traces/module';
-import * as trendPanel from 'app/plugins/panel/trend/module';
-import * as welcomeBanner from 'app/plugins/panel/welcome/module';
 
 // Async loaded panels
+const alertListPanel = async () =>
+  await import(/* webpackChunkName: "alertListPanel" */ 'app/plugins/panel/alertlist/module');
+const annoListPanel = async () =>
+  await import(/* webpackChunkName: "annoListPanel" */ 'app/plugins/panel/annolist/module');
+const barChartPanel = async () =>
+  await import(/* webpackChunkName: "barChartPanel" */ 'app/plugins/panel/barchart/module');
+const barGaugePanel = async () =>
+  await import(/* webpackChunkName: "barGaugePanel" */ 'app/plugins/panel/bargauge/module');
+const candlestickPanel = async () =>
+  await import(/* webpackChunkName: "candlestickPanel" */ 'app/plugins/panel/candlestick/module');
+const dashListPanel = async () =>
+  await import(/* webpackChunkName: "dashListPanel" */ 'app/plugins/panel/dashlist/module');
+const dataGridPanel = async () =>
+  await import(/* webpackChunkName: "dataGridPanel" */ 'app/plugins/panel/datagrid/module');
+const debugPanel = async () => await import(/* webpackChunkName: "debugPanel" */ 'app/plugins/panel/debug/module');
+const flamegraphPanel = async () =>
+  await import(/* webpackChunkName: "flamegraphPanel" */ 'app/plugins/panel/flamegraph/module');
+const gaugePanel = async () => await import(/* webpackChunkName: "gaugePanel" */ 'app/plugins/panel/gauge/module');
+const gettingStartedPanel = async () =>
+  await import(/* webpackChunkName: "gettingStartedPanel" */ 'app/plugins/panel/gettingstarted/module');
+const histogramPanel = async () =>
+  await import(/* webpackChunkName: "histogramPanel" */ 'app/plugins/panel/histogram/module');
+const livePanel = async () => await import(/* webpackChunkName: "livePanel" */ 'app/plugins/panel/live/module');
+const logsPanel = async () => await import(/* webpackChunkName: "logsPanel" */ 'app/plugins/panel/logs/module');
+const newsPanel = async () => await import(/* webpackChunkName: "newsPanel" */ 'app/plugins/panel/news/module');
+const pieChartPanel = async () =>
+  await import(/* webpackChunkName: "pieChartPanel" */ 'app/plugins/panel/piechart/module');
+const statPanel = async () => await import(/* webpackChunkName: "statPanel" */ 'app/plugins/panel/stat/module');
+const stateTimelinePanel = async () =>
+  await import(/* webpackChunkName: "stateTimelinePanel" */ 'app/plugins/panel/state-timeline/module');
+const statusHistoryPanel = async () =>
+  await import(/* webpackChunkName: "statusHistoryPanel" */ 'app/plugins/panel/status-history/module');
+const tablePanel = async () => await import(/* webpackChunkName: "tablePanel" */ 'app/plugins/panel/table/module');
+const textPanel = async () => await import(/* webpackChunkName: "textPanel" */ 'app/plugins/panel/text/module');
+const timeseriesPanel = async () =>
+  await import(/* webpackChunkName: "timeseriesPanel" */ 'app/plugins/panel/timeseries/module');
+const tracesPanel = async () => await import(/* webpackChunkName: "tracesPanel" */ 'app/plugins/panel/traces/module');
+const trendPanel = async () => await import(/* webpackChunkName: "trendPanel" */ 'app/plugins/panel/trend/module');
+const welcomeBanner = async () =>
+  await import(/* webpackChunkName: "welcomeBanner" */ 'app/plugins/panel/welcome/module');
+
 const geomapPanel = async () => await import(/* webpackChunkName: "geomapPanel" */ 'app/plugins/panel/geomap/module');
 const canvasPanel = async () => await import(/* webpackChunkName: "canvasPanel" */ 'app/plugins/panel/canvas/module');
 const graphPanel = async () => await import(/* webpackChunkName: "graphPlugin" */ 'app/plugins/panel/graph/module');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This PR changes the built in plugins so they are all dynamically loaded via chunks instead of bundled into the initial chunks.

**Why do we need this feature?**
By taking these panel plugins out of the initial chunks we see some reduction on initial chunk sizes as the panels and a lot of their dependencies aren't included. The largest packages this PR removes from the initial chunks are D3 and @glideapps/glide-data-grid.

_webpack build stats for entrypoint_

| | Before | After |
| --- | --- | --- |
Unminified | 24.2 MiB | 21.3 MiB |
Minified | 9.82 MiB | 8.6 MiB |

Within the initial chunks we can observe the following changes:

_/app/features/plugins_
| Before | After |
| --- | --- |
| <img width="902" alt="Screenshot 2024-08-28 at 12 25 34" src="https://github.com/user-attachments/assets/2113640d-5f11-4548-8b3c-1284ce17b897"> | <img width="846" alt="Screenshot 2024-08-28 at 12 25 12" src="https://github.com/user-attachments/assets/57559505-b708-40ff-8c64-e13df1a85635"> |

_node_modules_
| Before | After |
| --- | --- |
| <img width="1212" alt="Screenshot 2024-08-28 at 12 27 38" src="https://github.com/user-attachments/assets/4cdec896-86ad-424a-8357-eb773a50a1e8"> | <img width="1219" alt="Screenshot 2024-08-28 at 12 27 54" src="https://github.com/user-attachments/assets/1e17d5c6-7187-4db3-917b-e813cd8c9637"> |



**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
