### PR TITLE
DashboardScene: Update view panel scene variables properly after row repeat is performed

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -23,7 +23,7 @@ import {
   getDashboardSceneFor,
   getLibraryPanel,
   isPanelClone,
-  isWithinRepeatRow,
+  isWithinUnactivatedRepeatRow,
 } from '../utils/utils';
 
 import { DashboardScene, DashboardSceneState } from './DashboardScene';
@@ -127,7 +127,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         return;
       }
 
-      if (isWithinRepeatRow(panel)) {
+      if (isWithinUnactivatedRepeatRow(panel)) {
         this._handleViewRepeatClone(values.viewPanel);
         return;
       }

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -18,7 +18,13 @@ import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { createDashboardEditViewFor } from '../settings/utils';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { ShareModal } from '../sharing/ShareModal';
-import { findVizPanelByKey, getDashboardSceneFor, getLibraryPanel, isPanelClone } from '../utils/utils';
+import {
+  findVizPanelByKey,
+  getDashboardSceneFor,
+  getLibraryPanel,
+  isPanelClone,
+  isWithinRepeatRow,
+} from '../utils/utils';
 
 import { DashboardScene, DashboardSceneState } from './DashboardScene';
 import { LibraryVizPanel } from './LibraryVizPanel';
@@ -118,6 +124,11 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
       if (getLibraryPanel(panel)) {
         this._handleLibraryPanel(panel, (p) => this._buildLibraryPanelViewScene(p));
+        return;
+      }
+
+      if (isWithinRepeatRow(panel)) {
+        this._handleViewRepeatClone(values.viewPanel);
         return;
       }
 

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -18,6 +18,7 @@ import { DashboardScene } from '../scene/DashboardScene';
 import { LibraryVizPanel } from '../scene/LibraryVizPanel';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelMenuBehavior } from '../scene/PanelMenuBehavior';
+import { RowRepeaterBehavior } from '../scene/RowRepeaterBehavior';
 import { RowActions } from '../scene/row-actions/RowActions';
 
 import { dashboardSceneGraph } from './dashboardSceneGraph';
@@ -260,4 +261,16 @@ export function getLibraryPanel(vizPanel: VizPanel): LibraryVizPanel | undefined
     return vizPanel.parent;
   }
   return;
+}
+
+export function isWithinRepeatRow(panel: VizPanel): boolean {
+  let row;
+
+  try {
+    row = sceneGraph.getAncestor(panel, SceneGridRow);
+  } catch (err) {
+    return false;
+  }
+
+  return row && row.state.$behaviors?.[0] instanceof RowRepeaterBehavior;
 }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -263,7 +263,7 @@ export function getLibraryPanel(vizPanel: VizPanel): LibraryVizPanel | undefined
   return;
 }
 
-export function isWithinRepeatRow(panel: VizPanel): boolean {
+export function isWithinUnactivatedRepeatRow(panel: VizPanel): boolean {
   let row;
 
   try {
@@ -272,5 +272,8 @@ export function isWithinRepeatRow(panel: VizPanel): boolean {
     return false;
   }
 
-  return !!(row.state.$behaviors && row.state.$behaviors.find((b) => b instanceof RowRepeaterBehavior));
+  const hasBehavior = !!(row.state.$behaviors && row.state.$behaviors.find((b) => b instanceof RowRepeaterBehavior));
+  const hasVariables = !!(row.state.$variables && row.state.$variables.state.variables.length > 0);
+
+  return hasBehavior && !hasVariables;
 }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -272,5 +272,5 @@ export function isWithinRepeatRow(panel: VizPanel): boolean {
     return false;
   }
 
-  return row && row.state.$behaviors?.[0] instanceof RowRepeaterBehavior;
+  return !!(row.state.$behaviors && row.state.$behaviors.find((b) => b instanceof RowRepeaterBehavior));
 }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -263,6 +263,10 @@ export function getLibraryPanel(vizPanel: VizPanel): LibraryVizPanel | undefined
   return;
 }
 
+/**
+ * If the panel is within a repeated row, it must wait until the row resolves the variables.
+ * This ensures that the scoped variable for the row is assigned and the panel is initialized with them.
+ */
 export function isWithinUnactivatedRepeatRow(panel: VizPanel): boolean {
   let row;
 


### PR DESCRIPTION
This PR fixes a scenario where, where a repeated panel through a repeated row would use the wrong variable to repeat. It would use the dashboard level multi-value variable, instead of the attributed row local variable. Because of this queries would crash and show no data or show erroneous data because instead of having the correct single value of the correct variable from the row, it used all the values from the multi variable.

This would only happen on initial dashboard load and not when jumping from a dashboard to a panels view mode.

Before:

https://github.com/user-attachments/assets/79bbd6e8-fb0b-462e-a8a9-13a14c88eb4a


After:

https://github.com/user-attachments/assets/2213685c-375b-4829-941c-625565742409

