### PR TITLE
ImportDashboard: adjust flaky e2e test

### DIFF
--- a/e2e/scenes/utils/flows/importDashboard.ts
+++ b/e2e/scenes/utils/flows/importDashboard.ts
@@ -51,7 +51,9 @@ export const importDashboard = (dashboardToImport: Dashboard, queryTimeout?: num
       e2e.components.Panels.Panel.menu(panel.title).click({ force: true }); // force click because menu is hidden and show on hover
       e2e.components.Panels.Panel.menuItems('Inspect').should('be.visible').click();
       e2e.components.Tab.title('JSON').should('be.visible').click();
-      e2e.components.PanelInspector.Json.content().should('be.visible').contains('Panel JSON').click({ force: true });
+      e2e.components.PanelInspector.Json.content().should('be.visible');
+      e2e.components.ReactMonacoEditor.editorLazy().should('be.visible');
+      cy.contains('Panel JSON').click({ force: true });
       e2e.components.Select.option().should('be.visible').contains('Panel data').click();
 
       // ensures that panel has loaded without knowingly hitting an error


### PR DESCRIPTION
adjust test to wait for monaco editor to load before proceeding