### PR TITLE
CloudMigrations: improve nil handling

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -137,8 +137,15 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	s.gmsClient = gmsClientMock
 
 	// Insert a session and snapshot into the database before we start
-	sess, err := s.store.CreateMigrationSession(context.Background(), cloudmigration.CloudMigrationSession{})
+	createTokenResp, err := s.CreateToken(context.Background())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, createTokenResp.Token)
+
+	sess, err := s.store.CreateMigrationSession(context.Background(), cloudmigration.CloudMigrationSession{
+		AuthToken: createTokenResp.Token,
+	})
 	require.NoError(t, err)
+
 	uid, err := s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
 		UID:            "test uid",
 		SessionUID:     sess.UID,
@@ -306,8 +313,15 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 	s.gmsClient = gmsClientMock
 
 	// Insert a snapshot into the database before we start
-	sess, err := s.store.CreateMigrationSession(context.Background(), cloudmigration.CloudMigrationSession{})
+	createTokenResp, err := s.CreateToken(context.Background())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, createTokenResp.Token)
+
+	sess, err := s.store.CreateMigrationSession(context.Background(), cloudmigration.CloudMigrationSession{
+		AuthToken: createTokenResp.Token,
+	})
 	require.NoError(t, err)
+
 	uid, err := s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
 		UID:            uuid.NewString(),
 		SessionUID:     sess.UID,
@@ -416,7 +430,13 @@ func Test_NonCoreDataSourcesHaveWarning(t *testing.T) {
 	s := setUpServiceTest(t, false).(*Service)
 
 	// Insert a processing snapshot into the database before we start so we query GMS
-	sess, err := s.store.CreateMigrationSession(context.Background(), cloudmigration.CloudMigrationSession{})
+	createTokenResp, err := s.CreateToken(context.Background())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, createTokenResp.Token)
+
+	sess, err := s.store.CreateMigrationSession(context.Background(), cloudmigration.CloudMigrationSession{
+		AuthToken: createTokenResp.Token,
+	})
 	require.NoError(t, err)
 	snapshotUid, err := s.store.CreateSnapshot(context.Background(), cloudmigration.CloudMigrationSnapshot{
 		UID:            uuid.NewString(),

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -45,7 +45,7 @@ func (ss *sqlStore) GetMigrationSessionByUID(ctx context.Context, uid string) (*
 	}
 
 	if err := ss.decryptToken(ctx, &cm); err != nil {
-		return &cm, err
+		return nil, fmt.Errorf("decrypting token: %w", err)
 	}
 
 	return &cm, err
@@ -69,7 +69,7 @@ func (ss *sqlStore) CreateMigrationRun(ctx context.Context, cmr cloudmigration.C
 
 func (ss *sqlStore) CreateMigrationSession(ctx context.Context, migration cloudmigration.CloudMigrationSession) (*cloudmigration.CloudMigrationSession, error) {
 	if err := ss.encryptToken(ctx, &migration); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encrypting token: %w", err)
 	}
 
 	err := ss.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
@@ -101,8 +101,9 @@ func (ss *sqlStore) GetCloudMigrationSessionList(ctx context.Context) ([]*cloudm
 
 	for i := 0; i < len(migrations); i++ {
 		m := migrations[i]
+
 		if err := ss.decryptToken(ctx, m); err != nil {
-			return migrations, err
+			return nil, fmt.Errorf("decrypting token: %w", err)
 		}
 	}
 
@@ -169,7 +170,7 @@ func (ss *sqlStore) DeleteMigrationSessionByUID(ctx context.Context, uid string)
 	}
 
 	if err := ss.decryptToken(ctx, &c); err != nil {
-		return &c, snapshots, err
+		return nil, nil, fmt.Errorf("decrypting token: %w", err)
 	}
 
 	return &c, snapshots, nil
@@ -474,6 +475,14 @@ func (ss *sqlStore) encryptToken(ctx context.Context, cm *cloudmigration.CloudMi
 }
 
 func (ss *sqlStore) decryptToken(ctx context.Context, cm *cloudmigration.CloudMigrationSession) error {
+	if cm == nil {
+		return cloudmigration.ErrMigrationNotFound
+	}
+
+	if len(cm.AuthToken) == 0 {
+		return cloudmigration.ErrTokenNotFound
+	}
+
 	decoded, err := base64.StdEncoding.DecodeString(cm.AuthToken)
 	if err != nil {
 		return fmt.Errorf("token could not be decoded")
@@ -483,6 +492,7 @@ func (ss *sqlStore) decryptToken(ctx context.Context, cm *cloudmigration.CloudMi
 	if err != nil {
 		return fmt.Errorf("decrypting auth token: %w", err)
 	}
+
 	cm.AuthToken = string(t)
 
 	return nil


### PR DESCRIPTION
**What is this feature?**

This addresses a panic when deleting the migration session for cases where the session token does not exist at the moment of deletion.

**Why do we need this feature?**

We can provide a better error handling message to the user to be able to assist with debugging.

**Who is this feature for?**

Cloud migration assistant users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/959
