### PR TITLE
Alerting docs: improve alert rule definitions

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -43,32 +43,32 @@ refs:
 
 # Configure data source-managed alert rules
 
-Create alert rules for an external Grafana Mimir or Loki instance that has ruler API enabled; these are called data source-managed alert rules.
+Create data source-managed alert rules for Grafana Mimir or Grafana Loki data sources, which have been configured to support rule creation.
+
+They are only supported for Grafana Mimir or Grafana Loki data sources with the Ruler API enabled. For more information, refer to the [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
 
 **Note**:
 
-Alert rules for an external Grafana Mimir or Loki instance can be edited or deleted by users with Editor or Admin roles.
+Alert rules for a Grafana Mimir or Loki instance can be edited or deleted by users with Editor or Admin roles.
 
 If you delete an alerting resource created in the UI, you can no longer retrieve it.
 To make a backup of your configuration and to be able to restore deleted alerting resources, create your alerting resources using file provisioning, Terraform, or the Alerting API.
 
 ## Before you begin
 
-- Verify that you have write permission to the Prometheus or Loki data source. Otherwise, you will not be able to create or update Grafana Mimir managed alert rules.
+- Verify that you have write permission to the Mimir or Loki data source. Otherwise, you cannot create or update Grafana Mimir-managed alert rules.
 
-- For Grafana Mimir and Loki data sources, enable the Ruler API by configuring their respective services.
+- Enable the Mimir or Loki Ruler API.
 
   - **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 
   - **Grafana Mimir** - use the `/prometheus` prefix. The Prometheus data source supports both Grafana Mimir and Prometheus, and Grafana expects that both the [Query API](/docs/mimir/latest/operators-guide/reference-http-api/#querier--query-frontend) and [Ruler API](/docs/mimir/latest/operators-guide/reference-http-api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
 
-Watch this video to learn more about how to create a Mimir managed alert rule: {{< vimeo 720001865 >}}
+Watch this video to learn more about how to create a Mimir-managed alert rule: {{< vimeo 720001865 >}}
 
 {{% admonition type="note" %}}
-If you do not want to manage alert rules for a particular Loki or Prometheus data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
+If you do not want to manage alert rules for a particular Loki or Mimir data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 {{% /admonition %}}
-
-In the following sections, we’ll guide you through the process of creating your data source-managed alert rules.
 
 To create a data source-managed alert rule, use the in-product alert creation flow and follow these steps to help you.
 

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -45,7 +45,9 @@ refs:
 
 Create data source-managed alert rules for Grafana Mimir or Grafana Loki data sources, which have been configured to support rule creation.
 
-They are only supported for Grafana Mimir or Grafana Loki data sources with the Ruler API enabled. For more information, refer to the [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
+To configure your Grafana Mimir or Loki data source for alert rule creation, enable either the Loki Ruler API or the Mimir Ruler API.
+
+For more information, refer to [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
 
 **Note**:
 
@@ -56,7 +58,7 @@ To make a backup of your configuration and to be able to restore deleted alertin
 
 ## Before you begin
 
-- Verify that you have write permission to the Mimir or Loki data source. Otherwise, you cannot create or update Grafana Mimir-managed alert rules.
+- Verify that you have write permission to the Mimir or Loki data source. Otherwise, you cannot create or update Grafana Mimir or Loki-managed alert rules.
 
 - Enable the Mimir or Loki Ruler API.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -76,8 +76,8 @@ Additionally, you can also add [expressions to transform your data](ref:expressi
 {{< figure src="/media/docs/alerting/grafana-managed-alerting-architecture.png" max-width="750px" caption="How Grafana-managed alerting works by default" >}}
 
 1. Alert rules are created within Grafana based on one or more data sources.
-2. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
-3. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
+1. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
+1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
 
 ### Supported data sources
 
@@ -96,9 +96,9 @@ They are only supported for Grafana Mimir or Grafana Loki data sources with the 
 {{< figure src="/media/docs/alerting/mimir-managed-alerting-architecture-v2.png" max-width="750px" caption="Mimir-managed alerting architecture" >}}
 
 1. Alert rules are created and stored within the data source itself.
-2. Alert rules can only query Prometheus-based data. It can use either queries or [recording rules](#recording-rules).
-3. Alert rules are evaluated by the Alert Rule Evaluation Engine.
-4. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
+1. Alert rules can only query Prometheus-based data. It can use either queries or [recording rules](#recording-rules).
+1. Alert rules are evaluated by the Alert Rule Evaluation Engine.
+1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
 
 ## Recording rules
 

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -69,15 +69,15 @@ Grafana supports two different alert rule types: Grafana-managed alert rules and
 
 ## Grafana-managed alert rules
 
-Grafana-managed alert rules are the most flexible alert rule type. They allow you to create alerts that can act on data from any of the [supported data sources](#supported-data-sources), and use multiple data sources in a single alert rule.
+Grafana-managed alert rules are the most flexible alert rule type. They allow you to create alert rules that can act on data from any of the [supported data sources](#supported-data-sources), and use multiple data sources in a single alert rule. You can also add expressions to transform your data and set alert conditions. Using images in alert notifications is also supported.
 
 Additionally, you can also add [expressions to transform your data](ref:expression-queries), set custom alert conditions, and include [images in alert notifications](ref:notification-images).
 
 {{< figure src="/media/docs/alerting/grafana-managed-alerting-architecture.png" max-width="750px" caption="How Grafana-managed alerting works by default" >}}
 
 1. Alert rules are created within Grafana based on one or more data sources.
-1. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
-1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
+2. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
+3. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
 
 ### Supported data sources
 
@@ -87,16 +87,18 @@ Find the public data sources supporting Alerting in the [Grafana Plugins directo
 
 ## Data source-managed alert rules
 
-Data source-managed alert rules can improve query performance via [recording rules](#recording-rules) and ensure high-availability and fault tolerance when implementing a distributed architecture.
+Data source-managed alert rules can be used for Grafana Mimir or Grafana Loki data sources which have been configured to support rule creation.
 
-They are only supported for Prometheus-based or Loki data sources with the Ruler API enabled. For more information, refer to the [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
+They can improve query performance via [recording rules](#recording-rules) and ensure high-availability and fault tolerance when implementing a distributed architecture.
+
+They are only supported for Grafana Mimir or Grafana Loki data sources with the Ruler API enabled. For more information, refer to the [Loki Ruler API](/docs/loki/<GRAFANA_VERSION>/api/#ruler) or [Mimir Ruler API](/docs/mimir/<GRAFANA_VERSION>/references/http-api/#ruler).
 
 {{< figure src="/media/docs/alerting/mimir-managed-alerting-architecture-v2.png" max-width="750px" caption="Mimir-managed alerting architecture" >}}
 
 1. Alert rules are created and stored within the data source itself.
-1. Alert rules can only query Prometheus-based data. It can use either queries or [recording rules](#recording-rules).
-1. Alert rules are evaluated by the Alert Rule Evaluation Engine.
-1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
+2. Alert rules can only query Prometheus-based data. It can use either queries or [recording rules](#recording-rules).
+3. Alert rules are evaluated by the Alert Rule Evaluation Engine.
+4. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
 
 ## Recording rules
 


### PR DESCRIPTION
attempting to clean up grafana managed alert rules vs data source managed alert rule definition and remove the use of "external"