### PR TITLE
Add extra width to menu to accomodate checkbox

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -39,7 +39,7 @@ const VIRTUAL_LIST_ITEM_HEIGHT = 37;
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
 const VIRTUAL_LIST_PADDING = 8;
 // Some list items have icons or checkboxes so we need some extra width
-const VIRTUAL_LIST_WIDTH_EXTRA = 68;
+const VIRTUAL_LIST_WIDTH_EXTRA = 58;
 
 // A virtualized version of the SelectMenu, descriptions for SelectableValue options not supported since those are of a variable height.
 //

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -39,7 +39,7 @@ const VIRTUAL_LIST_ITEM_HEIGHT = 37;
 const VIRTUAL_LIST_WIDTH_ESTIMATE_MULTIPLIER = 8;
 const VIRTUAL_LIST_PADDING = 8;
 // Some list items have icons or checkboxes so we need some extra width
-const VIRTUAL_LIST_WIDTH_EXTRA = 36;
+const VIRTUAL_LIST_WIDTH_EXTRA = 68;
 
 // A virtualized version of the SelectMenu, descriptions for SelectableValue options not supported since those are of a variable height.
 //


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds extra width to the select menu list, similar to what was done [here](https://github.com/grafana/grafana/pull/86444). This is done to also fit the new checkbox options in scenes.

**Why do we need this feature?**

We have an [escalation](https://github.com/grafana/support-escalations/issues/12162) around this issue. This only happens in the new scenes dashboards because it uses a different checkbox interface in the options so the values don't fit properly.

Before:
![Screenshot 2024-08-28 at 17 35 23](https://github.com/user-attachments/assets/6c82f049-e969-4bf0-8c9f-149de208494b)

After:
![Screenshot 2024-08-28 at 17 39 26](https://github.com/user-attachments/assets/492e1031-de1f-468c-a811-ef961f45a0bd)


Although now the non-multi variable values also have a larger gap since `VIRTUAL_LIST_WIDTH_EXTRA` is always applied. wonder if we could check if it's multi or has icon somehow, and then apply the extra width, at some point?

**Who is this feature for?**

everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
