### PR TITLE
Docs: Added instructions for configuring a private CA in Helm installs

### DIFF
--- a/docs/sources/setup-grafana/installation/helm/index.md
+++ b/docs/sources/setup-grafana/installation/helm/index.md
@@ -285,6 +285,7 @@ In many enterprise networks, TLS certificates are issued by a private certificat
 If your Grafana instance needs to interact with services exposing certificates issued by these private CAs, then you need to ensure Grafana trusts the root certificate.
 
 You might need to configure this if you:
+
 - have plugins that require connectivity to other self hosted systems. For example, if you've installed the Grafana Enterprise Metrics (GEM) plugin, and your GEM cluster is using a private certificate.
 - want to connect to data sources which are listening on HTTPS with a private certificate.
 - are using a backend database for persistence, or caching service that uses private certificates for encryption in transit.
@@ -301,12 +302,12 @@ A simple solution which should work across your entire instance (plugins, data s
    apiVersion: v1
    kind: ConfigMap
    metadata:
-      name: grafana-ca-cert
+     name: grafana-ca-cert
    data:
-      ca.pem: |
-         -----BEGIN CERTIFICATE-----
-         (rest of the CA cert)
-         -----END CERTIFICATE-----
+     ca.pem: |
+       -----BEGIN CERTIFICATE-----
+       (rest of the CA cert)
+       -----END CERTIFICATE-----
    ```
 
    ```bash

--- a/docs/sources/setup-grafana/installation/helm/index.md
+++ b/docs/sources/setup-grafana/installation/helm/index.md
@@ -286,7 +286,7 @@ If your Grafana instance needs to interact with services exposing certificates i
 
 You might need to configure this if you:
 
-- have plugins that require connectivity to other self hosted systems. For example, if you've installed the Grafana Enterprise Metrics (GEM) plugin, and your GEM cluster is using a private certificate.
+- have plugins that require connectivity to other self hosted systems. For example, if you've installed the Grafana Enterprise Metrics, Logs, or Traces (GEM, GEL, GET) plugins, and your GEM (or GEL/GET) cluster is using a private certificate.
 - want to connect to data sources which are listening on HTTPS with a private certificate.
 - are using a backend database for persistence, or caching service that uses private certificates for encryption in transit.
 

--- a/docs/sources/setup-grafana/installation/helm/index.md
+++ b/docs/sources/setup-grafana/installation/helm/index.md
@@ -278,6 +278,66 @@ To install plugins in the Grafana Helm Charts, complete the following steps:
 
 1. Search for the above plugins and they should be marked as installed.
 
+### Configure a Private CA (Certificate Authority)
+
+In many enterprise networks, TLS certificates are issued by a private certificate authority and are not trusted by default (using the provided OS trust chain).
+
+If your Grafana instance needs to interact with services exposing certificates issued by these private CAs, then you need to ensure Grafana trusts the root certificate.
+
+You might need to configure this if you:
+- have plugins that require connectivity to other self hosted systems. For example, if you've installed the Grafana Enterprise Metrics (GEM) plugin, and your GEM cluster is using a private certificate.
+- want to connect to data sources which are listening on HTTPS with a private certificate.
+- are using a backend database for persistence, or caching service that uses private certificates for encryption in transit.
+
+In some cases you can specify a self-signed certificate within Grafana (such as in some data sources), or choose to skip TLS certificate validation (this is not recommended unless absolutely necessary).
+
+A simple solution which should work across your entire instance (plugins, data sources, and backend connections) is to add your self-signed CA certificate to your Kubernetes deployment.
+
+1. Create a ConfigMap containing the certificate, and deploy it to your Kubernetes cluster
+
+   ```yaml
+   # grafana-ca-configmap.yaml
+   ---
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+      name: grafana-ca-cert
+   data:
+      ca.pem: |
+         -----BEGIN CERTIFICATE-----
+         (rest of the CA cert)
+         -----END CERTIFICATE-----
+   ```
+
+   ```bash
+   kubectl apply --filename grafana-ca-configmap.yaml --namespace monitoring
+   ```
+
+1. Open the Helm `values.yaml` file in your favorite editor.
+
+1. Find the line that says `extraConfigmapMounts:` and under that section, specify the additional ConfigMap that you want to mount.
+
+   ```yaml
+   .......
+   ............
+   ......
+   extraConfigmapMounts:
+      - name: ca-certs-configmap
+        mountPath: /etc/ssl/certs/ca.pem
+        subPath: ca.pem
+        configMap: grafana-ca-cert
+        readOnly: true
+   .......
+   ............
+   ......
+   ```
+
+1. Save the changes and use the `helm upgrade` command to update your Grafana deployment and mount the new ConfigMap:
+
+   ```bash
+   helm upgrade my-grafana grafana/grafana --values values.yaml --namespace monitoring
+   ```
+
 ## Troubleshooting
 
 This section includes troubleshooting tips you might find helpful when deploying Grafana on Kubernetes via Helm.


### PR DESCRIPTION
**What is this feature?**

When Grafana is deployed in environments which use private certificates, it's necessary to configure the private CA so that Grafana is able to trust them. In some areas this can be configured within Grafana, but in some cases it is necessary to add the private CA to the Grafana deployment.

**Why do we need this feature?**

This additional section in our documentation makes it easy for Grafana operators to configure a private CA cert as part of their deployment.

**Who is this feature for?**

Grafana operators (who manage a self hosted Grafana deployment)
