### PR TITLE
Ops: Add query param essentials to open Essentials drawer

### DIFF
--- a/public/app/features/gops/configuration-tracker/components/ConfigureIRM.tsx
+++ b/public/app/features/gops/configuration-tracker/components/ConfigureIRM.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -59,11 +59,9 @@ export function ConfigureIRM() {
     });
   }, [dataSourceConfigurationData.dataSourceCompatibleWithAlerting]);
 
-  // query param 'essentials' is used to open essentials drawer when landing on the page
-  const [queryParams] = useURLSearchParams();
-  const essentialsIsOpenFromUrl = queryParams.get('essentials') === 'open';
-
-  const [essentialsOpen, setEssentialsOpen] = useState(essentialsIsOpenFromUrl);
+  // query param 'essentials' is used to open essentials drawer
+  const [queryParams, setQueryParams] = useURLSearchParams();
+  const essentialsOpen = queryParams.get('essentials') === 'open';
 
   const handleActionClick = (configID: number, isDone?: boolean) => {
     trackIrmConfigurationTrackerEvent(IRMInteractionNames.ClickDataSources, {
@@ -80,7 +78,7 @@ export function ConfigureIRM() {
         }
         break;
       case ConfigurationStepsEnum.ESSENTIALS:
-        setEssentialsOpen(true);
+        setQueryParams({ essentials: 'open' });
         trackIrmConfigurationTrackerEvent(IRMInteractionNames.OpenEssentials, {
           essentialStepsDone: essentialsConfigurationData.stepsDone,
           essentialStepsToDo: essentialsConfigurationData.totalStepsToDo,
@@ -93,7 +91,7 @@ export function ConfigureIRM() {
   };
 
   function onCloseEssentials() {
-    setEssentialsOpen(false);
+    setQueryParams({ essentials: undefined });
     trackIrmConfigurationTrackerEvent(IRMInteractionNames.CloseEssentials, {
       essentialStepsDone: essentialsConfigurationData.stepsDone,
       essentialStepsToDo: essentialsConfigurationData.totalStepsToDo,

--- a/public/app/features/gops/configuration-tracker/components/ConfigureIRM.tsx
+++ b/public/app/features/gops/configuration-tracker/components/ConfigureIRM.tsx
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { IconName, Text, useStyles2 } from '@grafana/ui';
+import { useURLSearchParams } from 'app/features/alerting/unified/hooks/useURLSearchParams';
 import { getFirstCompatibleDataSource } from 'app/features/alerting/unified/utils/datasource';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 
@@ -58,7 +59,11 @@ export function ConfigureIRM() {
     });
   }, [dataSourceConfigurationData.dataSourceCompatibleWithAlerting]);
 
-  const [essentialsOpen, setEssentialsOpen] = useState(false);
+  // query param 'essentials' is used to open essentials drawer when landing on the page
+  const [queryParams] = useURLSearchParams();
+  const essentialsIsOpenFromUrl = queryParams.get('essentials') === 'open';
+
+  const [essentialsOpen, setEssentialsOpen] = useState(essentialsIsOpenFromUrl);
 
   const handleActionClick = (configID: number, isDone?: boolean) => {
     trackIrmConfigurationTrackerEvent(IRMInteractionNames.ClickDataSources, {


### PR DESCRIPTION
**What is this feature?**

This PR adds the `essentials` query parameter to the url, to enable direct navigation to the configuration tracker page with the essentials drawer open by default.

**Why do we need this feature?**

There are some workflows that need to send the user to the Essentials page.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**


https://github.com/user-attachments/assets/364eb465-8614-452c-881c-8114347d79be



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
