### PR TITLE
replace myself with Irene in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@
 /docs/                                                                            @grafana/docs-tooling
 
 /docs/.codespellignore                                                            @grafana/docs-tooling
-/docs/sources/                                                                    @Eve832
+/docs/sources/                                                                    @irenerl24
 
 /docs/sources/administration/                                                     @jdbaldry
 /docs/sources/alerting/                                                           @brendamuir


### PR DESCRIPTION
Modified the CODEOWNER file with Irene as the docs as the codeowner for `/docs/sources/`. Before we merge, I'd like to make sure that Irene has merge rights. Adding Jack B as a reviewer for visibility. 