### PR TITLE
XYChart: Avoid tick collisions on x-axis

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -92,6 +92,8 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       distr = ScaleDistribution.Linear,
     } = this.props;
 
+    console.log(space);
+
     const font = `${UPLOT_AXIS_FONT_SIZE}px ${theme.typography.fontFamily}`;
 
     const gridColor = theme.isDark ? 'rgba(240, 250, 255, 0.09)' : 'rgba(0, 10, 23, 0.09)';
@@ -245,12 +247,16 @@ function calculateSpace(
   const maxTicks = plotDim / X_TICK_SPACING_NORMAL;
   const increment = (scaleMax - scaleMin) / maxTicks;
 
+  // not super great, since 0.000005 has many more chars than 1.0
+  // it also doesn't work well with "short" or adaptive units, e.g. 7 K and 6.40 K
+  const bigValue = Math.max(Math.abs(scaleMin), Math.abs(scaleMax));
+
   let sample = '';
 
   if (scale.time) {
-    sample = formatTime(self, [scaleMin], axisIdx, X_TICK_SPACING_NORMAL, increment)[0];
+    sample = formatTime(self, [bigValue], axisIdx, X_TICK_SPACING_NORMAL, increment)[0];
   } else if (formatValue != null) {
-    sample = formatValue(scaleMin);
+    sample = formatValue(bigValue);
   } else {
     return X_TICK_SPACING_NORMAL;
   }

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -92,8 +92,6 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
       distr = ScaleDistribution.Linear,
     } = this.props;
 
-    console.log(space);
-
     const font = `${UPLOT_AXIS_FONT_SIZE}px ${theme.typography.fontFamily}`;
 
     const gridColor = theme.isDark ? 'rgba(240, 250, 255, 0.09)' : 'rgba(0, 10, 23, 0.09)';


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11861

(this change affects all uPlot-based panels with non-time x)

the first commit just moves the util functions out of the class. the next commits are the logic changes:  https://github.com/grafana/grafana/pull/93195/files/f7e1e47b02819a6632cb12ac4b77fe76177e2d8f..c6b6687baaa487db088b9acf466249d2e52119c4

when testing, make sure nothing wacky happens with the x axis ticks in panels like BarChart, Histogram, Trend, XYChart.

before:

![image](https://github.com/user-attachments/assets/1f087e81-0e3e-4c62-b1fb-f5df61659db1)

after:

![image](https://github.com/user-attachments/assets/22fc28be-2b41-4d39-80a5-386692073c39)
