### PR TITLE
Annotations: Optimize search by tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -259,7 +259,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -48,6 +48,9 @@ func (hs *HTTPServer) GetAnnotations(c *contextmodel.ReqContext) response.Respon
 		MatchAny:     c.QueryBool("matchAny"),
 		SignedInUser: c.SignedInUser,
 	}
+	if query.Limit == 0 {
+		query.Limit = 1000
+	}
 
 	// When dashboard UID present in the request, we ignore dashboard ID
 	if query.DashboardUID != "" {

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -22,6 +22,8 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+const defaultAnnotationsLimit = 100
+
 // swagger:route GET /annotations annotations getAnnotations
 //
 // Find Annotations.
@@ -49,7 +51,7 @@ func (hs *HTTPServer) GetAnnotations(c *contextmodel.ReqContext) response.Respon
 		SignedInUser: c.SignedInUser,
 	}
 	if query.Limit == 0 {
-		query.Limit = 1000
+		query.Limit = defaultAnnotationsLimit
 	}
 
 	// When dashboard UID present in the request, we ignore dashboard ID

--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -134,7 +134,9 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 	}
 
 	sb := &searchstore.Builder{Dialect: authz.db.GetDialect(), Filters: filters, Features: authz.features}
-	sql, params := sb.ToSQL(query.Limit, query.Page)
+	// This is a limit for a batch size, not for the end query result.
+	var limit int64 = 1000
+	sql, params := sb.ToSQL(limit, query.Page)
 
 	visibleDashboards := make(map[string]int64)
 	var res []dashboardProjection

--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -39,7 +39,7 @@ func NewAuthService(db db.DB, features featuremgmt.FeatureToggles) *AuthService 
 }
 
 // Authorize checks if the user has permission to read annotations, then returns a struct containing dashboards and scope types that the user has access to.
-func (authz *AuthService) Authorize(ctx context.Context, orgID int64, query *annotations.ItemQuery) (*AccessResources, error) {
+func (authz *AuthService) Authorize(ctx context.Context, query *annotations.ItemQuery) (*AccessResources, error) {
 	user := query.SignedInUser
 	if user == nil || user.IsNil() {
 		return nil, ErrReadForbidden.Errorf("missing user")
@@ -60,14 +60,14 @@ func (authz *AuthService) Authorize(ctx context.Context, orgID int64, query *ann
 	var err error
 	if canAccessDashAnnotations {
 		if query.AnnotationID != 0 {
-			annotationDashboardID, err := authz.getAnnotationDashboard(ctx, query, orgID)
+			annotationDashboardID, err := authz.getAnnotationDashboard(ctx, query)
 			if err != nil {
 				return nil, ErrAccessControlInternal.Errorf("failed to fetch annotations: %w", err)
 			}
 			query.DashboardID = annotationDashboardID
 		}
 
-		visibleDashboards, err = authz.dashboardsWithVisibleAnnotations(ctx, query, orgID)
+		visibleDashboards, err = authz.dashboardsWithVisibleAnnotations(ctx, query)
 		if err != nil {
 			return nil, ErrAccessControlInternal.Errorf("failed to fetch dashboards: %w", err)
 		}
@@ -80,7 +80,7 @@ func (authz *AuthService) Authorize(ctx context.Context, orgID int64, query *ann
 	}, nil
 }
 
-func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *annotations.ItemQuery, orgID int64) (int64, error) {
+func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *annotations.ItemQuery) (int64, error) {
 	var items []annotations.Item
 	params := make([]any, 0)
 	err := authz.db.WithDbSession(ctx, func(sess *db.Session) error {
@@ -92,7 +92,7 @@ func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *ann
 			FROM annotation as a
 			WHERE a.org_id = ? AND a.id = ?
 			`
-		params = append(params, orgID, query.AnnotationID)
+		params = append(params, query.OrgID, query.AnnotationID)
 
 		return sess.SQL(sql, params...).Find(&items)
 	})
@@ -106,7 +106,7 @@ func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *ann
 	return items[0].DashboardID, nil
 }
 
-func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, query *annotations.ItemQuery, orgID int64) (map[string]int64, error) {
+func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, query *annotations.ItemQuery) (map[string]int64, error) {
 	recursiveQueriesSupported, err := authz.db.RecursiveQueriesAreSupported()
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 
 	filters := []any{
 		permissions.NewAccessControlDashboardPermissionFilter(query.SignedInUser, dashboardaccess.PERMISSION_VIEW, filterType, authz.features, recursiveQueriesSupported),
-		searchstore.OrgFilter{OrgId: orgID},
+		searchstore.OrgFilter{OrgId: query.OrgID},
 	}
 
 	if query.DashboardUID != "" {
@@ -134,14 +134,10 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 	}
 
 	sb := &searchstore.Builder{Dialect: authz.db.GetDialect(), Filters: filters, Features: authz.features}
+	sql, params := sb.ToSQL(query.Limit, query.Page)
 
 	visibleDashboards := make(map[string]int64)
-
-	var page int64 = query.Page
-	var limit int64 = query.Limit
-
 	var res []dashboardProjection
-	sql, params := sb.ToSQL(limit, page)
 
 	err = authz.db.WithDbSession(ctx, func(sess *db.Session) error {
 		return sess.SQL(sql, params...).Find(&res)

--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -136,6 +136,9 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 	sb := &searchstore.Builder{Dialect: authz.db.GetDialect(), Filters: filters, Features: authz.features}
 	// This is a limit for a batch size, not for the end query result.
 	var limit int64 = 1000
+	if query.Page == 0 {
+		query.Page = 1
+	}
 	sql, params := sb.ToSQL(limit, query.Page)
 
 	visibleDashboards := make(map[string]int64)

--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -137,29 +137,21 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 
 	visibleDashboards := make(map[string]int64)
 
-	var page int64 = 1
-	var limit int64 = 1000
-	for {
-		var res []dashboardProjection
-		sql, params := sb.ToSQL(limit, page)
+	var page int64 = query.Page
+	var limit int64 = query.Limit
 
-		err = authz.db.WithDbSession(ctx, func(sess *db.Session) error {
-			return sess.SQL(sql, params...).Find(&res)
-		})
-		if err != nil {
-			return nil, err
-		}
+	var res []dashboardProjection
+	sql, params := sb.ToSQL(limit, page)
 
-		for _, p := range res {
-			visibleDashboards[p.UID] = p.ID
-		}
+	err = authz.db.WithDbSession(ctx, func(sess *db.Session) error {
+		return sess.SQL(sql, params...).Find(&res)
+	})
+	if err != nil {
+		return nil, err
+	}
 
-		// if the result is less than the limit, we have reached the end
-		if len(res) < int(limit) {
-			break
-		}
-
-		page++
+	for _, p := range res {
+		visibleDashboards[p.UID] = p.ID
 	}
 
 	return visibleDashboards, nil

--- a/pkg/services/annotations/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol_test.go
@@ -175,8 +175,8 @@ func TestIntegrationAuthorize(t *testing.T) {
 
 			authz := NewAuthService(sql, featuremgmt.WithFeatures(tc.featureToggle))
 
-			query := &annotations.ItemQuery{SignedInUser: u}
-			resources, err := authz.Authorize(context.Background(), 1, query)
+			query := &annotations.ItemQuery{SignedInUser: u, OrgID: 1}
+			resources, err := authz.Authorize(context.Background(), query)
 			require.NoError(t, err)
 
 			if tc.expectedResources.Dashboards != nil {

--- a/pkg/services/annotations/accesscontrol/models.go
+++ b/pkg/services/annotations/accesscontrol/models.go
@@ -8,6 +8,8 @@ type AccessResources struct {
 	CanAccessDashAnnotations bool
 	// CanAccessOrgAnnotations true if the user is allowed to access organization annotations
 	CanAccessOrgAnnotations bool
+	// Skip filtering
+	SkipAccessControlFilter bool
 }
 
 type dashboardProjection struct {

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -81,6 +81,10 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 		if err != nil || len(res) == 0 {
 			return []*annotations.ItemDTO{}, err
 		}
+		// If number of resources is less than limit, it makes sense to set query limit to this
+		// value, otherwise query will be iterating over all user's dashboards since original
+		// query limit is never reached.
+		query.Limit = int64(len(res))
 	}
 
 	results := make([]*annotations.ItemDTO, 0, query.Limit)

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -76,8 +76,8 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 		query.Limit = 100
 	}
 
-	// Search by tags is expensive, so check without access control first
-	if len(query.Tags) > 0 && query.DashboardID == 0 && query.DashboardUID == "" {
+	// Search without dashboard UID filter is expensive, so check without access control first
+	if query.DashboardID == 0 && query.DashboardUID == "" {
 		// Return early if no annotations found, it's not necessary to perform expensive access control filtering
 		res, err := r.reader.Get(ctx, query, &accesscontrol.AccessResources{
 			SkipAccessControlFilter: true,

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -80,7 +80,7 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 	query.Page = 1
 
 	for len(results) < int(query.Limit) {
-		resources, err := r.authZ.Authorize(ctx, query.OrgID, query)
+		resources, err := r.authZ.Authorize(ctx, query)
 		if err != nil {
 			return []*annotations.ItemDTO{}, err
 		}

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -72,6 +72,10 @@ func (r *RepositoryImpl) Update(ctx context.Context, item *annotations.Item) err
 }
 
 func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+	if query.Limit == 0 {
+		query.Limit = 100
+	}
+
 	// Search by tags is expensive, so check without access control first
 	if len(query.Tags) > 0 && query.DashboardID == 0 && query.DashboardUID == "" {
 		// Return early if no annotations found, it's not necessary to perform expensive access control filtering

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -72,10 +72,6 @@ func (r *RepositoryImpl) Update(ctx context.Context, item *annotations.Item) err
 }
 
 func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
-	if query.Limit == 0 {
-		query.Limit = 1000
-	}
-
 	// Return early if no annotations found, it's not necessary to perform expensive access control filtering
 	res, err := r.reader.Get(ctx, query, &accesscontrol.AccessResources{
 		Dashboards:               map[string]int64{},

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -90,7 +90,7 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 	results := make([]*annotations.ItemDTO, 0, query.Limit)
 	query.Page = 1
 
-	// Iterate over available annotations util query limit is reached
+	// Iterate over available annotations until query limit is reached
 	// or all available dashboards are checked
 	for len(results) < int(query.Limit) {
 		resources, err := r.authZ.Authorize(ctx, query)

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -76,6 +76,16 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 		query.Limit = 1000
 	}
 
+	// Return early if no annotations found, it's not necessary to perform expensive access control filtering
+	res, err := r.reader.Get(ctx, query, &accesscontrol.AccessResources{
+		Dashboards:               map[string]int64{},
+		CanAccessDashAnnotations: true,
+		CanAccessOrgAnnotations:  true,
+	})
+	if err != nil || len(res) == 0 {
+		return []*annotations.ItemDTO{}, err
+	}
+
 	results := make([]*annotations.ItemDTO, 0, query.Limit)
 	query.Page = 1
 

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -94,12 +94,12 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 	for len(results) < int(query.Limit) {
 		resources, err := r.authZ.Authorize(ctx, query)
 		if err != nil {
-			return []*annotations.ItemDTO{}, err
+			return nil, err
 		}
 
 		res, err := r.reader.Get(ctx, query, resources)
 		if err != nil {
-			return []*annotations.ItemDTO{}, err
+			return nil, err
 		}
 
 		results = append(results, res...)

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -79,6 +79,8 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 	results := make([]*annotations.ItemDTO, 0, query.Limit)
 	query.Page = 1
 
+	// Iterate over available annotations util query limit is reached
+	// or all available dashboards are checked
 	for len(results) < int(query.Limit) {
 		resources, err := r.authZ.Authorize(ctx, query)
 		if err != nil {
@@ -92,6 +94,7 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 
 		results = append(results, res...)
 		query.Page++
+		// All user's dashboards are fetched
 		if len(resources.Dashboards) < int(query.Limit) {
 			break
 		}

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -72,14 +72,15 @@ func (r *RepositoryImpl) Update(ctx context.Context, item *annotations.Item) err
 }
 
 func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
-	// Return early if no annotations found, it's not necessary to perform expensive access control filtering
-	res, err := r.reader.Get(ctx, query, &accesscontrol.AccessResources{
-		Dashboards:               map[string]int64{},
-		CanAccessDashAnnotations: true,
-		CanAccessOrgAnnotations:  true,
-	})
-	if err != nil || len(res) == 0 {
-		return []*annotations.ItemDTO{}, err
+	// Search by tags is expensive, so check without access control first
+	if len(query.Tags) > 0 && query.DashboardID == 0 && query.DashboardUID == "" {
+		// Return early if no annotations found, it's not necessary to perform expensive access control filtering
+		res, err := r.reader.Get(ctx, query, &accesscontrol.AccessResources{
+			SkipAccessControlFilter: true,
+		})
+		if err != nil || len(res) == 0 {
+			return []*annotations.ItemDTO{}, err
+		}
 	}
 
 	results := make([]*annotations.ItemDTO, 0, query.Limit)

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -355,10 +355,6 @@ func (r *xormRepositoryImpl) Get(ctx context.Context, query *annotations.ItemQue
 			sql.WriteString(fmt.Sprintf(" AND (%s)", acFilter))
 		}
 
-		if query.Limit == 0 {
-			query.Limit = 100
-		}
-
 		// order of ORDER BY arguments match the order of a sql index for performance
 		sql.WriteString(" ORDER BY a.org_id, a.epoch_end DESC, a.epoch DESC" + r.db.GetDialect().Limit(query.Limit) + " ) dt on dt.id = annotation.id")
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -351,7 +351,9 @@ func (r *xormRepositoryImpl) Get(ctx context.Context, query *annotations.ItemQue
 		if err != nil {
 			return err
 		}
-		sql.WriteString(fmt.Sprintf(" AND (%s)", acFilter))
+		if acFilter != "" {
+			sql.WriteString(fmt.Sprintf(" AND (%s)", acFilter))
+		}
 
 		if query.Limit == 0 {
 			query.Limit = 100
@@ -372,6 +374,10 @@ func (r *xormRepositoryImpl) Get(ctx context.Context, query *annotations.ItemQue
 }
 
 func (r *xormRepositoryImpl) getAccessControlFilter(user identity.Requester, accessResources *accesscontrol.AccessResources) (string, error) {
+	if accessResources.SkipAccessControlFilter {
+		return "", nil
+	}
+
 	var filters []string
 
 	if accessResources.CanAccessOrgAnnotations {

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -356,7 +356,11 @@ func (r *xormRepositoryImpl) Get(ctx context.Context, query *annotations.ItemQue
 		}
 
 		// order of ORDER BY arguments match the order of a sql index for performance
-		sql.WriteString(" ORDER BY a.org_id, a.epoch_end DESC, a.epoch DESC" + r.db.GetDialect().Limit(query.Limit) + " ) dt on dt.id = annotation.id")
+		orderBy := " ORDER BY a.org_id, a.epoch_end DESC, a.epoch DESC"
+		if query.Limit > 0 {
+			orderBy += r.db.GetDialect().Limit(query.Limit)
+		}
+		sql.WriteString(orderBy + " ) dt on dt.id = annotation.id")
 
 		if err := sess.SQL(sql.String(), params...).Find(&items); err != nil {
 			items = nil

--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -21,6 +21,7 @@ type ItemQuery struct {
 	SignedInUser identity.Requester
 
 	Limit int64 `json:"limit"`
+	Page  int64
 }
 
 // TagsQuery is the query for a tags search.


### PR DESCRIPTION
**What is this feature?**

This PR adds some optimization to the annotations search, especially for the case where annotations are not filtered by the specific dashboard. In this case access control filter iterates over all user's dashboards, but it can return earlier, as soon as number of items matches query limit.

**Why do we need this feature?**

There's some serious performance degradation for the requests that do not contain `dashboardUID` parameter.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/93489

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
