### PR TITLE
Alerting: Don't redirect after failed contact point creation

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useContactPoints.tsx
@@ -410,10 +410,12 @@ export const useCreateContactPoint = ({ alertmanager }: BaseAlertmanagerArgs) =>
         oldConfig: config,
         alertManagerSourceName: alertmanager,
       })
-    ).then(() => {
-      dispatch(alertingApi.util.invalidateTags(['AlertmanagerConfiguration', 'ContactPoint', 'ContactPointsStatus']));
-      dispatch(generatedReceiversApi.util.invalidateTags(['Receiver']));
-    });
+    )
+      .unwrap()
+      .then(() => {
+        dispatch(alertingApi.util.invalidateTags(['AlertmanagerConfiguration', 'ContactPoint', 'ContactPointsStatus']));
+        dispatch(generatedReceiversApi.util.invalidateTags(['Receiver']));
+      });
   };
 };
 

--- a/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
@@ -125,7 +125,6 @@ describe('alerting API server disabled', () => {
 
 const ui = {
   saveContactButton: byRole('button', { name: /save contact point/i }),
-  savingButton: byRole('button', { name: /saving/i }),
 
   testContactPointButton: byRole('button', { name: /Test/ }),
   testContactPointModal: byRole('heading', { name: /test contact point/i }),

--- a/public/app/features/alerting/unified/components/receivers/form/CloudReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/CloudReceiverForm.tsx
@@ -54,12 +54,16 @@ export const CloudReceiverForm = ({ contactPoint, alertManagerSourceName, readOn
 
   const onSubmit = async (values: ReceiverFormValues<CloudChannelValues>) => {
     const newReceiver = formValuesToCloudReceiver(values, defaultChannelValues);
-    if (editMode) {
-      await updateContactPoint({ contactPoint: newReceiver, originalName: contactPoint!.name });
-    } else {
-      await createContactPoint({ contactPoint: newReceiver });
+    try {
+      if (editMode) {
+        await updateContactPoint({ contactPoint: newReceiver, originalName: contactPoint!.name });
+      } else {
+        await createContactPoint({ contactPoint: newReceiver });
+      }
+      locationService.push('/alerting/notifications');
+    } catch (error) {
+      // React form validation will handle this for us
     }
-    locationService.push('/alerting/notifications');
   };
 
   // this basically checks if we can manage the selected alert manager data source, either because it's a Grafana Managed one

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -81,17 +81,21 @@ export const GrafanaReceiverForm = ({ contactPoint, readOnly = false, editMode }
 
   const onSubmit = async (values: ReceiverFormValues<GrafanaChannelValues>) => {
     const newReceiver = formValuesToGrafanaReceiver(values, id2original, defaultChannelValues, grafanaNotifiers);
-    if (editMode) {
-      await updateContactPoint({
-        contactPoint: newReceiver,
-        id: contactPoint!.id,
-        resourceVersion: contactPoint?.metadata?.resourceVersion,
-        originalName: contactPoint?.name,
-      });
-    } else {
-      await createContactPoint({ contactPoint: newReceiver });
+    try {
+      if (editMode) {
+        await updateContactPoint({
+          contactPoint: newReceiver,
+          id: contactPoint!.id,
+          resourceVersion: contactPoint?.metadata?.resourceVersion,
+          originalName: contactPoint?.name,
+        });
+      } else {
+        await createContactPoint({ contactPoint: newReceiver });
+      }
+      locationService.push('/alerting/notifications');
+    } catch (error) {
+      // React form validation will handle this for us
     }
-    locationService.push('/alerting/notifications');
   };
 
   const onTestChannel = (values: GrafanaChannelValues) => {

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -4,9 +4,11 @@ import { config } from '@grafana/runtime';
 import server, { mockFeatureDiscoveryApi } from 'app/features/alerting/unified/mockApi';
 import { mockDataSource, mockFolder } from 'app/features/alerting/unified/mocks';
 import {
+  ALERTMANAGER_UPDATE_ERROR_RESPONSE,
   getAlertmanagerConfigHandler,
   getGrafanaAlertmanagerConfigHandler,
   grafanaAlertingConfigurationStatusHandler,
+  updateGrafanaAlertmanagerConfigHandler,
 } from 'app/features/alerting/unified/mocks/server/handlers/alertmanagers';
 import { getFolderHandler } from 'app/features/alerting/unified/mocks/server/handlers/folders';
 import { listNamespacedTimeIntervalHandler } from 'app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s';
@@ -125,4 +127,9 @@ export const removePlugin = (pluginId: string) => {
 /** Make a plugin respond with `enabled: false`, as if its installed but disabled */
 export const disablePlugin = (pluginId: SupportedPlugin) => {
   server.use(getDisabledPluginHandler(pluginId));
+};
+
+/** Make alertmanager config update fail */
+export const makeGrafanaAlertmanagerConfigUpdateFail = () => {
+  server.use(updateGrafanaAlertmanagerConfigHandler(ALERTMANAGER_UPDATE_ERROR_RESPONSE));
 };


### PR DESCRIPTION
**What is this feature?**

Stops redirecting after failing to create a contact point, due to a missed `unwrap` on a promise.
