### PR TITLE
Chore: Only auto-triage issues for authors non associated to the repository

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -44,7 +44,7 @@ jobs:
           fi
   auto-triage:
     needs: [main, config]
-    if: needs.config.outputs.has-secrets
+    if: needs.config.outputs.has-secrets && (github.event.issue.author_association == 'NONE' || github.event.issue.author_association == 'FIRST_TIMER' || github.event.issue.author_association == 'FIRST_TIME_CONTRIBUTOR')
     runs-on: ubuntu-latest
     steps:
       - name: "Generate token"


### PR DESCRIPTION
**What is this feature?**

Makes sure that the issue auto-triager only runs for issues that are not created by users belonging to the grafana organization.

**Why do we need this feature?**

So we only triage external issues.
