### PR TITLE
i18n: Add test to check languages match a canonical locale

### DIFF
--- a/public/app/core/internationalization/constants.test.ts
+++ b/public/app/core/internationalization/constants.test.ts
@@ -25,6 +25,13 @@ describe('internationalization constants', () => {
     expect(DEFAULT_LANGUAGE).toBe(ENGLISH_US);
   });
 
+  it('should match a canonical locale definition', () => {
+    for (const lang of LANGUAGES) {
+      const resolved = Intl.getCanonicalLocales(lang.code);
+      expect(lang.code).toEqual(resolved[0]);
+    }
+  });
+
   it('should not have duplicate languages codes', () => {
     const uniqLocales = uniqBy(LANGUAGES, (v) => v.code);
     expect(LANGUAGES).toHaveLength(uniqLocales.length);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds a unit test to check all language codes exactly match a canonical locale

**Why do we need this feature?**

- so we can ensure that any new language codes added are in the correct format

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

- see slack context here: https://raintank-corp.slack.com/archives/C025WTVRBSN/p1725874539086649?thread_ts=1725873513.698019&cid=C025WTVRBSN
- don't actually _need_ to rename `pseudo-LOCALE` for now, since it's only included in the languages array in development mode
  - `pseudo-LOCALE` would technically need to be renamed to `pseudo-locale`, but 🤷 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
