### PR TITLE
Grafana SQL: Fix broken import in NumberInput component

### DIFF
--- a/packages/grafana-sql/src/components/configuration/NumberInput.tsx
+++ b/packages/grafana-sql/src/components/configuration/NumberInput.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Input } from '@grafana/ui/src/components/Input/Input';
+import { Input } from '@grafana/ui';
 
 type NumberInputProps = {
   value: number;


### PR DESCRIPTION
**What is this feature?**

I'm using grafana-sql as a dependency for my plugin. This import works only from the built-in plugins yarn project where grafana-ui is a local module.

**Why do we need this feature?**

After fixing the import, grafana-sql can be used as a dependency for user plugins.

**Who is this feature for?**

Plugin developers

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
