### PR TITLE
Backend: stop redirection in organization switch

### DIFF
--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -50,7 +50,7 @@ func OrgRedirect(cfg *setting.Cfg, userSvc user.Service) web.Handler {
 			qs = fmt.Sprintf("%s&kiosk", urlParams.Encode())
 		}
 
-		newURL := fmt.Sprintf("%s%s?%s", cfg.AppURL, strings.TrimPrefix(c.Req.URL.Path, "/"), qs)
+		newURL := fmt.Sprintf("%s://%s%s?%s", cfg.Protocol, c.Req.Host, strings.TrimPrefix(c.Req.URL.Path, "/"), qs)
 
 		c.Redirect(newURL, 302)
 	}


### PR DESCRIPTION
**What is this feature?**
Stop Redirecting grafana url base on conf file when we change organization 

[Organization change in main page.]

**Why do we need this feature?**

[Redirect URL when don't need to this redirection.]

**Who is this feature for?**

[all grafana users.]

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/grafana/issues/89321

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
