### PR TITLE
GrafanaUI: Improve Switch cursor focus on screen readers

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -85,8 +85,9 @@ const getSwitchStyles = (theme: GrafanaTheme2, transparent?: boolean) => ({
     lineHeight: 1,
 
     input: {
+      height: '100%',
+      width: '100% !important',
       opacity: 0,
-      left: '-100vw',
       zIndex: -1000,
       position: 'absolute',
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This improves how the cursor focus shows up on the Switch component for users with screen readers.

| Before | After |
| --- | --- |
| <img width="485" alt="Screenshot 2024-09-09 at 12 14 22" src="https://github.com/user-attachments/assets/e61d8d3b-554e-4138-9262-59cfc02a2dbb"> | <img width="430" alt="Screenshot 2024-09-09 at 12 13 37" src="https://github.com/user-attachments/assets/c90a6945-da72-4f51-b02d-08395527b083"> |

**Why do we need this feature?**

To make sure users with low visibility know which element is focused when using assisted technology.

**Who is this feature for?**

Screen reader users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes part of #73500

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
