### PR TITLE
Auth: Add LDAP scope to Grafana Admin

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -497,6 +497,8 @@ var (
 		return Scope("settings", "auth."+provider, "*")
 	}
 
+	ScopeSettingsLDAP = Scope("settings", "auth.ldap", "*")
+
 	// Annotation scopes
 	ScopeAnnotationsRoot             = "annotations"
 	ScopeAnnotationsProvider         = NewScopeProvider(ScopeAnnotationsRoot)

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -265,6 +265,14 @@ var (
 				Action: ActionSettingsWrite,
 				Scope:  ScopeSettingsOAuth("generic_oauth"),
 			},
+			{
+				Action: ActionSettingsRead,
+				Scope:  ScopeSettingsOAuth("ldap"),
+			},
+			{
+				Action: ActionSettingsWrite,
+				Scope:  ScopeSettingsOAuth("ldap"),
+			},
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

This feature adds LDAP scope to Grafana Admin.

**Why do we need this feature?**

LDAP is an OSS feature.

**Who is this feature for?**

IAM

**Special notes for your reviewer:**

Please comment if we should backport this fix.