### PR TITLE
chore(tests): Attempting to fix flaxy SMTP unit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // @grafana/alerting-backend
 	github.com/microsoft/go-mssqldb v1.7.0 // @grafana/grafana-bi-squad
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c //@grafana/identity-access-team
-	github.com/mocktools/go-smtp-mock/v2 v2.3.0 // @grafana/grafana-backend-group
+	github.com/mocktools/go-smtp-mock/v2 v2.3.1 // @grafana/grafana-backend-group
 	github.com/modern-go/reflect2 v1.0.2 // @grafana/alerting-backend
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // @grafana/alerting-backend
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // @grafana/grafana-operator-experience-squad

--- a/go.sum
+++ b/go.sum
@@ -2745,8 +2745,8 @@ github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
-github.com/mocktools/go-smtp-mock/v2 v2.3.0 h1:jgTDBEoQ8Kpw/fPWxy6qR2pGwtNn5j01T3Wut4xJo5Y=
-github.com/mocktools/go-smtp-mock/v2 v2.3.0/go.mod h1:n8aNpDYncZHH/cZHtJKzQyeYT/Dut00RghVM+J1Ed94=
+github.com/mocktools/go-smtp-mock/v2 v2.3.1 h1:wq75NDSsOy5oHo/gEQQT0fRRaYKRqr1IdkjhIPXxagM=
+github.com/mocktools/go-smtp-mock/v2 v2.3.1/go.mod h1:h9AOf/IXLSU2m/1u4zsjtOM/WddPwdOUBz56dV9f81M=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.work.sum
+++ b/go.work.sum
@@ -885,6 +885,8 @@ github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWe
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mithrandie/readline-csvq v1.3.0 h1:VTJEOGouJ8j27jJCD4kBBbNTxM0OdBvE1aY1tMhlqE8=
 github.com/mithrandie/readline-csvq v1.3.0/go.mod h1:FKyYqDgf/G4SNov7SMFXRWO6LQLXIOeTog/NB97FZl0=
+github.com/mocktools/go-smtp-mock/v2 v2.3.1 h1:wq75NDSsOy5oHo/gEQQT0fRRaYKRqr1IdkjhIPXxagM=
+github.com/mocktools/go-smtp-mock/v2 v2.3.1/go.mod h1:h9AOf/IXLSU2m/1u4zsjtOM/WddPwdOUBz56dV9f81M=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5 h1:8Q0qkMVC/MmWkpIdlvZgcv2o2jrlF6zqVOh7W5YHdMA=
 github.com/montanaflynn/stats v0.7.0 h1:r3y12KyNxj/Sb/iOE46ws+3mS1+MZca1wlHQFPsY/JU=
 github.com/mostynb/go-grpc-compression v1.2.2 h1:XaDbnRvt2+1vgr0b/l0qh4mJAfIxE0bKXtz2Znl3GGI=

--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -294,16 +294,16 @@ func TestSmtpSend(t *testing.T) {
 
 		count, err := client.Send(ctx, msgs...)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
+		assert.Equal(t, 3, count)
 
 		// workaround for https://github.com/mocktools/go-smtp-mock/issues/181
 		time.Sleep(1 * time.Millisecond)
 		messages := srv.MessagesAndPurge()
-		require.Len(t, messages, 3)
+		assert.Len(t, messages, 3)
 
 		for i, sentMsg := range messages {
 			rcpts := sentMsg.RcpttoRequestResponse()
-			require.EqualValues(t, [][]string{
+			assert.EqualValues(t, [][]string{
 				{fmt.Sprintf("RCPT TO:<rcpt%d@example.com>", i+1), "250 Received"},
 			}, rcpts)
 
@@ -316,7 +316,7 @@ func TestSmtpSend(t *testing.T) {
 			// make sure the trace is propagated
 			traceId := span.SpanContext().TraceID().String()
 			hasPrefix := strings.HasPrefix(hdr.Get("traceparent"), "00-"+traceId+"-")
-			require.True(t, hasPrefix)
+			assert.True(t, hasPrefix)
 
 			// one of the lines should be the body we expect!
 			found := false
@@ -334,7 +334,7 @@ func TestSmtpSend(t *testing.T) {
 				}
 			}
 
-			require.True(t, found)
+			assert.True(t, found)
 		}
 	})
 }


### PR DESCRIPTION
**What is this feature?**

This attempts to fix #92614. I haven't been able to reproduce the test flakes, but I suspect the issue is in the `github.com/mocktools/go-smtp-mock/v2` package we're using. I've therefore updated the module to the latest version.

I've also changed a few non-error-related checks from `require`s to `assert`s, so that hopefully we can gain a bit more context about what exactly is going wrong. I _suspect_ this is an ordering thing (the first and second elements are swapped), but can't prove it since the test fails early with `require`.

**Which issue(s) does this PR fix?**:

Fixes #92614 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
