### PR TITLE
Alerting: Add metadata field with editor_settings to alert rule

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -575,6 +575,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 			IsPaused:             r.IsPaused,
 			NotificationSettings: AlertRuleNotificationSettingsFromNotificationSettings(r.NotificationSettings),
 			Record:               ApiRecordFromModelRecord(r.Record),
+			EditorSettings:       AlertRuleEditorSettingsFromEditorSettings(r.EditorSettings),
 		},
 	}
 	forDuration := model.Duration(r.For)

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -575,7 +575,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 			IsPaused:             r.IsPaused,
 			NotificationSettings: AlertRuleNotificationSettingsFromNotificationSettings(r.NotificationSettings),
 			Record:               ApiRecordFromModelRecord(r.Record),
-			EditorSettings:       AlertRuleEditorSettingsFromEditorSettings(r.EditorSettings),
+			Metadata:             AlertRuleMetadataFromModelMetadata(r.Metadata),
 		},
 	}
 	forDuration := model.Duration(r.For)

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -334,7 +334,10 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		groupKey.NamespaceUID = folder.UID
 		gen := models.RuleGen.With(models.RuleGen.WithGroupKey(groupKey))
 
-		createdRules := gen.With(gen.WithUniqueGroupIndex(), gen.WithUniqueID()).GenerateManyRef(3)
+		createdRules := gen.With(
+			gen.WithUniqueGroupIndex(), gen.WithUniqueID(),
+			gen.WithEditorSettingsSimplifiedQueryEditor(true),
+		).GenerateManyRef(3)
 		require.Len(t, createdRules, 3)
 		ruleStore.PutRule(context.Background(), createdRules...)
 
@@ -352,6 +355,7 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		require.Equal(t, expectedRule.UID, result.GrafanaManagedAlert.UID)
 		require.Equal(t, expectedRule.RuleGroup, result.GrafanaManagedAlert.RuleGroup)
 		require.Equal(t, expectedRule.Title, result.GrafanaManagedAlert.Title)
+		require.True(t, result.GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor)
 	})
 
 	t.Run("error when fetching rule with non-existent UID", func(t *testing.T) {

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -355,7 +355,7 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		require.Equal(t, expectedRule.UID, result.GrafanaManagedAlert.UID)
 		require.Equal(t, expectedRule.RuleGroup, result.GrafanaManagedAlert.RuleGroup)
 		require.Equal(t, expectedRule.Title, result.GrafanaManagedAlert.Title)
-		require.True(t, result.GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection)
+		require.True(t, result.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
 	})
 
 	t.Run("error when fetching rule with non-existent UID", func(t *testing.T) {

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -336,7 +336,7 @@ func TestRouteGetRuleByUID(t *testing.T) {
 
 		createdRules := gen.With(
 			gen.WithUniqueGroupIndex(), gen.WithUniqueID(),
-			gen.WithEditorSettingsSimplifiedQueryEditor(true),
+			gen.WithEditorSettingsSimplifiedQueryAndExpressionsSection(true),
 		).GenerateManyRef(3)
 		require.Len(t, createdRules, 3)
 		ruleStore.PutRule(context.Background(), createdRules...)
@@ -355,7 +355,7 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		require.Equal(t, expectedRule.UID, result.GrafanaManagedAlert.UID)
 		require.Equal(t, expectedRule.RuleGroup, result.GrafanaManagedAlert.RuleGroup)
 		require.Equal(t, expectedRule.Title, result.GrafanaManagedAlert.Title)
-		require.True(t, result.GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor)
+		require.True(t, result.GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection)
 	})
 
 	t.Run("error when fetching rule with non-existent UID", func(t *testing.T) {

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -144,6 +144,12 @@ func validateAlertingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule 
 		}
 	}
 
+	if in.GrafanaManagedAlert.EditorSettings != nil {
+		newRule.EditorSettings = ngmodels.EditorSettings{
+			SimplifiedQueryEditor: in.GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor,
+		}
+	}
+
 	newRule.For, err = validateForInterval(in)
 	if err != nil {
 		return ngmodels.AlertRule{}, err

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -144,9 +144,9 @@ func validateAlertingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule 
 		}
 	}
 
-	if in.GrafanaManagedAlert.EditorSettings != nil {
-		newRule.EditorSettings = ngmodels.EditorSettings{
-			SimplifiedQueryAndExpressionsSection: in.GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection,
+	if in.GrafanaManagedAlert.Metadata != nil {
+		newRule.Metadata.EditorSettings = ngmodels.EditorSettings{
+			SimplifiedQueryAndExpressionsSection: in.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection,
 		}
 	}
 

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -146,7 +146,7 @@ func validateAlertingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule 
 
 	if in.GrafanaManagedAlert.EditorSettings != nil {
 		newRule.EditorSettings = ngmodels.EditorSettings{
-			SimplifiedQueryEditor: in.GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor,
+			SimplifiedQueryAndExpressionsSection: in.GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection,
 		}
 	}
 

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -415,6 +415,13 @@ func MuteTimingIntervalToMuteTimeIntervalHclExport(m definitions.MuteTimeInterva
 	return result, err
 }
 
+// AlertRuleEditorSettingsFromEditorSettings converts models.EditorSettings to definitions.AlertRuleEditorSettings
+func AlertRuleEditorSettingsFromEditorSettings(es models.EditorSettings) *definitions.AlertRuleEditorSettings {
+	return &definitions.AlertRuleEditorSettings{
+		SimplifiedQueryEditor: es.SimplifiedQueryEditor,
+	}
+}
+
 // AlertRuleNotificationSettingsFromNotificationSettings converts []models.NotificationSettings to definitions.AlertRuleNotificationSettings
 func AlertRuleNotificationSettingsFromNotificationSettings(ns []models.NotificationSettings) *definitions.AlertRuleNotificationSettings {
 	if len(ns) == 0 {

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -416,9 +416,16 @@ func MuteTimingIntervalToMuteTimeIntervalHclExport(m definitions.MuteTimeInterva
 }
 
 // AlertRuleEditorSettingsFromEditorSettings converts models.EditorSettings to definitions.AlertRuleEditorSettings
-func AlertRuleEditorSettingsFromEditorSettings(es models.EditorSettings) *definitions.AlertRuleEditorSettings {
+func AlertRuleEditorSettingsFromModelEditorSettings(es models.EditorSettings) *definitions.AlertRuleEditorSettings {
 	return &definitions.AlertRuleEditorSettings{
 		SimplifiedQueryAndExpressionsSection: es.SimplifiedQueryAndExpressionsSection,
+	}
+}
+
+// AlertRuleMetadataFromMetadata converts models.AlertRuleMetadata to definitions.AlertRuleMetadata
+func AlertRuleMetadataFromModelMetadata(es models.AlertRuleMetadata) *definitions.AlertRuleMetadata {
+	return &definitions.AlertRuleMetadata{
+		EditorSettings: *AlertRuleEditorSettingsFromModelEditorSettings(es.EditorSettings),
 	}
 }
 

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -418,7 +418,7 @@ func MuteTimingIntervalToMuteTimeIntervalHclExport(m definitions.MuteTimeInterva
 // AlertRuleEditorSettingsFromEditorSettings converts models.EditorSettings to definitions.AlertRuleEditorSettings
 func AlertRuleEditorSettingsFromEditorSettings(es models.EditorSettings) *definitions.AlertRuleEditorSettings {
 	return &definitions.AlertRuleEditorSettings{
-		SimplifiedQueryEditor: es.SimplifiedQueryEditor,
+		SimplifiedQueryAndExpressionsSection: es.SimplifiedQueryAndExpressionsSection,
 	}
 }
 

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -434,6 +434,11 @@ const (
 )
 
 // swagger:model
+type AlertRuleMetadata struct {
+	EditorSettings AlertRuleEditorSettings `json:"editor_settings" yaml:"editor_settings"`
+}
+
+// swagger:model
 type AlertRuleEditorSettings struct {
 	SimplifiedQueryAndExpressionsSection bool `json:"simplified_query_and_expressions_section" yaml:"simplified_query_and_expressions_section"`
 }
@@ -505,7 +510,7 @@ type PostableGrafanaRule struct {
 	IsPaused             *bool                          `json:"is_paused" yaml:"is_paused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings" yaml:"notification_settings"`
 	Record               *Record                        `json:"record" yaml:"record"`
-	EditorSettings       *AlertRuleEditorSettings       `json:"editor_settings,omitempty" yaml:"editor_settings,omitempty"`
+	Metadata             *AlertRuleMetadata             `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // swagger:model
@@ -527,7 +532,7 @@ type GettableGrafanaRule struct {
 	IsPaused             bool                           `json:"is_paused" yaml:"is_paused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings,omitempty" yaml:"notification_settings,omitempty"`
 	Record               *Record                        `json:"record,omitempty" yaml:"record,omitempty"`
-	EditorSettings       *AlertRuleEditorSettings       `json:"editor_settings,omitempty" yaml:"editor_settings,omitempty"`
+	Metadata             *AlertRuleMetadata             `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // AlertQuery represents a single query associated with an alert definition.

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -435,7 +435,7 @@ const (
 
 // swagger:model
 type AlertRuleEditorSettings struct {
-	SimplifiedQueryEditor bool `json:"simplified_query_editor" yaml:"simplified_query_editor"`
+	SimplifiedQueryAndExpressionsSection bool `json:"simplified_query_and_expressions_section" yaml:"simplified_query_and_expressions_section"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -434,6 +434,11 @@ const (
 )
 
 // swagger:model
+type AlertRuleEditorSettings struct {
+	SimplifiedQueryEditor bool `json:"simplified_query_editor" yaml:"simplified_query_editor"`
+}
+
+// swagger:model
 type AlertRuleNotificationSettings struct {
 	// Name of the receiver to send notifications to.
 	// required: true
@@ -500,6 +505,7 @@ type PostableGrafanaRule struct {
 	IsPaused             *bool                          `json:"is_paused" yaml:"is_paused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings" yaml:"notification_settings"`
 	Record               *Record                        `json:"record" yaml:"record"`
+	EditorSettings       *AlertRuleEditorSettings       `json:"editor_settings,omitempty" yaml:"editor_settings,omitempty"`
 }
 
 // swagger:model
@@ -521,6 +527,7 @@ type GettableGrafanaRule struct {
 	IsPaused             bool                           `json:"is_paused" yaml:"is_paused"`
 	NotificationSettings *AlertRuleNotificationSettings `json:"notification_settings,omitempty" yaml:"notification_settings,omitempty"`
 	Record               *Record                        `json:"record,omitempty" yaml:"record,omitempty"`
+	EditorSettings       *AlertRuleEditorSettings       `json:"editor_settings,omitempty" yaml:"editor_settings,omitempty"`
 }
 
 // AlertQuery represents a single query associated with an alert definition.

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -269,6 +269,11 @@ type AlertRule struct {
 	Labels               map[string]string
 	IsPaused             bool
 	NotificationSettings []NotificationSettings
+	EditorSettings       EditorSettings
+}
+
+type EditorSettings struct {
+	SimplifiedQueryEditor bool `json:"simplified_query_editor"`
 }
 
 // Namespaced describes a class of resources that are stored in a specific namespace.

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -269,7 +269,11 @@ type AlertRule struct {
 	Labels               map[string]string
 	IsPaused             bool
 	NotificationSettings []NotificationSettings
-	EditorSettings       EditorSettings
+	Metadata             AlertRuleMetadata
+}
+
+type AlertRuleMetadata struct {
+	EditorSettings EditorSettings `json:"editor_settings"`
 }
 
 type EditorSettings struct {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -273,7 +273,7 @@ type AlertRule struct {
 }
 
 type EditorSettings struct {
-	SimplifiedQueryEditor bool `json:"simplified_query_editor"`
+	SimplifiedQueryAndExpressionsSection bool `json:"simplified_query_and_expressions_section"`
 }
 
 // Namespaced describes a class of resources that are stored in a specific namespace.

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -197,6 +197,12 @@ func (a *AlertRuleMutators) WithUniqueID() AlertRuleMutator {
 	}
 }
 
+func (a *AlertRuleMutators) WithEditorSettingsSimplifiedQueryEditor(mode bool) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		rule.EditorSettings.SimplifiedQueryEditor = mode
+	}
+}
+
 func (a *AlertRuleMutators) WithGroupIndex(groupIndex int) AlertRuleMutator {
 	return func(rule *AlertRule) {
 		rule.RuleGroupIndex = groupIndex

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -199,7 +199,7 @@ func (a *AlertRuleMutators) WithUniqueID() AlertRuleMutator {
 
 func (a *AlertRuleMutators) WithEditorSettingsSimplifiedQueryAndExpressionsSection(mode bool) AlertRuleMutator {
 	return func(rule *AlertRule) {
-		rule.EditorSettings.SimplifiedQueryAndExpressionsSection = mode
+		rule.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection = mode
 	}
 }
 

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -197,9 +197,9 @@ func (a *AlertRuleMutators) WithUniqueID() AlertRuleMutator {
 	}
 }
 
-func (a *AlertRuleMutators) WithEditorSettingsSimplifiedQueryEditor(mode bool) AlertRuleMutator {
+func (a *AlertRuleMutators) WithEditorSettingsSimplifiedQueryAndExpressionsSection(mode bool) AlertRuleMutator {
 	return func(rule *AlertRule) {
-		rule.EditorSettings.SimplifiedQueryEditor = mode
+		rule.EditorSettings.SimplifiedQueryAndExpressionsSection = mode
 	}
 }
 

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -204,6 +204,9 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 			NotificationSettings: []models.NotificationSettings{
 				models.NotificationSettingsGen()(),
 			},
+			EditorSettings: models.EditorSettings{
+				SimplifiedQueryEditor: false,
+			},
 		}
 		r2 := &models.AlertRule{
 			ID:        2,
@@ -242,6 +245,9 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 			IsPaused: true,
 			NotificationSettings: []models.NotificationSettings{
 				models.NotificationSettingsGen()(),
+			},
+			EditorSettings: models.EditorSettings{
+				SimplifiedQueryEditor: true,
 			},
 		}
 

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -204,8 +204,10 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 			NotificationSettings: []models.NotificationSettings{
 				models.NotificationSettingsGen()(),
 			},
-			EditorSettings: models.EditorSettings{
-				SimplifiedQueryAndExpressionsSection: false,
+			Metadata: models.AlertRuleMetadata{
+				EditorSettings: models.EditorSettings{
+					SimplifiedQueryAndExpressionsSection: false,
+				},
 			},
 		}
 		r2 := &models.AlertRule{
@@ -246,8 +248,10 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 			NotificationSettings: []models.NotificationSettings{
 				models.NotificationSettingsGen()(),
 			},
-			EditorSettings: models.EditorSettings{
-				SimplifiedQueryAndExpressionsSection: true,
+			Metadata: models.AlertRuleMetadata{
+				EditorSettings: models.EditorSettings{
+					SimplifiedQueryAndExpressionsSection: true,
+				},
 			},
 		}
 

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -205,7 +205,7 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 				models.NotificationSettingsGen()(),
 			},
 			EditorSettings: models.EditorSettings{
-				SimplifiedQueryEditor: false,
+				SimplifiedQueryAndExpressionsSection: false,
 			},
 		}
 		r2 := &models.AlertRule{
@@ -247,7 +247,7 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 				models.NotificationSettingsGen()(),
 			},
 			EditorSettings: models.EditorSettings{
-				SimplifiedQueryEditor: true,
+				SimplifiedQueryAndExpressionsSection: true,
 			},
 		}
 

--- a/pkg/services/ngalert/store/compat.go
+++ b/pkg/services/ngalert/store/compat.go
@@ -80,6 +80,14 @@ func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, e
 		}
 		result.NotificationSettings = ns
 	}
+
+	if ar.EditorSettings != "" {
+		err = json.Unmarshal([]byte(ar.EditorSettings), &result.EditorSettings)
+		if err != nil {
+			return models.AlertRule{}, fmt.Errorf("failed to parse editor settings: %w", err)
+		}
+	}
+
 	return result, nil
 }
 
@@ -151,6 +159,12 @@ func alertRuleFromModelsAlertRule(ar models.AlertRule) (alertRule, error) {
 		result.NotificationSettings = string(notificationSettingsData)
 	}
 
+	editorSettingsData, err := json.Marshal(ar.EditorSettings)
+	if err != nil {
+		return alertRule{}, fmt.Errorf("failed to marshal editor settings: %w", err)
+	}
+	result.EditorSettings = string(editorSettingsData)
+
 	return result, nil
 }
 
@@ -177,5 +191,6 @@ func alertRuleToAlertRuleVersion(rule alertRule) alertRuleVersion {
 		Labels:               rule.Labels,
 		IsPaused:             rule.IsPaused,
 		NotificationSettings: rule.NotificationSettings,
+		EditorSettings:       rule.EditorSettings,
 	}
 }

--- a/pkg/services/ngalert/store/compat.go
+++ b/pkg/services/ngalert/store/compat.go
@@ -81,10 +81,10 @@ func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, e
 		result.NotificationSettings = ns
 	}
 
-	if ar.EditorSettings != "" {
-		err = json.Unmarshal([]byte(ar.EditorSettings), &result.EditorSettings)
+	if ar.Metadata != "" {
+		err = json.Unmarshal([]byte(ar.Metadata), &result.Metadata)
 		if err != nil {
-			return models.AlertRule{}, fmt.Errorf("failed to parse editor settings: %w", err)
+			return models.AlertRule{}, fmt.Errorf("failed to metadata: %w", err)
 		}
 	}
 
@@ -159,11 +159,11 @@ func alertRuleFromModelsAlertRule(ar models.AlertRule) (alertRule, error) {
 		result.NotificationSettings = string(notificationSettingsData)
 	}
 
-	editorSettingsData, err := json.Marshal(ar.EditorSettings)
+	metadata, err := json.Marshal(ar.Metadata)
 	if err != nil {
-		return alertRule{}, fmt.Errorf("failed to marshal editor settings: %w", err)
+		return alertRule{}, fmt.Errorf("failed to metadata: %w", err)
 	}
-	result.EditorSettings = string(editorSettingsData)
+	result.Metadata = string(metadata)
 
 	return result, nil
 }
@@ -191,6 +191,6 @@ func alertRuleToAlertRuleVersion(rule alertRule) alertRuleVersion {
 		Labels:               rule.Labels,
 		IsPaused:             rule.IsPaused,
 		NotificationSettings: rule.NotificationSettings,
-		EditorSettings:       rule.EditorSettings,
+		Metadata:             rule.Metadata,
 	}
 }

--- a/pkg/services/ngalert/store/models.go
+++ b/pkg/services/ngalert/store/models.go
@@ -26,6 +26,7 @@ type alertRule struct {
 	Labels               string
 	IsPaused             bool
 	NotificationSettings string `xorm:"notification_settings"`
+	EditorSettings       string `xorm:"editor_settings"`
 }
 
 func (a alertRule) TableName() string {
@@ -59,6 +60,7 @@ type alertRuleVersion struct {
 	Labels               string
 	IsPaused             bool
 	NotificationSettings string `xorm:"notification_settings"`
+	EditorSettings       string `xorm:"editor_settings"`
 }
 
 func (a alertRuleVersion) TableName() string {

--- a/pkg/services/ngalert/store/models.go
+++ b/pkg/services/ngalert/store/models.go
@@ -26,7 +26,7 @@ type alertRule struct {
 	Labels               string
 	IsPaused             bool
 	NotificationSettings string `xorm:"notification_settings"`
-	EditorSettings       string `xorm:"editor_settings"`
+	Metadata             string `xorm:"metadata"`
 }
 
 func (a alertRule) TableName() string {
@@ -60,7 +60,7 @@ type alertRuleVersion struct {
 	Labels               string
 	IsPaused             bool
 	NotificationSettings string `xorm:"notification_settings"`
-	EditorSettings       string `xorm:"editor_settings"`
+	Metadata             string `xorm:"metadata"`
 }
 
 func (a alertRuleVersion) TableName() string {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -129,6 +129,8 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	enableTraceQLStreaming(mg, oss.features != nil && oss.features.IsEnabledGlobally(featuremgmt.FlagTraceQLStreaming))
 
 	ualert.AddReceiverActionScopesMigration(mg)
+
+	ualert.AddRuleEditorSettings(mg)
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -130,7 +130,7 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 
 	ualert.AddReceiverActionScopesMigration(mg)
 
-	ualert.AddRuleEditorSettings(mg)
+	ualert.AddRuleMetadata(mg)
 }
 
 func addStarMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_editor_settings.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_editor_settings.go
@@ -2,20 +2,20 @@ package ualert
 
 import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 
-// AddRuleEditorSettings adds column to store alerting rule editor settings for the UI.
-func AddRuleEditorSettings(mg *migrator.Migrator) {
+// AddRuleMetadata adds column to store alerting rule metadata, such as editor settings for the UI.
+func AddRuleMetadata(mg *migrator.Migrator) {
 	column := &migrator.Column{
-		Name:     "editor_settings",
+		Name:     "metadata",
 		Type:     migrator.DB_Text,
 		Nullable: true,
 	}
 
 	mg.AddMigration(
-		"add editor_settings column to alert_rule table",
+		"add metadata column to alert_rule table",
 		migrator.NewAddColumnMigration(migrator.Table{Name: "alert_rule"}, column),
 	)
 	mg.AddMigration(
-		"add editor_settings column to alert_rule_version table",
+		"add metadata column to alert_rule_version table",
 		migrator.NewAddColumnMigration(migrator.Table{Name: "alert_rule_version"}, column),
 	)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_editor_settings.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_editor_settings.go
@@ -1,0 +1,21 @@
+package ualert
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// AddRuleEditorSettings adds column to store alerting rule editor settings for the UI.
+func AddRuleEditorSettings(mg *migrator.Migrator) {
+	column := &migrator.Column{
+		Name:     "editor_settings",
+		Type:     migrator.DB_Text,
+		Nullable: true,
+	}
+
+	mg.AddMigration(
+		"add editor_settings column to alert_rule table",
+		migrator.NewAddColumnMigration(migrator.Table{Name: "alert_rule"}, column),
+	)
+	mg.AddMigration(
+		"add editor_settings column to alert_rule_version table",
+		migrator.NewAddColumnMigration(migrator.Table{Name: "alert_rule_version"}, column),
+	)
+}

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -790,7 +790,10 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 								"namespace_uid": %q,
 								"rule_group": "arulegroup",
 								"no_data_state": "NoData",
-								"exec_err_state": "Alerting"
+								"exec_err_state": "Alerting",
+								"editor_settings": {
+									"simplified_query_editor": false
+								}
 							}
 						}
 					]
@@ -1268,7 +1271,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+					   	  "editor_settings": {
+					   	  	"simplified_query_editor": false
+					   	  }
 					   }
 					},
 					{
@@ -1304,7 +1310,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"Alerting",
-						  "exec_err_state":"Alerting"
+						  "exec_err_state":"Alerting",
+					   	  "editor_settings": {
+					   	  	"simplified_query_editor": false
+					   	  }
 					   }
 					}
 				 ]
@@ -1612,7 +1621,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                  "namespace_uid":"nsuid",
 		                  "rule_group":"arulegroup",
 		                  "no_data_state":"Alerting",
-		                  "exec_err_state":"Alerting"
+		                  "exec_err_state":"Alerting",
+					   	  "editor_settings": {
+					   	  	"simplified_query_editor": false
+					   	  }
 		               }
 		            }
 		         ]
@@ -1721,7 +1733,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "namespace_uid":"nsuid",
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
-					  "exec_err_state":"Alerting"
+					  "exec_err_state":"Alerting",
+					  "editor_settings": {
+					    "simplified_query_editor": false
+					   }
 				       }
 				    }
 				 ]
@@ -1809,7 +1824,10 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "namespace_uid":"nsuid",
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
-					  "exec_err_state":"Alerting"
+					  "exec_err_state":"Alerting",
+					  "editor_settings": {
+					    "simplified_query_editor": false
+					   }
 				       }
 				    }
 				 ]
@@ -2336,8 +2354,11 @@ func TestIntegrationQuota(t *testing.T) {
 						  "namespace_uid":"nsuid",
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
-						  "exec_err_state":"Alerting"
-					       }
+						  "exec_err_state":"Alerting",
+						  "editor_settings": {
+							"simplified_query_editor": false
+						  }
+					      }
 					    }
 					 ]
 				      }

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -791,8 +791,10 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 								"rule_group": "arulegroup",
 								"no_data_state": "NoData",
 								"exec_err_state": "Alerting",
-								"editor_settings": {
-									"simplified_query_and_expressions_section": false
+								"metadata": {
+									"editor_settings": {
+										"simplified_query_and_expressions_section": false
+									}
 								}
 							}
 						}
@@ -1272,9 +1274,11 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
 						  "exec_err_state":"Alerting",
-					   	  "editor_settings": {
-					   	  	"simplified_query_and_expressions_section": false
-					   	  }
+						  "metadata": {
+						      "editor_settings": {
+							      "simplified_query_and_expressions_section": false
+							  }
+						  }
 					   }
 					},
 					{
@@ -1311,9 +1315,11 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "rule_group":"arulegroup",
 						  "no_data_state":"Alerting",
 						  "exec_err_state":"Alerting",
-					   	  "editor_settings": {
-					   	  	"simplified_query_and_expressions_section": false
-					   	  }
+						  "metadata": {
+						      "editor_settings": {
+							      "simplified_query_and_expressions_section": false
+							  }
+						  }
 					   }
 					}
 				 ]
@@ -1622,9 +1628,11 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                  "rule_group":"arulegroup",
 		                  "no_data_state":"Alerting",
 		                  "exec_err_state":"Alerting",
-					   	  "editor_settings": {
-					   	  	"simplified_query_and_expressions_section": false
-					   	  }
+						  "metadata": {
+						      "editor_settings": {
+							      "simplified_query_and_expressions_section": false
+							  }
+						  }
 		               }
 		            }
 		         ]
@@ -1734,10 +1742,12 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
 					  "exec_err_state":"Alerting",
-					  "editor_settings": {
-					    "simplified_query_and_expressions_section": false
+					  "metadata": {
+				        "editor_settings": {
+					      "simplified_query_and_expressions_section": false
+					    }
 					   }
-				       }
+				      }
 				    }
 				 ]
 			      }
@@ -1825,10 +1835,12 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "rule_group":"arulegroup",
 					  "no_data_state":"Alerting",
 					  "exec_err_state":"Alerting",
-					  "editor_settings": {
-					    "simplified_query_and_expressions_section": false
+					  "metadata": {
+				        "editor_settings": {
+					      "simplified_query_and_expressions_section": false
+					    }
 					   }
-				       }
+				      }
 				    }
 				 ]
 			      }
@@ -2355,9 +2367,11 @@ func TestIntegrationQuota(t *testing.T) {
 						  "rule_group":"arulegroup",
 						  "no_data_state":"NoData",
 						  "exec_err_state":"Alerting",
-						  "editor_settings": {
-							"simplified_query_and_expressions_section": false
-						  }
+						  "metadata": {
+						    "editor_settings": {
+							  "simplified_query_and_expressions_section": false
+							 }
+						   }
 					      }
 					    }
 					 ]

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -792,7 +792,7 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 								"no_data_state": "NoData",
 								"exec_err_state": "Alerting",
 								"editor_settings": {
-									"simplified_query_editor": false
+									"simplified_query_and_expressions_section": false
 								}
 							}
 						}
@@ -1273,7 +1273,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "no_data_state":"NoData",
 						  "exec_err_state":"Alerting",
 					   	  "editor_settings": {
-					   	  	"simplified_query_editor": false
+					   	  	"simplified_query_and_expressions_section": false
 					   	  }
 					   }
 					},
@@ -1312,7 +1312,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "no_data_state":"Alerting",
 						  "exec_err_state":"Alerting",
 					   	  "editor_settings": {
-					   	  	"simplified_query_editor": false
+					   	  	"simplified_query_and_expressions_section": false
 					   	  }
 					   }
 					}
@@ -1623,7 +1623,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                  "no_data_state":"Alerting",
 		                  "exec_err_state":"Alerting",
 					   	  "editor_settings": {
-					   	  	"simplified_query_editor": false
+					   	  	"simplified_query_and_expressions_section": false
 					   	  }
 		               }
 		            }
@@ -1735,7 +1735,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "no_data_state":"Alerting",
 					  "exec_err_state":"Alerting",
 					  "editor_settings": {
-					    "simplified_query_editor": false
+					    "simplified_query_and_expressions_section": false
 					   }
 				       }
 				    }
@@ -1826,7 +1826,7 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "no_data_state":"Alerting",
 					  "exec_err_state":"Alerting",
 					  "editor_settings": {
-					    "simplified_query_editor": false
+					    "simplified_query_and_expressions_section": false
 					   }
 				       }
 				    }
@@ -2356,7 +2356,7 @@ func TestIntegrationQuota(t *testing.T) {
 						  "no_data_state":"NoData",
 						  "exec_err_state":"Alerting",
 						  "editor_settings": {
-							"simplified_query_editor": false
+							"simplified_query_and_expressions_section": false
 						  }
 					      }
 					    }

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -850,7 +850,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 				},
 			},
 			EditorSettings: &apimodels.AlertRuleEditorSettings{
-				SimplifiedQueryEditor: false,
+				SimplifiedQueryAndExpressionsSection: false,
 			},
 		},
 	}
@@ -867,12 +867,12 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 
 	createdRuleGroup := apiClient.GetRulesGroup(t, folderName, rules.Name).GettableRuleGroupConfig
 	require.Len(t, createdRuleGroup.Rules, 1)
-	require.Equal(t, alertRule.GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor, createdRuleGroup.Rules[0].GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor)
+	require.Equal(t, alertRule.GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection, createdRuleGroup.Rules[0].GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection)
 
 	t.Run("set simplified query editor in editor settings", func(t *testing.T) {
 		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
 		rulesWithUID.Rules[0].GrafanaManagedAlert.EditorSettings = &apimodels.AlertRuleEditorSettings{
-			SimplifiedQueryEditor: false,
+			SimplifiedQueryAndExpressionsSection: false,
 		}
 
 		_, status, body := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
@@ -881,7 +881,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 
 		updatedRuleGroup := apiClient.GetRulesGroup(t, folderName, rules.Name).GettableRuleGroupConfig
 		require.Len(t, updatedRuleGroup.Rules, 1)
-		require.False(t, false, updatedRuleGroup.Rules[0].GrafanaManagedAlert.EditorSettings.SimplifiedQueryEditor)
+		require.False(t, false, updatedRuleGroup.Rules[0].GrafanaManagedAlert.EditorSettings.SimplifiedQueryAndExpressionsSection)
 	})
 }
 
@@ -1110,7 +1110,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"no_data_state": "NoData",
 				"exec_err_state": "Alerting",
 				"editor_settings": {
-					"simplified_query_editor": false
+					"simplified_query_and_expressions_section": false
 				}
 			}
 		}, {
@@ -1146,7 +1146,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"no_data_state": "Alerting",
 				"exec_err_state": "Alerting",
 				"editor_settings": {
-					"simplified_query_editor": false
+					"simplified_query_and_expressions_section": false
 				}
 			}
 		}]
@@ -1194,7 +1194,7 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"no_data_state": "NoData",
 				"exec_err_state": "Alerting",
 				"editor_settings": {
-					"simplified_query_editor": false
+					"simplified_query_and_expressions_section": false
 				}
 			}
 		}]

--- a/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
@@ -41,7 +41,10 @@
         "rule_group": "Group1",
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
-        "is_paused": false
+        "is_paused": false,
+        "editor_settings": {
+          "simplified_query_editor": false
+        }
       }
     },
     {
@@ -83,7 +86,10 @@
         "rule_group": "Group1",
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
-        "is_paused": false
+        "is_paused": false,
+        "editor_settings": {
+          "simplified_query_editor": false
+        }
       }
     }
   ]

--- a/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
@@ -42,8 +42,10 @@
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
         "is_paused": false,
-        "editor_settings": {
-          "simplified_query_and_expressions_section": false
+        "metadata": {
+          "editor_settings": {
+            "simplified_query_and_expressions_section": false
+          }
         }
       }
     },
@@ -87,8 +89,10 @@
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
         "is_paused": false,
-        "editor_settings": {
-          "simplified_query_and_expressions_section": false
+        "metadata": {
+          "editor_settings": {
+            "simplified_query_and_expressions_section": false
+          }
         }
       }
     }

--- a/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
@@ -43,7 +43,7 @@
         "exec_err_state": "Alerting",
         "is_paused": false,
         "editor_settings": {
-          "simplified_query_editor": false
+          "simplified_query_and_expressions_section": false
         }
       }
     },
@@ -88,7 +88,7 @@
         "exec_err_state": "Alerting",
         "is_paused": false,
         "editor_settings": {
-          "simplified_query_editor": false
+          "simplified_query_and_expressions_section": false
         }
       }
     }

--- a/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
@@ -41,7 +41,10 @@
         "rule_group": "Group2",
         "no_data_state": "NoData",
         "exec_err_state": "Error",
-        "is_paused": false
+        "is_paused": false,
+        "editor_settings": {
+          "simplified_query_editor": false
+        }
       }
     }
   ]

--- a/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
@@ -42,8 +42,10 @@
         "no_data_state": "NoData",
         "exec_err_state": "Error",
         "is_paused": false,
-        "editor_settings": {
-          "simplified_query_and_expressions_section": false
+        "metadata": {
+          "editor_settings": {
+            "simplified_query_and_expressions_section": false
+          }
         }
       }
     }

--- a/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
@@ -43,7 +43,7 @@
         "exec_err_state": "Error",
         "is_paused": false,
         "editor_settings": {
-          "simplified_query_editor": false
+          "simplified_query_and_expressions_section": false
         }
       }
     }

--- a/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
@@ -41,7 +41,10 @@
         "rule_group": "Group3",
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
-        "is_paused": false
+        "is_paused": false,
+        "editor_settings": {
+          "simplified_query_editor": false
+        }
       }
     },
     {
@@ -83,7 +86,10 @@
         "rule_group": "Group3",
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
-        "is_paused": false
+        "is_paused": false,
+        "editor_settings": {
+          "simplified_query_editor": false
+        }
       }
     }
   ]

--- a/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
@@ -42,8 +42,10 @@
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
         "is_paused": false,
-        "editor_settings": {
-          "simplified_query_and_expressions_section": false
+        "metadata": {
+          "editor_settings": {
+            "simplified_query_and_expressions_section": false
+          }
         }
       }
     },
@@ -87,8 +89,10 @@
         "no_data_state": "NoData",
         "exec_err_state": "Alerting",
         "is_paused": false,
-        "editor_settings": {
-          "simplified_query_and_expressions_section": false
+        "metadata": {
+          "editor_settings": {
+            "simplified_query_and_expressions_section": false
+          }
         }
       }
     }

--- a/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
@@ -43,7 +43,7 @@
         "exec_err_state": "Alerting",
         "is_paused": false,
         "editor_settings": {
-          "simplified_query_editor": false
+          "simplified_query_and_expressions_section": false
         }
       }
     },
@@ -88,7 +88,7 @@
         "exec_err_state": "Alerting",
         "is_paused": false,
         "editor_settings": {
-          "simplified_query_editor": false
+          "simplified_query_and_expressions_section": false
         }
       }
     }

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -233,6 +233,7 @@ func convertGettableGrafanaRuleToPostable(gettable *apimodels.GettableGrafanaRul
 		ExecErrState:         gettable.ExecErrState,
 		IsPaused:             &gettable.IsPaused,
 		NotificationSettings: gettable.NotificationSettings,
+		Metadata:             gettable.Metadata,
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds the `metadata.editor_settings` field to the API and the AlertRule model:

```
metadata:
  editor_settings: {
    simplified_query_and_expressions_section: true
  }
}
```

It's a JSON because `simplified_query_and_expressions_section` is only the first field, and there will be more.

**Why do we need this feature?**

Related to https://github.com/grafana/grafana/pull/93022. Adds rule-level persistence for the editor settings used to change and save the rule.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/alerting-squad/issues/849

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
