### PR TITLE
Alerting: Fix target rule group for moving alert rule group

### DIFF
--- a/public/app/features/alerting/unified/hooks/ruleGroup/__snapshots__/useMoveRuleFromRuleGroup.test.tsx.snap
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/__snapshots__/useMoveRuleFromRuleGroup.test.tsx.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Moving a Data source managed rule should move a rule in a namespace to another existing namespace 1`] = `
+[
+  {
+    "body": {
+      "name": "group-1",
+      "rules": [
+        {
+          "alert": "alert1",
+          "annotations": {
+            "summary": "test alert",
+          },
+          "expr": "up = 1",
+          "labels": {
+            "severity": "warning",
+          },
+        },
+      ],
+    },
+    "headers": [
+      [
+        "content-type",
+        "application/json",
+      ],
+      [
+        "accept",
+        "application/json, text/plain, */*",
+      ],
+    ],
+    "method": "POST",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/namespace-2?subtype=mimir",
+  },
+  {
+    "body": "",
+    "headers": [
+      [
+        "accept",
+        "application/json, text/plain, */*",
+      ],
+    ],
+    "method": "DELETE",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/namespace-1/group-1?subtype=mimir",
+  },
+]
+`;
+
 exports[`Moving a Data source managed rule should move a rule in an existing group to a new group 1`] = `
 [
   {
@@ -125,7 +170,7 @@ exports[`Moving a Data source managed rule should move a rule in an existing gro
       ],
     ],
     "method": "POST",
-    "url": "http://localhost/api/ruler/mimir/api/v1/rules/namespace-1?subtype=mimir",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/namespace-2?subtype=mimir",
   },
   {
     "body": "",

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useMoveRuleFromRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useMoveRuleFromRuleGroup.test.tsx
@@ -184,6 +184,45 @@ describe('Moving a Data source managed rule', () => {
     expect(serializedRequests).toMatchSnapshot();
   });
 
+  it('should move a rule in a namespace to another existing namespace', async () => {
+    const capture = captureRequests((r) => r.method === 'POST' || r.method === 'DELETE');
+
+    const ruleToMove = group1.rules[0];
+
+    const coreRuleGroup = {
+      dataSourceName: MIMIR_DATASOURCE_UID,
+      groupName: group1.name,
+    };
+
+    const currentRuleGroupID: RuleGroupIdentifier = {
+      ...coreRuleGroup,
+      namespaceName: NAMESPACE_1,
+    };
+
+    const targetRuleGroupID: RuleGroupIdentifier = {
+      ...coreRuleGroup,
+      namespaceName: NAMESPACE_2,
+    };
+
+    const ruleID = fromRulerRuleAndRuleGroupIdentifier(currentRuleGroupID, ruleToMove);
+
+    const { user } = render(
+      <MoveRuleTestComponent
+        currentRuleGroupIdentifier={currentRuleGroupID}
+        targetRuleGroupIdentifier={targetRuleGroupID}
+        ruleID={ruleID}
+        rule={ruleToMove}
+      />
+    );
+    await user.click(byRole('button').get());
+
+    expect(await byText(/success/i).find()).toBeInTheDocument();
+
+    const requests = await capture;
+    const serializedRequests = await serializeRequests(requests);
+    expect(serializedRequests).toMatchSnapshot();
+  });
+
   it('should fail if the rule group does not exist', async () => {
     const groupToUpdate = group1;
     const ruleToUpdate = groupToUpdate.rules[0];

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useUpsertRuleFromRuleGroup.ts
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useUpsertRuleFromRuleGroup.ts
@@ -114,7 +114,7 @@ export function useMoveRuleToRuleGroup() {
 
       const result = await upsertRuleGroup({
         rulerConfig: targetGroupRulerConfig,
-        namespace: currentRuleGroup.namespaceName,
+        namespace: targetRuleGroup.namespaceName,
         payload: newTargetGroup,
         notificationOptions: { successMessage },
       }).unwrap();


### PR DESCRIPTION
**What is this feature?**
Fixes an issue when moving rules from one namespace to another - introduced in https://github.com/grafana/grafana/pull/90497

When switching the rule group, we were producing a new group but incorrectly using the `currentRuleGroup.namespaceName` instead of the target.

If the target rule namespace did not exist/contain any rules, then all other existing rules would be removed, and only the one that was trying to be moved was left in place.

If the target rule namespace did have rules in it, then instead of the rule being moved to that group, all of the existing ones would be moved to that group