### PR TITLE
SparklineCell: Improve text alignment factor

### DIFF
--- a/packages/grafana-ui/src/components/Table/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/SparklineCell.tsx
@@ -8,6 +8,7 @@ import {
   isDataFrame,
   Field,
   isDataFrameWithValue,
+  formattedValueToString,
 } from '@grafana/data';
 import {
   BarAlignment,
@@ -92,9 +93,7 @@ export const SparklineCell = (props: TableCellProps) => {
     const displayValue = field.display!(value);
     const alignmentFactor = getAlignmentFactor(field, displayValue, cell.row.index);
 
-    valueWidth =
-      measureText(`${alignmentFactor.prefix ?? ''}${alignmentFactor.text}${alignmentFactor.suffix ?? ''}`, 16).width +
-      theme.spacing.gridSize;
+    valueWidth = measureText(formattedValueToString(alignmentFactor), 16).width + theme.spacing.gridSize;
 
     valueElement = (
       <FormattedValueDisplay

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -531,8 +531,9 @@ export function getAlignmentFactor(
 
   if (alignmentFactor) {
     // check if current alignmentFactor is still the longest
-    if (alignmentFactor.text.length < displayValue.text.length) {
-      alignmentFactor.text = displayValue.text;
+    if (formattedValueToString(alignmentFactor).length < formattedValueToString(displayValue).length) {
+      alignmentFactor = { ...displayValue };
+      field.state!.alignmentFactors = alignmentFactor;
     }
     return alignmentFactor;
   } else {
@@ -542,7 +543,7 @@ export function getAlignmentFactor(
 
     for (let i = rowIndex + 1; i < maxIndex; i++) {
       const nextDisplayValue = field.display!(field.values[i]);
-      if (nextDisplayValue.text.length > alignmentFactor.text.length) {
+      if (formattedValueToString(alignmentFactor).length > formattedValueToString(nextDisplayValue).length) {
         alignmentFactor.text = displayValue.text;
       }
     }


### PR DESCRIPTION
**What is this feature?**
* Takes the prefix and suffix into account when finding the alignment factor
* Alignment factor is used in SparklineCell and BarGaugeCell

![Screenshot 2024-09-20 at 13 18 08](https://github.com/user-attachments/assets/b412b7af-e215-47b6-a722-29154db8f002)


**Why do we need this feature?**
The previous behavior only looked at the length of the value so `10.00 s` and `34.57 ms` and since both of these values are 5 characters long the alignment factor could be based on `10.00 s` instead of `34.57 ms` which is longer due to the longer suffix.

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
