### PR TITLE
Add missing permissions for auto-triage bot

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -4,6 +4,11 @@ on:
     types: [opened]
 concurrency:
   group: issue-opened-${{ github.event.issue.number }}
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What is this feature?**

Adds missing permissions for the issue-opened github action.

**Why do we need this feature?**

To make the auto-triage workflow work.
