### PR TITLE
Prometheus: Use Combobox for metric select

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+import { DataSourceInstanceSettings, MetricFindValue } from '@grafana/data';
+
+import { PrometheusDatasource } from '../../datasource';
+import { PromOptions } from '../../types';
+
+import { MetricCombobox, MetricComboboxProps } from './MetricCombobox';
+
+describe('MetricCombobox', () => {
+  const instanceSettings = {
+    url: 'proxied',
+    id: 1,
+    user: 'test',
+    password: 'mupp',
+    jsonData: { httpMethod: 'GET' },
+  } as unknown as DataSourceInstanceSettings<PromOptions>;
+
+  const mockDatasource = new PrometheusDatasource(instanceSettings);
+  const mockValues = [{ label: 'random_metric' }, { label: 'unique_metric' }, { label: 'more_unique_metric' }];
+
+  // Mock metricFindQuery which will call backend API
+  //@ts-ignore
+  mockDatasource.metricFindQuery = jest.fn((query: string) => {
+    // Use the label values regex to get the values inside the label_values function call
+    const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
+    const queryValueArray = query.match(labelValuesRegex) as RegExpMatchArray;
+    const queryValueRaw = queryValueArray[1] as string;
+
+    // Remove the wrapping regex
+    const queryValue = queryValueRaw.substring(queryValueRaw.indexOf('".*') + 3, queryValueRaw.indexOf('.*"'));
+
+    // Run the regex that we'd pass into prometheus API against the strings in the test
+    return Promise.resolve(
+      mockValues
+        .filter((value) => value.label.match(queryValue))
+        .map((result) => {
+          return {
+            text: result.label,
+          };
+        }) as MetricFindValue[]
+    );
+  });
+
+  const mockOnChange = jest.fn();
+  const mockOnGetMetrics = jest.fn();
+
+  const defaultProps: MetricComboboxProps = {
+    metricLookupDisabled: false,
+    query: {
+      metric: '',
+      labels: [],
+      operations: [],
+    },
+    onChange: mockOnChange,
+    onGetMetrics: mockOnGetMetrics,
+    datasource: mockDatasource,
+    labelsFilters: [],
+    variableEditor: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    render(<MetricCombobox {...defaultProps} />);
+    expect(screen.getByPlaceholderText('Select metric')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the correct value when a metric is selected', () => {
+    render(<MetricCombobox {...defaultProps} />);
+    fireEvent.change(screen.getByPlaceholderText('Select metric'), { target: { value: 'metric1' } });
+    fireEvent.keyDown(screen.getByPlaceholderText('Select metric'), { key: 'Enter', code: 'Enter' });
+    expect(mockOnChange).toHaveBeenCalledWith({ metric: 'metric1' });
+  });
+
+  it('fetches metrics correctly when loadOptions is called', async () => {
+    mockOnGetMetrics.mockResolvedValue([{ label: 'metric1', value: 'metric1' }]);
+    render(<MetricCombobox {...defaultProps} />);
+    fireEvent.change(screen.getByPlaceholderText('Select metric'), { target: { value: 'metric' } });
+    await waitFor(() => expect(mockOnGetMetrics).toHaveBeenCalled());
+  });
+
+  it('formats the results correctly in getMetricLabels', async () => {
+    jest.mocked(mockDatasource.metricFindQuery).mockResolvedValue([{ text: 'metric1' }]);
+
+    render(<MetricCombobox {...defaultProps} />);
+    fireEvent.change(screen.getByPlaceholderText('Select metric'), { target: { value: 'metric' } });
+    await waitFor(() => expect(mockDatasource.metricFindQuery).toHaveBeenCalled());
+  });
+});

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import '@testing-library/jest-dom';
 import { DataSourceInstanceSettings, MetricFindValue } from '@grafana/data';
@@ -9,6 +10,21 @@ import { PromOptions } from '../../types';
 import { MetricCombobox, MetricComboboxProps } from './MetricCombobox';
 
 describe('MetricCombobox', () => {
+  beforeAll(() => {
+    const mockGetBoundingClientRect = jest.fn(() => ({
+      width: 120,
+      height: 120,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+    }));
+
+    Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+      value: mockGetBoundingClientRect,
+    });
+  });
+
   const instanceSettings = {
     url: 'proxied',
     id: 1,
@@ -21,12 +37,12 @@ describe('MetricCombobox', () => {
   const mockValues = [{ label: 'random_metric' }, { label: 'unique_metric' }, { label: 'more_unique_metric' }];
 
   // Mock metricFindQuery which will call backend API
-  //@ts-ignore
   mockDatasource.metricFindQuery = jest.fn((query: string) => {
+    // return Promise.resolve([]);
     // Use the label values regex to get the values inside the label_values function call
     const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
     const queryValueArray = query.match(labelValuesRegex) as RegExpMatchArray;
-    const queryValueRaw = queryValueArray[1] as string;
+    const queryValueRaw = queryValueArray[1];
 
     // Remove the wrapping regex
     const queryValue = queryValueRaw.substring(queryValueRaw.indexOf('".*') + 3, queryValueRaw.indexOf('.*"'));
@@ -44,7 +60,7 @@ describe('MetricCombobox', () => {
   });
 
   const mockOnChange = jest.fn();
-  const mockOnGetMetrics = jest.fn();
+  const mockOnGetMetrics = jest.fn(() => Promise.resolve(mockValues.map((v) => ({ value: v.label }))));
 
   const defaultProps: MetricComboboxProps = {
     metricLookupDisabled: false,
@@ -69,25 +85,43 @@ describe('MetricCombobox', () => {
     expect(screen.getByPlaceholderText('Select metric')).toBeInTheDocument();
   });
 
-  it('calls onChange with the correct value when a metric is selected', () => {
+  it('fetches top metrics when the combobox is opened ', async () => {
     render(<MetricCombobox {...defaultProps} />);
-    fireEvent.change(screen.getByPlaceholderText('Select metric'), { target: { value: 'metric1' } });
-    fireEvent.keyDown(screen.getByPlaceholderText('Select metric'), { key: 'Enter', code: 'Enter' });
-    expect(mockOnChange).toHaveBeenCalledWith({ metric: 'metric1' });
+
+    const combobox = screen.getByPlaceholderText('Select metric');
+    await userEvent.click(combobox);
+
+    expect(mockOnGetMetrics).toHaveBeenCalledTimes(1);
+
+    const item = await screen.findByRole('option', { name: 'random_metric' });
+    expect(item).toBeInTheDocument();
   });
 
-  it('fetches metrics correctly when loadOptions is called', async () => {
-    mockOnGetMetrics.mockResolvedValue([{ label: 'metric1', value: 'metric1' }]);
+  it('fetches metrics for the users query', async () => {
     render(<MetricCombobox {...defaultProps} />);
-    fireEvent.change(screen.getByPlaceholderText('Select metric'), { target: { value: 'metric' } });
-    await waitFor(() => expect(mockOnGetMetrics).toHaveBeenCalled());
+
+    const combobox = screen.getByPlaceholderText('Select metric');
+    await userEvent.click(combobox);
+
+    await userEvent.type(combobox, 'unique');
+    expect(jest.mocked(mockDatasource.metricFindQuery)).toHaveBeenCalled();
+
+    const item = await screen.findByRole('option', { name: 'unique_metric' });
+    expect(item).toBeInTheDocument();
+
+    const negativeItem = await screen.queryByRole('option', { name: 'random_metric' });
+    expect(negativeItem).not.toBeInTheDocument();
   });
 
-  it('formats the results correctly in getMetricLabels', async () => {
-    jest.mocked(mockDatasource.metricFindQuery).mockResolvedValue([{ text: 'metric1' }]);
-
+  it('calls onChange with the correct value when a metric is selected', async () => {
     render(<MetricCombobox {...defaultProps} />);
-    fireEvent.change(screen.getByPlaceholderText('Select metric'), { target: { value: 'metric' } });
-    await waitFor(() => expect(mockDatasource.metricFindQuery).toHaveBeenCalled());
+
+    const combobox = screen.getByPlaceholderText('Select metric');
+    await userEvent.click(combobox);
+
+    const item = await screen.findByRole('option', { name: 'random_metric' });
+    await userEvent.click(item);
+
+    expect(mockOnChange).toHaveBeenCalledWith({ metric: 'random_metric', labels: [], operations: [] });
   });
 });

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -1,0 +1,198 @@
+// Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
+import { css } from '@emotion/css';
+import { useCallback, useState } from 'react';
+import * as React from 'react';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { EditorField, EditorFieldGroup } from '@grafana/experimental';
+import { config } from '@grafana/runtime';
+import { InlineField, InlineFieldRow } from '@grafana/ui';
+import { Combobox, ComboboxOption } from '@grafana/ui/src/components/Combobox/Combobox';
+
+import { PrometheusDatasource } from '../../datasource';
+import { QueryBuilderLabelFilter } from '../shared/types';
+import { PromVisualQuery } from '../types';
+
+import { MetricsModal } from './metrics-modal/MetricsModal';
+
+export interface MetricComboboxProps {
+  metricLookupDisabled: boolean;
+  query: PromVisualQuery;
+  onChange: (query: PromVisualQuery) => void;
+  onGetMetrics: () => Promise<SelectableValue[]>;
+  datasource: PrometheusDatasource;
+  labelsFilters: QueryBuilderLabelFilter[];
+  onBlur?: () => void;
+  variableEditor?: boolean;
+}
+
+export const PROMETHEUS_QUERY_BUILDER_MAX_RESULTS = 1000;
+
+export function MetricCombobox({
+  datasource,
+  query,
+  onChange,
+  onGetMetrics,
+  labelsFilters,
+  metricLookupDisabled,
+  onBlur,
+  variableEditor,
+}: Readonly<MetricComboboxProps>) {
+  const [state, setState] = useState<{
+    metrics?: SelectableValue[];
+    isLoading?: boolean;
+    metricsModalOpen?: boolean;
+    initialMetrics?: string[];
+    resultsTruncated?: boolean;
+  }>({});
+
+  const prometheusMetricEncyclopedia = config.featureToggles.prometheusMetricEncyclopedia;
+
+  /**
+   * Reformat the query string and label filters to return all valid results for current query editor state
+   */
+  // const formatKeyValueStringsForLabelValuesQuery = (
+  //   query: string,
+  //   labelsFilters?: QueryBuilderLabelFilter[]
+  // ): string => {
+  //   const queryString = regexifyLabelValuesQueryString(query);
+
+  //   return formatPrometheusLabelFiltersToString(queryString, labelsFilters);
+  // };
+
+  /**
+   * Gets label_values response from prometheus API for current autocomplete query string and any existing labels filters
+   */
+  // const getMetricLabels = (query: string) => {
+  //   // Since some customers can have millions of metrics, whenever the user changes the autocomplete text we want to call the backend and request all metrics that match the current query string
+  //   const results = datasource.metricFindQuery(formatKeyValueStringsForLabelValuesQuery(query, labelsFilters));
+  //   return results.then((results) => {
+  //     const resultsLength = results.length;
+  //     truncateResult(results);
+
+  //     if (resultsLength > results.length) {
+  //       setState({ ...state, resultsTruncated: true });
+  //     } else {
+  //       setState({ ...state, resultsTruncated: false });
+  //     }
+
+  //     const resultsOptions = results.map((result) => {
+  //       return {
+  //         label: result.text,
+  //         value: result.text,
+  //       };
+  //     });
+
+  //     if (prometheusMetricEncyclopedia) {
+  //       return [...metricsModalOption, ...resultsOptions];
+  //     } else {
+  //       return resultsOptions;
+  //     }
+  //   });
+  // };
+
+  const [comboboxOptions, setCombobboxOptions] = useState<ComboboxOption[]>([]);
+
+  // Load initial options for the dropdown immediately on mount
+  // This is different vs select, which loaded them lazily once the dropdown was opened
+  const hasloadedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (hasloadedRef.current) {
+      return;
+    }
+
+    hasloadedRef.current = true;
+    onGetMetrics().then((selectOptions) => {
+      const options: ComboboxOption[] = selectOptions.map((option) => ({
+        label: option.label ?? option.value,
+        value: option.value,
+      }));
+
+      setCombobboxOptions(options);
+    });
+  }, [onGetMetrics]);
+
+  // TODO: debounce this
+  // const onInputChange = useCallback(
+  //   (input: string) => {
+  //     if (!input) {
+  //       return;
+  //     }
+
+  //     getMetricLabels(input).then((selectOptions) => {
+  //       const options: ComboboxOption[] = selectOptions.map((option) => ({
+  //         label: option.label ?? option.value,
+  //         value: option.value,
+  //       }));
+
+  //       setCombobboxOptions(options);
+  //     });
+  //   },
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  //   []
+  // );
+
+  const onComboboxChange = useCallback(
+    (opt: ComboboxOption<string> | null) => {
+      onChange({ ...query, metric: opt?.value ?? '' });
+    },
+    [onChange, query]
+  );
+
+  const asyncSelect = () => {
+    return (
+      <Combobox
+        options={comboboxOptions}
+        value={query.metric}
+        onChange={onComboboxChange}
+        // onInputChange={onInputChange}
+      />
+    );
+  };
+
+  return (
+    <>
+      {prometheusMetricEncyclopedia && !datasource.lookupsDisabled && state.metricsModalOpen && (
+        <MetricsModal
+          datasource={datasource}
+          isOpen={state.metricsModalOpen}
+          onClose={() => setState({ ...state, metricsModalOpen: false })}
+          query={query}
+          onChange={onChange}
+          initialMetrics={state.initialMetrics ?? []}
+        />
+      )}
+      {/* format the ui for either the query editor or the variable editor */}
+      {variableEditor ? (
+        <InlineFieldRow>
+          <InlineField
+            label="Metric"
+            labelWidth={20}
+            tooltip={<div>Optional: returns a list of label values for the label name in the specified metric.</div>}
+          >
+            {asyncSelect()}
+          </InlineField>
+        </InlineFieldRow>
+      ) : (
+        <EditorFieldGroup>
+          <EditorField label="Metric">{asyncSelect()}</EditorField>
+        </EditorFieldGroup>
+      )}
+    </>
+  );
+}
+
+export const formatPrometheusLabelFiltersToString = (
+  queryString: string,
+  labelsFilters: QueryBuilderLabelFilter[] | undefined
+): string => {
+  const filterArray = labelsFilters ? formatPrometheusLabelFilters(labelsFilters) : [];
+
+  return `label_values({__name__=~".*${queryString}"${filterArray ? filterArray.join('') : ''}},__name__)`;
+};
+
+export const formatPrometheusLabelFilters = (labelsFilters: QueryBuilderLabelFilter[]): string[] => {
+  return labelsFilters.map((label) => {
+    return `,${label.label}="${label.value}"`;
+  });
+};

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -1,4 +1,3 @@
-// Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/MetricSelect.tsx
 import { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -70,6 +70,7 @@ export function MetricCombobox({
       const _devStart = Date.now();
 
       const metrics = input.length ? await getMetricLabels(input) : await onGetMetrics();
+
       const _devEnd = Date.now();
       const timeRemaining = _devMinTime - (_devEnd - _devStart);
       if (timeRemaining > 0) {

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -86,7 +86,9 @@ export function MetricCombobox({
   );
 
   const asyncSelect = () => {
-    return <Combobox options={loadOptions} value={query.metric} onChange={onComboboxChange} />;
+    return (
+      <Combobox placeholder="Select metric" options={loadOptions} value={query.metric} onChange={onComboboxChange} />
+    );
   };
 
   return (
@@ -101,6 +103,7 @@ export function MetricCombobox({
           initialMetrics={state.initialMetrics ?? []}
         />
       )} */}
+
       {/* format the ui for either the query editor or the variable editor */}
       {variableEditor ? (
         <InlineFieldRow>

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -2,8 +2,7 @@ import { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
-import { InlineField, InlineFieldRow } from '@grafana/ui';
-import { Combobox, ComboboxOption } from '@grafana/ui/src/components/Combobox/Combobox';
+import { InlineField, InlineFieldRow, Combobox, ComboboxOption } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../../datasource';
 import { regexifyLabelValuesQueryString } from '../parsingUtils';

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
@@ -2,6 +2,7 @@
 import { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { PrometheusDatasource } from '../../datasource';
 import { getMetadataString } from '../../language_provider';
@@ -12,6 +13,7 @@ import { QueryBuilderLabelFilter } from '../shared/types';
 import { PromVisualQuery } from '../types';
 
 import { LabelFilters } from './LabelFilters';
+import { MetricCombobox } from './MetricCombobox';
 import { MetricSelect } from './MetricSelect';
 
 export interface MetricsLabelsSectionProps {
@@ -192,9 +194,11 @@ export function MetricsLabelsSection({
     return withTemplateVariableOptions(getMetrics(datasource, query));
   }, [datasource, query, withTemplateVariableOptions]);
 
+  const MetricSelectComponent = config.featureToggles.prometheusUsesCombobox ? MetricCombobox : MetricSelect;
+
   return (
     <>
-      <MetricSelect
+      <MetricSelectComponent
         query={query}
         onChange={onChange}
         onGetMetrics={onGetMetrics}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -280,7 +280,6 @@ export const Combobox = <T extends string | number>({
           'aria-labelledby': ariaLabelledBy, // Label should be handled with the Field component
         })}
       />
-
       <div
         className={cx(styles.menu, !isOpen && styles.menuClosed)}
         style={{

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -280,6 +280,7 @@ export const Combobox = <T extends string | number>({
           'aria-labelledby': ariaLabelledBy, // Label should be handled with the Field component
         })}
       />
+
       <div
         className={cx(styles.menu, !isOpen && styles.menuClosed)}
         style={{

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -204,10 +204,18 @@ export const Combobox = <T extends string | number>({
 
       if (isOpen && isAsync) {
         setAsyncLoading(true);
-        loadOptions(inputValue ?? '').then((options) => {
-          setItems(options);
-          setAsyncLoading(false);
-        });
+        loadOptions(inputValue ?? '')
+          .then((options) => {
+            setItems(options);
+            setAsyncLoading(false);
+          })
+          .catch((err) => {
+            if (!(err instanceof StaleResultError)) {
+              // TODO: handle error
+              setAsyncLoading(false);
+              throw err;
+            }
+          });
         return;
       }
     },


### PR DESCRIPTION

This PR changes the Prometheus query editor to use the new fast select component Combobbox, gated by an experimental feature toggle `prometheusUsesCombobox`. This PR is not a change that is ready to be rolled out to users, but to validate that the component is usable for Prometheus.

![image](https://github.com/user-attachments/assets/62c1d358-eb8d-4608-b177-b094014762a2)

Combobox's visual appearance is largely identical to Select, but it deliberately lacks many customisation options. Differences in Prometheus's usage:

 - no scroll indicators - rather than individual consumers implementing this differently, we're just going to add it globally to Combobox https://github.com/grafana/grafana/issues/94467 
 - no custom item renderer for opening metric explorer - we don't plan to add this customisation option in, so we will need to find a new home to open the Metrics Explorer.
   -  That's not in this PR, but we will find a temporary home for it before enabling this in internal environments, and then a final home for it before turning it on for users
 - no footer rendering - also no plan to restore this, but as Combobox can handle significantly more options at once the previous disclaimer that was renderered there no longer applies
