### PR TITLE
Chore: Update commands.json to expand labels and their related projects

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -464,7 +464,7 @@
     "name": "area/alerting",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/52/"
+      "url": "https://github.com/orgs/grafana/projects/52"
     }
   },
   {
@@ -552,7 +552,7 @@
     "name": "area/provisioning",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/52/"
+      "url": "https://github.com/orgs/grafana/projects/52"
     }
   },
   {
@@ -808,7 +808,7 @@
     "name": "area/backend/db/postgres",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/96/"
+      "url": "https://github.com/orgs/grafana/projects/96"
     }
   },
   {
@@ -944,7 +944,7 @@
     "name": "datasource/TestDataDB",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/76/"
+      "url": "https://github.com/orgs/grafana/projects/76"
     }
   },
   {
@@ -992,7 +992,7 @@
     "name": "datasource/Alertmanager",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/52/"
+      "url": "https://github.com/orgs/grafana/projects/52"
     }
   },
   {

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -458,5 +458,637 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/471"
     }
+  },
+  {
+    "type": "label",
+    "name": "area/alerting",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/52/"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/backend",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/665"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "type/accessibility",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/transformations",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/templating",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/plugins",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/76"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/annotations",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/annotations",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/provisioning",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/599"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/provisioning",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/52/"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/scenes",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Postgres",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/logs",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/203"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboards/panel",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/public-dashboards",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/482"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/exploremetrics",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/112"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/oauth",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/traceview",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/rbac",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/expressions",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/112"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/data-links",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/backend/api",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/319"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/security",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/47"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/admin/user",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/node-graph",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/snapshot",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/folders",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/configuration",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/96"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/frontend/library-panels",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/ldap",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/timerange",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/MSSQL",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Jaeger",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/navigation",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/search",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/search",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/flame-graph",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/serviceaccount",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/field/overrides",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/backend/db/sql",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/image-rendering",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/482"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/backend/db/postgres",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/96/"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/permissions",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/import",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/backend/db/sqlite",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/599"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/backend/db/mysql",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/45"
+    }
+  },
+  {
+    "type": "label",
+    "name": "type/browser-compatibility",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/text",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/dashboard/links",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Zipkin",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/streaming",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/319"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/frontend/login",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Parca",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/CSV",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/datagrid",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/dashboard-list",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "team/grafana-aws-datasources",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Zabbix",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/TestDataDB",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/76/"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Splunk",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/55"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/SiteWIse",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Phlare",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/221"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/JSON",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/BigQuery",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Alertmanager",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/52/"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/recorded-queries",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/112"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/singlestat",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/panel/annotation-list",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/202"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/editor",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/grafana/grafana/projects/21"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/data/export",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/56"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/azure-cosmosdb",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/190"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/X-Ray",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/Timestream",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/OpenSearch",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/GoogleSheets",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/GitHub",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
+  },
+  {
+    "type": "label",
+    "name": "datasource/MySQL",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/457"
+    }
   }
 ]


### PR DESCRIPTION
**What is this feature?**

Updates our existing commands.json that acts when labels are added to issues.

This update adds a more comprehensive list of labels that were not previously included in the commands.json file.

**Why do we need this feature?**

We are moving towards an automated triaging of issues and we need to ensure the labels we'll use to auto-triage
will assign the issue to the correct project board.

**Who is this feature for?**

All issues opened in the Grafana repository.

**Where does the list of labels and projects come from?**

The list of labels was gathered from the current list of github labels https://github.com/grafana/grafana/labels?page=20&sort=count-desc and then matched (by hand) to the github projects based on the internal teams responsibilities document.

It is much possible some of the labels have an incorrect project assigned as the work was done in a "good faith effort"


## Big thanks to @tonypowa and @usmangt for going through all the list of labels!