### PR TITLE
Alerting/Chore: Move plugin logic into render test util method and remove mocks

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -3,10 +3,8 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { render, screen, waitFor, within } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
-import { PluginExtensionTypes } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { locationService, setAppEvents, usePluginLinks } from '@grafana/runtime';
-import appEvents from 'app/core/app_events';
+import { locationService } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { setAlertmanagerChoices } from 'app/features/alerting/unified/mocks/server/configure';
 import * as actions from 'app/features/alerting/unified/state/actions';
@@ -36,12 +34,6 @@ import {
 import { setupPluginsExtensionsHook } from './testSetup/plugins';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getPluginLinkExtensions: jest.fn(),
-  usePluginLinks: jest.fn(),
-  useReturnToPrevious: jest.fn(),
-}));
 jest.mock('./api/buildInfo');
 jest.mock('./api/prometheus');
 jest.mock('./api/ruler');
@@ -49,11 +41,9 @@ jest.mock('./api/ruler');
 jest.spyOn(actions, 'rulesInSameGroupHaveInvalidFor').mockReturnValue([]);
 jest.spyOn(apiRuler, 'rulerUrlBuilder');
 
-setAppEvents(appEvents);
 setupPluginsExtensionsHook();
 
 const mocks = {
-  usePluginLinksMock: jest.mocked(usePluginLinks),
   rulesInSameGroupHaveInvalidForMock: jest.mocked(actions.rulesInSameGroupHaveInvalidFor),
 
   api: {
@@ -143,20 +133,7 @@ describe('RuleList', () => {
       AccessControlAction.AlertingRuleExternalWrite,
     ]);
     mocks.rulesInSameGroupHaveInvalidForMock.mockReturnValue([]);
-    mocks.usePluginLinksMock.mockReturnValue({
-      links: [
-        {
-          pluginId: 'grafana-ml-app',
-          id: '1',
-          type: PluginExtensionTypes.link,
-          title: 'Run investigation',
-          category: 'Sift',
-          description: 'Run a Sift investigation for this alert',
-          onClick: jest.fn(),
-        },
-      ],
-      isLoading: false,
-    });
+
     setupDataSources(...Object.values(dataSources));
   });
 

--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -8,11 +8,6 @@ import { setupGrafanaManagedServer, withExternalOnlySetting } from './components
 import { setupMswServer } from './mockApi';
 import { grantUserRole } from './mocks';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  useReturnToPrevious: jest.fn(),
-}));
-
 const server = setupMswServer();
 
 const ui = {

--- a/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertInstanceExtensionPoint.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useMemo, useState } from 'react';
 
 import { PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
-import { Dropdown, IconButton } from '@grafana/ui';
+import { Dropdown, Icon, IconButton } from '@grafana/ui';
 import { t } from 'app/core/internationalization';
 import { ConfirmNavigationModal } from 'app/features/explore/extensions/ConfirmNavigationModal';
 // We might want to customise this in future but right now the toolbar menu from the Explore view is fine.
@@ -22,8 +22,11 @@ export const AlertInstanceExtensionPoint = ({
 }: AlertInstanceExtensionPointProps): ReactElement | null => {
   const [selectedExtension, setSelectedExtension] = useState<PluginExtensionLink | undefined>();
   const context = useMemo(() => ({ instance, rule }), [instance, rule]);
-  const { links } = usePluginLinks({ context, extensionPointId, limitPerPlugin: 3 });
+  const { isLoading, links } = usePluginLinks({ context, extensionPointId, limitPerPlugin: 3 });
 
+  if (isLoading) {
+    return <Icon name="spinner" role="progressbar" />;
+  }
   if (links.length === 0) {
     return null;
   }

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
 import { byLabelText, byRole, byText } from 'testing-library-selector';
 
+import { PluginExtensionPoints } from '@grafana/data';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { AlertManagerDataSourceJsonData } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
@@ -13,7 +14,6 @@ import {
   grantUserPermissions,
   mockCombinedCloudRuleNamespace,
   mockDataSource,
-  mockPluginLinkExtension,
   mockPromAlertingRule,
   mockRulerGrafanaRecordingRule,
 } from '../../mocks';
@@ -62,7 +62,6 @@ const ELEMENTS = {
 };
 
 setupMswServer();
-setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'mimir-1' }));
 
 const openSilenceDrawer = async () => {
   const user = userEvent.setup();
@@ -392,17 +391,30 @@ const renderRuleViewer = async (rule: CombinedRule, identifier: RuleIdentifier, 
     </AlertRuleProvider>,
     {
       historyOptions: { initialEntries: [path] },
-      pluginLinks: () => ({
-        links: [
-          mockPluginLinkExtension({ pluginId: 'grafana-slo-app', title: 'SLO dashboard', path: '/a/grafana-slo-app' }),
-          mockPluginLinkExtension({
-            pluginId: 'grafana-asserts-app',
-            title: 'Open workbench',
-            path: '/a/grafana-asserts-app',
-          }),
-        ],
-        isLoading: false,
-      }),
+      pluginLinks: [
+        {
+          pluginId: 'grafana-slo-app',
+          configs: [
+            {
+              targets: PluginExtensionPoints.AlertingAlertingRuleAction,
+              title: 'SLO dashboard',
+              description: '1',
+              path: '/a/grafana-slo-app/foo-bar',
+            },
+          ],
+        },
+        {
+          pluginId: 'grafana-asserts-app',
+          configs: [
+            {
+              targets: PluginExtensionPoints.AlertingAlertingRuleAction,
+              title: 'Open workbench',
+              description: '1',
+              path: '/a/grafana-asserts-app/foo',
+            },
+          ],
+        },
+      ],
     }
   );
 

--- a/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
@@ -3,7 +3,18 @@ import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { DataSourceInstanceSettings, GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Button, Field, Icon, Input, Label, RadioButtonGroup, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import {
+  Button,
+  Field,
+  Icon,
+  Input,
+  Label,
+  LoadingPlaceholder,
+  RadioButtonGroup,
+  Stack,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
 import { DashboardPicker } from 'app/core/components/Select/DashboardPicker';
 import { contextSrv } from 'app/core/core';
 import { Trans, t } from 'app/core/internationalization';
@@ -53,7 +64,7 @@ const RuleStateOptions = Object.entries(PromAlertingRuleState).map(([key, value]
 
 const RulesFilter = ({ onClear = () => undefined }: RulesFilerProps) => {
   const styles = useStyles2(getStyles);
-  const { pluginsFilterEnabled } = usePluginsFilterStatus();
+  const { isLoading: pluginsIsLoading, pluginsFilterEnabled } = usePluginsFilterStatus();
   const { filterState, hasActiveFilters, searchQuery, setSearchQuery, updateFilters } = useRulesFilter();
 
   // This key is used to force a rerender on the inputs when the filters are cleared
@@ -125,6 +136,10 @@ const RulesFilter = ({ onClear = () => undefined }: RulesFilerProps) => {
   };
 
   const searchIcon = <Icon name={'search'} />;
+
+  if (pluginsIsLoading) {
+    return <LoadingPlaceholder text={t('alerting.common.loading', 'Loading...')} />;
+  }
 
   return (
     <Stack direction="column" gap={0}>
@@ -251,7 +266,7 @@ const RulesFilter = ({ onClear = () => undefined }: RulesFilerProps) => {
             </Stack>
           </AlertmanagerProvider>
         )}
-        {pluginsFilterEnabled && (
+        {!pluginsIsLoading && pluginsFilterEnabled && (
           <div>
             <Label>
               <Trans i18nKey="alerting.rules-filter.plugin-rules">Plugin rules</Trans>
@@ -418,8 +433,8 @@ const helpStyles = (theme: GrafanaTheme2) => ({
 });
 
 function usePluginsFilterStatus() {
-  const { components } = useAlertingHomePageExtensions();
-  return { pluginsFilterEnabled: components.length > 0 };
+  const { components, isLoading } = useAlertingHomePageExtensions();
+  return { isLoading, pluginsFilterEnabled: components.length > 0 };
 }
 
 export default RulesFilter;

--- a/public/app/features/alerting/unified/components/rules/RuleActionsButtons.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleActionsButtons.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, userEvent } from 'test/test-utils';
 import { byLabelText, byRole } from 'testing-library-selector';
 
-import { config, locationService, setPluginLinksHook } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { interceptLinkClicks } from 'app/core/navigation/patch/interceptLinkClicks';
 import { contextSrv } from 'app/core/services/context_srv';
 import { RuleActionsButtons } from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
@@ -58,11 +58,6 @@ const getMenuContents = async () => {
 
   return [...allMenuItems, ...allLinkItems];
 };
-
-setPluginLinksHook(() => ({
-  links: [],
-  isLoading: false,
-}));
 
 const mimirDs = mockDataSource({ uid: MIMIR_DATASOURCE_UID, name: 'Mimir' });
 const prometheusDs = mockDataSource({ uid: 'prometheus', name: 'Prometheus' });

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
@@ -1,8 +1,6 @@
 import { render } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { PluginExtensionTypes } from '@grafana/data';
-import { usePluginLinks } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
 import { useIsRuleEditable } from '../../hooks/useIsRuleEditable';
@@ -10,16 +8,9 @@ import { getCloudRule, getGrafanaRule } from '../../mocks';
 
 import { RuleDetails } from './RuleDetails';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  usePluginLinks: jest.fn(),
-  useReturnToPrevious: jest.fn(),
-}));
-
 jest.mock('../../hooks/useIsRuleEditable');
 
 const mocks = {
-  usePluginLinksMock: jest.mocked(usePluginLinks),
   useIsRuleEditable: jest.mocked(useIsRuleEditable),
 };
 
@@ -34,23 +25,6 @@ setupMswServer();
 
 beforeAll(() => {
   jest.clearAllMocks();
-});
-
-beforeEach(() => {
-  mocks.usePluginLinksMock.mockReturnValue({
-    links: [
-      {
-        pluginId: 'grafana-ml-app',
-        id: '1',
-        type: PluginExtensionTypes.link,
-        title: 'Run investigation',
-        category: 'Sift',
-        description: 'Run a Sift investigation for this alert',
-        onClick: jest.fn(),
-      },
-    ],
-    isLoading: false,
-  });
 });
 
 describe('RuleDetails RBAC', () => {

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
@@ -1,4 +1,5 @@
-import { render } from 'test/test-utils';
+import { ComponentProps } from 'react';
+import { render, screen, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
@@ -27,6 +28,12 @@ beforeAll(() => {
   jest.clearAllMocks();
 });
 
+const renderRuleDetails = async (rule: ComponentProps<typeof RuleDetails>['rule']) => {
+  const view = render(<RuleDetails rule={rule} />);
+  await waitFor(async () => screen.queryAllByRole('progressbar').length === 0);
+  return view;
+};
+
 describe('RuleDetails RBAC', () => {
   describe('Grafana rules action buttons in details', () => {
     const grafanaRule = getGrafanaRule({ name: 'Grafana' });
@@ -36,7 +43,7 @@ describe('RuleDetails RBAC', () => {
       mocks.useIsRuleEditable.mockReturnValue({ loading: false, isEditable: true });
 
       // Act
-      render(<RuleDetails rule={grafanaRule} />);
+      await renderRuleDetails(grafanaRule);
 
       // Assert
       expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
@@ -47,7 +54,7 @@ describe('RuleDetails RBAC', () => {
       mocks.useIsRuleEditable.mockReturnValue({ loading: false, isRemovable: true });
 
       // Act
-      render(<RuleDetails rule={grafanaRule} />);
+      await renderRuleDetails(grafanaRule);
 
       // Assert
       expect(ui.actionButtons.delete.query()).not.toBeInTheDocument();
@@ -62,7 +69,7 @@ describe('RuleDetails RBAC', () => {
       mocks.useIsRuleEditable.mockReturnValue({ loading: false, isEditable: true });
 
       // Act
-      render(<RuleDetails rule={cloudRule} />);
+      await renderRuleDetails(cloudRule);
 
       // Assert
       expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
@@ -73,7 +80,7 @@ describe('RuleDetails RBAC', () => {
       mocks.useIsRuleEditable.mockReturnValue({ loading: false, isRemovable: true });
 
       // Act
-      render(<RuleDetails rule={cloudRule} />);
+      await renderRuleDetails(cloudRule);
 
       // Assert
       expect(ui.actionButtons.delete.query()).not.toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -1,10 +1,6 @@
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { times } from 'lodash';
+import { render, userEvent } from 'test/test-utils';
 import { byLabelText, byRole, byTestId } from 'testing-library-selector';
-
-import { PluginExtensionTypes } from '@grafana/data';
-import { usePluginLinks } from '@grafana/runtime';
 
 import { CombinedRuleNamespace } from '../../../../../types/unified-alerting';
 import { GrafanaAlertState, PromAlertingRuleState } from '../../../../../types/unified-alerting-dto';
@@ -12,16 +8,6 @@ import { mockCombinedRule, mockDataSource, mockPromAlert, mockPromAlertingRule }
 import { alertStateToReadable } from '../../utils/rules';
 
 import { RuleDetailsMatchingInstances } from './RuleDetailsMatchingInstances';
-
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getPluginLinkExtensions: jest.fn(),
-  usePluginLinks: jest.fn(),
-}));
-
-const mocks = {
-  usePluginLinksMock: jest.mocked(usePluginLinks),
-};
 
 const ui = {
   stateFilter: byTestId('alert-instance-state-filter'),
@@ -43,23 +29,6 @@ const ui = {
 };
 
 describe('RuleDetailsMatchingInstances', () => {
-  beforeEach(() => {
-    mocks.usePluginLinksMock.mockReturnValue({
-      links: [
-        {
-          pluginId: 'grafana-ml-app',
-          id: '1',
-          type: PluginExtensionTypes.link,
-          title: 'Run investigation',
-          category: 'Sift',
-          description: 'Run a Sift investigation for this alert',
-          onClick: jest.fn(),
-        },
-      ],
-      isLoading: false,
-    });
-  });
-
   describe('Filtering', () => {
     it('For Grafana Managed rules instances filter should contain six states', () => {
       const rule = mockCombinedRule();

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.test.tsx
@@ -1,5 +1,5 @@
 import { times } from 'lodash';
-import { render, userEvent } from 'test/test-utils';
+import { render, screen, userEvent, waitFor } from 'test/test-utils';
 import { byLabelText, byRole, byTestId } from 'testing-library-selector';
 
 import { CombinedRuleNamespace } from '../../../../../types/unified-alerting';
@@ -30,10 +30,11 @@ const ui = {
 
 describe('RuleDetailsMatchingInstances', () => {
   describe('Filtering', () => {
-    it('For Grafana Managed rules instances filter should contain six states', () => {
+    it('For Grafana Managed rules instances filter should contain six states', async () => {
       const rule = mockCombinedRule();
 
       render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
+      await waitFor(() => screen.queryAllByRole('progressbar').length === 0);
 
       const stateFilter = ui.stateFilter.get();
       expect(stateFilter).toBeInTheDocument();
@@ -80,12 +81,13 @@ describe('RuleDetailsMatchingInstances', () => {
       expect(ui.instanceRow.get()).toHaveTextContent(alertStateToReadable(state));
     });
 
-    it('For Cloud rules instances filter should contain two states', () => {
+    it('For Cloud rules instances filter should contain two states', async () => {
       const rule = mockCombinedRule({
         namespace: mockPromNamespace(),
       });
 
       render(<RuleDetailsMatchingInstances rule={rule} enableFiltering />);
+      await waitFor(() => screen.queryAllByRole('progressbar').length === 0);
 
       const stateFilter = ui.stateFilter.get();
       expect(stateFilter).toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
@@ -2,7 +2,6 @@ import { waitFor } from '@testing-library/react';
 import { render } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { setPluginLinksHook } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types';
 import { CombinedRuleNamespace } from 'app/types/unified-alerting';
@@ -21,11 +20,6 @@ const ui = {
   grafanaRulesHeading: byRole('heading', { name: 'Grafana-managed' }),
   cloudRulesHeading: byRole('heading', { name: 'Data source-managed' }),
 };
-
-setPluginLinksHook(() => ({
-  links: [],
-  isLoading: false,
-}));
 
 setupMswServer();
 const mimirDs = mimirDataSource();

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.test.tsx
@@ -5,22 +5,14 @@ import { locationService } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
 import * as analytics from '../../Analytics';
-import { setupPluginsExtensionsHook } from '../../testSetup/plugins';
+import { setupDataSources } from '../../testSetup/datasources';
 
 import RulesFilter from './Filter/RulesFilter';
 
 setupMswServer();
+setupDataSources();
+
 jest.spyOn(analytics, 'logInfo');
-
-jest.mock('./MultipleDataSourcePicker', () => {
-  const original = jest.requireActual('./MultipleDataSourcePicker');
-  return {
-    ...original,
-    MultipleDataSourcePicker: () => null,
-  };
-});
-
-setupPluginsExtensionsHook();
 
 const ui = {
   stateFilter: {
@@ -44,7 +36,7 @@ describe('RulesFilter', () => {
   it('Should apply state filter to the search input', async () => {
     const { user } = render(<RulesFilter />);
 
-    await user.click(ui.stateFilter.firing.get());
+    await user.click(await ui.stateFilter.firing.find());
 
     expect(ui.searchInput.get()).toHaveValue('state:firing');
   });
@@ -52,7 +44,7 @@ describe('RulesFilter', () => {
   it('Should apply multiple UI-based filters to the search input', async () => {
     const { user } = render(<RulesFilter />);
 
-    await user.click(ui.health.ok.get());
+    await user.click(await ui.health.ok.find());
     await user.click(ui.ruleType.alert.get());
     await user.click(ui.stateFilter.normal.get());
 
@@ -62,7 +54,7 @@ describe('RulesFilter', () => {
   it('Should combine UI filters and typed expressions', async () => {
     const { user } = render(<RulesFilter />);
 
-    await user.type(ui.searchInput.get(), 'cpu{Enter}');
+    await user.type(await ui.searchInput.find(), 'cpu{Enter}');
     await user.click(ui.health.ok.get());
     await user.type(ui.searchInput.get(), ' usage');
 
@@ -74,7 +66,7 @@ describe('Analytics', () => {
   it('Sends log info when clicking alert state filters', async () => {
     const { user } = render(<RulesFilter />);
 
-    const button = screen.getByText('Pending');
+    const button = await screen.findByText('Pending');
 
     await user.click(button);
 

--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, userEvent, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import { setPluginLinksHook } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
 import { AlertRuleAction, useAlertRuleAbility, useRulerRuleAbility } from '../../hooks/useAbilities';
@@ -19,11 +18,6 @@ const mocks = {
   useRulerRuleAbility: jest.mocked(useRulerRuleAbility),
   useAlertRuleAbility: jest.mocked(useAlertRuleAbility),
 };
-
-setPluginLinksHook(() => ({
-  links: [],
-  isLoading: false,
-}));
 
 const ui = {
   actionButtons: {

--- a/public/app/features/alerting/unified/components/settings/AlertmanagerCard.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerCard.test.tsx
@@ -6,11 +6,6 @@ import { ConnectionStatus } from '../../hooks/useExternalAmSelector';
 
 import { AlertmanagerCard } from './AlertmanagerCard';
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  useReturnToPrevious: jest.fn(),
-}));
-
 describe('Alertmanager card', () => {
   it('should show metadata', () => {
     render(

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -1,7 +1,6 @@
-import { render } from 'test/test-utils';
+import { render, screen, waitForElementToBeRemoved } from 'test/test-utils';
 import { byRole, byTestId } from 'testing-library-selector';
 
-import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types';
 
 import { setupMswServer } from '../mockApi';
@@ -25,9 +24,6 @@ const ui = {
   groupedView: byTestId('grouped-view'),
 };
 
-setPluginLinksHook(() => ({ links: [], isLoading: false }));
-setPluginComponentsHook(() => ({ components: [], isLoading: false }));
-
 grantUserPermissions([AccessControlAction.AlertingRuleExternalRead]);
 
 setupMswServer();
@@ -36,33 +32,37 @@ alertingFactory.dataSource.build({ name: 'Mimir', uid: 'mimir' });
 alertingFactory.dataSource.build({ name: 'Prometheus', uid: 'prometheus' });
 
 describe('RuleList v2', () => {
-  it('should show grouped view by default', () => {
+  it('should show grouped view by default', async () => {
     render(<RuleList />);
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
     expect(ui.groupedView.get()).toBeInTheDocument();
     expect(ui.filterView.query()).not.toBeInTheDocument();
   });
 
-  it('should show grouped view when invalid view parameter is provided', () => {
+  it('should show grouped view when invalid view parameter is provided', async () => {
     render(<RuleList />, {
       historyOptions: {
         initialEntries: ['/?view=invalid'],
       },
     });
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
     expect(ui.groupedView.get()).toBeInTheDocument();
     expect(ui.filterView.query()).not.toBeInTheDocument();
   });
 
-  it('should show list view when "view=list" URL parameter is present', () => {
+  it('should show list view when "view=list" URL parameter is present', async () => {
     render(<RuleList />, { historyOptions: { initialEntries: ['/?view=list'] } });
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
     expect(ui.filterView.get()).toBeInTheDocument();
     expect(ui.groupedView.query()).not.toBeInTheDocument();
   });
 
-  it('should show list view when a filter is applied', () => {
+  it('should show list view when a filter is applied', async () => {
     render(<RuleList />, { historyOptions: { initialEntries: ['/?search=rule:cpu-alert'] } });
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
 
     expect(ui.filterView.get()).toBeInTheDocument();
     expect(ui.groupedView.query()).not.toBeInTheDocument();

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
@@ -1,12 +1,10 @@
-import userEvent from '@testing-library/user-event';
-import { render } from 'test/test-utils';
+import { render, userEvent } from 'test/test-utils';
 import { byTestId } from 'testing-library-selector';
 
 import { PromOptions } from '@grafana/prometheus';
 import { config, locationService, setPluginLinksHook } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import * as ruler from 'app/features/alerting/unified/api/ruler';
-import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import * as alertingAbilities from 'app/features/alerting/unified/hooks/useAbilities';
 import { mockAlertRuleApi, setupMswServer } from 'app/features/alerting/unified/mockApi';
 import {
@@ -24,7 +22,6 @@ import { Annotation } from 'app/features/alerting/unified/utils/constants';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction, DashboardDataDTO } from 'app/types';
 import { AlertQuery, PromRulesResponse } from 'app/types/unified-alerting-dto';
 
@@ -38,17 +35,8 @@ import { PanelDataAlertingTab, PanelDataAlertingTabRendered } from './PanelDataA
  * These tests has been copied from public/app/features/alerting/unified/PanelAlertTabContent.test.tsx and been slightly modified to make sure the scenes alert edit tab is as close to the old alert edit tab as possible
  */
 
-jest.mock('app/features/alerting/unified/api/prometheus');
-jest.mock('app/features/alerting/unified/api/ruler');
-
-jest.spyOn(ruleActionButtons, 'matchesWidth').mockReturnValue(false);
 jest.spyOn(ruler, 'rulerUrlBuilder');
 jest.spyOn(alertingAbilities, 'useAlertRuleAbility');
-
-setPluginLinksHook(() => ({
-  links: [],
-  isLoading: false,
-}));
 
 const dataSources = {
   prometheus: mockDataSource<PromOptions>(
@@ -81,10 +69,6 @@ const dataSources = {
 const mocks = {
   useAlertRuleAbilityMock: jest.mocked(alertingAbilities.useAlertRuleAbility),
   rulerBuilderMock: jest.mocked(ruler.rulerUrlBuilder),
-};
-
-const renderAlertTabContent = (model: PanelDataAlertingTab, initialStore?: ReturnType<typeof configureStore>) => {
-  render(<PanelDataAlertingTabRendered model={model} />);
 };
 
 const promResponse: PromRulesResponse = {
@@ -174,7 +158,6 @@ const ui = {
 const server = setupMswServer();
 
 describe('PanelAlertTabContent', () => {
-  // silenceConsoleOutput();
   beforeEach(() => {
     jest.resetAllMocks();
     grantUserPermissions([
@@ -337,17 +320,16 @@ describe('PanelAlertTabContent', () => {
 
 function renderAlertTab(dashboard: DashboardModel, dto: DashboardDataDTO) {
   const model = createModel(dashboard, dto);
-  renderAlertTabContent(model);
+  return render(<PanelDataAlertingTabRendered model={model}></PanelDataAlertingTabRendered>);
 }
 
 async function clickNewButton() {
+  const user = userEvent.setup();
   const pushMock = jest.fn();
   const oldPush = locationService.push;
   locationService.push = pushMock;
   const button = await ui.createButton.find();
-
-  await userEvent.click(button);
-
+  await user.click(button);
   const match = pushMock.mock.lastCall[0].match(/alerting\/new\?defaults=(.*)&returnTo=/);
   const defaults = JSON.parse(decodeURIComponent(match![1]));
   locationService.push = oldPush;

--- a/public/app/features/dashboard/utils/getPanelMenu.test.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.test.ts
@@ -1,7 +1,6 @@
 import { Store } from 'redux';
 
 import { PanelMenuItem, PluginExtensionLink, PluginExtensionTypes } from '@grafana/data';
-import { usePluginLinks } from '@grafana/runtime';
 import config from 'app/core/config';
 import { grantUserPermissions } from 'app/features/alerting/unified/mocks';
 import * as actions from 'app/features/explore/state/main';
@@ -20,18 +19,8 @@ jest.mock('app/core/services/context_srv', () => ({
   },
 }));
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  setPluginLinksHook: jest.fn(),
-  usePluginLinks: jest.fn(),
-}));
-
-const usePluginLinksMock = jest.mocked(usePluginLinks);
-
 describe('getPanelMenu()', () => {
   beforeEach(() => {
-    usePluginLinksMock.mockRestore();
-    usePluginLinksMock.mockReturnValue({ links: [], isLoading: false });
     grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
     config.unifiedAlertingEnabled = false;
   });

--- a/public/app/setup.ts
+++ b/public/app/setup.ts
@@ -1,0 +1,44 @@
+import {
+  setPluginComponentHook,
+  setPluginComponentsHook,
+  setPluginLinksHook,
+  config,
+  setPluginFunctionsHook,
+} from '@grafana/runtime';
+import { setGetObservablePluginComponents, setGetObservablePluginLinks } from '@grafana/runtime/internal';
+
+import { contextSrv } from './core/services/context_srv';
+import {
+  getObservablePluginComponents,
+  getObservablePluginLinks,
+} from './features/plugins/extensions/getPluginExtensions';
+import { usePluginComponent } from './features/plugins/extensions/usePluginComponent';
+import { usePluginComponents } from './features/plugins/extensions/usePluginComponents';
+import { usePluginFunctions } from './features/plugins/extensions/usePluginFunctions';
+import { usePluginLinks } from './features/plugins/extensions/usePluginLinks';
+import { getAppPluginsToAwait, getAppPluginsToPreload } from './features/plugins/extensions/utils';
+import { preloadPlugins } from './features/plugins/pluginPreloader';
+
+export const setupPluginHooks = () => {
+  setPluginLinksHook(usePluginLinks);
+  setPluginComponentHook(usePluginComponent);
+  setPluginComponentsHook(usePluginComponents);
+  setPluginFunctionsHook(usePluginFunctions);
+  setGetObservablePluginLinks(getObservablePluginLinks);
+  setGetObservablePluginComponents(getObservablePluginComponents);
+};
+
+export async function initPlugins() {
+  // Do not pre-load apps if rendererDisableAppPluginsPreload is true and the request comes from the image renderer
+  const skipAppPluginsPreload =
+    config.featureToggles.rendererDisableAppPluginsPreload && contextSrv.user.authenticatedBy === 'render';
+  if (contextSrv.user.orgRole !== '' && !skipAppPluginsPreload) {
+    const appPluginsToAwait = getAppPluginsToAwait();
+    const appPluginsToPreload = getAppPluginsToPreload();
+
+    preloadPlugins(appPluginsToPreload);
+    await preloadPlugins(appPluginsToAwait);
+  }
+
+  setupPluginHooks();
+}

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -5,28 +5,37 @@ import { createMemoryHistory, MemoryHistoryBuildOptions } from 'history';
 import { Fragment, PropsWithChildren } from 'react';
 import * as React from 'react';
 import { Provider } from 'react-redux';
-// eslint-disable-next-line no-restricted-imports
 import { Router } from 'react-router-dom';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
+import { PluginExtensionAddedLinkConfig } from '@grafana/data';
 import {
   HistoryWrapper,
   LocationServiceProvider,
   setAppEvents,
   setLocationService,
-  setPluginComponentsHook,
-  setPluginLinksHook,
   setReturnToPreviousHook,
 } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { GrafanaContext, GrafanaContextType, useReturnToPreviousInternal } from 'app/core/context/GrafanaContext';
 import { ModalsContextProvider } from 'app/core/context/ModalsContextProvider';
-import { setupPluginExtensionRegistries } from 'app/features/plugins/extensions/registry/setup';
-import { createUsePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
-import { createUsePluginLinks } from 'app/features/plugins/extensions/usePluginLinks';
+import { ExtensionRegistriesProvider } from 'app/features/plugins/extensions/ExtensionRegistriesContext';
+import { AddedComponentsRegistry } from 'app/features/plugins/extensions/registry/AddedComponentsRegistry';
+import { AddedLinksRegistry } from 'app/features/plugins/extensions/registry/AddedLinksRegistry';
+import { ExposedComponentsRegistry } from 'app/features/plugins/extensions/registry/ExposedComponentsRegistry';
+import { PluginExtensionConfigs } from 'app/features/plugins/extensions/registry/Registry';
+import { setupPluginHooks } from 'app/setup';
 import { configureStore } from 'app/store/configureStore';
 import { StoreState } from 'app/types/store';
+
+const getFreshPluginExtensionRegistries = () => {
+  return {
+    addedComponentsRegistry: new AddedComponentsRegistry(),
+    exposedComponentsRegistry: new ExposedComponentsRegistry(),
+    addedLinksRegistry: new AddedLinksRegistry(),
+  };
+};
 
 interface ExtendedRenderOptions extends RenderOptions {
   /**
@@ -51,29 +60,34 @@ interface ExtendedRenderOptions extends RenderOptions {
   /**
    * Method to return any preset plugin links that you would like to be available for the component being rendered
    */
-  pluginLinks?: Parameters<typeof setPluginLinksHook>[0];
+  pluginLinks?: Array<PluginExtensionConfigs<PluginExtensionAddedLinkConfig>>;
 }
 
 /** Perform the same setup that we expect `app.ts` to have done when our components are rendering "for real" */
 const performAppSetup = (options: ExtendedRenderOptions) => {
   const { historyOptions, pluginLinks } = options;
+  const store = options.store || configureStore();
   // Create a fresh location service for each test - otherwise we run the risk
   // of it being stateful in between runs
   const history = createMemoryHistory(historyOptions);
   const locationService = new HistoryWrapper(history);
   setLocationService(locationService);
-
-  const pluginExtensionsRegistries = setupPluginExtensionRegistries();
-  setPluginLinksHook(pluginLinks || createUsePluginLinks(pluginExtensionsRegistries.addedLinksRegistry));
-  setPluginComponentsHook(createUsePluginComponents(pluginExtensionsRegistries.addedComponentsRegistry));
-
   setAppEvents(appEvents);
+
+  const pluginExtensionRegistries = getFreshPluginExtensionRegistries();
+  (pluginLinks || []).forEach((pluginLink) => {
+    pluginExtensionRegistries.addedLinksRegistry.register(pluginLink);
+  });
+
+  setupPluginHooks();
 
   setReturnToPreviousHook(useReturnToPreviousInternal);
 
   return {
     locationService,
     history,
+    store,
+    pluginExtensionRegistries,
   };
 };
 
@@ -86,10 +100,8 @@ const getWrapper = (
     grafanaContext?: Partial<GrafanaContextType>;
   }
 ) => {
-  const { store, renderWithRouter, grafanaContext } = options;
-  const reduxStore = store || configureStore();
-
-  const { locationService, history } = performAppSetup(options);
+  const { renderWithRouter, grafanaContext } = options;
+  const { locationService, history, store: reduxStore, pluginExtensionRegistries } = performAppSetup(options);
 
   /**
    * Conditional router - either a MemoryRouter or just a Fragment
@@ -113,13 +125,15 @@ const getWrapper = (
     return (
       <Provider store={reduxStore}>
         <GrafanaContext.Provider value={context}>
-          <PotentialRouter>
-            <LocationServiceProvider service={locationService}>
-              <PotentialCompatRouter>
-                <ModalsContextProvider>{children}</ModalsContextProvider>
-              </PotentialCompatRouter>
-            </LocationServiceProvider>
-          </PotentialRouter>
+          <ExtensionRegistriesProvider registries={pluginExtensionRegistries}>
+            <PotentialRouter>
+              <LocationServiceProvider service={locationService}>
+                <PotentialCompatRouter>
+                  <ModalsContextProvider>{children}</ModalsContextProvider>
+                </PotentialCompatRouter>
+              </LocationServiceProvider>
+            </PotentialRouter>
+          </ExtensionRegistriesProvider>
         </GrafanaContext.Provider>
       </Provider>
     );


### PR DESCRIPTION
**What is this feature?**

Builds from https://github.com/grafana/grafana/pull/92723. Moves the plugin setup logic into the `test-utils` method and then removes the appropriate pieces from the existing tests that were manually mocking this out

**Why do we need this feature?**

Simplifying the logic within tests so they have to care less about what's happening outside of their scope

**Who is this feature for?**

UI devs
