### PR TITLE
Loki: Fixing the Traces to Logs query parameters when using filter by trace/span id options

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -383,10 +383,10 @@ function getQueryForLoki(
 
   let expr = '{${__tags}}';
   if (filterByTraceID && span.traceID) {
-    expr += ' |="${__span.traceId}"';
+    expr += ' | trace_id="${__span.traceId}"';
   }
   if (filterBySpanID && span.spanID) {
-    expr += ' |="${__span.spanId}"';
+    expr += ' | span_id="${__span.spanId}"';
   }
 
   return {


### PR DESCRIPTION
**What is this feature?**

This is a bug fix that enables "filter by trace id" and "filter by span id" to work as expected.

**Why do we need this feature?**

When enabling "Traces to Logs" in the Tempo data source and enabling "Filter by trace ID" and "Filter by span ID", the query made when clicking a "logs" link against any span is as follows:

```
{service_name="my-cool-service"} |="123123123123123123123123" |="123123123123"
```

This isn't valid, so this PR changes it to:

```
{service_name="my-cool-service"} | trace_id="123123123123123123123123" | span_id="123123123123"
```

Which is valid.

**Who is this feature for?**

Anyone using the Tempo data source with the "Traces to Logs" feature.

**Which issue(s) does this PR fix?**:

Fixes #90335

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
