### PR TITLE
FieldConfig: Add missing "min/max" FieldConfigProperty option

### DIFF
--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -137,6 +137,7 @@ export enum FieldConfigProperty {
   Unit = 'unit',
   Min = 'min',
   Max = 'max',
+  FieldMinMax = 'fieldMinMax',
   Decimals = 'decimals',
   DisplayName = 'displayName',
   NoValue = 'noValue',


### PR DESCRIPTION
Adding an enum item that was not added when the option was added in https://github.com/grafana/grafana/pull/75952.

This will allow to hide unused option in Heatmap Panel and keep just data links option:

| Before | After |
|--------|--------|
| <img width="1698" alt="Screenshot 2024-08-28 at 15 32 09" src="https://github.com/user-attachments/assets/19ed1e36-2eb7-4c07-a884-59812721a724"> | <img width="1710" alt="Screenshot 2024-08-28 at 15 46 51" src="https://github.com/user-attachments/assets/92170835-8dca-48d6-806d-096781fdf8c0"> |

It's needed by https://github.com/grafana/grafana/pull/90163 (same use case as Heatmap panel, i.e. showing only data links section)