### PR TITLE
AutoSizeInput: Allow to be controlled by value

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.story.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.story.tsx
@@ -35,6 +35,8 @@ const meta: Meta = {
     suffixVisible: '',
     invalid: false,
     loading: false,
+    value: '',
+    defaultValue: '',
   },
   argTypes: {
     prefixVisible: {
@@ -80,6 +82,8 @@ export const Simple: StoryFn = (args) => {
       type={args.type}
       placeholder={args.placeholder}
       minWidth={args.minWidth}
+      value={args.value}
+      defaultValue={args.defaultValue}
     />
   );
 };
@@ -88,6 +92,8 @@ Simple.args = {
   before: false,
   after: false,
   placeholder: 'Enter your name here...',
+  value: '',
+  defaultValue: '',
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
@@ -1,4 +1,5 @@
 import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
 
 import { measureText } from '../../utils/measureText';
 
@@ -116,5 +117,31 @@ describe('AutoSizeInput', () => {
     await waitFor(() => expect(measureText).toHaveBeenCalled());
 
     expect(getComputedStyle(screen.getByTestId('input-wrapper')).width).toBe('32px');
+  });
+
+  it('should update the input value if the value prop changes', () => {
+    // Wrapper component to control the `value` prop
+    const Wrapper = () => {
+      const [value, setValue] = useState('Initial');
+
+      // Simulate prop change after render
+      useEffect(() => {
+        setTimeout(() => setValue('Updated'), 100); // Update `value` after 100ms
+      }, []);
+
+      return <AutoSizeInput value={value} />;
+    };
+
+    render(<Wrapper />);
+
+    const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+    // Check initial value
+    expect(input.value).toBe('Initial');
+
+    // Wait for the value to update
+    return waitFor(() => {
+      expect(input.value).toBe('Updated');
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -15,13 +15,32 @@ export interface Props extends InputProps {
 }
 
 export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { defaultValue = '', minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
-  const [value, setValue] = React.useState(defaultValue);
+  const {
+    defaultValue = '',
+    minWidth = 10,
+    maxWidth,
+    onCommitChange,
+    onKeyDown,
+    onBlur,
+    value: controlledValue,
+    ...restProps
+  } = props;
+
+  // Initialize internal state
+  const [value, setValue] = React.useState(controlledValue ?? defaultValue);
   const [inputWidth, setInputWidth] = React.useState(minWidth);
 
+  // Update internal state when controlled `value` prop changes
+  useEffect(() => {
+    if (controlledValue !== undefined) {
+      setValue(controlledValue);
+    }
+  }, [controlledValue]);
+
+  // Update input width when `value`, `minWidth`, or `maxWidth` change
   useEffect(() => {
     setInputWidth(getWidthFor(value.toString(), minWidth, maxWidth));
-  }, [value, maxWidth, minWidth]);
+  }, [value, minWidth, maxWidth]);
 
   return (
     <Input


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We discovered in [this PR](https://github.com/grafana/scenes/pull/890
) the AutoSizeInput doesn't respect the value prop. This is because this component doesn't support to be controlled.

**Why do we need this feature?**

We need to control the component to set the value by the VariableInput component, that takes the value from the URL that can be updated at any time for any component in the dashboard, for example a data link

**Which issue(s) does this PR fix?**:

Enables https://github.com/grafana/scenes/pull/890

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
