### PR TITLE
Chore: Change condition to run auto triager based on user association

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -60,7 +60,7 @@ jobs:
 
   auto-triage:
     needs: [main]
-    if: github.repository == 'grafana/grafana' && (github.event.issue.author_association == 'NONE' || github.event.issue.author_association == 'FIRST_TIMER' || github.event.issue.author_association == 'FIRST_TIME_CONTRIBUTOR')
+    if: github.repository == 'grafana/grafana' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'OWNER'
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
**What is this feature?**

The auto-triager is only triaging issues created with author_association "NONE" of Grafana which means it skips issues created by contributors.

This means issues created by external contributors will not be auto-triaged.

This PR changes so the auto-triager will triage issues created by anyone that is not a member of the Grafana organization or the owner of the repository.

**Why do we need this feature?**

So all issues created by external contributors and non-contributors will be auto-triaged.

**Who is this feature for?**

All users creating issues in the Grafana/grafana repository.
