### PR TITLE
Unistore: fix DualWriter context cancelation on mode 1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/pkg/apiserver/rest/dualwriter_mode1.go
+++ b/pkg/apiserver/rest/dualwriter_mode1.go
@@ -58,7 +58,8 @@ func (d *DualWriterMode1) Create(ctx context.Context, original runtime.Object, c
 	createdCopy := created.DeepCopyObject()
 
 	go func(createdCopy runtime.Object) {
-		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage create timeout"))
+		// Ignores cancellation signals from parent context. Will automatically be canceled after 10 seconds.
+		ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("storage create timeout"))
 		defer cancel()
 
 		if err := enrichLegacyObject(original, createdCopy); err != nil {
@@ -96,7 +97,8 @@ func (d *DualWriterMode1) Get(ctx context.Context, name string, options *metav1.
 
 	go func(res runtime.Object) {
 		startStorage := time.Now()
-		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage get timeout"))
+		// Ignores cancellation signals from parent context. Will automatically be canceled after 10 seconds.
+		ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("storage get timeout"))
 		defer cancel()
 		storageObj, err := d.Storage.Get(ctx, name, options)
 		d.recordStorageDuration(err != nil, mode1Str, d.resource, method, startStorage)
@@ -130,7 +132,8 @@ func (d *DualWriterMode1) List(ctx context.Context, options *metainternalversion
 
 	go func(res runtime.Object) {
 		startStorage := time.Now()
-		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage list timeout"))
+		// Ignores cancellation signals from parent context. Will automatically be canceled after 10 seconds.
+		ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("storage list timeout"))
 		defer cancel()
 		storageObj, err := d.Storage.List(ctx, options)
 		d.recordStorageDuration(err != nil, mode1Str, d.resource, method, startStorage)
@@ -163,7 +166,8 @@ func (d *DualWriterMode1) Delete(ctx context.Context, name string, deleteValidat
 
 	go func(res runtime.Object) {
 		startStorage := time.Now()
-		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage delete timeout"))
+		// Ignores cancellation signals from parent context. Will automatically be canceled after 10 seconds.
+		ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("storage delete timeout"))
 		defer cancel()
 		storageObj, _, err := d.Storage.Delete(ctx, name, deleteValidation, options)
 		d.recordStorageDuration(err != nil, mode1Str, d.resource, method, startStorage)
@@ -197,7 +201,8 @@ func (d *DualWriterMode1) DeleteCollection(ctx context.Context, deleteValidation
 
 	go func(res runtime.Object) {
 		startStorage := time.Now()
-		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage deletecollection timeout"))
+		// Ignores cancellation signals from parent context. Will automatically be canceled after 10 seconds.
+		ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("storage deletecollection timeout"))
 		defer cancel()
 		storageObj, err := d.Storage.DeleteCollection(ctx, deleteValidation, options, listOptions)
 		d.recordStorageDuration(err != nil, mode1Str, d.resource, method, startStorage)
@@ -229,7 +234,8 @@ func (d *DualWriterMode1) Update(ctx context.Context, name string, objInfo rest.
 	d.recordLegacyDuration(false, mode1Str, d.resource, method, startLegacy)
 
 	go func(res runtime.Object) {
-		ctx, cancel := context.WithTimeoutCause(ctx, time.Second*10, errors.New("storage update timeout"))
+		// Ignores cancellation signals from parent context. Will automatically be canceled after 10 seconds.
+		ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("storage update timeout"))
 
 		resCopy := res.DeepCopyObject()
 		// get the object to be updated

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -84,6 +84,12 @@ func (m legacyStoreMock) DeleteCollection(ctx context.Context, deleteValidation 
 
 // Unified Store
 func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("context canceled")
+	default:
+	}
+
 	args := m.Called(ctx, name, options)
 	if name == "object-fail" {
 		return nil, args.Error(1)
@@ -95,6 +101,12 @@ func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("context canceled")
+	default:
+	}
+
 	args := m.Called(ctx, obj, createValidation, options)
 	acc, err := meta.Accessor(obj)
 	if err != nil {
@@ -126,6 +138,12 @@ func (m storageMock) NewList() runtime.Object {
 }
 
 func (m storageMock) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	select {
+	case <-ctx.Done():
+		return nil, false, errors.New("context canceled")
+	default:
+	}
+
 	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 	if name == "object-fail" {
 		return nil, false, args.Error(2)
@@ -134,6 +152,12 @@ func (m storageMock) Update(ctx context.Context, name string, objInfo rest.Updat
 }
 
 func (m storageMock) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	select {
+	case <-ctx.Done():
+		return nil, false, errors.New("context canceled")
+	default:
+	}
+
 	args := m.Called(ctx, name, deleteValidation, options)
 	if name == "object-fail" {
 		return nil, false, args.Error(2)
@@ -142,6 +166,12 @@ func (m storageMock) Delete(ctx context.Context, name string, deleteValidation r
 }
 
 func (m storageMock) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("context canceled")
+	default:
+	}
+
 	args := m.Called(ctx, deleteValidation, options, listOptions)
 	if options.Kind == "fail" {
 		return nil, args.Error(1)

--- a/pkg/apiserver/rest/storage_mocks_test.go
+++ b/pkg/apiserver/rest/storage_mocks_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"errors"
 
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -107,6 +108,12 @@ func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValid
 }
 
 func (m storageMock) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	select {
+	case <-ctx.Done():
+		return nil, errors.New("context canceled")
+	default:
+	}
+
 	args := m.Called(ctx, options)
 	if options.Kind == "fail" {
 		return nil, args.Error(1)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

DualWriter is failing to perform write/reads operations (to Unified Storage) when running on mode 1;
This happens because the parent context get canceled before the goroutine that executes operations on Unified Storage starts.
This PR ensures that the goroutine that executes operations on Unified Storage uses a copy of parent context without any canceling clause, and then adds a new 10 second timeout.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-org/issues/213
Part of https://github.com/grafana/grafana-org/issues/156

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
