### PR TITLE
Templating: Fix searching non-latin template variables

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -860,6 +860,47 @@ describe('optionsPickerReducer', () => {
     });
   });
 
+  describe('when searching non-latin chars', () => {
+    it('should skip fuzzy matching and fall back to substring', () => {
+      const searchQuery = '水';
+
+      const options: VariableOption[] = 'A水'.split(' ').map((v) => ({
+        selected: false,
+        text: v,
+        value: v,
+      }));
+
+      const expect: VariableOption[] = [
+        {
+          selected: false,
+          text: '> ' + searchQuery,
+          value: searchQuery,
+        },
+      ].concat(
+        'A水'.split(' ').map((v) => ({
+          selected: false,
+          text: v,
+          value: v,
+        }))
+      );
+
+      const { initialState } = getVariableTestContext({
+        queryValue: searchQuery,
+      });
+
+      reducerTester<OptionsPickerState>()
+        .givenReducer(optionsPickerReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateOptionsAndFilter(options))
+        .thenStateShouldEqual({
+          ...cloneDeep(initialState),
+          options: expect,
+          selectedValues: [],
+          queryValue: searchQuery,
+          highlightIndex: 1,
+        });
+    });
+  });
+
   describe('when large data for updateOptionsFromSearch is dispatched and variable has searchFilter', () => {
     it('then state should be correct', () => {
       const searchQuery = '__searchFilter';

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -8,6 +8,9 @@ import { applyStateChanges } from '../../../../core/utils/applyStateChanges';
 import { ALL_VARIABLE_VALUE } from '../../constants';
 import { isMulti, isQuery } from '../../guard';
 
+// https://catonmat.net/my-favorite-regex :)
+const REGEXP_NON_ASCII = /[^ -~]/gm;
+
 export interface ToggleOption {
   option?: VariableOption;
   forceSelect: boolean;
@@ -251,6 +254,8 @@ const optionsPickerSlice = createSlice({
 
       if (needle === '') {
         opts = action.payload;
+      } else if (REGEXP_NON_ASCII.test(needle)) {
+        opts = action.payload.filter((o) => o.text.includes(needle));
       } else {
         // with current API, not seeing a way to cache this on state using action.payload's uniqueness
         // since it's recreated and includes selected state on each item :(


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/90459

our fuzzy search is currently only configured to handle ascii/latin chars. this makes search terms in Chinese, Russian, etc. non-searchable. doing this properly is (maybe?) tricky with the current redux/reducer architecture since it requires preparing the haystack into a normalized index, and this can be impractical to do for large lists on every keypress.

this PR offers a quick fix that simply falls back to substring matching when the search needle contains non-ascii chars.

previously:

- https://github.com/grafana/grafana/pull/79286
- https://github.com/grafana/grafana/pull/84790