### PR TITLE
DashboardScenes: Fix duplicate query modifying original query on panel duplication

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -785,6 +785,22 @@ describe('DashboardScene', () => {
         expect(libVizPanel.state.key).toBe('panel-7');
       });
 
+      it('Should deep clone data provider when duplicating a panel', () => {
+        const vizPanel = ((scene.state.body as SceneGridLayout).state.children[0] as DashboardGridItem).state.body;
+        scene.duplicatePanel(vizPanel as VizPanel);
+
+        const panelQueries = (
+          ((scene.state.body as SceneGridLayout).state.children[0] as DashboardGridItem).state.body.state.$data?.state
+            .$data as SceneQueryRunner
+        ).state.queries;
+        const duplicatedPanelQueries = (
+          ((scene.state.body as SceneGridLayout).state.children[5] as DashboardGridItem).state.body.state.$data?.state
+            .$data as SceneQueryRunner
+        ).state.queries;
+
+        expect(panelQueries[0]).not.toBe(duplicatedPanelQueries[0]);
+      });
+
       it('Should duplicate a repeated panel', () => {
         const scene = buildTestScene({
           body: new SceneGridLayout({
@@ -1225,7 +1241,10 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
             }),
             $data: new SceneDataTransformer({
               transformations: [],
-              $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
+              $data: new SceneQueryRunner({
+                key: 'data-query-runner',
+                queries: [{ refId: 'A', target: 'aliasByMetric(carbon.**)' }],
+              }),
             }),
           }),
         }),

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -60,6 +60,7 @@ import {
   getDefaultRow,
   getDefaultVizPanel,
   getPanelIdForVizPanel,
+  getQueryRunnerFor,
   getVizPanelKeyForPanelId,
   isPanelClone,
 } from '../utils/utils';
@@ -569,10 +570,18 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
 
     if (gridItem instanceof DashboardGridItem) {
       panelState = sceneUtils.cloneSceneObjectState(gridItem.state.body.state);
-      panelData = sceneGraph.getData(gridItem.state.body).clone();
+
+      let queryRunner = getQueryRunnerFor(gridItem.state.body);
+      const queries = queryRunner?.state.queries.map((q) => ({ ...q }));
+      queryRunner = queryRunner?.clone({ queries });
+      panelData = sceneGraph.getData(gridItem.state.body).clone({ $data: queryRunner });
     } else {
       panelState = sceneUtils.cloneSceneObjectState(vizPanel.state);
-      panelData = sceneGraph.getData(vizPanel).clone();
+
+      let queryRunner = getQueryRunnerFor(vizPanel);
+      const queries = queryRunner?.state.queries.map((q) => ({ ...q }));
+      queryRunner = queryRunner?.clone({ queries });
+      panelData = sceneGraph.getData(vizPanel).clone({ $data: queryRunner });
     }
 
     // when we duplicate a panel we don't want to clone the alert state


### PR DESCRIPTION
An issue arose when duplicating a panel in a dashboard and then trying to modify the cloned panel query. Changing the cloned panel query would actually affect the original panels query. Not all datasources reproduce this, it was noticed on the `graphiteDS`.

This PR fixes the issue and makes sure the two query sets are different.

