### PR TITLE
Prometheus: Variable query editor, display selected label when using query type of label values

### DIFF
--- a/packages/grafana-prometheus/src/components/VariableQueryEditor.test.tsx
+++ b/packages/grafana-prometheus/src/components/VariableQueryEditor.test.tsx
@@ -265,6 +265,8 @@ describe('PromVariableQueryEditor', () => {
     const labelSelect = screen.getByLabelText('label-select');
     await userEvent.type(labelSelect, 'this');
     await selectOptionInTest(labelSelect, 'this');
+    //display label in label select
+    await waitFor(() => expect(screen.getByText('this')).toBeInTheDocument());
 
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith({

--- a/packages/grafana-prometheus/src/components/VariableQueryEditor.tsx
+++ b/packages/grafana-prometheus/src/components/VariableQueryEditor.tsx
@@ -2,7 +2,7 @@
 import debounce from 'debounce-promise';
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { QueryEditorProps, SelectableValue, toOption } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { AsyncSelect, InlineField, InlineFieldRow, Input, Select, TextArea } from '@grafana/ui';
 
@@ -286,7 +286,7 @@ export const PromVariableQueryEditor = ({ onChange, query, datasource, range }: 
               <AsyncSelect
                 aria-label="label-select"
                 onChange={onLabelChange}
-                value={label}
+                value={label ? toOption(label) : null}
                 defaultOptions={truncatedLabelOptions}
                 width={25}
                 allowCustomValue


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/12146

Fixes https://github.com/grafana/support-escalations/issues/12192

This bug was introduced in https://github.com/grafana/grafana/pull/92026. 

1. Create a variable query type with Prometheus
2. Select label values
3. Select a label, see the label selected does not populate the input

The <AsyncSelect> component requires the value set to be transformed using the function `toOption` to show the selected label. This is a bug fix for that.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
