### PR TITLE
Alerting: Include in-use metadata in k8s receiver LIST & GET

### DIFF
--- a/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
@@ -2,7 +2,6 @@ package v0alpha1
 
 import (
 	"fmt"
-	"strings"
 )
 
 const InternalPrefix = "grafana.com/"
@@ -69,7 +68,7 @@ func (o *Receiver) SetInUse(routesCnt int, rules []string) {
 		o.Annotations = make(map[string]string, 2)
 	}
 	o.Annotations[InUseAnnotation("routes")] = fmt.Sprintf("%d", routesCnt)
-	o.Annotations[InUseAnnotation("rules")] = strings.Join(rules, ",")
+	o.Annotations[InUseAnnotation("rules")] = fmt.Sprintf("%d", len(rules))
 }
 
 // InUseAnnotation returns the key for the in-use annotation for the given resource.

--- a/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
@@ -1,6 +1,9 @@
 package v0alpha1
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const InternalPrefix = "grafana.com/"
 const ProvenanceStatusAnnotationKey = InternalPrefix + "provenance"
@@ -59,4 +62,18 @@ func (o *Receiver) SetAccessControl(action string) {
 // Ex. grafana.com/access/canDelete.
 func AccessControlAnnotation(action string) string {
 	return fmt.Sprintf("%s%s/%s", InternalPrefix, "access", action)
+}
+
+func (o *Receiver) SetInUse(routesCnt int, rules []string) {
+	if o.Annotations == nil {
+		o.Annotations = make(map[string]string, 2)
+	}
+	o.Annotations[InUseAnnotation("routes")] = fmt.Sprintf("%d", routesCnt)
+	o.Annotations[InUseAnnotation("rules")] = strings.Join(rules, ",")
+}
+
+// InUseAnnotation returns the key for the in-use annotation for the given resource.
+// Ex. grafana.com/inUse/routes, grafana.com/inUse/rules.
+func InUseAnnotation(resource string) string {
+	return fmt.Sprintf("%s%s/%s", InternalPrefix, "inUse", resource)
 }

--- a/pkg/registry/apis/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/conversions.go
@@ -15,7 +15,14 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 )
 
-func convertToK8sResources(orgID int64, receivers []*ngmodels.Receiver, accesses map[string]ngmodels.ReceiverPermissionSet, namespacer request.NamespaceMapper, selector fields.Selector) (*model.ReceiverList, error) {
+func convertToK8sResources(
+	orgID int64,
+	receivers []*ngmodels.Receiver,
+	accesses map[string]ngmodels.ReceiverPermissionSet,
+	metadatas map[string]ngmodels.ReceiverMetadata,
+	namespacer request.NamespaceMapper,
+	selector fields.Selector,
+) (*model.ReceiverList, error) {
 	result := &model.ReceiverList{
 		Items: make([]model.Receiver, 0, len(receivers)),
 	}
@@ -26,7 +33,13 @@ func convertToK8sResources(orgID int64, receivers []*ngmodels.Receiver, accesses
 				access = &a
 			}
 		}
-		k8sResource, err := convertToK8sResource(orgID, receiver, access, namespacer)
+		var metadata *ngmodels.ReceiverMetadata
+		if metadatas != nil {
+			if m, ok := metadatas[receiver.GetUID()]; ok {
+				metadata = &m
+			}
+		}
+		k8sResource, err := convertToK8sResource(orgID, receiver, access, metadata, namespacer)
 		if err != nil {
 			return nil, err
 		}
@@ -38,7 +51,13 @@ func convertToK8sResources(orgID int64, receivers []*ngmodels.Receiver, accesses
 	return result, nil
 }
 
-func convertToK8sResource(orgID int64, receiver *ngmodels.Receiver, access *ngmodels.ReceiverPermissionSet, namespacer request.NamespaceMapper) (*model.Receiver, error) {
+func convertToK8sResource(
+	orgID int64,
+	receiver *ngmodels.Receiver,
+	access *ngmodels.ReceiverPermissionSet,
+	metadata *ngmodels.ReceiverMetadata,
+	namespacer request.NamespaceMapper,
+) (*model.Receiver, error) {
 	spec := model.ReceiverSpec{
 		Title: receiver.Name,
 	}
@@ -74,6 +93,14 @@ func convertToK8sResource(orgID int64, receiver *ngmodels.Receiver, access *ngmo
 				r.SetAccessControl(mappedAction)
 			}
 		}
+	}
+
+	if metadata != nil {
+		rules := make([]string, 0, len(metadata.InUseByRules))
+		for _, rule := range metadata.InUseByRules {
+			rules = append(rules, rule.UID)
+		}
+		r.SetInUse(metadata.InUseByRoutes, rules)
 	}
 
 	return r, nil

--- a/pkg/registry/apis/alerting/notifications/register.go
+++ b/pkg/registry/apis/alerting/notifications/register.go
@@ -85,7 +85,7 @@ func (t *NotificationsAPIBuilder) GetAPIGroupInfo(
 		return nil, fmt.Errorf("failed to initialize time-interval storage: %w", err)
 	}
 
-	recvStorage, err := receiver.NewStorage(t.ng.Api.ReceiverService, t.namespacer, scheme, optsGetter, dualWriteBuilder, ac.NewReceiverAccess[*ngmodels.Receiver](t.ng.Api.AccessControl, false))
+	recvStorage, err := receiver.NewStorage(t.ng.Api.ReceiverService, t.namespacer, scheme, optsGetter, dualWriteBuilder, t.ng.Api.ReceiverService)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize receiver storage: %w", err)
 	}

--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -40,6 +40,11 @@ type ListReceiversQuery struct {
 	Offset int
 }
 
+type ReceiverMetadata struct {
+	InUseByRules  []AlertRuleKey
+	InUseByRoutes int
+}
+
 // Receiver is the domain model representation of a receiver / contact point.
 type Receiver struct {
 	UID          string

--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -40,6 +40,7 @@ type ListReceiversQuery struct {
 	Offset int
 }
 
+// ReceiverMetadata contains metadata about a receiver's usage in routes and rules.
 type ReceiverMetadata struct {
 	InUseByRules  []AlertRuleKey
 	InUseByRoutes int

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers.go
@@ -70,10 +70,12 @@ func (rev *ConfigRevision) UpdateReceiver(receiver *models.Receiver) error {
 	return nil
 }
 
+// ReceiverNameUsedByRoutes checks if a receiver name is used in any routes.
 func (rev *ConfigRevision) ReceiverNameUsedByRoutes(name string) bool {
 	return isReceiverInUse(name, []*definitions.Route{rev.Config.AlertmanagerConfig.Route})
 }
 
+// ReceiverUseByName returns a map of receiver names to the number of times they are used in routes.
 func (rev *ConfigRevision) ReceiverUseByName() map[string]int {
 	m := make(map[string]int)
 	receiverUseCounts([]*definitions.Route{rev.Config.AlertmanagerConfig.Route}, m)

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers.go
@@ -172,7 +172,6 @@ func receiverUseCounts(routes []*definitions.Route, m map[string]int) {
 		m[route.Receiver]++
 		receiverUseCounts(route.Routes, m)
 	}
-	return
 }
 
 // validateAndSetIntegrationUIDs validates existing integration UIDs and generates them if they are empty.

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -300,7 +300,9 @@ func TestIntegrationAccessControl(t *testing.T) {
 			}
 
 			if tc.canRead {
+				// Set expected metadata.
 				expectedWithMetadata := expected.DeepCopy()
+				expectedWithMetadata.SetInUse(0, nil)
 				if tc.canUpdate {
 					expectedWithMetadata.SetAccessControl("canWrite")
 				}
@@ -883,9 +885,10 @@ func TestIntegrationCRUD(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, receiver.Spec.Integrations, len(integrations))
 
-		// Set access control metadata
+		// Set expected metadata
 		receiver.SetAccessControl("canWrite")
 		receiver.SetAccessControl("canDelete")
+		receiver.SetInUse(0, nil)
 
 		// Use export endpoint because it's the only way to get decrypted secrets fast.
 		cliCfg := helper.Org1.Admin.NewRestConfig()

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -415,6 +415,132 @@ func TestIntegrationAccessControl(t *testing.T) {
 	}
 }
 
+func TestIntegrationInUseMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+	helper := getTestHelper(t)
+
+	cliCfg := helper.Org1.Admin.NewRestConfig()
+	legacyCli := alerting.NewAlertingLegacyAPIClient(helper.GetEnv().Server.HTTPServer.Listener.Addr().String(), cliCfg.Username, cliCfg.Password)
+
+	// Prepare environment and create notification policy and rule that use receiver
+	alertmanagerRaw, err := testData.ReadFile(path.Join("test-data", "notification-settings.json"))
+	require.NoError(t, err)
+	var amConfig definitions.PostableUserConfig
+	require.NoError(t, json.Unmarshal(alertmanagerRaw, &amConfig))
+
+	// Add more references to the receiver in other routes.
+	route1 := *amConfig.AlertmanagerConfig.Route.Routes[0]
+	route1.Routes = nil
+	route2 := route1
+	parentRoute := *amConfig.AlertmanagerConfig.Route.Routes[0]
+	parentRoute.Routes = []*definitions.Route{&route1, &route2}
+	amConfig.AlertmanagerConfig.Route.Routes = append(amConfig.AlertmanagerConfig.Route.Routes, &parentRoute)
+
+	success, err := legacyCli.PostConfiguration(t, amConfig)
+	require.Truef(t, success, "Failed to post Alertmanager configuration: %s", err)
+
+	postGroupRaw, err := testData.ReadFile(path.Join("test-data", "rulegroup-1.json"))
+	require.NoError(t, err)
+	var ruleGroup definitions.PostableRuleGroupConfig
+	require.NoError(t, json.Unmarshal(postGroupRaw, &ruleGroup))
+
+	// Add more references to the receiver by creating adding same rule with a different title.
+	ruleGen := func() definitions.PostableGrafanaRule { return *ruleGroup.Rules[0].GrafanaManagedAlert }
+	rule2 := ruleGen()
+	rule2.Title = "Rule2"
+	rule2.NotificationSettings = &definitions.AlertRuleNotificationSettings{Receiver: "grafana-default-email"}
+	rule3 := ruleGen()
+	rule3.Title = "Rule3"
+	ruleGroup.Rules = append(ruleGroup.Rules,
+		definitions.PostableExtendedRuleNode{
+			ApiRuleNode:         ruleGroup.Rules[0].ApiRuleNode,
+			GrafanaManagedAlert: &rule2,
+		},
+		definitions.PostableExtendedRuleNode{
+			ApiRuleNode:         ruleGroup.Rules[0].ApiRuleNode,
+			GrafanaManagedAlert: &rule3,
+		},
+	)
+
+	folderUID := "test-folder"
+	legacyCli.CreateFolder(t, folderUID, "TEST")
+	_, status, data := legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
+
+	adminK8sClient, err := versioned.NewForConfig(cliCfg)
+	require.NoError(t, err)
+	adminClient := adminK8sClient.NotificationsV0alpha1().Receivers("default")
+
+	requestReceivers := func(t *testing.T, title string) (v0alpha1.Receiver, v0alpha1.Receiver) {
+		t.Helper()
+		receivers, err := adminClient.List(ctx, v1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, receivers.Items, 2)
+		idx := slices.IndexFunc(receivers.Items, func(interval v0alpha1.Receiver) bool {
+			return interval.Spec.Title == title
+		})
+		receiverListed := receivers.Items[idx]
+
+		receiverGet, err := adminClient.Get(ctx, receiverListed.Name, v1.GetOptions{})
+		require.NoError(t, err)
+
+		return receiverListed, *receiverGet
+	}
+
+	checkInUse := func(t *testing.T, receiverList, receiverGet v0alpha1.Receiver, routes, rules int) {
+		t.Helper()
+		assert.Equalf(t, fmt.Sprintf("%d", routes), receiverList.Annotations[v0alpha1.InUseAnnotation("routes")], "LIST: Expected %s used by %d routes", receiverList.Spec.Title, routes)
+		assert.Equalf(t, fmt.Sprintf("%d", rules), receiverList.Annotations[v0alpha1.InUseAnnotation("rules")], "LIST: Expected %s used by %d rules", receiverList.Spec.Title, rules)
+		assert.Equalf(t, fmt.Sprintf("%d", routes), receiverGet.Annotations[v0alpha1.InUseAnnotation("routes")], "GET: Expected %s used by %d routes", receiverGet.Spec.Title, routes)
+		assert.Equalf(t, fmt.Sprintf("%d", rules), receiverGet.Annotations[v0alpha1.InUseAnnotation("rules")], "GET: Expected %s used by %d rules", receiverGet.Spec.Title, rules)
+	}
+
+	receiverListed, receiverGet := requestReceivers(t, "user-defined")
+	checkInUse(t, receiverListed, receiverGet, 4, 2)
+
+	// Verify the default.
+	receiverListed, receiverGet = requestReceivers(t, "grafana-default-email")
+	checkInUse(t, receiverListed, receiverGet, 1, 1)
+
+	// Removing the new extra route should leave only 1.
+	amConfig.AlertmanagerConfig.Route.Routes = amConfig.AlertmanagerConfig.Route.Routes[:1]
+	success, err = legacyCli.PostConfiguration(t, amConfig)
+	require.Truef(t, success, "Failed to post Alertmanager configuration: %s", err)
+
+	receiverListed, receiverGet = requestReceivers(t, "user-defined")
+	checkInUse(t, receiverListed, receiverGet, 1, 2)
+
+	// Remove the extra rules.
+	ruleGroup.Rules = ruleGroup.Rules[:1]
+	_, status, data = legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
+
+	receiverListed, receiverGet = requestReceivers(t, "user-defined")
+	checkInUse(t, receiverListed, receiverGet, 1, 1)
+
+	receiverListed, receiverGet = requestReceivers(t, "grafana-default-email")
+	checkInUse(t, receiverListed, receiverGet, 1, 0)
+
+	// Remove the rest.
+	amConfig.AlertmanagerConfig.Route.Routes = nil
+	success, err = legacyCli.PostConfiguration(t, amConfig)
+	require.Truef(t, success, "Failed to post Alertmanager configuration: %s", err)
+
+	ruleGroup.Rules = nil
+	_, status, data = legacyCli.PostRulesGroupWithStatus(t, folderUID, &ruleGroup)
+	require.Equalf(t, http.StatusAccepted, status, "Failed to post Rule: %s", data)
+
+	receiverListed, receiverGet = requestReceivers(t, "user-defined")
+	checkInUse(t, receiverListed, receiverGet, 0, 0)
+
+	receiverListed, receiverGet = requestReceivers(t, "grafana-default-email")
+	checkInUse(t, receiverListed, receiverGet, 1, 0)
+}
+
 func TestIntegrationProvisioning(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")


### PR DESCRIPTION
This adds in-use metadata to k8s receivers API GET/LIST requests in a similar way to https://github.com/grafana/grafana/pull/93013

Example:
```json
"annotations": {
  "grafana.com/inUse/routes": "2",
  "grafana.com/inUse/rules": "4"
}
```