### PR TITLE
Revert "RBAC: Optimize permissions caching"

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/grafana/authlib/claims"
-
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -243,11 +242,6 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	defer span.End()
 
 	permissions := []accesscontrol.Permission{}
-	cacheKey := accesscontrol.GetUserPermissionCacheKey(user)
-	if cachedPermissions, ok := s.cache.Get(cacheKey); ok {
-		return cachedPermissions.([]accesscontrol.Permission), nil
-	}
-
 	permissions, err := s.getCachedBasicRolesPermissions(ctx, user, options, permissions)
 	if err != nil {
 		return nil, err
@@ -264,7 +258,6 @@ func (s *Service) getCachedUserPermissions(ctx context.Context, user identity.Re
 	}
 
 	permissions = append(permissions, userPermissions...)
-	s.cache.Set(cacheKey, permissions, cacheTTL)
 	span.SetAttributes(attribute.Int("num_permissions", len(permissions)))
 
 	return permissions, nil
@@ -344,14 +337,8 @@ func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.R
 	teams := user.GetTeams()
 	orgID := user.GetOrgID()
 	miss := teams
-	compositeKey := accesscontrol.GetTeamPermissionCompositeCacheKey(teams, orgID)
 
 	if !options.ReloadCache {
-		teamsPermissions, ok := s.cache.Get(compositeKey)
-		if ok {
-			return teamsPermissions.([]accesscontrol.Permission), nil
-		}
-
 		miss = make([]int64, 0)
 		for _, teamID := range teams {
 			key := accesscontrol.GetTeamPermissionCacheKey(teamID, orgID)
@@ -381,13 +368,12 @@ func (s *Service) getCachedTeamsPermissions(ctx context.Context, user identity.R
 			permissions = append(permissions, teamPermissions...)
 		}
 	}
-	s.cache.Set(compositeKey, permissions, cacheTTL)
 
 	return permissions, nil
 }
 
 func (s *Service) ClearUserPermissionCache(user identity.Requester) {
-	s.cache.Delete(accesscontrol.GetUserPermissionCacheKey(user))
+	s.cache.Delete(accesscontrol.GetPermissionCacheKey(user))
 	s.cache.Delete(accesscontrol.GetUserDirectPermissionCacheKey(user))
 }
 

--- a/pkg/services/accesscontrol/cacheutils.go
+++ b/pkg/services/accesscontrol/cacheutils.go
@@ -2,14 +2,12 @@ package accesscontrol
 
 import (
 	"fmt"
-	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
-func GetUserPermissionCacheKey(user identity.Requester) string {
+func GetPermissionCacheKey(user identity.Requester) string {
 	return fmt.Sprintf("rbac-permissions-%s", user.GetCacheKey())
 }
 
@@ -42,13 +40,4 @@ func GetBasicRolePermissionCacheKey(role string, orgID int64) string {
 
 func GetTeamPermissionCacheKey(teamID int64, orgID int64) string {
 	return fmt.Sprintf("rbac-permissions-team-%d-%d", orgID, teamID)
-}
-
-func GetTeamPermissionCompositeCacheKey(teamIds []int64, orgID int64) string {
-	teams := make([]string, 0)
-	for _, id := range teamIds {
-		teams = append(teams, strconv.FormatInt(id, 10))
-	}
-	slices.Sort(teams)
-	return fmt.Sprintf("rbac-permissions-team-%d-%s", orgID, strings.Join(teams, "-"))
 }

--- a/pkg/services/accesscontrol/cacheutils_test.go
+++ b/pkg/services/accesscontrol/cacheutils_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/authlib/claims"
-
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -69,7 +68,7 @@ func TestPermissionCacheKey(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, GetUserPermissionCacheKey(tc.signedInUser))
+			assert.Equal(t, tc.expected, GetPermissionCacheKey(tc.signedInUser))
 		})
 	}
 }


### PR DESCRIPTION
Reverts grafana/grafana#92412

Based on discussion on this slack thread: https://raintank-corp.slack.com/archives/C05JDQ100NS/p1724761749644809

We have observed that permission cache for RBAC is having issues describing the correct permissions for some user-created service accounts in customer instances and grafana-internal instances. Disabling the RBAC permission cache through configuration remediated the issue in a given instance. For now, I'd like to revert this PR as it seems like the most likely candidate that would have caused a new cache issue to present itself.