### PR TITLE
Update workflows to use actions that don't need organization secrets

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -1,38 +1,21 @@
-name: "publish-technical-documentation-next"
+name: publish-technical-documentation-next
 
 on:
   push:
     branches:
-      - "main"
+      - main
     paths:
       - "docs/sources/**"
   workflow_dispatch:
 jobs:
   sync:
     if: github.repository == 'grafana/grafana'
-    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Grafana repo"
-        uses: "actions/checkout@v4"
-
-      - name: "Clone website-sync Action"
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
-
-      - name: "Publish to website repository (next)"
-        uses: "./.github/actions/website-sync"
-        id: "publish-next"
+      - uses: actions/checkout@v4
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
-          repository: "grafana/website"
-          branch: "master"
-          host: "github.com"
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
-          source_folder: "docs/sources"
-          target_folder: "content/docs/grafana/next"
+          website_directory: content/docs/grafana/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -1,4 +1,4 @@
-name: "publish-technical-documentation-release"
+name: publish-technical-documentation-release
 
 on:
   push:
@@ -12,63 +12,18 @@ on:
 jobs:
   sync:
     if: github.repository == 'grafana/grafana'
-    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Grafana repo"
-        uses: "actions/checkout@v4"
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: "Checkout Actions library"
-        uses: "actions/checkout@v4"
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
         with:
-          repository: "grafana/grafana-github-actions"
-          path: "./actions"
-
-      - name: "Install Actions from library"
-        run: "npm install --production --prefix ./actions"
-
-      - name: "Determine if there is a matching release tag"
-        id: "has-matching-release-tag"
-        uses: "./actions/has-matching-release-tag"
-        with:
-          ref_name: "${{ github.ref_name }}"
           release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
           release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
-
-      - name: "Determine technical documentation version"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        uses: "./actions/docs-target"
-        id: "target"
-        with:
-          ref_name: "${{ github.ref_name }}"
-
-      - name: "Clone website-sync Action"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
-
-      - name: "Switch to HEAD of version branch for tags"
-        # Tags aren't necessarily made to the HEAD of the version branch.
-        # The documentation to be published is always on the HEAD of the version branch.
-        if: "steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'"
-        run: "git switch --detach origin/${{ steps.target.outputs.target }}.x"
-
-      - name: "Publish to website repository (release)"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        uses: "./.github/actions/website-sync"
-        id: "publish-release"
-        with:
-          repository: "grafana/website"
-          branch: "master"
-          host: "github.com"
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
-          source_folder: "docs/sources"
-          target_folder: "content/docs/grafana/${{ steps.target.outputs.target }}"
+          release_branch_with_patch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          website_directory: content/docs/grafana
+          version_suffix: ""


### PR DESCRIPTION

**Why do we need this feature?**

Each repository can only have 100 organization secrets and there are now more than 100 in our organization which causes inconsistent behavior.

Some repositories don't have the secrets they need assigned.

These composite actions use secrets stored in Vault that are available to all repositories.

- `publish-technical-documentation-next.yml` has been tested with https://github.com/grafana/writers-toolkit/blob/main/.github/workflows/publish-technical-documentation.yml.
- `publish-technical-documentation-release.yml` has been tested with https://github.com/grafana/backend-enterprise/blob/gem-release-2.13/.github/workflows/publish-technical-documentation-release.yml.



We'll also need to backport this to any branches where you are maintaining documentation that you want synced to the website.

**Which issue(s) does this PR fix?**


Fixes https://github.com/grafana/technical-documentation/issues/983

**Special notes for your reviewer:**


There is some copy-paste involved in the creation of these workflows. Please check:

For `publish-technical-documentation-next.yml`:

- [ ] The `on.push` `branches` and `paths` filters are correct for your repository.
- [ ] The `jobs.sync.if` repository matches your repository.
- [ ] The `jobs.sync.steps[1].with.website_directory` matches the directory you publish to in the website repository.

For `publish-technical-documentation-release.yml`:

- [ ] The `on.push` `branches`, `tags`, and `paths` filters are correct for your repository.
- [ ] The `jobs.sync.if` repository matches your repository.
- [ ] The `jobs.sync.steps[1].with.release_tag_regexp` regular expression matches your tags and captures major, minor, and patch versions from those tags.
- [ ] The `jobs.sync.steps[1].with.release_branch_regexp` regular expression matches your release branch names and captures major and minor versions from those branch names.
- [ ] The `jobs.sync.steps[1].with.release_branch_with_patch_regexp` regular expression matches your release branch names if they were to include a patch version, and that it would capture major, minor, and patch versions from those branch names.
- [ ] The `jobs.sync.steps[1].with.website_directory` matches the directory you publish to in the website repository.

