### PR TITLE
Remove condition on where we return from unified storage in mode2

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -181,11 +181,7 @@ func (d *DualWriterMode2) List(ctx context.Context, options *metainternalversion
 		return nil, err
 	}
 
-	// if the number of items in the legacy list and the storage list are the same, we can return the storage list
-	if len(storageList) == len(legacyList) {
-		return sl, nil
-	}
-	log.Info("lists from legacy and storage are not the same size")
+	// always return the list from legacy storage
 	return ll, nil
 }
 


### PR DESCRIPTION
**What is this feature?**
Removing an optimist return of unified storage in mode2 for the dual writer if what we return from the list method has the same number of elements between legacy storage and unified.

This initial decision was made in an attempt to exercise unified list results as much as possible, but with the current easy access to the unified storage DB, it is safer to keep the result as consistent as possible.
Also, it will be much easier to troubleshoot mode2.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
