### PR TITLE
Triager: Add area/query-library to commands.json

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -1098,5 +1098,13 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/457"
     }
+  },
+  {
+    "type": "label",
+    "name": "area/query-library",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/736"
+    }
   }
 ]


### PR DESCRIPTION
**What is this feature?**

updates commands.json to include the label area/query-library and its project

**Why do we need this feature?**

to more accurately assign teams to issues
