### PR TITLE
I18n: Add constants value tests to avoid typos

### DIFF
--- a/public/app/core/internationalization/constants.test.ts
+++ b/public/app/core/internationalization/constants.test.ts
@@ -1,8 +1,30 @@
 import { uniqBy } from 'lodash';
 
-import { LANGUAGES, VALID_LANGUAGES } from './constants';
+import {
+  BRAZILIAN_PORTUGUESE,
+  CHINESE_SIMPLIFIED,
+  DEFAULT_LANGUAGE,
+  ENGLISH_US,
+  FRENCH_FRANCE,
+  GERMAN_GERMANY,
+  LANGUAGES,
+  PSEUDO_LOCALE,
+  SPANISH_SPAIN,
+  VALID_LANGUAGES,
+} from './constants';
 
 describe('internationalization constants', () => {
+  it('should have set the constants correctly', () => {
+    expect(ENGLISH_US).toBe('en-US');
+    expect(FRENCH_FRANCE).toBe('fr-FR');
+    expect(SPANISH_SPAIN).toBe('es-ES');
+    expect(GERMAN_GERMANY).toBe('de-DE');
+    expect(BRAZILIAN_PORTUGUESE).toBe('pt-BR');
+    expect(CHINESE_SIMPLIFIED).toBe('zh-Hans');
+    expect(PSEUDO_LOCALE).toBe('pseudo-LOCALE');
+    expect(DEFAULT_LANGUAGE).toBe(ENGLISH_US);
+  });
+
   it('should not have duplicate languages codes', () => {
     const uniqLocales = uniqBy(LANGUAGES, (v) => v.code);
     expect(LANGUAGES).toHaveLength(uniqLocales.length);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Tests for internationalization constants values to assert that there aren't typos or unwanted changes.

**Why do we need this feature?**

To assure that unwanted changes in internationalization constants can be caught by unit tests, avoiding production errors.

**Special notes for your reviewer:**

I'm brazilian and few weeks ago I was installing Grafana for internal dashboards for my company, one of the prerequisites were that it must be totally in Portuguese for the viewers so I've setup a local demo and they approved. But when I deployed in version 11.2.0 it was broke, every language but Portuguese changes the interface, then I had to downgrade.
I was going to find and fix this bug, but then I saw this [PR #89375](https://github.com/grafana/grafana/pull/89375) fixing that without adding tests, it works but I want to make sure that is more easy to notice these kinds of bugs.
