### PR TITLE
DetectChanges: Serialize message payload to avoid non-clonable props

### DIFF
--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.test.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.test.ts
@@ -1,6 +1,22 @@
+import { SceneObjectStateChangedEvent } from '@grafana/scenes';
+import { Dashboard } from '@grafana/schema';
+import { CorsWorker } from 'app/core/utils/CorsWorker';
 import * as createDetectChangesWorker from 'app/features/dashboard-scene/saving/createDetectChangesWorker';
 
+import { DashboardScene } from '../scene/DashboardScene';
+
 import { DashboardSceneChangeTracker } from './DashboardSceneChangeTracker';
+
+jest.mock('../serialization/transformSceneToSaveModel', () => {
+  return {
+    transformSceneToSaveModel: () => {
+      return {
+        title: 'updated dashboard',
+        invalidProp: () => 'function',
+      };
+    },
+  };
+});
 
 describe('DashboardSceneChangeTracker', () => {
   it('should set _changesWorker to undefined when terminate is called', () => {
@@ -19,5 +35,33 @@ describe('DashboardSceneChangeTracker', () => {
     expect(changeTracker['_changesWorker']).not.toBeUndefined();
     changeTracker.terminate();
     expect(changeTracker['_changesWorker']).toBeUndefined();
+  });
+
+  it('should remove non clonable properties before sending to worker', () => {
+    const scene = new DashboardScene({});
+    const postMessage = jest.fn();
+
+    jest.spyOn(createDetectChangesWorker, 'createWorker').mockImplementation(() => {
+      return {
+        postMessage,
+      } as unknown as CorsWorker;
+    });
+    jest.spyOn(DashboardSceneChangeTracker, 'isUpdatingPersistedState').mockImplementation(() => {
+      return true;
+    });
+    jest.spyOn(scene, 'getInitialSaveModel').mockReturnValue({
+      title: 'initial dashboard',
+      invalidProp: () => 'function',
+    } as unknown as Dashboard);
+
+    const changeTracker = new DashboardSceneChangeTracker(scene);
+    changeTracker.startTrackingChanges();
+
+    scene.publishEvent({ type: SceneObjectStateChangedEvent.type, payload: { a: 1 } });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      initial: { title: 'initial dashboard' },
+      changed: { title: 'updated dashboard' },
+    });
   });
 });

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -139,10 +139,16 @@ export class DashboardSceneChangeTracker {
   }
 
   private detectSaveModelChanges() {
-    this._changesWorker?.postMessage({
-      changed: transformSceneToSaveModel(this._dashboard),
-      initial: this._dashboard.getInitialSaveModel(),
-    });
+    const changedDashboard = transformSceneToSaveModel(this._dashboard);
+    const initialDashboard = this._dashboard.getInitialSaveModel();
+
+    // Objects must be stringify to ensure they are clonable, so they don't contain functions
+    const changed =
+      typeof changedDashboard === 'object' ? JSON.parse(JSON.stringify(changedDashboard)) : changedDashboard;
+    const initial =
+      typeof initialDashboard === 'object' ? JSON.parse(JSON.stringify(initialDashboard)) : initialDashboard;
+
+    this._changesWorker?.postMessage({ initial, changed });
   }
 
   private hasMetadataChanges() {


### PR DESCRIPTION
**Problem**
We found some DS plugins that could include functions as props for the query options. This is incorrect but since we can't control every plugin in Grafana, we should remove any non-serializable prop before sending the JSON payload to the Worker.

When posting a message to a worker, the object must be [transferable objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects). This means it can't include functions or circular references.

We found the case of the GH plugin that includes a function as part of the query. This was breaking the change detection.

**Solution**
Serialize the object before sending it to the Worker.

**Error captured when updating a GitHub DS query**
![Captura de pantalla 2024-09-02 a las 17 52 45](https://github.com/user-attachments/assets/79608fe7-39ab-4452-8043-d45fe8cafc83)
