### PR TITLE
K8s: Use stacks plural not singular in grafana namespaces

### DIFF
--- a/pkg/services/apiserver/endpoints/request/namespace.go
+++ b/pkg/services/apiserver/endpoints/request/namespace.go
@@ -18,11 +18,13 @@ type NamespaceMapper = claims.NamespaceFormatter
 // GetNamespaceMapper returns a function that will convert orgIds into a consistent namespace
 func GetNamespaceMapper(cfg *setting.Cfg) NamespaceMapper {
 	if cfg != nil && cfg.StackID != "" {
-		stackIdInt, err := strconv.ParseInt(cfg.StackID, 10, 64)
+		stackId, err := strconv.ParseInt(cfg.StackID, 10, 64)
 		if err != nil {
-			stackIdInt = 0
+			stackId = 0
 		}
-		cloudNamespace := claims.CloudNamespaceFormatter(stackIdInt)
+		// Temporarily force this as plural
+		cloudNamespace := fmt.Sprintf("stacks-%d", stackId)
+		// cloudNamespace := claims.CloudNamespaceFormatter(stackIdInt)
 		return func(_ int64) string { return cloudNamespace }
 	}
 	return claims.OrgNamespaceFormatter

--- a/pkg/services/apiserver/endpoints/request/namespace.go
+++ b/pkg/services/apiserver/endpoints/request/namespace.go
@@ -30,6 +30,19 @@ func GetNamespaceMapper(cfg *setting.Cfg) NamespaceMapper {
 	return claims.OrgNamespaceFormatter
 }
 
+// Temporary version that is only passed to th
+func GetTemporarySingularNamespaceMapper(cfg *setting.Cfg) NamespaceMapper {
+	if cfg != nil && cfg.StackID != "" {
+		stackIdInt, err := strconv.ParseInt(cfg.StackID, 10, 64)
+		if err != nil {
+			stackIdInt = 0
+		}
+		cloudNamespace := claims.CloudNamespaceFormatter(stackIdInt)
+		return func(_ int64) string { return cloudNamespace }
+	}
+	return claims.OrgNamespaceFormatter
+}
+
 func NamespaceInfoFrom(ctx context.Context, requireOrgID bool) (claims.NamespaceInfo, error) {
 	info, err := claims.ParseNamespace(request.NamespaceValue(ctx))
 	if err == nil && requireOrgID && info.OrgID < 1 {

--- a/pkg/services/apiserver/endpoints/request/namespace_test.go
+++ b/pkg/services/apiserver/endpoints/request/namespace_test.go
@@ -32,8 +32,8 @@ func TestNamespaceMapper(t *testing.T) {
 		{
 			name:     "with stackId",
 			cfg:      "abc",
-			orgId:    123,       // ignored
-			expected: "stack-0", // we parse to int and default to 0
+			orgId:    123,        // ignored
+			expected: "stacks-0", // we parse to int and default to 0
 		},
 	}
 

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -39,7 +39,7 @@ func ProvideService(
 		cfg: cfg, logger: log.New("id-service"),
 		signer: signer, cache: cache,
 		metrics:  newMetrics(reg),
-		nsMapper: request.GetNamespaceMapper(cfg),
+		nsMapper: request.GetTemporarySingularNamespaceMapper(cfg), // TODO replace with the plural one
 	}
 
 	authnService.RegisterPostAuthHook(s.hook, 140)


### PR DESCRIPTION
This PR switches grafana to use plural "stacks-123" rather than singular "stack-123" -- the change in grafana/grafana is temporary -- eventually it will be removed from here and implemented only once in authlib.

See also https://github.com/grafana/grafana/pull/92332