### PR TITLE
Auth: Display page not found when the provider is invalid

### DIFF
--- a/public/app/features/auth-config/ProviderConfigPage.tsx
+++ b/public/app/features/auth-config/ProviderConfigPage.tsx
@@ -6,6 +6,7 @@ import { Badge, Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 
+import { PageNotFound } from '../../core/components/PageNotFound/PageNotFound';
 import { StoreState } from '../../types';
 
 import { ProviderConfigForm } from './ProviderConfigForm';
@@ -57,15 +58,16 @@ export type Props = ConnectedProps<typeof connector>;
  * Separate the Page logic from the Content logic for easier testing.
  */
 export const ProviderConfigPage = ({ config, loadProviders, isLoading, provider }: Props) => {
-  const pageNav = getPageNav(config);
-
   useEffect(() => {
     loadProviders(provider);
   }, [loadProviders, provider]);
 
-  if (!config) {
-    return null;
+  if (!config || !config.provider || !UIMap[config.provider]) {
+    return <PageNotFound />;
   }
+
+  const pageNav = getPageNav(config);
+
   return (
     <Page
       navId="authentication"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Grafana displays `page not found` when the user tries to access an invalid provider configuration page using the page URL.

Example of a valid URL: <grafana_instance_domain>/admin/authentication/okta
Example of an invalid URL: <grafana_instance_domain>/admin/authentication/invalid

**Why do we need this feature?**

We need this because previously an empty page was displayed when the provider was invalid.

**Who is this feature for?**

everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to escalation https://github.com/grafana/support-escalations/issues/12163

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
