### PR TITLE
Plugins: Add rudderstack events to plugins update

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { AppEvents } from '@grafana/data';
-import { config, locationService } from '@grafana/runtime';
+import { config, locationService, reportInteraction } from '@grafana/runtime';
 import { Button, ConfirmModal, Stack } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import configCore from 'app/core/config';
@@ -20,6 +20,8 @@ import {
 } from '../../state/hooks';
 import { trackPluginInstalled, trackPluginUninstalled } from '../../tracking';
 import { CatalogPlugin, PluginStatus, PluginTabIds, Version } from '../../types';
+
+const PLUGIN_UPDATE_INTERACTION_EVENT_NAME = 'plugin_update_clicked';
 
 type InstallControlsButtonProps = {
   plugin: CatalogPlugin;
@@ -107,6 +109,8 @@ export function InstallControlsButton({
   };
 
   const onUpdate = async () => {
+    reportInteraction(PLUGIN_UPDATE_INTERACTION_EVENT_NAME);
+
     await install(plugin.id, latestCompatibleVersion?.version, true);
     if (!errorInstalling) {
       appEvents.emit(AppEvents.alertSuccess, [`Updated ${plugin.name}`]);

--- a/public/app/features/plugins/admin/components/UpdateAllModal.tsx
+++ b/public/app/features/plugins/admin/components/UpdateAllModal.tsx
@@ -290,7 +290,6 @@ export const UpdateAllModal = ({ isOpen, onDismiss, plugins }: Props) => {
           ? `${t('plugins.catalog.update-all.modal-confirmation', 'Update')} (${selectedPlugins?.size})`
           : t('plugins.catalog.update-all.modal-dismiss', 'Close')
       }
-      confirmButtonVariant="primary"
     />
   );
 };

--- a/public/app/features/plugins/admin/components/UpdateAllModal.tsx
+++ b/public/app/features/plugins/admin/components/UpdateAllModal.tsx
@@ -2,12 +2,14 @@ import { css } from '@emotion/css';
 import { useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Checkbox, ConfirmModal, EmptyState, Icon, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
 import { useInstall, useInstallStatus } from '../state/hooks';
 import { CatalogPlugin } from '../types';
+
+const PLUGINS_UPDATE_ALL_INTERACTION_EVENT_NAME = 'plugins_update_all_clicked';
 
 type UpdateError = {
   id: string;
@@ -220,6 +222,8 @@ export const UpdateAllModal = ({ isOpen, onDismiss, plugins }: Props) => {
 
   const onConfirm = async () => {
     if (!inProgress) {
+      reportInteraction(PLUGINS_UPDATE_ALL_INTERACTION_EVENT_NAME);
+
       setInProgress(true);
 
       // in cloud the requests need to be sync
@@ -286,6 +290,7 @@ export const UpdateAllModal = ({ isOpen, onDismiss, plugins }: Props) => {
           ? `${t('plugins.catalog.update-all.modal-confirmation', 'Update')} (${selectedPlugins?.size})`
           : t('plugins.catalog.update-all.modal-dismiss', 'Close')
       }
+      confirmButtonVariant="primary"
     />
   );
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add rudderstack events to check update all and normal plugins update usage

**Why do we need this feature?**

Check update all and normal plugin update usage.

**Who is this feature for?**

Plugins platform team mainly.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
