### PR TITLE
unistore: fix watch events forever looping

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -546,7 +546,9 @@ func (b *backend) poller(ctx context.Context, since groupResourceRV, stream chan
 						t.Reset(interval)
 						continue
 					}
-					since[group][resource] = next
+					if next > since[group][resource] {
+						since[group][resource] = next
+					}
 				}
 			}
 


### PR DESCRIPTION
**What is this feature?**
Fix the sql broadcaster that keeps on watching to zero when no events are found.
Only apply when using [WatchNEXT](https://github.com/grafana/grafana/blob/450932b57df6436ee3020fb6c2dd8b6f31cc67c8/pkg/storage/unified/apistore/store.go#L238) instead of Watch. Tests will be covered by the existing watch tests when flipping back watchnext->watch (WIP).

```
kubectl get namespaces -w
NAME              STATUS   AGE
default           Active   32s
kube-node-lease   Active   32s
kube-public       Active   32s
kube-system       Active   32s
abc               Active   0s
abc               Active   0s
abc               Active   0s
abc               Active   1s
abc               Active   1s
abc               Active   1s
abc               Active   1s
abc               Active   2s
abc               Active   2s
abc               Active   2s
abc               Active   2s
abc               Active   3s
abc               Active   3s
...
```

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
