### PR TITLE
RBAC: Allow specifying several valid scopes for a kind

### DIFF
--- a/pkg/services/accesscontrol/permreg/permreg_test.go
+++ b/pkg/services/accesscontrol/permreg/permreg_test.go
@@ -39,7 +39,8 @@ func Test_permissionRegistry_RegisterPluginScope(t *testing.T) {
 			pr.RegisterPluginScope(tt.scope)
 			got, ok := pr.kindScopePrefix[tt.wantKind]
 			require.True(t, ok)
-			require.Equal(t, tt.wantScope, got)
+			require.Len(t, got, 1)
+			require.Equal(t, tt.wantScope, got[0])
 		})
 	}
 }
@@ -105,6 +106,8 @@ func Test_permissionRegistry_IsPermissionValid(t *testing.T) {
 	pr := newPermissionRegistry()
 	err := pr.RegisterPermission("folders:read", "folders:uid:")
 	require.NoError(t, err)
+	err = pr.RegisterPermission("dashboards:read", "dashboards:uid:")
+	require.NoError(t, err)
 	err = pr.RegisterPermission("test-app.settings:read", "")
 	require.NoError(t, err)
 
@@ -149,6 +152,18 @@ func Test_permissionRegistry_IsPermissionValid(t *testing.T) {
 			action:  "folders:read",
 			scope:   "folders:id:3",
 			wantErr: true,
+		},
+		{
+			name:    "valid dashboards read with dashboard scope",
+			action:  "dashboards:read",
+			scope:   "dashboards:uid:my_team_dash",
+			wantErr: false,
+		},
+		{
+			name:    "valid dashboards read with folder scope",
+			action:  "dashboards:read",
+			scope:   "folders:uid:my_team_folder",
+			wantErr: false,
 		},
 		{
 			name:    "valid app plugin settings read",


### PR DESCRIPTION
**What is this feature?**

Some actions have several valid scopes. Eg, `dashboards:read` can be scoped to a specific dashboard or to a folder. We used to only specify one valid scope, so permission validation that we run when roles are created would fail and complain about an invalid scope. This PR extends the permission registry to accept several valid scopes.

**Why do we need this feature?**

Currently custom role creation is broken if a valid scope that is not listed is used.

**Who is this feature for?**

Anyone that uses custom roles.

**Special notes for your reviewer:**

Not sure if we need to backport. We only received complaints about it recently, but looking at the code I feel like we should've had this issue for a while.
