### PR TITLE
Chore: Clean up old API methods in manage-dashboards/actions

### DIFF
--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -260,35 +260,9 @@ const getDataSourceDescription = (input: { usage?: InputUsage }): string | undef
   return undefined;
 };
 
-export async function moveFolders(folderUIDs: string[], toFolder: FolderInfo) {
-  const result = {
-    totalCount: folderUIDs.length,
-    successCount: 0,
-  };
-
-  for (const folderUID of folderUIDs) {
-    try {
-      const newFolderDTO = await moveFolder(folderUID, toFolder);
-      if (newFolderDTO !== null) {
-        result.successCount += 1;
-      }
-    } catch (err) {
-      console.error('Failed to move a folder', err);
-    }
-  }
-
-  return result;
-}
-
+/** @deprecated Use RTK Query methods from features/browse-dashboards/api/browseDashboardsAPI.ts instead */
 export function createFolder(payload: any) {
   return getBackendSrv().post('/api/folders', payload);
-}
-
-export function moveFolder(uid: string, toFolder: FolderInfo) {
-  const payload = {
-    parentUid: toFolder.uid,
-  };
-  return getBackendSrv().post(`/api/folders/${uid}/move`, payload, { showErrorAlert: false });
 }
 
 export const SLICE_FOLDER_RESULTS_TO = 1000;

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -3,7 +3,7 @@ import { getBackendSrv, getDataSourceSrv, isFetchError } from '@grafana/runtime'
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { browseDashboardsAPI, ImportInputs } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
-import { FolderInfo, PermissionLevelString, SearchQueryType, ThunkResult } from 'app/types';
+import { PermissionLevelString, SearchQueryType, ThunkResult } from 'app/types';
 
 import {
   Input,


### PR DESCRIPTION
Since the new Browse Dashboards experience, we've centralised dashboards/folder API usage with a single React Toolkit Query (RKTQ) slice. It's important as many API requests go through this to ensure proper caching/invalidation across the app.

Within the 'legacy' manage-dashboards folder, there exists some API functions (that are largely untyped as well - yuck!) that aren't really called from many places.

Both `moveFolder` and `moveFolders` are not used anywhere, so they can be deleted.

`createFolder` is only used by Alerting, which we need to fix. Otherwise, that's deprecated and shouldn't be used any more.