### PR TITLE
Alerting: Fix reseting secure fields

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Controller, FieldErrors, FieldValues, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
@@ -90,12 +90,12 @@ export function ChannelSubForm<R extends ChannelValues>({
     return () => subscription.unsubscribe();
   }, [selectedType, initialValues, setValue, fieldName, watch]);
 
-  const [_secureFields, setSecureFields] = useState(secureFields ?? {});
+  const [_secureFields, setSecureFields] = useState<Record<string, boolean | ''>>(secureFields ?? {});
 
   const onResetSecureField = (key: string) => {
     if (_secureFields[key]) {
       const updatedSecureFields = { ..._secureFields };
-      delete updatedSecureFields[key];
+      updatedSecureFields[key] = '';
       setSecureFields(updatedSecureFields);
       setValue(`${pathPrefix}.secureFields`, updatedSecureFields);
     }

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -111,7 +111,7 @@ export interface NotificationChannelDTO {
 }
 
 export type NotificationChannelSecureSettings = Record<string, string | number>;
-export type NotificationChannelSecureFields = Record<string, boolean>;
+export type NotificationChannelSecureFields = Record<string, boolean | ''>;
 
 export interface ChannelTypeSettings {
   [key: string]: any;


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue where secure fields in contact points were not being properly reset after clicking 'Reset' and saving the receiver

**Why do we need this feature?**

User should be able to reset these fields.

**Who is this feature for?**

All users.

**Special notes for your reviewer:**

**Before the change:**

https://github.com/user-attachments/assets/f909b097-d640-4078-b2c7-f9de903ea867

**After the change**

https://github.com/user-attachments/assets/982aa1ff-75ab-448a-9a26-2d93d36fc123




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
