### PR TITLE
AuthN: Introduce `DefaultOrgID` function for managed service accounts

### DIFF
--- a/pkg/services/accesscontrol/database/externalservices.go
+++ b/pkg/services/accesscontrol/database/externalservices.go
@@ -230,7 +230,7 @@ func (*AccessControlStore) savePermissions(ctx context.Context, sess *db.Session
 	return nil
 }
 
-func (s *AccessControlStore) saveUserAssignment(ctx context.Context, sess *db.Session, assignment accesscontrol.UserRole) error {
+func (*AccessControlStore) saveUserAssignment(ctx context.Context, sess *db.Session, assignment accesscontrol.UserRole) error {
 	ctx, span := tracer.Start(ctx, "accesscontrol.database.saveUserAssignment")
 	defer span.End()
 

--- a/pkg/services/accesscontrol/database/externalservices.go
+++ b/pkg/services/accesscontrol/database/externalservices.go
@@ -230,7 +230,7 @@ func (*AccessControlStore) savePermissions(ctx context.Context, sess *db.Session
 	return nil
 }
 
-func (*AccessControlStore) saveUserAssignment(ctx context.Context, sess *db.Session, assignment accesscontrol.UserRole) error {
+func (s *AccessControlStore) saveUserAssignment(ctx context.Context, sess *db.Session, assignment accesscontrol.UserRole) error {
 	ctx, span := tracer.Start(ctx, "accesscontrol.database.saveUserAssignment")
 	defer span.End()
 
@@ -240,16 +240,20 @@ func (*AccessControlStore) saveUserAssignment(ctx context.Context, sess *db.Sess
 		return errGetAssigns
 	}
 
+	// Revoke assignment if it's assigned to another user or service account
+	if len(assignments) > 0 && assignments[0].UserID != assignment.UserID {
+		if _, errDel := sess.Where("role_id = ?", assignment.RoleID).Delete(&accesscontrol.UserRole{}); errDel != nil {
+			return errDel
+		}
+		assignments = nil
+	}
+
+	// If no assignment exists, insert a new one.
 	if len(assignments) == 0 {
 		if _, errInsert := sess.Insert(&assignment); errInsert != nil {
 			return errInsert
 		}
 		return nil
-	}
-
-	// Ensure the role was assigned only to this service account
-	if len(assignments) > 1 || assignments[0].UserID != assignment.UserID {
-		return errors.New("external service role assigned to another user or service account")
 	}
 
 	// Ensure the assignment is in the correct organization

--- a/pkg/services/accesscontrol/database/externalservices_test.go
+++ b/pkg/services/accesscontrol/database/externalservices_test.go
@@ -103,10 +103,10 @@ func TestAccessControlStore_SaveExternalServiceRole(t *testing.T) {
 				{
 					cmd: accesscontrol.SaveExternalServiceRoleCommand{
 						ExternalServiceID: "app1",
-						AssignmentOrgID:   1,
+						AssignmentOrgID:   2,
 						ServiceAccountID:  2,
 					},
-					wantErr: true,
+					wantErr: false,
 				},
 			},
 		},

--- a/pkg/services/extsvcauth/models.go
+++ b/pkg/services/extsvcauth/models.go
@@ -4,15 +4,20 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 const (
 	ServiceAccounts AuthProvider = "ServiceAccounts"
-
-	// TmpOrgID is the orgID we use while global service accounts are not supported.
-	TmpOrgIDStr string = "1"
-	TmpOrgID    int64  = 1
 )
+
+func DefaultOrgID(cfg *setting.Cfg) int64 {
+	defaultOrgID := int64(cfg.AutoAssignOrgId)
+	if defaultOrgID == 0 {
+		defaultOrgID = 1
+	}
+	return defaultOrgID
+}
 
 type AuthProvider string
 

--- a/pkg/services/extsvcauth/models.go
+++ b/pkg/services/extsvcauth/models.go
@@ -12,11 +12,11 @@ const (
 )
 
 func DefaultOrgID(cfg *setting.Cfg) int64 {
-	defaultOrgID := int64(cfg.AutoAssignOrgId)
-	if defaultOrgID == 0 {
-		defaultOrgID = 1
+	orgID := int64(1)
+	if cfg.AutoAssignOrg && cfg.AutoAssignOrgId > 0 {
+		orgID = int64(cfg.AutoAssignOrgId)
 	}
-	return defaultOrgID
+	return orgID
 }
 
 type AuthProvider string

--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -334,7 +334,7 @@ func (s *ServiceAccountsStoreImpl) SearchOrgServiceAccounts(ctx context.Context,
 			whereConditions = append(
 				whereConditions,
 				"login "+s.sqlStore.GetDialect().LikeStr()+" ?")
-			whereParams = append(whereParams, serviceaccounts.ExtSvcLoginPrefix+"%")
+			whereParams = append(whereParams, serviceaccounts.ExtSvcLoginPrefix(query.OrgID)+"%")
 		default:
 			s.log.Warn("Invalid filter user for service account filtering", "service account search filtering", query.Filter)
 		}

--- a/pkg/services/serviceaccounts/extsvcaccounts/metrics.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/metrics.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -16,7 +15,7 @@ type metrics struct {
 	deletedCount prometheus.Counter
 }
 
-func newMetrics(reg prometheus.Registerer, saSvc serviceaccounts.Service, logger log.Logger) *metrics {
+func newMetrics(reg prometheus.Registerer, defaultOrgID int64, saSvc serviceaccounts.Service, logger log.Logger) *metrics {
 	var m metrics
 
 	m.storedCount = prometheus.NewGaugeFunc(
@@ -29,10 +28,10 @@ func newMetrics(reg prometheus.Registerer, saSvc serviceaccounts.Service, logger
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			res, err := saSvc.SearchOrgServiceAccounts(ctx, &serviceaccounts.SearchOrgServiceAccountsQuery{
-				OrgID:        extsvcauth.TmpOrgID,
+				OrgID:        defaultOrgID,
 				Filter:       serviceaccounts.FilterOnlyExternal,
 				CountOnly:    true,
-				SignedInUser: extsvcuser,
+				SignedInUser: extsvcuser(defaultOrgID),
 			})
 			if err != nil {
 				logger.Error("Could not compute extsvc_total metric", "error", err)

--- a/pkg/services/serviceaccounts/extsvcaccounts/models.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/models.go
@@ -4,7 +4,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -28,14 +27,16 @@ var (
 	ErrCredentialsGenFailed = errutil.Internal("extsvcaccounts.ErrCredentialsGenFailed")
 	ErrCredentialsNotFound  = errutil.NotFound("extsvcaccounts.ErrCredentialsNotFound")
 	ErrInvalidName          = errutil.BadRequest("extsvcaccounts.ErrInvalidName", errutil.WithPublicMessage("only external service account names can be prefixed with 'extsvc-'"))
+)
 
-	extsvcuser = &user.SignedInUser{
-		OrgID: extsvcauth.TmpOrgID,
+func extsvcuser(orgID int64) *user.SignedInUser {
+	return &user.SignedInUser{
+		OrgID: orgID,
 		Permissions: map[int64]map[string][]string{
-			extsvcauth.TmpOrgID: {serviceaccounts.ActionRead: {"serviceaccounts:id:*"}},
+			orgID: {serviceaccounts.ActionRead: {"serviceaccounts:id:*"}},
 		},
 	}
-)
+}
 
 // Credentials represents the credentials associated to an external service
 type Credentials struct {

--- a/pkg/services/serviceaccounts/extsvcaccounts/service_test.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/service_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+var (
+	autoAssignOrgID = int64(2)
+)
+
 type TestEnv struct {
 	S        *ExtSvcAccountsService
 	AcStore  *actest.MockStore
@@ -51,12 +55,13 @@ func setupTestEnv(t *testing.T) *TestEnv {
 			localcache.New(0, 0), fmgt, tracing.InitializeTracerForTest(), nil, nil,
 			permreg.ProvidePermissionRegistry(),
 		),
-		features: fmgt,
-		logger:   logger,
-		metrics:  newMetrics(nil, env.SaSvc, logger),
-		saSvc:    env.SaSvc,
-		skvStore: env.SkvStore,
-		tracer:   tracing.InitializeTracerForTest(),
+		defaultOrgID: autoAssignOrgID,
+		features:     fmgt,
+		logger:       logger,
+		metrics:      newMetrics(nil, autoAssignOrgID, env.SaSvc, logger),
+		saSvc:        env.SaSvc,
+		skvStore:     env.SkvStore,
+		tracer:       tracing.InitializeTracerForTest(),
 	}
 	return env
 }
@@ -207,14 +212,13 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 	extSvcSlug := "grafana-test-app"
 	validToken, err := satokengen.New(extSvcSlug)
 	require.NoError(t, err, "failed to generate a valid token for the tests")
-	tmpOrgID := int64(1)
 	extSvcAccID := int64(10)
 	extSvcPerms := []ac.Permission{{Action: ac.ActionUsersRead, Scope: ac.ScopeUsersAll}}
 	extSvcAccount := &sa.ServiceAccountDTO{
 		Id:         extSvcAccID,
 		Name:       extSvcSlug,
 		Login:      extSvcSlug,
-		OrgId:      tmpOrgID,
+		OrgId:      autoAssignOrgID,
 		IsDisabled: false,
 		Role:       string(identity.RoleNone),
 	}
@@ -231,19 +235,19 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 			name: "should disable service account",
 			init: func(env *TestEnv) {
 				// A previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(extSvcAccID, nil)
-				env.SaSvc.On("EnableServiceAccount", mock.Anything, tmpOrgID, extSvcAccID, false).Return(nil)
+				env.SaSvc.On("EnableServiceAccount", mock.Anything, autoAssignOrgID, extSvcAccID, false).Return(nil)
 				env.AcStore.On("SaveExternalServiceRole",
 					mock.Anything,
 					mock.MatchedBy(func(cmd ac.SaveExternalServiceRoleCommand) bool {
 						return cmd.ServiceAccountID == extSvcAccID && cmd.ExternalServiceID == extSvcSlug &&
-							cmd.AssignmentOrgID == tmpOrgID && len(cmd.Permissions) == 1 &&
+							cmd.AssignmentOrgID == autoAssignOrgID && len(cmd.Permissions) == 1 &&
 							cmd.Permissions[0] == extSvcPerms[0]
 					})).
 					Return(nil)
 				// A token was previously stored in the secret store
-				_ = env.SkvStore.Set(context.Background(), tmpOrgID, extSvcSlug, kvStoreType, validToken.ClientSecret)
+				_ = env.SkvStore.Set(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType, validToken.ClientSecret)
 			},
 			cmd: extsvcauth.ExternalServiceRegistration{
 				Name: extSvcSlug,
@@ -253,7 +257,7 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 				},
 			},
 			checks: func(t *testing.T, env *TestEnv) {
-				_, ok, _ := env.SkvStore.Get(context.Background(), tmpOrgID, extSvcSlug, kvStoreType)
+				_, ok, _ := env.SkvStore.Get(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType)
 				require.True(t, ok, "secret should have been kept in store")
 			},
 			want: &extsvcauth.ExternalService{
@@ -267,12 +271,12 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 			name: "should remove service account when no permission",
 			init: func(env *TestEnv) {
 				// A previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(extSvcAccID, nil)
-				env.SaSvc.On("DeleteServiceAccount", mock.Anything, tmpOrgID, extSvcAccID).Return(nil)
+				env.SaSvc.On("DeleteServiceAccount", mock.Anything, autoAssignOrgID, extSvcAccID).Return(nil)
 				env.AcStore.On("DeleteExternalServiceRole", mock.Anything, extSvcSlug).Return(nil)
 				// A token was previously stored in the secret store
-				_ = env.SkvStore.Set(context.Background(), tmpOrgID, extSvcSlug, kvStoreType, validToken.ClientSecret)
+				_ = env.SkvStore.Set(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType, validToken.ClientSecret)
 			},
 			cmd: extsvcauth.ExternalServiceRegistration{
 				Name: extSvcSlug,
@@ -282,7 +286,7 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 				},
 			},
 			checks: func(t *testing.T, env *TestEnv) {
-				_, ok, _ := env.SkvStore.Get(context.Background(), tmpOrgID, extSvcSlug, kvStoreType)
+				_, ok, _ := env.SkvStore.Get(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType)
 				require.False(t, ok, "secret should have been removed from store")
 			},
 			want:    nil,
@@ -292,23 +296,23 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 			name: "should create new service account",
 			init: func(env *TestEnv) {
 				// No previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(int64(0), sa.ErrServiceAccountNotFound.Errorf("mock"))
 				env.SaSvc.On("CreateServiceAccount",
 					mock.Anything,
-					tmpOrgID,
+					autoAssignOrgID,
 					mock.MatchedBy(func(cmd *sa.CreateServiceAccountForm) bool {
 						return cmd.Name == sa.ExtSvcPrefix+extSvcSlug && *cmd.Role == identity.RoleNone
 					})).
 					Return(extSvcAccount, nil)
-				env.SaSvc.On("EnableServiceAccount", mock.Anything, tmpOrgID, extSvcAccID, true).Return(nil)
+				env.SaSvc.On("EnableServiceAccount", mock.Anything, autoAssignOrgID, extSvcAccID, true).Return(nil)
 				// Api Key was added without problem
 				env.SaSvc.On("AddServiceAccountToken", mock.Anything, mock.Anything, mock.Anything).Return(&apikey.APIKey{}, nil)
 				env.AcStore.On("SaveExternalServiceRole",
 					mock.Anything,
 					mock.MatchedBy(func(cmd ac.SaveExternalServiceRoleCommand) bool {
 						return cmd.ServiceAccountID == extSvcAccount.Id && cmd.ExternalServiceID == extSvcSlug &&
-							cmd.AssignmentOrgID == tmpOrgID && len(cmd.Permissions) == 1 &&
+							cmd.AssignmentOrgID == autoAssignOrgID && len(cmd.Permissions) == 1 &&
 							cmd.Permissions[0] == extSvcPerms[0]
 					})).
 					Return(nil)
@@ -331,19 +335,19 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 			name: "should update service account",
 			init: func(env *TestEnv) {
 				// A previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(int64(11), nil)
 				env.AcStore.On("SaveExternalServiceRole",
 					mock.Anything,
 					mock.MatchedBy(func(cmd ac.SaveExternalServiceRoleCommand) bool {
 						return cmd.ServiceAccountID == int64(11) && cmd.ExternalServiceID == extSvcSlug &&
-							cmd.AssignmentOrgID == tmpOrgID && len(cmd.Permissions) == 1 &&
+							cmd.AssignmentOrgID == autoAssignOrgID && len(cmd.Permissions) == 1 &&
 							cmd.Permissions[0] == extSvcPerms[0]
 					})).
 					Return(nil)
-				env.SaSvc.On("EnableServiceAccount", mock.Anything, extsvcauth.TmpOrgID, int64(11), true).Return(nil)
+				env.SaSvc.On("EnableServiceAccount", mock.Anything, autoAssignOrgID, int64(11), true).Return(nil)
 				// This time we don't add a token but rely on the secret store
-				_ = env.SkvStore.Set(context.Background(), tmpOrgID, extSvcSlug, kvStoreType, validToken.ClientSecret)
+				_ = env.SkvStore.Set(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType, validToken.ClientSecret)
 			},
 			cmd: extsvcauth.ExternalServiceRegistration{
 				Name: extSvcSlug,
@@ -363,20 +367,20 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 			name: "should recover from a failed token encryption",
 			init: func(env *TestEnv) {
 				// A previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(int64(11), nil)
 				env.AcStore.On("SaveExternalServiceRole",
 					mock.Anything,
 					mock.MatchedBy(func(cmd ac.SaveExternalServiceRoleCommand) bool {
 						return cmd.ServiceAccountID == int64(11) && cmd.ExternalServiceID == extSvcSlug &&
-							cmd.AssignmentOrgID == tmpOrgID && len(cmd.Permissions) == 1 &&
+							cmd.AssignmentOrgID == autoAssignOrgID && len(cmd.Permissions) == 1 &&
 							cmd.Permissions[0] == extSvcPerms[0]
 					})).
 					Return(nil)
-				env.SaSvc.On("EnableServiceAccount", mock.Anything, extsvcauth.TmpOrgID, int64(11), true).Return(nil)
+				env.SaSvc.On("EnableServiceAccount", mock.Anything, autoAssignOrgID, int64(11), true).Return(nil)
 
 				// This time the token in the secret store is invalid
-				_ = env.SkvStore.Set(context.Background(), tmpOrgID, extSvcSlug, kvStoreType, "failedTokenEncryption")
+				_ = env.SkvStore.Set(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType, "failedTokenEncryption")
 				// Delete the API key and entry in the skv store
 				env.SaSvc.On("ListTokens", mock.Anything, mock.Anything).
 					Return([]apikey.APIKey{{ID: 3, Name: tokenNamePrefix + "-" + extSvcSlug}}, nil)
@@ -386,7 +390,7 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 			},
 			checks: func(t *testing.T, env *TestEnv) {
 				// Make sure the secret was updated
-				v, ok, _ := env.SkvStore.Get(context.Background(), tmpOrgID, extSvcSlug, kvStoreType)
+				v, ok, _ := env.SkvStore.Get(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType)
 				require.True(t, ok, "secret should have been removed from store")
 				require.NotEqual(t, "failedTokenEncryption", v)
 			},
@@ -439,7 +443,7 @@ func TestExtSvcAccountsService_SaveExternalService(t *testing.T) {
 
 func TestExtSvcAccountsService_RemoveExtSvcAccount(t *testing.T) {
 	extSvcSlug := "grafana-test-app"
-	tmpOrgID := int64(1)
+	autoAssignOrgID := int64(1)
 	extSvcAccID := int64(10)
 	tests := []struct {
 		name   string
@@ -452,7 +456,7 @@ func TestExtSvcAccountsService_RemoveExtSvcAccount(t *testing.T) {
 			name: "should not fail if the service account does not exist",
 			init: func(env *TestEnv) {
 				// No previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(int64(0), sa.ErrServiceAccountNotFound.Errorf("not found"))
 			},
 			slug: extSvcSlug,
@@ -462,16 +466,16 @@ func TestExtSvcAccountsService_RemoveExtSvcAccount(t *testing.T) {
 			name: "should remove service account",
 			init: func(env *TestEnv) {
 				// A previous service account was attached to this slug
-				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, tmpOrgID, sa.ExtSvcPrefix+extSvcSlug).
+				env.SaSvc.On("RetrieveServiceAccountIdByName", mock.Anything, autoAssignOrgID, sa.ExtSvcPrefix+extSvcSlug).
 					Return(extSvcAccID, nil)
-				env.SaSvc.On("DeleteServiceAccount", mock.Anything, tmpOrgID, extSvcAccID).Return(nil)
+				env.SaSvc.On("DeleteServiceAccount", mock.Anything, autoAssignOrgID, extSvcAccID).Return(nil)
 				env.AcStore.On("DeleteExternalServiceRole", mock.Anything, extSvcSlug).Return(nil)
 				// A token was previously stored in the secret store
-				_ = env.SkvStore.Set(context.Background(), tmpOrgID, extSvcSlug, kvStoreType, "ExtSvcSecretToken")
+				_ = env.SkvStore.Set(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType, "ExtSvcSecretToken")
 			},
 			slug: extSvcSlug,
 			checks: func(t *testing.T, env *TestEnv) {
-				_, ok, _ := env.SkvStore.Get(context.Background(), tmpOrgID, extSvcSlug, kvStoreType)
+				_, ok, _ := env.SkvStore.Get(context.Background(), autoAssignOrgID, extSvcSlug, kvStoreType)
 				require.False(t, ok, "secret should have been removed from store")
 			},
 			want: nil,
@@ -486,7 +490,7 @@ func TestExtSvcAccountsService_RemoveExtSvcAccount(t *testing.T) {
 				tt.init(env)
 			}
 
-			err := env.S.RemoveExtSvcAccount(ctx, tmpOrgID, tt.slug)
+			err := env.S.RemoveExtSvcAccount(ctx, autoAssignOrgID, tt.slug)
 			require.NoError(t, err)
 
 			if tt.checks != nil {
@@ -501,15 +505,15 @@ func TestExtSvcAccountsService_RemoveExtSvcAccount(t *testing.T) {
 func TestExtSvcAccountsService_GetExternalServiceNames(t *testing.T) {
 	sa1 := sa.ServiceAccountDTO{
 		Id:    1,
-		Name:  sa.ExtSvcPrefix + "sa-svc-1",
-		Login: sa.ExtSvcLoginPrefix + "sa-svc-1",
-		OrgId: extsvcauth.TmpOrgID,
+		Name:  sa.ExtSvcPrefix + "svc-1",
+		Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "svc-1",
+		OrgId: autoAssignOrgID,
 	}
 	sa2 := sa.ServiceAccountDTO{
 		Id:    2,
-		Name:  sa.ExtSvcPrefix + "sa-svc-2",
-		Login: sa.ExtSvcLoginPrefix + "sa-svc-2",
-		OrgId: extsvcauth.TmpOrgID,
+		Name:  sa.ExtSvcPrefix + "svc-2",
+		Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "svc-2",
+		OrgId: autoAssignOrgID,
 	}
 	tests := []struct {
 		name string
@@ -520,7 +524,7 @@ func TestExtSvcAccountsService_GetExternalServiceNames(t *testing.T) {
 			name: "should return names",
 			init: func(env *TestEnv) {
 				env.SaSvc.On("SearchOrgServiceAccounts", mock.Anything, mock.MatchedBy(func(cmd *sa.SearchOrgServiceAccountsQuery) bool {
-					return cmd.OrgID == extsvcauth.TmpOrgID &&
+					return cmd.OrgID == autoAssignOrgID &&
 						cmd.Filter == sa.FilterOnlyExternal &&
 						len(cmd.SignedInUser.GetPermissions()[sa.ActionRead]) > 0
 				})).Return(&sa.SearchOrgServiceAccountsResult{
@@ -530,13 +534,13 @@ func TestExtSvcAccountsService_GetExternalServiceNames(t *testing.T) {
 					PerPage:         2,
 				}, nil)
 			},
-			want: []string{"sa-svc-1", "sa-svc-2"},
+			want: []string{"svc-1", "svc-2"},
 		},
 		{
 			name: "should handle nil search",
 			init: func(env *TestEnv) {
 				env.SaSvc.On("SearchOrgServiceAccounts", mock.Anything, mock.MatchedBy(func(cmd *sa.SearchOrgServiceAccountsQuery) bool {
-					return cmd.OrgID == extsvcauth.TmpOrgID &&
+					return cmd.OrgID == autoAssignOrgID &&
 						cmd.Filter == sa.FilterOnlyExternal &&
 						len(cmd.SignedInUser.GetPermissions()[sa.ActionRead]) > 0
 				})).Return(nil, nil)

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -219,7 +219,7 @@ func IsExternalServiceAccount(login string) bool {
 		return false
 	}
 
-	if parts[0] != ServiceAccountPrefix || parts[2] != ExtSvcPrefix {
+	if parts[0]+"-" != ServiceAccountPrefix || parts[2]+"-" != ExtSvcPrefix {
 		return false
 	}
 

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -214,19 +214,9 @@ func ExtSvcLoginPrefix(orgID int64) string {
 
 func IsExternalServiceAccount(login string) bool {
 	parts := strings.Split(login, "-")
-
 	if len(parts) < 4 {
 		return false
 	}
 
-	if parts[0]+"-" != ServiceAccountPrefix || parts[2]+"-" != ExtSvcPrefix {
-		return false
-	}
-
-	// The orgID must be a number
-	if _, err := strconv.ParseInt(parts[1], 10, 64); err != nil {
-		return false
-	}
-
-	return true
+	return parts[0]+"-" == ServiceAccountPrefix && parts[2]+"-" == ExtSvcPrefix
 }

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -2,7 +2,6 @@ package serviceaccounts
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -213,10 +212,10 @@ func ExtSvcLoginPrefix(orgID int64) string {
 }
 
 func IsExternalServiceAccount(login string) bool {
-	parts := strings.Split(login, "-")
+	parts := strings.SplitAfter(login, "-")
 	if len(parts) < 4 {
 		return false
 	}
 
-	return parts[0]+"-" == ServiceAccountPrefix && parts[2]+"-" == ExtSvcPrefix
+	return parts[0] == ServiceAccountPrefix && parts[2] == ExtSvcPrefix
 }

--- a/pkg/services/serviceaccounts/models_test.go
+++ b/pkg/services/serviceaccounts/models_test.go
@@ -1,0 +1,42 @@
+package serviceaccounts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExternalServiceAccount(t *testing.T) {
+	tests := []struct {
+		name  string
+		login string
+		want  bool
+	}{
+		{
+			name:  "external service account",
+			login: "sa-1-extsvc-test",
+			want:  true,
+		},
+		{
+			name:  "not external service account (too short)",
+			login: "sa-1-test",
+			want:  false,
+		},
+		{
+			name:  "not external service account (wrong sa prefix)",
+			login: "saN-1-extsvc-",
+			want:  false,
+		},
+		{
+			name:  "not external service account (wrong extsvc prefix)",
+			login: "sa-1-extsvcN-",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsExternalServiceAccount(tt.login)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/services/serviceaccounts/models_test.go
+++ b/pkg/services/serviceaccounts/models_test.go
@@ -24,12 +24,12 @@ func TestIsExternalServiceAccount(t *testing.T) {
 		},
 		{
 			name:  "not external service account (wrong sa prefix)",
-			login: "saN-1-extsvc-",
+			login: "saN-1-extsvc-test",
 			want:  false,
 		},
 		{
 			name:  "not external service account (wrong extsvc prefix)",
-			login: "sa-1-extsvcN-",
+			login: "sa-1-extsvcN-test",
 			want:  false,
 		},
 	}

--- a/pkg/services/serviceaccounts/proxy/service.go
+++ b/pkg/services/serviceaccounts/proxy/service.go
@@ -56,7 +56,7 @@ func (s *ServiceAccountsProxy) AddServiceAccountToken(ctx context.Context, servi
 			return nil, err
 		}
 
-		if isExternalServiceAccount(sa.Login) {
+		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to create tokens for external service accounts", "serviceAccountID", serviceAccountID)
 			return nil, extsvcaccounts.ErrCannotCreateToken
 		}
@@ -82,7 +82,7 @@ func (s *ServiceAccountsProxy) DeleteServiceAccount(ctx context.Context, orgID, 
 			return err
 		}
 
-		if isExternalServiceAccount(sa.Login) {
+		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to delete external service accounts", "serviceAccountID", serviceAccountID)
 			return extsvcaccounts.ErrCannotBeDeleted
 		}
@@ -97,7 +97,7 @@ func (s *ServiceAccountsProxy) DeleteServiceAccountToken(ctx context.Context, or
 			return err
 		}
 
-		if isExternalServiceAccount(sa.Login) {
+		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to delete tokens for external service accounts", "serviceAccountID", serviceAccountID)
 			return extsvcaccounts.ErrCannotDeleteToken
 		}
@@ -111,7 +111,7 @@ func (s *ServiceAccountsProxy) EnableServiceAccount(ctx context.Context, orgID i
 		if err != nil {
 			return err
 		}
-		if isExternalServiceAccount(sa.Login) {
+		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to enable/disable external service accounts", "serviceAccountID", serviceAccountID)
 			return extsvcaccounts.ErrCannotBeUpdated
 		}
@@ -138,7 +138,7 @@ func (s *ServiceAccountsProxy) RetrieveServiceAccount(ctx context.Context, orgID
 	}
 
 	if s.isProxyEnabled {
-		sa.IsExternal = isExternalServiceAccount(sa.Login)
+		sa.IsExternal = serviceaccounts.IsExternalServiceAccount(sa.Login)
 		sa.RequiredBy = strings.ReplaceAll(sa.Name, serviceaccounts.ExtSvcPrefix, "")
 	}
 
@@ -159,7 +159,7 @@ func (s *ServiceAccountsProxy) UpdateServiceAccount(ctx context.Context, orgID, 
 		if err != nil {
 			return nil, err
 		}
-		if isExternalServiceAccount(sa.Login) {
+		if serviceaccounts.IsExternalServiceAccount(sa.Login) {
 			s.log.Error("unable to update external service accounts", "serviceAccountID", serviceAccountID)
 			return nil, extsvcaccounts.ErrCannotBeUpdated
 		}
@@ -176,7 +176,7 @@ func (s *ServiceAccountsProxy) SearchOrgServiceAccounts(ctx context.Context, que
 
 	if s.isProxyEnabled {
 		for i := range sa.ServiceAccounts {
-			sa.ServiceAccounts[i].IsExternal = isExternalServiceAccount(sa.ServiceAccounts[i].Login)
+			sa.ServiceAccounts[i].IsExternal = serviceaccounts.IsExternalServiceAccount(sa.ServiceAccounts[i].Login)
 		}
 	}
 	return sa, nil
@@ -184,8 +184,4 @@ func (s *ServiceAccountsProxy) SearchOrgServiceAccounts(ctx context.Context, que
 
 func isNameValid(name string) bool {
 	return !strings.HasPrefix(name, serviceaccounts.ExtSvcPrefix)
-}
-
-func isExternalServiceAccount(login string) bool {
-	return strings.HasPrefix(login, serviceaccounts.ExtSvcLoginPrefix)
 }

--- a/pkg/services/serviceaccounts/proxy/service_test.go
+++ b/pkg/services/serviceaccounts/proxy/service_test.go
@@ -20,7 +20,6 @@ var (
 )
 
 func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
-	testOrgId := int64(1)
 	testServiceAccountId := int64(1)
 	testServiceAccountTokenId := int64(1)
 	serviceMock := &tests.FakeServiceAccountService{}
@@ -55,7 +54,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.description, func(t *testing.T) {
 				tc := tc
-				_, err := svc.CreateServiceAccount(context.Background(), testOrgId, &tc.form)
+				_, err := svc.CreateServiceAccount(context.Background(), autoAssignOrgID, &tc.form)
 				assert.Equal(t, err, tc.expectedError, tc.description)
 			})
 		}
@@ -86,7 +85,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.description, func(t *testing.T) {
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
-				err := svc.DeleteServiceAccount(context.Background(), testOrgId, testServiceAccountId)
+				err := svc.DeleteServiceAccount(context.Background(), autoAssignOrgID, testServiceAccountId)
 				assert.Equal(t, err, tc.expectedError, tc.description)
 			})
 		}
@@ -117,7 +116,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.description, func(t *testing.T) {
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
-				err := svc.DeleteServiceAccountToken(context.Background(), testOrgId, testServiceAccountId, testServiceAccountTokenId)
+				err := svc.DeleteServiceAccountToken(context.Background(), autoAssignOrgID, testServiceAccountId, testServiceAccountTokenId)
 				assert.Equal(t, err, tc.expectedError, tc.description)
 			})
 		}
@@ -148,7 +147,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.description, func(t *testing.T) {
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
-				sa, err := svc.RetrieveServiceAccount(context.Background(), testOrgId, testServiceAccountId)
+				sa, err := svc.RetrieveServiceAccount(context.Background(), autoAssignOrgID, testServiceAccountId)
 				assert.NoError(t, err, tc.description)
 				assert.Equal(t, tc.expectedIsExternal, sa.IsExternal, tc.description)
 			})
@@ -227,7 +226,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			t.Run(tc.description, func(t *testing.T) {
 				tc := tc
 				serviceMock.ExpectedServiceAccountProfile = tc.expectedServiceAccount
-				_, err := svc.UpdateServiceAccount(context.Background(), testOrgId, testServiceAccountId, &tc.form)
+				_, err := svc.UpdateServiceAccount(context.Background(), autoAssignOrgID, testServiceAccountId, &tc.form)
 				assert.Equal(t, tc.expectedError, err, tc.description)
 			})
 		}
@@ -243,7 +242,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			{
 				description: "should allow to create a service account token",
 				cmd: sa.AddServiceAccountTokenCommand{
-					OrgId: testOrgId,
+					OrgId: autoAssignOrgID,
 				},
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
 					Login: "my-service-account",
@@ -253,7 +252,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			{
 				description: "should not allow to create a service account token",
 				cmd: sa.AddServiceAccountTokenCommand{
-					OrgId: testOrgId,
+					OrgId: autoAssignOrgID,
 				},
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
 					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",

--- a/pkg/services/serviceaccounts/proxy/service_test.go
+++ b/pkg/services/serviceaccounts/proxy/service_test.go
@@ -13,7 +13,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
 )
 
-var _ sa.Service = (*tests.FakeServiceAccountService)(nil)
+var (
+	_ sa.Service = (*tests.FakeServiceAccountService)(nil)
+
+	autoAssignOrgID = int64(2)
+)
 
 func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 	testOrgId := int64(1)
@@ -71,10 +75,10 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 				},
 			},
 			{
-				description:   "should not allow to delete a service account with " + sa.ExtSvcLoginPrefix + " prefix",
+				description:   "should not allow to delete a service account with " + sa.ExtSvcLoginPrefix(autoAssignOrgID) + " prefix",
 				expectedError: extsvcaccounts.ErrCannotBeDeleted,
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
-					Login: sa.ExtSvcLoginPrefix + "my-service-account",
+					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",
 				},
 			},
 		}
@@ -105,7 +109,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 				description:   "should not allow to delete a external service account token",
 				expectedError: extsvcaccounts.ErrCannotDeleteToken,
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
-					Login: sa.ExtSvcLoginPrefix + "my-service-account",
+					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",
 				},
 			},
 		}
@@ -135,7 +139,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			{
 				description: "should mark as external",
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
-					Login: sa.ExtSvcLoginPrefix + "my-service-account",
+					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",
 				},
 				expectedIsExternal: true,
 			},
@@ -156,7 +160,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 			TotalCount: 2,
 			ServiceAccounts: []*sa.ServiceAccountDTO{
 				{Login: "test"},
-				{Login: sa.ExtSvcLoginPrefix + "test"},
+				{Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "test"},
 			},
 			Page:    1,
 			PerPage: 2,
@@ -203,7 +207,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 					Name: &nameWithoutProtectedPrefix,
 				},
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
-					Login: sa.ExtSvcLoginPrefix + "my-service-account",
+					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",
 				},
 				expectedError: extsvcaccounts.ErrCannotBeUpdated,
 			},
@@ -213,7 +217,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 					Name: &nameWithProtectedPrefix,
 				},
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
-					Login: sa.ExtSvcLoginPrefix + "my-service-account",
+					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",
 				},
 				expectedError: extsvcaccounts.ErrInvalidName,
 			},
@@ -252,7 +256,7 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 					OrgId: testOrgId,
 				},
 				expectedServiceAccount: &sa.ServiceAccountProfileDTO{
-					Login: sa.ExtSvcLoginPrefix + "my-service-account",
+					Login: sa.ExtSvcLoginPrefix(autoAssignOrgID) + "my-service-account",
 				},
 				expectedError: extsvcaccounts.ErrCannotCreateToken,
 			},
@@ -269,9 +273,9 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 	})
 
 	t.Run("should identify service account logins for being external or not", func(t *testing.T) {
-		assert.False(t, isExternalServiceAccount("my-service-account"))
-		assert.False(t, isExternalServiceAccount("sa-my-service-account"))
-		assert.False(t, isExternalServiceAccount(sa.ExtSvcPrefix+"my-service-account")) // It's not a external service account login
-		assert.True(t, isExternalServiceAccount(sa.ExtSvcLoginPrefix+"my-service-account"))
+		assert.False(t, sa.IsExternalServiceAccount("my-service-account"))
+		assert.False(t, sa.IsExternalServiceAccount("sa-my-service-account"))
+		assert.False(t, sa.IsExternalServiceAccount(sa.ExtSvcPrefix+"my-service-account")) // It's not a external service account login
+		assert.True(t, sa.IsExternalServiceAccount(sa.ExtSvcLoginPrefix(autoAssignOrgID)+"my-service-account"))
 	})
 }


### PR DESCRIPTION
**What is this feature?**

This PR replaces the hardcoded `tmpOrgID := int64(1)` with a new `DefaultOrgID` function. 

This function provides more flexibility by:

* Returning `AutoAssignOrgID` if it's set.
* Falling back to `int64(1)` as the default organization ID.

We still don't support multiple organizations but this change allows on-premise customers to configure the plugin service accounts to be created in an organization other than `1`. This is especially useful for setups where `AutoAssignOrgID` is already used. 

This PR also changes the service account role assignment logic to ensure that there is always only one active assignment.

Previously, the code failed if the service account role was already assigned to a different user. This can prevent Grafana from starting if the default organization changes. Now, instead of failing, the code revokes all existing assignments for the service account role and creates a new one with the correct organization. 

**Known issue**
If the default organization changes, a new service account is created but the previous one is not removed.

