### PR TITLE
Alerting: Update rules empty state CTA

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -812,6 +812,7 @@ describe('RuleList', () => {
         expect(ui.exportButton.get()).toBeInTheDocument();
       });
     });
+
     describe('Grafana Managed Alerts', () => {
       it('New alert button should be visible when the user has alert rule create and folder read permissions and no rules exists', async () => {
         grantUserPermissions([
@@ -828,6 +829,7 @@ describe('RuleList', () => {
         renderRuleList();
 
         await waitFor(() => expect(mocks.api.fetchRules).toHaveBeenCalledTimes(1));
+
         expect(ui.newRuleButton.get()).toBeInTheDocument();
       });
 
@@ -901,35 +903,6 @@ describe('RuleList', () => {
         await waitFor(() => expect(mocks.api.fetchRules).toHaveBeenCalledTimes(1));
         expect(ui.newRuleButton.get()).toBeInTheDocument();
       });
-    });
-  });
-
-  describe('Analytics', () => {
-    it('Sends log info when creating an alert rule from a scratch', async () => {
-      grantUserPermissions([
-        AccessControlAction.FoldersRead,
-        AccessControlAction.AlertingRuleCreate,
-        AccessControlAction.AlertingRuleRead,
-      ]);
-
-      mocks.getAllDataSourcesMock.mockReturnValue([]);
-      setDataSourceSrv(new MockDataSourceSrv({}));
-      mocks.api.fetchRules.mockResolvedValue([]);
-      mocks.api.fetchRulerRules.mockResolvedValue({});
-
-      renderRuleList();
-
-      await waitFor(() => expect(mocks.api.fetchRules).toHaveBeenCalledTimes(1));
-
-      const button = screen.getByText('New alert rule');
-
-      button.addEventListener('click', (event) => event.preventDefault(), false);
-
-      expect(button).toBeEnabled();
-
-      await userEvent.click(button);
-
-      expect(analytics.logInfo).toHaveBeenCalledWith(analytics.LogMessages.alertRuleFromScratch);
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -17,12 +17,12 @@ export const NoRulesSplash = () => {
             <Stack direction="row" alignItems="center" justifyContent="center">
               {canCreateAnything && (
                 <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/alerting">
-                  <Trans i18nKey='alerting.list-view".empty.new-alert-rule'>New alert rule</Trans>
+                  <Trans i18nKey='alerting.list-view.empty.new-alert-rule'>New alert rule</Trans>
                 </LinkButton>
               )}
               {canCreateCloudRules && (
                 <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/recording">
-                  <Trans i18nKey='alerting.list-view".empty.new-recording-rule'>New recording rule</Trans>
+                  <Trans i18nKey='alerting.list-view.empty.new-recording-rule'>New recording rule</Trans>
                 </LinkButton>
               )}
             </Stack>
@@ -30,7 +30,7 @@ export const NoRulesSplash = () => {
         }
       >
         <>
-          <Trans i18nKey='alerting.list-view".empty.provisioning'>
+          <Trans i18nKey='alerting.list-view.empty.provisioning'>
             You can also define rules through file provisioning or Terraform.{' '}
             <TextLink
               href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/"

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -1,37 +1,44 @@
 import { EmptyState, LinkButton, Stack, TextLink } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
 
 import { useRulesAccess } from '../../utils/accessControlHooks';
 
 export const NoRulesSplash = () => {
   const { canCreateGrafanaRules, canCreateCloudRules } = useRulesAccess();
-  const canCreateAnything = canCreateGrafanaRules && canCreateCloudRules;
+  const canCreateAnything = canCreateGrafanaRules || canCreateCloudRules;
 
   return (
     <div>
       <EmptyState
-        message={"You haven't created any rules yet"}
+        message="You haven't created any rules yet"
         variant="call-to-action"
         button={
           canCreateAnything ? (
             <Stack direction="row" alignItems="center" justifyContent="center">
-              <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/alerting">
-                New alert rule
-              </LinkButton>
-              <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/recording">
-                New recording rule
-              </LinkButton>
+              {canCreateGrafanaRules && (
+                <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/alerting">
+                  <Trans i18nKey='alerting.list-view".empty.new-alert-rule'>New alert rule</Trans>
+                </LinkButton>
+              )}
+              {canCreateCloudRules && (
+                <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/recording">
+                  <Trans i18nKey='alerting.list-view".empty.new-recording-rule'>New recording rule</Trans>
+                </LinkButton>
+              )}
             </Stack>
           ) : null
         }
       >
         <>
-          You can also define rules through file provisioning or Terraform.{' '}
-          <TextLink
-            href={'https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/'}
-            external
-          >
-            Learn more
-          </TextLink>
+          <Trans i18nKey='alerting.list-view".empty.provisioning'>
+            You can also define rules through file provisioning or Terraform.{' '}
+            <TextLink
+              href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/"
+              external
+            >
+              Learn more
+            </TextLink>
+          </Trans>
         </>
       </EmptyState>
     </div>

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -1,56 +1,39 @@
-import { css } from '@emotion/css';
+import { EmptyState, LinkButton, Stack, TextLink } from '@grafana/ui';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { CallToActionCard, useStyles2, Stack } from '@grafana/ui';
-import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
-
-import { logInfo, LogMessages } from '../../Analytics';
 import { useRulesAccess } from '../../utils/accessControlHooks';
 
 export const NoRulesSplash = () => {
   const { canCreateGrafanaRules, canCreateCloudRules } = useRulesAccess();
-  const styles = useStyles2(getStyles);
-  if (canCreateGrafanaRules || canCreateCloudRules) {
-    return (
-      <div>
-        <p>{"You haven't created any alert rules yet"}</p>
-        <Stack gap={1}>
-          <div className={styles.newRuleCard}>
-            <EmptyListCTA
-              title=""
-              buttonIcon="bell"
-              buttonLink={'alerting/new/alerting'}
-              buttonTitle="New alert rule"
-              proTip="you can also create alert rules from existing panels and queries."
-              proTipLink="https://grafana.com/docs/"
-              proTipLinkTitle="Learn more"
-              proTipTarget="_blank"
-              onClick={() => logInfo(LogMessages.alertRuleFromScratch)}
-            />
-          </div>
+  const canCreateAnything = canCreateGrafanaRules && canCreateCloudRules;
 
-          <div className={styles.newRuleCard}>
-            <EmptyListCTA
-              title=""
-              buttonIcon="plus"
-              buttonLink={'alerting/new/recording'}
-              buttonTitle="New recording rule"
-              onClick={() => logInfo(LogMessages.recordingRuleFromScratch)}
-            />
-          </div>
-        </Stack>
-      </div>
-    );
-  }
-  return <CallToActionCard message="No rules exist yet." callToActionElement={<div />} />;
+  return (
+    <div>
+      <EmptyState
+        message={"You haven't created any rules yet"}
+        variant="call-to-action"
+        button={
+          canCreateAnything ? (
+            <Stack direction="row" alignItems="center" justifyContent="center">
+              <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/alerting">
+                New alert rule
+              </LinkButton>
+              <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/recording">
+                New recording rule
+              </LinkButton>
+            </Stack>
+          ) : null
+        }
+      >
+        <>
+          You can also define rules through file provisioning or Terraform.{' '}
+          <TextLink
+            href={'https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/'}
+            external
+          >
+            Learn more
+          </TextLink>
+        </>
+      </EmptyState>
+    </div>
+  );
 };
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  newRuleCard: css({
-    width: `calc(50% - ${theme.spacing(1)})`,
-
-    '> div': {
-      height: '100%',
-    },
-  }),
-});

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -17,12 +17,12 @@ export const NoRulesSplash = () => {
             <Stack direction="row" alignItems="center" justifyContent="center">
               {canCreateAnything && (
                 <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/alerting">
-                  <Trans i18nKey='alerting.list-view.empty.new-alert-rule'>New alert rule</Trans>
+                  <Trans i18nKey="alerting.list-view.empty.new-alert-rule">New alert rule</Trans>
                 </LinkButton>
               )}
               {canCreateCloudRules && (
                 <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/recording">
-                  <Trans i18nKey='alerting.list-view.empty.new-recording-rule'>New recording rule</Trans>
+                  <Trans i18nKey="alerting.list-view.empty.new-recording-rule">New recording rule</Trans>
                 </LinkButton>
               )}
             </Stack>
@@ -30,7 +30,7 @@ export const NoRulesSplash = () => {
         }
       >
         <>
-          <Trans i18nKey='alerting.list-view.empty.provisioning'>
+          <Trans i18nKey="alerting.list-view.empty.provisioning">
             You can also define rules through file provisioning or Terraform.{' '}
             <TextLink
               href="https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/"

--- a/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
+++ b/public/app/features/alerting/unified/components/rules/NoRulesCTA.tsx
@@ -15,7 +15,7 @@ export const NoRulesSplash = () => {
         button={
           canCreateAnything ? (
             <Stack direction="row" alignItems="center" justifyContent="center">
-              {canCreateGrafanaRules && (
+              {canCreateAnything && (
                 <LinkButton variant="primary" icon="plus" size="lg" href="alerting/new/alerting">
                   <Trans i18nKey='alerting.list-view".empty.new-alert-rule'>New alert rule</Trans>
                 </LinkButton>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -124,6 +124,11 @@
       "label": "Contact point"
     },
     "list-view": {
+      "empty": {
+        "new-alert-rule": "New alert rule",
+        "new-recording-rule": "New recording rule",
+        "provisioning": "You can also define rules through file provisioning or Terraform. <2>Learn more</2>"
+      },
       "section": {
         "dataSourceManaged": {
           "title": "Data source-managed"
@@ -134,13 +139,6 @@
           "new-recording-rule": "New recording rule",
           "title": "Grafana-managed"
         }
-      }
-    },
-    "list-view\"": {
-      "empty": {
-        "new-alert-rule": "New alert rule",
-        "new-recording-rule": "New recording rule",
-        "provisioning": "You can also define rules through file provisioning or Terraform. <2>Learn more</2>"
       }
     },
     "mute_timings": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -136,6 +136,13 @@
         }
       }
     },
+    "list-view\"": {
+      "empty": {
+        "new-alert-rule": "New alert rule",
+        "new-recording-rule": "New recording rule",
+        "provisioning": "You can also define rules through file provisioning or Terraform. <2>Learn more</2>"
+      }
+    },
     "mute_timings": {
       "error-loading": {
         "description": "Could not load mute timings. Please try again later.",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -136,6 +136,13 @@
         }
       }
     },
+    "list-view\"": {
+      "empty": {
+        "new-alert-rule": "Ńęŵ äľęřŧ řūľę",
+        "new-recording-rule": "Ńęŵ řęčőřđįŉģ řūľę",
+        "provisioning": "Ÿőū čäŉ äľşő đęƒįŉę řūľęş ŧĥřőūģĥ ƒįľę přővįşįőŉįŉģ őř Ŧęřřäƒőřm. <2>Ŀęäřŉ mőřę</2>"
+      }
+    },
     "mute_timings": {
       "error-loading": {
         "description": "Cőūľđ ŉőŧ ľőäđ mūŧę ŧįmįŉģş. Pľęäşę ŧřy äģäįŉ ľäŧęř.",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -124,6 +124,11 @@
       "label": "Cőŉŧäčŧ pőįŉŧ"
     },
     "list-view": {
+      "empty": {
+        "new-alert-rule": "Ńęŵ äľęřŧ řūľę",
+        "new-recording-rule": "Ńęŵ řęčőřđįŉģ řūľę",
+        "provisioning": "Ÿőū čäŉ äľşő đęƒįŉę řūľęş ŧĥřőūģĥ ƒįľę přővįşįőŉįŉģ őř Ŧęřřäƒőřm. <2>Ŀęäřŉ mőřę</2>"
+      },
       "section": {
         "dataSourceManaged": {
           "title": "Đäŧä şőūřčę-mäŉäģęđ"
@@ -134,13 +139,6 @@
           "new-recording-rule": "Ńęŵ řęčőřđįŉģ řūľę",
           "title": "Ğřäƒäŉä-mäŉäģęđ"
         }
-      }
-    },
-    "list-view\"": {
-      "empty": {
-        "new-alert-rule": "Ńęŵ äľęřŧ řūľę",
-        "new-recording-rule": "Ńęŵ řęčőřđįŉģ řūľę",
-        "provisioning": "Ÿőū čäŉ äľşő đęƒįŉę řūľęş ŧĥřőūģĥ ƒįľę přővįşįőŉįŉģ őř Ŧęřřäƒőřm. <2>Ŀęäřŉ mőřę</2>"
       }
     },
     "mute_timings": {


### PR DESCRIPTION
**What is this feature?**

Update the CTA for an empty list of alerts to be more in line with the other Grafana pages.

**Before**

<img width="914" alt="image" src="https://github.com/user-attachments/assets/380c5c25-239b-4043-8df3-c431cf8f0830">

**After**

<img width="686" alt="image" src="https://github.com/user-attachments/assets/b7200abe-025a-44f6-919e-01d39af26ee9">
