### PR TITLE
UniStore: Use epoch with microsecond resolution as RV

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -666,12 +666,7 @@ func resourceVersionAtomicInc(ctx context.Context, x db.ContextExecer, d sqltemp
 
 	// 1. Increase the resource version to the current epoch with microseconds precision.
 	// This is an update statement that will lock to row and prevent concurrent updates until the transaction is commited.
-	//
-	// Note: there is a small chance that the resource version will be the same as the previous one when
-	// concurrent updates are too close in time. This is due to the fact that the current epoch is unlikely to cause
-	// real issues in practice (given network latency, etc).
-	// In rare occasions (like master clock changes) the resource version might go backwards for a short period of time.
-	// In those scenarios, watchers might not receive the expected events.
+
 	// This is a trade-off between performance and consistency.
 
 	_, err = dbutil.Exec(ctx, x, sqlResourceVersionInc, sqlResourceVersionRequest{

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -666,8 +666,6 @@ func resourceVersionAtomicInc(ctx context.Context, x db.ContextExecer, d sqltemp
 	// 1. Increase the resource version to the current epoch with microseconds precision.
 	// This is an update statement that will lock to row and prevent concurrent updates until the transaction is committed.
 
-	// This is a trade-off between performance and consistency.
-
 	_, err = dbutil.Exec(ctx, x, sqlResourceVersionInc, sqlResourceVersionRequest{
 		SQLTemplate:     sqltemplate.New(d),
 		Group:           key.Group,

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -663,9 +663,8 @@ func (b *backend) poll(ctx context.Context, grp string, res string, since int64,
 // in a single roundtrip. This would reduce the latency of the operation, and also increase the
 // throughput of the system. This is a good candidate for a future optimization.
 func resourceVersionAtomicInc(ctx context.Context, x db.ContextExecer, d sqltemplate.Dialect, key *resource.ResourceKey) (newVersion int64, err error) {
-
 	// 1. Increase the resource version to the current epoch with microseconds precision.
-	// This is an update statement that will lock to row and prevent concurrent updates until the transaction is commited.
+	// This is an update statement that will lock to row and prevent concurrent updates until the transaction is committed.
 
 	// This is a trade-off between performance and consistency.
 

--- a/pkg/storage/unified/sql/data/resource_version_get.sql
+++ b/pkg/storage/unified/sql/data/resource_version_get.sql
@@ -1,5 +1,6 @@
 SELECT
-        {{ .Ident "resource_version" | .Into .ResourceVersion }}
+        {{ .Ident "resource_version" | .Into .Response.ResourceVersion }},
+        {{ .CurrentEpoch | .Into .Response.CurrentEpoch }}
     FROM {{ .Ident "resource_version" }}
     WHERE 1 = 1
         AND {{ .Ident "group" }}    = {{ .Arg .Group }}

--- a/pkg/storage/unified/sql/data/resource_version_inc.sql
+++ b/pkg/storage/unified/sql/data/resource_version_inc.sql
@@ -1,6 +1,6 @@
 UPDATE {{ .Ident "resource_version" }}
 SET
-    {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion}}
+    {{ .Ident "resource_version" }} = {{ .CurrentEpoch }}
 WHERE 1 = 1
     AND {{ .Ident "group" }}    = {{ .Arg .Group }}
     AND {{ .Ident "resource" }} = {{ .Arg .Resource }}

--- a/pkg/storage/unified/sql/data/resource_version_inc.sql
+++ b/pkg/storage/unified/sql/data/resource_version_inc.sql
@@ -1,6 +1,6 @@
 UPDATE {{ .Ident "resource_version" }}
 SET
-    {{ .Ident "resource_version" }} = {{ .CurrentEpoch }}
+    {{ .Ident "resource_version" }} = MAX({{ .CurrentEpoch }}, {{ .Ident "resource_version" }} + 1)
 WHERE 1 = 1
     AND {{ .Ident "group" }}    = {{ .Arg .Group }}
     AND {{ .Ident "resource" }} = {{ .Arg .Resource }}

--- a/pkg/storage/unified/sql/data/resource_version_inc.sql
+++ b/pkg/storage/unified/sql/data/resource_version_inc.sql
@@ -1,6 +1,6 @@
 UPDATE {{ .Ident "resource_version" }}
 SET
-    {{ .Ident "resource_version" }} = MAX({{ .CurrentEpoch }}, {{ .Ident "resource_version" }} + 1)
+    {{ .Ident "resource_version" }} = {{.Greatest  .CurrentEpoch (print (.Ident "resource_version")  " + 1") }}
 WHERE 1 = 1
     AND {{ .Ident "group" }}    = {{ .Arg .Group }}
     AND {{ .Ident "resource" }} = {{ .Arg .Resource }}

--- a/pkg/storage/unified/sql/data/resource_version_insert.sql
+++ b/pkg/storage/unified/sql/data/resource_version_insert.sql
@@ -8,6 +8,6 @@ INSERT INTO {{ .Ident "resource_version" }}
     VALUES (
         {{ .Arg .Group }},
         {{ .Arg .Resource }},
-        2
+        {{ .CurrentEpoch }}
     )
 ;

--- a/pkg/storage/unified/sql/data/resource_version_update.sql
+++ b/pkg/storage/unified/sql/data/resource_version_update.sql
@@ -1,6 +1,6 @@
 UPDATE {{ .Ident "resource_version" }}
 SET
-    {{ .Ident "resource_version" }} = {{.Greatest  .CurrentEpoch (print (.Ident "resource_version")  " + 1") }}
+    {{ .Ident "resource_version" }} = {{ .Arg .ResourceVersion }}
 WHERE 1 = 1
     AND {{ .Ident "group" }}    = {{ .Arg .Group }}
     AND {{ .Ident "resource" }} = {{ .Arg .Resource }}

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -41,7 +41,7 @@ var (
 
 	// sqlResourceLabelsInsert = mustTemplate("resource_labels_insert.sql")
 	sqlResourceVersionGet    = mustTemplate("resource_version_get.sql")
-	sqlResourceVersionInc    = mustTemplate("resource_version_inc.sql")
+	sqlResourceVersionUpdate = mustTemplate("resource_version_update.sql")
 	sqlResourceVersionInsert = mustTemplate("resource_version_insert.sql")
 	sqlResourceVersionList   = mustTemplate("resource_version_list.sql")
 )
@@ -191,8 +191,13 @@ func (r sqlResourceUpdateRVRequest) Validate() error {
 }
 
 // resource_version table requests.
-type resourceVersion struct {
+type resourceVersionResponse struct {
 	ResourceVersion int64
+	CurrentEpoch    int64
+}
+
+func (r *resourceVersionResponse) Results() (*resourceVersionResponse, error) {
+	return r, nil
 }
 
 type groupResourceVersion struct {
@@ -200,19 +205,31 @@ type groupResourceVersion struct {
 	ResourceVersion int64
 }
 
-func (r *resourceVersion) Results() (*resourceVersion, error) {
-	return r, nil
+type sqlResourceVersionUpsertRequest struct {
+	sqltemplate.SQLTemplate
+	Group, Resource string
+	ResourceVersion int64
 }
 
-type sqlResourceVersionRequest struct {
+func (r sqlResourceVersionUpsertRequest) Validate() error {
+	return nil // TODO
+}
+
+type sqlResourceVersionGetRequest struct {
 	sqltemplate.SQLTemplate
 	Group, Resource string
 	ReadOnly        bool
-	*resourceVersion
+	Response        *resourceVersionResponse
 }
 
-func (r sqlResourceVersionRequest) Validate() error {
+func (r sqlResourceVersionGetRequest) Validate() error {
 	return nil // TODO
+}
+func (r sqlResourceVersionGetRequest) Results() (*resourceVersionResponse, error) {
+	return &resourceVersionResponse{
+		ResourceVersion: r.Response.ResourceVersion,
+		CurrentEpoch:    r.Response.CurrentEpoch,
+	}, nil
 }
 
 type sqlResourceVersionListRequest struct {

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -52,7 +52,12 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Data: &sqlResourceRequest{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
 						WriteEvent: resource.WriteEvent{
-							Key: &resource.ResourceKey{},
+							Key: &resource.ResourceKey{
+								Namespace: "nn",
+								Group:     "gg",
+								Resource:  "rr",
+								Name:      "name",
+							},
 						},
 					},
 				},
@@ -63,7 +68,12 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Data: &sqlResourceReadRequest{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
 						Request: &resource.ReadRequest{
-							Key: &resource.ResourceKey{},
+							Key: &resource.ResourceKey{
+								Namespace: "nn",
+								Group:     "gg",
+								Resource:  "rr",
+								Name:      "name",
+							},
 						},
 						readResponse: new(readResponse),
 					},
@@ -155,7 +165,12 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Data: &sqlResourceRequest{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
 						WriteEvent: resource.WriteEvent{
-							Key:        &resource.ResourceKey{},
+							Key: &resource.ResourceKey{
+								Namespace: "nn",
+								Group:     "gg",
+								Resource:  "rr",
+								Name:      "name",
+							},
 							PreviousRV: 1234,
 						},
 					},
@@ -165,20 +180,24 @@ func TestUnifiedStorageQueries(t *testing.T) {
 			sqlResourceVersionGet: {
 				{
 					Name: "single path",
-					Data: &sqlResourceVersionRequest{
-						SQLTemplate:     mocks.NewTestingSQLTemplate(),
-						resourceVersion: new(resourceVersion),
-						ReadOnly:        false,
+					Data: &sqlResourceVersionGetRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Resource:    "resource",
+						Group:       "group",
+						Response:    new(resourceVersionResponse),
+						ReadOnly:    false,
 					},
 				},
 			},
 
-			sqlResourceVersionInc: {
+			sqlResourceVersionUpdate: {
 				{
 					Name: "increment resource version",
-					Data: &sqlResourceVersionRequest{
+					Data: &sqlResourceVersionUpsertRequest{
 						SQLTemplate:     mocks.NewTestingSQLTemplate(),
-						resourceVersion: new(resourceVersion),
+						Resource:        "resource",
+						Group:           "group",
+						ResourceVersion: int64(12354),
 					},
 				},
 			},
@@ -186,8 +205,9 @@ func TestUnifiedStorageQueries(t *testing.T) {
 			sqlResourceVersionInsert: {
 				{
 					Name: "single path",
-					Data: &sqlResourceVersionRequest{
-						SQLTemplate: mocks.NewTestingSQLTemplate(),
+					Data: &sqlResourceVersionUpsertRequest{
+						SQLTemplate:     mocks.NewTestingSQLTemplate(),
+						ResourceVersion: int64(12354),
 					},
 				},
 			},

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -177,10 +177,8 @@ func TestUnifiedStorageQueries(t *testing.T) {
 				{
 					Name: "increment resource version",
 					Data: &sqlResourceVersionRequest{
-						SQLTemplate: mocks.NewTestingSQLTemplate(),
-						resourceVersion: &resourceVersion{
-							ResourceVersion: 123,
-						},
+						SQLTemplate:     mocks.NewTestingSQLTemplate(),
+						resourceVersion: new(resourceVersion),
 					},
 				},
 			},

--- a/pkg/storage/unified/sql/sqltemplate/dialect.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect.go
@@ -62,6 +62,9 @@ type Dialect interface {
 	//		WHERE id = ?
 	//		{{ .SelectFor "Update NoWait" }}; -- will be uppercased
 	SelectFor(...string) (string, error)
+
+	// CurrentEpoch returns the current epoch value for the database in microseconds.
+	CurrentEpoch() string
 }
 
 // RowLockingClause represents a row-locking clause in a SELECT statement.

--- a/pkg/storage/unified/sql/sqltemplate/dialect.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect.go
@@ -65,6 +65,10 @@ type Dialect interface {
 
 	// CurrentEpoch returns the current epoch value for the database in microseconds.
 	CurrentEpoch() string
+
+	// Greatest returns the function name to use for the greatest value of a list
+	// of expressions.
+	Greatest(string, string) string
 }
 
 // RowLockingClause represents a row-locking clause in a SELECT statement.

--- a/pkg/storage/unified/sql/sqltemplate/dialect.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect.go
@@ -65,10 +65,6 @@ type Dialect interface {
 
 	// CurrentEpoch returns the current epoch value for the database in microseconds.
 	CurrentEpoch() string
-
-	// Greatest returns the function name to use for the greatest value of a list
-	// of expressions.
-	Greatest(string, string) string
 }
 
 // RowLockingClause represents a row-locking clause in a SELECT statement.

--- a/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
@@ -33,3 +33,7 @@ func (backtickIdent) Ident(s string) (string, error) {
 		return s
 	})
 }
+
+func (mysql) CurrentEpoch() string {
+	return "(UNIX_TIMESTAMP(NOW(6)) * 1000000)"
+}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
@@ -37,3 +37,7 @@ func (backtickIdent) Ident(s string) (string, error) {
 func (mysql) CurrentEpoch() string {
 	return "(UNIX_TIMESTAMP(NOW(6)) * 1000000)"
 }
+
+func (mysql) Greatest(m, n string) string {
+	return "GREATEST(" + m + ", " + n + ")"
+}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
@@ -35,5 +35,5 @@ func (backtickIdent) Ident(s string) (string, error) {
 }
 
 func (mysql) CurrentEpoch() string {
-	return "FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)"
+	return "CAST(FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000) AS SIGNED)"
 }

--- a/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
@@ -35,7 +35,7 @@ func (backtickIdent) Ident(s string) (string, error) {
 }
 
 func (mysql) CurrentEpoch() string {
-	return "(UNIX_TIMESTAMP(NOW(6)) * 1000000)"
+	return "FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)"
 }
 
 func (mysql) Greatest(m, n string) string {

--- a/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_mysql.go
@@ -37,7 +37,3 @@ func (backtickIdent) Ident(s string) (string, error) {
 func (mysql) CurrentEpoch() string {
 	return "FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)"
 }
-
-func (mysql) Greatest(m, n string) string {
-	return "GREATEST(" + m + ", " + n + ")"
-}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
@@ -35,3 +35,7 @@ func (p postgresql) Ident(s string) (string, error) {
 
 	return p.standardIdent.Ident(s)
 }
+
+func (postgresql) CurrentEpoch() string {
+	return "EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT"
+}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
@@ -39,3 +39,7 @@ func (p postgresql) Ident(s string) (string, error) {
 func (postgresql) CurrentEpoch() string {
 	return "EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT"
 }
+
+func (postgresql) Greatest(m, n string) string {
+	return "GREATEST(" + m + ", " + n + ")"
+}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
@@ -37,5 +37,5 @@ func (p postgresql) Ident(s string) (string, error) {
 }
 
 func (postgresql) CurrentEpoch() string {
-	return "(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT"
+	return "(EXTRACT(EPOCH FROM statement_timestamp()) * 1000000)::BIGINT"
 }

--- a/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
@@ -37,7 +37,7 @@ func (p postgresql) Ident(s string) (string, error) {
 }
 
 func (postgresql) CurrentEpoch() string {
-	return "EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT"
+	return "(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT"
 }
 
 func (postgresql) Greatest(m, n string) string {

--- a/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_postgresql.go
@@ -39,7 +39,3 @@ func (p postgresql) Ident(s string) (string, error) {
 func (postgresql) CurrentEpoch() string {
 	return "(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT"
 }
-
-func (postgresql) Greatest(m, n string) string {
-	return "GREATEST(" + m + ", " + n + ")"
-}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
@@ -16,3 +16,8 @@ type sqlite struct {
 	argPlaceholderFunc
 	name
 }
+
+func (sqlite) CurrentEpoch() string {
+	// Alternative approaches like `unixepoch('subsecond') * 1000000` returns millisecond precision.
+	return "CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)"
+}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
@@ -21,3 +21,7 @@ func (sqlite) CurrentEpoch() string {
 	// Alternative approaches like `unixepoch('subsecond') * 1000000` returns millisecond precision.
 	return "CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)"
 }
+
+func (sqlite) Greatest(m, n string) string {
+	return "MAX(" + m + ", " + n + ")"
+}

--- a/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
@@ -19,7 +19,7 @@ type sqlite struct {
 
 func (sqlite) CurrentEpoch() string {
 	// Alternative approaches like `unixepoch('subsecond') * 1000000` returns millisecond precision.
-	return "CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)"
+	return "CAST((julianday('now') - 2440587.5) * 86400000000.0 AS BIGINT)"
 }
 
 func (sqlite) Greatest(m, n string) string {

--- a/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
+++ b/pkg/storage/unified/sql/sqltemplate/dialect_sqlite.go
@@ -21,7 +21,3 @@ func (sqlite) CurrentEpoch() string {
 	// Alternative approaches like `unixepoch('subsecond') * 1000000` returns millisecond precision.
 	return "CAST((julianday('now') - 2440587.5) * 86400000000.0 AS BIGINT)"
 }
-
-func (sqlite) Greatest(m, n string) string {
-	return "MAX(" + m + ", " + n + ")"
-}

--- a/pkg/storage/unified/sql/sqltemplate/mocks/SQLTemplateIface.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/SQLTemplateIface.go
@@ -171,6 +171,51 @@ func (_c *SQLTemplate_ArgPlaceholder_Call) RunAndReturn(run func(int) string) *S
 	return _c
 }
 
+// CurrentEpoch provides a mock function with given fields:
+func (_m *SQLTemplate) CurrentEpoch() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CurrentEpoch")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// SQLTemplate_CurrentEpoch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CurrentEpoch'
+type SQLTemplate_CurrentEpoch_Call struct {
+	*mock.Call
+}
+
+// CurrentEpoch is a helper method to define mock.On call
+func (_e *SQLTemplate_Expecter) CurrentEpoch() *SQLTemplate_CurrentEpoch_Call {
+	return &SQLTemplate_CurrentEpoch_Call{Call: _e.mock.On("CurrentEpoch")}
+}
+
+func (_c *SQLTemplate_CurrentEpoch_Call) Run(run func()) *SQLTemplate_CurrentEpoch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SQLTemplate_CurrentEpoch_Call) Return(_a0 string) *SQLTemplate_CurrentEpoch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SQLTemplate_CurrentEpoch_Call) RunAndReturn(run func() string) *SQLTemplate_CurrentEpoch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DialectName provides a mock function with given fields:
 func (_m *SQLTemplate) DialectName() string {
 	ret := _m.Called()

--- a/pkg/storage/unified/sql/sqltemplate/mocks/SQLTemplateIface.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/SQLTemplateIface.go
@@ -402,6 +402,53 @@ func (_c *SQLTemplate_GetScanDest_Call) RunAndReturn(run func() []interface{}) *
 	return _c
 }
 
+// Greatest provides a mock function with given fields: _a0, _a1
+func (_m *SQLTemplate) Greatest(_a0 string, _a1 string) string {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Greatest")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// SQLTemplate_Greatest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Greatest'
+type SQLTemplate_Greatest_Call struct {
+	*mock.Call
+}
+
+// Greatest is a helper method to define mock.On call
+//   - _a0 string
+//   - _a1 string
+func (_e *SQLTemplate_Expecter) Greatest(_a0 interface{}, _a1 interface{}) *SQLTemplate_Greatest_Call {
+	return &SQLTemplate_Greatest_Call{Call: _e.mock.On("Greatest", _a0, _a1)}
+}
+
+func (_c *SQLTemplate_Greatest_Call) Run(run func(_a0 string, _a1 string)) *SQLTemplate_Greatest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *SQLTemplate_Greatest_Call) Return(_a0 string) *SQLTemplate_Greatest_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SQLTemplate_Greatest_Call) RunAndReturn(run func(string, string) string) *SQLTemplate_Greatest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Ident provides a mock function with given fields: _a0
 func (_m *SQLTemplate) Ident(_a0 string) (string, error) {
 	ret := _m.Called(_a0)

--- a/pkg/storage/unified/sql/sqltemplate/mocks/SQLTemplateIface.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/SQLTemplateIface.go
@@ -402,53 +402,6 @@ func (_c *SQLTemplate_GetScanDest_Call) RunAndReturn(run func() []interface{}) *
 	return _c
 }
 
-// Greatest provides a mock function with given fields: _a0, _a1
-func (_m *SQLTemplate) Greatest(_a0 string, _a1 string) string {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Greatest")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// SQLTemplate_Greatest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Greatest'
-type SQLTemplate_Greatest_Call struct {
-	*mock.Call
-}
-
-// Greatest is a helper method to define mock.On call
-//   - _a0 string
-//   - _a1 string
-func (_e *SQLTemplate_Expecter) Greatest(_a0 interface{}, _a1 interface{}) *SQLTemplate_Greatest_Call {
-	return &SQLTemplate_Greatest_Call{Call: _e.mock.On("Greatest", _a0, _a1)}
-}
-
-func (_c *SQLTemplate_Greatest_Call) Run(run func(_a0 string, _a1 string)) *SQLTemplate_Greatest_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *SQLTemplate_Greatest_Call) Return(_a0 string) *SQLTemplate_Greatest_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *SQLTemplate_Greatest_Call) RunAndReturn(run func(string, string) string) *SQLTemplate_Greatest_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Ident provides a mock function with given fields: _a0
 func (_m *SQLTemplate) Ident(_a0 string) (string, error) {
 	ret := _m.Called(_a0)

--- a/pkg/storage/unified/sql/sqltemplate/mocks/WithResults.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/WithResults.go
@@ -171,6 +171,51 @@ func (_c *WithResults_ArgPlaceholder_Call[T]) RunAndReturn(run func(int) string)
 	return _c
 }
 
+// CurrentEpoch provides a mock function with given fields:
+func (_m *WithResults[T]) CurrentEpoch() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CurrentEpoch")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// WithResults_CurrentEpoch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CurrentEpoch'
+type WithResults_CurrentEpoch_Call[T interface{}] struct {
+	*mock.Call
+}
+
+// CurrentEpoch is a helper method to define mock.On call
+func (_e *WithResults_Expecter[T]) CurrentEpoch() *WithResults_CurrentEpoch_Call[T] {
+	return &WithResults_CurrentEpoch_Call[T]{Call: _e.mock.On("CurrentEpoch")}
+}
+
+func (_c *WithResults_CurrentEpoch_Call[T]) Run(run func()) *WithResults_CurrentEpoch_Call[T] {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *WithResults_CurrentEpoch_Call[T]) Return(_a0 string) *WithResults_CurrentEpoch_Call[T] {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *WithResults_CurrentEpoch_Call[T]) RunAndReturn(run func() string) *WithResults_CurrentEpoch_Call[T] {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DialectName provides a mock function with given fields:
 func (_m *WithResults[T]) DialectName() string {
 	ret := _m.Called()

--- a/pkg/storage/unified/sql/sqltemplate/mocks/WithResults.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/WithResults.go
@@ -402,6 +402,53 @@ func (_c *WithResults_GetScanDest_Call[T]) RunAndReturn(run func() []interface{}
 	return _c
 }
 
+// Greatest provides a mock function with given fields: _a0, _a1
+func (_m *WithResults[T]) Greatest(_a0 string, _a1 string) string {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Greatest")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// WithResults_Greatest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Greatest'
+type WithResults_Greatest_Call[T interface{}] struct {
+	*mock.Call
+}
+
+// Greatest is a helper method to define mock.On call
+//   - _a0 string
+//   - _a1 string
+func (_e *WithResults_Expecter[T]) Greatest(_a0 interface{}, _a1 interface{}) *WithResults_Greatest_Call[T] {
+	return &WithResults_Greatest_Call[T]{Call: _e.mock.On("Greatest", _a0, _a1)}
+}
+
+func (_c *WithResults_Greatest_Call[T]) Run(run func(_a0 string, _a1 string)) *WithResults_Greatest_Call[T] {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *WithResults_Greatest_Call[T]) Return(_a0 string) *WithResults_Greatest_Call[T] {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *WithResults_Greatest_Call[T]) RunAndReturn(run func(string, string) string) *WithResults_Greatest_Call[T] {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Ident provides a mock function with given fields: _a0
 func (_m *WithResults[T]) Ident(_a0 string) (string, error) {
 	ret := _m.Called(_a0)

--- a/pkg/storage/unified/sql/sqltemplate/mocks/WithResults.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/WithResults.go
@@ -402,53 +402,6 @@ func (_c *WithResults_GetScanDest_Call[T]) RunAndReturn(run func() []interface{}
 	return _c
 }
 
-// Greatest provides a mock function with given fields: _a0, _a1
-func (_m *WithResults[T]) Greatest(_a0 string, _a1 string) string {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Greatest")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// WithResults_Greatest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Greatest'
-type WithResults_Greatest_Call[T interface{}] struct {
-	*mock.Call
-}
-
-// Greatest is a helper method to define mock.On call
-//   - _a0 string
-//   - _a1 string
-func (_e *WithResults_Expecter[T]) Greatest(_a0 interface{}, _a1 interface{}) *WithResults_Greatest_Call[T] {
-	return &WithResults_Greatest_Call[T]{Call: _e.mock.On("Greatest", _a0, _a1)}
-}
-
-func (_c *WithResults_Greatest_Call[T]) Run(run func(_a0 string, _a1 string)) *WithResults_Greatest_Call[T] {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *WithResults_Greatest_Call[T]) Return(_a0 string) *WithResults_Greatest_Call[T] {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *WithResults_Greatest_Call[T]) RunAndReturn(run func(string, string) string) *WithResults_Greatest_Call[T] {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Ident provides a mock function with given fields: _a0
 func (_m *WithResults[T]) Ident(_a0 string) (string, error) {
 	ret := _m.Called(_a0)

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -412,12 +412,6 @@ func TestClientServer(t *testing.T) {
 }
 
 func writeEvent(ctx context.Context, store sql.Backend, name string, action resource.WatchEvent_Type) (int64, error) {
-	// There is a small chance that the resource version is the same if we write too fast.
-	// This is a test limitation and should not be a real-world issue.
-	// time.Sleep(1 * time.Millisecond)
-	if infraDB.IsTestDbSQLite() {
-		time.Sleep(1 * time.Millisecond)
-	}
 
 	return store.WriteEvent(ctx, resource.WriteEvent{
 		Type:  action,

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -91,7 +91,6 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 		rv3, err = writeEvent(ctx, backend, "item3", resource.WatchEvent_ADDED)
 		require.NoError(t, err)
 		require.Greater(t, rv3, rv2)
-
 	})
 
 	t.Run("Update item2", func(t *testing.T) {
@@ -412,7 +411,6 @@ func TestClientServer(t *testing.T) {
 }
 
 func writeEvent(ctx context.Context, store sql.Backend, name string, action resource.WatchEvent_Type) (int64, error) {
-
 	return store.WriteEvent(ctx, resource.WriteEvent{
 		Type:  action,
 		Value: []byte(name + " " + resource.WatchEvent_Type_name[int32(action)]),

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -57,9 +57,9 @@ func newServer(t *testing.T) (sql.Backend, resource.ResourceServer) {
 }
 
 func TestIntegrationBackendHappyPath(t *testing.T) {
-	if infraDB.IsTestDbSQLite() {
-		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
-	}
+	// if infraDB.IsTestDbSQLite() {
+	// 	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// }
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -57,9 +57,9 @@ func newServer(t *testing.T) (sql.Backend, resource.ResourceServer) {
 }
 
 func TestIntegrationBackendHappyPath(t *testing.T) {
-	// if infraDB.IsTestDbSQLite() {
-	// 	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
-	// }
+	if infraDB.IsTestDbSQLite() {
+		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	}
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -57,7 +57,9 @@ func newServer(t *testing.T) (sql.Backend, resource.ResourceServer) {
 }
 
 func TestIntegrationBackendHappyPath(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	if infraDB.IsTestDbSQLite() {
+		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	}
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -75,47 +77,49 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 
 	stream, err := backend.WatchWriteEvents(context.Background()) // Using a different context to avoid canceling the stream after the DefaultContextTimeout
 	require.NoError(t, err)
+	var rv1, rv2, rv3, rv4, rv5 int64
 
 	t.Run("Add 3 resources", func(t *testing.T) {
-		rv, err := writeEvent(ctx, backend, "item1", resource.WatchEvent_ADDED)
+		rv1, err = writeEvent(ctx, backend, "item1", resource.WatchEvent_ADDED)
 		require.NoError(t, err)
-		require.Equal(t, int64(1), rv)
+		require.Greater(t, rv1, int64(0))
 
-		rv, err = writeEvent(ctx, backend, "item2", resource.WatchEvent_ADDED)
+		rv2, err = writeEvent(ctx, backend, "item2", resource.WatchEvent_ADDED)
 		require.NoError(t, err)
-		require.Equal(t, int64(2), rv)
+		require.Greater(t, rv2, rv1)
 
-		rv, err = writeEvent(ctx, backend, "item3", resource.WatchEvent_ADDED)
+		rv3, err = writeEvent(ctx, backend, "item3", resource.WatchEvent_ADDED)
 		require.NoError(t, err)
-		require.Equal(t, int64(3), rv)
+		require.Greater(t, rv3, rv2)
+
 	})
 
 	t.Run("Update item2", func(t *testing.T) {
-		rv, err := writeEvent(ctx, backend, "item2", resource.WatchEvent_MODIFIED)
+		rv4, err = writeEvent(ctx, backend, "item2", resource.WatchEvent_MODIFIED)
 		require.NoError(t, err)
-		require.Equal(t, int64(4), rv)
+		require.Greater(t, rv4, rv3)
 	})
 
 	t.Run("Delete item1", func(t *testing.T) {
-		rv, err := writeEvent(ctx, backend, "item1", resource.WatchEvent_DELETED)
+		rv5, err = writeEvent(ctx, backend, "item1", resource.WatchEvent_DELETED)
 		require.NoError(t, err)
-		require.Equal(t, int64(5), rv)
+		require.Greater(t, rv5, rv4)
 	})
 
 	t.Run("Read latest item 2", func(t *testing.T) {
 		resp := backend.ReadResource(ctx, &resource.ReadRequest{Key: resourceKey("item2")})
 		require.Nil(t, resp.Error)
-		require.Equal(t, int64(4), resp.ResourceVersion)
+		require.Equal(t, rv4, resp.ResourceVersion)
 		require.Equal(t, "item2 MODIFIED", string(resp.Value))
 	})
 
 	t.Run("Read early version of item2", func(t *testing.T) {
 		resp := backend.ReadResource(ctx, &resource.ReadRequest{
 			Key:             resourceKey("item2"),
-			ResourceVersion: 3, // item2 was created at rv=2 and updated at rv=4
+			ResourceVersion: rv3, // item2 was created at rv2 and updated at rv4
 		})
 		require.Nil(t, resp.Error)
-		require.Equal(t, int64(2), resp.ResourceVersion)
+		require.Equal(t, rv2, resp.ResourceVersion)
 		require.Equal(t, "item2 ADDED", string(resp.Value))
 	})
 
@@ -134,38 +138,40 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 		require.Len(t, resp.Items, 2)
 		require.Equal(t, "item2 MODIFIED", string(resp.Items[0].Value))
 		require.Equal(t, "item3 ADDED", string(resp.Items[1].Value))
-		require.Equal(t, int64(5), resp.ResourceVersion)
+		require.Equal(t, rv5, resp.ResourceVersion)
 	})
 
 	t.Run("Watch events", func(t *testing.T) {
 		event := <-stream
 		require.Equal(t, "item1", event.Key.Name)
-		require.Equal(t, int64(1), event.ResourceVersion)
+		require.Equal(t, rv1, event.ResourceVersion)
 		require.Equal(t, resource.WatchEvent_ADDED, event.Type)
 		event = <-stream
 		require.Equal(t, "item2", event.Key.Name)
-		require.Equal(t, int64(2), event.ResourceVersion)
+		require.Equal(t, rv2, event.ResourceVersion)
 		require.Equal(t, resource.WatchEvent_ADDED, event.Type)
 
 		event = <-stream
 		require.Equal(t, "item3", event.Key.Name)
-		require.Equal(t, int64(3), event.ResourceVersion)
+		require.Equal(t, rv3, event.ResourceVersion)
 		require.Equal(t, resource.WatchEvent_ADDED, event.Type)
 
 		event = <-stream
 		require.Equal(t, "item2", event.Key.Name)
-		require.Equal(t, int64(4), event.ResourceVersion)
+		require.Equal(t, rv4, event.ResourceVersion)
 		require.Equal(t, resource.WatchEvent_MODIFIED, event.Type)
 
 		event = <-stream
 		require.Equal(t, "item1", event.Key.Name)
-		require.Equal(t, int64(5), event.ResourceVersion)
+		require.Equal(t, rv5, event.ResourceVersion)
 		require.Equal(t, resource.WatchEvent_DELETED, event.Type)
 	})
 }
 
 func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	if infraDB.IsTestDbSQLite() {
+		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	}
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -188,7 +194,9 @@ func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
 }
 
 func TestIntegrationBackendList(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	if infraDB.IsTestDbSQLite() {
+		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	}
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -197,14 +205,23 @@ func TestIntegrationBackendList(t *testing.T) {
 	backend, server := newServer(t)
 
 	// Create a few resources before starting the watch
-	_, _ = writeEvent(ctx, backend, "item1", resource.WatchEvent_ADDED)    // rv=1
-	_, _ = writeEvent(ctx, backend, "item2", resource.WatchEvent_ADDED)    // rv=2 - will be modified at rv=6
-	_, _ = writeEvent(ctx, backend, "item3", resource.WatchEvent_ADDED)    // rv=3 - will be deleted  at rv=7
-	_, _ = writeEvent(ctx, backend, "item4", resource.WatchEvent_ADDED)    // rv=4
-	_, _ = writeEvent(ctx, backend, "item5", resource.WatchEvent_ADDED)    // rv=5
-	_, _ = writeEvent(ctx, backend, "item2", resource.WatchEvent_MODIFIED) // rv=6
-	_, _ = writeEvent(ctx, backend, "item3", resource.WatchEvent_DELETED)  // rv=7
-	_, _ = writeEvent(ctx, backend, "item6", resource.WatchEvent_ADDED)    // rv=8
+	rv1, _ := writeEvent(ctx, backend, "item1", resource.WatchEvent_ADDED)
+	require.Greater(t, rv1, int64(0))
+	rv2, _ := writeEvent(ctx, backend, "item2", resource.WatchEvent_ADDED) // rv=2 - will be modified at rv=6
+	require.Greater(t, rv2, rv1)
+	rv3, _ := writeEvent(ctx, backend, "item3", resource.WatchEvent_ADDED) // rv=3 - will be deleted  at rv=7
+	require.Greater(t, rv3, rv2)
+	rv4, _ := writeEvent(ctx, backend, "item4", resource.WatchEvent_ADDED)
+	require.Greater(t, rv4, rv3)
+	rv5, _ := writeEvent(ctx, backend, "item5", resource.WatchEvent_ADDED)
+	require.Greater(t, rv5, rv4)
+	rv6, _ := writeEvent(ctx, backend, "item2", resource.WatchEvent_MODIFIED)
+	require.Greater(t, rv6, rv5)
+	rv7, _ := writeEvent(ctx, backend, "item3", resource.WatchEvent_DELETED)
+	require.Greater(t, rv7, rv6)
+	rv8, _ := writeEvent(ctx, backend, "item6", resource.WatchEvent_ADDED)
+	require.Greater(t, rv8, rv7)
+
 	t.Run("fetch all latest", func(t *testing.T) {
 		res, err := server.List(ctx, &resource.ListRequest{
 			Options: &resource.ListOptions{
@@ -245,12 +262,12 @@ func TestIntegrationBackendList(t *testing.T) {
 		require.Equal(t, "item1 ADDED", string(res.Items[0].Value))
 		require.Equal(t, "item2 MODIFIED", string(res.Items[1].Value))
 		require.Equal(t, "item4 ADDED", string(res.Items[2].Value))
-		require.Equal(t, int64(8), continueToken.ResourceVersion)
+		require.Equal(t, rv8, continueToken.ResourceVersion)
 	})
 
 	t.Run("list at revision", func(t *testing.T) {
 		res, err := server.List(ctx, &resource.ListRequest{
-			ResourceVersion: 4,
+			ResourceVersion: rv4,
 			Options: &resource.ListOptions{
 				Key: &resource.ResourceKey{
 					Group:    "group",
@@ -271,7 +288,7 @@ func TestIntegrationBackendList(t *testing.T) {
 	t.Run("fetch first page at revision with limit", func(t *testing.T) {
 		res, err := server.List(ctx, &resource.ListRequest{
 			Limit:           3,
-			ResourceVersion: 7,
+			ResourceVersion: rv7,
 			Options: &resource.ListOptions{
 				Key: &resource.ResourceKey{
 					Group:    "group",
@@ -290,12 +307,12 @@ func TestIntegrationBackendList(t *testing.T) {
 
 		continueToken, err := sql.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
-		require.Equal(t, int64(7), continueToken.ResourceVersion)
+		require.Equal(t, rv7, continueToken.ResourceVersion)
 	})
 
 	t.Run("fetch second page at revision", func(t *testing.T) {
 		continueToken := &sql.ContinueToken{
-			ResourceVersion: 8,
+			ResourceVersion: rv8,
 			StartOffset:     2,
 		}
 		res, err := server.List(ctx, &resource.ListRequest{
@@ -317,12 +334,14 @@ func TestIntegrationBackendList(t *testing.T) {
 
 		continueToken, err = sql.GetContinueToken(res.NextPageToken)
 		require.NoError(t, err)
-		require.Equal(t, int64(8), continueToken.ResourceVersion)
+		require.Equal(t, rv8, continueToken.ResourceVersion)
 		require.Equal(t, int64(4), continueToken.StartOffset)
 	})
 }
 func TestClientServer(t *testing.T) {
-	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	if infraDB.IsTestDbSQLite() {
+		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	}
 	ctx := testutil.NewTestContext(t, time.Now().Add(5*time.Second))
 	dbstore := infraDB.InitTestDB(t)
 
@@ -393,6 +412,13 @@ func TestClientServer(t *testing.T) {
 }
 
 func writeEvent(ctx context.Context, store sql.Backend, name string, action resource.WatchEvent_Type) (int64, error) {
+	// There is a small chance that the resource version is the same if we write too fast.
+	// This is a test limitation and should not be a real-world issue.
+	// time.Sleep(1 * time.Millisecond)
+	if infraDB.IsTestDbSQLite() {
+		time.Sleep(1 * time.Millisecond)
+	}
+
 	return store.WriteEvent(ctx, resource.WriteEvent{
 		Type:  action,
 		Value: []byte(name + " " + resource.WatchEvent_Type_name[int32(action)]),

--- a/pkg/storage/unified/sql/testdata/mysql--resource_history_insert-insert into resource_history.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_history_insert-insert into resource_history.sql
@@ -11,10 +11,10 @@ INSERT INTO `resource_history`
     )
     VALUES (
         '',
-        '',
-        '',
-        '',
-        '',
+        'gg',
+        'rr',
+        'nn',
+        'name',
         1234,
         '[]',
         'UNKNOWN'

--- a/pkg/storage/unified/sql/testdata/mysql--resource_read-without_resource_version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_read-without_resource_version.sql
@@ -3,8 +3,8 @@ SELECT
     `value`
     FROM `resource`
     WHERE 1 = 1
-        AND `namespace` = ''
-        AND `group`     = ''
-        AND `resource`  = ''
-        AND `name`      = ''
+        AND `namespace` = 'nn'
+        AND `group`     = 'gg'
+        AND `resource`  = 'rr'
+        AND `name`      = 'name'
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_update-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_update-single path.sql
@@ -4,8 +4,8 @@ UPDATE `resource`
         `value`  = '[]',
         `action` = 'UNKNOWN'  
     WHERE 1 = 1
-        AND `group`     = ''
-        AND `resource`  = ''
-        AND `namespace` = ''
-        AND `name`      = ''
+        AND `group`     = 'gg'
+        AND `resource`  = 'rr'
+        AND `namespace` = 'nn'
+        AND `name`      = 'name'
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_get-single path.sql
@@ -1,8 +1,9 @@
 SELECT
-        `resource_version`
+        `resource_version`,
+        (UNIX_TIMESTAMP(NOW(6)) * 1000000)
     FROM `resource_version`
     WHERE 1 = 1
-        AND `group`    = ''
-        AND `resource` = ''
+        AND `group`    = 'group'
+        AND `resource` = 'resource'
     FOR UPDATE
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_get-single path.sql
@@ -1,6 +1,6 @@
 SELECT
         `resource_version`,
-        FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)
+        CAST(FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000) AS SIGNED)
     FROM `resource_version`
     WHERE 1 = 1
         AND `group`    = 'group'

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_get-single path.sql
@@ -1,6 +1,6 @@
 SELECT
         `resource_version`,
-        (UNIX_TIMESTAMP(NOW(6)) * 1000000)
+        FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)
     FROM `resource_version`
     WHERE 1 = 1
         AND `group`    = 'group'

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE `resource_version`
 SET
-    `resource_version` = 123
+    `resource_version` = (UNIX_TIMESTAMP(NOW(6)) * 1000000)
 WHERE 1 = 1
     AND `group`    = ''
     AND `resource` = ''

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE `resource_version`
 SET
-    `resource_version` = (UNIX_TIMESTAMP(NOW(6)) * 1000000)
+    `resource_version` = MAX((UNIX_TIMESTAMP(NOW(6)) * 1000000), `resource_version` + 1)
 WHERE 1 = 1
     AND `group`    = ''
     AND `resource` = ''

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE `resource_version`
 SET
-    `resource_version` = MAX((UNIX_TIMESTAMP(NOW(6)) * 1000000), `resource_version` + 1)
+    `resource_version` = GREATEST((UNIX_TIMESTAMP(NOW(6)) * 1000000), `resource_version` + 1)
 WHERE 1 = 1
     AND `group`    = ''
     AND `resource` = ''

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_inc-increment resource version.sql
@@ -1,7 +1,0 @@
-UPDATE `resource_version`
-SET
-    `resource_version` = GREATEST((UNIX_TIMESTAMP(NOW(6)) * 1000000), `resource_version` + 1)
-WHERE 1 = 1
-    AND `group`    = ''
-    AND `resource` = ''
-;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO `resource_version`
     VALUES (
         '',
         '',
-        2
+        (UNIX_TIMESTAMP(NOW(6)) * 1000000)
     )
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO `resource_version`
     VALUES (
         '',
         '',
-        (UNIX_TIMESTAMP(NOW(6)) * 1000000)
+        FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)
     )
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO `resource_version`
     VALUES (
         '',
         '',
-        FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000)
+        CAST(FLOOR(UNIX_TIMESTAMP(NOW(6)) * 1000000) AS SIGNED)
     )
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_version_update-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_version_update-increment resource version.sql
@@ -1,0 +1,7 @@
+UPDATE `resource_version`
+SET
+    `resource_version` = 12354
+WHERE 1 = 1
+    AND `group`    = 'group'
+    AND `resource` = 'resource'
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_insert-insert into resource_history.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_insert-insert into resource_history.sql
@@ -11,10 +11,10 @@ INSERT INTO "resource_history"
     )
     VALUES (
         '',
-        '',
-        '',
-        '',
-        '',
+        'gg',
+        'rr',
+        'nn',
+        'name',
         1234,
         '[]',
         'UNKNOWN'

--- a/pkg/storage/unified/sql/testdata/postgres--resource_read-without_resource_version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_read-without_resource_version.sql
@@ -3,8 +3,8 @@ SELECT
     "value"
     FROM "resource"
     WHERE 1 = 1
-        AND "namespace" = ''
-        AND "group"     = ''
-        AND "resource"  = ''
-        AND "name"      = ''
+        AND "namespace" = 'nn'
+        AND "group"     = 'gg'
+        AND "resource"  = 'rr'
+        AND "name"      = 'name'
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_update-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_update-single path.sql
@@ -4,8 +4,8 @@ UPDATE "resource"
         "value"  = '[]',
         "action" = 'UNKNOWN'  
     WHERE 1 = 1
-        AND "group"     = ''
-        AND "resource"  = ''
-        AND "namespace" = ''
-        AND "name"      = ''
+        AND "group"     = 'gg'
+        AND "resource"  = 'rr'
+        AND "namespace" = 'nn'
+        AND "name"      = 'name'
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_get-single path.sql
@@ -1,6 +1,6 @@
 SELECT
         "resource_version",
-        EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT
+        (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT
     FROM "resource_version"
     WHERE 1 = 1
         AND "group"    = 'group'

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_get-single path.sql
@@ -1,8 +1,9 @@
 SELECT
-        "resource_version"
+        "resource_version",
+        EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT
     FROM "resource_version"
     WHERE 1 = 1
-        AND "group"    = ''
-        AND "resource" = ''
+        AND "group"    = 'group'
+        AND "resource" = 'resource'
     FOR UPDATE
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_get-single path.sql
@@ -1,6 +1,6 @@
 SELECT
         "resource_version",
-        (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT
+        (EXTRACT(EPOCH FROM statement_timestamp()) * 1000000)::BIGINT
     FROM "resource_version"
     WHERE 1 = 1
         AND "group"    = 'group'

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE "resource_version"
 SET
-    "resource_version" = 123
+    "resource_version" = EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT
 WHERE 1 = 1
     AND "group"    = ''
     AND "resource" = ''

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE "resource_version"
 SET
-    "resource_version" = EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT
+    "resource_version" = MAX(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT, "resource_version" + 1)
 WHERE 1 = 1
     AND "group"    = ''
     AND "resource" = ''

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE "resource_version"
 SET
-    "resource_version" = MAX(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT, "resource_version" + 1)
+    "resource_version" = GREATEST(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT, "resource_version" + 1)
 WHERE 1 = 1
     AND "group"    = ''
     AND "resource" = ''

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_inc-increment resource version.sql
@@ -1,7 +1,0 @@
-UPDATE "resource_version"
-SET
-    "resource_version" = GREATEST(EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT, "resource_version" + 1)
-WHERE 1 = 1
-    AND "group"    = ''
-    AND "resource" = ''
-;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO "resource_version"
     VALUES (
         '',
         '',
-        (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT
+        (EXTRACT(EPOCH FROM statement_timestamp()) * 1000000)::BIGINT
     )
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO "resource_version"
     VALUES (
         '',
         '',
-        EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT
+        (EXTRACT(EPOCH FROM clock_timestamp()) * 1000000)::BIGINT
     )
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO "resource_version"
     VALUES (
         '',
         '',
-        2
+        EXTRACT(EPOCH FROM clock_timestamp()) * 1000000::BIGINT
     )
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_version_update-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_version_update-increment resource version.sql
@@ -1,0 +1,7 @@
+UPDATE "resource_version"
+SET
+    "resource_version" = 12354
+WHERE 1 = 1
+    AND "group"    = 'group'
+    AND "resource" = 'resource'
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_insert-insert into resource_history.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_insert-insert into resource_history.sql
@@ -11,10 +11,10 @@ INSERT INTO "resource_history"
     )
     VALUES (
         '',
-        '',
-        '',
-        '',
-        '',
+        'gg',
+        'rr',
+        'nn',
+        'name',
         1234,
         '[]',
         'UNKNOWN'

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_read-without_resource_version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_read-without_resource_version.sql
@@ -3,8 +3,8 @@ SELECT
     "value"
     FROM "resource"
     WHERE 1 = 1
-        AND "namespace" = ''
-        AND "group"     = ''
-        AND "resource"  = ''
-        AND "name"      = ''
+        AND "namespace" = 'nn'
+        AND "group"     = 'gg'
+        AND "resource"  = 'rr'
+        AND "name"      = 'name'
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_update-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_update-single path.sql
@@ -4,8 +4,8 @@ UPDATE "resource"
         "value"  = '[]',
         "action" = 'UNKNOWN'  
     WHERE 1 = 1
-        AND "group"     = ''
-        AND "resource"  = ''
-        AND "namespace" = ''
-        AND "name"      = ''
+        AND "group"     = 'gg'
+        AND "resource"  = 'rr'
+        AND "namespace" = 'nn'
+        AND "name"      = 'name'
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_get-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_get-single path.sql
@@ -1,7 +1,8 @@
 SELECT
-        "resource_version"
+        "resource_version",
+        CAST((julianday('now') - 2440587.5) * 86400000000.0 AS BIGINT)
     FROM "resource_version"
     WHERE 1 = 1
-        AND "group"    = ''
-        AND "resource" = ''
+        AND "group"    = 'group'
+        AND "resource" = 'resource'
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE "resource_version"
 SET
-    "resource_version" = 123
+    "resource_version" = CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)
 WHERE 1 = 1
     AND "group"    = ''
     AND "resource" = ''

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE "resource_version"
 SET
-    "resource_version" = CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)
+    "resource_version" = MAX(CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER), "resource_version" + 1)
 WHERE 1 = 1
     AND "group"    = ''
     AND "resource" = ''

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
@@ -1,7 +1,0 @@
-UPDATE "resource_version"
-SET
-    "resource_version" = MAX(CAST((julianday('now') - 2440587.5) * 86400000000.0 AS BIGINT), "resource_version" + 1)
-WHERE 1 = 1
-    AND "group"    = ''
-    AND "resource" = ''
-;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_inc-increment resource version.sql
@@ -1,6 +1,6 @@
 UPDATE "resource_version"
 SET
-    "resource_version" = MAX(CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER), "resource_version" + 1)
+    "resource_version" = MAX(CAST((julianday('now') - 2440587.5) * 86400000000.0 AS BIGINT), "resource_version" + 1)
 WHERE 1 = 1
     AND "group"    = ''
     AND "resource" = ''

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO "resource_version"
     VALUES (
         '',
         '',
-        2
+        CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)
     )
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_insert-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_insert-single path.sql
@@ -7,6 +7,6 @@ INSERT INTO "resource_version"
     VALUES (
         '',
         '',
-        CAST((julianday('now') - 2440587.5) * 86400000000.0 AS INTEGER)
+        CAST((julianday('now') - 2440587.5) * 86400000000.0 AS BIGINT)
     )
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_version_update-increment resource version.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_version_update-increment resource version.sql
@@ -1,0 +1,7 @@
+UPDATE "resource_version"
+SET
+    "resource_version" = 12354
+WHERE 1 = 1
+    AND "group"    = 'group'
+    AND "resource" = 'resource'
+;


### PR DESCRIPTION
**What is this feature?**
Change the sql atomic resource_version generation from a scritly monotonic sequence (1,2,3 ...) to a unix epoch (with  microseconds precision).

The Epoch is generated differently for each SQL dialect (there isn't a generic way to do this).

**Why do we need this feature?**
Simplify comparing RVs beteween kinds, but also migrate data between cells. 

**Who is this feature for?**
Search and Storage.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
