### PR TITLE
CI/CD: Update retry logic for package validation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3879,8 +3879,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - 'echo "Step 6: Verifying Grafana installation..."'
@@ -3928,8 +3928,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - '    echo "Verifying GPG key..."'
@@ -4056,8 +4056,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - 'echo "Step 6: Verifying Grafana installation..."'
@@ -4106,8 +4106,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - '    echo "Verifying GPG key..."'
@@ -6108,6 +6108,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 7c752913b444e0efe410d5a8a0d300e1b4d48d2cac8df602c35314bc62b7ac3c
+hmac: 2d2609164c9a0848f1ea367a2cf2bcc7cd82f1b8f6507261b719a56d58795afc
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1266,7 +1266,8 @@ def publish_linux_packages_step(package_manager = "deb"):
         },
     }
 
-def retry_command(command, attempts = 5, delay = 60):
+# This retry will currently continue for 10 minutes until fail, unless successful.
+def retry_command(command, attempts = 20, delay = 30):
     return [
         "for i in $(seq 1 %d); do" % attempts,
         "    if %s; then" % command,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1266,8 +1266,8 @@ def publish_linux_packages_step(package_manager = "deb"):
         },
     }
 
-# This retry will currently continue for 10 minutes until fail, unless successful.
-def retry_command(command, attempts = 20, delay = 30):
+# This retry will currently continue for 15 minutes until fail, unless successful.
+def retry_command(command, attempts = 30, delay = 30):
     return [
         "for i in $(seq 1 %d); do" % attempts,
         "    if %s; then" % command,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1266,8 +1266,8 @@ def publish_linux_packages_step(package_manager = "deb"):
         },
     }
 
-# This retry will currently continue for 15 minutes until fail, unless successful.
-def retry_command(command, attempts = 30, delay = 30):
+# This retry will currently continue for 30 minutes until fail, unless successful.
+def retry_command(command, attempts = 60, delay = 30):
     return [
         "for i in $(seq 1 %d); do" % attempts,
         "    if %s; then" % command,


### PR DESCRIPTION
**What is this feature?**

This updates the retry logic when validating our build packages, specifically our RPM build was having timeout issues and failing.

**Why do we need this feature?**

Our RPM package validation was failing, most likely due to the time it takes for the new build to become available in the RPM repo for use. Sometimes it can take upwards of 5-10+ minutes; this PR updates the logic from 5 to 15 minutes to retries.

**Who is this feature for?**

Release engineers.

**Which issue(s) does this PR fix?**:

Fixes: https://github.com/grafana/grafana-release/issues/1108

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
