### PR TITLE
Explore Metrics: Fix infinite loop while opening a panel in explore metrics

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { AdHocVariableFilter, GrafanaTheme2, PageLayoutType, VariableHide, urlUtil } from '@grafana/data';
+import { AdHocVariableFilter, GrafanaTheme2, urlUtil, VariableHide } from '@grafana/data';
 import { config, locationService, useChromeHeaderHeight } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -24,7 +24,6 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
-import { Page } from 'app/core/components/Page/Page';
 
 import { DataTrailSettings } from './DataTrailSettings';
 import { DataTrailHistory } from './DataTrailsHistory';
@@ -35,7 +34,6 @@ import { getTrailStore } from './TrailStore/TrailStore';
 import { MetricDatasourceHelper } from './helpers/MetricDatasourceHelper';
 import { reportChangeInLabelFilters } from './interactions';
 import { MetricSelectedEvent, trailDS, VAR_DATASOURCE, VAR_FILTERS } from './shared';
-import { getMetricName } from './utils';
 
 export interface DataTrailState extends SceneObjectState {
   topScene?: SceneObject;
@@ -211,7 +209,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
   }
 
   static Component = ({ model }: SceneComponentProps<DataTrail>) => {
-    const { controls, topScene, history, settings, metric } = model.useState();
+    const { controls, topScene, history, settings } = model.useState();
     const chromeHeaderHeight = useChromeHeaderHeight();
     const styles = useStyles2(getStyles, chromeHeaderHeight ?? 0);
     const showHeaderForFirstTimeUsers = getTrailStore().recent.length < 2;

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -217,21 +217,19 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     const showHeaderForFirstTimeUsers = getTrailStore().recent.length < 2;
 
     return (
-      <Page navId="explore/metrics" pageNav={{ text: getMetricName(metric) }} layout={PageLayoutType.Custom}>
-        <div className={styles.container}>
-          {showHeaderForFirstTimeUsers && <MetricsHeader />}
-          <history.Component model={history} />
-          {controls && (
-            <div className={styles.controls}>
-              {controls.map((control) => (
-                <control.Component key={control.state.key} model={control} />
-              ))}
-              <settings.Component model={settings} />
-            </div>
-          )}
-          <div className={styles.body}>{topScene && <topScene.Component model={topScene} />}</div>
-        </div>
-      </Page>
+      <div className={styles.container}>
+        {showHeaderForFirstTimeUsers && <MetricsHeader />}
+        <history.Component model={history} />
+        {controls && (
+          <div className={styles.controls}>
+            {controls.map((control) => (
+              <control.Component key={control.state.key} model={control} />
+            ))}
+            <settings.Component model={settings} />
+          </div>
+        )}
+        <div className={styles.body}>{topScene && <topScene.Component model={topScene} />}</div>
+      </div>
     );
   };
 }

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -11,7 +11,7 @@ import { DataTrailsHome } from './DataTrailsHome';
 import { MetricsHeader } from './MetricsHeader';
 import { getTrailStore } from './TrailStore/TrailStore';
 import { HOME_ROUTE, TRAILS_ROUTE } from './shared';
-import { getUrlForTrail, newMetricsTrail } from './utils';
+import { getMetricName, getUrlForTrail, newMetricsTrail } from './utils';
 
 export interface DataTrailsAppState extends SceneObjectState {
   trail: DataTrail;
@@ -55,6 +55,7 @@ export class DataTrailsApp extends SceneObjectBase<DataTrailsAppState> {
 
 function DataTrailView({ trail }: { trail: DataTrail }) {
   const [isInitialized, setIsInitialized] = useState(false);
+  const { metric } = trail.useState();
 
   useEffect(() => {
     if (!isInitialized) {
@@ -69,7 +70,9 @@ function DataTrailView({ trail }: { trail: DataTrail }) {
 
   return (
     <UrlSyncContextProvider scene={trail}>
-      <trail.Component model={trail} />
+      <Page navId="explore/metrics" pageNav={{ text: getMetricName(metric) }} layout={PageLayoutType.Custom}>
+        <trail.Component model={trail} />
+      </Page>
     </UrlSyncContextProvider>
   );
 }

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import { PageLayoutType } from '@grafana/data';


### PR DESCRIPTION
**What is this feature?**

With [the PR](https://github.com/grafana/grafana/pull/88836) an infinite loop occurs while trying to open a panel in explore metrics. This PR is moving the `Page` wrapper to one level up so the infinite loop won't occur. 

Create a dashboard panel and try to open it in Explore Metrics. 
![image](https://github.com/user-attachments/assets/e5736096-d1c6-4d93-ac9c-2dab9a0b2bd3)

You'll get the following error and the browser tab will freeze completely. Switch to this branch and try again. 

<details><summary>Error Details</summary>

```
react-dom.development.js:86 Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
    at Page (http://localhost:3000/public/build/app.03bdfac….js:189344:3)
    at push../public/app/features/trails/DataTrail.tsx.Component (http://localhost:3000/public/build/app.03bdfac….js:296353:25)
    at SceneComponentWrapperWithoutMemo (http://localhost:3000/public/build/app.03bdfac….js:33782:18)
    at DataTrailEmbeddedRenderer (http://localhost:3000/public/build/app.03bdfac….js:296932:38)
    at SceneComponentWrapperWithoutMemo (http://localhost:3000/public/build/app.03bdfac….js:33782:18)
    at div
    at div
    at div
    at div
    at Scrollbars (http://localhost:3000/public/build/app.03bdfac….js:425280:9)
    at CustomScrollbar (http://localhost:3000/public/build/app.03bdfac….js:140811:3)
    at div
    at $9bf71ea28793e738$export$20e40289641fbbb6 (http://localhost:3000/public/build/app.03bdfac….js:593461:21)
    at div
    at DrawerPanel (http://localhost:3000/public/build/app.03bdfac….js:410259:25)
    at div
    at DomWrapper (http://localhost:3000/public/build/app.03bdfac….js:411010:90)
    at http://localhost:3000/public/build/app.03bdfac….js:410696:32
    at div
    at DrawerPopup (http://localhost:3000/public/build/app.03bdfac….js:410329:25)
    at http://localhost:3000/public/build/app.03bdfac….js:84758:20
    at Drawer (http://localhost:3000/public/build/app.03bdfac….js:410116:27)
    at Drawer (http://localhost:3000/public/build/app.03bdfac….js:146978:3)
    at SceneDrawer (http://localhost:3000/public/build/app.03bdfac….js:296973:11)
    at Component (http://localhost:3000/public/build/app.03bdfac….js:296981:22)
    at SceneComponentWrapperWithoutMemo (http://localhost:3000/public/build/app.03bdfac….js:33782:18)
    at div
    at Page (http://localhost:3000/public/build/app.03bdfac….js:189344:3)
    at DashboardSceneRenderer (http://localhost:3000/public/build/app.03bdfac….js:230580:35)
    at SceneComponentWrapperWithoutMemo (http://localhost:3000/public/build/app.03bdfac….js:33782:18)
    at UrlSyncContextProvider (http://localhost:3000/public/build/app.03bdfac….js:37439:35)
    at DashboardScenePage (http://localhost:3000/public/build/DashboardPageProxy.95c57c0….js:698:31)
    at DashboardPageProxy (http://localhost:3000/public/build/DashboardPageProxy.95c57c0….js:6816:29)
    at Suspense
    at ErrorBoundary (http://localhost:3000/public/build/app.03bdfac….js:147731:5)
    at GrafanaRoute (http://localhost:3000/public/build/app.03bdfac….js:195447:102)
    at Route (http://localhost:3000/public/build/app.03bdfac….js:491919:29)
    at RenderedRoute (http://localhost:3000/public/build/app.03bdfac….js:490154:5)
    at Routes (http://localhost:3000/public/build/app.03bdfac….js:490844:5)
    at CompatRoute (http://localhost:3000/public/build/app.03bdfac….js:484329:5)
    at Switch (http://localhost:3000/public/build/app.03bdfac….js:492121:29)
    at div
    at http://localhost:3000/public/build/app.03bdfac….js:153146:5
    at main
    at div
    at div
    at div
    at AppChrome (http://localhost:3000/public/build/app.03bdfac….js:182198:22)
    at div
    at ModalsContextProvider (http://localhost:3000/public/build/app.03bdfac….js:193678:76)
    at RenderedRoute (http://localhost:3000/public/build/app.03bdfac….js:490154:5)
    at Routes (http://localhost:3000/public/build/app.03bdfac….js:490844:5)
    at Router (http://localhost:3000/public/build/app.03bdfac….js:490778:15)
    at CompatRouter (http://localhost:3000/public/build/app.03bdfac….js:484345:5)
    at LocationServiceProvider (http://localhost:3000/public/build/app.03bdfac….js:133238:3)
    at Router (http://localhost:3000/public/build/app.03bdfac….js:491538:30)
    at KBarProvider (http://localhost:3000/public/build/app.03bdfac….js:347982:48)
    at SkeletonTheme (http://localhost:3000/public/build/app.03bdfac….js:644598:26)
    at ThemeProvider (http://localhost:3000/public/build/app.03bdfac….js:199354:26)
    at ErrorBoundary (http://localhost:3000/public/build/app.03bdfac….js:147731:5)
    at ErrorBoundaryAlert (http://localhost:3000/public/build/app.03bdfac….js:147769:1)
    at Provider (http://localhost:3000/public/build/app.03bdfac….js:645663:3)
    at AppWrapper (http://localhost:3000/public/build/app.03bdfac….js:180707:5)
```
</details>


