### PR TITLE
Logs Panel: Only send DataHoverClearEvent on container mouse leave event

### DIFF
--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -149,9 +149,6 @@ class UnThemedLogRow extends PureComponent<Props, State> {
 
   onMouseLeave = () => {
     this.setState({ mouseIsOver: false });
-    if (this.props.onLogRowHover) {
-      this.props.onLogRowHover(undefined);
-    }
   };
 
   componentDidMount() {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -127,7 +127,7 @@ export const LogsPanel = ({
     [eventBus]
   );
 
-  const onLogContainerMouseOut = useCallback(() => {
+  const onLogContainerMouseLeave = useCallback(() => {
     eventBus.publish(new DataHoverClearEvent());
   }, [eventBus]);
 
@@ -352,7 +352,7 @@ export const LogsPanel = ({
         scrollTop={scrollTop}
         scrollRefCallback={(scrollElement) => setScrollElement(scrollElement)}
       >
-        <div onMouseLeave={onLogContainerMouseOut} className={style.container} ref={logsContainerRef}>
+        <div onMouseLeave={onLogContainerMouseLeave} className={style.container} ref={logsContainerRef}>
           {showCommonLabels && !isAscending && renderCommonLabels()}
           <LogRows
             containerRendered={logsContainerRef.current !== null}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -127,6 +127,10 @@ export const LogsPanel = ({
     [eventBus]
   );
 
+  const onLogContainerMouseOut = useCallback(() => {
+    eventBus.publish(new DataHoverClearEvent());
+  }, [eventBus]);
+
   const onCloseContext = useCallback(() => {
     setContextRow(null);
     if (closeCallback.current) {
@@ -348,13 +352,7 @@ export const LogsPanel = ({
         scrollTop={scrollTop}
         scrollRefCallback={(scrollElement) => setScrollElement(scrollElement)}
       >
-        <div
-          onMouseLeave={() => {
-            eventBus.publish(new DataHoverClearEvent());
-          }}
-          className={style.container}
-          ref={logsContainerRef}
-        >
+        <div onMouseLeave={onLogContainerMouseOut} className={style.container} ref={logsContainerRef}>
           {showCommonLabels && !isAscending && renderCommonLabels()}
           <LogRows
             containerRendered={logsContainerRef.current !== null}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -114,9 +114,7 @@ export const LogsPanel = ({
   const { eventBus, onAddAdHocFilter } = usePanelContext();
   const onLogRowHover = useCallback(
     (row?: LogRowModel) => {
-      if (!row) {
-        eventBus.publish(new DataHoverClearEvent());
-      } else {
+      if (row) {
         eventBus.publish(
           new DataHoverEvent({
             point: {
@@ -350,7 +348,13 @@ export const LogsPanel = ({
         scrollTop={scrollTop}
         scrollRefCallback={(scrollElement) => setScrollElement(scrollElement)}
       >
-        <div className={style.container} ref={logsContainerRef}>
+        <div
+          onMouseLeave={() => {
+            eventBus.publish(new DataHoverClearEvent());
+          }}
+          className={style.container}
+          ref={logsContainerRef}
+        >
           {showCommonLabels && !isAscending && renderCommonLabels()}
           <LogRows
             containerRendered={logsContainerRef.current !== null}


### PR DESCRIPTION
**What is this feature?**
Small change to how we send DataHoverClearEvent in the LogsPanel. Currently we send the DataHoverClearEvent whenever the mouse moves between log rows, this change only emits the event when the mouse leaves the container.

**Why do we need this feature?**
To prevent tooltip from persisting when user is not hovering over the logs panel.

**Who is this feature for?**
Logs panel users in dashboards with shared cursor tooltips enabled

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/92527

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
