### PR TITLE
Dashboards: `SaveButton` not available after changing the folder

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -48,6 +48,7 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
   const { state, onSaveDashboard } = useSaveDashboard(false);
 
   const [contentSent, setContentSent] = useState<{ title?: string; folderUid?: string }>({});
+  const [hasFolderChanged, setHasFolderChanged] = useState(false);
   const onSave = async (overwrite: boolean) => {
     const data = getValues();
 
@@ -70,10 +71,10 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
     </Button>
   );
 
-  const saveButton = (overwrite: boolean) => (
-    <SaveButton isValid={isValid} isLoading={state.loading} onSave={onSave} overwrite={overwrite} />
-  );
-
+  const saveButton = (overwrite: boolean) => {
+    const showSaveButton = !isValid && hasFolderChanged ? true : isValid;
+    return <SaveButton isValid={showSaveButton} isLoading={state.loading} onSave={onSave} overwrite={overwrite} />;
+  };
   function renderFooter(error?: Error) {
     const formValuesMatchContentSent =
       formValues.title.trim() === contentSent.title && formValues.folder.uid === contentSent.folderUid;
@@ -127,6 +128,8 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
         <FolderPicker
           onChange={(uid: string | undefined, title: string | undefined) => {
             setValue('folder', { uid, title });
+            const folderUid = dashboard.state.meta.folderUid;
+            setHasFolderChanged(uid !== folderUid);
           }}
           // Old folder picker fields
           value={formValues.folder?.uid}


### PR DESCRIPTION
**What is this feature?**
A follow-up of this PR #92330 to fix what is described in [this comment](https://github.com/grafana/grafana/pull/92330#pullrequestreview-2296096620).

**Why do we need this feature?**
When a folder's title is invalid because it already exists in a specific location, the `saveButton` is disabled. If the user changes the location, selecting another folder, the `saveButton` keps disabled. This PR enables the `saveButton` if the folder changes. 

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
After changing the folder, the user can click on the `saveButton`. This also triggers a check, so if the title exists in that folder we get an error message explaining this.


**Demo:**
1.- There is a dashboard called '_New dashboard_' in the root folder and another one called '_Try permissions_' in the '_Try_' folder.
2.- I opened the '_Try_' folder and created a new dashboard with the "_New dashboard_" name. There is no invalid error on the save drawer.
3. I changed the folder to '_Dashboards_' (the root one), clicked on the `saveButton,` and got an error telling me this dashboard name already exists.
4.- I changed the folder again, and the message is gone.
5.- I tried to save a '_Try permissions_' dashboard in the '_Try_' folder, and I got the invalid error. The `saveButton` is disabled.
6. I changed the folder to the root one, and the button is enabled so I can save it.

https://github.com/user-attachments/assets/13fbebe6-1da0-4c93-b70e-99326ca8ec10




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
