### PR TITLE
RBAC: FIX Allow specifying several valid scopes for a kind

### DIFF
--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -128,7 +128,9 @@ func (pr *permissionRegistry) RegisterPluginScope(scope string) {
 }
 
 func (pr *permissionRegistry) RegisterPermission(action, scope string) error {
-	pr.actionScopePrefixes[action] = PrefixSet{}
+	if _, ok := pr.actionScopePrefixes[action]; !ok {
+		pr.actionScopePrefixes[action] = PrefixSet{}
+	}
 
 	if scope == "" {
 		// scopeless action

--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -128,10 +128,6 @@ func (pr *permissionRegistry) RegisterPluginScope(scope string) {
 }
 
 func (pr *permissionRegistry) RegisterPermission(action, scope string) error {
-	if _, ok := pr.actionScopePrefixes[action]; ok {
-		// action already registered
-		return nil
-	}
 	pr.actionScopePrefixes[action] = PrefixSet{}
 
 	if scope == "" {

--- a/pkg/services/accesscontrol/permreg/permreg_test.go
+++ b/pkg/services/accesscontrol/permreg/permreg_test.go
@@ -103,7 +103,11 @@ func Test_permissionRegistry_RegisterPermission(t *testing.T) {
 
 func Test_permissionRegistry_IsPermissionValid(t *testing.T) {
 	pr := newPermissionRegistry()
-	err := pr.RegisterPermission("folders:read", "folders:uid:")
+	err := pr.RegisterPermission("folders:read", "folders:*")
+	require.NoError(t, err)
+	err = pr.RegisterPermission("dashboards:read", "dashboards:*")
+	require.NoError(t, err)
+	err = pr.RegisterPermission("dashboards:read", "folders:*")
 	require.NoError(t, err)
 	err = pr.RegisterPermission("test-app.settings:read", "")
 	require.NoError(t, err)
@@ -130,6 +134,18 @@ func Test_permissionRegistry_IsPermissionValid(t *testing.T) {
 			name:    "valid folders read with kind level wildcard",
 			action:  "folders:read",
 			scope:   "folders:*",
+			wantErr: false,
+		},
+		{
+			name:    "valid dashboards read with dashboard scope",
+			action:  "dashboards:read",
+			scope:   "dashboards:uid:my_team_dash",
+			wantErr: false,
+		},
+		{
+			name:    "valid dashboards read with folder scope",
+			action:  "dashboards:read",
+			scope:   "folders:uid:my_team_folder",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Co-authored-by: Ieva <ieva.vasiljeva@grafana.com>

Replacement for https://github.com/grafana/grafana/pull/93039

**What is this feature?**

Currently, some actions like `dashboards:read` can have multiple valid scopes (e.g., a specific dashboard or a folder). However, the change introduced in #91247 causes an early return after the first registered scope is found, potentially skipping over other valid scopes.

**Why do we need this feature?**

Currently custom role creation is broken if a valid scope that is not registered properly is used.

**Who is this feature for?**

Anyone that uses custom roles.

**Special notes for your reviewer:**

Not sure if we need to backport. We only received complaints about it recently, but looking at the code I feel like we should've had this issue for a while.