### PR TITLE
[v11.2.x] DashboardScenes: Fix duplicate query modifying original query on panel duplication

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -797,6 +797,22 @@ describe('DashboardScene', () => {
         expect(libVizPanel.state.panel?.state.key).toBe('panel-7');
       });
 
+      it('Should deep clone data provider when duplicating a panel', () => {
+        const vizPanel = ((scene.state.body as SceneGridLayout).state.children[0] as DashboardGridItem).state.body;
+        scene.duplicatePanel(vizPanel as VizPanel);
+
+        const panelQueries = (
+          ((scene.state.body as SceneGridLayout).state.children[0] as DashboardGridItem).state.body.state.$data?.state
+            .$data as SceneQueryRunner
+        ).state.queries;
+        const duplicatedPanelQueries = (
+          ((scene.state.body as SceneGridLayout).state.children[5] as DashboardGridItem).state.body.state.$data?.state
+            .$data as SceneQueryRunner
+        ).state.queries;
+
+        expect(panelQueries[0]).not.toBe(duplicatedPanelQueries[0]);
+      });
+
       it('Should duplicate a repeated panel', () => {
         const scene = buildTestScene({
           body: new SceneGridLayout({
@@ -1242,7 +1258,10 @@ function buildTestScene(overrides?: Partial<DashboardSceneState>) {
             }),
             $data: new SceneDataTransformer({
               transformations: [],
-              $data: new SceneQueryRunner({ key: 'data-query-runner', queries: [{ refId: 'A' }] }),
+              $data: new SceneQueryRunner({
+                key: 'data-query-runner',
+                queries: [{ refId: 'A', target: 'aliasByMetric(carbon.**)' }],
+              }),
             }),
           }),
         }),

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -63,6 +63,7 @@ import {
   getDefaultRow,
   getDefaultVizPanel,
   getPanelIdForVizPanel,
+  getQueryRunnerFor,
   getVizPanelKeyForPanelId,
   isPanelClone,
 } from '../utils/utils';
@@ -577,10 +578,18 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     } else {
       if (gridItem instanceof DashboardGridItem) {
         panelState = sceneUtils.cloneSceneObjectState(gridItem.state.body.state);
-        panelData = sceneGraph.getData(gridItem.state.body).clone();
+
+        let queryRunner = getQueryRunnerFor(gridItem.state.body);
+        const queries = queryRunner?.state.queries.map((q) => ({ ...q }));
+        queryRunner = queryRunner?.clone({ queries });
+        panelData = sceneGraph.getData(gridItem.state.body).clone({ $data: queryRunner });
       } else {
         panelState = sceneUtils.cloneSceneObjectState(vizPanel.state);
-        panelData = sceneGraph.getData(vizPanel).clone();
+
+        let queryRunner = getQueryRunnerFor(vizPanel);
+        const queries = queryRunner?.state.queries.map((q) => ({ ...q }));
+        queryRunner = queryRunner?.clone({ queries });
+        panelData = sceneGraph.getData(vizPanel).clone({ $data: queryRunner });
       }
 
       // when we duplicate a panel we don't want to clone the alert state


### PR DESCRIPTION
Backport 8eb7e55f8f33cac7d021d822cbb7eb40acafbd4b from #93038

---

An issue arose when duplicating a panel in a dashboard and then trying to modify the cloned panel query. Changing the cloned panel query would actually affect the original panels query. Not all datasources reproduce this, it was noticed on the `graphiteDS`.

This PR fixes the issue and makes sure the two query sets are different.

