### PR TITLE
DashboardGridItem: Fixes repeating panels issue when variable depends on time range

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -1,3 +1,4 @@
+import { VariableRefresh } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneGridLayout, VizPanel } from '@grafana/scenes';
@@ -10,6 +11,12 @@ setPluginImportUtils({
   importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
   getPanelPluginFromCache: (id: string) => undefined,
 });
+
+const mockGetQueryRunnerFor = jest.fn();
+jest.mock('../utils/utils', () => ({
+  ...jest.requireActual('../utils/utils'),
+  getQueryRunnerFor: jest.fn().mockImplementation(() => mockGetQueryRunnerFor()),
+}));
 
 describe('PanelRepeaterGridItem', () => {
   it('Given scene with variable with 2 values', async () => {
@@ -38,6 +45,32 @@ describe('PanelRepeaterGridItem', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(repeater.state.repeatedPanels?.length).toBe(5);
+  });
+
+  it('Should update panels on refresh if variables load on time range change', async () => {
+    const { scene, repeater } = buildPanelRepeaterScene({
+      variableQueryTime: 0,
+      variableRefresh: VariableRefresh.onTimeRangeChanged,
+    });
+
+    const notifyPanelsSpy = jest.spyOn(repeater, 'notifyRepeatedPanelsWaitingForVariables');
+
+    activateFullSceneTree(scene);
+
+    expect(repeater.state.repeatedPanels?.length).toBe(5);
+
+    expect(notifyPanelsSpy).toHaveBeenCalledTimes(0);
+
+    scene.state.$timeRange?.onRefresh();
+
+    //make sure notifier is called
+    expect(notifyPanelsSpy).toHaveBeenCalledTimes(1);
+
+    //make sure getQueryRunner is called for each repeated panel
+    expect(mockGetQueryRunnerFor).toHaveBeenCalledTimes(5);
+
+    notifyPanelsSpy.mockRestore();
+    mockGetQueryRunnerFor.mockClear();
   });
 
   it('Should display a panel when there are no options', async () => {

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -1,3 +1,4 @@
+import { VariableRefresh } from '@grafana/data';
 import {
   DeepPartial,
   EmbeddedScene,
@@ -103,6 +104,7 @@ interface SceneOptions {
   usePanelRepeater?: boolean;
   useRowRepeater?: boolean;
   throwError?: string;
+  variableRefresh?: VariableRefresh;
 }
 
 export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel | LibraryVizPanel) {
@@ -157,6 +159,7 @@ export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel
       { label: 'E', value: '5' },
     ].slice(0, options.numberOfOptions),
     throwError: defaults.throwError,
+    refresh: options.variableRefresh,
   });
 
   const rowRepeatVariable = new TestVariable({


### PR DESCRIPTION
Fixes escallation https://github.com/grafana/support-escalations/issues/12110 

This one was very tricky! 

Problem is with variables that depend on time range, so when you refresh time range the variable starts loading, and this blocks the panel query runners from running a new query (Rightly so) and they go in to loading state. 

The problem is when the variable completes and no value has changed, the DashboardGridItem detects no value changes so does no repeat. and the completion of this variable is never propagated to the repeated panels (rightly so) as that is blocked by the local variable that wraps each panel. The reason we stop the propagation of variable updates to panels wrapped in a local value is to prevent double or invalid queries. 

The solution is that DashboardGridItem needs to propagate the variable value completion for scenarios when the variable has not changed (we will need to do the same when we add some caching of repeated panel instances) 

TODO
* Add tests 