### PR TITLE
github: remove reviwer notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,9 +42,3 @@ Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
 
 Fixes #
 
-**Special notes for your reviewer:**
-
-Please check that:
-- [ ] It works as expected from a user's perspective.
-- [ ] If this is a pre-GA feature, it is behind a feature toggle.
-- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


### PR DESCRIPTION
I feel like we can remove these check items. Less is more. WDYT?