### PR TITLE
Fix `playlist` tests

### DIFF
--- a/pkg/apis/playlist/v0alpha1/register.go
+++ b/pkg/apis/playlist/v0alpha1/register.go
@@ -15,7 +15,7 @@ const (
 	VERSION       = "v0alpha1"
 	APIVERSION    = GROUP + "/" + VERSION
 	RESOURCE      = "playlists"
-	GROUPRESOURCE = GROUP + "/" + RESOURCE
+	RESOURCEGROUP = RESOURCE + "." + GROUP
 )
 
 var PlaylistResourceInfo = utils.NewResourceInfo(GROUP, VERSION,

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -94,7 +94,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 			DisableAnonymous:     true,
 			APIServerStorageType: "file", // write the files to disk
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode0,
 				},
 			},
@@ -110,7 +110,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 			DisableAnonymous:     true,
 			APIServerStorageType: "file", // write the files to disk
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode1,
 				},
 			},
@@ -126,7 +126,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 			DisableAnonymous:     true,
 			APIServerStorageType: "file", // write the files to disk
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode2,
 				},
 			},
@@ -142,7 +142,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 			DisableAnonymous:     true,
 			APIServerStorageType: "file", // write the files to disk
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode3,
 				},
 			},
@@ -161,7 +161,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode0,
 				},
 			},
@@ -186,7 +186,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode2,
 				},
 			},
@@ -202,7 +202,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode3,
 				},
 			},
@@ -218,7 +218,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 			DisableAnonymous:     true,
 			APIServerStorageType: "etcd", // requires etcd running on localhost:2379
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode0,
 				},
 			},
@@ -250,7 +250,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode1,
 				},
 			},
@@ -279,7 +279,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode2,
 				},
 			},
@@ -308,7 +308,7 @@ func TestIntegrationPlaylist(t *testing.T) {
 				featuremgmt.FlagKubernetesPlaylists, // Required so that legacy calls are also written
 			},
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				playlistv0alpha1.GROUPRESOURCE: {
+				playlistv0alpha1.RESOURCEGROUP: {
 					DualWriterMode: grafanarest.Mode3,
 				},
 			},


### PR DESCRIPTION
**What is this feature?**

This is a fix for `playlist` tests.
Per [this comment](https://github.com/grafana/grafana/blob/cdf035f813606da7b2deed779b84e1b1688020c9/pkg/setting/setting_unified_storage.go#L9-L14), the config key format is `[unified_storage.<group>.<resource>]`, for example `[unified_storage.playlists.playlist.grafana.app]`.
The current key used in tests is formed incorrectly and looks like this: `playlist.grafana.app/playlists`, hence the tests fail to setup the correct `DualWriter` mode.

Related to: https://github.com/grafana/grafana/pull/91882 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
