### PR TITLE
Transformations: Fix crash in Config from query results

### DIFF
--- a/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
@@ -62,7 +62,7 @@ export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
   );
 
   const opts = options ?? {};
-  const isBool = isBooleanReducer(options.reducer);
+  const isBool = isBooleanReducer(options?.reducer);
 
   return (
     <div className={styles.spot}>

--- a/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
+++ b/packages/grafana-ui/src/components/MatchersUI/FieldValueMatcher.tsx
@@ -62,7 +62,7 @@ export const FieldValueMatcherEditor = ({ options, onChange }: Props) => {
   );
 
   const opts = options ?? {};
-  const isBool = isBooleanReducer(options?.reducer);
+  const isBool = isBooleanReducer(opts.reducer);
 
   return (
     <div className={styles.spot}>


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:


Fixes #93372
when config query is not choosed, choose `apply to` `Fields with Values`. there will be a crash.
 because `options` don't check is undefined or not
![image](https://github.com/user-attachments/assets/67c1755b-bc27-4a6e-a5b0-322666b0e832)



