### PR TITLE
Auth: Prevent scheduled token rotation jobs with large delay from rolling back to 1 ms

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -197,9 +197,8 @@ export class ContextSrv {
       // to distribute the scheduling of the job. For now this can be between 1 and 20 seconds
       const expiresWithDistribution = expires - Math.floor(Math.random() * (20 - 1) + 1);
 
-      // nextRun is when the job should be scheduled for
-      let nextRun = expiresWithDistribution * 1000 - Date.now();
-
+      // nextRun is when the job should be scheduled for in ms. setTimeout ms has a max value of 2147483647.
+      let nextRun = Math.min(expiresWithDistribution * 1000 - Date.now(), 2147483647);
       // @ts-ignore
       this.tokenRotationJobId = setTimeout(() => {
         // if we have a new expiry time from the expiry cookie another tab have already performed the rotation


### PR DESCRIPTION
**What is this feature?**

If `token_rotation_interval_minutes` was set to a large value, when `setTimeout` was called to delay the token rotation job, `delay` would roll back to ` ms, creating a loop of token rotation jobs every 1 ms while a user was logged in. 
From node timer:
> When `delay` is larger than `2147483647` or less than `1`, the `delay` will be set to `1`. Non-integer delays are truncated to an integer.

This change sets a cap on the max value for `nextRun` to prevent this behavior. The cap sets the max token rotation interval at ~24.8 days.

**Which issue(s) does this PR fix?**: 
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #90839

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
