### PR TITLE
[DOC] Add landing page for simplified exploration

### DIFF
--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -18,19 +18,19 @@ cards:
   items:
     - title: Explore Metrics
       href: ./metrics/
-      description: Grafana Explore Metrics is a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.
+      description: Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.
       height: 24
     - title: Explore Logs
       href: ./logs/
-      description: Explore Logs offers a queryless experience for easily surfacing insights from logs stored in Grafana Loki, Grafana Cloud Logs, and Grafana Enterprise Logs. Explore Logs generates visualizations of log volumes to let you easily detect anomalies or related changes across labels and over time.
+      description: Visualize log volumes to easily detect anomalies or significant changes across labels and fields over time.
       height: 24
     - title: Explore Traces
       href: ./traces/
-      description: Explore Traces helps you make sense of your tracing data so you can automatically visualize insights from your Tempo traces data. Using the app, you can use Rate, Errors, and Duration (RED) metrics derived from traces to investigate to understand errors and latency issues within complex distributed systems.
+      description: Use Rate, Errors, and Duration (RED) metrics derived from traces to investigate to understand errors and latency issues within complex distributed systems.
       height: 24
     - title: Explore Profiles
       href: ./profiles/
-      description: Using Explore Profiles, you can view high-level service performance to get a high-level view of all of your services and how they're functioning. You can identify problem processes or services that you can optimize for better performance and diagnose issues to determine the root cause.
+      description: View and analyze high-level service performance, identify problem processes for optimization, and diagnose issues to determine root causes.
       height: 24
 ---
 

--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -18,7 +18,7 @@ cards:
   items:
     - title: Explore Metrics
       href: ./metrics/
-      description: Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.
+      description: Quickly find related metrics with a few clicks, without needing to write PromQL queries to retrieve metrics.
       height: 24
     - title: Explore Logs
       href: ./logs/
@@ -26,7 +26,7 @@ cards:
       height: 24
     - title: Explore Traces
       href: ./traces/
-      description: Use Rate, Errors, and Duration (RED) metrics derived from traces to investigate to understand errors and latency issues within complex distributed systems.
+      description: Use Rate, Errors, and Duration (RED) metrics derived from traces to investigate and understand errors and latency issues within complex distributed systems.
       height: 24
     - title: Explore Profiles
       href: ./profiles/

--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -22,7 +22,7 @@ cards:
       height: 24
     - title: Explore Logs
       href: ./logs/
-      description: Visualize log volumes to easily detect anomalies or significant changes across labels and fields over time.
+      description: Visualize log volumes to easily detect anomalies or significant changes over time, without needing to compose LogQL queries.
       height: 24
     - title: Explore Traces
       href: ./traces/

--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -7,6 +7,31 @@ keywords:
 title: Simplified exploration
 menuTitle: Simplified exploration
 weight: 100
+hero:
+  title: Simplified exploration with the Explore apps
+  level: 1
+  width: 100
+  height: 100
+  description: Use Explore Profiles to investigate and identify issues using profiling data.
+cards:
+  title_class: pt-0 lh-1
+  items:
+    - title: Explore Metrics
+      href: ./metrics/
+      description: Grafana Explore Metrics is a query-less experience for browsing Prometheus-compatible metrics. Quickly find related metrics with just a few simple clicks, without needing to write PromQL queries to retrieve metrics.
+      height: 24
+    - title: Explore Logs
+      href: ./logs/
+      description: Explore Logs offers a queryless experience for easily surfacing insights from logs stored in Grafana Loki, Grafana Cloud Logs, and Grafana Enterprise Logs. Explore Logs generates visualizations of log volumes to let you easily detect anomalies or related changes across labels and over time.
+      height: 24
+    - title: Explore Traces
+      href: ./traces/
+      description: Explore Traces helps you make sense of your tracing data so you can automatically visualize insights from your Tempo traces data. Using the app, you can use Rate, Errors, and Duration (RED) metrics derived from traces to investigate to understand errors and latency issues within complex distributed systems.
+      height: 24
+    - title: Explore Profiles
+      href: ./profiles/
+      description: Using Explore Profiles, you can view high-level service performance to get a high-level view of all of your services and how they're functioning. You can identify problem processes or services that you can optimize for better performance and diagnose issues to determine the root cause.
+      height: 24
 ---
 
 # Simplified exploration
@@ -15,4 +40,6 @@ Introducing the Grafana Explore apps, designed for effortless data exploration t
 
 Easily explore telemetry signals with these specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
 
-{{< section >}}
+## Explore
+
+{{< card-grid key="cards" type="simple" >}}


### PR DESCRIPTION
**What is this feature?**

Adds a new landing page for the Explore apps on the Explore > Simplified exploration documentation page. 

Fixes #

![image](https://github.com/user-attachments/assets/0408e570-417c-4160-9a94-cdcb2457a1c2)



**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
