### PR TITLE
InfluxDB: Fix variable interpolation in influx db

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -324,11 +324,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   }
 
   interpolateQueryExpr(value: string | string[] = [], variable: QueryVariableModel, query?: string) {
-    // If there is no query just return the value directly
-    if (!query) {
-      return value;
-    }
-
     if (typeof value === 'string') {
       // Check the value is a number. If not run to escape special characters
       if (!isNaN(parseFloat(value))) {
@@ -358,7 +353,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // regex below checks if the variable inside /^...$/ (^ and $ is optional)
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
-    if (regex.test(query)) {
+    if (query && regex.test(query)) {
       if (typeof value === 'string') {
         return escapeRegex(value);
       }


### PR DESCRIPTION
There's an issue with scenes powered dashboards and influx db. Query variables inside query variable queries are not properly interpolated because the query parameter is not passed.

