### PR TITLE
AzureMonitor: Deduplicate resource picker rows

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -225,14 +225,14 @@ describe('AzureMonitor resourcePickerData', () => {
     it('makes 1 call to ARG with the correct path and query arguments', async () => {
       const mockResponse = createARGResourcesResponse();
       const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
-      await resourcePickerData.getResourcesForResourceGroup('dev', 'logs');
+      await resourcePickerData.getResourcesForResourceGroup('/subscription/sub1/resourceGroups/dev', 'logs');
 
       expect(postResource).toBeCalledTimes(1);
       const firstCall = postResource.mock.calls[0];
       const [path, postBody] = firstCall;
       expect(path).toEqual('resourcegraph/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01');
       expect(postBody.query).toContain('resources');
-      expect(postBody.query).toContain('where id hasprefix "dev"');
+      expect(postBody.query).toContain('where id hasprefix "/subscription/sub1/resourceGroups/dev/"');
     });
 
     it('returns formatted resources', async () => {

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -93,7 +93,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     const nestedRows =
       parentRow.type === ResourceRowType.Subscription
         ? await this.getResourceGroupsBySubscriptionId(parentRow.id, type)
-        : await this.getResourcesForResourceGroup(parentRow.id, type);
+        : await this.getResourcesForResourceGroup(parentRow.uri, type);
 
     return addResources(rows, parentRow.uri, nestedRows);
   }
@@ -185,6 +185,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     subscriptionId: string,
     type: ResourcePickerQueryType
   ): Promise<ResourceRowGroup> {
+    // We can use subscription ID for the filtering here as they're unique
     const query = `
     resources
      | join kind=inner (
@@ -232,12 +233,15 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
   }
 
   async getResourcesForResourceGroup(
-    resourceGroupId: string,
+    resourceGroupUri: string,
     type: ResourcePickerQueryType
   ): Promise<ResourceRowGroup> {
+    // We use resource group URI for the filtering here because resource group names are not unique across subscriptions
+    // We also add a slash at the end of the resource group URI to ensure we do not pull resources from a resource group
+    // that has a similar naming prefix e.g. resourceGroup1 and resourceGroup10
     const { data: response } = await this.makeResourceGraphRequest<RawAzureResourceItem[]>(`
       resources
-      | where id hasprefix "${resourceGroupId}"
+      | where id hasprefix "${resourceGroupUri}/"
       ${await this.filterByType(type)}
     `);
 


### PR DESCRIPTION
When expanding resource group rows, the original resource query used the row ID rather than the URI. The row ID only includes the resource group name and this can lead to issues when retrieving resources for two reasons:

- Resource group names are not unique across multiple subscriptions
- Resource group names may share prefixes e.g. `dev-1`, `dev-12` leading to resources from `dev-12` being returned when querying `dev-1`.

The logic has been updated to use the full resource URI in the query now to ensure that the returned results are deduplicated across subscriptions. A `/` is also appended to ensure that resources from resource groups sharing a naming convention or prefix will not be returned.

Fixes #92154 