### PR TITLE
LibraryPanels: Fix folderUid nil pointer dereference

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -145,7 +145,7 @@ func (l *LibraryElementService) createLibraryElement(c context.Context, signedIn
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
 	// folderUID *string will be changed to string
-	var folderUID string
+	var folderUID = ""
 	if cmd.FolderUID != nil {
 		folderUID = *cmd.FolderUID
 	}
@@ -172,9 +172,9 @@ func (l *LibraryElementService) createLibraryElement(c context.Context, signedIn
 
 	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
 		if l.features.IsEnabled(c, featuremgmt.FlagLibraryPanelRBAC) {
-			allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(*cmd.FolderUID)))
+			allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, dashboards.ScopeFoldersProvider.GetResourceScopeUID(folderUID)))
 			if !allowed {
-				return fmt.Errorf("insufficient permissions for creating library panel in folder with UID %s", *cmd.FolderUID)
+				return fmt.Errorf("insufficient permissions for creating library panel in folder with UID %s", folderUID)
 			}
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes an issue where library panels code could cause a crash if the supplied command didn't have FolderUID set.