### PR TITLE
LibPanelBehavior: Fixes view panel and edit panel full page reload issues 

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -58,30 +58,6 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
       this.performRepeat();
     }
 
-    // Subscriptions that handles body updates
-    this._subs.add(
-      this.subscribeToState((newState, prevState) => {
-        if (newState.body !== prevState.body) {
-          if (newState.body instanceof VizPanel && isLibraryPanel(newState.body)) {
-            const libraryPanel = getLibraryPanelBehavior(newState.body);
-
-            if (!libraryPanel) {
-              return;
-            }
-            if (libraryPanel.state._loadedPanel?.model.repeat) {
-              this.setState({
-                variableName: libraryPanel.state._loadedPanel.model.repeat,
-                repeatDirection: libraryPanel.state._loadedPanel.model.repeatDirection,
-                maxPerRow: libraryPanel.state._loadedPanel.model.maxPerRow,
-                itemHeight: this.state.height ?? 10,
-              });
-              this.performRepeat();
-            }
-          }
-        }
-      })
-    );
-
     return () => {
       this._libPanelSubscription?.unsubscribe();
       this._libPanelSubscription = undefined;

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -24,9 +24,10 @@ import {
 } from '@grafana/scenes';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from 'app/core/constants';
 
-import { getMultiVariableValues, getQueryRunnerFor, isLibraryPanel, getLibraryPanelBehavior } from '../utils/utils';
+import { getMultiVariableValues, getQueryRunnerFor } from '../utils/utils';
 
 import { repeatPanelMenuBehavior } from './PanelMenuBehavior';
+import { DashboardLayoutElement } from './layouts/types';
 import { DashboardRepeatsProcessedEvent } from './types';
 
 export interface DashboardGridItemState extends SceneGridItemStateLike {
@@ -40,7 +41,10 @@ export interface DashboardGridItemState extends SceneGridItemStateLike {
 
 export type RepeatDirection = 'v' | 'h';
 
-export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> implements SceneGridItemLike {
+export class DashboardGridItem
+  extends SceneObjectBase<DashboardGridItemState>
+  implements SceneGridItemLike, DashboardLayoutElement
+{
   private _libPanelSubscription: Unsubscribable | undefined;
   private _prevRepeatValues?: VariableValueSingle[];
 
@@ -206,6 +210,20 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
   public isRepeated() {
     return this.state.variableName !== undefined;
   }
+
+  /**
+   * DashboardLayoutElement interface impementation
+   */
+  public isDashboardLayoutElement: true = true;
+
+  public setPanel(panel: VizPanel) {
+    this.setState({ body: panel });
+  }
+
+  public getPanel() {
+    return this.state.body;
+  }
+  /** End of DashboardLayoutElement interface impementation */
 
   public static Component = ({ model }: SceneComponentProps<DashboardGridItem>) => {
     const { repeatedPanels, itemHeight, variableName, body } = model.useState();

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -6,6 +6,7 @@ import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 
 import { DashboardGridItem } from './DashboardGridItem';
+import { isDashboardLayoutElement } from './layouts/types';
 
 interface LibraryPanelBehaviorState extends SceneObjectState {
   // Library panels use title from dashboard JSON's panel model, not from library panel definition, hence we pass it.
@@ -54,10 +55,15 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
     };
 
     this.setState({ _loadedPanel: libPanel, isLoaded: true, name: libPanel.name, title: libPanelModel.title });
-    vizPanel.setState(vizPanelState);
+
+    const layoutElement = vizPanel.parent!;
+
+    // Update panel instance on the layout element
+    if (isDashboardLayoutElement(layoutElement)) {
+      layoutElement.setPanel(vizPanel.clone(vizPanelState));
+    }
 
     // Migrate repeat options to layout element
-    const layoutElement = vizPanel.parent;
     if (libPanelModel.repeat && layoutElement instanceof DashboardGridItem) {
       layoutElement.setState({
         variableName: libPanelModel.repeat,

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -40,12 +40,6 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
       return;
     }
 
-    const gridItem = vizPanel.parent;
-
-    if (!(gridItem instanceof DashboardGridItem)) {
-      return;
-    }
-
     const libPanelModel = new PanelModel(libPanel.model);
 
     const vizPanelState: VizPanelState = {
@@ -60,9 +54,18 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
     };
 
     this.setState({ _loadedPanel: libPanel, isLoaded: true, name: libPanel.name, title: libPanelModel.title });
+    vizPanel.setState(vizPanelState);
 
-    const clone = vizPanel.clone(vizPanelState);
-    gridItem.setState({ body: clone });
+    // Migrate repeat options to layout element
+    const layoutElement = vizPanel.parent;
+    if (libPanelModel.repeat && layoutElement instanceof DashboardGridItem) {
+      layoutElement.setState({
+        variableName: libPanelModel.repeat,
+        repeatDirection: libPanelModel.repeatDirection === 'h' ? 'h' : 'v',
+        maxPerRow: libPanelModel.maxPerRow,
+      });
+      layoutElement.performRepeat();
+    }
   }
 
   private async loadLibraryPanelFromPanelModel() {

--- a/public/app/features/dashboard-scene/scene/ViewPanelScene.tsx
+++ b/public/app/features/dashboard-scene/scene/ViewPanelScene.tsx
@@ -12,12 +12,14 @@ import {
   SceneVariable,
 } from '@grafana/scenes';
 
+import { DashboardLayoutElement } from './layouts/types';
+
 interface ViewPanelSceneState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
   body?: VizPanel;
 }
 
-export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> {
+export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> implements DashboardLayoutElement {
   public constructor(state: ViewPanelSceneState) {
     super(state);
 
@@ -71,6 +73,18 @@ export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> {
 
   public getUrlKey() {
     return this.state.panelRef.resolve().state.key;
+  }
+
+  /**
+   * DashboardLayoutElement interface impementation
+   */
+  public isDashboardLayoutElement: true = true;
+
+  public setPanel(panel: VizPanel) {
+    this.setState({ body: panel });
+  }
+  public getPanel() {
+    return this.state.body!;
   }
 
   public static Component = ({ model }: SceneComponentProps<ViewPanelScene>) => {

--- a/public/app/features/dashboard-scene/scene/layouts/types.ts
+++ b/public/app/features/dashboard-scene/scene/layouts/types.ts
@@ -1,0 +1,25 @@
+import { SceneObject, VizPanel } from '@grafana/scenes';
+
+/**
+ * Abstraction to handle editing of different layout elements (wrappers for VizPanels and other objects)
+ * Also useful to when rendering / viewing an element outside it's layout scope
+ */
+export interface DashboardLayoutElement extends SceneObject {
+  /**
+   * Marks this object as a layout element
+   */
+  isDashboardLayoutElement: true;
+  /**
+   * Useful to update the layout element's inner panel
+   */
+  setPanel(panel: VizPanel): void;
+
+  /**
+   * Get the inner panel
+   */
+  getPanel(): VizPanel;
+}
+
+export function isDashboardLayoutElement(obj: SceneObject): obj is DashboardLayoutElement {
+  return 'isDashboardLayoutElement' in obj;
+}

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -253,22 +253,14 @@ export function getDefaultRow(dashboard: DashboardScene): SceneGridRow {
 }
 
 export function isLibraryPanel(vizPanel: VizPanel): boolean {
-  return Boolean(
-    vizPanel.state.$behaviors &&
-      vizPanel.state.$behaviors?.find((behaviour) => behaviour instanceof LibraryPanelBehavior) instanceof
-        LibraryPanelBehavior
-  );
+  return getLibraryPanelBehavior(vizPanel) !== undefined;
 }
 
 export function getLibraryPanelBehavior(vizPanel: VizPanel): LibraryPanelBehavior | undefined {
-  if (isLibraryPanel(vizPanel)) {
-    const behavior = vizPanel.state.$behaviors?.find((behaviour) => behaviour instanceof LibraryPanelBehavior);
+  const behavior = vizPanel.state.$behaviors?.find((behaviour) => behaviour instanceof LibraryPanelBehavior);
 
-    if (behavior instanceof LibraryPanelBehavior) {
-      return behavior;
-    }
-
-    return undefined;
+  if (behavior) {
+    return behavior;
   }
 
   return undefined;


### PR DESCRIPTION
Fixes issue in https://github.com/grafana/grafana/pull/90886 (merge base)

Doing a full page reload of view panel did not work (as the parent is not a grid item). 

I fixed it by introducing an small bit of an abstraction / interface from https://github.com/grafana/grafana/pull/92797 which we will need later. 

with this layout element abstraction the library behavior can replace the viz panel body in a way that works for both DashboardGridItem and ViewPanelScene.

Another bug is panel edit where  also full page reload is not working (in base PR or in this), for panel edit I am not sure what we should do we, updating the viz panel instance after could cause a lot of issues as the so much of panel edit might need to be re-initialized. Do not like it, need to rethink panel edit or how we go into panel edit... hmm

Got full page load into panel edit working it's not pretty, had to similar state sub in the URL sync handler to wait for the lib panel to load before going into panel edit. Made a bit extra complex as the LibraryPanelBehavior replaces the VizPanel instance on it's parent parent  (and the behavior clones itself which also adds a bit of complexity). But seems to working now. The only thing not working is going into panel edit for a repeated lib panel and having the variable scope be only the first value, but that is due to the repeat option being part of lib panel model instead of dashboard (something https://github.com/grafana/grafana/pull/92836 should fix)