### PR TITLE
TimePicker: Support strings in ISO formats

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.test.tsx
@@ -76,6 +76,23 @@ describe('TimeRangeForm', () => {
     expect(getByLabelText('To')).toHaveValue(toValue);
   });
 
+  it('should parse UTC iso strings and render in current timezone', () => {
+    const { getByLabelText } = setup(
+      {
+        from: defaultTimeRange.from,
+        to: defaultTimeRange.to,
+        raw: {
+          from: defaultTimeRange.from.toISOString(),
+          to: defaultTimeRange.to.toISOString(),
+        },
+      },
+      'America/New_York'
+    );
+
+    expect(getByLabelText('From')).toHaveValue('2021-06-16 20:00:00');
+    expect(getByLabelText('To')).toHaveValue('2021-06-19 19:59:00');
+  });
+
   it('should close calendar when clicking the close icon', () => {
     const { queryByLabelText, getAllByRole, getByRole } = setup();
     const { TimePicker } = selectors.components;

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -268,12 +268,12 @@ function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
     return dateTimeFormat(value, { timeZone });
   }
 
-  if (value.indexOf('now') !== -1) {
-    return value;
+  if (value.endsWith('Z')) {
+    const dt = dateTimeParse(value, { timeZone: 'utc' });
+    return dateTimeFormat(dt, { timeZone });
   }
 
-  const dt = dateTimeParse(value, { timeZone: 'utc' });
-  return dateTimeFormat(dt, { timeZone });
+  return value;
 }
 
 function getStyles(theme: GrafanaTheme2) {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -267,7 +267,13 @@ function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {
   if (isDateTime(value)) {
     return dateTimeFormat(value, { timeZone });
   }
-  return value;
+
+  if (value.indexOf('now') !== -1) {
+    return value;
+  }
+
+  const dt = dateTimeParse(value, { timeZone: 'utc' });
+  return dateTimeFormat(dt, { timeZone });
 }
 
 function getStyles(theme: GrafanaTheme2) {


### PR DESCRIPTION
I am a bit torn on where the bug / fix should be here. 

In scenes we changed so that time range in URL and raw format is always the same UTC ISO string (instead of a ms epoch in URL and moment DateTime in TimeRange.raw.from/to), mainly to make URL more readable for humans and the raw be the same value as used in URL. 

Then we have super strange / messy TimeRange and it's raw property (that has the string version for relative time range), but in the old TimeSrv system the raw from/to where moment DateTimes (for absolute ranges). 

In scenes, I tried changing this so that raw from/to is always strings (no matter if absolute or not). Seems to have worked except for TimeRangeContent that parses from/to from the raw property but assumes that they should be moment DateTime objects (or relative strings expressions). 

This adds some code to check if the from/to contains a relative time expressions and if not tries to parse the string as UTC date times. 

https://github.com/grafana/support-escalations/issues/12532

Bug where time picker shows unformatted raw iso string 
<img width="306" alt="Screenshot 2024-09-19 at 14 19 04" src="https://github.com/user-attachments/assets/5ba5f770-9979-4a73-8f11-2e806f6e6419">



Related to:
https://github.com/grafana/scenes/blob/main/packages/scenes/src/utils/evaluateTimeRange.ts#L17 
