### PR TITLE
fix(apiserver): append errors correctly from options

### DIFF
--- a/pkg/cmd/grafana/apiserver/server.go
+++ b/pkg/cmd/grafana/apiserver/server.go
@@ -144,7 +144,7 @@ func (o *APIServerOptions) Validate() error {
 	}
 
 	if errs := o.Options.Validate(); len(errs) > 0 {
-		errors = append(errors, errors...)
+		errors = append(errors, errs...)
 	}
 
 	return utilerrors.NewAggregate(errors)


### PR DESCRIPTION
This PR fixes a bug that the errors from the options validation would not be appended correctly, thus the server not failing to start when the config was invalid. 