### PR TITLE
Scopes: Move `dashboardTitle` and `groups` to status

### DIFF
--- a/packages/grafana-data/src/types/scopes.ts
+++ b/packages/grafana-data/src/types/scopes.ts
@@ -1,7 +1,10 @@
 export interface ScopeDashboardBindingSpec {
   dashboard: string;
-  dashboardTitle: string;
   scope: string;
+}
+
+export interface ScopeDashboardBindingStatus {
+  dashboardTitle: string;
   groups?: string[];
 }
 
@@ -11,6 +14,7 @@ export interface ScopeDashboardBinding {
     name: string;
   };
   spec: ScopeDashboardBindingSpec;
+  status: ScopeDashboardBindingStatus;
 }
 
 export type ScopeFilterOperator = 'equals' | 'not-equals' | 'regex-match' | 'regex-not-match';

--- a/public/app/features/scopes/internal/utils.ts
+++ b/public/app/features/scopes/internal/utils.ts
@@ -48,7 +48,7 @@ export function groupDashboards(dashboards: ScopeDashboardBinding[]): SuggestedD
   return dashboards.reduce<SuggestedDashboardsFoldersMap>(
     (acc, dashboard) => {
       const rootNode = acc[''];
-      const groups = dashboard.spec.groups ?? [];
+      const groups = dashboard.status.groups ?? [];
 
       groups.forEach((group) => {
         if (group && !rootNode.folders[group]) {
@@ -70,7 +70,7 @@ export function groupDashboards(dashboards: ScopeDashboardBinding[]): SuggestedD
         if (!target[dashboard.spec.dashboard]) {
           target[dashboard.spec.dashboard] = {
             dashboard: dashboard.spec.dashboard,
-            dashboardTitle: dashboard.spec.dashboardTitle,
+            dashboardTitle: dashboard.status.dashboardTitle,
             items: [],
           };
         }

--- a/public/app/features/scopes/tests/utils.test.ts
+++ b/public/app/features/scopes/tests/utils.test.ts
@@ -22,7 +22,7 @@ describe('Scopes', () => {
             dashboards: {
               [dashboardWithoutFolder.spec.dashboard]: {
                 dashboard: dashboardWithoutFolder.spec.dashboard,
-                dashboardTitle: dashboardWithoutFolder.spec.dashboardTitle,
+                dashboardTitle: dashboardWithoutFolder.status.dashboardTitle,
                 items: [dashboardWithoutFolder],
               },
             },
@@ -39,7 +39,7 @@ describe('Scopes', () => {
             dashboards: {
               [dashboardWithRootFolder.spec.dashboard]: {
                 dashboard: dashboardWithRootFolder.spec.dashboard,
-                dashboardTitle: dashboardWithRootFolder.spec.dashboardTitle,
+                dashboardTitle: dashboardWithRootFolder.status.dashboardTitle,
                 items: [dashboardWithRootFolder],
               },
             },
@@ -60,12 +60,12 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithOneFolder.spec.dashboard]: {
                     dashboard: dashboardWithOneFolder.spec.dashboard,
-                    dashboardTitle: dashboardWithOneFolder.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithOneFolder.status.dashboardTitle,
                     items: [dashboardWithOneFolder],
                   },
                   [dashboardWithTwoFolders.spec.dashboard]: {
                     dashboard: dashboardWithTwoFolders.spec.dashboard,
-                    dashboardTitle: dashboardWithTwoFolders.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithTwoFolders.status.dashboardTitle,
                     items: [dashboardWithTwoFolders],
                   },
                 },
@@ -77,7 +77,7 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithTwoFolders.spec.dashboard]: {
                     dashboard: dashboardWithTwoFolders.spec.dashboard,
-                    dashboardTitle: dashboardWithTwoFolders.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithTwoFolders.status.dashboardTitle,
                     items: [dashboardWithTwoFolders],
                   },
                 },
@@ -101,7 +101,7 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithTwoFolders.spec.dashboard]: {
                     dashboard: dashboardWithTwoFolders.spec.dashboard,
-                    dashboardTitle: dashboardWithTwoFolders.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithTwoFolders.status.dashboardTitle,
                     items: [dashboardWithTwoFolders, alternativeDashboardWithTwoFolders],
                   },
                 },
@@ -113,7 +113,7 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithTwoFolders.spec.dashboard]: {
                     dashboard: dashboardWithTwoFolders.spec.dashboard,
-                    dashboardTitle: dashboardWithTwoFolders.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithTwoFolders.status.dashboardTitle,
                     items: [dashboardWithTwoFolders, alternativeDashboardWithTwoFolders],
                   },
                 },
@@ -140,17 +140,17 @@ describe('Scopes', () => {
             dashboards: {
               [dashboardWithRootFolderAndOtherFolder.spec.dashboard]: {
                 dashboard: dashboardWithRootFolderAndOtherFolder.spec.dashboard,
-                dashboardTitle: dashboardWithRootFolderAndOtherFolder.spec.dashboardTitle,
+                dashboardTitle: dashboardWithRootFolderAndOtherFolder.status.dashboardTitle,
                 items: [dashboardWithRootFolderAndOtherFolder],
               },
               [dashboardWithRootFolder.spec.dashboard]: {
                 dashboard: dashboardWithRootFolder.spec.dashboard,
-                dashboardTitle: dashboardWithRootFolder.spec.dashboardTitle,
+                dashboardTitle: dashboardWithRootFolder.status.dashboardTitle,
                 items: [dashboardWithRootFolder, alternativeDashboardWithRootFolder],
               },
               [dashboardWithoutFolder.spec.dashboard]: {
                 dashboard: dashboardWithoutFolder.spec.dashboard,
-                dashboardTitle: dashboardWithoutFolder.spec.dashboardTitle,
+                dashboardTitle: dashboardWithoutFolder.status.dashboardTitle,
                 items: [dashboardWithoutFolder],
               },
             },
@@ -159,12 +159,12 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithOneFolder.spec.dashboard]: {
                     dashboard: dashboardWithOneFolder.spec.dashboard,
-                    dashboardTitle: dashboardWithOneFolder.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithOneFolder.status.dashboardTitle,
                     items: [dashboardWithOneFolder],
                   },
                   [dashboardWithTwoFolders.spec.dashboard]: {
                     dashboard: dashboardWithTwoFolders.spec.dashboard,
-                    dashboardTitle: dashboardWithTwoFolders.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithTwoFolders.status.dashboardTitle,
                     items: [dashboardWithTwoFolders, alternativeDashboardWithTwoFolders],
                   },
                 },
@@ -176,7 +176,7 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithTwoFolders.spec.dashboard]: {
                     dashboard: dashboardWithTwoFolders.spec.dashboard,
-                    dashboardTitle: dashboardWithTwoFolders.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithTwoFolders.status.dashboardTitle,
                     items: [dashboardWithTwoFolders, alternativeDashboardWithTwoFolders],
                   },
                 },
@@ -188,7 +188,7 @@ describe('Scopes', () => {
                 dashboards: {
                   [dashboardWithRootFolderAndOtherFolder.spec.dashboard]: {
                     dashboard: dashboardWithRootFolderAndOtherFolder.spec.dashboard,
-                    dashboardTitle: dashboardWithRootFolderAndOtherFolder.spec.dashboardTitle,
+                    dashboardTitle: dashboardWithRootFolderAndOtherFolder.status.dashboardTitle,
                     items: [dashboardWithRootFolderAndOtherFolder],
                   },
                 },

--- a/public/app/features/scopes/tests/utils/mocks.ts
+++ b/public/app/features/scopes/tests/utils/mocks.ts
@@ -111,8 +111,10 @@ const dashboardBindingsGenerator = (
             metadata: { name: `${scope}-${dashboard}` },
             spec: {
               dashboard,
-              dashboardTitle,
               scope,
+            },
+            status: {
+              dashboardTitle,
               groups,
             },
           },
@@ -415,8 +417,10 @@ const generateScopeDashboardBinding = (dashboardTitle: string, groups?: string[]
   metadata: { name: `${dashboardTitle}-name` },
   spec: {
     dashboard: `${dashboardId ?? dashboardTitle}-dashboard`,
-    dashboardTitle,
     scope: `${dashboardTitle}-scope`,
+  },
+  status: {
+    dashboardTitle,
     groups,
   },
 });


### PR DESCRIPTION
**What is this feature?**

Move `dashboardTitle` and `groups` property from `spec` to `status` on `ScopeDashboardBinding`.

**Why do we need this feature?**

Because breaking changes are introduced in #92377.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Will have to wait for #92377 before merging this one.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
