### PR TITLE
Alerting: Ensure k8s receiver API create/update will never store nil settings

### DIFF
--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -32,13 +32,17 @@ func IntegrationToPostableGrafanaReceiver(integration *models.Integration) (*api
 		SecureSettings:        maps.Clone(integration.SecureSettings),
 	}
 
-	if len(integration.Settings) > 0 {
-		jsonBytes, err := json.Marshal(integration.Settings)
-		if err != nil {
-			return nil, err
-		}
-		postable.Settings = jsonBytes
+	// Alertmanager will fail validation with nil Settings , so ensure we always have at least an empty map.
+	settings := integration.Settings
+	if settings == nil {
+		settings = make(map[string]any)
 	}
+
+	jsonBytes, err := json.Marshal(settings)
+	if err != nil {
+		return nil, err
+	}
+	postable.Settings = jsonBytes
 	return postable, nil
 }
 


### PR DESCRIPTION
**What is this feature?**

Ensure that even when saving an integration with no plain `Settings`, the k8s receiver API will store it with an empty map as `Settings` instead of `nil`.

**Why do we need this feature?**

Alertmanager validation will fail if the provided `Settings` json is `null` instead of `{}`.

**Who is this feature for?**

Only affects under-development API behind feature flag