### PR TITLE
fix whatsNewUrl in package.json for v11.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "generate-apis": "rtk-query-codegen-openapi ./scripts/generate-rtk-apis.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v11-0/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v11-2/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "devDependencies": {


### PR DESCRIPTION
**What is this feature?**

Fix `whatsNewUrl` in `package.json`.

Similar to: https://github.com/grafana/grafana/pull/90736
