### PR TITLE
Dashboards: Fix 'days' unit pluralization

### DIFF
--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -185,7 +185,7 @@ export function toDays(size: number, decimals?: DecimalCount): FormattedValue {
   }
 
   if (Math.abs(size) < 7) {
-    return { text: toFixed(size, decimals), suffix: ' day' };
+    return toFixedScaled(size, decimals, ' day');
   } else if (Math.abs(size) < 365) {
     return toFixedScaled(size / 7, decimals, ' week');
   } else {


### PR DESCRIPTION
Fixes an issue where values formatted as 'days' weren't being pluralized correctly ('2 day' instead of '2 days', etc).

Closes #77592 