### PR TITLE
Chore: Update auto triager github action to use private repository

### DIFF
--- a/.github/workflows/auto-triager.yml
+++ b/.github/workflows/auto-triager.yml
@@ -1,21 +1,49 @@
 # This workflow is triggered when a new issue is opened
 # It will run an internal github action to try to automate the triage process
+name: Auto Triage Issues
 on:
   issues:
     types: [opened]
 
 jobs:
-  check-label:
-    runs-on: ubuntu-latest
-
+  config:
+    runs-on: "ubuntu-latest"
+    outputs:
+      has-secrets: ${{ steps.check.outputs.has-secrets }}
     steps:
-      - name: Checkout repository
+      - name: "Check for secrets"
+        id: check
+        shell: bash
+        run: |
+          if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' &&
+                        secrets.GRAFANA_DELIVERY_BOT_APP_PEM != ''
+                        ) || '' }}" ]; then
+            echo "has-secrets=1" >> "$GITHUB_OUTPUT"
+          fi
+  auto-triage:
+    needs: config
+    if: needs.config.outputs.has-secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Generate token"
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_ID }}
+          private_key: ${{ secrets.GRAFANA_DELIVERY_BOT_APP_PEM }}
+
+      - name: Checkout auto-triager repository
         uses: actions/checkout@v4
+        with:
+          repository: grafana/auto-triager
+          path: auto-triager
+          token:  ${{ steps.generate_token.outputs.token }}
 
       - name: Send issue to the auto triager action
         id: auto_triage
         # https://github.com/grafana/auto-triager/blob/main/action.yml
-        uses: grafana/auto-triager@main
+        #uses: grafana/auto-triager@main
+        uses: ./auto-triager
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/auto-triager.yml
+++ b/.github/workflows/auto-triager.yml
@@ -16,7 +16,9 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ (secrets.GRAFANA_DELIVERY_BOT_APP_ID != '' &&
-                        secrets.GRAFANA_DELIVERY_BOT_APP_PEM != ''
+                        secrets.GRAFANA_DELIVERY_BOT_APP_PEM != '' &&
+                        secrets.OPENAI_API_KEY != '' &&
+                        secrets.SLACK_WEBHOOK_URL != ''
                         ) || '' }}" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
**What is this feature?**

Follow up to https://github.com/grafana/grafana/pull/92807

The previous PR tried to use an action that is not published yet.

The current approach first clones the private repo, then uses the action to auto triage
