### PR TITLE
RBAC: Always store action sets

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -725,7 +725,7 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 }
 
 func (s *store) shouldStoreActionSet(resource, permission string) bool {
-	if !(s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) && permission != "") {
+	if permission == "" {
 		return false
 	}
 	actionSetName := GetActionSetName(resource, permission)


### PR DESCRIPTION
**What is this feature?**

Store action sets even if `accessActionSets` feature toggle is disabled.

**Why do we need this feature?**

We need to transition over to using action sets. We are adding a migration to add action sets where they are missing (https://github.com/grafana/grafana/pull/92832), so we also need to start always storing them (in case people downgrade after the migration has ran).

This should have no impact - it only stores action sets, but doesn't evaluate them for reads.

**Who is this feature for?**

Everyone that uses dash and folder permissions, but it shouldn't change the behaviour in any way.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/854