### PR TITLE
Alerting: Include access control metadata in k8s receiver LIST & GET

### DIFF
--- a/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
@@ -1,6 +1,9 @@
 package v0alpha1
 
-const ProvenanceStatusAnnotationKey = "grafana.com/provenance"
+import "fmt"
+
+const InternalPrefix = "grafana.com/"
+const ProvenanceStatusAnnotationKey = InternalPrefix + "provenance"
 const ProvenanceStatusNone = "none"
 
 func (o *TimeInterval) GetProvenanceStatus() string {
@@ -43,4 +46,11 @@ func (o *Receiver) SetProvenanceStatus(status string) {
 		status = ProvenanceStatusNone
 	}
 	o.Annotations[ProvenanceStatusAnnotationKey] = status
+}
+
+func (o *Receiver) SetAccessControl(action string) {
+	if o.Annotations == nil {
+		o.Annotations = make(map[string]string, 1)
+	}
+	o.Annotations[fmt.Sprintf("%s%s/%s", InternalPrefix, "access", action)] = "true"
 }

--- a/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
@@ -52,5 +52,11 @@ func (o *Receiver) SetAccessControl(action string) {
 	if o.Annotations == nil {
 		o.Annotations = make(map[string]string, 1)
 	}
-	o.Annotations[fmt.Sprintf("%s%s/%s", InternalPrefix, "access", action)] = "true"
+	o.Annotations[AccessControlAnnotation(action)] = "true"
+}
+
+// AccessControlAnnotation returns the key for the access control annotation for the given action.
+// Ex. grafana.com/access/canDelete.
+func AccessControlAnnotation(action string) string {
+	return fmt.Sprintf("%s%s/%s", InternalPrefix, "access", action)
 }

--- a/pkg/registry/apis/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/conversions.go
@@ -1,6 +1,7 @@
 package receiver
 
 import (
+	"fmt"
 	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,12 +15,18 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 )
 
-func convertToK8sResources(orgID int64, receivers []*ngmodels.Receiver, namespacer request.NamespaceMapper, selector fields.Selector) (*model.ReceiverList, error) {
+func convertToK8sResources(orgID int64, receivers []*ngmodels.Receiver, accesses map[string]ngmodels.ReceiverPermissionSet, namespacer request.NamespaceMapper, selector fields.Selector) (*model.ReceiverList, error) {
 	result := &model.ReceiverList{
 		Items: make([]model.Receiver, 0, len(receivers)),
 	}
 	for _, receiver := range receivers {
-		k8sResource, err := convertToK8sResource(orgID, receiver, namespacer)
+		var access *ngmodels.ReceiverPermissionSet
+		if accesses != nil {
+			if a, ok := accesses[receiver.GetUID()]; ok {
+				access = &a
+			}
+		}
+		k8sResource, err := convertToK8sResource(orgID, receiver, access, namespacer)
 		if err != nil {
 			return nil, err
 		}
@@ -31,7 +38,7 @@ func convertToK8sResources(orgID int64, receivers []*ngmodels.Receiver, namespac
 	return result, nil
 }
 
-func convertToK8sResource(orgID int64, receiver *ngmodels.Receiver, namespacer request.NamespaceMapper) (*model.Receiver, error) {
+func convertToK8sResource(orgID int64, receiver *ngmodels.Receiver, access *ngmodels.ReceiverPermissionSet, namespacer request.NamespaceMapper) (*model.Receiver, error) {
 	spec := model.ReceiverSpec{
 		Title: receiver.Name,
 	}
@@ -56,7 +63,27 @@ func convertToK8sResource(orgID int64, receiver *ngmodels.Receiver, namespacer r
 		Spec: spec,
 	}
 	r.SetProvenanceStatus(string(receiver.Provenance))
+
+	if access != nil {
+		for _, action := range ngmodels.ReceiverPermissions() {
+			mappedAction, ok := permissionMapper[action]
+			if !ok {
+				return nil, fmt.Errorf("unknown action %v", action)
+			}
+			if can, _ := access.Has(action); can {
+				r.SetAccessControl(mappedAction)
+			}
+		}
+	}
+
 	return r, nil
+}
+
+var permissionMapper = map[ngmodels.ReceiverPermission]string{
+	ngmodels.ReceiverPermissionReadSecret: "canReadSecrets",
+	//ngmodels.ReceiverPermissionAdmin:      "canAdmin", // TODO: Add when resource permissions are implemented.
+	ngmodels.ReceiverPermissionWrite:  "canWrite",
+	ngmodels.ReceiverPermissionDelete: "canDelete",
 }
 
 func convertToDomainModel(receiver *model.Receiver) (*ngmodels.Receiver, map[string][]string, error) {

--- a/pkg/registry/apis/alerting/notifications/receiver/legacy_storage.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/legacy_storage.go
@@ -25,6 +25,9 @@ var (
 
 var resourceInfo = notifications.ReceiverResourceInfo
 
+// AccessControlKey is the label selector key used to return access control metadata during List queries.
+const AccessControlKey = "grafana.com/accessControl"
+
 type ReceiverService interface {
 	GetReceiver(ctx context.Context, q ngmodels.GetReceiverQuery, user identity.Requester) (*ngmodels.Receiver, error)
 	GetReceivers(ctx context.Context, q ngmodels.GetReceiversQuery, user identity.Requester) ([]*ngmodels.Receiver, error)
@@ -33,10 +36,15 @@ type ReceiverService interface {
 	DeleteReceiver(ctx context.Context, name string, provenance definitions.Provenance, version string, orgID int64, user identity.Requester) error
 }
 
+type MetadataService interface {
+	Access(ctx context.Context, user identity.Requester, receivers ...*ngmodels.Receiver) (map[string]ngmodels.ReceiverPermissionSet, error)
+}
+
 type legacyStorage struct {
 	service        ReceiverService
 	namespacer     request.NamespaceMapper
 	tableConverter rest.TableConvertor
+	metadata       MetadataService
 }
 
 func (s *legacyStorage) New() runtime.Object {
@@ -85,7 +93,27 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
-	return convertToK8sResources(orgId, res, s.namespacer, opts.FieldSelector)
+	var accesses map[string]ngmodels.ReceiverPermissionSet
+	if shouldIncludeAccessControlMetadata(opts) {
+		accesses, err = s.metadata.Access(ctx, user, res...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get access control metadata: %w", err)
+		}
+	}
+
+	return convertToK8sResources(orgId, res, accesses, s.namespacer, opts.FieldSelector)
+}
+
+func shouldIncludeAccessControlMetadata(opts *internalversion.ListOptions) bool {
+	if opts.LabelSelector != nil {
+		labelSelectors, _ := opts.LabelSelector.Requirements()
+		for _, req := range labelSelectors {
+			if req.Key() == AccessControlKey {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -113,7 +141,18 @@ func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOption
 	if err != nil {
 		return nil, err
 	}
-	return convertToK8sResource(info.OrgID, r, s.namespacer)
+
+	var access *ngmodels.ReceiverPermissionSet
+	accesses, err := s.metadata.Access(ctx, user, r)
+	if err == nil {
+		if a, ok := accesses[r.GetUID()]; ok {
+			access = &a
+		}
+	} else {
+		return nil, fmt.Errorf("failed to get access control metadata: %w", err)
+	}
+
+	return convertToK8sResource(info.OrgID, r, access, s.namespacer)
 }
 
 func (s *legacyStorage) Create(ctx context.Context,
@@ -151,7 +190,7 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return convertToK8sResource(info.OrgID, out, s.namespacer)
+	return convertToK8sResource(info.OrgID, out, nil, s.namespacer)
 }
 
 func (s *legacyStorage) Update(ctx context.Context,
@@ -203,7 +242,7 @@ func (s *legacyStorage) Update(ctx context.Context,
 		return nil, false, err
 	}
 
-	r, err := convertToK8sResource(info.OrgID, updated, s.namespacer)
+	r, err := convertToK8sResource(info.OrgID, updated, nil, s.namespacer)
 	return r, false, err
 }
 

--- a/pkg/registry/apis/alerting/notifications/receiver/storage.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/storage.go
@@ -34,11 +34,13 @@ func NewStorage(
 	scheme *runtime.Scheme,
 	optsGetter generic.RESTOptionsGetter,
 	dualWriteBuilder grafanarest.DualWriteBuilder,
+	metadata MetadataService,
 ) (rest.Storage, error) {
 	legacyStore := &legacyStorage{
 		service:        legacySvc,
 		namespacer:     namespacer,
 		tableConverter: resourceInfo.TableConverter(),
+		metadata:       metadata,
 	}
 	if optsGetter != nil && dualWriteBuilder != nil {
 		strategy := grafanaregistry.NewStrategy(scheme, resourceInfo.GroupVersion())

--- a/pkg/registry/apis/alerting/notifications/register.go
+++ b/pkg/registry/apis/alerting/notifications/register.go
@@ -85,7 +85,7 @@ func (t *NotificationsAPIBuilder) GetAPIGroupInfo(
 		return nil, fmt.Errorf("failed to initialize time-interval storage: %w", err)
 	}
 
-	recvStorage, err := receiver.NewStorage(t.ng.Api.ReceiverService, t.namespacer, scheme, optsGetter, dualWriteBuilder)
+	recvStorage, err := receiver.NewStorage(t.ng.Api.ReceiverService, t.namespacer, scheme, optsGetter, dualWriteBuilder, ac.NewReceiverAccess[*ngmodels.Receiver](t.ng.Api.AccessControl, false))
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize receiver storage: %w", err)
 	}

--- a/pkg/services/ngalert/accesscontrol/receivers.go
+++ b/pkg/services/ngalert/accesscontrol/receivers.go
@@ -237,8 +237,8 @@ func extendAccessControl[T models.Identified](base *actionAccess[T], operator fu
 	// Extend the access control of base with the extension.
 	base.authorizeSome = operator(extension.authorizeSome, baseSome)
 	base.authorizeAll = operator(extension.authorizeAll, baseAll)
-	base.authorizeOne = func(receiver models.Identified) ac.Evaluator {
-		return operator(extension.authorizeOne(receiver), baseOne(receiver))
+	base.authorizeOne = func(resource models.Identified) ac.Evaluator {
+		return operator(extension.authorizeOne(resource), baseOne(resource))
 	}
 }
 

--- a/pkg/services/ngalert/accesscontrol/receivers_test.go
+++ b/pkg/services/ngalert/accesscontrol/receivers_test.go
@@ -1,0 +1,351 @@
+package accesscontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+func TestReceiverAccess(t *testing.T) {
+	recv1 := models.ReceiverGen(models.ReceiverMuts.WithName("test receiver 1"), models.ReceiverMuts.WithValidIntegration("slack"))()
+	recv2 := models.ReceiverGen(models.ReceiverMuts.WithName("test receiver 2"), models.ReceiverMuts.WithValidIntegration("email"))()
+	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("test receiver 3"), models.ReceiverMuts.WithValidIntegration("webhook"))()
+
+	allReceivers := []*models.Receiver{
+		&recv1,
+		&recv2,
+		&recv3,
+	}
+
+	permissions := func(perms ...models.ReceiverPermission) models.ReceiverPermissionSet {
+		set := models.NewReceiverPermissionSet()
+		for _, v := range models.ReceiverPermissions() {
+			set.Set(v, false)
+		}
+		for _, v := range perms {
+			set.Set(v, true)
+		}
+		return set
+	}
+
+	testCases := []struct {
+		name                     string
+		user                     identity.Requester
+		expected                 map[string]models.ReceiverPermissionSet
+		expectedWithProvisioning map[string]models.ReceiverPermissionSet
+	}{
+		// Legacy read.
+		{
+			name: "legacy global reader should have no elevated permissions",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingNotificationsRead}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		{
+			name: "legacy global notifications provisioning reader should have no elevated permissions",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningRead}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		{
+			name: "legacy global provisioning reader should have no elevated permissions",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingProvisioningRead}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		{
+			name: "legacy global provisioning secret reader should have secret permissions on provisioning only",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingProvisioningReadSecrets}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+			expectedWithProvisioning: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv2.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret),
+			},
+		},
+		// Receiver read.
+		{
+			name: "global receiver reader should have no elevated permissions",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingReceiversRead, Scope: ScopeReceiversAll}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		{
+			name: "global receiver secret reader should have secret permissions",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversAll}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv2.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret),
+			},
+		},
+		{
+			name: "per-receiver secret reader should have per-receiver",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret),
+			},
+		},
+		// Legacy write.
+		{
+			name: "legacy global writer should have full write",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingNotificationsWrite}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+				recv2.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+				recv3.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+			},
+		},
+		{
+			name: "legacy writers should require read",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingNotificationsWrite}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		//{
+		//	name: "legacy global notifications provisioning writer should have full write on provisioning only",
+		//	user: newViewUser(ac.Permission{Action: ac.ActionAlertingNotificationsProvisioningWrite}),
+		//	expected: map[string]models.ReceiverPermissionSet{
+		//		recv1.UID: permissions(),
+		//		recv2.UID: permissions(),
+		//		recv3.UID: permissions(),
+		//	},
+		//	expectedWithProvisioning: map[string]models.ReceiverPermissionSet{
+		//		recv1.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+		//		recv2.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+		//		recv3.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+		//	},
+		//},
+		//{
+		//	name: "legacy global provisioning writer should have full write on provisioning only",
+		//	user: newViewUser(ac.Permission{Action: ac.ActionAlertingProvisioningWrite}),
+		//	expected: map[string]models.ReceiverPermissionSet{
+		//		recv1.UID: permissions(),
+		//		recv2.UID: permissions(),
+		//		recv3.UID: permissions(),
+		//	},
+		//	expectedWithProvisioning: map[string]models.ReceiverPermissionSet{
+		//		recv1.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+		//		recv2.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+		//		recv3.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+		//	},
+		//},
+		// Receiver create
+		{
+			name: "receiver create should not have write",
+			user: newEmptyUser(ac.Permission{Action: ac.ActionAlertingReceiversCreate}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		// Receiver update.
+		{
+			name: "global receiver update should have write but no delete",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversAll}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionWrite),
+				recv2.UID: permissions(models.ReceiverPermissionWrite),
+				recv3.UID: permissions(models.ReceiverPermissionWrite),
+			},
+		},
+		{
+			name: "per-receiver update should have per-receiver write but no delete",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionWrite),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(models.ReceiverPermissionWrite),
+			},
+		},
+		{
+			name: "per-receiver update should require read",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		// Receiver delete.
+		{
+			name: "global receiver delete should have delete but no write",
+			user: newViewUser(ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversAll}),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionDelete),
+				recv2.UID: permissions(models.ReceiverPermissionDelete),
+				recv3.UID: permissions(models.ReceiverPermissionDelete),
+			},
+		},
+		{
+			name: "per-receiver delete should have per-receiver delete but no write",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionDelete),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(models.ReceiverPermissionDelete),
+			},
+		},
+		{
+			name: "per-receiver delete should require read",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(),
+			},
+		},
+		// Mixed permissions.
+		{
+			name: "legacy provisioning secret read, receiver write",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingProvisioningReadSecrets},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(models.ReceiverPermissionWrite),
+				recv3.UID: permissions(),
+			},
+			expectedWithProvisioning: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv2.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionWrite),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret),
+			},
+		},
+		{
+			name: "legacy provisioning secret read, receiver delete",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingProvisioningReadSecrets},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(),
+				recv2.UID: permissions(models.ReceiverPermissionDelete),
+				recv3.UID: permissions(),
+			},
+			expectedWithProvisioning: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret),
+				recv2.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionDelete),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret),
+			},
+		},
+		{
+			name: "legacy write, receiver secret",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingNotificationsWrite},
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+				recv2.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+				recv3.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+			},
+		},
+		{
+			name: "mixed secret / delete / write",
+			user: newViewUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionWrite),
+				recv2.UID: permissions(models.ReceiverPermissionWrite, models.ReceiverPermissionDelete),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionDelete),
+			},
+		},
+		{
+			name: "mixed requires read",
+			user: newEmptyUser(
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversReadSecrets, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv1.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversUpdate, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv2.UID)},
+				ac.Permission{Action: ac.ActionAlertingReceiversDelete, Scope: ScopeReceiversProvider.GetResourceScopeUID(recv3.UID)},
+			),
+			expected: map[string]models.ReceiverPermissionSet{
+				recv1.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionWrite),
+				recv2.UID: permissions(),
+				recv3.UID: permissions(models.ReceiverPermissionReadSecret, models.ReceiverPermissionDelete),
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc := NewReceiverAccess[*models.Receiver](&recordingAccessControlFake{}, false)
+
+			actual, err := svc.Access(context.Background(), testCase.user, allReceivers...)
+
+			assert.NoError(t, err)
+			assert.Equalf(t, testCase.expected, actual, "expected: %v, actual: %v", testCase.expected, actual)
+
+			provisioningPerms := testCase.expected
+			if testCase.expectedWithProvisioning != nil {
+				provisioningPerms = testCase.expectedWithProvisioning
+			}
+			svc = NewReceiverAccess[*models.Receiver](&recordingAccessControlFake{}, true)
+			actual, err = svc.Access(context.Background(), testCase.user, allReceivers...)
+			assert.NoError(t, err)
+			assert.Equalf(t, provisioningPerms, actual, "expectedWithProvisioning: %v, actual: %v", provisioningPerms, actual)
+		})
+	}
+}
+
+func newEmptyUser(permissions ...ac.Permission) identity.Requester {
+	return ac.BackgroundUser("test", orgID, org.RoleNone, permissions)
+}
+
+func newViewUser(permissions ...ac.Permission) identity.Requester {
+	return ac.BackgroundUser("test", orgID, org.RoleNone, append([]ac.Permission{
+		{Action: ac.ActionAlertingReceiversRead, Scope: ScopeReceiversAll},
+		{Action: ac.ActionAlertingNotificationsRead},
+	}, permissions...))
+}

--- a/pkg/services/ngalert/models/permissions.go
+++ b/pkg/services/ngalert/models/permissions.go
@@ -1,0 +1,75 @@
+package models
+
+import (
+	"maps"
+	"slices"
+)
+
+// ReceiverPermission is a type for representing permission to perform a receiver action.
+type ReceiverPermission string
+
+const (
+	ReceiverPermissionReadSecret ReceiverPermission = "secrets"
+	//ReceiverPermissionAdmin      ReceiverPermission = "admin" // TODO: Add when resource permissions are implemented.
+	ReceiverPermissionWrite  ReceiverPermission = "write"
+	ReceiverPermissionDelete ReceiverPermission = "delete"
+)
+
+// ReceiverPermissions returns all possible silence permissions.
+func ReceiverPermissions() []ReceiverPermission {
+	return []ReceiverPermission{
+		ReceiverPermissionReadSecret,
+		//ReceiverPermissionAdmin, // TODO: Add when resource permissions are implemented.
+		ReceiverPermissionWrite,
+		ReceiverPermissionDelete,
+	}
+}
+
+// ReceiverPermissionSet represents a set of permissions for a receiver.
+type ReceiverPermissionSet = PermissionSet[ReceiverPermission]
+
+func NewReceiverPermissionSet() ReceiverPermissionSet {
+	return NewPermissionSet(ReceiverPermissions())
+}
+
+// PermissionSet represents a set of permissions on a resource.
+type PermissionSet[T ~string] struct {
+	set map[T]bool
+	all []T
+}
+
+func NewPermissionSet[T ~string](all []T) PermissionSet[T] {
+	return PermissionSet[T]{
+		set: make(map[T]bool),
+		all: slices.Clone(all),
+	}
+}
+
+// Clone returns a deep copy of the permission set.
+func (p PermissionSet[T]) Clone() PermissionSet[T] {
+	return PermissionSet[T]{
+		set: maps.Clone(p.set),
+		all: p.all,
+	}
+}
+
+// AllSet returns true if all possible permissions are set.
+func (p PermissionSet[T]) AllSet() bool {
+	for _, permission := range p.all {
+		if _, ok := p.set[permission]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Has returns true if the given permission is allowed in the set.
+func (p PermissionSet[T]) Has(permission T) (bool, bool) {
+	allowed, ok := p.set[permission]
+	return allowed, ok
+}
+
+// Set sets the given permission to the given allowed state.
+func (p PermissionSet[T]) Set(permission T, allowed bool) {
+	p.set[permission] = allowed
+}

--- a/pkg/services/ngalert/models/silence.go
+++ b/pkg/services/ngalert/models/silence.go
@@ -75,7 +75,7 @@ func SilencePermissions() [3]SilencePermission {
 }
 
 // SilencePermissionSet represents a set of permissions for a silence.
-type SilencePermissionSet map[SilencePermission]bool
+type SilencePermissionSet map[SilencePermission]bool // TODO: Implement using PermissionSet[SilencePermission]
 
 // Clone returns a deep copy of the permission set.
 func (p SilencePermissionSet) Clone() SilencePermissionSet {

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -133,11 +133,12 @@ func TestIntegrationAccessControl(t *testing.T) {
 	org1 := helper.Org1
 
 	type testCase struct {
-		user      apis.User
-		canRead   bool
-		canUpdate bool
-		canCreate bool
-		canDelete bool
+		user           apis.User
+		canRead        bool
+		canUpdate      bool
+		canCreate      bool
+		canDelete      bool
+		canReadSecrets bool
 	}
 	// region users
 	unauthorized := helper.CreateUser("unauthorized", "Org1", org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{})
@@ -215,8 +216,9 @@ func TestIntegrationAccessControl(t *testing.T) {
 			canRead: true,
 		},
 		{
-			user:    secretsReader,
-			canRead: true,
+			user:           secretsReader,
+			canRead:        true,
+			canReadSecrets: true,
 		},
 		{
 			user:      creator,
@@ -298,6 +300,16 @@ func TestIntegrationAccessControl(t *testing.T) {
 			}
 
 			if tc.canRead {
+				expectedWithMetadata := expected.DeepCopy()
+				if tc.canUpdate {
+					expectedWithMetadata.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canWrite")] = "true"
+				}
+				if tc.canDelete {
+					expectedWithMetadata.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canDelete")] = "true"
+				}
+				if tc.canReadSecrets {
+					expectedWithMetadata.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canReadSecrets")] = "true"
+				}
 				t.Run("should be able to list receivers", func(t *testing.T) {
 					list, err := client.List(ctx, v1.ListOptions{})
 					require.NoError(t, err)
@@ -307,7 +319,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 				t.Run("should be able to read receiver by resource identifier", func(t *testing.T) {
 					got, err := client.Get(ctx, expected.Name, v1.GetOptions{})
 					require.NoError(t, err)
-					require.Equal(t, expected, got)
+					require.Equal(t, expectedWithMetadata, got)
 
 					t.Run("should get NotFound if resource does not exist", func(t *testing.T) {
 						_, err := client.Get(ctx, "Notfound", v1.GetOptions{})
@@ -870,6 +882,10 @@ func TestIntegrationCRUD(t *testing.T) {
 		}, v1.CreateOptions{})
 		require.NoError(t, err)
 		require.Len(t, receiver.Spec.Integrations, len(integrations))
+
+		// Set access control metadata
+		receiver.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canWrite")] = "true"
+		receiver.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canDelete")] = "true"
 
 		// Use export endpoint because it's the only way to get decrypted secrets fast.
 		cliCfg := helper.Org1.Admin.NewRestConfig()

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -302,13 +302,13 @@ func TestIntegrationAccessControl(t *testing.T) {
 			if tc.canRead {
 				expectedWithMetadata := expected.DeepCopy()
 				if tc.canUpdate {
-					expectedWithMetadata.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canWrite")] = "true"
+					expectedWithMetadata.SetAccessControl("canWrite")
 				}
 				if tc.canDelete {
-					expectedWithMetadata.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canDelete")] = "true"
+					expectedWithMetadata.SetAccessControl("canDelete")
 				}
 				if tc.canReadSecrets {
-					expectedWithMetadata.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canReadSecrets")] = "true"
+					expectedWithMetadata.SetAccessControl("canReadSecrets")
 				}
 				t.Run("should be able to list receivers", func(t *testing.T) {
 					list, err := client.List(ctx, v1.ListOptions{})
@@ -884,8 +884,8 @@ func TestIntegrationCRUD(t *testing.T) {
 		require.Len(t, receiver.Spec.Integrations, len(integrations))
 
 		// Set access control metadata
-		receiver.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canWrite")] = "true"
-		receiver.ObjectMeta.Annotations[fmt.Sprintf("%s%s/%s", v0alpha1.InternalPrefix, "access", "canDelete")] = "true"
+		receiver.SetAccessControl("canWrite")
+		receiver.SetAccessControl("canDelete")
 
 		// Use export endpoint because it's the only way to get decrypted secrets fast.
 		cliCfg := helper.Org1.Admin.NewRestConfig()


### PR DESCRIPTION
This adds access control metadata to k8s receivers API GET/LIST requests:

Example Viewer:
```json
"annotations": {
}
```
Example Editor:
```json
"annotations": {
    "grafana.com/access/canDelete": "true",
    "grafana.com/access/canWrite": "true",
}
```
Example: Admin
```json
"annotations": {
    "grafana.com/access/canDelete": "true",
    "grafana.com/access/canReadSecrets": "true",
    "grafana.com/access/canWrite": "true",
}
```
`grafana.com/access/canAdmin` will be added alongside resource permissions.