### PR TITLE
Docs: Add a doc page for RBAC for app plugins

### DIFF
--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -56,7 +56,7 @@ Use app plugins when you want an out-of-the-box monitoring experience.
 
 ### Managing access for app plugins
 
-Customize access to app plugins with [RBAC]({{< relref "../roles-and-permissions/access-control/#about-rbac" >}}).
+Customize access to app plugins with [RBAC]({{< relref "../roles-and-permissions/access-control/rbac-for-app-plugins" >}}).
 
 By default, the Viewer, Editor and Admin roles have access to all app plugins that their Organization role allows them to access. Access is granted by the `fixed:plugins.app:reader` role.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -190,8 +190,8 @@ Assign fixed roles when the basic roles do not meet your permission requirements
 - [Provisioning](/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/)
 - [Reports](ref:dashboards-create-reports)
 - [Roles](ref:roles-and-permissions)
-- [Settings](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/settings-updates-at-runtime/)
 - [Service accounts](ref:service-accounts)
+- [Settings](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/settings-updates-at-runtime/)
 - [Teams](/docs/grafana/<GRAFANA_VERSION>/administration/team-management/)
 - [Users](/docs/grafana/<GRAFANA_VERSION>/administration/user-management/)
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes/index.md
@@ -181,38 +181,6 @@ The following list contains role-based access control actions.
 { .no-spacing-list }
 <!-- prettier-ignore-end -->
 
-### Grafana OnCall action definitions (beta)
-
-The following list contains role-based access control actions used by Grafana OnCall application plugin.
-
-| Action                                           | Applicable scopes | Description                                       |
-| ------------------------------------------------ | ----------------- | ------------------------------------------------- |
-| `grafana-oncall-app.alert-groups:read`           | None              | Read OnCall alert groups.                         |
-| `grafana-oncall-app.alert-groups:write`          | None              | Create, edit and delete OnCall alert groups.      |
-| `grafana-oncall-app.integrations:read`           | None              | Read OnCall integrations.                         |
-| `grafana-oncall-app.integrations:write`          | None              | Create, edit and delete OnCall integrations.      |
-| `grafana-oncall-app.integrations:test`           | None              | Test OnCall integrations.                         |
-| `grafana-oncall-app.escalation-chains:read`      | None              | Read OnCall escalation chains.                    |
-| `grafana-oncall-app.escalation-chains:write`     | None              | Create, edit and delete OnCall escalation chains. |
-| `grafana-oncall-app.schedules:read`              | None              | Read OnCall schedules.                            |
-| `grafana-oncall-app.schedules:write`             | None              | Create, edit and delete OnCall schedules.         |
-| `grafana-oncall-app.schedules:export`            | None              | Export OnCall schedules.                          |
-| `grafana-oncall-app.chatops:read`                | None              | Read OnCall ChatOps.                              |
-| `grafana-oncall-app.chatops:write`               | None              | Edit OnCall ChatOps.                              |
-| `grafana-oncall-app.chatops:update-settings`     | None              | Edit OnCall ChatOps settings.                     |
-| `grafana-oncall-app.maintenance:read`            | None              | Read OnCall maintenance.                          |
-| `grafana-oncall-app.maintenance:write`           | None              | Edit OnCall maintenance.                          |
-| `grafana-oncall-app.api-keys:read`               | None              | Read OnCall API keys.                             |
-| `grafana-oncall-app.api-keys:write`              | None              | Create, edit and delete OnCall API keys.          |
-| `grafana-oncall-app.notifications:read`          | None              | Receive OnCall notifications.                     |
-| `grafana-oncall-app.notification-settings:read`  | None              | Read OnCall notification settings.                |
-| `grafana-oncall-app.notification-settings:write` | None              | Edit OnCall notification settings.                |
-| `grafana-oncall-app.user-settings:read`          | None              | Read user's own OnCall user settings.             |
-| `grafana-oncall-app.user-settings:write`         | None              | Edit user's own OnCall user settings.             |
-| `grafana-oncall-app.user-settings:admin`         | None              | Read and edit all users' OnCall user settings.    |
-| `grafana-oncall-app.other-settings:read`         | None              | Read OnCall settings.                             |
-| `grafana-oncall-app.other-settings:write`        | None              | Edit OnCall settings.                             |
-
 ### Grafana Adaptive Metrics action definitions
 
 The following list contains role-based access control actions used by Grafana Adaptive Metrics.

--- a/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles/index.md
@@ -74,8 +74,6 @@ refs:
 Available in [Grafana Enterprise](/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](/docs/grafana-cloud).
 {{% /admonition %}}
 
-{{< table-of-contents >}}
-
 This section includes instructions for how to view permissions associated with roles, create custom roles, and update and delete roles.
 
 The following example includes the base64 username:password Basic Authorization. You cannot use authorization tokens in the request.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
@@ -1,0 +1,82 @@
+---
+aliases:
+  - ../../../enterprise/access-control/rbac-for-app-plugins/
+description: Learn about how to configure access to app plugins using RBAC
+labels:
+  products:
+    - cloud
+menuTitle: RBAC for app plugins
+title: RBAC for app plugins
+weight: 90
+refs:
+  manage-rbac-roles-update-basic-role-permissions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/manage-rbac-roles/#update-basic-role-permissions
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/manage-rbac-roles/#update-basic-role-permissions
+  restrict-access-to-app-plugin-example:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/#prevent-viewers-from-accessing-an-app-plugin
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/plan-rbac-rollout-strategy/#prevent-viewers-from-accessing-an-app-plugin
+  adaptive-metrics-permissions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/#grafana-adaptive-metrics-action-definitions
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/custom-role-actions-scopes/#grafana-adaptive-metrics-action-definitions
+  rbac-role-definitions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+---
+
+# RBAC for app plugins
+
+{{% admonition type="note" %}}
+Available in [Grafana Cloud](/docs/grafana-cloud).
+{{% /admonition %}}
+
+RBAC can be used to manage access to [app plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#app-plugins).
+Each app plugin grants the basic Viewer, Editor and Admin organization roles a default set of plugin permissions.
+You can use RBAC to restrict which app plugins a basic organization role has access to.
+Some app plugins have fine-grained RBAC support, which allows you to grant additional access to these app plugins to teams and users regardless of their basic organization roles.
+
+## Restricting access to app plugins
+
+By default, Viewers, Editors and Admins have access to all App Plugins that their organization role allows them to access.
+To change this default behavior and prevent a basic organization role from accessing an App plugin, you must [update the basic role's permissions](ref:manage-rbac-roles-update-basic-role-permissions).
+See an example of [preventing Viewers from accessing an app plugin](ref:restrict-access-to-app-plugin-example) to learn more.
+To grant access to a limited set of app plugins, you will need plugin IDs. You can find them in `plugin.json` files or in the URL when you open the app plugin in the Grafana Cloud UI.
+
+Note that unless an app plugin has fine-grained RBAC support, it is not possible to grant access to this app plugin for a user whose organization role does not have access to that app plugin.
+
+## Fine-grained access to app plugins
+
+Plugins with fine-grained RBAC support allow you to manage access to plugin features at a more granular level.
+For instance, you can grant admin access to an app plugin to a user with Viewer organization role. Or restrict the Editor organization role from being able to edit plugin resources.
+
+Please refer to plugin documentation to see what RBAC permissions the plugin has and what default access the plugin grants to Viewer, Editor and Admin organization roles.
+
+The following list contains app plugins that have fine-grained RBAC support.
+
+| App plugin                                                                                                                                                                            | App plugin ID                  | App plugin permission documentation                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Access policies](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/)                                                          | `grafana-auth-app`             | n/a                                                                                                                                                                        |
+| [Adaptive metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/adaptive-metrics-plugin/) | `grafana-adaptive-metrics-app` | [RBAC actions for Adaptive Metrics](ref:adaptive-metrics-permissions)                                                                                                      |
+| [Incident](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/incident/)                                                                                                     | `grafana-incident-app`         | n/a                                                                                                                                                                        |
+| [OnCall](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/oncall/)                                                                                                         | `grafana-oncall-app`           | [Configure RBAC for OnCall](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/oncall/manage/user-and-team-management/#manage-users-and-teams-for-grafana-oncall) |
+| [Performance Testing (K6)](https://grafana.com/docs/grafana-cloud/testing/k6/)                                                                                                        | `k6-app`                       | [Configure RBAC for K6](https://grafana.com/docs/grafana-cloud/testing/k6/projects-and-users/configure-rbac/)                                                              |
+| [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/)                                                    | `grafana-pdc-app`              | n/a                                                                                                                                                                        |
+| [Service Level Objective (SLO)](https://grafana.com/docs/grafana-cloud/alerting-and-irm/slo/)                                                                                         | `grafana-slo-app`              | [Configure RBAC for SLO](https://grafana.com/docs/grafana-cloud/alerting-and-irm/slo/set-up/rbac/)                                                                         |
+
+### Revoke fine-grained access from app plugins
+
+To list all the permissions granted to a basic role, use the [HTTP API endpoint to query for the role](https://grafana.com/docs/grafana/latest/developers/http_api/access_control/#get-a-role).
+Basic role UIDs are listed in [RBAC role definitions list](ref:rbac-role-definitions).
+To remove the undesired plugin permissions from a basic role, you must [update the basic role's permissions](ref:manage-rbac-roles-update-basic-role-permissions).
+
+### Grant additional access to app plugins
+
+To grant access to app plugins, you can use the predefined [fixed plugin roles](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/#fixed-roles) or create [custom roles](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/#custom-roles) with specific plugin permissions.
+To learn about how to assign an RBAC role, refer to [the documentation on assigning RBAC roles](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/assign-rbac-roles/#assign-rbac-roles).

--- a/docs/sources/administration/roles-and-permissions/access-control/troubleshooting/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/troubleshooting/index.md
@@ -8,7 +8,7 @@ labels:
     - enterprise
 menuTitle: Troubleshooting RBAC
 title: Troubleshooting RBAC
-weight: 80
+weight: 100
 ---
 
 # Troubleshooting RBAC


### PR DESCRIPTION
**What is this feature?**

Adding documentation for RBAC for app plugins. The main goals are:
* to outline how access to app plugins can be managed to RBAC;
* link to other existing documentation;
* list plugins that support fine-grained RBAC.

**Why do we need this feature?**

The existing docs for managing access to app plugins are scattered and incomplete. We've got feedback that this is a gap in our RBAC documentation, so this is an attempt to improve it.

**Who is this feature for?**

Any cloud user who wants to customize access to their apps.

**Special notes for your reviewer:**

I know this this is still not great. Main things that are lacking are:
* plugin specific docs for all plugins that have RBAC roles and permissions;
* a list that maps plugins to their IDs (or better instructions for finding plugin's ID).

However, this is out of IAM team's realm, so we should ask plugin devs to work on this documentation.