### PR TITLE
Plugin.json schema: Update the meta-info for extensions

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -199,11 +199,17 @@
             }
           }
         },
-        "exposedComponents": {
-          "type": "array",
-          "description": "An array of exposed component ids that this plugin depends on.",
-          "items": {
-            "type": "string"
+        "extensions": {
+          "type": "object",
+          "description": "Plugin extensions that this plugin depends on.",
+          "properties": {
+            "exposedComponents": {
+              "type": "array",
+              "description": "An array of exposed component ids that this plugin depends on.",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         }
       }

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -198,6 +198,13 @@
               }
             }
           }
+        },
+        "exposedComponents": {
+          "type": "array",
+          "description": "...",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -642,7 +642,8 @@
             "properties": {
               "id": {
                 "type": "string",
-                "description": "A unique identifier for your exposed component. This is used to reference the component in other plugins."
+                "description": "A unique identifier for your exposed component. This is used to reference the component in other plugins. It must be in the following format: '{PLUGIN_ID}/name-of-component/v1'.",
+                "pattern": "^[0-9a-z]+-([0-9a-z]+-)?(app|panel|datasource|secretsmanager)\\/[a-zA-Z0-9_-]+\\/v[0-9_.-]+$"
               },
               "title": {
                 "type": "string",

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -597,7 +597,8 @@
               },
               "title": {
                 "type": "string",
-                "description": "An informative title for your component extension."
+                "description": "An informative title for your component extension.",
+                "minLength": 10
               },
               "description": {
                 "type": "string",
@@ -622,7 +623,8 @@
               },
               "title": {
                 "type": "string",
-                "description": "An informative title for your link extension."
+                "description": "An informative title for your link extension.",
+                "minLength": 10
               },
               "description": {
                 "type": "string",

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -566,26 +566,103 @@
       }
     },
     "extensions": {
-      "type": "array",
-      "description": "List of link and component extensions which the plugin registers to given extension points.",
-      "items": {
-        "type": "object",
-        "properties": {
-          "extensionPointId": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["link", "component"]
+      "type": "object",
+      "description": "...",
+      "properties": {
+        "addedComponents": {
+          "type": "array",
+          "description": "...",
+          "items": {
+            "type": "object",
+            "properties": {
+              "targets": {
+                "type": "array",
+                "description": "...",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "title": {
+                "type": "string",
+                "description": "..."
+              },
+              "description": {
+                "type": "string",
+                "description": "..."
+              }
+            },
+            "required": ["targets", "title"]
           }
         },
-        "required": ["extensionPointId", "title", "type"]
+        "addedLinks": {
+          "type": "array",
+          "description": "...",
+          "items": {
+            "type": "object",
+            "properties": {
+              "targets": {
+                "type": "array",
+                "description": "...",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "title": {
+                "type": "string",
+                "description": "..."
+              },
+              "description": {
+                "type": "string",
+                "description": "..."
+              }
+            },
+            "required": ["targets", "title"]
+          }
+        },
+        "exposedComponents": {
+          "type": "array",
+          "description": "...",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "..."
+              },
+              "title": {
+                "type": "string",
+                "description": "..."
+              },
+              "description": {
+                "type": "string",
+                "description": "..."
+              }
+            },
+            "required": ["id"]
+          }
+        },
+        "extensionPoints": {
+          "type": "array",
+          "description": "...",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "..."
+              },
+              "title": {
+                "type": "string",
+                "description": "..."
+              },
+              "description": {
+                "type": "string",
+                "description": "..."
+              }
+            },
+            "required": ["id"]
+          }
+        }
       }
     }
   }

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -201,7 +201,7 @@
         },
         "exposedComponents": {
           "type": "array",
-          "description": "...",
+          "description": "An array of exposed component ids that this plugin depends on.",
           "items": {
             "type": "string"
           }
@@ -574,28 +574,28 @@
     },
     "extensions": {
       "type": "object",
-      "description": "...",
+      "description": "Plugin extensions are a way to extend either the UI of core Grafana or other plugins.",
       "properties": {
         "addedComponents": {
           "type": "array",
-          "description": "...",
+          "description": "Any component extensions that your plugin registers to extension points.",
           "items": {
             "type": "object",
             "properties": {
               "targets": {
                 "type": "array",
-                "description": "...",
+                "description": "The list of the targeted extension point ids that the component is added to.",
                 "items": {
                   "type": "string"
                 }
               },
               "title": {
                 "type": "string",
-                "description": "..."
+                "description": "An informative title for your component extension."
               },
               "description": {
                 "type": "string",
-                "description": "..."
+                "description": "Additional information about your component extension."
               }
             },
             "required": ["targets", "title"]
@@ -603,24 +603,24 @@
         },
         "addedLinks": {
           "type": "array",
-          "description": "...",
+          "description": "Any link extensions that your plugin registers to extension points.",
           "items": {
             "type": "object",
             "properties": {
               "targets": {
                 "type": "array",
-                "description": "...",
+                "description": "The list of the targeted extension point ids that the link is added to.",
                 "items": {
                   "type": "string"
                 }
               },
               "title": {
                 "type": "string",
-                "description": "..."
+                "description": "An informative title for your link extension."
               },
               "description": {
                 "type": "string",
-                "description": "..."
+                "description": "Additional information about your link extension."
               }
             },
             "required": ["targets", "title"]
@@ -628,21 +628,21 @@
         },
         "exposedComponents": {
           "type": "array",
-          "description": "...",
+          "description": "Any React component that your plugin exposes so it can be reused by other app plugins.",
           "items": {
             "type": "object",
             "properties": {
               "id": {
                 "type": "string",
-                "description": "..."
+                "description": "A unique identifier for your exposed component. This is used to reference the component in other plugins."
               },
               "title": {
                 "type": "string",
-                "description": "..."
+                "description": "An informative title for your exposed component."
               },
               "description": {
                 "type": "string",
-                "description": "..."
+                "description": "Additional information about your exposed component."
               }
             },
             "required": ["id"]
@@ -650,21 +650,21 @@
         },
         "extensionPoints": {
           "type": "array",
-          "description": "...",
+          "description": "Any extension points that your plugin provides.",
           "items": {
             "type": "object",
             "properties": {
               "id": {
                 "type": "string",
-                "description": "..."
+                "description": "A unique identifier for your extension point. This is used to reference the extension point in other plugins."
               },
               "title": {
                 "type": "string",
-                "description": "..."
+                "description": "An informative title for your extension point."
               },
               "description": {
                 "type": "string",
-                "description": "..."
+                "description": "Additional information about your extension point."
               }
             },
             "required": ["id"]

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -662,7 +662,8 @@
             "properties": {
               "id": {
                 "type": "string",
-                "description": "A unique identifier for your extension point. This is used to reference the extension point in other plugins."
+                "description": "A unique identifier for your extension point. This is used to reference the extension point in other plugins. It must be in the following format: '{PLUGIN_ID}/name-of-my-extension-point/v1'.",
+                "pattern": "^[0-9a-z]+-([0-9a-z]+-)?(app|panel|datasource|secretsmanager)\\/[a-zA-Z0-9_-]+\\/v[0-9_.-]+$"
               },
               "title": {
                 "type": "string",


### PR DESCRIPTION
### Goals
- Identify *registered extensions* (necessary so we know if we should load the plugin for a certain extension point)
- Identify *exposed components* (necessary for the admin page - discoverability, and maybe for error handling)
- Identify *used exposed components* (necessary so we know what plugins to load when this plugin is loaded)
- Identify *extension points* (necessary for the admin page - discoverability)


### What changed?
Updated the `plugin.json` schema to be able to hold all necessary extensions related information in a way that is open for extension but (hopefully) closed for changes. 

**Before**
```typescript
// plugin.json
{
  "extensions": [
    { 
      extensionPointId: "",
      title: "",
      description: "",
      type: ""
    }
  ],
}
```

**After**
```typescript
// plugin.json
{
  "extensions": {
    "addedComponents": [
      {
        "title": "",
        "targets": [""]
      }  
    ],
    "addedLinks": [
      {
        "title": "",
        "targets": [""]
      }    
    ],
    "exposedComponents": [
      {
        "id": "",
      }
    ],
    "extensionPoints": [
      {
        "id": ""
      }
    ]
  },

  // ...

  "dependencies": {
    "extensions": {
       "exposedComponents": [
         "id-1",
         "id-2"
        ] 
     }
  }
}
```

### Whys

- **Re-using the "includes" property:** we didn't re-use it (= registering the extensions as items under it) because:
  - there are existing includes properties which wouldn't make sense for extensions (e.g. "addToNav", "path", etc.) and could create confusion
  - we would need to introduce new properties that wouldn't make sense for other includes (e.g. "targets")
- **Using the "dependencies" property:** we thought that exposed components used by the plugin wouldn't fit semantically under extensions (or we would somehow need to differentiate them from the exposed components they offer), so we opted for re-using the existing "dependencies" prop.

### Affected internal apps
As we haven't used the existing meta information for anything yet, the change in the schema should cause any breaking changes in the following plugins:
- [grafana-oncall-app](https://github.com/grafana/oncall/blob/fc07a22c56609d2110ccf0dfefda9129c0877c3c/grafana-plugin/src/plugin.json#L692)
- [grafana-asserts-app](https://github.com/grafana/asserts-app-plugin/blob/e35590845f8dbe47201acdc84188a5a7ea523933/src/plugin.json#L136)
- [grafana-pdc-app](https://github.com/grafana/grafana-pdc-app/blob/e55f6355dfa2566625a12632ee96f2e5c2b241dc/src/plugin.json#L129)
- [grafana-irm-app](https://github.com/grafana/irm/blob/489ab1816a9b64a0c0526266ea0749915e26e288/packages/grafana-irm-app/src/plugin.json#L667)
- [grafana-ml-app](https://github.com/grafana/machine-learning/blob/48c1cfbbf0b36b50c37c5cab77da1086ab325052/ui-plugins/grafana-ml-app/src/plugin.json#L87)
- [grafana-llmexamples-app](https://github.com/grafana/grafana-llmexamples-app/blob/08c05636cbac266222b8b86c0f7eccfb20a0585d/src/plugin.json#L46)
- [grafana-slo-app](https://github.com/grafana/slo/blob/e59c0f08dd76fe97086fc5ae6a899354831d1ba3/src/plugin.json#L164)
- [grafana-incident-app](https://github.com/grafana/incident/blob/b39cf21ce69ae0da430d112446dcc3f84705f4f6/packages/grafana-incident-app/src/plugin.json)