### PR TITLE
chore(tests): fix flaky SMTP test

### DIFF
--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/textproto"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -300,6 +301,11 @@ func TestSmtpSend(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 		messages := srv.MessagesAndPurge()
 		assert.Len(t, messages, 3)
+
+		// sort for test consistency
+		sort.Slice(messages, func(i, j int) bool {
+			return messages[i].RcpttoRequestResponse()[0][0] < messages[j].RcpttoRequestResponse()[0][0]
+		})
 
 		for i, sentMsg := range messages {
 			rcpts := sentMsg.RcpttoRequestResponse()


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/92786

We check the result messages in the same order as we define them, but the response order is not guaranteed.
Each message is appended to the results once its respective handler completes:
https://github.com/mocktools/go-smtp-mock/blob/master/server.go#L220

Sorting the responses before our test checks should prevent flaky issues with ordering. 