### PR TITLE
only run crowdin actions on grafana/grafana

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   download-sources-from-crowdin:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   upload-sources-to-crowdin:
+    if: github.repository == 'grafana/grafana'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The crowdin download action is run hourly, and fails in forked repositories because the required credentials are not available.

This PR disables the download and upload actions for repositories other than grafana/grafana, so these errors aren't produced. I can't think of a case where running them on a forked repo would make sense, but we can explore alternatives if there is a use-case for that.