### PR TITLE
Prometheus: Fix escaping of quotation marks for variables

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -289,6 +289,16 @@ describe('PrometheusDatasource', () => {
           operator: '=~',
           value: `v'.*`,
         },
+        {
+          key: 'k3',
+          operator: '=~',
+          value: `v".*`,
+        },
+        {
+          key: 'k4',
+          operator: '=~',
+          value: `\\v.*`,
+        },
       ];
       ds.query({
         interval: '15s',
@@ -298,7 +308,7 @@ describe('PrometheusDatasource', () => {
       } as DataQueryRequest<PromQuery>);
       const [result] = fetchMockCalledWith(fetchMock);
       expect(result).toMatchObject({
-        expr: `metric{job="foo", k1=~"v.*", k2=~"v\\\\'.*"} - metric{k1=~"v.*", k2=~"v\\\\'.*"}`,
+        expr: `metric{job="foo", k1=~"v.*", k2=~"v'.*", k3=~"v\\".*", k4=~"\\\\v.*"} - metric{k1=~"v.*", k2=~"v'.*", k3=~"v\\".*", k4=~"\\\\v.*"}`,
       });
     });
   });
@@ -478,8 +488,12 @@ describe('PrometheusDatasource', () => {
       expect(prometheusRegularEscape('cryptodepression')).toEqual('cryptodepression');
     });
 
-    it("should escape '", () => {
-      expect(prometheusRegularEscape("looking'glass")).toEqual("looking\\\\'glass");
+    it("should not escape '", () => {
+      expect(prometheusRegularEscape("looking'glass")).toEqual("looking'glass");
+    });
+
+    it('should escape "', () => {
+      expect(prometheusRegularEscape('looking"glass')).toEqual('looking\\"glass');
     });
 
     it('should escape \\', () => {
@@ -487,11 +501,11 @@ describe('PrometheusDatasource', () => {
     });
 
     it('should escape multiple characters', () => {
-      expect(prometheusRegularEscape("'looking'glass'")).toEqual("\\\\'looking\\\\'glass\\\\'");
+      expect(prometheusRegularEscape('"looking"glass"')).toEqual('\\"looking\\"glass\\"');
     });
 
     it('should escape multiple different characters', () => {
-      expect(prometheusRegularEscape("'loo\\king'glass'")).toEqual("\\\\'loo\\\\king\\\\'glass\\\\'");
+      expect(prometheusRegularEscape('"loo\\king"glass"')).toEqual('\\"loo\\\\king\\"glass\\"');
     });
   });
 
@@ -549,8 +563,8 @@ describe('PrometheusDatasource', () => {
     });
 
     describe('and value is a string', () => {
-      it('should only escape single quotes', () => {
-        expect(ds.interpolateQueryExpr("abc'$^*{}[]+?.()|", customVariable)).toEqual("abc\\\\'$^*{}[]+?.()|");
+      it('should only escape double quotes and backslashes', () => {
+        expect(ds.interpolateQueryExpr('abc\'"$^*{}[]+?.()|\\', customVariable)).toEqual('abc\'\\"$^*{}[]+?.()|\\\\');
       });
     });
 

--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -514,8 +514,9 @@ describe('PrometheusDatasource', () => {
       expect(prometheusSpecialRegexEscape('cryptodepression')).toEqual('cryptodepression');
     });
 
-    it('should escape $^*+?.()|\\', () => {
+    it('should escape $^*+?.()|\\"', () => {
       expect(prometheusSpecialRegexEscape("looking'glass")).toEqual("looking\\\\'glass");
+      expect(prometheusSpecialRegexEscape('looking"glass')).toEqual('looking\\\\\\"glass');
       expect(prometheusSpecialRegexEscape('looking{glass')).toEqual('looking\\\\{glass');
       expect(prometheusSpecialRegexEscape('looking}glass')).toEqual('looking\\\\}glass');
       expect(prometheusSpecialRegexEscape('looking[glass')).toEqual('looking\\\\[glass');

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -1047,7 +1047,7 @@ export function extractRuleMappingFromGroups(groups: RawRecordingRules[]): RuleQ
 // in language_utils.ts, but they are not exactly the same algorithm, and we found
 // no way to reuse one in the another or vice versa.
 export function prometheusRegularEscape<T>(value: T) {
-  return typeof value === 'string' ? value.replace(/\\/g, '\\\\').replace(/'/g, "\\\\'") : value;
+  return typeof value === 'string' ? value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') : value;
 }
 
 export function prometheusSpecialRegexEscape<T>(value: T) {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -642,7 +642,7 @@ export class PrometheusDatasource
 
     const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({
       label: f.key,
-      value: f.value,
+      value: prometheusRegularEscape(f.value),
       op: f.operator,
     }));
     const expr = promQueryModeller.renderLabels(labelFilters);
@@ -674,7 +674,7 @@ export class PrometheusDatasource
 
     const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({
       label: f.key,
-      value: f.value,
+      value: prometheusRegularEscape(f.value),
       op: f.operator,
     }));
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -1051,5 +1051,10 @@ export function prometheusRegularEscape<T>(value: T) {
 }
 
 export function prometheusSpecialRegexEscape<T>(value: T) {
-  return typeof value === 'string' ? value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&') : value;
+  return typeof value === 'string'
+    ? value
+        .replace(/\\/g, '\\\\\\\\')
+        .replace(/"/g, '\\\\\\"')
+        .replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&')
+    : value;
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes both regular and regex variable escaping in the prometheus data source for templated queries which use variables that contain double or single quotation marks.

This PR also adds escaping for adhoc filter label queries which allows adhoc filters to handle label values which contain backslashes or quotation marks.

**Why do we need this feature?**

There are a number of bugs in the current escaping behaviour when interpolating variables for prometheus, which can cause issues when querying for data in prometheus that use special characters in label values, such as `'`, `"` or `\`.

For example, if we have the following prometheus metrics:

```
singlequote_escape_test{label="looking'glass"} 1
doublequote_escape_test{label="looking\"glass"} 1
```

And create the following grafana dashboard variables:

```json
  "templating": {
    "list": [
      {
        "current": {
          "selected": true,
          "text": "looking'glass",
          "value": "looking'glass"
        },
        "hide": 0,
        "includeAll": false,
        "multi": false,
        "name": "singlequote_var",
        "options": [
          {
            "selected": true,
            "text": "looking'glass",
            "value": "looking'glass"
          }
        ],
        "query": "looking'glass",
        "queryValue": "",
        "skipUrlSync": false,
        "type": "custom"
      },
      {
        "current": {
          "selected": true,
          "text": "looking\"glass",
          "value": "looking\"glass"
        },
        "hide": 0,
        "includeAll": false,
        "multi": false,
        "name": "doublequote_var",
        "options": [
          {
            "selected": true,
            "text": "looking\"glass",
            "value": "looking\"glass"
          }
        ],
        "query": "looking\"glass",
        "queryValue": "",
        "skipUrlSync": false,
        "type": "custom"
      }
    ]
  },
```

If we try to use these variables in the following promql queries wrapped with double quotation marks (as is predominately the case for promql queries):

```
singlequote_escape_test{label="${singlequote_var}"}
doublequote_escape_test{label="${doublequote_var}"}
```

These queries will be interpolated as follows and sent to prometheus which will either not return the expected result, or trigger an error:

```
Expr: singlequote_escape_test{label="looking\\'glass"}    0 rows
Expr: doublequote_escape_test{label="looking"glass"}      Status: 400. Message: bad_data: invalid parameter "query": 1:40: parse error: unexpected identifier "glass" in label matching, expected "," or "}"
````

There is also a similar issue with adhoc filters where the label query made to prometheus when adding additional filters wasn't being escaped, so the query to `/api/v1/labels` has a similar issue:

```
request:    match[]	{label="looking"glass"}
response:   {"status":"error","errorType":"bad_data","error":"1:17: parse error: unexpected identifier \"glass\" in label matching, expected \",\" or \"}\""}
```

This PR addresses all of the above issues and allows dashboards using the prometheus datasource to properly handle variables that may contain special characters. The are also a number of test cases added to catch future regressions.
