### PR TITLE
Alerting: Receiver resource permissions service

### DIFF
--- a/pkg/registry/apis/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apis/alerting/notifications/receiver/conversions.go
@@ -107,9 +107,9 @@ func convertToK8sResource(
 
 var permissionMapper = map[ngmodels.ReceiverPermission]string{
 	ngmodels.ReceiverPermissionReadSecret: "canReadSecrets",
-	//ngmodels.ReceiverPermissionAdmin:      "canAdmin", // TODO: Add when resource permissions are implemented.
-	ngmodels.ReceiverPermissionWrite:  "canWrite",
-	ngmodels.ReceiverPermissionDelete: "canDelete",
+	ngmodels.ReceiverPermissionAdmin:      "canAdmin",
+	ngmodels.ReceiverPermissionWrite:      "canWrite",
+	ngmodels.ReceiverPermissionDelete:     "canDelete",
 }
 
 func convertToDomainModel(receiver *model.Receiver) (*ngmodels.Receiver, map[string][]string, error) {

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -315,6 +315,8 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(accesscontrol.FolderPermissionsService), new(*ossaccesscontrol.FolderPermissionsService)),
 	ossaccesscontrol.ProvideDashboardPermissions,
 	wire.Bind(new(accesscontrol.DashboardPermissionsService), new(*ossaccesscontrol.DashboardPermissionsService)),
+	ossaccesscontrol.ProvideReceiverPermissionsService,
+	wire.Bind(new(accesscontrol.ReceiverPermissionsService), new(*ossaccesscontrol.ReceiverPermissionsService)),
 	starimpl.ProvideService,
 	playlistimpl.ProvideService,
 	apikeyimpl.ProvideService,

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/authlib/claims"
+
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -145,6 +146,10 @@ type DatasourcePermissionsService interface {
 }
 
 type ServiceAccountPermissionsService interface {
+	PermissionsService
+}
+
+type ReceiverPermissionsService interface {
 	PermissionsService
 }
 

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -444,12 +444,14 @@ const (
 	ActionAlertingNotificationsTimeIntervalsDelete = "alert.notifications.time-intervals:delete"
 
 	// Alerting receiver actions
-	ActionAlertingReceiversList        = "alert.notifications.receivers:list"
-	ActionAlertingReceiversRead        = "alert.notifications.receivers:read"
-	ActionAlertingReceiversReadSecrets = "alert.notifications.receivers.secrets:read"
-	ActionAlertingReceiversCreate      = "alert.notifications.receivers:create"
-	ActionAlertingReceiversUpdate      = "alert.notifications.receivers:write"
-	ActionAlertingReceiversDelete      = "alert.notifications.receivers:delete"
+	ActionAlertingReceiversList             = "alert.notifications.receivers:list"
+	ActionAlertingReceiversRead             = "alert.notifications.receivers:read"
+	ActionAlertingReceiversReadSecrets      = "alert.notifications.receivers.secrets:read"
+	ActionAlertingReceiversCreate           = "alert.notifications.receivers:create"
+	ActionAlertingReceiversUpdate           = "alert.notifications.receivers:write"
+	ActionAlertingReceiversDelete           = "alert.notifications.receivers:delete"
+	ActionAlertingReceiversPermissionsRead  = "receivers.permissions:read"
+	ActionAlertingReceiversPermissionsWrite = "receivers.permissions:write"
 
 	// External alerting rule actions. We can only narrow it down to writes or reads, as we don't control the atomicity in the external system.
 	ActionAlertingRuleExternalWrite = "alert.rules.external:write"

--- a/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
@@ -1,0 +1,60 @@
+package ossaccesscontrol
+
+import (
+	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/services/ngalert"
+	alertingac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/team"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var ReceiversViewActions = []string{accesscontrol.ActionAlertingReceiversRead}
+var ReceiversEditActions = append(ReceiversViewActions, []string{accesscontrol.ActionAlertingReceiversUpdate, accesscontrol.ActionAlertingReceiversDelete}...)
+var ReceiversAdminActions = append(ReceiversEditActions, []string{accesscontrol.ActionAlertingReceiversReadSecrets, accesscontrol.ActionAlertingReceiversPermissionsRead, accesscontrol.ActionAlertingReceiversPermissionsWrite}...)
+
+func ProvideReceiverPermissionsService(
+	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
+	license licensing.Licensing, service accesscontrol.Service,
+	teamService team.Service, userService user.Service, actionSetService resourcepermissions.ActionSetService,
+) (*ReceiverPermissionsService, error) {
+	if !features.IsEnabledGlobally(featuremgmt.FlagAlertingApiServer) {
+		return nil, nil
+	}
+
+	options := resourcepermissions.Options{
+		Resource:          "receivers",
+		ResourceAttribute: "uid",
+		Assignments: resourcepermissions.Assignments{
+			Users:           true,
+			Teams:           true,
+			BuiltInRoles:    true,
+			ServiceAccounts: true,
+		},
+		PermissionsToActions: map[string][]string{
+			string(alertingac.ReceiverPermissionView):  append([]string{}, ReceiversViewActions...),
+			string(alertingac.ReceiverPermissionEdit):  append([]string{}, ReceiversEditActions...),
+			string(alertingac.ReceiverPermissionAdmin): append([]string{}, ReceiversAdminActions...),
+		},
+		ReaderRoleName: "Alerting receiver permission reader",
+		WriterRoleName: "Alerting receiver permission writer",
+		RoleGroup:      ngalert.AlertRolesGroup,
+	}
+
+	srv, err := resourcepermissions.New(cfg, options, features, router, license, ac, service, sql, teamService, userService, actionSetService)
+	if err != nil {
+		return nil, err
+	}
+	return &ReceiverPermissionsService{Service: srv}, nil
+}
+
+var _ accesscontrol.ReceiverPermissionsService = new(ReceiverPermissionsService)
+
+type ReceiverPermissionsService struct {
+	*resourcepermissions.Service
+}

--- a/pkg/services/ngalert/accesscontrol/receivers.go
+++ b/pkg/services/ngalert/accesscontrol/receivers.go
@@ -17,6 +17,15 @@ var (
 	ScopeReceiversAll      = ScopeReceiversProvider.GetResourceAllScope()
 )
 
+// ReceiverPermission is a type for representing a receiver permission.
+type ReceiverPermission string
+
+const (
+	ReceiverPermissionView  ReceiverPermission = "View"
+	ReceiverPermissionEdit  ReceiverPermission = "Edit"
+	ReceiverPermissionAdmin ReceiverPermission = "Admin"
+)
+
 var (
 	// Asserts pre-conditions for read access to redacted receivers. If this evaluates to false, the user cannot read any redacted receivers.
 	readRedactedReceiversPreConditionsEval = ac.EvalAny(
@@ -125,6 +134,28 @@ var (
 			ac.EvalPermission(ac.ActionAlertingReceiversDelete, ScopeReceiversProvider.GetResourceScopeUID(uid)),
 		)
 	}
+
+	// Admin
+
+	// Asserts pre-conditions for resource permissions access to receivers. If this evaluates to false, the user cannot modify permissions for any receivers.
+	permissionsReceiversPreConditionsEval = ac.EvalAll(
+		ac.EvalPermission(ac.ActionAlertingReceiversPermissionsRead),  // Action for receivers. UID scope.
+		ac.EvalPermission(ac.ActionAlertingReceiversPermissionsWrite), // Action for receivers. UID scope.
+	)
+
+	// Asserts resource permissions access to all receivers.
+	permissionsAllReceiversEval = ac.EvalAll(
+		ac.EvalPermission(ac.ActionAlertingReceiversPermissionsRead, ScopeReceiversAll),
+		ac.EvalPermission(ac.ActionAlertingReceiversPermissionsWrite, ScopeReceiversAll),
+	)
+
+	// Asserts resource permissions access to a specific receiver.
+	permissionsReceiverEval = func(uid string) ac.Evaluator {
+		return ac.EvalAll(
+			ac.EvalPermission(ac.ActionAlertingReceiversPermissionsRead, ScopeReceiversProvider.GetResourceScopeUID(uid)),
+			ac.EvalPermission(ac.ActionAlertingReceiversPermissionsWrite, ScopeReceiversProvider.GetResourceScopeUID(uid)),
+		)
+	}
 )
 
 type ReceiverAccess[T models.Identified] struct {
@@ -133,6 +164,7 @@ type ReceiverAccess[T models.Identified] struct {
 	create        actionAccess[T]
 	update        actionAccess[T]
 	delete        actionAccess[T]
+	permissions   actionAccess[T]
 }
 
 // NewReceiverAccess creates a new ReceiverAccess service. If includeProvisioningActions is true, the service will include
@@ -199,6 +231,18 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 			},
 			authorizeAll: deleteAllReceiversEval,
 		},
+		permissions: actionAccess[T]{
+			genericService: genericService{
+				ac: a,
+			},
+			resource:      "receiver",
+			action:        "admin", // Essentially read+write receiver resource permissions.
+			authorizeSome: permissionsReceiversPreConditionsEval,
+			authorizeOne: func(receiver models.Identified) ac.Evaluator {
+				return permissionsReceiverEval(receiver.GetUID())
+			},
+			authorizeAll: permissionsAllReceiversEval,
+		},
 	}
 
 	// If this service is meant for the provisioning API, we include the provisioning actions as possible permissions.
@@ -219,9 +263,10 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 		})
 	}
 
-	// Write and delete permissions should require read permissions.
+	// Write, delete, and permissions management should require read permissions.
 	extendAccessControl(&rcvAccess.update, ac.EvalAll, rcvAccess.read)
 	extendAccessControl(&rcvAccess.delete, ac.EvalAll, rcvAccess.read)
+	extendAccessControl(&rcvAccess.permissions, ac.EvalAll, rcvAccess.read)
 
 	return rcvAccess
 }
@@ -335,12 +380,11 @@ func (s ReceiverAccess[T]) Access(ctx context.Context, user identity.Requester, 
 		basePerms.Set(models.ReceiverPermissionReadSecret, true) // Has access to all receivers.
 	}
 
-	// TODO: Add when resource permissions are implemented.
-	//if err := s.permissions.AuthorizePreConditions(ctx, user); err != nil {
-	//	basePerms.Set(models.ReceiverPermissionAdmin, false) // Doesn't match the preconditions.
-	//} else if err := s.permissions.AuthorizeAll(ctx, user); err == nil {
-	//	basePerms.Set(models.ReceiverPermissionAdmin, true) // Has access to all receivers.
-	//}
+	if err := s.permissions.AuthorizePreConditions(ctx, user); err != nil {
+		basePerms.Set(models.ReceiverPermissionAdmin, false) // Doesn't match the preconditions.
+	} else if err := s.permissions.AuthorizeAll(ctx, user); err == nil {
+		basePerms.Set(models.ReceiverPermissionAdmin, true) // Has access to all receivers.
+	}
 
 	if err := s.update.AuthorizePreConditions(ctx, user); err != nil {
 		basePerms.Set(models.ReceiverPermissionWrite, false) // Doesn't match the preconditions.
@@ -371,11 +415,10 @@ func (s ReceiverAccess[T]) Access(ctx context.Context, user identity.Requester, 
 			permSet.Set(models.ReceiverPermissionReadSecret, err == nil)
 		}
 
-		// TODO: Add when resource permissions are implemented.
-		//if _, ok := permSet.Has(models.ReceiverPermissionAdmin); !ok {
-		//	err := s.permissions.authorize(ctx, user, rcv)
-		//	permSet.Set(models.ReceiverPermissionAdmin, err == nil)
-		//}
+		if _, ok := permSet.Has(models.ReceiverPermissionAdmin); !ok {
+			err := s.permissions.authorize(ctx, user, rcv)
+			permSet.Set(models.ReceiverPermissionAdmin, err == nil)
+		}
 
 		if _, ok := permSet.Has(models.ReceiverPermissionWrite); !ok {
 			err := s.update.authorize(ctx, user, rcv)

--- a/pkg/services/ngalert/models/permissions.go
+++ b/pkg/services/ngalert/models/permissions.go
@@ -10,16 +10,16 @@ type ReceiverPermission string
 
 const (
 	ReceiverPermissionReadSecret ReceiverPermission = "secrets"
-	//ReceiverPermissionAdmin      ReceiverPermission = "admin" // TODO: Add when resource permissions are implemented.
-	ReceiverPermissionWrite  ReceiverPermission = "write"
-	ReceiverPermissionDelete ReceiverPermission = "delete"
+	ReceiverPermissionAdmin      ReceiverPermission = "admin"
+	ReceiverPermissionWrite      ReceiverPermission = "write"
+	ReceiverPermissionDelete     ReceiverPermission = "delete"
 )
 
 // ReceiverPermissions returns all possible silence permissions.
 func ReceiverPermissions() []ReceiverPermission {
 	return []ReceiverPermission{
 		ReceiverPermissionReadSecret,
-		//ReceiverPermissionAdmin, // TODO: Add when resource permissions are implemented.
+		ReceiverPermissionAdmin,
 		ReceiverPermissionWrite,
 		ReceiverPermissionDelete,
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -489,7 +489,7 @@ func (ng *AlertNG) init() error {
 		return key.LogContext(), true
 	})
 
-	return DeclareFixedRoles(ng.accesscontrolService)
+	return DeclareFixedRoles(ng.accesscontrolService, ng.FeatureToggles)
 }
 
 func subscribeToFolderChanges(logger log.Logger, bus bus.Bus, dbStore api.RuleStore) {


### PR DESCRIPTION
Extracted from https://github.com/grafana/grafana/pull/92885 as part of per-receiver RBAC.

**What is this feature?**

- Adds an access control resource service for receivers gated by the `FlagAlertingApiServer` feature flag.
- Extends k8s receiver API access control metadata to include `canAdmin` which denotes when a user can "administrate" a receiver, ie. read and modify its access permissions in a similar way to other resources dashboards/datasources/...
- This PR does not include the maintenance (creation/update/deletion) of resource permissions when managed via API. This will be added in a followup.

**Why do we need this feature?**

This adds the backing services required for managing per-receiver RBAC in the UI via resource permissions. It adds `api/access-control/receivers/...` endpoints needed to leverage the `Manage Permissions` front-end components used by Dashboards/Folders/Datasource/...

**Who is this feature for?**

Frontend developers.

**Special notes for your reviewer:**

Note it conditionally exposes the new  `...alerting.receivers:...` fixed roles only if the feature flag is enabled.