### PR TITLE
RBAC: Hide the root level dashboard creation button from users who can't create dashboards on root level

### DIFF
--- a/public/app/features/browse-dashboards/permissions.ts
+++ b/public/app/features/browse-dashboards/permissions.ts
@@ -3,10 +3,7 @@ import { contextSrv } from 'app/core/core';
 import { AccessControlAction, FolderDTO } from 'app/types';
 
 function checkFolderPermission(action: AccessControlAction, folderDTO?: FolderDTO) {
-  // Only some permissions are assigned in the root folder (aka "general" folder), so we can ignore them in most cases
-  return folderDTO && folderDTO.uid !== 'general'
-    ? contextSrv.hasPermissionInMetadata(action, folderDTO)
-    : contextSrv.hasPermission(action);
+  return folderDTO ? contextSrv.hasPermissionInMetadata(action, folderDTO) : contextSrv.hasPermission(action);
 }
 
 function checkCanCreateFolders(folderDTO?: FolderDTO) {
@@ -25,9 +22,7 @@ function checkCanCreateFolders(folderDTO?: FolderDTO) {
     );
   }
 
-  return folderDTO
-    ? contextSrv.hasPermissionInMetadata(AccessControlAction.FoldersCreate, folderDTO)
-    : contextSrv.hasPermission(AccessControlAction.FoldersCreate);
+  return checkFolderPermission(AccessControlAction.FoldersCreate, folderDTO);
 }
 
 export function getFolderPermissions(folderDTO?: FolderDTO) {


### PR DESCRIPTION
**What is this feature?**

Hiding dashboard creation button on the root level dashboard page for users who can't create dashboards there.

Before the change:
<img width="945" alt="Screenshot 2024-09-04 at 16 49 01" src="https://github.com/user-attachments/assets/30c79064-6d52-4395-bcf0-7510fff34adc">

After the change:
<img width="943" alt="Screenshot 2024-09-04 at 16 46 40" src="https://github.com/user-attachments/assets/6b910912-3057-444a-b7ea-0db88df794fb">

**Why do we need this feature?**

The button appears for users who can create dashboards anywhere (eg, in one of the folders). But it has been confusing for users when displayed on the root level, as this makes users assume that they can create dashboards there.

**Who is this feature for?**

Anyone

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/89205
