### PR TITLE
Docs: Extend docs with service account limitations

### DIFF
--- a/docs/sources/administration/service-accounts/index.md
+++ b/docs/sources/administration/service-accounts/index.md
@@ -37,6 +37,8 @@ In [Grafana Enterprise]({{< relref "../../introduction/grafana-enterprise/" >}})
 
 {{% admonition type="note" %}}
 Service accounts can only act in the organization they are created for. If you have the same task that is needed for multiple organizations, we recommend creating service accounts in each organization.
+
+Service accounts can't be used for instance-wide operations, such as global user management and organization management. For these tasks, you need to use a user with [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
 {{% /admonition %}}
 
 {{< vimeo 742056367 >}}

--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -18,9 +18,12 @@ title: 'Admin HTTP API '
 
 # Admin API
 
-The Admin HTTP API does not currently work with an API Token. API Tokens are currently only linked to an organization and an organization role. They cannot be given
-the permission of server admin, only users can be given that permission. So in order to use these API calls you will have to use Basic Auth and the Grafana user
-must have the Grafana Admin permission. (The default admin user is called `admin` and has permission to use this API.)
+{{% admonition type="caution" %}}
+The Admin HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
+In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+
+The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
+{{% /admonition %}}
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 

--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -18,12 +18,15 @@ title: 'Admin HTTP API '
 
 # Admin API
 
-{{% admonition type="caution" %}}
-The Admin HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
-In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+{{< admonition type="caution" >}}
+You can't authenticate to the Admin HTTP API with service account tokens.
+Service accounts are limited to an organization and an organization role.
+They can't be granted [Grafana server administrator permissions](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators).
+
+To use these API endpoints you have to use Basic authentication and the Grafana user must have the Grafana server administrator permission.
 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
-{{% /admonition %}}
+{{< /admonition >}}
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -30,6 +30,7 @@ To use these API endpoints you have to use Basic authentication and the Grafana 
 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
 {{< /admonition >}}
+
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Check license availability

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -21,13 +21,15 @@ title: Licensing HTTP API
 
 Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
-{{% admonition type="caution" %}}
-The Licensing HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
-In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+{{< admonition type="caution" >}}
+You can't authenticate to the Licensing HTTP API with service account tokens.
+Service accounts are limited to an organization and an organization role.
+They can't be granted [Grafana server administrator permissions](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators).
+
+To use these API endpoints you have to use Basic authentication and the Grafana user must have the Grafana server administrator permission.
 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
-{{% /admonition %}}
-
+{{< /admonition >}}
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Check license availability

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -21,6 +21,13 @@ title: Licensing HTTP API
 
 Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "/docs/grafana/latest/introduction/grafana-enterprise" >}}).
 
+{{% admonition type="caution" %}}
+The Licensing HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
+In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+
+The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
+{{% /admonition %}}
+
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes" >}}) for more information.
 
 ## Check license availability

--- a/docs/sources/developers/http_api/org.md
+++ b/docs/sources/developers/http_api/org.md
@@ -282,11 +282,12 @@ Content-Type: application/json
 
 ## Admin Organizations API
 
-The Admin Organizations HTTP API does not currently work with an API Token. API Tokens are currently
-only linked to an organization and an organization role. They cannot be given the permission of server
-admin, only users can be given that permission. So in order to use these API calls you will have to
-use Basic Auth and the Grafana user must have the Grafana Admin permission (The default admin user
-is called `admin` and has permission to use this API).
+{{% admonition type="caution" %}}
+The Admin Organizations HTTP API currently does not work with service account tokens. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
+In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+
+The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
+{{% /admonition %}}
 
 ### Get Organization by Id
 

--- a/docs/sources/developers/http_api/org.md
+++ b/docs/sources/developers/http_api/org.md
@@ -282,12 +282,15 @@ Content-Type: application/json
 
 ## Admin Organizations API
 
-{{% admonition type="caution" %}}
-The Admin Organizations HTTP API currently does not work with service account tokens. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
-In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+{{< admonition type="caution" >}}
+You can't authenticate to the Admin Organizations HTTP API with service account tokens.
+Service accounts are limited to an organization and an organization role.
+They can't be granted [Grafana server administrator permissions](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators).
+
+To use these API endpoints you have to use Basic authentication and the Grafana user must have the Grafana server administrator permission.
 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ### Get Organization by Id
 

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -24,15 +24,16 @@ refs:
 
 # User API
 
-{{% admonition type="caution" %}}
-The Users HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
-In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+{{< admonition type="caution" >}}
+You can't authenticate to the User HTTP API with service account tokens.
+Service accounts are limited to an organization and an organization role.
+They can't be granted [Grafana server administrator permissions](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators).
+You can use service account tokens to manage users in an organization with [Organization HTTP API](/docs/grafana/<GRAFANA_VERSION>/developers/http_api/org/#current-organization-api).
+
+To use these API endpoints you have to use Basic authentication and the Grafana user must have the Grafana server administrator permission.
 
 The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
-
-Service account tokens can be used with Organization HTTP API to get users of specific organization.
-
-{{% /admonition %}}
+{{< /admonition >}}
 
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -26,14 +26,14 @@ refs:
 
 {{% admonition type="caution" %}}
 The Users HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
-  In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
+In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
 
-  The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
+The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
 
 Service account tokens can be used with Organization HTTP API to get users of specific organization.
 
 {{% /admonition %}}
-    
+
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 
 ## Search Users

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -24,12 +24,16 @@ refs:
 
 # User API
 
-The Users HTTP API does not currently work with an API Token. API Tokens are linked to an organization and an organization role. They cannot be given
-the permission of server users access, only users can be given that permission. To use these API calls you can use Basic Auth and the Grafana
-user must have the Grafana Admin role.
+{{% admonition type="caution" %}}
+The Users HTTP API currently does not work with service account tokens. Service accounts are limited to an organization and an organization role. They cannot be granted [Grafana server administrator permissions]({{< relref "../roles-and-permissions/#grafana-server-administrators" >}}).
+  In order to use these API endpoints you have to use Basic Auth and the Grafana user must have the Grafana server administrator permission.
 
-API Tokens can be used with Organization HTTP API to get users of specific organization.
+  The `admin` user that Grafana is provisioned with by default has permissions to use these API endpoints.
 
+Service account tokens can be used with Organization HTTP API to get users of specific organization.
+
+{{% /admonition %}}
+    
 > If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions](ref:role-based-access-control-permissions) for more information.
 
 ## Search Users

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -28,7 +28,8 @@ refs:
 You can't authenticate to the User HTTP API with service account tokens.
 Service accounts are limited to an organization and an organization role.
 They can't be granted [Grafana server administrator permissions](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators).
-You can use service account tokens to manage users in an organization with [Organization HTTP API](/docs/grafana/<GRAFANA_VERSION>/developers/http_api/org/#current-organization-api).
+
+Alternatively, you can use the [Organization HTTP API](/docs/grafana/<GRAFANA_VERSION>/developers/http_api/org/#current-organization-api) with service account tokens to manage users in a specific organization
 
 To use these API endpoints you have to use Basic authentication and the Grafana user must have the Grafana server administrator permission.
 


### PR DESCRIPTION
**What is this feature?**

Extend/update the docs to make it clear that there are endpoints which can't be accessed using service account tokens.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/844
