### PR TITLE
LibraryPanels: Migrate repeat options to the dashboard level

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -226,6 +226,9 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
     }
 
     if (!repeatedPanels) {
+      if (body instanceof LibraryVizPanel) {
+        return <body.Component model={body} key={body.state.key} />;
+      }
       return null;
     }
 

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
 import { useMemo } from 'react';
-import { Unsubscribable } from 'rxjs';
 
 import { config } from '@grafana/runtime';
 import {
@@ -43,7 +42,6 @@ export interface DashboardGridItemState extends SceneGridItemStateLike {
 export type RepeatDirection = 'v' | 'h';
 
 export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> implements SceneGridItemLike {
-  private _libPanelSubscription: Unsubscribable | undefined;
   private _prevRepeatValues?: VariableValueSingle[];
 
   protected _variableDependency = new DashboardGridItemVariableDependencyHandler(this);
@@ -59,45 +57,6 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
       this._subs.add(this.subscribeToState((newState, prevState) => this._handleGridResize(newState, prevState)));
       this.performRepeat();
     }
-
-    // Subscriptions that handles body updates, i.e. VizPanel -> LibraryVizPanel, AddLibPanelWidget -> LibraryVizPanel
-    this._subs.add(
-      this.subscribeToState((newState, prevState) => {
-        if (newState.body !== prevState.body) {
-          if (newState.body instanceof LibraryVizPanel) {
-            this.setupLibraryPanelChangeSubscription(newState.body);
-          }
-        }
-      })
-    );
-
-    // Initial setup of the lbrary panel subscription. Lib panels are lazy laded, so only then we can subscribe to the repeat config changes
-    if (this.state.body instanceof LibraryVizPanel) {
-      this.setupLibraryPanelChangeSubscription(this.state.body);
-    }
-
-    return () => {
-      this._libPanelSubscription?.unsubscribe();
-      this._libPanelSubscription = undefined;
-    };
-  }
-
-  private setupLibraryPanelChangeSubscription(panel: LibraryVizPanel) {
-    if (this._libPanelSubscription) {
-      this._libPanelSubscription.unsubscribe();
-      this._libPanelSubscription = undefined;
-    }
-
-    this._libPanelSubscription = panel.subscribeToState((newState) => {
-      if (newState._loadedPanel?.model.repeat) {
-        this.setState({
-          variableName: newState._loadedPanel.model.repeat,
-          repeatDirection: newState._loadedPanel.model.repeatDirection,
-          maxPerRow: newState._loadedPanel.model.maxPerRow,
-        });
-        this.performRepeat();
-      }
-    });
   }
 
   /**

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -7,6 +7,7 @@ import {
   VizPanelState,
 } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
+import { appEvents } from 'app/core/core';
 import { PanelModel } from 'app/features/dashboard/state';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
@@ -92,6 +93,11 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
       // Migrate repeat settings from lib panel to grid item
       if (this.parent instanceof DashboardGridItem) {
         if (!this.parent.state.variableName) {
+          appEvents.emit('alert-error', [
+            'Library panel with repeat detected',
+            'Panel repeat option has moved to the dashboard level. Save dashboard and reload to resolve any issues',
+          ]);
+
           this.parent.setState({
             variableName: libPanel.model.repeat,
             repeatDirection: libPanel.model.repeatDirection === 'h' ? 'h' : 'v',

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -7,7 +7,6 @@ import {
   VizPanelState,
 } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
-import { appEvents } from 'app/core/core';
 import { PanelModel } from 'app/features/dashboard/state';
 import { showLibrayPanelWithRepeatNotice } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
@@ -93,7 +92,7 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
 
       // Migrate repeat settings from lib panel to grid item
       if (this.parent instanceof DashboardGridItem) {
-        if (!this.parent.state.variableName) {
+        if (libPanel.model.repeat && !this.parent.state.variableName) {
           showLibrayPanelWithRepeatNotice();
 
           this.parent.setState({
@@ -101,6 +100,8 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
             repeatDirection: libPanel.model.repeatDirection === 'h' ? 'h' : 'v',
             maxPerRow: libPanel.model.maxPerRow,
           });
+
+          this.parent.performRepeat();
         }
       }
     } catch (err) {

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -88,12 +88,16 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
     try {
       const libPanel = await getLibraryPanel(this.state.uid, true);
       this.setPanelFromLibPanel(libPanel);
+
+      // Migrate repeat settings from lib panel to grid item
       if (this.parent instanceof DashboardGridItem) {
-        this.parent.setState({
-          variableName: libPanel.model.repeat,
-          repeatDirection: libPanel.model.repeatDirection === 'h' ? 'h' : 'v',
-          maxPerRow: libPanel.model.maxPerRow,
-        });
+        if (!this.parent.state.variableName) {
+          this.parent.setState({
+            variableName: libPanel.model.repeat,
+            repeatDirection: libPanel.model.repeatDirection === 'h' ? 'h' : 'v',
+            maxPerRow: libPanel.model.maxPerRow,
+          });
+        }
       }
     } catch (err) {
       vizPanel.setState({

--- a/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryVizPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { LibraryPanel } from '@grafana/schema';
 import { appEvents } from 'app/core/core';
 import { PanelModel } from 'app/features/dashboard/state';
+import { showLibrayPanelWithRepeatNotice } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
@@ -93,10 +94,7 @@ export class LibraryVizPanel extends SceneObjectBase<LibraryVizPanelState> {
       // Migrate repeat settings from lib panel to grid item
       if (this.parent instanceof DashboardGridItem) {
         if (!this.parent.state.variableName) {
-          appEvents.emit('alert-error', [
-            'Library panel with repeat detected',
-            'Panel repeat option has moved to the dashboard level. Save dashboard and reload to resolve any issues',
-          ]);
+          showLibrayPanelWithRepeatNotice();
 
           this.parent.setState({
             variableName: libPanel.model.repeat,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -29,7 +29,7 @@ import { AlertStatesDataLayer } from '../scene/AlertStatesDataLayer';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardControls } from '../scene/DashboardControls';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
-import { DashboardGridItem, RepeatDirection } from '../scene/DashboardGridItem';
+import { DashboardGridItem, DashboardGridItemState } from '../scene/DashboardGridItem';
 import { registerDashboardMacro } from '../scene/DashboardMacro';
 import { DashboardScene } from '../scene/DashboardScene';
 import { LibraryVizPanel } from '../scene/LibraryVizPanel';
@@ -307,17 +307,24 @@ export function buildGridItemForLibPanel(panel: PanelModel) {
     height: panel.gridPos.h,
     itemHeight: panel.gridPos.h,
     body,
+    ...getRepeatOptions(panel),
   });
 }
 
-export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
-  const repeatOptions: Partial<{ variableName: string; repeatDirection: RepeatDirection }> = panel.repeat
-    ? {
-        variableName: panel.repeat,
-        repeatDirection: panel.repeatDirection === 'h' ? 'h' : 'v',
-      }
-    : {};
+function getRepeatOptions(panel: PanelModel): Partial<DashboardGridItemState> {
+  if (!panel.repeat) {
+    return {};
+  }
 
+  return {
+    maxPerRow: panel.maxPerRow,
+    variableName: panel.repeat,
+    repeatDirection: panel.repeatDirection === 'v' ? 'v' : 'h',
+    width: panel.repeat != null && panel.repeatDirection === 'h' ? 24 : panel.gridPos.w,
+  };
+}
+
+export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
   const titleItems: SceneObject[] = [];
 
   titleItems.push(
@@ -368,12 +375,11 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     key: `grid-item-${panel.id}`,
     x: panel.gridPos.x,
     y: panel.gridPos.y,
-    width: repeatOptions.repeatDirection === 'h' ? 24 : panel.gridPos.w,
+    width: panel.gridPos.w,
     height: panel.gridPos.h,
     itemHeight: panel.gridPos.h,
     body,
-    maxPerRow: panel.maxPerRow,
-    ...repeatOptions,
+    ...getRepeatOptions(panel),
   });
 }
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -291,20 +291,6 @@ export class DashboardModel implements TimeModel {
     return this.panels
       .filter((panel) => this.isSnapshotTruthy() || !(panel.repeatPanelId || panel.repeatedByRow))
       .map((panel) => {
-        // Clean libarary panels on save
-        if (panel.libraryPanel) {
-          const { id, title, libraryPanel, gridPos } = panel;
-          return {
-            id,
-            title,
-            gridPos,
-            libraryPanel: {
-              uid: libraryPanel.uid,
-              name: libraryPanel.name,
-            },
-          };
-        }
-
         // If we save while editing we should include the panel in edit mode instead of the
         // unmodified source panel
         if (this.panelInEdit && this.panelInEdit.id === panel.id) {
@@ -681,7 +667,7 @@ export class DashboardModel implements TimeModel {
       return sourcePanel;
     }
 
-    const m = sourcePanel.getSaveModel();
+    const m = sourcePanel.getSaveModel(true);
     m.id = this.getNextPanelId();
     const clone = new PanelModel(m);
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -742,7 +742,6 @@ export class DashboardModel implements TimeModel {
       copy = this.getPanelRepeatClone(panel, index, panelIndex);
       copy.scopedVars ??= {};
       copy.scopedVars[variable.name] = option;
-      console.log('repeatPanel copy', copy);
 
       if (panel.repeatDirection === REPEAT_DIR_VERTICAL) {
         if (index > 0) {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -742,6 +742,7 @@ export class DashboardModel implements TimeModel {
       copy = this.getPanelRepeatClone(panel, index, panelIndex);
       copy.scopedVars ??= {};
       copy.scopedVars[variable.name] = option;
+      console.log('repeatPanel copy', copy);
 
       if (panel.repeatDirection === REPEAT_DIR_VERTICAL) {
         if (index > 0) {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -687,12 +687,23 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       switch (key) {
         case 'id':
         case 'gridPos':
+        case 'repeat':
+        case 'repeatDirection':
+        case 'maxPerRow':
         case 'libraryPanel': // recursive?
           continue;
       }
       (this as any)[key] = val; // :grimmice:
     }
+
     this.libraryPanel = libPanel;
+
+    if (libPanel.model.repeat && !this.repeatPanelId) {
+      this.repeat = libPanel.model.repeat;
+      this.repeatDirection = libPanel.model.repeatDirection;
+      this.maxPerRow = libPanel.model.maxPerRow;
+    }
+
     console.log('initLibraryPanel', this);
   }
 
@@ -734,6 +745,7 @@ function getSaveModelWithLibPanelRef(model: PanelModel) {
     gridPos: model.gridPos,
     repeat: model.repeat,
     repeatDirection: model.repeatDirection,
+    maxPerRow: model.maxPerRow,
     libraryPanel: {
       uid: model.libraryPanel!.uid,
       name: model.libraryPanel!.name,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -24,6 +24,7 @@ import {
 import { getTemplateSrv, RefreshEvent } from '@grafana/runtime';
 import { LibraryPanel, LibraryPanelRef } from '@grafana/schema';
 import config from 'app/core/config';
+import { appEvents } from 'app/core/core';
 import { safeStringifyValue } from 'app/core/utils/explore';
 import { QueryGroupOptions } from 'app/types';
 import {
@@ -698,13 +699,14 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
     this.libraryPanel = libPanel;
 
-    if (libPanel.model.repeat && !this.repeatPanelId) {
+    // Migrate repeat options on libary panel to the panel model
+    // But only if there is no repeat options set on panel and if this is not repeat clone
+    if (this.repeat == null && libPanel.model.repeat != null && !this.repeatPanelId) {
       this.repeat = libPanel.model.repeat;
       this.repeatDirection = libPanel.model.repeatDirection;
       this.maxPerRow = libPanel.model.maxPerRow;
+      showLibrayPanelWithRepeatNotice();
     }
-
-    console.log('initLibraryPanel', this);
   }
 
   unlinkLibraryPanel() {
@@ -751,4 +753,11 @@ function getSaveModelWithLibPanelRef(model: PanelModel) {
       name: model.libraryPanel!.name,
     },
   };
+}
+
+export function showLibrayPanelWithRepeatNotice() {
+  appEvents.emit('alert-error', [
+    'Library panel with repeat detected',
+    'Panel repeat option has moved to the dashboard level. Save dashboard and reload to resolve any issues',
+  ]);
 }

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -311,8 +311,13 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.render();
   }
 
-  getSaveModel() {
+  getSaveModel(forRepeat?: boolean): any {
     const model: any = {};
+
+    // Clean libarary panels on save
+    if (this.libraryPanel && !forRepeat) {
+      return getSaveModelWithLibPanelRef(this);
+    }
 
     for (const property in this) {
       if (notPersistedProperties[property] || !this.hasOwnProperty(property)) {
@@ -330,16 +335,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     if (this.type === 'row' && this.panels && this.panels.length > 0) {
       model.panels = this.panels.map((panel) => {
         if (panel.libraryPanel) {
-          const { id, title, libraryPanel, gridPos } = panel;
-          return {
-            id,
-            title,
-            gridPos,
-            libraryPanel: {
-              uid: libraryPanel.uid,
-              name: libraryPanel.name,
-            },
-          };
+          return getSaveModelWithLibPanelRef(this);
         }
 
         return panel;
@@ -697,6 +693,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       (this as any)[key] = val; // :grimmice:
     }
     this.libraryPanel = libPanel;
+    console.log('initLibraryPanel', this);
   }
 
   unlinkLibraryPanel() {
@@ -728,4 +725,18 @@ export function stringifyPanelModel(panel: PanelModel) {
     });
 
   return safeStringifyValue(model);
+}
+
+function getSaveModelWithLibPanelRef(model: PanelModel) {
+  return {
+    id: model.id,
+    title: model.title,
+    gridPos: model.gridPos,
+    repeat: model.repeat,
+    repeatDirection: model.repeatDirection,
+    libraryPanel: {
+      uid: model.libraryPanel!.uid,
+      name: model.libraryPanel!.name,
+    },
+  };
 }

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -155,13 +155,13 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
       const libPanel = await getLibraryPanel(uid, true);
       panel.initLibraryPanel(libPanel);
 
-      const dashboard = getStore().dashboard.getModel();
-      if (panel.repeat && dashboard) {
-        const panelIndex = dashboard.panels.findIndex((p) => p.id === panel.id);
-        dashboard.repeatPanel(panel, panelIndex);
-        dashboard.sortPanelsByGridPos();
-        dashboard.events.publish(new DashboardPanelsChangedEvent());
-      }
+      // const dashboard = getStore().dashboard.getModel();
+      // if (panel.repeat && dashboard) {
+      //   const panelIndex = dashboard.panels.findIndex((p) => p.id === panel.id);
+      //   dashboard.repeatPanel(panel, panelIndex);
+      //   dashboard.sortPanelsByGridPos();
+      //   dashboard.events.publish(new DashboardPanelsChangedEvent());
+      // }
 
       await dispatch(initPanelState(panel));
     } catch (ex) {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -156,11 +156,6 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
       const libPanel = await getLibraryPanel(uid, true);
       panel.initLibraryPanel(libPanel);
 
-      appEvents.emit('alert-error', [
-        'Library panel with repeat detected',
-        'Save dashboard and reload to fix any issues',
-      ]);
-
       await dispatch(initPanelState(panel));
     } catch (ex) {
       console.log('ERROR: ', ex);
@@ -172,4 +167,11 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
       );
     }
   };
+}
+
+export function showLibrayPanelWithRepeatNotice() {
+  appEvents.emit('alert-error', [
+    'Library panel with repeat detected',
+    'Panel repeat option has moved to the dashboard level. Save dashboard and reload to resolve any issues',
+  ]);
 }

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,11 +1,12 @@
 import { DataTransformerConfig, FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
+import appEvents from 'app/core/app_events';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { LibraryElementDTO } from 'app/features/library-panels/types';
 import { getPanelPluginNotFound } from 'app/features/panel/components/PanelPluginError';
 import { loadPanelPlugin } from 'app/features/plugins/admin/state/actions';
 import { ThunkResult } from 'app/types';
-import { DashboardPanelsChangedEvent, PanelOptionsChangedEvent, PanelQueriesChangedEvent } from 'app/types/events';
+import { PanelOptionsChangedEvent, PanelQueriesChangedEvent } from 'app/types/events';
 
 import { changePanelKey, panelModelAndPluginReady, removePanel } from './reducers';
 
@@ -155,13 +156,10 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
       const libPanel = await getLibraryPanel(uid, true);
       panel.initLibraryPanel(libPanel);
 
-      // const dashboard = getStore().dashboard.getModel();
-      // if (panel.repeat && dashboard) {
-      //   const panelIndex = dashboard.panels.findIndex((p) => p.id === panel.id);
-      //   dashboard.repeatPanel(panel, panelIndex);
-      //   dashboard.sortPanelsByGridPos();
-      //   dashboard.events.publish(new DashboardPanelsChangedEvent());
-      // }
+      appEvents.emit('alert-error', [
+        'Library panel with repeat detected',
+        'Save dashboard and reload to fix any issues',
+      ]);
 
       await dispatch(initPanelState(panel));
     } catch (ex) {


### PR DESCRIPTION
Think we made a mistake when we many years ago fixed a bug involving a library panel + repeats. This is something that we should never have supported. The repeating option acts on the "grid item" level (ie the dashboard) we should leave library panels as only a viz + queries thing and leave any layout options (gridPos, size, repeat etc to the dashboard they are used in). 

Supporting library panels with repeats in the old and new architecture is very messy and complex (in the old it's causing repeated/duplicated calls to the repeat process), in the scenes architecture it's causing a very messy state flow between DashboardGridItem and its containing panel. 

Also making panel edit more complicated. 

This PR explores moving it to the dashboard level. 

Current dashboards with library panels with repeats will see this error alert when they load it. I oped for this approach as it's the simplest implementation-wise and has the least complexity to the current code base going forward. I think it's not feasible to do it in Dashboard schema migrator (Without loading all library panels as part of schema migration). Because we load library panels async and this is after the repeating process has run all we can really do is show an error.

If a user changes variable or refreshes time (if the variable depends on time range) it will fix itself. But to be safe I recommend that users save and reload the dashboard. For scenes we might be able to simply call this.parent.performRepeat() after we migrate the options, but the width of the grid item is not correct (this is bug today in main where library panels with repeats does not get correct width). 

<img width="659" alt="Screenshot 2024-09-02 at 19 52 23" src="https://github.com/user-attachments/assets/ce488743-ee9a-4e3b-a881-4ed164f2ea52">

For the scenes implementation to fully work I think we need to merge https://github.com/grafana/grafana/pull/90886 (that changes library panels into behaviors) 