### PR TITLE
Auth: Update extra_hosts property

### DIFF
--- a/devenv/docker/blocks/auth/jwt_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/jwt_proxy/docker-compose.yaml
@@ -51,7 +51,7 @@
     depends_on:
       - oauthkeycloak
     extra_hosts:
-      - "env.grafana.local:host.containers.internal"
+      - "env.grafana.local:host-gateway"
     ports:
       - 8088:8088
     restart: unless-stopped


### PR DESCRIPTION
**What is this feature?**

Updates the  docker internal network reference for `jwt_proxy` development environment.

**Why do we need this feature?**

The development environment for `jwt_proxy` has stopped working.

**Who is this feature for?**

iam
