### PR TITLE
Alerting: Add an MQTT receiver setting to append group key to the topic name

### DIFF
--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -503,26 +503,27 @@ The following sections detail the supported settings and secure settings for eac
 
 #### Alert notification `MQTT`
 
-| Name          | Secure setting |
-| ------------- | -------------- |
-| brokerUrl     |                |
-| clientId      |                |
-| topic         |                |
-| messageFormat |                |
-| username      |                |
-| password      | yes            |
-| retain        |                |
-| qos           |                |
-| tlsConfig     |                |
+| Name                 | Secure setting |
+| -------------------- | -------------- |
+| `brokerUrl`          |                |
+| `clientId`           |                |
+| `topic`              |                |
+| `messageFormat`      |                |
+| `username`           |                |
+| `password`           | yes            |
+| `retain`             |                |
+| `qos`                |                |
+| `tlsConfig`          |                |
+| `addGroupKeyToTopic` |                |
 
 ##### TLS config
 
-| Name               | Secure setting |
-| ------------------ | -------------- |
-| insecureSkipVerify |                |
-| clientCertificate  | yes            |
-| clientKey          | yes            |
-| caCertificate      | yes            |
+| Name                 | Secure setting |
+| -------------------- | -------------- |
+| `insecureSkipVerify` |                |
+| `clientCertificate`  | yes            |
+| `clientKey`          | yes            |
+| `caCertificate`      | yes            |
 
 #### Alert notification `pagerduty`
 

--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -376,6 +376,8 @@ settings:
     clientKey: key in PEM format
     # <string>
     caCertificate: CA certificate in PEM format
+  # <bool>
+  addGroupKeyToTopic: false
 ```
 
 {{< /collapse >}}

--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -131,7 +131,10 @@ export const calculateFieldTransformer: DataTransformerInfo<CalculateFieldTransf
     const mode = options.mode ?? CalculateFieldMode.ReduceRow;
 
     const asTimeSeries = options.timeSeries !== false;
-    const isBinaryFixed = mode === CalculateFieldMode.BinaryOperation && options.binary?.right.fixed != null;
+
+    const right = options.binary?.right;
+    const rightVal = typeof right === 'string' ? right : typeof right === 'object' ? right.fixed : undefined;
+    const isBinaryFixed = mode === CalculateFieldMode.BinaryOperation && !Number.isNaN(Number(rightVal));
 
     const needsSingleFrame = asTimeSeries && !isBinaryFixed;
 

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -118,16 +118,17 @@ type TLSConfig struct {
 type MqttIntegration struct {
 	DisableResolveMessage *bool `json:"-" yaml:"-" hcl:"disable_resolve_message"`
 
-	BrokerURL     *string    `json:"brokerUrl,omitempty" yaml:"brokerUrl,omitempty" hcl:"broker_url"`
-	ClientID      *string    `json:"clientId,omitempty" yaml:"clientId,omitempty" hcl:"client_id"`
-	Topic         *string    `json:"topic,omitempty" yaml:"topic,omitempty" hcl:"topic"`
-	Message       *string    `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
-	MessageFormat *string    `json:"messageFormat,omitempty" yaml:"messageFormat,omitempty" hcl:"message_format"`
-	Username      *string    `json:"username,omitempty" yaml:"username,omitempty" hcl:"username"`
-	Password      *Secret    `json:"password,omitempty" yaml:"password,omitempty" hcl:"password"`
-	QoS           *int64     `json:"qos,omitempty" yaml:"qos,omitempty" hcl:"qos"`
-	Retain        *bool      `json:"retain,omitempty" yaml:"retain,omitempty" hcl:"retain"`
-	TLSConfig     *TLSConfig `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty" hcl:"tls_config,block"`
+	BrokerURL          *string    `json:"brokerUrl,omitempty" yaml:"brokerUrl,omitempty" hcl:"broker_url"`
+	ClientID           *string    `json:"clientId,omitempty" yaml:"clientId,omitempty" hcl:"client_id"`
+	Topic              *string    `json:"topic,omitempty" yaml:"topic,omitempty" hcl:"topic"`
+	Message            *string    `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
+	MessageFormat      *string    `json:"messageFormat,omitempty" yaml:"messageFormat,omitempty" hcl:"message_format"`
+	Username           *string    `json:"username,omitempty" yaml:"username,omitempty" hcl:"username"`
+	Password           *Secret    `json:"password,omitempty" yaml:"password,omitempty" hcl:"password"`
+	QoS                *int64     `json:"qos,omitempty" yaml:"qos,omitempty" hcl:"qos"`
+	Retain             *bool      `json:"retain,omitempty" yaml:"retain,omitempty" hcl:"retain"`
+	TLSConfig          *TLSConfig `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty" hcl:"tls_config,block"`
+	AddGroupKeyToTopic *bool      `json:"addGroupKeyToTopic,omitempty" yaml:"addGroupKeyToTopic,omitempty" hcl:"add_group_key_to_topic"`
 }
 
 type OnCallIntegration struct {

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1325,6 +1325,13 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Required:     true,
 				},
 				{
+					Label:        "Add group key to topic",
+					Element:      ElementTypeCheckbox,
+					Description:  "If set, the group key will be appended to the topic.",
+					PropertyName: "addGroupKeyToTopic",
+					Required:     false,
+				},
+				{
 					Label:   "Message format",
 					Element: ElementTypeSelect,
 					SelectOptions: []SelectOption{


### PR DESCRIPTION
**What is this feature?**

Add an MQTT receiver setting to append group key to the topic name.

Alerting PR: https://github.com/grafana/alerting/pull/236