### PR TITLE
New Select: Extract floating ui setup into hook

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -162,7 +162,7 @@ export const Combobox = <T extends string | number>({
       }
     },
   });
-  const { inputRef, floatingRef, popoverStyles } = useComboboxFloat(items, rowVirtualizer.range, isOpen);
+  const { inputRef, floatingRef, floatStyles } = useComboboxFloat(items, rowVirtualizer.range, isOpen);
 
   const onBlur = useCallback(() => {
     setInputValue(selectedItem?.label ?? value?.toString() ?? '');
@@ -219,7 +219,7 @@ export const Combobox = <T extends string | number>({
       <div
         className={cx(styles.menu, hasMinHeight && styles.menuHeight, !isOpen && styles.menuClosed)}
         style={{
-          ...popoverStyles,
+          ...floatStyles,
         }}
         {...getMenuProps({
           ref: floatingRef,
@@ -333,12 +333,12 @@ const useComboboxFloat = (
     }
   }, [items, range, setPopoverWidth]);
 
-  const popoverStyles = {
+  const floatStyles = {
     ...floatingStyles,
     width: popoverWidth,
     maxWidth: popoverMaxWidth,
     minWidth: inputRef.current?.offsetWidth,
   };
 
-  return { inputRef, floatingRef, popoverStyles };
+  return { inputRef, floatingRef, floatStyles };
 };

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -46,7 +46,6 @@ function estimateSize() {
   return 45;
 }
 
-const MIN_HEIGHT = 400;
 // On every 100th index we will recalculate the width of the popover.
 const INDEX_WIDTH_CALCULATION = 100;
 // A multiplier guesstimate times the amount of characters. If any padding or image support etc. is added this will need to be updated.
@@ -168,8 +167,6 @@ export const Combobox = <T extends string | number>({
     setInputValue(selectedItem?.label ?? value?.toString() ?? '');
   }, [selectedItem, setInputValue, value]);
 
-  const hasMinHeight = isOpen && rowVirtualizer.getTotalSize() >= MIN_HEIGHT;
-
   return (
     <div>
       <Input
@@ -217,7 +214,7 @@ export const Combobox = <T extends string | number>({
         })}
       />
       <div
-        className={cx(styles.menu, hasMinHeight && styles.menuHeight, !isOpen && styles.menuClosed)}
+        className={cx(styles.menu, !isOpen && styles.menuClosed)}
         style={{
           ...floatStyles,
         }}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -340,5 +340,5 @@ const useComboboxFloat = (
     minWidth: inputRef.current?.offsetWidth,
   };
 
-  return { inputRef, floatingRef, popoverWidth, popoverMaxWidth, popoverStyles };
+  return { inputRef, floatingRef, popoverStyles };
 };

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,8 +1,7 @@
 import { cx } from '@emotion/css';
-import { autoUpdate, flip, size, useFloating } from '@floating-ui/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 
 import { useStyles2 } from '../../themes';
 import { t } from '../../utils/i18n';
@@ -10,6 +9,7 @@ import { Icon } from '../Icon/Icon';
 import { Input, Props as InputProps } from '../Input/Input';
 
 import { getComboboxStyles } from './getComboboxStyles';
+import { estimateSize, useComboboxFloat } from './useComboboxFloat';
 
 export type ComboboxOption<T extends string | number = string> = {
   label: string;
@@ -41,15 +41,6 @@ function itemFilter<T extends string | number>(inputValue: string) {
     );
   };
 }
-
-function estimateSize() {
-  return 45;
-}
-
-// On every 100th index we will recalculate the width of the popover.
-const INDEX_WIDTH_CALCULATION = 100;
-// A multiplier guesstimate times the amount of characters. If any padding or image support etc. is added this will need to be updated.
-const WIDTH_MULTIPLIER = 7.3;
 
 /**
  * A performant Select replacement.
@@ -258,84 +249,4 @@ export const Combobox = <T extends string | number>({
       </div>
     </div>
   );
-};
-
-const useComboboxFloat = (
-  items: Array<ComboboxOption<string | number>>,
-  range: { startIndex: number; endIndex: number } | null,
-  isOpen: boolean
-) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const floatingRef = useRef<HTMLDivElement>(null);
-  const [popoverWidth, setPopoverWidth] = useState<number | undefined>(undefined);
-  const [popoverMaxWidth, setPopoverMaxWidth] = useState<number | undefined>(undefined);
-
-  // the order of middleware is important!
-  const middleware = [
-    flip({
-      // see https://floating-ui.com/docs/flip#combining-with-shift
-      crossAxis: true,
-      boundary: document.body,
-    }),
-    size({
-      apply({ availableWidth }) {
-        setPopoverMaxWidth(availableWidth);
-      },
-    }),
-  ];
-  const elements = { reference: inputRef.current, floating: floatingRef.current };
-  const { floatingStyles } = useFloating({
-    strategy: 'fixed',
-    open: isOpen,
-    placement: 'bottom-start',
-    middleware,
-    elements,
-    whileElementsMounted: autoUpdate,
-  });
-
-  useEffect(() => {
-    if (range === null) {
-      return;
-    }
-    const startVisibleIndex = range?.startIndex;
-    const endVisibleIndex = range?.endIndex;
-
-    if (typeof startVisibleIndex === 'undefined' || typeof endVisibleIndex === 'undefined') {
-      return;
-    }
-
-    // Scroll down and default case
-    if (
-      startVisibleIndex === 0 ||
-      (startVisibleIndex % INDEX_WIDTH_CALCULATION === 0 && startVisibleIndex >= INDEX_WIDTH_CALCULATION)
-    ) {
-      let maxLength = 0;
-      const calculationEnd = Math.min(items.length, endVisibleIndex + INDEX_WIDTH_CALCULATION);
-
-      for (let i = startVisibleIndex; i < calculationEnd; i++) {
-        maxLength = Math.max(maxLength, items[i].label.length);
-      }
-
-      setPopoverWidth(maxLength * WIDTH_MULTIPLIER);
-    } else if (endVisibleIndex % INDEX_WIDTH_CALCULATION === 0 && endVisibleIndex >= INDEX_WIDTH_CALCULATION) {
-      // Scroll up case
-      let maxLength = 0;
-      const calculationStart = Math.max(0, startVisibleIndex - INDEX_WIDTH_CALCULATION);
-
-      for (let i = calculationStart; i < endVisibleIndex; i++) {
-        maxLength = Math.max(maxLength, items[i].label.length);
-      }
-
-      setPopoverWidth(maxLength * WIDTH_MULTIPLIER);
-    }
-  }, [items, range, setPopoverWidth]);
-
-  const floatStyles = {
-    ...floatingStyles,
-    width: popoverWidth,
-    maxWidth: popoverMaxWidth,
-    minWidth: inputRef.current?.offsetWidth,
-  };
-
-  return { inputRef, floatingRef, floatStyles };
 };

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -2,6 +2,8 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
+const MAX_HEIGHT = 400;
+
 export const getComboboxStyles = (theme: GrafanaTheme2) => {
   return {
     menuClosed: css({
@@ -12,10 +14,8 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
       background: theme.components.dropdown.background,
       boxShadow: theme.shadows.z3,
       zIndex: theme.zIndex.dropdown,
-    }),
-    menuHeight: css({
-      height: 400,
-      overflowY: 'scroll',
+      maxHeight: MAX_HEIGHT,
+      overflowY: 'auto',
       position: 'relative',
     }),
     menuUlContainer: css({

--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -1,0 +1,96 @@
+import { autoUpdate, flip, size, useFloating } from '@floating-ui/react';
+import { useEffect, useRef, useState } from 'react';
+
+import { ComboboxOption } from './Combobox';
+
+// On every 100th index we will recalculate the width of the popover.
+const INDEX_WIDTH_CALCULATION = 100;
+// A multiplier guesstimate times the amount of characters. If any padding or image support etc. is added this will need to be updated.
+const WIDTH_MULTIPLIER = 7.3;
+
+/**
+ * Used with Downshift to get the height of each item
+ */
+export function estimateSize() {
+  return 45;
+}
+
+export const useComboboxFloat = (
+  items: Array<ComboboxOption<string | number>>,
+  range: { startIndex: number; endIndex: number } | null,
+  isOpen: boolean
+) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  const [popoverWidth, setPopoverWidth] = useState<number | undefined>(undefined);
+  const [popoverMaxWidth, setPopoverMaxWidth] = useState<number | undefined>(undefined);
+
+  // the order of middleware is important!
+  const middleware = [
+    flip({
+      // see https://floating-ui.com/docs/flip#combining-with-shift
+      crossAxis: true,
+      boundary: document.body,
+    }),
+    size({
+      apply({ availableWidth }) {
+        setPopoverMaxWidth(availableWidth);
+      },
+    }),
+  ];
+  const elements = { reference: inputRef.current, floating: floatingRef.current };
+  const { floatingStyles } = useFloating({
+    strategy: 'fixed',
+    open: isOpen,
+    placement: 'bottom-start',
+    middleware,
+    elements,
+    whileElementsMounted: autoUpdate,
+  });
+
+  useEffect(() => {
+    if (range === null) {
+      return;
+    }
+    const startVisibleIndex = range?.startIndex;
+    const endVisibleIndex = range?.endIndex;
+
+    if (typeof startVisibleIndex === 'undefined' || typeof endVisibleIndex === 'undefined') {
+      return;
+    }
+
+    // Scroll down and default case
+    if (
+      startVisibleIndex === 0 ||
+      (startVisibleIndex % INDEX_WIDTH_CALCULATION === 0 && startVisibleIndex >= INDEX_WIDTH_CALCULATION)
+    ) {
+      let maxLength = 0;
+      const calculationEnd = Math.min(items.length, endVisibleIndex + INDEX_WIDTH_CALCULATION);
+
+      for (let i = startVisibleIndex; i < calculationEnd; i++) {
+        maxLength = Math.max(maxLength, items[i].label.length);
+      }
+
+      setPopoverWidth(maxLength * WIDTH_MULTIPLIER);
+    } else if (endVisibleIndex % INDEX_WIDTH_CALCULATION === 0 && endVisibleIndex >= INDEX_WIDTH_CALCULATION) {
+      // Scroll up case
+      let maxLength = 0;
+      const calculationStart = Math.max(0, startVisibleIndex - INDEX_WIDTH_CALCULATION);
+
+      for (let i = calculationStart; i < endVisibleIndex; i++) {
+        maxLength = Math.max(maxLength, items[i].label.length);
+      }
+
+      setPopoverWidth(maxLength * WIDTH_MULTIPLIER);
+    }
+  }, [items, range, setPopoverWidth]);
+
+  const floatStyles = {
+    ...floatingStyles,
+    width: popoverWidth,
+    maxWidth: popoverMaxWidth,
+    minWidth: inputRef.current?.offsetWidth,
+  };
+
+  return { inputRef, floatingRef, floatStyles };
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Extract floating ui/ popver handling into the hook

**Why do we need this feature?**

Better separation of concernes and readability. This can possibly be used with other combobox-like components.

**Who is this feature for?**

Combobox users, and/or combobox authors

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I did this rfactor a bit fast, so I might need to revisit and test things.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
