### PR TITLE
Correlations: Limit access to correlations page to users who can access Explore

### DIFF
--- a/pkg/services/correlations/accesscontrol.go
+++ b/pkg/services/correlations/accesscontrol.go
@@ -2,10 +2,9 @@ package correlations
 
 import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
 var (
 	// ConfigurationPageAccess is used to protect the "Configure > correlations" tab access
-	ConfigurationPageAccess = accesscontrol.EvalPermission(datasources.ActionRead)
+	ConfigurationPageAccess = accesscontrol.EvalPermission(accesscontrol.ActionDatasourcesExplore)
 )


### PR DESCRIPTION
Fixes #93518

How to test:

Correlations page should show up only if user has access to Explore:

1. User is Editor or Admin
2. User is Viewer and:

```
[users] viewers_can_edit = true
```

3. User is Anonymous and 

```
[auth.anonymous]
enabled = true
org_role = Viewer

[users]
viewers_can_edit = false
``` 
4. User is anonymous and

```
[auth.anonymous]
enabled = true
org_role = Editor
```