### PR TITLE
DualWriter: Return error for unsupported watch

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -283,8 +283,9 @@ func (d *DualWriterMode1) Destroy() {
 }
 
 func (d *DualWriterMode1) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	d.Log.Error(errors.New("Watch not implemented in mode 1"), "Watch not implemented in mode 1")
-	return nil, nil
+	err := errors.New("Watch not implemented in mode 1")
+	d.Log.Error(err, err.Error())
+	return nil, err
 }
 
 func (d *DualWriterMode1) GetSingularName() string {

--- a/pkg/apiserver/rest/dualwriter_mode2.go
+++ b/pkg/apiserver/rest/dualwriter_mode2.go
@@ -331,8 +331,9 @@ func (d *DualWriterMode2) Update(ctx context.Context, name string, objInfo rest.
 }
 
 func (d *DualWriterMode2) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	d.Log.Error(errors.New("Watch not implemented in mode 2"), "Watch not implemented in mode 2")
-	return nil, nil
+	err := errors.New("Watch not implemented in mode 2")
+	d.Log.Error(err, err.Error())
+	return nil, err
 }
 
 func (d *DualWriterMode2) Destroy() {


### PR DESCRIPTION
This now returns an error rather than a panic for an unsupported watch request:
```
Error from server (InternalError): an error on the server ("unknown") has prevented the request from succeeding (get playlists.playlist.grafana.app)
```
and the logs:
```
ERROR[09-10|13:15:27] Watch not implemented in mode 2          logger=grafana-apiserver err="Watch not implemented in mode 2" logger=DualWriterMode2 mode=2 resource=playlists.playlist.grafana.app
ERROR[09-10|13:15:27] Unhandled Error                          logger=grafana-apiserver logger=UnhandledError err="apiserver received an error that is not an metav1.Status: &errors.errorString{s:\"Watch not implemented in mode 2\"}: Watch not implemented in mode 2"
```