### PR TITLE
DashboardScene: Alternative fix for only preserving specific url keys 

### DIFF
--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
@@ -60,19 +60,6 @@ describe('dashboardSessionState', () => {
       expect(timeRange?.state.to).toEqual('now');
     });
 
-    it('should remove query params that start with _dash.hide', () => {
-      window.sessionStorage.setItem(
-        PRESERVED_SCENE_STATE_KEY,
-        '?var-customVar=b&from=now-5m&to=now&timezone=browser&_dash.hideTimePicker=true&_dash.hideVariables=true'
-      );
-      const scene = buildTestScene();
-
-      restoreDashboardStateFromLocalStorage(scene);
-      const location = locationService.getLocation();
-
-      expect(location.search).toBe('?var-customVar=b&from=now-5m&to=now&timezone=browser');
-    });
-
     it('should remove query params that are not applicable on a target dashboard', () => {
       window.sessionStorage.setItem(
         PRESERVED_SCENE_STATE_KEY,

--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
@@ -60,6 +60,19 @@ describe('dashboardSessionState', () => {
       expect(timeRange?.state.to).toEqual('now');
     });
 
+    it('should remove query params that start with _dash.hide', () => {
+      window.sessionStorage.setItem(
+        PRESERVED_SCENE_STATE_KEY,
+        '?var-customVar=b&from=now-5m&to=now&timezone=browser&_dash.hideTimePicker=true&_dash.hideVariables=true'
+      );
+      const scene = buildTestScene();
+
+      restoreDashboardStateFromLocalStorage(scene);
+      const location = locationService.getLocation();
+
+      expect(location.search).toBe('?var-customVar=b&from=now-5m&to=now&timezone=browser');
+    });
+
     it('should remove query params that are not applicable on a target dashboard', () => {
       window.sessionStorage.setItem(
         PRESERVED_SCENE_STATE_KEY,

--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
@@ -15,11 +15,6 @@ export function restoreDashboardStateFromLocalStorage(dashboard: DashboardScene)
 
     // iterate over preserved query params and append them to current query params if they don't already exist
     preservedQueryParams.forEach((value, key) => {
-      // ignore dashboard hide options
-      if (key.startsWith('_dash.hide')) {
-        return;
-      }
-
       if (!currentQueryParams.has(key)) {
         currentQueryParams.append(key, value);
       }
@@ -64,13 +59,9 @@ export function preserveDashboardSceneStateInLocalStorage(scene: DashboardScene)
       )
     );
 
-    const nonEmptyUrlStates = Object.fromEntries(
-      Object.entries(urlStates).filter(([key, value]) => !(Array.isArray(value) && value.length === 0))
-    );
-
     // If there's anything to preserve, save it to local storage
-    if (Object.keys(nonEmptyUrlStates).length > 0) {
-      window.sessionStorage.setItem(PRESERVED_SCENE_STATE_KEY, urlUtil.renderUrl('', nonEmptyUrlStates));
+    if (Object.keys(urlStates).length > 0) {
+      window.sessionStorage.setItem(PRESERVED_SCENE_STATE_KEY, urlUtil.renderUrl('', urlStates));
     } else {
       window.sessionStorage.removeItem(PRESERVED_SCENE_STATE_KEY);
     }

--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.ts
@@ -15,6 +15,11 @@ export function restoreDashboardStateFromLocalStorage(dashboard: DashboardScene)
 
     // iterate over preserved query params and append them to current query params if they don't already exist
     preservedQueryParams.forEach((value, key) => {
+      // ignore dashboard hide options
+      if (key.startsWith('_dash.hide')) {
+        return;
+      }
+
       if (!currentQueryParams.has(key)) {
         currentQueryParams.append(key, value);
       }


### PR DESCRIPTION
Alt fix for https://github.com/grafana/grafana/pull/93420

Looks very strange that we have this urlStates that has the filter (only including variables and time range URL keys) but that is not used when setting PRESERVED_SCENE_STATE_KEY 

