### PR TITLE
[v11.2.x] Dashboard: Fix Annotation runtime error when a data source does not support annotations 

### DIFF
--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
@@ -1,7 +1,18 @@
 import { map, of } from 'rxjs';
+import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 
-import { AnnotationQuery, DataQueryRequest, DataSourceApi, LoadingState, PanelData } from '@grafana/data';
+import {
+  AnnotationQuery,
+  DataQueryRequest,
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  DataSourcePluginMeta,
+  getDataSourceUID,
+  LoadingState,
+  PanelData,
+} from '@grafana/data';
 import { SceneGridLayout, SceneTimeRange, dataLayers } from '@grafana/scenes';
+import { DataSourceRef } from '@grafana/schema';
 
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
@@ -29,11 +40,49 @@ const runRequestMock = jest.fn().mockImplementation((ds: DataSourceApi, request:
   );
 });
 
+const noAnnotationsDsInstanceSettings = {
+  name: 'noAnnotationsDs',
+  uid: 'noAnnotationsDs',
+  meta: {
+    annotations: false,
+  } as DataSourcePluginMeta,
+  readOnly: false,
+  type: 'noAnnotations',
+} as DataSourceInstanceSettings;
+
+const grafanaDsInstanceSettings = {
+  name: 'Grafana',
+  uid: '-- Grafana --',
+  meta: {
+    annotations: true,
+  } as DataSourcePluginMeta,
+  readOnly: false,
+  type: 'grafana',
+} as DataSourceInstanceSettings;
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => {
     return {
-      getInstanceSettings: jest.fn().mockResolvedValue({ uid: 'ds1' }),
+      //return default datasource when no ref is provided
+      getInstanceSettings: (ref: DataSourceRef | string | null) => {
+        if (!ref) {
+          return new MockDataSourceApi(noAnnotationsDsInstanceSettings);
+        }
+        if (getDataSourceUID(ref) === '-- Grafana --') {
+          return new MockDataSourceApi(grafanaDsInstanceSettings);
+        }
+        return jest.fn().mockResolvedValue({ uid: 'ds1' });
+      },
+      get: (ref: DataSourceRef) => {
+        if (getDataSourceUID(ref) === 'noAnnotationsDs') {
+          return Promise.resolve(new MockDataSourceApi(noAnnotationsDsInstanceSettings));
+        }
+        if (getDataSourceUID(ref) === '-- Grafana --') {
+          return Promise.resolve(new MockDataSourceApi(grafanaDsInstanceSettings));
+        }
+        return Promise.resolve(new MockDataSourceApi('ds1'));
+      },
     };
   },
   getRunRequest: () => (ds: DataSourceApi, request: DataQueryRequest) => {
@@ -52,17 +101,23 @@ describe('AnnotationsEditView', () => {
     beforeEach(async () => {
       const result = await buildTestScene();
       annotationsView = result.annotationsView;
+      jest.spyOn(console, 'error').mockImplementation();
     });
 
     it('should return the correct urlKey', () => {
       expect(annotationsView.getUrlKey()).toBe('annotations');
     });
 
+    it('should return undefined when datasource does not support annotations', () => {
+      const ds = annotationsView.getDataSourceRefForAnnotation();
+      expect(ds).toBe(undefined);
+      expect(console.error).toHaveBeenCalledWith('Default datasource does not support annotations');
+    });
+
     it('should add a new annotation and group it with the other annotations', () => {
       const dataLayers = dashboardSceneGraph.getDataLayers(annotationsView.getDashboard());
 
       expect(dataLayers?.state.annotationLayers.length).toBe(1);
-
       annotationsView.onNew();
 
       expect(dataLayers?.state.annotationLayers.length).toBe(2);

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -1,4 +1,4 @@
-import { AnnotationQuery, NavModel, NavModelItem, PageLayoutType, getDataSourceRef } from '@grafana/data';
+import { AnnotationQuery, getDataSourceRef, NavModel, NavModelItem, PageLayoutType } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, VizPanel, dataLayers } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
@@ -51,11 +51,23 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     return this._dashboard;
   }
 
-  public onNew = () => {
+  public getDataSourceRefForAnnotation = () => {
+    // get current default datasource ref from instance settings
+    // null is passed to get the default datasource
+    const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
+    // check for an annotation flag in the plugin json to see if it supports annotations
+    if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
+      console.error('Default datasource does not support annotations');
+      return undefined;
+    }
+    return getDataSourceRef(defaultInstanceDS);
+  };
+
+  public onNew = async () => {
     const newAnnotationQuery: AnnotationQuery = {
       name: newAnnotationName,
       enable: true,
-      datasource: getDataSourceRef(getDataSourceSrv().getInstanceSettings(null)!),
+      datasource: this.getDataSourceRefForAnnotation(),
       iconColor: 'red',
     };
 
@@ -69,7 +81,6 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
 
     data.addAnnotationLayer(newAnnotation);
-
     this.setState({ editIndex: data.state.annotationLayers.length - 1 });
   };
 

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
@@ -14,8 +14,9 @@ import { selectors } from '@grafana/e2e-selectors';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
 import { AnnotationPanelFilter } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
-import { Button, Checkbox, Field, FieldSet, Input, MultiSelect, Select, useStyles2, Stack } from '@grafana/ui';
+import { Button, Checkbox, Field, FieldSet, Input, MultiSelect, Select, useStyles2, Stack, Alert } from '@grafana/ui';
 import { ColorValueEditor } from 'app/core/components/OptionsUI/color';
+import { Trans } from 'app/core/internationalization';
 import StandardAnnotationQueryEditor from 'app/features/annotations/components/StandardAnnotationQueryEditor';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 
@@ -183,6 +184,13 @@ export const AnnotationSettingsEdit = ({ annotation, editIndex, panels, onUpdate
         <Field label="Data source" htmlFor="data-source-picker">
           <DataSourcePicker annotations variables current={annotation.datasource} onChange={onDataSourceChange} />
         </Field>
+        {!ds?.meta.annotations && (
+          <Alert title="No annotation support for this data source" severity="error">
+            <Trans i18nKey="errors.dashboard-settings.annotations.datasource">
+              The selected data source does not support annotations. Please select a different data source.
+            </Trans>
+          </Alert>
+        )}
         <Field label="Enabled" description="When enabled the annotation query is issued every dashboard refresh">
           <Checkbox
             name="enable"

--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -24,9 +24,11 @@ import {
   Select,
   useStyles2,
   Stack,
+  Alert,
 } from '@grafana/ui';
 import { ColorValueEditor } from 'app/core/components/OptionsUI/color';
 import config from 'app/core/config';
+import { Trans } from 'app/core/internationalization';
 import StandardAnnotationQueryEditor from 'app/features/annotations/components/StandardAnnotationQueryEditor';
 import { AngularEditorLoader } from 'app/features/dashboard-scene/settings/annotations/AngularEditorLoader';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
@@ -189,6 +191,13 @@ export const AnnotationSettingsEdit = ({ editIdx, dashboard }: Props) => {
         <Field label="Data source" htmlFor="data-source-picker">
           <DataSourcePicker annotations variables current={annotation.datasource} onChange={onDataSourceChange} />
         </Field>
+        {!ds?.meta.annotations && (
+          <Alert title="No annotation support for this data source" severity="error">
+            <Trans i18nKey="errors.dashboard-settings.annotations.datasource">
+              The selected data source does not support annotations. Please select a different data source.
+            </Trans>
+          </Alert>
+        )}
         <Field label="Enabled" description="When enabled the annotation query is issued every dashboard refresh">
           <Checkbox name="enable" id="enable" value={annotation.enable} onChange={onChange} />
         </Field>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -117,7 +117,7 @@
         "parse-mode-warning-title": "Telegram messages are limited to 4096 UTF-8 characters."
       },
       "used-by_one": "Used by {{ count }} notification policy",
-      "used-by_other": "Used by {{ count }} notification policies"
+      "used-by_other": "Used by {{ count }} notification policy"
     },
     "grafana-rules": {
       "export-rules": "Export rules",
@@ -234,15 +234,15 @@
     },
     "counts": {
       "alertRule_one": "{{count}} alert rule",
-      "alertRule_other": "{{count}} alert rules",
+      "alertRule_other": "{{count}} alert rule",
       "dashboard_one": "{{count}} dashboard",
-      "dashboard_other": "{{count}} dashboards",
+      "dashboard_other": "{{count}} dashboard",
       "folder_one": "{{count}} folder",
-      "folder_other": "{{count}} folders",
+      "folder_other": "{{count}} folder",
       "libraryPanel_one": "{{count}} library panel",
-      "libraryPanel_other": "{{count}} library panels",
+      "libraryPanel_other": "{{count}} library panel",
       "total_one": "{{count}} item",
-      "total_other": "{{count}} items"
+      "total_other": "{{count}} item"
     },
     "dashboards-tree": {
       "collapse-folder-button": "Collapse folder {{title}}",
@@ -673,6 +673,13 @@
     },
     "empty-state": {
       "message": "No data sources found"
+    }
+  },
+  "errors": {
+    "dashboard-settings": {
+      "annotations": {
+        "datasource": "The selected data source does not support annotations. Please select a different data source."
+      }
     }
   },
   "explore": {
@@ -1871,14 +1878,14 @@
       "confirm-text": "Delete",
       "delete-button": "Delete",
       "delete-loading": "Deleting...",
-      "text_one": "This action will delete {{numberOfDashboards}} dashboard.",
+      "text_one": "This action will delete {{numberOfDashboards}} dashboards.",
       "text_other": "This action will delete {{numberOfDashboards}} dashboards.",
       "title": "Permanently Delete Dashboards"
     },
     "restore-modal": {
       "restore-button": "Restore",
       "restore-loading": "Restoring...",
-      "text_one": "This action will restore {{numberOfDashboards}} dashboard.",
+      "text_one": "This action will restore {{numberOfDashboards}} dashboards.",
       "text_other": "This action will restore {{numberOfDashboards}} dashboards.",
       "title": "Restore Dashboards"
     }

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -117,7 +117,7 @@
         "parse-mode-warning-title": "Ŧęľęģřäm męşşäģęş äřę ľįmįŧęđ ŧő 4096 ŮŦF-8 čĥäřäčŧęřş."
       },
       "used-by_one": "Ůşęđ þy {{ count }} ŉőŧįƒįčäŧįőŉ pőľįčy",
-      "used-by_other": "Ůşęđ þy {{ count }} ŉőŧįƒįčäŧįőŉ pőľįčįęş"
+      "used-by_other": "Ůşęđ þy {{ count }} ŉőŧįƒįčäŧįőŉ pőľįčy"
     },
     "grafana-rules": {
       "export-rules": "Ēχpőřŧ řūľęş",
@@ -234,15 +234,15 @@
     },
     "counts": {
       "alertRule_one": "{{count}} äľęřŧ řūľę",
-      "alertRule_other": "{{count}} äľęřŧ řūľęş",
+      "alertRule_other": "{{count}} äľęřŧ řūľę",
       "dashboard_one": "{{count}} đäşĥþőäřđ",
-      "dashboard_other": "{{count}} đäşĥþőäřđş",
+      "dashboard_other": "{{count}} đäşĥþőäřđ",
       "folder_one": "{{count}} ƒőľđęř",
-      "folder_other": "{{count}} ƒőľđęřş",
+      "folder_other": "{{count}} ƒőľđęř",
       "libraryPanel_one": "{{count}} ľįþřäřy päŉęľ",
-      "libraryPanel_other": "{{count}} ľįþřäřy päŉęľş",
+      "libraryPanel_other": "{{count}} ľįþřäřy päŉęľ",
       "total_one": "{{count}} įŧęm",
-      "total_other": "{{count}} įŧęmş"
+      "total_other": "{{count}} įŧęm"
     },
     "dashboards-tree": {
       "collapse-folder-button": "Cőľľäpşę ƒőľđęř {{title}}",
@@ -673,6 +673,13 @@
     },
     "empty-state": {
       "message": "Ńő đäŧä şőūřčęş ƒőūŉđ"
+    }
+  },
+  "errors": {
+    "dashboard-settings": {
+      "annotations": {
+        "datasource": "Ŧĥę şęľęčŧęđ đäŧä şőūřčę đőęş ŉőŧ şūppőřŧ äŉŉőŧäŧįőŉş. Pľęäşę şęľęčŧ ä đįƒƒęřęŉŧ đäŧä şőūřčę."
+      }
     }
   },
   "explore": {
@@ -1871,14 +1878,14 @@
       "confirm-text": "Đęľęŧę",
       "delete-button": "Đęľęŧę",
       "delete-loading": "Đęľęŧįŉģ...",
-      "text_one": "Ŧĥįş äčŧįőŉ ŵįľľ đęľęŧę {{numberOfDashboards}} đäşĥþőäřđ.",
+      "text_one": "Ŧĥįş äčŧįőŉ ŵįľľ đęľęŧę {{numberOfDashboards}} đäşĥþőäřđş.",
       "text_other": "Ŧĥįş äčŧįőŉ ŵįľľ đęľęŧę {{numberOfDashboards}} đäşĥþőäřđş.",
       "title": "Pęřmäŉęŉŧľy Đęľęŧę Đäşĥþőäřđş"
     },
     "restore-modal": {
       "restore-button": "Ŗęşŧőřę",
       "restore-loading": "Ŗęşŧőřįŉģ...",
-      "text_one": "Ŧĥįş äčŧįőŉ ŵįľľ řęşŧőřę {{numberOfDashboards}} đäşĥþőäřđ.",
+      "text_one": "Ŧĥįş äčŧįőŉ ŵįľľ řęşŧőřę {{numberOfDashboards}} đäşĥþőäřđş.",
       "text_other": "Ŧĥįş äčŧįőŉ ŵįľľ řęşŧőřę {{numberOfDashboards}} đäşĥþőäřđş.",
       "title": "Ŗęşŧőřę Đäşĥþőäřđş"
     }


### PR DESCRIPTION
Backport f8cd448441b8761944c04239166e171f7607b455 from #92504

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this PR about?**

A runtime error occurred when a default data source with no annotation support was configured. In this pull request, I am handling the runtime error and informing the user the current data source is not supported.


#### Before:
`TypeError: this.angularComponent.getScope(...).$watch is not a function`

![image](https://github.com/user-attachments/assets/77701f4d-17dc-4ebe-8444-ea8b026e1fe7)


#### After:

![AnnotationDSNotSupported](https://github.com/user-attachments/assets/cb898521-3184-42ad-83b5-4c5a96914368)


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related [#11948](https://github.com/grafana/support-escalations/issues/11948)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
