### PR TITLE
ViewPanel: Refactoring to simplify logic by rendering the source panel instead of a clone

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -58,7 +58,6 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
         this._prevRepeatValues = undefined;
       }
 
-      this._oldBody = this.state.body;
       this.performRepeat();
     }
   }
@@ -117,7 +116,9 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
       return;
     }
 
+    this._oldBody = this.state.body;
     this._prevRepeatValues = values;
+
     const panelToRepeat = this.state.body;
     const repeatedPanels: VizPanel[] = [];
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -1,11 +1,10 @@
 import { AppEvents } from '@grafana/data';
-import { SceneGridLayout, SceneGridRow, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+import { SceneGridLayout, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 import appEvents from 'app/core/app_events';
 import { KioskMode } from 'app/types';
 
 import { DashboardGridItem } from './DashboardGridItem';
 import { DashboardScene } from './DashboardScene';
-import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 import { DashboardRepeatsProcessedEvent } from './types';
 
 describe('DashboardSceneUrlSync', () => {
@@ -108,35 +107,6 @@ describe('DashboardSceneUrlSync', () => {
     // Verify it subscribes to DashboardRepeatsProcessedEvent
     scene.publishEvent(new DashboardRepeatsProcessedEvent({ source: scene }));
     expect(scene.state.viewPanelScene?.getUrlKey()).toBe('panel-1-clone-1');
-  });
-
-  it('should subscribe and update view panel if panel is in a repeated row', () => {
-    const scene = buildTestScene();
-
-    // fake adding row panel
-    const layout = scene.state.body as SceneGridLayout;
-    layout.setState({
-      children: [
-        new SceneGridRow({
-          $behaviors: [new RowRepeaterBehavior({ variableName: 'test' })],
-          children: [
-            new VizPanel({
-              title: 'Panel A',
-              key: 'panel-1',
-              pluginId: 'table',
-            }),
-          ],
-        }),
-      ],
-    });
-
-    scene.urlSync?.updateFromUrl({ viewPanel: 'panel-1' });
-
-    expect(scene.state.viewPanelScene?.getUrlKey()).toBeUndefined();
-
-    // Verify it subscribes to DashboardRepeatsProcessedEvent
-    scene.publishEvent(new DashboardRepeatsProcessedEvent({ source: scene }));
-    expect(scene.state.viewPanelScene?.getUrlKey()).toBe('panel-1');
   });
 });
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -18,13 +18,7 @@ import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { createDashboardEditViewFor } from '../settings/utils';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { ShareModal } from '../sharing/ShareModal';
-import {
-  findVizPanelByKey,
-  getDashboardSceneFor,
-  getLibraryPanelBehavior,
-  isPanelClone,
-  isWithinUnactivatedRepeatRow,
-} from '../utils/utils';
+import { findVizPanelByKey, getDashboardSceneFor, getLibraryPanelBehavior, isPanelClone } from '../utils/utils';
 
 import { DashboardScene, DashboardSceneState } from './DashboardScene';
 import { LibraryPanelBehavior } from './LibraryPanelBehavior';
@@ -105,11 +99,6 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
 
         appEvents.emit(AppEvents.alertError, ['Panel not found']);
         locationService.partial({ viewPanel: null });
-        return;
-      }
-
-      if (isWithinUnactivatedRepeatRow(panel)) {
-        this._handleViewRepeatClone(values.viewPanel);
         return;
       }
 
@@ -234,10 +223,6 @@ class ResolveInspectPanelByKey extends SceneObjectBase<ResolveInspectPanelByKeyS
 
     if (dashboard.state.editPanel) {
       panel = dashboard.state.editPanel.state.vizManager.state.panel;
-    }
-
-    if (dashboard.state.viewPanelScene && dashboard.state.viewPanelScene.state.body) {
-      panel = dashboard.state.viewPanelScene.state.body;
     }
 
     if (panel) {

--- a/public/app/features/dashboard-scene/scene/ViewPanelScene.tsx
+++ b/public/app/features/dashboard-scene/scene/ViewPanelScene.tsx
@@ -1,12 +1,6 @@
-import {
-  CancelActivationHandler,
-  SceneComponentProps,
-  SceneObject,
-  SceneObjectBase,
-  SceneObjectRef,
-  SceneObjectState,
-  VizPanel,
-} from '@grafana/scenes';
+import { SceneComponentProps, SceneObjectBase, SceneObjectRef, SceneObjectState, VizPanel } from '@grafana/scenes';
+
+import { activateInActiveParents } from '../utils/utils';
 
 interface ViewPanelSceneState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
@@ -33,25 +27,5 @@ export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> {
     const panel = panelRef.resolve();
 
     return <panel.Component model={panel} />;
-  };
-}
-
-function activateInActiveParents(so: SceneObject): CancelActivationHandler | undefined {
-  let cancel: CancelActivationHandler | undefined;
-  let parentCancel: CancelActivationHandler | undefined;
-
-  if (so.isActive) {
-    return cancel;
-  }
-
-  if (so.parent) {
-    parentCancel = activateInActiveParents(so.parent);
-  }
-
-  cancel = so.activate();
-
-  return () => {
-    parentCancel?.();
-    cancel();
   };
 }

--- a/public/app/features/dashboard-scene/scene/ViewPanelScene.tsx
+++ b/public/app/features/dashboard-scene/scene/ViewPanelScene.tsx
@@ -1,20 +1,15 @@
 import {
+  CancelActivationHandler,
   SceneComponentProps,
+  SceneObject,
   SceneObjectBase,
   SceneObjectRef,
   SceneObjectState,
   VizPanel,
-  sceneUtils,
-  SceneVariables,
-  SceneGridRow,
-  sceneGraph,
-  SceneVariableSet,
-  SceneVariable,
 } from '@grafana/scenes';
 
 interface ViewPanelSceneState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
-  body?: VizPanel;
 }
 
 export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> {
@@ -26,47 +21,7 @@ export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> {
 
   public _activationHandler() {
     const panel = this.state.panelRef.resolve();
-    const panelState = sceneUtils.cloneSceneObjectState(panel.state, {
-      key: panel.state.key + '-view',
-      $variables: this.getScopedVariables(panel),
-    });
-
-    const body = new VizPanel(panelState);
-
-    this.setState({ body });
-
-    return () => {
-      // Make sure we preserve data state
-      if (body.state.$data) {
-        panel.setState({ $data: body.state.$data.clone() });
-      }
-    };
-  }
-
-  // In case the panel is inside a repeated row
-  private getScopedVariables(panel: VizPanel): SceneVariables | undefined {
-    const row = tryGetParentRow(panel);
-    const variables: SceneVariable[] = [];
-
-    // Because we are rendering the panel outside it's potential row context we need to copy the row (scoped) varables
-    if (row && row.state.$variables) {
-      for (const variable of row.state.$variables.state.variables) {
-        variables.push(variable.clone());
-      }
-    }
-
-    // If we have local scoped panel variables we need to add the row variables to it
-    if (panel.state.$variables) {
-      for (const variable of panel.state.$variables.state.variables) {
-        variables.push(variable.clone());
-      }
-    }
-
-    if (variables.length > 0) {
-      return new SceneVariableSet({ variables });
-    }
-
-    return undefined;
+    return activateInActiveParents(panel);
   }
 
   public getUrlKey() {
@@ -74,20 +29,29 @@ export class ViewPanelScene extends SceneObjectBase<ViewPanelSceneState> {
   }
 
   public static Component = ({ model }: SceneComponentProps<ViewPanelScene>) => {
-    const { body } = model.useState();
+    const { panelRef } = model.useState();
+    const panel = panelRef.resolve();
 
-    if (!body) {
-      return null;
-    }
-
-    return <body.Component model={body} />;
+    return <panel.Component model={panel} />;
   };
 }
 
-function tryGetParentRow(panel: VizPanel): SceneGridRow | undefined {
-  try {
-    return sceneGraph.getAncestor(panel, SceneGridRow);
-  } catch {
-    return undefined;
+function activateInActiveParents(so: SceneObject): CancelActivationHandler | undefined {
+  let cancel: CancelActivationHandler | undefined;
+  let parentCancel: CancelActivationHandler | undefined;
+
+  if (so.isActive) {
+    return cancel;
   }
+
+  if (so.parent) {
+    parentCancel = activateInActiveParents(so.parent);
+  }
+
+  cancel = so.activate();
+
+  return () => {
+    parentCancel?.();
+    cancel();
+  };
 }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -18,7 +18,6 @@ import { DashboardScene } from '../scene/DashboardScene';
 import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelMenuBehavior } from '../scene/PanelMenuBehavior';
-import { RowRepeaterBehavior } from '../scene/RowRepeaterBehavior';
 import { RowActions } from '../scene/row-actions/RowActions';
 
 import { dashboardSceneGraph } from './dashboardSceneGraph';
@@ -264,23 +263,4 @@ export function getLibraryPanelBehavior(vizPanel: VizPanel): LibraryPanelBehavio
   }
 
   return undefined;
-}
-
-/**
- * If the panel is within a repeated row, it must wait until the row resolves the variables.
- * This ensures that the scoped variable for the row is assigned and the panel is initialized with them.
- */
-export function isWithinUnactivatedRepeatRow(panel: VizPanel): boolean {
-  let row;
-
-  try {
-    row = sceneGraph.getAncestor(panel, SceneGridRow);
-  } catch (err) {
-    return false;
-  }
-
-  const hasBehavior = !!(row.state.$behaviors && row.state.$behaviors.find((b) => b instanceof RowRepeaterBehavior));
-  const hasVariables = !!(row.state.$variables && row.state.$variables.state.variables.length > 0);
-
-  return hasBehavior && !hasVariables;
 }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -1,6 +1,7 @@
 import { getDataSourceRef, IntervalVariableModel } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import {
+  CancelActivationHandler,
   CustomVariable,
   MultiValueVariable,
   SceneDataTransformer,
@@ -263,4 +264,29 @@ export function getLibraryPanelBehavior(vizPanel: VizPanel): LibraryPanelBehavio
   }
 
   return undefined;
+}
+
+/**
+ * Activates any inactive parents of the scene object.
+ * Useful when rendering a scene object out of context of it's parent
+ * @returns
+ */
+export function activateInActiveParents(so: SceneObject): CancelActivationHandler | undefined {
+  let cancel: CancelActivationHandler | undefined;
+  let parentCancel: CancelActivationHandler | undefined;
+
+  if (so.isActive) {
+    return cancel;
+  }
+
+  if (so.parent) {
+    parentCancel = activateInActiveParents(so.parent);
+  }
+
+  cancel = so.activate();
+
+  return () => {
+    parentCancel?.();
+    cancel();
+  };
 }


### PR DESCRIPTION
By activing the parents (if not already active) of a panel we want to view we can view/render it directly without having to create a clone and try to copy it's variable context. 

I think a further refactoring where the panel key for repeated panels included a chain of parent elements that generate the repeated (dynamic element) could help remove the complexity around resolving repeated panels. Right now DashboardUrlSync has to wait to enter view panel by first rendering the dashboard (so rows and grid items activate and generate repeated elements). It would be pretty clean if ViewPanelScene could would just be given an object key like `rowA-clone2-panel2-clone3`  where it could look up "rowA" activate it (so it's repeats are generated), then when "row-clone2-panel2" can be resolved we activate it and then wait for `rowA-clone2-panel2-clone3` to resolve to an object. 

This way we do not need to render the full dashboard to view an individual repeated/generated panel , just need to activate the relevant objects that generate them.  

Anyway that refactoring is for the future. 