### PR TITLE
Alerting: Fix cloud rules edit url

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -14,6 +14,7 @@ import InfoPausedRule from 'app/features/alerting/unified/components/InfoPausedR
 import {
   getRuleGroupLocationFromFormValues,
   getRuleGroupLocationFromRuleWithLocation,
+  isCloudRulerRule,
   isGrafanaManagedRuleByType,
   isGrafanaRulerRule,
   isGrafanaRulerRulePaused,
@@ -42,7 +43,7 @@ import {
   formValuesToRulerGrafanaRuleDTO,
   formValuesToRulerRuleDTO,
 } from '../../../utils/rule-form';
-import { fromRulerRuleAndRuleGroupIdentifier } from '../../../utils/rule-id';
+import { fromRulerRule, fromRulerRuleAndRuleGroupIdentifier, stringifyIdentifier } from '../../../utils/rule-id';
 import { GrafanaRuleExporter } from '../../export/GrafanaRuleExporter';
 import { AlertRuleNameAndMetric } from '../AlertRuleNameInput';
 import AnnotationsStep from '../AnnotationsStep';
@@ -167,6 +168,10 @@ export const AlertRuleForm = ({ existing, prefill }: Props) => {
 
     if (exitOnSave && returnTo) {
       locationService.push(returnTo);
+    } else if (isCloudRulerRule(ruleDefinition)) {
+      const { dataSourceName, namespaceName, groupName } = getRuleGroupLocationFromFormValues(values);
+      const updatedRuleIdentifier = fromRulerRule(dataSourceName, namespaceName, groupName, ruleDefinition);
+      locationService.replace(`/alerting/${encodeURIComponent(stringifyIdentifier(updatedRuleIdentifier))}/edit`);
     }
   };
 


### PR DESCRIPTION
**What is this feature?**
This PR fixes the URL on the Cloud Rules Edit page after saving updates to a rule.

The Cloud Rules URLs contain a hash that is generated based on the rule’s definition. When the rule is updated, the hash changes, which in turn changes the URL.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
