### PR TITLE
Chore: Fix running frontend unit tests in JetBrains

### DIFF
--- a/scripts/webpack/env-util.js
+++ b/scripts/webpack/env-util.js
@@ -1,13 +1,15 @@
 const { parse } = require('ini');
 const { readFileSync, existsSync } = require('node:fs');
+const path = require('path');
 
 const getEnvConfig = () => {
-  const defaultSettings = readFileSync(`./conf/defaults.ini`, {
+  const grafanaRoot = path.join(__dirname, '../..');
+  const defaultSettings = readFileSync(`${grafanaRoot}/conf/defaults.ini`, {
     encoding: 'utf-8',
   });
 
-  const customSettings = existsSync(`./conf/custom.ini`)
-    ? readFileSync(`./conf/custom.ini`, {
+  const customSettings = existsSync(`${grafanaRoot}/conf/custom.ini`)
+    ? readFileSync(`${grafanaRoot}/conf/custom.ini`, {
         encoding: 'utf-8',
       })
     : '';


### PR DESCRIPTION
**What is this feature?**

I use Goland as IDE and I use little green buttons to run my frontend unit tests.
i.e.
![image](https://github.com/user-attachments/assets/c1f110ab-938b-477b-96a7-a2fae7031501)

After a [recent change](https://github.com/grafana/grafana/pull/85603) when I try to run my tests I got the following error message:

```
ENOENT: no such file or directory, open './conf/defaults.ini'
```
![image](https://github.com/user-attachments/assets/65def8b7-d997-442c-afc2-bb58589e332b)

This PR is going to fix that. 

**Why do we need this feature?**

Better IDE support 

**Who is this feature for?**

Grafana Developers
