### PR TITLE
Datasources: allow for query but with warning

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -54,7 +54,7 @@ func (hs *HTTPServer) GetDataSources(c *contextmodel.ReqContext) response.Respon
 		return response.Error(http.StatusInternalServerError, "Failed to query datasources", err)
 	}
 
-	filtered, err := hs.dsGuardian.New(c.SignedInUser.OrgID, c.SignedInUser).FilterDatasourcesByQueryPermissions(dataSources)
+	filtered, err := hs.dsGuardian.New(c.SignedInUser.OrgID, c.SignedInUser).FilterDatasourcesByReadPermissions(dataSources)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to query datasources", err)
 	}

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -410,7 +410,7 @@ func (hs *HTTPServer) getFSDataSources(c *contextmodel.ReqContext, availablePlug
 			// If RBAC is enabled, it will filter out all datasources for a public user, so we need to skip it
 			orgDataSources = dataSources
 		} else {
-			filtered, err := hs.dsGuardian.New(c.SignedInUser.OrgID, c.SignedInUser).FilterDatasourcesByQueryPermissions(dataSources)
+			filtered, err := hs.dsGuardian.New(c.SignedInUser.OrgID, c.SignedInUser).FilterDatasourcesByReadPermissions(dataSources)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/services/datasources/guardian/allow_guardian.go
+++ b/pkg/services/datasources/guardian/allow_guardian.go
@@ -14,6 +14,10 @@ func (n AllowGuardian) CanQuery(datasourceID int64) (bool, error) {
 	return true, nil
 }
 
+func (n AllowGuardian) FilterDatasourcesByReadPermissions(ds []*datasources.DataSource) ([]*datasources.DataSource, error) {
+	return ds, nil
+}
+
 func (n AllowGuardian) FilterDatasourcesByQueryPermissions(ds []*datasources.DataSource) ([]*datasources.DataSource, error) {
 	return ds, nil
 }

--- a/pkg/services/datasources/guardian/provider.go
+++ b/pkg/services/datasources/guardian/provider.go
@@ -11,6 +11,7 @@ type DatasourceGuardianProvider interface {
 
 type DatasourceGuardian interface {
 	CanQuery(datasourceID int64) (bool, error)
+	FilterDatasourcesByReadPermissions([]*datasources.DataSource) ([]*datasources.DataSource, error)
 	FilterDatasourcesByQueryPermissions([]*datasources.DataSource) ([]*datasources.DataSource, error)
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds a new function to the datasources guardian for separating access control to datasources by each of "read" and "query" operations. 

The change will allow us to provide varying access checks for datasources API calls to remediate an issue of inconsistent behavior between `datasources:read` and `datasources:query` actions.

There is no change to the underlying permissions check yet, we log a warning message if the user has only read/query permission.

**Why do we need this feature?**

We want to differentiate between `read` and `query` for the datasources. This is a stepping stone to allow us to warn and see if there are multiple datasources with only `read` or only `query` permissions.

**Who is this feature for?**

Anyone who wants to set that users want to read but not query the datasources

**Which issue(s) does this PR fix?**:
