### PR TITLE
Chore: Add auto-triager github action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -693,6 +693,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/commands.yml @torkelo
 /.github/workflows/community-release.yml @grafana/grafana-release-guild
 /.github/workflows/detect-breaking-changes-* @grafana/plugins-platform-frontend
+/.github/workflows/auto-triager.yml @grafana/plugins-platform-frontend
 /.github/workflows/doc-validator.yml @grafana/docs-tooling
 /.github/workflows/epic-add-to-platform-ux-parent-project.yml @meanmina
 /.github/workflows/github-release.yml @grafana/grafana-release-guild

--- a/.github/workflows/auto-triager.yml
+++ b/.github/workflows/auto-triager.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Send issue to the auto triager action
         id: auto_triage

--- a/.github/workflows/auto-triager.yml
+++ b/.github/workflows/auto-triager.yml
@@ -12,8 +12,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Use Check Issue Label action
+      - name: Send issue to the auto triager action
         id: auto_triage
+        # https://github.com/grafana/auto-triager/blob/main/action.yml
         uses: grafana/auto-triager@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-triager.yml
+++ b/.github/workflows/auto-triager.yml
@@ -1,0 +1,44 @@
+# This workflow is triggered when a new issue is opened
+# It will run an internal github action to try to automate the triage process
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use Check Issue Label action
+        id: auto_triage
+        uses: grafana/auto-triager@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue_number: ${{ github.event.issue.number }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # Leaving the actionin monitoring mode for now
+          # should be set to true when ready to use
+          # add_labels: true
+          add_labels: false
+
+      - name: Labels from auto triage
+        run: |
+          echo ${{ steps.auto_triage.outputs.triage_labels }}
+
+      - name: "Send Slack notification"
+        if : ${{ steps.auto_triage.outputs.triage_labels != '' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: >
+            {
+              "icon_emoji": ":robocto:",
+              "username": "Auto Triager",
+              "type": "mrkdwn",
+              "text": "Auto triager found the following labels: ${{ steps.auto_triage.outputs.triage_labels }} for [issue #${{ github.event.issue.number }}](${{ github.event.issue.html_url }})",
+              "channel": "#triage-automation-ci"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
**What is this feature?**

It adds a new github action that will execute when an issue in the grafana repository is created without an `internal` label.

This will trigger an internal custom-action that will attempt to automatically triage the issue.

For now this action will merely report the results to slack while we test its functionality and effectiveness.

**Why do we need this feature?**

We want to be able to automatically triage issues in the grafana repository and reduce the load on the current triage process.

**Who is this feature for?**

All issues in the grafana repository without an `internal` label.
