### PR TITLE
DashboardScene: Fixes preserve dashboard state for hidden options

### DIFF
--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
@@ -60,6 +60,19 @@ describe('dashboardSessionState', () => {
       expect(timeRange?.state.to).toEqual('now');
     });
 
+    it('should remove query params that start with _dash.hide', () => {
+      window.sessionStorage.setItem(
+        PRESERVED_SCENE_STATE_KEY,
+        '?var-customVar=b&from=now-5m&to=now&timezone=browser&_dash.hideTimePicker=true&_dash.hideVariables=true'
+      );
+      const scene = buildTestScene();
+
+      restoreDashboardStateFromLocalStorage(scene);
+      const location = locationService.getLocation();
+
+      expect(location.search).toBe('?var-customVar=b&from=now-5m&to=now&timezone=browser');
+    });
+
     it('should remove query params that are not applicable on a target dashboard', () => {
       window.sessionStorage.setItem(
         PRESERVED_SCENE_STATE_KEY,

--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
@@ -15,6 +15,11 @@ export function restoreDashboardStateFromLocalStorage(dashboard: DashboardScene)
 
     // iterate over preserved query params and append them to current query params if they don't already exist
     preservedQueryParams.forEach((value, key) => {
+      // ignore dashboard hide options
+      if (key.startsWith('_dash.hide')) {
+        return;
+      }
+
       if (!currentQueryParams.has(key)) {
         currentQueryParams.append(key, value);
       }


### PR DESCRIPTION
DashboardControls includes url state for ['_dash.hideTimePicker', '_dash.hideVariables', '_dash.hideLinks'], 

sadly these should really just be 1 time on init only synced, but we do not support 1 time only sync. 

And there seems to be some bugs int the preserve dashboard state code where it does not filter what keys to preserve but take all keys that have a value. 

https://github.com/grafana/grafana/blob/main/public/app/features/dashboard-scene/utils/dashboardSessionState.ts#L62

I think an alternative fix is using the filter there properly and only preserve the specific keys (variables and time range) 