### PR TITLE
fix(alerting): extend instant vector check for non-nullable types

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -796,10 +796,17 @@ func scalarInstantVector(f *data.Frame) (*float64, bool) {
 	if f.Fields[0].Len() > 1 || (f.Fields[0].Type() != data.FieldTypeNullableTime && f.Fields[0].Type() != data.FieldTypeTime) {
 		return &defaultReturnValue, false
 	}
-	if f.Fields[1].Len() > 1 || f.Fields[1].Type() != data.FieldTypeNullableFloat64 {
+	if f.Fields[1].Len() > 1 || (f.Fields[1].Type() != data.FieldTypeNullableFloat64 && f.Fields[1].Type() != data.FieldTypeFloat64) {
 		return &defaultReturnValue, false
 	}
-	return f.Fields[1].At(0).(*float64), true
+	switch f.Fields[1].Type() {
+	case data.FieldTypeFloat64:
+		val := f.Fields[1].At(0).(float64)
+		return &val, true
+	case data.FieldTypeNullableFloat64:
+		return f.Fields[1].At(0).(*float64), true
+	}
+	return &defaultReturnValue, true
 }
 
 // AsDataFrame forms the EvalResults in Frame suitable for displaying in the table panel of the front end.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -796,9 +796,6 @@ func scalarInstantVector(f *data.Frame) (*float64, bool) {
 	if f.Fields[0].Len() > 1 || (f.Fields[0].Type() != data.FieldTypeNullableTime && f.Fields[0].Type() != data.FieldTypeTime) {
 		return &defaultReturnValue, false
 	}
-	if f.Fields[1].Len() > 1 || (f.Fields[1].Type() != data.FieldTypeNullableFloat64 && f.Fields[1].Type() != data.FieldTypeFloat64) {
-		return &defaultReturnValue, false
-	}
 	switch f.Fields[1].Type() {
 	case data.FieldTypeFloat64:
 		val := f.Fields[1].At(0).(float64)

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -802,8 +802,9 @@ func scalarInstantVector(f *data.Frame) (*float64, bool) {
 		return &val, true
 	case data.FieldTypeNullableFloat64:
 		return f.Fields[1].At(0).(*float64), true
+	default:
+		return &defaultReturnValue, true
 	}
-	return &defaultReturnValue, true
 }
 
 // AsDataFrame forms the EvalResults in Frame suitable for displaying in the table panel of the front end.

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 var logger = log.New("ngalert.eval")
@@ -789,21 +790,19 @@ func buildResult(f *data.Frame, val *float64, ts time.Time) Result {
 }
 
 func scalarInstantVector(f *data.Frame) (*float64, bool) {
-	defaultReturnValue := 0.0
 	if len(f.Fields) != 2 {
-		return &defaultReturnValue, false
+		return nil, false
 	}
 	if f.Fields[0].Len() > 1 || (f.Fields[0].Type() != data.FieldTypeNullableTime && f.Fields[0].Type() != data.FieldTypeTime) {
-		return &defaultReturnValue, false
+		return nil, false
 	}
 	switch f.Fields[1].Type() {
 	case data.FieldTypeFloat64:
-		val := f.Fields[1].At(0).(float64)
-		return &val, true
+		return util.Pointer(f.Fields[1].At(0).(float64)), true
 	case data.FieldTypeNullableFloat64:
 		return f.Fields[1].At(0).(*float64), true
 	default:
-		return &defaultReturnValue, true
+		return nil, true
 	}
 }
 


### PR DESCRIPTION
This PR extends the check we do to also work with non-nullable types in the value frame. I added a specific test for the query service kind of response we got, that helped me to pin down this edge case.