### PR TITLE
[v11.0.x] CI/CD: Update retry logic for package validation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3150,8 +3150,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - 'echo "Step 6: Verifying Grafana installation..."'
@@ -3199,8 +3199,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - '    echo "Verifying GPG key..."'
@@ -3327,8 +3327,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - 'echo "Step 6: Verifying Grafana installation..."'
@@ -3377,8 +3377,8 @@ steps:
   - '            echo ''All attempts failed'''
   - '            exit 1'
   - '        fi'
-  - '        echo "Waiting 60 seconds before next attempt..."'
-  - '        sleep 60'
+  - '        echo "Waiting 30 seconds before next attempt..."'
+  - '        sleep 30'
   - '    fi'
   - done
   - '    echo "Verifying GPG key..."'
@@ -5381,6 +5381,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 6f869f73371948ecd50f13c122a7554b88dc8856768e5c068edb3b2411f2972b
+hmac: f849714663e8601fb31344bfb7550c5a4fc77c66ce4176c79bbd40179b678055
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1223,7 +1223,8 @@ def publish_linux_packages_step(package_manager = "deb"):
         },
     }
 
-def retry_command(command, attempts = 5, delay = 60):
+# This retry will currently continue for 30 minutes until fail, unless successful.
+def retry_command(command, attempts = 60, delay = 30):
     return [
         "for i in $(seq 1 %d); do" % attempts,
         "    if %s; then" % command,


### PR DESCRIPTION
Backport d3ceaf41c29cbd4d33868ce3b4f9c47ba5bf5d4f from #92943

---

**What is this feature?**

This updates the retry logic when validating our build packages, specifically our RPM build was having timeout issues and failing.

**Why do we need this feature?**

Our RPM package validation was failing, most likely due to the time it takes for the new build to become available in the RPM repo for use. Sometimes it can take upwards of 5-10+ minutes; this PR updates the logic from 5 to 15 minutes to retries.

**Who is this feature for?**

Release engineers.

**Which issue(s) does this PR fix?**:

Fixes: https://github.com/grafana/grafana-release/issues/1108

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
