### PR TITLE
Portal: Fix positioning when `bodyScrolling` is disabled

### DIFF
--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import { PropsWithChildren, useLayoutEffect, useRef } from 'react';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
@@ -51,25 +51,27 @@ export function getPortalContainer() {
 /** @internal */
 export function PortalContainer() {
   const styles = useStyles2(getStyles);
-  const isBodyScrolling = window.grafanaBootData?.settings.featureToggles.bodyScrolling;
-  return (
-    <div
-      id="grafana-portal-container"
-      className={cx({
-        [styles.grafanaPortalContainer]: isBodyScrolling,
-      })}
-    />
-  );
+  return <div id="grafana-portal-container" className={styles.grafanaPortalContainer} />;
 }
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  grafanaPortalContainer: css({
-    position: 'fixed',
-    top: 0,
-    width: '100%',
-    zIndex: theme.zIndex.portal,
-  }),
-});
+const getStyles = (theme: GrafanaTheme2) => {
+  const isBodyScrolling = window.grafanaBootData?.settings.featureToggles.bodyScrolling;
+  return {
+    grafanaPortalContainer: css(
+      isBodyScrolling
+        ? {
+            position: 'fixed',
+            top: 0,
+            width: '100%',
+            zIndex: theme.zIndex.portal,
+          }
+        : {
+            position: 'absolute',
+            width: '100%',
+          }
+    ),
+  };
+};
 
 export const RefForwardingPortal = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
   return <Portal {...props} forwardedRef={ref} />;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- size of `Portal` elements (tooltips etc) has regressed 
- `git bisect` tells me it was caused by https://github.com/grafana/grafana/pull/91648, but i'll be honest it's hard to spot exactly what the specific change in that PR that caused it is
- this tweaks the styles of the `Portal` elements slightly when `bodyScrolling` is disabled
  - given `bodyScrolling` is enabled in 100% of cloud prod instances, and is about to be the default behaviour on-prem in the next ~1-2 weeks, i think this is a reasonably low-risk change to bridge the gap

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f828c791-2136-4902-97f4-3f199ed05a46) | ![image](https://github.com/user-attachments/assets/512bc8a9-6f4d-49c7-90aa-94292787d3da) |

**Why do we need this feature?**

- so tooltips are shown correctly

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/hyperion-planning/issues/117

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
