### PR TITLE
Prometheus: Don't require exemplar query in instant query when "Both" is selected

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -390,6 +390,7 @@ export class PrometheusDatasource
           ...processedTarget,
           refId: processedTarget.refId + InstantQueryRefIdIndex,
           range: false,
+          exemplar: false,
         }
       );
     } else {


### PR DESCRIPTION

**What is this feature?**

Today with Prometheus Explore UI when a user selects `Both` and says show exemplars, the two independent range and instant queries both fire exemplar queries. ideally the instant query doesnt need to request exemplars. this PR removes the need for that. 

**Why do we need this feature?**

It removes the wasted API call to Prometheus

**Who is this feature for?**

Folks who use Prometheus explore UI

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
