### PR TITLE
resource-api: Loosen name validation to match K8s requirements

### DIFF
--- a/pkg/storage/unified/resource/validation.go
+++ b/pkg/storage/unified/resource/validation.go
@@ -4,14 +4,14 @@ import (
 	"regexp"
 )
 
-var validNameCharPattern = `a-zA-Z0-9\-\_\.`
+var validNameCharPattern = `a-zA-Z0-9:\-\_\.`
 var validNamePattern = regexp.MustCompile(`^[` + validNameCharPattern + `]*$`).MatchString
 
 func validateName(name string) *ErrorResult {
 	if len(name) == 0 {
 		return NewBadRequestError("name is too short")
 	}
-	if len(name) > 64 {
+	if len(name) > 253 {
 		return NewBadRequestError("name is too long")
 	}
 	if !validNamePattern(name) {

--- a/pkg/storage/unified/resource/validation_test.go
+++ b/pkg/storage/unified/resource/validation_test.go
@@ -1,22 +1,22 @@
 package resource
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestNameValidation(t *testing.T) {
-	require.NotNil(t, validateName("")) // too short
-	require.NotNil(t, validateName(     // too long (max 64)
-		"0123456789012345678901234567890123456789012345678901234567890123456789",
-	))
+	require.NotNil(t, validateName(""))                       // too short
+	require.NotNil(t, validateName(strings.Repeat("0", 254))) // too long (max 253)
 
 	// OK
 	require.Nil(t, validateName("a"))
 	require.Nil(t, validateName("hello-world"))
 	require.Nil(t, validateName("hello.world"))
 	require.Nil(t, validateName("hello_world"))
+	require.Nil(t, validateName("hello:world"))
 
 	// Bad characters
 	require.NotNil(t, validateName("hello world"))

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -22,7 +22,7 @@ func initResourceTables(mg *migrator.Migrator) string {
 			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "resource", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 63, Nullable: false},
-			{Name: "name", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "name", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},
 			{Name: "value", Type: migrator.DB_LongText, Nullable: true},
 			{Name: "action", Type: migrator.DB_Int, Nullable: false}, // 1: create, 2: update, 3: delete
 
@@ -44,7 +44,7 @@ func initResourceTables(mg *migrator.Migrator) string {
 			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "resource", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 63, Nullable: false},
-			{Name: "name", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "name", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},
 			{Name: "value", Type: migrator.DB_LongText, Nullable: true},
 			{Name: "action", Type: migrator.DB_Int, Nullable: false}, // 1: create, 2: update, 3: delete
 

--- a/pkg/tests/apis/scopes/scopes_test.go
+++ b/pkg/tests/apis/scopes/scopes_test.go
@@ -3,6 +3,7 @@ package scopes
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -155,6 +156,25 @@ func TestIntegrationScopes(t *testing.T) {
 
 		_, err = scopeClient.Resource.Create(ctx,
 			helper.LoadYAMLOrJSONFile("testdata/example-scope2.yaml"),
+			createOptions,
+		)
+		require.NoError(t, err)
+
+		// Name length test
+		scope3 := helper.LoadYAMLOrJSONFile("testdata/example-scope3.yaml")
+
+		// Name too long (>253)
+		scope3.SetName(strings.Repeat("0", 254))
+		_, err = scopeClient.Resource.Create(ctx,
+			scope3,
+			createOptions,
+		)
+		require.Error(t, err)
+
+		// Maximum allowed length for name (253)
+		scope3.SetName(strings.Repeat("0", 253))
+		_, err = scopeClient.Resource.Create(ctx,
+			scope3,
 			createOptions,
 		)
 		require.NoError(t, err)

--- a/pkg/tests/apis/scopes/testdata/example-scope3.yaml
+++ b/pkg/tests/apis/scopes/testdata/example-scope3.yaml
@@ -1,0 +1,14 @@
+apiVersion: scope.grafana.app/v0alpha1
+kind: Scope
+metadata:
+  name: example-long
+spec:
+    title: baz-scope
+    description: Longer description for a scope
+    filters: 
+      - key: aaa
+        operator: equals
+        value: eee
+      - key: ccc
+        operator: not-equals
+        value: fff


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This patch modifies some of the requirements for name validation of objects in Resource API to match Kubernetes. [K8s Docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)


**Why do we need this feature?**

The limit we have on characters in name is 64, but some resources allow upto 253 characters. Similarly we also include `:` in the regex, as many objects in default K8s setup use it in the name (the group `system:masters` for example)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
