### PR TITLE
Add link to row for dashboards

### DIFF
--- a/public/app/features/dashboard-scene/scene/row-actions/RowActions.tsx
+++ b/public/app/features/dashboard-scene/scene/row-actions/RowActions.tsx
@@ -110,6 +110,17 @@ export class RowActions extends SceneObjectBase<RowActionsState> {
     return undefined;
   };
 
+  private rowId = () => {
+    const row = this.getParent();
+    const { title } = row.useState();
+
+    return title.replace(/[.#\s]/g, '-').toLowerCase();
+  };
+
+  private rowAnchor = () => {
+    return `#${this.rowId()}`;
+  };
+
   static Component = ({ model }: SceneComponentProps<RowActions>) => {
     const dashboard = model.getDashboard();
     const row = model.getParent();
@@ -121,9 +132,14 @@ export class RowActions extends SceneObjectBase<RowActionsState> {
 
     return (
       <>
-        {meta.canEdit && isEditing && (
-          <>
-            <div className={styles.rowActions}>
+        <div className={styles.rowActions}>
+          <button type="button" aria-label="Link to row">
+            <a id={model.rowId()} href={model.rowAnchor()}>
+              <Icon name="link" />
+            </a>
+          </button>
+          {meta.canEdit && isEditing && (
+            <>
               <RowOptionsButton
                 title={title}
                 repeat={behaviour instanceof RowRepeaterBehavior ? behaviour.state.variableName : undefined}
@@ -134,9 +150,9 @@ export class RowActions extends SceneObjectBase<RowActionsState> {
               <button type="button" onClick={model.onDelete} aria-label="Delete row">
                 <Icon name="trash-alt" />
               </button>
-            </div>
-          </>
-        )}
+            </>
+          )}
+        </div>
       </>
     );
   };


### PR DESCRIPTION
> [!NOTE]:
> This is a work in progress and doesn't yet implement the feature.
> I just wanted to continue the discussion to get it implemented.

**What is this feature?**

This PR attempts to pick up from where https://github.com/grafana/grafana/pull/88155 left off and implement the functionality to link to a specific row in a dashboard.

The core functionality should be:

- Each row should have a clickable link for retrieving the row ID. There may be complications in supporting rows repeated with template variables. I'm happy to consider that out of scope for the MVP of this feature.
- Opening the URL with the row id fragment should take a user to that row in the dashboard.
- Collapsed rows should be uncollapsed when they are linked to directly.

So far I've implemented the link button but I'm unclear on the following:
- How do I set the row ID for the scenes row?
  
  Is that going to require me to make upstream changes in https://github.com/grafana/scenes/blob/main/packages/scenes/src/components/layout/grid/SceneGridRow.tsx?

- https://github.com/grafana/grafana/pull/88155 used the `componentDidMount` hook to uncollapse the row but I'm not sure what scenes hooks I can use to uncollapse a row after the component is mounted.

**Why do we need this feature?**

In long dashboards, or dashboards with many collapsed sections, it's useful to be able to take a view to a specific section and not just a specific panel.

**Who is this feature for?**

Users that wish to share long or sectioned Grafana dashboards.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/82827

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
