### PR TITLE
Alerting: Add `no-unused-vars` eslint and fix violations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -257,11 +257,12 @@ module.exports = [
       'prefer-const': 'error',
       'react/no-unused-prop-types': 'error',
       'unicorn/no-unused-properties': 'error',
-      'no-unused-vars': [
+      '@typescript-eslint/no-unused-vars': [
         'error',
         {
           destructuredArrayIgnorePattern: '^_',
           ignoreRestSiblings: true,
+          caughtErrors: 'none',
         },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -257,6 +257,13 @@ module.exports = [
       'prefer-const': 'error',
       'react/no-unused-prop-types': 'error',
       'unicorn/no-unused-properties': 'error',
+      'no-unused-vars': [
+        'error',
+        {
+          destructuredArrayIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
   {

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -15,7 +15,7 @@ import {
 import { PERMISSIONS_TEMPLATES } from './unified/components/templates/permissions';
 import { evaluateAccess } from './unified/utils/access-control';
 
-export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
+export function getAlertingRoutes(): RouteDescriptor[] {
   const routes = [
     {
       path: '/alerting',

--- a/public/app/features/alerting/state/query_part.ts
+++ b/public/app/features/alerting/state/query_part.ts
@@ -110,10 +110,10 @@ export function suffixRenderer(part: QueryPart, innerExpr: string) {
   return innerExpr + ' ' + part.params[0];
 }
 
-export function identityRenderer(part: QueryPart, innerExpr: string) {
+export function identityRenderer(part: QueryPart) {
   return part.params[0];
 }
 
-export function quotedIdentityRenderer(part: QueryPart, innerExpr: string) {
+export function quotedIdentityRenderer(part: QueryPart) {
   return '"' + part.params[0] + '"';
 }

--- a/public/app/features/alerting/unified/ExistingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/ExistingRuleEditor.tsx
@@ -10,10 +10,9 @@ import * as ruleId from './utils/rule-id';
 
 interface ExistingRuleEditorProps {
   identifier: RuleIdentifier;
-  id?: string;
 }
 
-export function ExistingRuleEditor({ identifier, id }: ExistingRuleEditorProps) {
+export function ExistingRuleEditor({ identifier }: ExistingRuleEditorProps) {
   const {
     loading: loadingAlertRule,
     result: ruleWithLocation,

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -70,7 +70,7 @@ export function GrafanaRuleQueryViewer({ rule, queries, condition, evalDataByQue
       </div>
       <div className={styles.maxWidthContainer}>
         <Stack gap={1} wrap="wrap" data-testid="expressions-container">
-          {expressions.map(({ model, refId, datasourceUid }, index) => {
+          {expressions.map(({ model, refId }, index) => {
             return (
               isExpressionQuery(model) && (
                 <ExpressionPreview

--- a/public/app/features/alerting/unified/RuleEditor.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.tsx
@@ -65,7 +65,7 @@ const RuleEditor = () => {
     }
 
     if (identifier) {
-      return <ExistingRuleEditor key={id} identifier={identifier} id={id} />;
+      return <ExistingRuleEditor key={id} identifier={identifier} />;
     }
 
     if (copyFromIdentifier) {

--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -7,7 +7,7 @@ import SettingsPage from './Settings';
 import DataSourcesResponse from './components/settings/__mocks__/api/datasources.json';
 import { setupGrafanaManagedServer, withExternalOnlySetting } from './components/settings/__mocks__/server';
 import { setupMswServer } from './mockApi';
-import { grantUserRole } from './mocks';
+import { grantAllUserRoles } from './mocks';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -39,7 +39,7 @@ const ui = {
 
 describe('Alerting settings', () => {
   beforeEach(() => {
-    grantUserRole('ServerAdmin');
+    grantAllUserRoles();
     setupGrafanaManagedServer(server);
   });
 

--- a/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
+++ b/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { ComponentProps, useMemo } from 'react';
 
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 import { InlineField, Select, SelectMenuOptions, useStyles2 } from '@grafana/ui';
 
 import { useAlertmanager } from '../state/AlertmanagerContext';
@@ -53,7 +53,7 @@ export const AlertManagerPicker = ({ disabled = false }: Props) => {
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   field: css({
     margin: 0,
   }),

--- a/public/app/features/alerting/unified/components/AnnotationDetailsField.tsx
+++ b/public/app/features/alerting/unified/components/AnnotationDetailsField.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { Annotation, annotationLabels } from '../utils/constants';
@@ -65,7 +64,7 @@ const AnnotationValue = ({ annotationKey, value, valueLink }: Props) => {
   return <>{tokenizeValue}</>;
 };
 
-export const getStyles = (theme: GrafanaTheme2) => ({
+export const getStyles = () => ({
   well: css({
     wordBreak: 'break-word',
   }),

--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -1,26 +1,18 @@
 import { HTMLAttributes } from 'react';
 
-import { Button, IconSize } from '@grafana/ui';
+import { Button, ComponentSize } from '@grafana/ui';
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   isCollapsed: boolean;
   onToggle: (isCollapsed: boolean) => void;
   // Todo: this should be made compulsory for a11y purposes
   idControlled?: string;
-  size?: IconSize;
+  size?: ComponentSize;
   className?: string;
   text?: string;
 }
 
-export const CollapseToggle = ({
-  isCollapsed,
-  onToggle,
-  idControlled,
-  className,
-  text,
-  size = 'xl',
-  ...restOfProps
-}: Props) => {
+export const CollapseToggle = ({ isCollapsed, onToggle, idControlled, className, text, ...restOfProps }: Props) => {
   return (
     <Button
       type="button"

--- a/public/app/features/alerting/unified/components/ConditionalWrap.tsx
+++ b/public/app/features/alerting/unified/components/ConditionalWrap.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, forwardRef, Ref } from 'react';
+import { Ref, cloneElement, forwardRef } from 'react';
 
 interface ConditionalWrapProps {
   shouldWrap: boolean;

--- a/public/app/features/alerting/unified/components/ConditionalWrap.tsx
+++ b/public/app/features/alerting/unified/components/ConditionalWrap.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, forwardRef } from 'react';
+import { cloneElement, forwardRef, Ref } from 'react';
 
 interface ConditionalWrapProps {
   shouldWrap: boolean;
@@ -6,8 +6,8 @@ interface ConditionalWrapProps {
   wrap: (children: JSX.Element) => JSX.Element;
 }
 
-function ConditionalWrap({ children, shouldWrap, wrap }: ConditionalWrapProps) {
-  return shouldWrap ? cloneElement(wrap(children)) : children;
+function ConditionalWrap({ children, shouldWrap, wrap }: ConditionalWrapProps, ref: Ref<HTMLElement>) {
+  return shouldWrap ? cloneElement(wrap(children), { ref }) : children;
 }
 
 export default forwardRef(ConditionalWrap);

--- a/public/app/features/alerting/unified/components/ConditionalWrap.tsx
+++ b/public/app/features/alerting/unified/components/ConditionalWrap.tsx
@@ -1,4 +1,4 @@
-import { Ref, cloneElement, forwardRef } from 'react';
+import { cloneElement, forwardRef } from 'react';
 
 interface ConditionalWrapProps {
   shouldWrap: boolean;
@@ -6,7 +6,7 @@ interface ConditionalWrapProps {
   wrap: (children: JSX.Element) => JSX.Element;
 }
 
-function ConditionalWrap({ children, shouldWrap, wrap }: ConditionalWrapProps, _ref: Ref<HTMLElement>) {
+function ConditionalWrap({ children, shouldWrap, wrap }: ConditionalWrapProps) {
   return shouldWrap ? cloneElement(wrap(children)) : children;
 }
 

--- a/public/app/features/alerting/unified/components/HoverCard.tsx
+++ b/public/app/features/alerting/unified/components/HoverCard.tsx
@@ -25,7 +25,6 @@ export const PopupCard = ({
   content,
   footer,
   arrow,
-  showAfter = 300,
   wrapperClassName,
   disabled = false,
   showOn = 'hover',

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -31,7 +31,6 @@ export const AlertGroup = ({ alertManagerSourceName, group }: Props) => {
       <div className={styles.header}>
         <div className={styles.group} data-testid="alert-group">
           <CollapseToggle
-            size="sm"
             isCollapsed={isCollapsed}
             onToggle={() => setIsCollapsed(!isCollapsed)}
             data-testid="alert-group-collapse-toggle"

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useDebounce } from 'react-use';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Icon, Input, Label, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { LogMessages, logInfo } from '../../Analytics';
@@ -81,7 +80,7 @@ export const MatcherFilter = ({ onFilterChange, defaultQueryString }: Props) => 
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   fixMargin: css({
     marginBottom: 0,
   }),

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -39,7 +39,6 @@ interface ExpressionProps {
   onSetCondition: (refId: string) => void;
   onUpdateRefId: (oldRefId: string, newRefId: string) => void;
   onRemoveExpression: (refId: string) => void;
-  onUpdateExpressionType: (refId: string, type: ExpressionQueryType) => void;
   onChangeQuery: (query: ExpressionQuery) => void;
 }
 
@@ -53,7 +52,6 @@ export const Expression: FC<ExpressionProps> = ({
   onSetCondition,
   onUpdateRefId,
   onRemoveExpression,
-  onUpdateExpressionType, // this method is not used? maybe we should remove it
   onChangeQuery,
 }) => {
   const styles = useStyles2(getStyles);

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
@@ -6,12 +6,7 @@ import { render } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/core';
-import {
-  AlertmanagerGroup,
-  MatcherOperator,
-  ObjectMatcher,
-  RouteWithID,
-} from 'app/plugins/datasource/alertmanager/types';
+import { AlertmanagerGroup, MatcherOperator, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 import { ReceiversState } from 'app/types/alerting';
 
 import { useAlertmanagerAbilities } from '../../hooks/useAbilities';
@@ -48,9 +43,7 @@ describe('Policy', () => {
     const onEditPolicy = jest.fn();
     const onAddPolicy = jest.fn();
     const onDeletePolicy = jest.fn();
-    const onShowAlertInstances = jest.fn(
-      (alertGroups: AlertmanagerGroup[], matchers?: ObjectMatcher[] | undefined) => {}
-    );
+    const onShowAlertInstances = jest.fn();
 
     const routeTree = mockRoutes;
     const user = userEvent.setup();
@@ -157,9 +150,7 @@ describe('Policy', () => {
     const onEditPolicy = jest.fn();
     const onAddPolicy = jest.fn();
     const onDeletePolicy = jest.fn();
-    const onShowAlertInstances = jest.fn(
-      (alertGroups: AlertmanagerGroup[], matchers?: ObjectMatcher[] | undefined) => {}
-    );
+    const onShowAlertInstances = jest.fn();
 
     const routeTree = mockRoutes;
     const user = userEvent.setup();
@@ -188,9 +179,7 @@ describe('Policy', () => {
     const onEditPolicy = jest.fn();
     const onAddPolicy = jest.fn();
     const onDeletePolicy = jest.fn();
-    const onShowAlertInstances = jest.fn(
-      (alertGroups: AlertmanagerGroup[], matchers?: ObjectMatcher[] | undefined) => {}
-    );
+    const onShowAlertInstances = jest.fn();
 
     const routeTree = mockRoutes;
 
@@ -225,9 +214,7 @@ describe('Policy', () => {
     const onEditPolicy = jest.fn();
     const onAddPolicy = jest.fn();
     const onDeletePolicy = jest.fn();
-    const onShowAlertInstances = jest.fn(
-      (alertGroups: AlertmanagerGroup[], matchers?: ObjectMatcher[] | undefined) => {}
-    );
+    const onShowAlertInstances = jest.fn();
 
     const routeTree = mockRoutes;
 

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
@@ -6,7 +6,7 @@ import { render } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/core';
-import { AlertmanagerGroup, MatcherOperator, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
+import { MatcherOperator, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 import { ReceiversState } from 'app/types/alerting';
 
 import { useAlertmanagerAbilities } from '../../hooks/useAbilities';

--- a/public/app/features/alerting/unified/components/receivers/form/CollapsibleSection.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/CollapsibleSection.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { IconSize, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 
 import { CollapseToggle } from '../../CollapseToggle';
 
@@ -11,16 +11,9 @@ interface Props {
   label: string;
   description?: string;
   className?: string;
-  size?: IconSize;
 }
 
-export const CollapsibleSection = ({
-  label,
-  description,
-  children,
-  className,
-  size = 'xl',
-}: React.PropsWithChildren<Props>) => {
+export const CollapsibleSection = ({ label, description, children, className }: React.PropsWithChildren<Props>) => {
   const styles = useStyles2(getStyles);
   const [isCollapsed, setIsCollapsed] = useState(true);
 
@@ -28,13 +21,7 @@ export const CollapsibleSection = ({
 
   return (
     <div className={cx(styles.wrapper, className)}>
-      <CollapseToggle
-        className={styles.toggle}
-        size={size}
-        onToggle={toggleCollapse}
-        isCollapsed={isCollapsed}
-        text={label}
-      />
+      <CollapseToggle className={styles.toggle} onToggle={toggleCollapse} isCollapsed={isCollapsed} text={label} />
       {description && <p className={styles.description}>{description}</p>}
       <div className={isCollapsed ? styles.hidden : styles.content}>{children}</div>
     </div>

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -83,8 +83,8 @@ export const GrafanaReceiverForm = ({ contactPoint, readOnly = false, editMode }
       return [undefined, {}];
     }
 
-    return grafanaReceiverToFormValues(extendOnCallReceivers(contactPoint), grafanaNotifiers);
-  }, [contactPoint, isLoadingNotifiers, grafanaNotifiers, extendOnCallReceivers, isLoadingOnCallIntegration]);
+    return grafanaReceiverToFormValues(extendOnCallReceivers(contactPoint));
+  }, [contactPoint, isLoadingNotifiers, extendOnCallReceivers, isLoadingOnCallIntegration]);
 
   const onSubmit = async (values: ReceiverFormValues<GrafanaChannelValues>) => {
     const newReceiver = formValuesToGrafanaReceiver(values, id2original, defaultChannelValues, grafanaNotifiers);

--- a/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
@@ -197,7 +197,7 @@ function TemplateSelector({ onSelect, onClose, option, valueInForm }: TemplateSe
                 data-testid="existing-templates-selector"
                 placeholder="Choose notification template"
                 aria-label="Choose notification template"
-                onChange={(value: SelectableValue<Template>, _) => {
+                onChange={(value: SelectableValue<Template>) => {
                   setTemplate(value);
                 }}
                 options={options}

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionsEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionsEditor.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { GrafanaTheme2, PanelData } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { ExpressionQuery } from 'app/features/expressions/types';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { Expression } from '../expressions/Expression';
@@ -18,7 +18,6 @@ interface Props {
   queries: AlertQuery[];
   onRemoveExpression: (refId: string) => void;
   onUpdateRefId: (oldRefId: string, newRefId: string) => void;
-  onUpdateExpressionType: (refId: string, type: ExpressionQueryType) => void;
   onUpdateQueryExpression: (query: ExpressionQuery) => void;
 }
 
@@ -29,7 +28,6 @@ export const ExpressionsEditor = ({
   panelData,
   onUpdateRefId,
   onRemoveExpression,
-  onUpdateExpressionType,
   onUpdateQueryExpression,
 }: Props) => {
   const expressionQueries = useMemo(() => {
@@ -60,7 +58,6 @@ export const ExpressionsEditor = ({
             onSetCondition={onSetCondition}
             onRemoveExpression={onRemoveExpression}
             onUpdateRefId={onUpdateRefId}
-            onUpdateExpressionType={onUpdateExpressionType}
             onChangeQuery={onUpdateQueryExpression}
           />
         );

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -196,7 +196,6 @@ export class QueryRows extends PureComponent<Props> {
                         key={query.refId}
                         dsSettings={dsSettings}
                         data={data}
-                        error={error}
                         query={query}
                         onChangeQuery={this.onChangeQuery}
                         onRemoveQuery={this.onRemoveQuery}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -171,6 +171,11 @@ export class QueryRows extends PureComponent<Props> {
                       error = errorFromPreviewData(data);
                     }
 
+                    if (error) {
+                      // TODO: use error correctly
+                      console.error(error);
+                    }
+
                     if (!dsSettings) {
                       return (
                         <DatasourceNotFound

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -51,7 +51,6 @@ interface Props {
   index: number;
   thresholds: ThresholdsConfig;
   thresholdsType?: GraphThresholdsStyleMode;
-  onChangeThreshold?: (thresholds: ThresholdsConfig, index: number) => void;
   condition: string | null;
   onSetCondition: (refId: string) => void;
   onChangeQueryOptions: (options: AlertQueryOptions, index: number) => void;
@@ -72,7 +71,6 @@ export const QueryWrapper = ({
   queries,
   thresholds,
   thresholdsType,
-  onChangeThreshold,
   condition,
   onSetCondition,
   onChangeQueryOptions,
@@ -143,6 +141,8 @@ export const QueryWrapper = ({
   // TODO add a warning label here too when the data looks like time series data and is used as an alert condition
   function HeaderExtras({
     query,
+    // TODO: Use and display the error, as this is otherwise unused
+    // eslint-disable-next-line no-unused-vars
     error,
     index,
     isAdvancedMode = true,

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -142,7 +142,7 @@ export const QueryWrapper = ({
   function HeaderExtras({
     query,
     // TODO: Use and display the error, as this is otherwise unused
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     error,
     index,
     isAdvancedMode = true,

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { SelectableValue } from '@grafana/data';
-import { ActionMeta, Field, FieldValidationMessage, Stack, TextLink } from '@grafana/ui';
+import { Field, FieldValidationMessage, Stack, TextLink } from '@grafana/ui';
 import { ContactPointSelector as ContactPointSelectorDropdown } from 'app/features/alerting/unified/components/notification-policies/ContactPointSelector';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { createRelativeUrl } from 'app/features/alerting/unified/utils/url';
@@ -41,7 +41,7 @@ export function ContactPointSelector({ alertManager, onSelectContactPoint }: Con
                 <Stack>
                   <ContactPointSelectorDropdown
                     selectProps={{
-                      onChange: (value: SelectableValue<ContactPointWithMetadata>, _: ActionMeta) => {
+                      onChange: (value: SelectableValue<ContactPointWithMetadata>) => {
                         onChange(value?.value?.name);
                         onSelectContactPoint(value?.value);
                       },

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -71,7 +71,6 @@ import {
   updateExpression,
   updateExpressionRefId,
   updateExpressionTimeRange,
-  updateExpressionType,
 } from './reducer';
 import { useAdvancedMode } from './useAdvancedMode';
 import { useAlertQueryRunner } from './useAlertQueryRunner';
@@ -627,9 +626,6 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
                     dispatch(removeExpression(refId));
                   }}
                   onUpdateRefId={onUpdateRefId}
-                  onUpdateExpressionType={(refId, type) => {
-                    dispatch(updateExpressionType({ refId, type }));
-                  }}
                   onUpdateQueryExpression={(model) => {
                     dispatch(updateExpression(model));
                   }}

--- a/public/app/features/alerting/unified/components/rule-editor/rule-types/RuleType.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/rule-types/RuleType.tsx
@@ -1,7 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { ReactNode } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { Card, useStyles2 } from '@grafana/ui';
 
 import { RuleFormType } from '../../../types/rule-form';
@@ -40,7 +39,7 @@ const RuleType = (props: Props) => {
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   wrapper: css({
     width: '380px',
     cursor: 'pointer',

--- a/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
@@ -44,7 +44,7 @@ interface RulesFilerProps {
   onClear?: () => void;
 }
 
-const RuleStateOptions = Object.entries(PromAlertingRuleState).map(([key, value]) => ({
+const RuleStateOptions = Object.entries(PromAlertingRuleState).map(([_key, value]) => ({
   label: alertStateToReadable(value),
   value,
 }));

--- a/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v2.tsx
@@ -28,6 +28,7 @@ type RulesFilterProps = {
 
 type ActiveTab = 'custom' | 'saved';
 
+// eslint-disable-next-line no-unused-vars
 export default function RulesFilter({ onClear = () => {} }: RulesFilterProps) {
   const styles = useStyles2(getStyles);
   const [activeTab, setActiveTab] = useState<ActiveTab>('custom');
@@ -155,6 +156,7 @@ type TableColumns = {
 };
 
 const SavedSearches = () => {
+  // eslint-disable-next-line no-unused-vars
   const applySearch = useCallback((name: string) => {}, []);
 
   return (

--- a/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v2.tsx
@@ -28,7 +28,7 @@ type RulesFilterProps = {
 
 type ActiveTab = 'custom' | 'saved';
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function RulesFilter({ onClear = () => {} }: RulesFilterProps) {
   const styles = useStyles2(getStyles);
   const [activeTab, setActiveTab] = useState<ActiveTab>('custom');
@@ -156,7 +156,7 @@ type TableColumns = {
 };
 
 const SavedSearches = () => {
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const applySearch = useCallback((name: string) => {}, []);
 
   return (

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
@@ -50,7 +50,7 @@ export function RuleDetailsDataSources(props: Props): JSX.Element | null {
 
   return (
     <DetailsField label="Data source">
-      {dataSources.map(({ name, icon }, index) => (
+      {dataSources.map(({ name, icon }) => (
         <div key={name}>
           {icon && (
             <>

--- a/public/app/features/alerting/unified/components/rules/RuleListStateSection.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateSection.tsx
@@ -25,7 +25,6 @@ export const RuleListStateSection = ({ rules, state, defaultCollapsed = false }:
       <h4 className={styles.header}>
         <CollapseToggle
           className={styles.collapseToggle}
-          size="xxl"
           isCollapsed={collapsed}
           onToggle={() => setCollapsed(!collapsed)}
         />

--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -238,7 +238,7 @@ function useColumns(
         id: 'health',
         label: 'Health',
         // eslint-disable-next-line react/display-name
-        renderCell: ({ data: { promRule, group } }) => (promRule ? <RuleHealth rule={promRule} /> : null),
+        renderCell: ({ data: { promRule } }) => (promRule ? <RuleHealth rule={promRule} /> : null),
         size: '75px',
       },
     ];

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -176,7 +176,7 @@ function logRecordsToDataFrame(instanceLabels: string, records: LogRecord[]): Da
       {
         name: instanceLabels,
         type: FieldType.number,
-        values: timeField.values.map((record) => 1),
+        values: timeField.values.map(() => 1),
         config: {},
       },
     ],

--- a/public/app/features/alerting/unified/components/settings/ConfigurationDrawer.tsx
+++ b/public/app/features/alerting/unified/components/settings/ConfigurationDrawer.tsx
@@ -68,9 +68,7 @@ export function useEditConfigurationDrawer() {
             onReset={resetAlertmanagerSettings}
           />
         )}
-        {activeTab === 'versions' && dataSourceName && (
-          <AlertmanagerConfigurationVersionManager alertmanagerName={dataSourceName} />
-        )}
+        {activeTab === 'versions' && dataSourceName && <AlertmanagerConfigurationVersionManager />}
       </Drawer>
     );
   }, [open, dataSourceName, handleDismiss, activeTab, updateAlertmanagerSettings, resetAlertmanagerSettings]);

--- a/public/app/features/alerting/unified/components/settings/VersionManager.tsx
+++ b/public/app/features/alerting/unified/components/settings/VersionManager.tsx
@@ -26,10 +26,6 @@ import { Spacer } from '../Spacer';
 
 const VERSIONS_PAGE_SIZE = 30;
 
-interface AlertmanagerConfigurationVersionManagerProps {
-  alertmanagerName: string;
-}
-
 type Diff = {
   added: number;
   removed: number;
@@ -45,9 +41,7 @@ interface ConfigWithDiff extends AlertManagerCortexConfig {
   diff: Diff;
 }
 
-const AlertmanagerConfigurationVersionManager = ({
-  alertmanagerName,
-}: AlertmanagerConfigurationVersionManagerProps) => {
+const AlertmanagerConfigurationVersionManager = () => {
   // we'll track the ID of the version we want to restore
   const [activeRestoreVersion, setActiveRestoreVersion] = useState<number | undefined>(undefined);
   const [confirmRestore, setConfirmRestore] = useState(false);

--- a/public/app/features/alerting/unified/insights/InsightsMenuButton.tsx
+++ b/public/app/features/alerting/unified/insights/InsightsMenuButton.tsx
@@ -39,7 +39,7 @@ const getPrometheusExploreUrl = ({
   const urlState: ExploreUrlState = {
     datasource: (queries?.length && queries[0].datasource?.uid) || null,
     queries:
-      queries?.map(({ expr, refId }, i) => {
+      queries?.map(({ expr, refId }) => {
         return { expr, refId };
       }) || [],
     range: toURLRange(range ? { from: range.from, to: range.to } : { from: 'now-1h', to: 'now' }),

--- a/public/app/features/alerting/unified/insights/InsightsMenuButton.tsx
+++ b/public/app/features/alerting/unified/insights/InsightsMenuButton.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { ExploreUrlState, GrafanaTheme2, serializeStateToUrlParam, toURLRange } from '@grafana/data';
+import { ExploreUrlState, serializeStateToUrlParam, toURLRange } from '@grafana/data';
 import {
   SceneComponentProps,
   SceneObjectBase,
@@ -128,7 +128,7 @@ export class InsightsMenuButton extends SceneObjectBase<InsightsMenuButtonState>
   static Component = InsightsMenuButtonRenderer;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   buttonsContainer: css({
     display: 'flex',
     flexDirection: 'row',

--- a/public/app/features/alerting/unified/insights/SectionSubheader.tsx
+++ b/public/app/features/alerting/unified/insights/SectionSubheader.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
 import { DataSourceInformation } from '../home/Insights';
@@ -22,7 +21,7 @@ export function SectionSubheader({
   );
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   container: css({
     display: 'flex',
     flexDirection: 'row',

--- a/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MostFiringLabels.tsx
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { DataQueryRequest, DataQueryResponse, DataQueryResponseData, TestDataSourceResponse } from '@grafana/data';
+import { DataQueryResponse, DataQueryResponseData, TestDataSourceResponse } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import {
   PanelBuilders,
@@ -10,7 +10,7 @@ import {
   SceneTimeRange,
   sceneUtils,
 } from '@grafana/scenes';
-import { DataQuery, DataSourceRef } from '@grafana/schema';
+import { DataSourceRef } from '@grafana/schema';
 import { getTimeRange } from 'app/features/dashboard/utils/timeRange';
 
 import { PANEL_STYLES } from '../../home/Insights';
@@ -31,7 +31,7 @@ class LokiAPIDatasource extends RuntimeDataSource {
     this.timeRange = timeRange;
   }
 
-  query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
+  query(): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
     const timeRange = getTimeRange({ from: this.timeRange.state.from, to: this.timeRange.state.to });
     return getLabelsInfo(timeRange.from.unix(), timeRange.to.unix());
   }

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -3,8 +3,6 @@ import { isEmpty, pick } from 'lodash';
 import { Observable } from 'rxjs';
 
 import {
-  DataQuery,
-  DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
@@ -408,7 +406,7 @@ class MockDataSourceApi extends DataSourceApi {
     super(instanceSettings);
   }
 
-  query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
+  query(): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
     throw new Error('Method not implemented.');
   }
   testDatasource(): Promise<TestDataSourceResponse> {
@@ -711,7 +709,7 @@ export const grantUserPermissions = (permissions: AccessControlAction[]) => {
     .mockImplementation((action) => permissions.includes(action as AccessControlAction));
 };
 
-export const grantUserRole = (role: string) => {
+export const grantUserRole = () => {
   jest.spyOn(contextSrv, 'hasRole').mockReturnValue(true);
 };
 

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -709,7 +709,7 @@ export const grantUserPermissions = (permissions: AccessControlAction[]) => {
     .mockImplementation((action) => permissions.includes(action as AccessControlAction));
 };
 
-export const grantUserRole = () => {
+export const grantAllUserRoles = () => {
   jest.spyOn(contextSrv, 'hasRole').mockReturnValue(true);
 };
 

--- a/public/app/features/alerting/unified/mocks/server/handlers/datasources.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/datasources.ts
@@ -30,7 +30,7 @@ export const datasourceBuildInfoHandler = () =>
 
 // TODO: Add more accurate endpoint responses as tests require
 const labelValuesHandler = () =>
-  http.get('/api/datasources/uid/:datasourceUid/resources/api/v1/label/__name__/values', ({ params }) => {
+  http.get('/api/datasources/uid/:datasourceUid/resources/api/v1/label/__name__/values', () => {
     return HttpResponse.json({ status: 'sucess', data: [] });
   });
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -36,24 +36,21 @@ import { safeParsePrometheusDuration } from '../utils/time';
 
 export const fetchPromRulesAction = createAsyncThunk(
   'unifiedalerting/fetchPromRules',
-  async (
-    {
-      rulesSourceName,
-      filter,
-      limitAlerts,
-      matcher,
-      state,
-      identifier,
-    }: {
-      rulesSourceName: string;
-      filter?: FetchPromRulesFilter;
-      limitAlerts?: number;
-      matcher?: Matcher[];
-      state?: string[];
-      identifier?: RuleIdentifier;
-    },
-    thunkAPI
-  ): Promise<RuleNamespace[]> => {
+  async ({
+    rulesSourceName,
+    filter,
+    limitAlerts,
+    matcher,
+    state,
+    identifier,
+  }: {
+    rulesSourceName: string;
+    filter?: FetchPromRulesFilter;
+    limitAlerts?: number;
+    matcher?: Matcher[];
+    state?: string[];
+    identifier?: RuleIdentifier;
+  }): Promise<RuleNamespace[]> => {
     const fetchRulesWithLogging = withPromRulesMetadataLogging('unifiedalerting/fetchPromRules', fetchRules, {
       dataSourceName: rulesSourceName,
       thunk: 'unifiedalerting/fetchPromRules',
@@ -75,7 +72,7 @@ export const fetchRulerRulesAction = createAsyncThunk(
       rulesSourceName: string;
       filter?: FetchRulerRulesFilter;
     },
-    { dispatch, getState }
+    { dispatch }
   ): Promise<RulerRulesConfigDTO | null> => {
     const { data: dsFeatures } = await dispatch(
       featureDiscoveryApi.endpoints.discoverDsFeatures.initiate({ rulesSourceName })

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -104,7 +104,7 @@ export function formValuesToCloudReceiver(
   const recv: AlertmanagerReceiver = {
     name: values.name,
   };
-  values.items.forEach(({ __id, type, settings, sendResolved }) => {
+  values.items.forEach(({ type, settings, sendResolved }) => {
     const channel = omitEmptyValues({
       ...omitTemporaryIdentifiers(settings),
       send_resolved: sendResolved ?? defaults.sendResolved,

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -18,8 +18,7 @@ import {
 } from '../types/receiver-form';
 
 export function grafanaReceiverToFormValues(
-  receiver: GrafanaManagedContactPoint,
-  notifiers: NotifierDTO[]
+  receiver: GrafanaManagedContactPoint
 ): [ReceiverFormValues<GrafanaChannelValues>, GrafanaChannelMap] {
   const channelMap: GrafanaChannelMap = {};
   // giving each form receiver item a unique id so we can use it to map back to "original" items
@@ -32,8 +31,7 @@ export function grafanaReceiverToFormValues(
       receiver.grafana_managed_receiver_configs?.map((channel) => {
         const id = String(idCounter++);
         channelMap[id] = channel;
-        const notifier = notifiers.find(({ type }) => type === channel.type);
-        return grafanaChannelConfigToFormChannelValues(id, channel, notifier);
+        return grafanaChannelConfigToFormChannelValues(id, channel);
       }) ?? [],
   };
   return [values, channelMap];
@@ -138,8 +136,7 @@ function cloudChannelConfigToFormChannelValues(
 
 function grafanaChannelConfigToFormChannelValues(
   id: string,
-  channel: GrafanaManagedReceiverConfig,
-  notifier?: NotifierDTO
+  channel: GrafanaManagedReceiverConfig
 ): GrafanaChannelValues {
   const values: GrafanaChannelValues = {
     __id: id,


### PR DESCRIPTION
**What is this feature?**
Enable `no-unused-vars` rule for alerting and fix all violations

**Why do we need this feature?**
Tidy code! There are a number of knock-on effects of removing some props/values that mean we can tidy up logic in a few places

**Who is this feature for?**

Alerting UI devs

**Which issue(s) does this PR fix?**:
Relates to https://github.com/grafana/grafana/pull/93022/files#diff-bfdc73b30535fefb185055a9429f341a30a316145d905b383e8148c0a01c39b3R54