### PR TITLE
Docs: Update Usage insights logs docs- Scope

### DIFF
--- a/docs/sources/setup-grafana/configure-security/export-logs.md
+++ b/docs/sources/setup-grafana/configure-security/export-logs.md
@@ -32,7 +32,11 @@ Usage insights logs are JSON objects that represent certain user activities, suc
 
 ### Scope
 
-A log is created every time a user opens a dashboard or when a query is sent to a data source in the dashboard view. A query that is performed via Explore does not generate a log.
+A log is created every time:
+
+- A user opens a dashboard.
+- A query is sent to a data source in the dashboard view.
+- A query is performed via Explore.
 
 ### Format
 


### PR DESCRIPTION
As far as I can tell, in https://github.com/grafana/grafana/pull/59931
we started to record Usage Insights events for Explore queries.
And in https://github.com/grafana/grafana/pull/78097 we further improved
our implementation of that logging.

This documentation should have been updated back then to match. So I'm
updating it now.
