### PR TITLE
Docker: Don't use legacy ENV syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY tsconfig.json .eslintrc .editorconfig .browserslistrc .prettierrc.js ./
 COPY scripts scripts
 COPY emails emails
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 RUN yarn build
 
 FROM ${GO_IMAGE} as go-builder

--- a/devenv/docker/blocks/collectd/Dockerfile
+++ b/devenv/docker/blocks/collectd/Dockerfile
@@ -1,6 +1,6 @@
 FROM    ubuntu:xenial
 
-ENV     DEBIAN_FRONTEND noninteractive
+ENV     DEBIAN_FRONTEND=noninteractive
 
 RUN     apt-get -y update
 RUN     apt-get -y install collectd curl python-pip

--- a/devenv/docker/buildcontainer/Dockerfile
+++ b/devenv/docker/buildcontainer/Dockerfile
@@ -2,18 +2,18 @@ FROM centos:6.6
 
 RUN yum install -y initscripts curl tar gcc libc6-dev git
 
-ENV GOLANG_VERSION 1.4.2
+ENV GOLANG_VERSION=1.4.2
 
 RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
 		| tar -v -C /usr/src -xz
 
 RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
 
-ENV PATH /usr/src/go/bin:$PATH
+ENV PATH=/usr/src/go/bin:$PATH
 
 RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
-ENV GOPATH /go
-ENV PATH /go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=/go/bin:$PATH
 
 WORKDIR /go/src/github.com/grafana/grafana
 

--- a/devenv/docker/ha-test-unified-alerting/Dockerfile
+++ b/devenv/docker/ha-test-unified-alerting/Dockerfile
@@ -7,6 +7,6 @@ WORKDIR /go/src/webhook
 RUN mkdir /tmp/logs
 RUN go build -o /bin webhook-listener.go
 
-ENV PORT 8080
+ENV PORT=8080
 
 ENTRYPOINT [ "/bin/webhook-listener" ]


### PR DESCRIPTION
**What is this feature?**

I'm seeing 

>  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format

erorrs

**Why do we need this feature?**

`ENV x y` is legacy

**Who is this feature for?**

Dockerfile users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
