### PR TITLE
Alerting: Add a metric to track the number of rules with simplified editor settings

### DIFF
--- a/pkg/services/ngalert/metrics/scheduler.go
+++ b/pkg/services/ngalert/metrics/scheduler.go
@@ -31,6 +31,7 @@ type Scheduler struct {
 	UpdateSchedulableAlertRulesDuration prometheus.Histogram
 	Ticker                              *ticker.Metrics
 	EvaluationMissed                    *prometheus.CounterVec
+	SimplifiedEditorRules               *prometheus.GaugeVec
 }
 
 func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
@@ -181,6 +182,15 @@ func NewSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 				Help:      "The total number of rule evaluations missed due to a slow rule evaluation.",
 			},
 			[]string{"org", "name"},
+		),
+		SimplifiedEditorRules: promauto.With(r).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "simplified_editor_rules",
+				Help:      "The number of alert rules using simplified editor settings.",
+			},
+			[]string{"org", "setting"},
 		),
 	}
 }

--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -47,7 +47,7 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	// gauge for groups per org
 	groupsPerOrg := make(map[int64]map[string]struct{})
 
-	simplifiedEditorSettingsPerOrg := make(map[int64]map[string]int64)
+	simplifiedEditorSettingsPerOrg := make(map[int64]map[string]int64) // orgID -> setting -> count
 
 	for _, rule := range alertRules {
 		// Count rules by org, type and state

--- a/pkg/services/ngalert/schedule/metrics.go
+++ b/pkg/services/ngalert/schedule/metrics.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
-	models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 // hashUIDs returns a fnv64 hash of the UIDs for all alert rules.
@@ -47,6 +47,8 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	// gauge for groups per org
 	groupsPerOrg := make(map[int64]map[string]struct{})
 
+	simplifiedEditorSettingsPerOrg := make(map[int64]map[string]int64)
+
 	for _, rule := range alertRules {
 		// Count rules by org, type and state
 		state := metrics.AlertRuleActiveLabelValue
@@ -70,6 +72,14 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 			orgsNfSettings[rule.OrgID]++
 		}
 
+		// Count rules with simplified editor settings per org
+		if rule.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection {
+			if _, ok := simplifiedEditorSettingsPerOrg[rule.OrgID]; !ok {
+				simplifiedEditorSettingsPerOrg[rule.OrgID] = make(map[string]int64)
+			}
+			simplifiedEditorSettingsPerOrg[rule.OrgID]["simplified_query_and_expressions_section"]++
+		}
+
 		// Count groups per org
 		orgGroups, ok := groupsPerOrg[rule.OrgID]
 		if !ok {
@@ -83,6 +93,7 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	sch.metrics.GroupRules.Reset()
 	sch.metrics.SimpleNotificationRules.Reset()
 	sch.metrics.Groups.Reset()
+	sch.metrics.SimplifiedEditorRules.Reset()
 
 	// Set metrics
 	for key, count := range buckets {
@@ -93,6 +104,11 @@ func (sch *schedule) updateRulesMetrics(alertRules []*models.AlertRule) {
 	}
 	for orgID, groups := range groupsPerOrg {
 		sch.metrics.Groups.WithLabelValues(fmt.Sprint(orgID)).Set(float64(len(groups)))
+	}
+	for orgID, settings := range simplifiedEditorSettingsPerOrg {
+		for setting, count := range settings {
+			sch.metrics.SimplifiedEditorRules.WithLabelValues(fmt.Sprint(orgID), setting).Set(float64(count))
+		}
 	}
 	// While these are the rules that we iterate over, at the moment there's no 100% guarantee that they'll be
 	// scheduled as rules could be removed before we get a chance to evaluate them.

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -716,6 +716,83 @@ func TestSchedule_updateRulesMetrics(t *testing.T) {
 		})
 	})
 
+	t.Run("simplified_editor_rules metric should reflect the current state", func(t *testing.T) {
+		const firstOrgID int64 = 1
+		const secondOrgID int64 = 2
+
+		alertRuleWithAdvancedSettings := models.RuleGen.With(
+			models.RuleGen.WithOrgID(firstOrgID),
+			models.RuleGen.WithEditorSettingsSimplifiedQueryAndExpressionsSection(false),
+		).GenerateRef()
+
+		// The rule does not have simplified editor enabled, should not be in the metrics
+		t.Run("it should not show metrics", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{alertRuleWithAdvancedSettings})
+
+			expectedMetric := ""
+			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_simplified_editor_rules")
+			require.ErrorContains(t, err, "expected metric name(s) not found: [grafana_alerting_simplified_editor_rules]")
+		})
+
+		alertRule1 := models.RuleGen.With(
+			models.RuleGen.WithOrgID(firstOrgID),
+			models.RuleGen.WithEditorSettingsSimplifiedQueryAndExpressionsSection(true),
+		).GenerateRef()
+
+		t.Run("it should show one rule in a single org", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{alertRuleWithAdvancedSettings, alertRule1})
+
+			expectedMetric := fmt.Sprintf(
+				`# HELP grafana_alerting_simplified_editor_rules The number of alert rules using simplified editor settings.
+								# TYPE grafana_alerting_simplified_editor_rules gauge
+								grafana_alerting_simplified_editor_rules{org="%[1]d",setting="simplified_query_and_expressions_section"} 1
+				`, alertRule1.OrgID)
+
+			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_simplified_editor_rules")
+			require.NoError(t, err)
+		})
+
+		alertRule2 := models.RuleGen.With(
+			models.RuleGen.WithOrgID(secondOrgID),
+			models.RuleGen.WithEditorSettingsSimplifiedQueryAndExpressionsSection(true),
+		).GenerateRef()
+
+		t.Run("it should show two rules in two orgs", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{alertRuleWithAdvancedSettings, alertRule1, alertRule2})
+
+			expectedMetric := fmt.Sprintf(
+				`# HELP grafana_alerting_simplified_editor_rules The number of alert rules using simplified editor settings.
+								# TYPE grafana_alerting_simplified_editor_rules gauge
+								grafana_alerting_simplified_editor_rules{org="%[1]d",setting="simplified_query_and_expressions_section"} 1
+								grafana_alerting_simplified_editor_rules{org="%[2]d",setting="simplified_query_and_expressions_section"} 1
+				`, alertRule1.OrgID, alertRule2.OrgID)
+
+			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_simplified_editor_rules")
+			require.NoError(t, err)
+		})
+
+		t.Run("after removing one of the rules it should show one present rule and two org", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{alertRuleWithAdvancedSettings, alertRule2})
+
+			expectedMetric := fmt.Sprintf(
+				`# HELP grafana_alerting_simplified_editor_rules The number of alert rules using simplified editor settings.
+								# TYPE grafana_alerting_simplified_editor_rules gauge
+								grafana_alerting_simplified_editor_rules{org="%[2]d",setting="simplified_query_and_expressions_section"} 1
+				`, alertRuleWithAdvancedSettings.OrgID, alertRule2.OrgID)
+
+			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_simplified_editor_rules")
+			require.NoError(t, err)
+		})
+
+		t.Run("after removing all rules it should not show any metrics", func(t *testing.T) {
+			sch.updateRulesMetrics([]*models.AlertRule{})
+
+			expectedMetric := ""
+			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_simplified_editor_rules")
+			require.ErrorContains(t, err, "expected metric name(s) not found: [grafana_alerting_simplified_editor_rules]")
+		})
+	})
+
 	t.Run("rule_groups metric should reflect the current state", func(t *testing.T) {
 		const firstOrgID int64 = 1
 		const secondOrgID int64 = 2

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -771,14 +771,14 @@ func TestSchedule_updateRulesMetrics(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		t.Run("after removing one of the rules it should show one present rule and two org", func(t *testing.T) {
+		t.Run("after removing one of the rules it should show one present rule and one org", func(t *testing.T) {
 			sch.updateRulesMetrics([]*models.AlertRule{alertRuleWithAdvancedSettings, alertRule2})
 
 			expectedMetric := fmt.Sprintf(
 				`# HELP grafana_alerting_simplified_editor_rules The number of alert rules using simplified editor settings.
 								# TYPE grafana_alerting_simplified_editor_rules gauge
-								grafana_alerting_simplified_editor_rules{org="%[2]d",setting="simplified_query_and_expressions_section"} 1
-				`, alertRuleWithAdvancedSettings.OrgID, alertRule2.OrgID)
+								grafana_alerting_simplified_editor_rules{org="%d",setting="simplified_query_and_expressions_section"} 1
+				`, alertRule2.OrgID)
 
 			err := testutil.GatherAndCompare(reg, bytes.NewBufferString(expectedMetric), "grafana_alerting_simplified_editor_rules")
 			require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

Adds `grafana_alerting_simplified_editor_rules` metric with `org` and `setting` labels.

**Why do we need this feature?**

Part of https://github.com/grafana/alerting-squad/issues/849

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
