### PR TITLE
Dashboards: add more status reasons for errors

### DIFF
--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrDashboardFolderNotFound = DashboardErr{
 		Reason:     "Folder not found",
 		StatusCode: 404,
+		Status:     "not-found",
 	}
 	ErrDashboardWithSameUIDExists = DashboardErr{
 		Reason:     "A dashboard with the same uid already exists",
@@ -62,6 +63,7 @@ var (
 	ErrDashboardFolderWithSameNameAsDashboard = DashboardErr{
 		Reason:     "Folder name cannot be the same as one of its dashboards",
 		StatusCode: 400,
+		Status:     "name-match",
 	}
 	ErrDashboardWithSameNameAsFolder = DashboardErr{
 		Reason:     "Dashboard name cannot be the same as folder",
@@ -71,6 +73,7 @@ var (
 	ErrDashboardFolderNameExists = DashboardErr{
 		Reason:     "A folder with that name already exists",
 		StatusCode: 400,
+		Status:     "name-exists",
 	}
 	ErrDashboardUpdateAccessDenied = DashboardErr{
 		Reason:     "Access denied to save dashboard",


### PR DESCRIPTION
**What is this feature?**

Adds some `status` reason for common errors that are being used by the CloudMigration feature.

**Why do we need this feature?**

With the CloudMigration feature, we'd like to be able to properly guide the user given to resolve a conflict given an error, such as when a folder in an on-prem installation is being imported into a cloud stack, and the cloud stack already has a dashboard with the same name, so they can rename the folder and retry.

**Who is this feature for?**

The cloud migration service primarily and users of it.

**Which issue(s) does this PR fix?**:

Related issue is https://github.com/grafana/grafana-operator-experience-squad/issues/957, we can workaround it by checking the status code and message, but it would be preferred to be able to check it by the `status` reason field.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
