### PR TITLE
Tempo: Remove usage of traceQLStreaming feature toggle

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -105,9 +105,10 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	// things. For example Node allows to publish messages to channels from server
 	// side with its Publish method.
 	node, err := centrifuge.New(centrifuge.Config{
-		LogHandler:       handleLog,
-		LogLevel:         centrifuge.LogLevelError,
-		MetricsNamespace: "grafana_live",
+		LogHandler:         handleLog,
+		LogLevel:           centrifuge.LogLevelError,
+		MetricsNamespace:   "grafana_live",
+		ClientQueueMaxSize: 4194304, // 4MB
 		// Use reasonably large expiration interval for stream meta key,
 		// much bigger than maximum HistoryLifetime value in Node config.
 		// This way stream meta data will expire, in some cases you may want

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -286,18 +286,13 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
    * Check if streaming for search queries is enabled (and available).
    *
    * We need to check:
-   * - the `traceQLStreaming` feature toggle, to disable streaming if customer support turned off the toggle in the past, which usually means that streaming does not work properly for the customer
-   * - the recently created Tempo data source plugin toggle, to disable streaming if the user disabled it in the data source configuration
-   * - whether streaming is actually available based on the Tempo version, just as a sanity check
+   * - the Tempo data source plugin toggle, to disable streaming if the user disabled it in the data source configuration
+   * - if Grafana Live is enabled
    *
    * @return true if streaming for search queries is enabled, false otherwise
    */
   isStreamingSearchEnabled() {
-    return (
-      (config.featureToggles.traceQLStreaming || this.streamingEnabled?.search) &&
-      this.isFeatureAvailable(FeatureName.streaming) &&
-      config.liveEnabled
-    );
+    return this.streamingEnabled?.search && config.liveEnabled;
   }
 
   isTraceQlMetricsQuery(query: string): boolean {
@@ -371,7 +366,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
               app: options.app ?? '',
               grafana_version: config.buildInfo.version,
               query: queryValue ?? '',
-              streaming: this.streamingEnabled,
+              streaming: this.isStreamingSearchEnabled(),
             });
             subQueries.push(this.handleTraceQlQuery(options, targets, queryValue));
           }
@@ -405,7 +400,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             app: options.app ?? '',
             grafana_version: config.buildInfo.version,
             query: queryValueFromFilters ?? '',
-            streaming: this.streamingEnabled,
+            streaming: this.isStreamingSearchEnabled(),
           });
 
           if (this.isStreamingSearchEnabled()) {


### PR DESCRIPTION
**What is this feature?**

Removes the check for the `traceQLStreaming` feature toggle to determine whether to enable streaming or not. We now rely only on the datasource config to enable streaming queries. 

We'll remove the actual feature toggle from the registry in a following PR.

Also fixes an issue with large messages causing streaming to disconnect the websocket with a [DisconnectSlow](https://centrifugal.dev/docs/server/codes#disconnectslow) reason. Updated the limit to `4MB` which replaces the default of `1MB`.

**Why do we need this feature?**

Completes the effort to move the Tempo streaming control to a datasource config. 

**Who is this feature for?**

Users of the Tempo datasource. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
