### PR TITLE
Templating: Make __data.fields.foo fall back to 'foo' field in other frames

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -53,6 +53,7 @@ export interface FieldDisplay {
 
   // Expose to the original values for delayed inspection (DataLinks etc)
   view?: DataFrameView;
+  frames?: DataFrame[];
   colIndex?: number; // The field column index
   rowIndex?: number; // only filled in when the value is from a row (ie, not a reduction)
   getLinks?: () => LinkModel[];

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
@@ -95,7 +95,7 @@ describe('getFieldDisplayValuesProxy', () => {
 
   it('should fall back to matching by name in non-primary frame', () => {
     const frameA = toDataFrame({ fields: [...shortTimeField, { name: 'foo', values: [1, 2, 3] }] });
-    const frameB = toDataFrame({ fields: [...shortTimeField, { name: 'bar', values: [4,5,6] }] });
+    const frameB = toDataFrame({ fields: [...shortTimeField, { name: 'bar', values: [4, 5, 6] }] });
 
     const p = getFieldDisplayValuesProxy({
       frame: frameA,

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.test.tsx
@@ -92,4 +92,18 @@ describe('getFieldDisplayValuesProxy', () => {
     expect(p.test.numeric).toBe(1);
     expect(p.test.toString()).toBe('1');
   });
+
+  it('should fall back to matching by name in non-primary frame', () => {
+    const frameA = toDataFrame({ fields: [...shortTimeField, { name: 'foo', values: [1, 2, 3] }] });
+    const frameB = toDataFrame({ fields: [...shortTimeField, { name: 'bar', values: [4,5,6] }] });
+
+    const p = getFieldDisplayValuesProxy({
+      frame: frameA,
+      frames: [frameA, frameB],
+      rowIndex: 0,
+    });
+
+    expect(p.foo.numeric).toBe(1);
+    expect(p.bar.numeric).toBe(4);
+  });
 });

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
@@ -1,11 +1,25 @@
 import { toNumber } from 'lodash';
 
-import { DataFrame } from '../types/dataFrame';
+import { DataFrame, Field } from '../types/dataFrame';
 import { DisplayValue } from '../types/displayValue';
 import { TimeZone } from '../types/time';
 import { formattedValueToString } from '../valueFormats/valueFormats';
 
 import { getDisplayProcessor } from './displayProcessor';
+
+function matchFieldByName(fields: Field[], key: string | symbol) {
+  // try to match by name from primary frame
+  return fields.find(
+    (f) =>
+      // 1. Match the name
+      key === f.name ||
+      // 2. Match by displayName
+      key === f.config.displayName ||
+      key === f.state?.displayName ||
+      // 3. Match by labels.name
+      key === f.labels?.name
+  );
+}
 
 /**
  * Creates a proxy object that allows accessing fields on dataFrame through various means and then returns it's
@@ -18,6 +32,7 @@ import { getDisplayProcessor } from './displayProcessor';
  */
 export function getFieldDisplayValuesProxy(options: {
   frame: DataFrame;
+  frames?: DataFrame[];
   rowIndex: number;
   timeZone?: TimeZone;
 }): Record<string, DisplayValue> {
@@ -25,29 +40,32 @@ export function getFieldDisplayValuesProxy(options: {
     {},
     {
       get: (obj, key): DisplayValue | undefined => {
-        // 1. Match the name
-        let field = options.frame.fields.find((f) => key === f.name);
+        // 1. Match by name in primary frame
+        let field = matchFieldByName(options.frame.fields, key);
+
+        // 2. Match by name in other frames
         if (!field) {
-          // 2. Match the array index
+          options.frames?.some((frame) => {
+            // skip primary frame
+            if (frame !== options.frame) {
+              field = matchFieldByName(frame.fields, key);
+            }
+
+            // will cause .some() to exit/break if truthy
+            return field;
+          });
+        }
+
+        if (!field) {
+          // 3. Match by array index in primary frame
           const k = toNumber(key);
           field = options.frame.fields[k];
         }
-        if (!field) {
-          // 3. Match the config displayName
-          field = options.frame.fields.find((f) => key === f.config.displayName);
-        }
-        if (!field) {
-          // 4. Match the name label
-          field = options.frame.fields.find((f) => {
-            if (f.labels) {
-              return key === f.labels.name;
-            }
-            return false;
-          });
-        }
+
         if (!field) {
           return undefined;
         }
+
         // TODO: we could supply the field here for the getDisplayProcessor fallback but we would also need theme which
         //  we do not have access to here
         const displayProcessor = field.display ?? getDisplayProcessor();

--- a/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
+++ b/packages/grafana-data/src/field/getFieldDisplayValuesProxy.ts
@@ -8,10 +8,9 @@ import { formattedValueToString } from '../valueFormats/valueFormats';
 import { getDisplayProcessor } from './displayProcessor';
 
 function matchFieldByName(fields: Field[], key: string | symbol) {
-  // try to match by name from primary frame
   return fields.find(
     (f) =>
-      // 1. Match the name
+      // 1. Match by name
       key === f.name ||
       // 2. Match by displayName
       key === f.config.displayName ||

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -104,6 +104,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
                 refId: dataFrame.refId,
                 fields: getFieldDisplayValuesProxy({
                   frame: dataFrame,
+                  frames: value.frames,
                   rowIndex: value.rowIndex!,
                 }),
               },

--- a/public/app/features/templating/dataMacros.ts
+++ b/public/app/features/templating/dataMacros.ts
@@ -103,7 +103,7 @@ export function dataMacro(
   const obj = {
     name: frame.name,
     refId: frame.refId,
-    fields: getFieldDisplayValuesProxy({ frame, rowIndex }),
+    fields: getFieldDisplayValuesProxy({ frame, frames: scopedVars.__dataContext?.value.data, rowIndex }),
   };
 
   const value = getFieldAccessor(fieldPath)(obj) ?? '';


### PR DESCRIPTION
~~Fixes https://github.com/grafana/support-escalations/issues/12356~~

We would like for data links constructed with `__data.fields.foo` to be able to access the `foo` field in another frame, e.g. produced by another query. this is especially useful for Canvas which can have many mixed data sources driving different elements and an element may need have a data link that cross-references other queries.

This PR does two things:

1. It slightly reorders the original matching logic to try matching by name more exhaustively before falling back to by-index field selection.
2. It then reuses the name matching util func over "other" frames to try to locate the field in the a non-primary frame.
3. Then it falls back to matching by index on the primary frame.

- [ ] probably we will need the same changes in Scenes.

test dashboard:

<details><summary>test-canvas-links</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 293,
  "links": [],
  "panels": [
    {
      "datasource": {
        "default": true,
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "infinitePan": false,
        "inlineEditing": false,
        "panZoom": false,
        "root": {
          "background": {
            "color": {
              "fixed": "transparent"
            }
          },
          "border": {
            "color": {
              "fixed": "dark-green"
            }
          },
          "constraint": {
            "horizontal": "left",
            "vertical": "top"
          },
          "elements": [
            {
              "background": {
                "color": {
                  "fixed": "#D9D9D9"
                }
              },
              "border": {
                "color": {
                  "fixed": "dark-green"
                }
              },
              "config": {
                "align": "center",
                "color": {
                  "fixed": "#000000"
                },
                "size": 20,
                "text": {
                  "fixed": "",
                  "mode": "field"
                },
                "valign": "middle"
              },
              "constraint": {
                "horizontal": "left",
                "vertical": "top"
              },
              "links": [
                {
                  "title": "${__data.fields.a}",
                  "url": "${__data.fields.a}"
                },
                {
                  "title": "${__data.fields.y}",
                  "url": "${__data.fields.y}"
                },
                {
                  "title": "${__data.fields.b.labels.foo}",
                  "url": "${__data.fields.b.labels.foo}"
                }
              ],
              "name": "Element 1",
              "oneClickMode": "off",
              "placement": {
                "height": 50,
                "left": 100,
                "rotation": 0,
                "top": 100,
                "width": 260
              },
              "type": "metric-value"
            }
          ],
          "name": "Element 1719973944559",
          "oneClickMode": "off",
          "placement": {
            "height": 100,
            "left": 0,
            "rotation": 0,
            "top": 0,
            "width": 100
          },
          "type": "frame"
        },
        "showAdvancedTypes": true
      },
      "pluginVersion": "11.3.0-pre",
      "targets": [
        {
          "csvContent": "a,b{foo=bar},c\n1,2,3\n4,5,6",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        },
        {
          "csvContent": "x,y{moo=cow}\n7,8\n9,0\n3,7",
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "type": "canvas"
    }
  ],
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "test-canvas-links",
  "uid": "adqlik8vtzojkc",
  "version": 9,
  "weekStart": ""
}
```
</details>