### PR TITLE
[v11.1.x] RBAC: Always store action sets

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -671,7 +671,7 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 	/*
 		Add ACTION SET of managed permissions to in-memory store
 	*/
-	if s.shouldStoreActionSet(permission) {
+	if s.shouldStoreActionSet(resource, permission) {
 		actionSetName := GetActionSetName(resource, permission)
 		p := managedPermission(actionSetName, resource, resourceID, resourceAttribute)
 		p.RoleID = roleID
@@ -683,13 +683,13 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 
 	// If there are no missing actions for the resource (in case of access level downgrade or resource removal), we don't need to insert any actions
 	// we still want to add the action set (when permission != "")
-	if len(missingActions) == 0 && !s.shouldStoreActionSet(permission) {
+	if len(missingActions) == 0 && !s.shouldStoreActionSet(resource, permission) {
 		return nil
 	}
 
 	// if we have actionset feature enabled and are only working with action sets
 	// skip adding the missing actions to the permissions table
-	if !(s.shouldStoreActionSet(permission) && s.cfg.OnlyStoreAccessActionSets) {
+	if !(s.shouldStoreActionSet(resource, permission) && s.cfg.OnlyStoreAccessActionSets) {
 		for action := range missingActions {
 			p := managedPermission(action, resource, resourceID, resourceAttribute)
 			p.RoleID = roleID
@@ -706,8 +706,12 @@ func (s *store) createPermissions(sess *db.Session, roleID int64, cmd SetResourc
 	return nil
 }
 
-func (s *store) shouldStoreActionSet(permission string) bool {
-	return (s.features.IsEnabled(context.TODO(), featuremgmt.FlagAccessActionSets) && permission != "")
+func (s *store) shouldStoreActionSet(resource, permission string) bool {
+	if permission == "" {
+		return false
+	}
+	actionSetName := GetActionSetName(resource, permission)
+	return isFolderOrDashboardAction(actionSetName)
 }
 
 func deletePermissions(sess *db.Session, ids []int64) error {


### PR DESCRIPTION
Backport 46e81e98cfd2cda4fc9f8d361bfe612a7d569428 from #92833

---

**What is this feature?**

Store action sets even if `accessActionSets` feature toggle is disabled.

**Why do we need this feature?**

We need to transition over to using action sets. We are adding a migration to add action sets where they are missing (https://github.com/grafana/grafana/pull/92832), so we also need to start always storing them (in case people downgrade after the migration has ran).

This should have no impact - it only stores action sets, but doesn't evaluate them for reads.

**Who is this feature for?**

Everyone that uses dash and folder permissions, but it shouldn't change the behaviour in any way.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/854
