### PR TITLE
InfluxDB: Update macro regexp

### DIFF
--- a/pkg/tsdb/influxdb/flux/macros.go
+++ b/pkg/tsdb/influxdb/flux/macros.go
@@ -22,7 +22,7 @@ func interpolateInterval(flux string, interval time.Duration) string {
 	return flux
 }
 
-var fluxVariableFilterExp = regexp.MustCompile(`(?m)([a-zA-Z]+)\.([a-zA-Z]+)`)
+var fluxVariableFilterExp = regexp.MustCompile(`(?m)(v)\.([a-zA-Z]+)`)
 
 func interpolateFluxSpecificVariables(query queryModel) string {
 	rawQuery := query.RawQuery

--- a/pkg/tsdb/influxdb/flux/macros_test.go
+++ b/pkg/tsdb/influxdb/flux/macros_test.go
@@ -28,13 +28,13 @@ func TestInterpolate(t *testing.T) {
 	}{
 		{
 			name:   "interpolate flux variables",
-			before: `v.timeRangeStart, something.timeRangeStop, XYZ.bucket, uuUUu.defaultBucket, aBcDefG.organization, window.windowPeriod, a91{}.bucket, $__interval, $__interval_ms`,
+			before: `v.timeRangeStart, v.timeRangeStop, v.bucket, v.defaultBucket, v.organization, v.windowPeriod, a91{}.bucket, $__interval, $__interval_ms`,
 			after:  `2021-09-22T10:12:51.310985041Z, 2021-09-22T11:12:51.310985042Z, "grafana2", "grafana3", "grafana1", 1m1.258s, a91{}.bucket, 1m, 61258`,
 		},
 		{
 			name:   "don't interpolate bucket variable in join query",
-			before: `range(start: v.timeRangeStart, stop: v.timeRangeStop) join.left(left: left |> group(), right: right,on:((l,r) => l.bucket == r.id), as: ((l, r) => ({l with name: r.name})))`,
-			after:  `range(start: 2021-09-22T10:12:51.310985041Z, stop: 2021-09-22T11:12:51.310985042Z) join.left(left: left |> group(), right: right,on:((l,r) => l.bucket == r.id), as: ((l, r) => ({l with name: r.name})))`,
+			before: `range(start: v.timeRangeStart, stop: v.timeRangeStop) join.left(left: left |> group(), right: right,on:((l,r) => v.bucket == r.id), as: ((l, r) => ({l with name: r.name})))`,
+			after:  `range(start: 2021-09-22T10:12:51.310985041Z, stop: 2021-09-22T11:12:51.310985042Z) join.left(left: left |> group(), right: right,on:((l,r) => v.bucket == r.id), as: ((l, r) => ({l with name: r.name})))`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
As per the [Flux](https://docs.influxdata.com/influxdb/v2/visualize-data/variables/) documentation predefined and custom dashboard variables are typically stored in a record with the label `v`.

To ensure consistency we are changing the data source to also follow the same pattern.

# Release notice breaking change

InfluxDB data sources configured to use Flux as the query language will now utilise the same logic as Influx for both predefined and custom dashboard variables. The following variables are affected: `timeRangeStart`, `timeRangeStop`, `windowPeriod`, `defaultBucket`, and `organization`. Previously the variables could be defined as `ANY_WORD.VARIABLE_NAME`. The variables must now be defined as `v.VARIABLE_NAME` to be correctly interpolated.