### PR TITLE
Alerting: Add field selectors for k8s receivers API

### DIFF
--- a/pkg/apis/alerting_notifications/v0alpha1/register.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/register.go
@@ -106,6 +106,22 @@ func AddKnownTypesGroup(scheme *runtime.Scheme, g schema.GroupVersion) error {
 		return err
 	}
 
+	err = scheme.AddFieldLabelConversionFunc(
+		ReceiverResourceInfo.GroupVersionKind(),
+		func(label, value string) (string, string, error) {
+			fieldSet := SelectableReceiverFields(&Receiver{})
+			for key := range fieldSet {
+				if label == key {
+					return label, value, nil
+				}
+			}
+			return "", "", fmt.Errorf("field label not supported for %s: %s", scope.ScopeNodeResourceInfo.GroupVersionKind(), label)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -116,6 +132,16 @@ func SelectableTimeIntervalsFields(obj *TimeInterval) fields.Set {
 	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
 		"metadata.provenance": obj.GetProvenanceStatus(),
 		"spec.name":           obj.Spec.Name,
+	})
+}
+
+func SelectableReceiverFields(obj *Receiver) fields.Set {
+	if obj == nil {
+		return nil
+	}
+	return generic.MergeFieldsSets(generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false), fields.Set{
+		"metadata.provenance": obj.GetProvenanceStatus(),
+		"spec.title":          obj.Spec.Title,
 	})
 }
 

--- a/pkg/registry/apis/alerting/notifications/receiver/legacy_storage.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/legacy_storage.go
@@ -61,7 +61,7 @@ func (s *legacyStorage) ConvertToTable(ctx context.Context, object runtime.Objec
 	return s.tableConverter.ConvertToTable(ctx, object, tableOptions)
 }
 
-func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
+func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOptions) (runtime.Object, error) {
 	orgId, err := request.OrgIDForList(ctx)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions
 		return nil, err
 	}
 
-	return convertToK8sResources(orgId, res, s.namespacer)
+	return convertToK8sResources(orgId, res, s.namespacer, opts.FieldSelector)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/apis/alerting/notifications/receiver/storage.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/storage.go
@@ -1,11 +1,17 @@
 package receiver
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	apistore "k8s.io/apiserver/pkg/storage"
 
+	model "github.com/grafana/grafana/pkg/apis/alerting_notifications/v0alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
@@ -39,7 +45,7 @@ func NewStorage(
 		s := &genericregistry.Store{
 			NewFunc:                   resourceInfo.NewFunc,
 			NewListFunc:               resourceInfo.NewListFunc,
-			PredicateFunc:             grafanaregistry.Matcher,
+			PredicateFunc:             Matcher,
 			DefaultQualifiedResource:  resourceInfo.GroupResource(),
 			SingularQualifiedResource: resourceInfo.SingularGroupResource(),
 			TableConvertor:            legacyStore.tableConverter,
@@ -54,4 +60,20 @@ func NewStorage(
 		return dualWriteBuilder(resourceInfo.GroupResource(), legacyStore, storage{Store: s})
 	}
 	return legacyStore, nil
+}
+
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	if s, ok := obj.(*model.Receiver); ok {
+		return s.Labels, model.SelectableReceiverFields(s), nil
+	}
+	return nil, nil, fmt.Errorf("object of type %T is not supported", obj)
+}
+
+// Matcher returns a generic.SelectionPredicate that matches on label and field selectors.
+func Matcher(label labels.Selector, field fields.Selector) apistore.SelectionPredicate {
+	return apistore.SelectionPredicate{
+		Label:    label,
+		Field:    field,
+		GetAttrs: GetAttrs,
+	}
 }


### PR DESCRIPTION
**What is this feature?**

Adds support for field selectors on `Receiver` kind. Available selectors: `metadata.name`, `metadata.provenance`, and `spec.title`.

**Why do we need this feature?**

Filtering by fields on `LIST`.

**Who is this feature for?**

UI
