### PR TITLE
Docs: Remove deprecation warning on webhook payload fields

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier.md
@@ -117,9 +117,9 @@ The webhook notification is a simple way to send information about a state chang
 | version           | string                    | Version of the payload                                                          |
 | groupKey          | string                    | Key that is used for grouping                                                   |
 | truncatedAlerts   | number                    | Number of alerts that were truncated                                            |
-| title             | string                    | **Will be deprecated soon**                                                     |
-| state             | string                    | **Will be deprecated soon**                                                     |
-| message           | string                    | **Will be deprecated soon**                                                     |
+| title             | string                    | Custom title                                                                    |
+| state             | string                    | State of the alert group (either `alerting` or `ok`)                            |
+| message           | string                    | Custom message                                                                  |
 
 ### Alert
 


### PR DESCRIPTION
This PR removes the `Will be deprecated soon` warning for the `title`, `state`, and `message` fields in the payload for the Grafana webhook integration.

This warning was introduced in our docs over two years ago ([PR](https://github.com/grafana/grafana/pull/49758)), we haven't discussed removing these fields since.