### PR TITLE
E2C: Add rudderstack reporting for cloud-side token generation

### DIFF
--- a/public/app/features/migrate-to-cloud/cloud/MigrationTokenPane/MigrationTokenPane.tsx
+++ b/public/app/features/migrate-to-cloud/cloud/MigrationTokenPane/MigrationTokenPane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { isFetchError } from '@grafana/runtime';
+import { isFetchError, reportInteraction } from '@grafana/runtime';
 import { Box, Button, Text } from '@grafana/ui';
 import { t, Trans } from 'app/core/internationalization';
 
@@ -51,6 +51,8 @@ export const MigrationTokenPane = () => {
   const isLoading = getTokenQuery.isFetching || createTokenResponse.isLoading;
 
   const handleGenerateToken = useCallback(async () => {
+    reportInteraction('grafana_e2c_generate_token_clicked');
+
     const resp = await createTokenMutation();
 
     if (!('error' in resp)) {
@@ -63,6 +65,7 @@ export const MigrationTokenPane = () => {
       return;
     }
 
+    reportInteraction('grafana_e2c_delete_token_clicked');
     const resp = await deleteTokenMutation({ uid: getTokenQuery.data.id });
     if (!('error' in resp)) {
       setShowDeleteModal(false);
@@ -98,7 +101,10 @@ export const MigrationTokenPane = () => {
 
       <CreateTokenModal
         isOpen={showCreateModal}
-        hideModal={() => setShowCreateModal(false)}
+        hideModal={() => {
+          reportInteraction('grafana_e2c_generated_token_modal_dismissed');
+          setShowCreateModal(false);
+        }}
         migrationToken={createTokenResponse.data?.token}
       />
 


### PR DESCRIPTION
Adds rudderstacks events for when the user generates a migration token on the Grafana Cloud side.

Adds three events:
 - `grafana_e2c_generate_token_clicked` when the user clicks on the "Generate a migration token" button. Note that this does not indicate a token was successfully created, just that the user clicked the button.
 - `grafana_e2c_delete_token_clicked` when the user clicks the "Delete token" button. Same as above, this doesn't indicate if it was successful or not.
 - `grafana_e2c_generated_token_modal_dismissed`. A modal is displayed after a token is generated. This is triggered when that modal is dismissed by any means.

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/945.