### PR TITLE
feat: add QueryIntWithDefault to web context

### DIFF
--- a/pkg/web/context.go
+++ b/pkg/web/context.go
@@ -182,12 +182,22 @@ func (ctx *Context) QueryInt(name string) int {
 	return n
 }
 
+// QueryIntWithDefault returns query result in int type, including a default when the query param is not a valid int.
+func (ctx *Context) QueryIntWithDefault(name string, d int) int {
+	n, err := strconv.Atoi(ctx.Query(name))
+	if err != nil {
+		return d
+	}
+	return n
+}
+
 // QueryInt64 returns query result in int64 type.
 func (ctx *Context) QueryInt64(name string) int64 {
 	n, _ := strconv.ParseInt(ctx.Query(name), 10, 64)
 	return n
 }
 
+// QueryInt64WithDefault returns query result in int64 type, including a default when the query param is not a valid int64.
 func (ctx *Context) QueryInt64WithDefault(name string, d int64) int64 {
 	n, err := strconv.ParseInt(ctx.Query(name), 10, 64)
 	if err != nil {


### PR DESCRIPTION
This is a minor addition to support changes I'm implementing for Group Attribute Sync. `QueryIntWithDefault(..)` was not present and I wanted to use this rather than the `int64` version. I realize I could just case the resulting `int64` to `int` but this seemed like a better approach to avoid the cast.