### PR TITLE
Make Combobox Storybook story public, with indev disclaimer

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7347,6 +7347,9 @@ exports[`no undocumented stories`] = {
     "packages/grafana-ui/src/components/ButtonCascader/ButtonCascader.story.tsx:5381": [
       [0, 0, 0, "No undocumented stories are allowed, please add an .mdx file with some documentation", "5381"]
     ],
+    "packages/grafana-ui/src/components/Combobox/Combobox.story.tsx:5381": [
+      [0, 0, 0, "No undocumented stories are allowed, please add an .mdx file with some documentation", "5381"]
+    ],
     "packages/grafana-ui/src/components/DateTimePickers/RelativeTimeRangePicker/RelativeTimeRangePicker.story.tsx:5381": [
       [0, 0, 0, "No undocumented stories are allowed, please add an .mdx file with some documentation", "5381"]
     ],

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -1,8 +1,9 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { Chance } from 'chance';
-import { ComponentProps, useEffect, useState } from 'react';
+import React, { ComponentProps, useEffect, useState } from 'react';
 
+import { Alert } from '../Alert/Alert';
 import { Field } from '../Forms/Field';
 
 import { Combobox, Option, Value } from './Combobox';
@@ -44,6 +45,7 @@ const meta: Meta<PropsAndCustomArgs> = {
   },
 
   render: (args) => <BasicWithState {...args} />,
+  decorators: [InDevDecorator],
 };
 
 const BasicWithState: StoryFn<typeof Combobox> = (args) => {
@@ -114,4 +116,24 @@ export const ManyOptions: StoryObj<PropsAndCustomArgs> = {
   render: ManyOptionsStory,
 };
 
+export const CustomValue: StoryObj<PropsAndCustomArgs> = {
+  args: {
+    createCustomValue: true,
+  },
+};
+
 export default meta;
+
+function InDevDecorator(Story: React.ElementType) {
+  return (
+    <div>
+      <Alert title="This component is still in development!" severity="info">
+        Combobox is still in development and not able to be used externally.
+        <br />
+        Within the Grafana repo, it can be used by importing it from{' '}
+        <span style={{ fontFamily: 'monospace' }}>@grafana/ui/src/unstable</span>
+      </Alert>
+      <Story />
+    </div>
+  );
+}


### PR DESCRIPTION
This makes the combobox story public so others can view it on developers.grafana.com, but with a disclaimer saying is not ready yet :)

![image](https://github.com/user-attachments/assets/887de755-76b0-45ee-98b8-c09a56a8ac89)
