### PR TITLE
Remove all documented references to `time_options`

### DIFF
--- a/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
+++ b/docs/sources/dashboards/build-dashboards/view-dashboard-json-model/index.md
@@ -58,7 +58,6 @@ In the following JSON, id is shown as null which is the default value assigned t
     "to": "now"
   },
   "timepicker": {
-    "time_options": [],
     "refresh_intervals": []
   },
   "templating": {
@@ -137,17 +136,6 @@ The grid has a negative gravity that moves panels up if there is empty space abo
     "now": true,
     "hidden": false,
     "nowDelay": "",
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ],
     "refresh_intervals": [
       "5s",
       "10s",
@@ -175,7 +163,6 @@ Usage of the fields is explained below:
 | **now**               |                                                                                                                                       |
 | **hidden**            | whether timepicker is hidden or not                                                                                                   |
 | **nowDelay**          | override the now time by entering a time delay. Use this option to accommodate known delays in data aggregation to avoid null values. |
-| **time_options**      | options available in the time picker dropdown                                                                                         |
 | **refresh_intervals** | interval options available in the refresh picker dropdown                                                                             |
 | **status**            |                                                                                                                                       |
 | **type**              |                                                                                                                                       |

--- a/docs/sources/developers/http_api/dashboard_versions.md
+++ b/docs/sources/developers/http_api/dashboard_versions.md
@@ -217,31 +217,7 @@ Content-Length: 1300
       "from": "now-6h",
       "to": "now"
     },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
-    },
+    "timepicker": {},
     "timezone": "browser",
     "title": "test",
     "version": 1
@@ -328,31 +304,7 @@ Content-Length: 1300
       "from": "now-6h",
       "to": "now"
     },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
-    },
+    "timepicker": {},
     "timezone": "browser",
     "title": "test",
     "version": 1

--- a/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md
+++ b/docs/sources/tutorials/provision-dashboards-and-data-sources/index.md
@@ -232,10 +232,7 @@ For more information on how to configure dashboard providers, refer to [Dashboar
        "from": "now-6h",
        "to": "now"
      },
-     "timepicker": {
-       "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
-       "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
-     },
+     "timepicker": {},
      "timezone": "browser",
      "title": "Cluster",
      "version": 0


### PR DESCRIPTION

**Why do we need this feature?**

Time options are now hardcoded in the [DateTimePicker component](https://github.com/grafana/grafana/blob/82417c916f387fe3fa5851c3b506636a31d50b17/packages/grafana-ui/src/components/DateTimePickers/options.ts#L3-L40). The `timepicker.time_options` field only appears in provisioned dashboards and is removed on save if you try and add it to non-provisioned dashboards.


**Who is this feature for?**

Users of dashboard documentation.

**Which issue(s) does this PR fix?**:

Thanks to @AleksandraGrafana for reporting this and @ashharrison90 for confirming the DateTimePicker component behavior in the code.

**Special notes for your reviewer:**

I've decided to not try and remove any references to `time_options` in the code because I feel like the most important goal is to stop confusing users. Later we can look to see if `time_options` can be removed from the schema and other places.

I'm gonna backport this to supported versions but potentially this could be backported much further back.
