### PR TITLE
RestoreDashboards: Show root location as 'Dashboards' in folder picker

### DIFF
--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -54,7 +54,7 @@ type Folder struct {
 }
 
 var GeneralFolder = Folder{ID: 0, Title: "General"}
-var RootFolder = &Folder{ID: 0, Title: "Root", UID: GeneralFolderUID, ParentUID: ""}
+var RootFolder = &Folder{ID: 0, Title: "Dashbboards", UID: GeneralFolderUID, ParentUID: ""}
 var SharedWithMeFolder = Folder{
 	Title:       "Shared with me",
 	Description: "Dashboards and folders shared with me",

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -250,7 +250,7 @@ export function NestedFolderPicker({
   });
 
   let label = selectedFolder.data?.title;
-  if (value === '') {
+  if (value === '' || label === 'Root') {
     label = 'Dashboards';
   }
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -250,7 +250,7 @@ export function NestedFolderPicker({
   });
 
   let label = selectedFolder.data?.title;
-  if (value === '' || label === 'Root') {
+  if (value === '') {
     label = 'Dashboards';
   }
 


### PR DESCRIPTION
**What is this feature?**
If the UID of the original folder is `general` and the folder picker is showing a preset value the folder is called `Root`. When opening the tree it is shown as `Dashboards`. This PR replaces the `Root` by `Dashboards`

**Why do we need this feature?**
Consistency

**Which issue(s) does this PR fix?**:
Fixes #92736

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
