### PR TITLE
feat(apiserver): add flag to control the request size limit

### DIFF
--- a/pkg/cmd/grafana/apiserver/server.go
+++ b/pkg/cmd/grafana/apiserver/server.go
@@ -84,7 +84,6 @@ func (o *APIServerOptions) Config(tracer tracing.Tracer) (*genericapiserver.Reco
 	}
 
 	o.Options.RecommendedOptions.Authentication.RemoteKubeConfigFileOptional = true
-
 	// TODO: determine authorization, currently insecure because Authorization provided by recommended options doesn't work
 	// reason: an aggregated server won't be able to post subjectaccessreviews (Grafana doesn't have this kind)
 	// exact error: the server could not find the requested resource (post subjectaccessreviews.authorization.k8s.io)

--- a/pkg/cmd/grafana/apiserver/server.go
+++ b/pkg/cmd/grafana/apiserver/server.go
@@ -84,6 +84,7 @@ func (o *APIServerOptions) Config(tracer tracing.Tracer) (*genericapiserver.Reco
 	}
 
 	o.Options.RecommendedOptions.Authentication.RemoteKubeConfigFileOptional = true
+
 	// TODO: determine authorization, currently insecure because Authorization provided by recommended options doesn't work
 	// reason: an aggregated server won't be able to post subjectaccessreviews (Grafana doesn't have this kind)
 	// exact error: the server could not find the requested resource (post subjectaccessreviews.authorization.k8s.io)

--- a/pkg/services/apiserver/standalone/options/options.go
+++ b/pkg/services/apiserver/standalone/options/options.go
@@ -201,7 +201,7 @@ func (o *Options) internalFlags(fs *pflag.FlagSet) {
 	// We also want to be able to set the MaxRequestSize by using flags. This is
 	// usually not exposed by k8s. The value is already set to the upstream default
 	// at this stage, so we can use it as the default.
-	// Reference: https://github.com/kubernetes/kubernetes/blob/7c599d37c0c3ae5b6455a94f19c0c17dcd031c6f/staging/src/k8s.io/apiserver/pkg/server/config.go#L453
+	// Reference: https://github.com/kubernetes/kubernetes/blob/v1.31.1/staging/src/k8s.io/apiserver/pkg/server/config.go#L453
 	fs.Int64Var(&o.ServerRunOptions.MaxRequestBodyBytes, "max-request-body-bytes",
 		o.ServerRunOptions.MaxRequestBodyBytes, ""+
 			"Specifies the maximum allowable size for a request payload sent to the API server in bytes."+

--- a/pkg/services/apiserver/standalone/options/options.go
+++ b/pkg/services/apiserver/standalone/options/options.go
@@ -209,7 +209,7 @@ func (o *Options) internalFlags(fs *pflag.FlagSet) {
 }
 
 func (o *Options) internalFlagsValidate() []error {
-	if o.ServerRunOptions.MaxRequestBodyBytes > 0 {
+	if o.ServerRunOptions.MaxRequestBodyBytes < 0 {
 		return []error{fmt.Errorf("--max-request-body-bytes can not be a negative value")}
 	}
 	return nil

--- a/pkg/services/apiserver/standalone/options/options.go
+++ b/pkg/services/apiserver/standalone/options/options.go
@@ -210,7 +210,7 @@ func (o *Options) internalFlags(fs *pflag.FlagSet) {
 
 func (o *Options) internalFlagsValidate() []error {
 	if o.ServerRunOptions.MaxRequestBodyBytes > 0 {
-		return []error{fmt.Errorf("--max-request-body-bytes can not be negative value")}
+		return []error{fmt.Errorf("--max-request-body-bytes can not be a negative value")}
 	}
 	return nil
 }

--- a/pkg/services/apiserver/standalone/options/options.go
+++ b/pkg/services/apiserver/standalone/options/options.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"fmt"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/spf13/pflag"
@@ -41,6 +43,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.MetricsOptions.AddFlags(fs)
 	o.ProfilingOptions.AddFlags(fs)
 	o.ServerRunOptions.AddUniversalFlags(fs)
+	o.internalFlags(fs)
 }
 
 func (o *Options) Validate() []error {
@@ -65,6 +68,10 @@ func (o *Options) Validate() []error {
 	}
 
 	if errs := o.ServerRunOptions.Validate(); len(errs) != 0 {
+		return errs
+	}
+
+	if errs := o.internalFlagsValidate(); len(errs) != 0 {
 		return errs
 	}
 
@@ -187,5 +194,23 @@ func (o *Options) ApplyTo(serverConfig *genericapiserver.RecommendedConfig) erro
 		}
 	}
 
+	return nil
+}
+
+func (o *Options) internalFlags(fs *pflag.FlagSet) {
+	// We also want to be able to set the MaxRequestSize by using flags. This is
+	// usually not exposed by k8s. The value is already set to the upstream default
+	// at this stage, so we can use it as the default.
+	// Reference: https://github.com/kubernetes/kubernetes/blob/7c599d37c0c3ae5b6455a94f19c0c17dcd031c6f/staging/src/k8s.io/apiserver/pkg/server/config.go#L453
+	fs.Int64Var(&o.ServerRunOptions.MaxRequestBodyBytes, "max-request-body-bytes",
+		o.ServerRunOptions.MaxRequestBodyBytes, ""+
+			"Specifies the maximum allowable size for a request payload sent to the API server in bytes."+
+			"The default is 3MB.")
+}
+
+func (o *Options) internalFlagsValidate() []error {
+	if o.ServerRunOptions.MaxRequestBodyBytes > 0 {
+		return []error{fmt.Errorf("--max-request-body-bytes can not be negative value")}
+	}
 	return nil
 }


### PR DESCRIPTION
This PR makes the request size limit configurable using a flag. This is not exposed by k8s normally, as they don't want users to meddle with it due to the restrictions that etcd comes with. We don't use etcd and want to save bigger payloads than 3mb, so we will need to bump this. 

This might not work with aggregations to our current knowledge, but is not relevant for our current use case. 