### PR TITLE
Scopes: Add more logging in custom handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -260,7 +260,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -260,7 +260,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/pkg/registry/apis/scope/find.go
+++ b/pkg/registry/apis/scope/find.go
@@ -13,7 +13,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	scope "github.com/grafana/grafana/pkg/apis/scope/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
 )
+
+var logger = log.New("find-scopenode")
 
 type findREST struct {
 	scopeNodeStorage *storage
@@ -89,6 +92,8 @@ func (r *findREST) Connect(ctx context.Context, name string, opts runtime.Object
 		for _, item := range all.Items {
 			filterAndAppendItem(item, parent, query, results)
 		}
+
+		logger.FromContext(req.Context()).Debug("find scopenode", "raw", len(all.Items), "filtered", len(results.Items))
 
 		responder.Object(200, results)
 	}), nil

--- a/pkg/registry/apis/scope/find_scope_dashboards.go
+++ b/pkg/registry/apis/scope/find_scope_dashboards.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	scope "github.com/grafana/grafana/pkg/apis/scope/v0alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/rest"
-
-	scope "github.com/grafana/grafana/pkg/apis/scope/v0alpha1"
 )
 
 type findScopeDashboardsREST struct {
@@ -92,6 +91,8 @@ func (f *findScopeDashboardsREST) Connect(ctx context.Context, name string, opts
 				}
 			}
 		}
+
+		logger.FromContext(req.Context()).Debug("find scopedashboardbinding", "raw", len(all.Items), "filtered", len(results.Items))
 
 		responder.Object(200, results)
 	}), nil


### PR DESCRIPTION
Add a bit more logging in the custom scope handlers.

At a certain number of objects the API doesn't return the expected number of items. More logging should be helpful when debugging this. 