### PR TITLE
GrafanaUI: Show focus on selected date of the date picker

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -99,7 +99,7 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
       fontSize: theme.typography.size.md,
       border: '1px solid transparent',
 
-      '&:hover': {
+      '&:hover, &:focus': {
         position: 'relative',
       },
 
@@ -157,7 +157,6 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         color: theme.colors.primary.contrastText,
         fontWeight: theme.typography.fontWeightMedium,
         background: theme.colors.primary.main,
-        boxShadow: 'none',
         border: '0px',
       },
 

--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -275,7 +275,7 @@ export function getElementStyles(theme: GrafanaTheme2) {
     // 2. Correct font properties not being inherited.
     // 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
     'button, input, optgroup, select, textarea': {
-      borderRadius: theme.shape.radius.default,
+      borderRadius: 0,
       color: 'inherit',
       font: 'inherit',
       lineHeight: 'inherit',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature makes sure the focus state is visible for all the days in the date picker, even if it is selected.

Before:

https://github.com/user-attachments/assets/b64def3f-a19d-4041-bf9e-349cc0229ed1

After:

https://github.com/user-attachments/assets/6aa4da1c-d31b-46aa-839c-d25c57163a94

**Why do we need this feature?**

So all dates have a focus state.

**Who is this feature for?**

Keyboard users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #86661

**Special notes for your reviewer:**

It is noticeable from the videos that in the "Before" there is a border radius that wasn't there in previous versions of grafana, I figured out that was related to a PR cleaning up CSS styles where [this](https://github.com/grafana/grafana/pull/92934/files#diff-2b4e1c2c59fb94b357b0544dc6f3c81209bb7a7d6d5fd74b16cb17cd2f0b836cL269) radius of 0 was [converted](https://github.com/grafana/grafana/pull/92934/files#diff-46bb96b5d7f80c7c5e74863b3c1fbc13b6787ca2888c0b9a9fcd02d27b0dc2ffR278) to a default radius, so I changed that back to 0 (might be worth @ashharrison90 double checking)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
