### PR TITLE
CloudWatch: Logs queries should retry on throttling errors

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	limitExceededException      = "LimitExceededException"
+	throttlingException         = "ThrottlingException"
 	defaultEventLimit           = int64(10)
 	defaultLogGroupLimit        = int64(50)
 	logIdentifierInternal       = "__log__grafana_internal__"
@@ -233,6 +234,9 @@ func (e *cloudWatchExecutor) executeStartQuery(ctx context.Context, logsClient c
 		if errors.As(err, &awsErr) && awsErr.Code() == "LimitExceededException" {
 			e.logger.FromContext(ctx).Debug("ExecuteStartQuery limit exceeded", "err", awsErr)
 			err = &AWSError{Code: limitExceededException, Message: err.Error()}
+		} else if errors.As(err, &awsErr) && awsErr.Code() == "ThrottlingException" {
+			e.logger.FromContext(ctx).Debug("ExecuteStartQuery rate exceeded", "err", awsErr)
+			err = &AWSError{Code: throttlingException, Message: err.Error()}
 		}
 		err = errorsource.DownstreamError(err, false)
 	}

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts
@@ -94,7 +94,10 @@ function splitErrorsData(errors: DataQueryError[]) {
   const refIdsForRequestsToRetry: string[] = [];
   const errorsNotToRetry: DataQueryError[] = [];
   errors.map((err) => {
-    if (err?.message?.includes('LimitExceededException') && err.refId) {
+    if (
+      err?.refId &&
+      (err.message?.includes('LimitExceededException') || err.message?.includes('ThrottlingException'))
+    ) {
       refIdsForRequestsToRetry.push(err.refId);
     } else {
       errorsNotToRetry.push(err);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds retrying for log queries on ThrottlingExceptions. This improvement was requested in a support escalation

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #91145 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
