### PR TITLE
Tracer: use from context instead of passing around in args

### DIFF
--- a/pkg/services/apiserver/standalone/factory.go
+++ b/pkg/services/apiserver/standalone/factory.go
@@ -32,7 +32,7 @@ type APIServerFactory interface {
 	GetEnabled(runtime []RuntimeConfig) ([]schema.GroupVersion, error)
 
 	// Optional override for apiserver's BuildHandlerChainFunc, return nil if you want to use the grafana's default chain func defined in pkg/services/apiserver/builder/helper.go
-	GetBuildHandlerChainFunc(tracer tracing.Tracer, builders []builder.APIGroupBuilder) builder.BuildHandlerChainFunc
+	GetBuildHandlerChainFunc(builders []builder.APIGroupBuilder) builder.BuildHandlerChainFunc
 
 	// Make an API server for a given group+version
 	MakeAPIServer(ctx context.Context, tracer tracing.Tracer, gv schema.GroupVersion) (builder.APIGroupBuilder, error)
@@ -51,7 +51,7 @@ func (p *DummyAPIFactory) GetOptions() options.OptionsProvider {
 	return nil
 }
 
-func (p *DummyAPIFactory) GetBuildHandlerChainFunc(_ tracing.Tracer, builders []builder.APIGroupBuilder) builder.BuildHandlerChainFunc {
+func (p *DummyAPIFactory) GetBuildHandlerChainFunc(builders []builder.APIGroupBuilder) builder.BuildHandlerChainFunc {
 	return nil
 }
 

--- a/pkg/services/contexthandler/contexthandler_test.go
+++ b/pkg/services/contexthandler/contexthandler_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
@@ -26,7 +25,6 @@ func TestContextHandler(t *testing.T) {
 	t.Run("should set auth error if authentication was unsuccessful", func(t *testing.T) {
 		handler := contexthandler.ProvideService(
 			setting.NewCfg(),
-			tracing.InitializeTracerForTest(),
 			&authntest.FakeService{ExpectedErr: errors.New("some error")},
 		)
 
@@ -47,7 +45,6 @@ func TestContextHandler(t *testing.T) {
 		id := &authn.Identity{ID: "1", Type: claims.TypeUser, OrgID: 1}
 		handler := contexthandler.ProvideService(
 			setting.NewCfg(),
-			tracing.InitializeTracerForTest(),
 			&authntest.FakeService{ExpectedIdentity: id},
 		)
 
@@ -72,7 +69,6 @@ func TestContextHandler(t *testing.T) {
 		identity := &authn.Identity{ID: "0", Type: claims.TypeAnonymous, OrgID: 1}
 		handler := contexthandler.ProvideService(
 			setting.NewCfg(),
-			tracing.InitializeTracerForTest(),
 			&authntest.FakeService{ExpectedIdentity: identity},
 		)
 
@@ -93,7 +89,6 @@ func TestContextHandler(t *testing.T) {
 		identity := &authn.Identity{OrgID: 1, AuthenticatedBy: login.RenderModule}
 		handler := contexthandler.ProvideService(
 			setting.NewCfg(),
-			tracing.InitializeTracerForTest(),
 			&authntest.FakeService{ExpectedIdentity: identity},
 		)
 
@@ -123,7 +118,6 @@ func TestContextHandler(t *testing.T) {
 
 		handler := contexthandler.ProvideService(
 			cfg,
-			tracing.InitializeTracerForTest(),
 			&authntest.FakeService{ExpectedIdentity: &authn.Identity{}},
 		)
 
@@ -151,7 +145,6 @@ func TestContextHandler(t *testing.T) {
 
 			handler := contexthandler.ProvideService(
 				cfg,
-				tracing.InitializeTracerForTest(),
 				&authntest.FakeService{ExpectedIdentity: &authn.Identity{ID: i, Type: typ}},
 			)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the tracer arg from contexthandler since https://github.com/grafana/grafana/pull/93052 introduces a better ability to just fetch it from context as needed.

**Why do we need this feature?**

Simplifies using ContextHandler.

**Who is this feature for?**

@grafana/cloud-app-platform-squad 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
