### PR TITLE
Alerting: experiment with generating rule identifiers

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -1,6 +1,7 @@
 package definitions
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -288,7 +289,8 @@ type GettableRuleGroupConfig struct {
 
 func (c *GettableRuleGroupConfig) PopulateRuleIdentifiers(namespace string) {
 	for i := range c.Rules {
-		c.Rules[i].Identifier = fmt.Sprintf("%s-%s-%d", namespace, c.Name, i)
+		identifier := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%s-%s-%s-%d", namespace, c.Name, c.Rules[i].Alert, i)))
+		c.Rules[i].Identifier = identifier
 	}
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -286,6 +286,12 @@ type GettableRuleGroupConfig struct {
 	Rules         []GettableExtendedRuleNode `yaml:"rules" json:"rules"`
 }
 
+func (c *GettableRuleGroupConfig) PopulateRuleIdentifiers(namespace string) {
+	for i := range c.Rules {
+		c.Rules[i].Identifier = fmt.Sprintf("%s-%s-%d", namespace, c.Name, i)
+	}
+}
+
 func (c *GettableRuleGroupConfig) UnmarshalJSON(b []byte) error {
 	type plain GettableRuleGroupConfig
 	if err := json.Unmarshal(b, (*plain)(c)); err != nil {
@@ -333,6 +339,7 @@ type ApiRuleNode struct {
 	KeepFiringFor *model.Duration   `yaml:"keep_firing_for,omitempty" json:"keep_firing_for,omitempty"`
 	Labels        map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Annotations   map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	Identifier    string            `yaml:"__identifier" json:"__identifier"`
 }
 
 type RuleType int

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -2,6 +2,7 @@ package definitions
 
 import (
 	"container/heap"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"sort"
@@ -102,7 +103,8 @@ type RuleGroup struct {
 
 func (g *RuleGroup) PopulateRuleIdentifiers() {
 	for i := range g.Rules {
-		g.Rules[i].Identifier = fmt.Sprintf("%s-%s-%d", g.File, g.Name, i)
+		identifier := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%s-%s-%s-%d", g.File, g.Name, g.Rules[i].Name, i)))
+		g.Rules[i].Identifier = identifier
 	}
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -100,6 +100,12 @@ type RuleGroup struct {
 	EvaluationTime float64   `json:"evaluationTime"`
 }
 
+func (g *RuleGroup) PopulateRuleIdentifiers() {
+	for i := range g.Rules {
+		g.Rules[i].Identifier = fmt.Sprintf("%s-%s-%d", g.File, g.Name, i)
+	}
+}
+
 // HTTPStatusCode returns the HTTP status code for a given Prometheus style error.
 func (d DiscoveryBase) HTTPStatusCode() int {
 	if d.Status == "success" {
@@ -158,6 +164,7 @@ type AlertingRule struct {
 	Alerts         []Alert          `json:"alerts,omitempty"`
 	Totals         map[string]int64 `json:"totals,omitempty"`
 	TotalsFiltered map[string]int64 `json:"totalsFiltered,omitempty"`
+	Identifier     string           `json:"__identifier"`
 	Rule
 }
 


### PR DESCRIPTION
**WIP, Experiment**

Adds `__identifier` field to the rules APIs.
Identifier of a rule is a string `base64({namespace|filename}-{group_name}-{rule_name}-{position})`