### PR TITLE
Docs: Re-order Explore docs in TOC

### DIFF
--- a/docs/sources/explore/correlations-editor-in-explore.md
+++ b/docs/sources/explore/correlations-editor-in-explore.md
@@ -4,7 +4,7 @@ labels:
     - enterprise
     - oss
 title: Correlations Editor in Explore
-weight: 400
+weight: 20
 ---
 
 # Correlations Editor in Explore

--- a/docs/sources/explore/explore-inspector.md
+++ b/docs/sources/explore/explore-inspector.md
@@ -8,7 +8,7 @@ labels:
 keywords:
   - Explore
 title: Query inspector in Explore
-weight: 40
+weight: 15
 ---
 
 # Query inspector in Explore

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -9,7 +9,8 @@ labels:
     - enterprise
     - oss
 title: Logs in Explore
-weight: 15
+weight: 25
+
 ---
 
 # Logs in Explore

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -10,7 +10,6 @@ labels:
     - oss
 title: Logs in Explore
 weight: 25
-
 ---
 
 # Logs in Explore

--- a/docs/sources/explore/trace-integration.md
+++ b/docs/sources/explore/trace-integration.md
@@ -8,7 +8,7 @@ labels:
     - enterprise
     - oss
 title: Traces in Explore
-weight: 20
+weight: 40
 ---
 
 # Traces in Explore


### PR DESCRIPTION
**What is this feature?**

Re-ordered the Explore docs for better cohesion, and for preparation to have them mounted to Grafana Cloud docs.

**Why do we need this feature?**

Better docs flow.

**Who is this feature for?**

Users can more easily search Grafana docs.



