### PR TITLE
Prometheus: Fix multi value variables extra regex escape issue

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -566,15 +566,16 @@ describe('PrometheusDatasource', () => {
       });
 
       it('should regex escape values if the value is a string', () => {
+        // if the value is a string, we should continue to escape it
         expect(ds.interpolateQueryExpr('looking*glass', customVariable)).toEqual('looking\\\\*glass');
       });
 
       it('should return pipe separated values if the value is an array of strings', () => {
-        expect(ds.interpolateQueryExpr(['a|bc', 'de|f'], customVariable)).toEqual('(a\\\\|bc|de\\\\|f)');
+        expect(ds.interpolateQueryExpr(['a|bc', 'de|f'], customVariable)).toEqual('(a|bc|de|f)');
       });
 
       it('should return 1 regex escaped value if there is just 1 value in an array of strings', () => {
-        expect(ds.interpolateQueryExpr(['looking*glass'], customVariable)).toEqual('looking\\\\*glass');
+        expect(ds.interpolateQueryExpr(['looking*glass'], customVariable)).toEqual('looking*glass');
       });
     });
 
@@ -588,11 +589,18 @@ describe('PrometheusDatasource', () => {
       });
 
       it('should return pipe separated values if the value is an array of strings', () => {
-        expect(ds.interpolateQueryExpr(['a|bc', 'de|f'], customVariable)).toEqual('(a\\\\|bc|de\\\\|f)');
+        expect(ds.interpolateQueryExpr(['a|bc', 'de|f'], customVariable)).toEqual('(a|bc|de|f)');
       });
 
       it('should return 1 regex escaped value if there is just 1 value in an array of strings', () => {
-        expect(ds.interpolateQueryExpr(['looking*glass'], customVariable)).toEqual('looking\\\\*glass');
+        expect(ds.interpolateQueryExpr(['looking*glass'], customVariable)).toEqual('looking*glass');
+      });
+
+      it('should not escape . chars in variables', () => {
+        // all variables passed in scenes are now multi variables
+        // this forces the interpolation function to add extra regex escaping
+        // but now we are not doing that
+        expect(ds.interpolateQueryExpr(['a.b|cd', 'ef|g.h'], customVariable)).toEqual('(a.b|cd|ef|g.h)');
       });
     });
   });

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -327,7 +327,10 @@ export class PrometheusDatasource
       return prometheusSpecialRegexEscape(value);
     }
 
-    const escapedValues = value.map((val) => prometheusSpecialRegexEscape(val));
+    // we should use =~`${variable:regex}` for special regex escapes
+    // This change below allows that multi variables with chars like . will not be escaped
+    // e.g. {client="auth.client.session"}
+    const escapedValues = value.map((val) => prometheusRegularEscape(val));
 
     if (escapedValues.length === 1) {
       return escapedValues[0];


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11769

**What is this?**

This change removes the special regex escaping for multi variables in the prometheus data source. This might be a problem in the future, but only for Prometheus variables of the query type that contain regex that need to be escaped.

**The problems:** 

Problem 1: Some label values contain characters that should not be interpreted as regex.

Problem 2: Scenes now turns all variables into multi variables. This changed how the Prometheus variable interpolation was done with single value variables that did not expect regex. For multi value variables we used to do special regex escaping because this would be used with the `=~` operator. 

So this single value variable now is changed because it contains a '.' character.
`"auth.client.session"` => `"auth\\\\.client\\\\.session"`

This fixes the issue by not special escaping regex for multi value Prometheus template variables.

**Special notes for your reviewer:**
If you were tagged on this, it is because your name was mentioned in the historical research for this issue. Please share your thoughts! Any context on this would be very helpful ❤️ 

Here is a little history on special regex escaping in Prometheus data source and Tempo DS. The last time this was changes in Prometheus was over 4 years ago. The time the special regex escaping was added was 2016. Since then this issue has come up in Tempo. We will probably see it again as OpenTelemetry gains users.

Prometheus escape regex history

Here is a 2016 issue
https://github.com/grafana/grafana/issues/4234
I can't find any current info that says Prometheus requires the double backslashes/extra escaping for regex, so please share info if you have more context on this.

Here is a fix used in tempo
https://github.com/grafana/grafana/issues/54849#issuecomment-1335517259

tempo issue
https://github.com/grafana/grafana/issues/79791#issue-2052247153

Ask Andre Oceanus about this
https://github.com/grafana/grafana/pull/83024

Could this work?
regex should be escaped like this
https://github.com/grafana/grafana/issues/40634#issuecomment-974005971
some_metric{repo=~`${repos:regex}`}
regex operator + backticks


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
