### PR TITLE
fix(querier): handle single alerting queries without expression

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -377,9 +377,19 @@ func (b *QueryAPIBuilder) handleExpressions(ctx context.Context, req parsedReque
 
 func (b *QueryAPIBuilder) convertQueryWithoutExpression(ctx context.Context, req datasourceRequest,
 	qdr *backend.QueryDataResponse) (*backend.QueryDataResponse, error) {
+	if len(req.Request.Queries) == 0 {
+		return nil, errors.New("no queries to convert")
+	}
+	if qdr == nil {
+		return nil, errors.New("queryDataResponse is nil")
+	}
 	allowLongFrames := false
 	refID := req.Request.Queries[0].RefID
-	_, results, err := b.converter.Convert(ctx, req.PluginId, qdr.Responses[refID].Frames, allowLongFrames)
+	if _, exist := qdr.Responses[refID]; !exist {
+		return nil, fmt.Errorf("refID '%s' does not exist", refID)
+	}
+	frames := qdr.Responses[refID].Frames
+	_, results, err := b.converter.Convert(ctx, req.PluginId, frames, allowLongFrames)
 	if err != nil {
 		results.Error = err
 	}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
@@ -157,6 +158,9 @@ func (b *QueryAPIBuilder) execute(ctx context.Context, req parsedRequestInfo) (q
 		qdr = &backend.QueryDataResponse{}
 	case 1:
 		qdr, err = b.handleQuerySingleDatasource(ctx, req.Requests[0])
+		if alertQueryWithoutExpression(req) {
+			qdr, err = b.convertQueryWithoutExpression(ctx, req.Requests[0], qdr)
+		}
 	default:
 		qdr, err = b.executeConcurrentQueries(ctx, req.Requests)
 	}
@@ -371,6 +375,25 @@ func (b *QueryAPIBuilder) handleExpressions(ctx context.Context, req parsedReque
 	return qdr, nil
 }
 
+func (b *QueryAPIBuilder) convertQueryWithoutExpression(ctx context.Context, req datasourceRequest,
+	qdr *backend.QueryDataResponse) (*backend.QueryDataResponse, error) {
+	allowLongFrames := false
+	refID := req.Request.Queries[0].RefID
+	_, results, err := b.converter.Convert(ctx, req.PluginId, qdr.Responses[refID].Frames, allowLongFrames)
+	if err != nil {
+		results.Error = err
+	}
+	qdr = &backend.QueryDataResponse{
+		Responses: map[string]backend.DataResponse{
+			refID: {
+				Frames: results.Values.AsDataFrames(refID),
+				Error:  results.Error,
+			},
+		},
+	}
+	return qdr, err
+}
+
 type responderWrapper struct {
 	wrapped    rest.Responder
 	onObjectFn func(statusCode int, obj runtime.Object)
@@ -399,4 +422,14 @@ func (r responderWrapper) Error(err error) {
 	}
 
 	r.wrapped.Error(err)
+}
+
+// Checks if the request only contains a single query and not expression.
+func alertQueryWithoutExpression(req parsedRequestInfo) bool {
+	headers := req.Requests[0].Headers
+	_, exist := headers[models.FromAlertHeaderName]
+	if exist && len(req.Requests) == 1 && len(req.Requests[0].Request.Queries) == 1 && len(req.Expressions) == 0 {
+		return true
+	}
+	return false
 }

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -436,9 +436,12 @@ func (r responderWrapper) Error(err error) {
 
 // Checks if the request only contains a single query and not expression.
 func alertQueryWithoutExpression(req parsedRequestInfo) bool {
+	if len(req.Requests) != 1 {
+		return false
+	}
 	headers := req.Requests[0].Headers
 	_, exist := headers[models.FromAlertHeaderName]
-	if exist && len(req.Requests) == 1 && len(req.Requests[0].Request.Queries) == 1 && len(req.Expressions) == 0 {
+	if exist && len(req.Requests[0].Request.Queries) == 1 && len(req.Expressions) == 0 {
 		return true
 	}
 	return false


### PR DESCRIPTION
This PR fixes the handling of single queries that come from alerting and do not have an expression. They need to be converted in a special format.