### PR TITLE
Docs: Removed public preview note from Explore Metrics

### DIFF
--- a/docs/sources/explore/simplified-exploration/metrics/index.md
+++ b/docs/sources/explore/simplified-exploration/metrics/index.md
@@ -16,10 +16,6 @@ weight: 200
 
 Grafana Explore Metrics is a query-less experience for browsing **Prometheus-compatible** metrics. Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.
 
-{{% admonition type="caution" %}}
-Explore Metrics is currently in [public preview](/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-{{% /admonition %}}
-
 With Explore Metrics, you can:
 
 - Easily segment metrics based on their labels, so you can immediately spot anomalies and identify issues.


### PR DESCRIPTION

**What is this feature?**

Explore Metrics is now GA, so I removed the public preview note from the doc.


