### PR TITLE
FieldColor: Prefer displayName for hashing

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.test.ts
+++ b/packages/grafana-data/src/field/fieldColor.test.ts
@@ -1,8 +1,9 @@
 import { createTheme } from '../themes/createTheme';
-import { Field, FieldType } from '../types/dataFrame';
+import { DataFrame, Field, FieldType } from '../types/dataFrame';
 import { FieldColorModeId } from '../types/fieldColor';
 
 import { fieldColorModeRegistry, FieldValueColorCalculator, getFieldSeriesColor } from './fieldColor';
+import { cacheFieldDisplayNames } from './fieldState';
 
 function getTestField(mode: string, fixedColor?: string, name = 'name'): Field {
   return {
@@ -53,6 +54,67 @@ describe('fieldColorModeRegistry', () => {
     const calcFn1 = getCalculator({ mode: FieldColorModeId.PaletteClassicByName, seriesIndex: 0, name: 'same name' });
     const calcFn2 = getCalculator({ mode: FieldColorModeId.PaletteClassicByName, seriesIndex: 1, name: 'same name' });
     expect(calcFn1(12, 34, undefined)).toEqual(calcFn2(56, 78, undefined));
+  });
+
+  it('Palette uses displayName with Value fields', () => {
+    let frames: DataFrame[] = [
+      {
+        length: 0,
+        fields: [
+          {
+            name: 'Time',
+            type: FieldType.time,
+            values: [],
+            config: {},
+          },
+          {
+            name: 'Value',
+            labels: { foo: 'bar' },
+            type: FieldType.number,
+            values: [],
+            config: {
+              color: {
+                mode: FieldColorModeId.PaletteClassicByName,
+              },
+            },
+            state: {},
+          },
+        ],
+      },
+      {
+        length: 0,
+        fields: [
+          {
+            name: 'Time',
+            type: FieldType.time,
+            values: [],
+            config: {},
+          },
+          {
+            name: 'Value',
+            labels: { foo: 'baz' },
+            type: FieldType.number,
+            values: [],
+            config: {
+              color: {
+                mode: FieldColorModeId.PaletteClassicByName,
+              },
+            },
+            state: {},
+          },
+        ],
+      },
+    ];
+
+    cacheFieldDisplayNames(frames);
+
+    const mode = fieldColorModeRegistry.get(FieldColorModeId.PaletteClassicByName);
+
+    const calcFn1 = mode.getCalculator(frames[0].fields[1], createTheme());
+    const calcFn2 = mode.getCalculator(frames[1].fields[1], createTheme());
+
+    expect(calcFn1(0, 0)).toEqual('#82B5D8');
+    expect(calcFn2(0, 0)).toEqual('#FCE2DE');
   });
 
   it('When color.seriesBy is set to last use that instead of v', () => {

--- a/packages/grafana-data/src/field/fieldColor.ts
+++ b/packages/grafana-data/src/field/fieldColor.ts
@@ -218,7 +218,7 @@ export class FieldColorSchemeMode implements FieldColorMode {
       }
     } else if (this.useSeriesName) {
       return (_: number, _percent: number, _threshold?: Threshold) => {
-        return colors[Math.abs(stringHash(field.name)) % colors.length];
+        return colors[Math.abs(stringHash(field.state?.displayName ?? field.name)) % colors.length];
       };
     } else {
       return (_: number, _percent: number, _threshold?: Threshold) => {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/93061

<details><summary>color-by-field-hash.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 351,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic-by-name"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "11.3.0-pre",
      "targets": [
        {
          "csvContent": "x,Value{foo=bar},Value{foo=baz}\n1,2,3\n2,4,5",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "type": "trend"
    }
  ],
  "preload": false,
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "color-by-field-hash",
  "uid": "fdx4w2u5l5khsf",
  "version": 2,
  "weekStart": ""
}
```
</details>

`displayName` is calculated to be unique, while `field.name` is often just `Value` for each series, with only labels distinguishing them.