### PR TITLE
Prometheus: Retain time field's interval with Table formatted queries

### DIFF
--- a/packages/grafana-prometheus/src/result_transformer.test.ts
+++ b/packages/grafana-prometheus/src/result_transformer.test.ts
@@ -1213,4 +1213,21 @@ describe('Prometheus Result Transformer', () => {
       expect(transformedTableDataFrames[1].meta?.executedQueryString).toEqual(executedQueryForRefB);
     });
   });
+
+  it("transforms dataFrame and retains time field's `config.interval`", () => {
+    const df = createDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2, 3], config: { interval: 1 } },
+        {
+          name: 'value',
+          type: FieldType.number,
+          values: [5, 10, 5],
+        },
+      ],
+    });
+
+    const tableDf = transformDFToTable([df])[0];
+    expect(tableDf.fields[0].config.interval).toEqual(1);
+  });
 });

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -212,6 +212,8 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
 
     // Fill valueField, timeField and labelFields with values
     dataFramesByRefId[refId].forEach((df) => {
+      timeField.config.interval ??= df.fields[0]?.config.interval;
+
       const timeFields = df.fields[0]?.values ?? [];
       const dataFields = df.fields[1]?.values ?? [];
       timeFields.forEach((value) => timeField.values.push(value));


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/12331

i don't think this will fix all cases of mixing Table format and Time series format queries, but should help.