### PR TITLE
Prometheus: Ad-hoc & Scope filters, combine equal filters into regex OR

### DIFF
--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -81,13 +81,19 @@ func filtersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matc
 		// if filter already exists and the existing one is equal operator, change existing filter to regex operator
 		// and append the value with or ("|"), else override the existing filter
 		if existing, ok := filterMap[filter.Key]; ok {
-			if existing.Type == labels.MatchEqual || changedToRegex[filter.Key] {
+			if filter.Operator == FilterOperatorEquals && (existing.Type == labels.MatchEqual || changedToRegex[filter.Key]) {
 				existing.Type = labels.MatchRegexp
 				changedToRegex[filter.Key] = true
 				existing.Value = existing.Value + "|" + matcher.Value
 				continue
 			}
 		}
+		// In the case of != , do we want to override or combine?
+		// Might that depend on if it is Ad-Hoc+ScopeFilters vs all the filters
+		// coming form the same source?
+		// In this case, it depends if the user wants to refine the results with
+		// additional conditions, or override. Perhaps directly using the regex
+		// filter operator should be a way to override, else it refines?
 		filterMap[filter.Key] = matcher
 	}
 

--- a/pkg/promlib/models/scope_test.go
+++ b/pkg/promlib/models/scope_test.go
@@ -68,15 +68,28 @@ func TestApplyQueryFiltersAndGroupBy_Filters(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:  "Adhoc and Scope filter conflict - adhoc wins",
+			name:  "Adhoc and Scope filter conflict - adhoc wins if not equal operator",
+			query: `http_requests_total{job="prometheus"}`,
+			scopeFilters: []ScopeFilter{
+				{Key: "status", Value: "404", Operator: FilterOperatorNotEquals},
+			},
+			adhocFilters: []ScopeFilter{
+				{Key: "status", Value: "200", Operator: FilterOperatorEquals},
+			},
+			expected:  `http_requests_total{job="prometheus",status="200"}`,
+			expectErr: false,
+		},
+		{
+			name:  "Multiple equals are combined into a single regex filter",
 			query: `http_requests_total{job="prometheus"}`,
 			scopeFilters: []ScopeFilter{
 				{Key: "status", Value: "404", Operator: FilterOperatorEquals},
 			},
 			adhocFilters: []ScopeFilter{
 				{Key: "status", Value: "200", Operator: FilterOperatorEquals},
+				{Key: "status", Value: "204", Operator: FilterOperatorEquals},
 			},
-			expected:  `http_requests_total{job="prometheus",status="200"}`,
+			expected:  `http_requests_total{job="prometheus",status=~"404|200|204"}`,
 			expectErr: false,
 		},
 		{

--- a/pkg/promlib/models/scope_test.go
+++ b/pkg/promlib/models/scope_test.go
@@ -68,7 +68,7 @@ func TestApplyQueryFiltersAndGroupBy_Filters(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:  "Adhoc and Scope filter conflict - adhoc wins if not equal operator",
+			name:  "Adhoc and Scope filter conflict - adhoc wins (except when the operators are equals)",
 			query: `http_requests_total{job="prometheus"}`,
 			scopeFilters: []ScopeFilter{
 				{Key: "status", Value: "404", Operator: FilterOperatorNotEquals},


### PR DESCRIPTION
**What is this feature?**

When multiple filters are selected with the equals operator on the same key (via Ad-hoc Filters and/or Scope Filters), this will combine them into a regex operator.

**Why do we need this feature?**

In PromQL, matchers are AND'd together, so `{a="x",a="y"}` creates an impossible condition. When translating Filters into PromQL Matchers, we OR these together instead, so it creates `{a=~"x|y"}` 

**Issues**
The feature needs better definition and more design:

 - When used with Scopes, I'm not sure when can derive if the user wants to override a filter, or add to it (refining it).
 - What to do with negated matches? So for example `{a != "x", a != "b"}` (in this case PromQL ANDing them together make sense (refining the results -- could also combine in a negative match regex). This PR currently doesn't do that
 - What if there is a mix of `!=` and `==`?

So beyond the basic what the behavior should be gets strange. We might want an additional property on Filters (used in the context of Ad-hoc) that says if they should override or not, and that has some UI element. 

For now, this does make selecting multiple equal filters on the same key become and OR operation (via regex), so if we want we can use this implementation for the time being.

**Who is this feature for?**

Prometheus + Ad-hoc Filters and/or Scopes

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
