### PR TITLE
Alerting: Managed receiver resource permission in receiver_svc

### DIFF
--- a/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
@@ -2,6 +2,7 @@ package v0alpha1
 
 import (
 	"fmt"
+	"strings"
 )
 
 const InternalPrefix = "grafana.com/"
@@ -55,6 +56,17 @@ func (o *Receiver) SetAccessControl(action string) {
 		o.Annotations = make(map[string]string, 1)
 	}
 	o.Annotations[AccessControlAnnotation(action)] = "true"
+}
+
+func (o *Receiver) ClearAccessControl() {
+	if o.Annotations == nil {
+		return
+	}
+	for k := range o.Annotations {
+		if strings.HasPrefix(k, fmt.Sprintf("%s%s/", InternalPrefix, "access")) {
+			delete(o.Annotations, k)
+		}
+	}
 }
 
 // AccessControlAnnotation returns the key for the access control annotation for the given action.

--- a/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
+++ b/pkg/apis/alerting_notifications/v0alpha1/types_ext.go
@@ -2,7 +2,6 @@ package v0alpha1
 
 import (
 	"fmt"
-	"strings"
 )
 
 const InternalPrefix = "grafana.com/"
@@ -56,17 +55,6 @@ func (o *Receiver) SetAccessControl(action string) {
 		o.Annotations = make(map[string]string, 1)
 	}
 	o.Annotations[AccessControlAnnotation(action)] = "true"
-}
-
-func (o *Receiver) ClearAccessControl() {
-	if o.Annotations == nil {
-		return
-	}
-	for k := range o.Annotations {
-		if strings.HasPrefix(k, fmt.Sprintf("%s%s/", InternalPrefix, "access")) {
-			delete(o.Annotations, k)
-		}
-	}
 }
 
 // AccessControlAnnotation returns the key for the access control annotation for the given action.

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -151,6 +151,8 @@ type ServiceAccountPermissionsService interface {
 
 type ReceiverPermissionsService interface {
 	PermissionsService
+	SetDefaultPermissions(ctx context.Context, orgID int64, user identity.Requester, uid string)
+	CopyPermissions(ctx context.Context, orgID int64, user identity.Requester, oldUID, newUID string) (int, error)
 }
 
 type PermissionsService interface {

--- a/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
@@ -1,14 +1,22 @@
 package ossaccesscontrol
 
 import (
+	"context"
+
+	"github.com/grafana/authlib/claims"
+
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/ngalert"
 	alertingac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -17,6 +25,14 @@ import (
 var ReceiversViewActions = []string{accesscontrol.ActionAlertingReceiversRead}
 var ReceiversEditActions = append(ReceiversViewActions, []string{accesscontrol.ActionAlertingReceiversUpdate, accesscontrol.ActionAlertingReceiversDelete}...)
 var ReceiversAdminActions = append(ReceiversEditActions, []string{accesscontrol.ActionAlertingReceiversReadSecrets, accesscontrol.ActionAlertingReceiversPermissionsRead, accesscontrol.ActionAlertingReceiversPermissionsWrite}...)
+
+// defaultPermissions returns the default permissions for a newly created receiver.
+func defaultPermissions() []accesscontrol.SetResourcePermissionCommand {
+	return []accesscontrol.SetResourcePermissionCommand{
+		{BuiltinRole: string(org.RoleEditor), Permission: string(alertingac.ReceiverPermissionEdit)},
+		{BuiltinRole: string(org.RoleViewer), Permission: string(alertingac.ReceiverPermissionView)},
+	}
+}
 
 func ProvideReceiverPermissionsService(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
@@ -50,11 +66,131 @@ func ProvideReceiverPermissionsService(
 	if err != nil {
 		return nil, err
 	}
-	return &ReceiverPermissionsService{Service: srv}, nil
+	return &ReceiverPermissionsService{srv, service, log.New("resourcepermissions.receivers")}, nil
 }
 
 var _ accesscontrol.ReceiverPermissionsService = new(ReceiverPermissionsService)
 
 type ReceiverPermissionsService struct {
 	*resourcepermissions.Service
+	ac  accesscontrol.Service
+	log log.Logger
+}
+
+// SetDefaultPermissions sets the default permissions for a newly created receiver.
+func (r ReceiverPermissionsService) SetDefaultPermissions(ctx context.Context, orgID int64, user identity.Requester, uid string) {
+	permissions := defaultPermissions()
+	clearCache := false
+	if user != nil && user.IsIdentityType(claims.TypeUser) {
+		userID, err := user.GetInternalID()
+		if err != nil {
+			r.log.Error("Could not make user admin", "receiver_uid", uid, "id", user.GetID(), "error", err)
+		} else {
+			permissions = append(permissions, accesscontrol.SetResourcePermissionCommand{
+				UserID: userID, Permission: string(alertingac.ReceiverPermissionAdmin),
+			})
+			clearCache = true
+		}
+	}
+
+	if _, err := r.SetPermissions(ctx, orgID, uid, permissions...); err != nil {
+		r.log.Error("Could not set default permissions", "receiver_uid", uid, "error", err)
+	}
+
+	if clearCache {
+		// Clear permission cache for the user who created the receiver, so that new permissions are fetched for their next call
+		// Required for cases when caller wants to immediately interact with the newly created object
+		r.ac.ClearUserPermissionCache(user)
+	}
+}
+
+// copyPermissionUser returns a user with permissions to copy permissions from one receiver to another. This must include
+// permissions to read and write permissions for the receiver, as well as read permissions for users, service accounts, and teams.
+func copyPermissionUser(orgID int64) identity.Requester {
+	return accesscontrol.BackgroundUser("receiver_access_service", orgID, org.RoleAdmin, accesscontrol.ConcatPermissions(
+		accesscontrol.PermissionsForActions(ReceiversAdminActions, alertingac.ScopeReceiversAll),
+		[]accesscontrol.Permission{ // Permissions needed for GetPermissions to return user, service account, and team permissions.
+			{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
+			{Action: serviceaccounts.ActionRead, Scope: serviceaccounts.ScopeAll},
+			{Action: accesscontrol.ActionTeamsRead, Scope: accesscontrol.ScopeTeamsAll},
+		},
+	),
+	)
+}
+
+// CopyPermissions copies the resource permissions from one receiver uid to a new uid. This is a temporary
+// method to be used during receiver renaming that is necessitated by receiver uids being generated from the receiver
+// name.
+func (r ReceiverPermissionsService) CopyPermissions(ctx context.Context, orgID int64, user identity.Requester, oldUID, newUID string) (int, error) {
+	currentPermissions, err := r.GetPermissions(ctx, copyPermissionUser(orgID), oldUID)
+	if err != nil {
+		return 0, err
+	}
+
+	setPermissionCommands := r.toSetResourcePermissionCommands(currentPermissions)
+	if _, err := r.SetPermissions(ctx, orgID, newUID, setPermissionCommands...); err != nil {
+		return 0, err
+	}
+
+	// Clear permission cache for the user who updated the receiver, so that new permissions are fetched for their next call
+	// Required for cases when caller wants to immediately interact with the newly updated object
+	if user != nil && user.IsIdentityType(claims.TypeUser) {
+		r.ac.ClearUserPermissionCache(user)
+	}
+
+	return countCustomPermissions(setPermissionCommands), nil
+}
+
+// toSetResourcePermissionCommands converts a list of resource permissions to a list of set resource permission commands.
+// Only includes managed permissions.
+func (r ReceiverPermissionsService) toSetResourcePermissionCommands(permissions []accesscontrol.ResourcePermission) []accesscontrol.SetResourcePermissionCommand {
+	cmds := make([]accesscontrol.SetResourcePermissionCommand, 0, len(permissions))
+	for _, p := range permissions {
+		if !p.IsManaged {
+			continue
+		}
+		permission := r.MapActions(p)
+		if permission == "" {
+			continue
+		}
+		cmds = append(cmds, accesscontrol.SetResourcePermissionCommand{
+			Permission:  permission,
+			BuiltinRole: p.BuiltInRole,
+			TeamID:      p.TeamId,
+			UserID:      p.UserId,
+		})
+	}
+	return cmds
+}
+
+// countCustomPermissions counts the number of custom permissions in a list of set resource permission commands. A
+// custom permission is a permission that is not a default permission for a receiver.
+func countCustomPermissions(permissions []accesscontrol.SetResourcePermissionCommand) int {
+	cacheKey := func(p accesscontrol.SetResourcePermissionCommand) accesscontrol.SetResourcePermissionCommand {
+		return accesscontrol.SetResourcePermissionCommand{
+			Permission:  "",
+			BuiltinRole: p.BuiltinRole,
+			TeamID:      p.TeamID,
+			UserID:      p.UserID,
+		}
+	}
+	missingDefaults := make(map[accesscontrol.SetResourcePermissionCommand]string, 2)
+	for _, p := range defaultPermissions() {
+		missingDefaults[cacheKey(p)] = p.Permission
+	}
+
+	diff := 0
+	for _, p := range permissions {
+		key := cacheKey(p)
+		perm, ok := missingDefaults[key]
+		if perm != p.Permission {
+			diff++
+		}
+		if ok {
+			delete(missingDefaults, key)
+		}
+	}
+
+	// missing + new
+	return len(missingDefaults) + diff
 }

--- a/pkg/services/ngalert/api/api_notifications_test.go
+++ b/pkg/services/ngalert/api/api_notifications_test.go
@@ -374,6 +374,7 @@ func createNotificationSrvSutFromEnv(t *testing.T, env *testEnvironment) Notific
 		env.secrets,
 		env.xact,
 		env.log,
+		fakes.NewFakeReceiverPermissionsService(),
 	)
 	return NotificationSrv{
 		logger:          env.log,

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	ngalertfakes "github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	secrets_fakes "github.com/grafana/grafana/pkg/services/secrets/fakes"
@@ -1901,6 +1902,7 @@ func createProvisioningSrvSutFromEnv(t *testing.T, env *testEnvironment) Provisi
 		env.secrets,
 		env.xact,
 		env.log,
+		ngalertfakes.NewFakeReceiverPermissionsService(),
 	)
 	return ProvisioningSrv{
 		log:                 env.log,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -99,7 +99,7 @@ func ProvideService(
 		dashboardService:     dashboardService,
 		renderService:        renderService,
 		bus:                  bus,
-		accesscontrolService: accesscontrolService,
+		AccesscontrolService: accesscontrolService,
 		annotationsRepo:      annotationsRepo,
 		pluginsStore:         pluginsStore,
 		tracer:               tracer,
@@ -149,7 +149,7 @@ type AlertNG struct {
 	MultiOrgAlertmanager *notifier.MultiOrgAlertmanager
 	AlertsRouter         *sender.AlertsRouter
 	accesscontrol        accesscontrol.AccessControl
-	accesscontrolService accesscontrol.Service
+	AccesscontrolService accesscontrol.Service
 	ResourcePermissions  accesscontrol.ReceiverPermissionsService
 	annotationsRepo      annotations.Repository
 	store                *store.DBstore
@@ -494,7 +494,7 @@ func (ng *AlertNG) init() error {
 		return key.LogContext(), true
 	})
 
-	return DeclareFixedRoles(ng.accesscontrolService, ng.FeatureToggles)
+	return DeclareFixedRoles(ng.AccesscontrolService, ng.FeatureToggles)
 }
 
 func subscribeToFolderChanges(logger log.Logger, bus bus.Bus, dbStore api.RuleStore) {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -77,6 +77,7 @@ func ProvideService(
 	tracer tracing.Tracer,
 	ruleStore *store.DBstore,
 	httpClientProvider httpclient.Provider,
+	resourcePermissions accesscontrol.ReceiverPermissionsService,
 ) (*AlertNG, error) {
 	ng := &AlertNG{
 		Cfg:                  cfg,
@@ -104,6 +105,7 @@ func ProvideService(
 		tracer:               tracer,
 		store:                ruleStore,
 		httpClientProvider:   httpClientProvider,
+		resourcePermissions:  resourcePermissions,
 	}
 
 	if ng.IsDisabled() {
@@ -148,6 +150,7 @@ type AlertNG struct {
 	AlertsRouter         *sender.AlertsRouter
 	accesscontrol        accesscontrol.AccessControl
 	accesscontrolService accesscontrol.Service
+	resourcePermissions  accesscontrol.ReceiverPermissionsService
 	annotationsRepo      annotations.Repository
 	store                *store.DBstore
 
@@ -423,6 +426,7 @@ func (ng *AlertNG) init() error {
 		ng.SecretsService,
 		ng.store,
 		ng.Log,
+		ng.resourcePermissions,
 	)
 	provisioningReceiverService := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, true),
@@ -432,6 +436,7 @@ func (ng *AlertNG) init() error {
 		ng.SecretsService,
 		ng.store,
 		ng.Log,
+		ng.resourcePermissions,
 	)
 
 	// Provisioning

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -105,7 +105,7 @@ func ProvideService(
 		tracer:               tracer,
 		store:                ruleStore,
 		httpClientProvider:   httpClientProvider,
-		resourcePermissions:  resourcePermissions,
+		ResourcePermissions:  resourcePermissions,
 	}
 
 	if ng.IsDisabled() {
@@ -150,7 +150,7 @@ type AlertNG struct {
 	AlertsRouter         *sender.AlertsRouter
 	accesscontrol        accesscontrol.AccessControl
 	accesscontrolService accesscontrol.Service
-	resourcePermissions  accesscontrol.ReceiverPermissionsService
+	ResourcePermissions  accesscontrol.ReceiverPermissionsService
 	annotationsRepo      annotations.Repository
 	store                *store.DBstore
 
@@ -426,7 +426,7 @@ func (ng *AlertNG) init() error {
 		ng.SecretsService,
 		ng.store,
 		ng.Log,
-		ng.resourcePermissions,
+		ng.ResourcePermissions,
 	)
 	provisioningReceiverService := notifier.NewReceiverService(
 		ac.NewReceiverAccess[*models.Receiver](ng.accesscontrol, true),
@@ -436,7 +436,7 @@ func (ng *AlertNG) init() error {
 		ng.SecretsService,
 		ng.store,
 		ng.Log,
-		ng.resourcePermissions,
+		ng.ResourcePermissions,
 	)
 
 	// Provisioning

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers.go
@@ -19,7 +19,7 @@ func (rev *ConfigRevision) DeleteReceiver(uid string) {
 
 func (rev *ConfigRevision) CreateReceiver(receiver *models.Receiver) (*definitions.PostableApiReceiver, error) {
 	// Check if the receiver already exists.
-	_, err := rev.GetReceiver(NameToUid(receiver.Name)) // get UID from name because the new receiver does not have UID yet.
+	_, err := rev.GetReceiver(receiver.GetUID())
 	if err == nil {
 		return nil, ErrReceiverExists.Errorf("")
 	}

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -1483,6 +1483,7 @@ func createReceiverServiceSut(t *testing.T, encryptSvc secretService) *ReceiverS
 		encryptSvc,
 		xact,
 		log.NewNopLogger(),
+		fakes.NewFakeReceiverPermissionsService(),
 	)
 }
 

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -493,6 +493,7 @@ func createContactPointServiceSutWithConfigStore(t *testing.T, secretService sec
 		secretService,
 		xact,
 		log.NewNopLogger(),
+		fakes.NewFakeReceiverPermissionsService(),
 	)
 
 	return &ContactPointService{

--- a/pkg/services/ngalert/tests/fakes/permissions.go
+++ b/pkg/services/ngalert/tests/fakes/permissions.go
@@ -1,0 +1,28 @@
+package fakes
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+)
+
+type FakeReceiverPermissionsService struct {
+	*actest.FakePermissionsService
+}
+
+func NewFakeReceiverPermissionsService() *FakeReceiverPermissionsService {
+	return &FakeReceiverPermissionsService{
+		FakePermissionsService: &actest.FakePermissionsService{},
+	}
+}
+
+func (f FakeReceiverPermissionsService) SetDefaultPermissions(ctx context.Context, orgID int64, user identity.Requester, uid string) {
+}
+
+func (f FakeReceiverPermissionsService) CopyPermissions(ctx context.Context, orgID int64, user identity.Requester, oldUID, newUID string) (int, error) {
+	return 0, nil
+}
+
+var _ accesscontrol.ReceiverPermissionsService = new(FakeReceiverPermissionsService)

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	ngalertfakes "github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/ngalert/testutil"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
@@ -70,7 +71,7 @@ func SetupTestEnv(tb testing.TB, baseInterval time.Duration) (*ngalert.AlertNG, 
 	ng, err := ngalert.ProvideService(
 		cfg, features, nil, nil, routing.NewRouteRegister(), sqlStore, kvstore.NewFakeKVStore(), nil, nil, quotatest.New(false, nil),
 		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus, ac,
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(),
 	)
 	require.NoError(tb, err)
 	return ng, &store.DBstore{

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -53,6 +53,7 @@ func ProvideService(
 	quotaService quota.Service,
 	secrectService secrets.Service,
 	orgService org.Service,
+	resourcePermissions accesscontrol.ReceiverPermissionsService,
 ) (*ProvisioningServiceImpl, error) {
 	s := &ProvisioningServiceImpl{
 		Cfg:                          cfg,
@@ -76,6 +77,7 @@ func ProvideService(
 		log:                          log.New("provisioning"),
 		orgService:                   orgService,
 		folderService:                folderService,
+		resourcePermissions:          resourcePermissions,
 	}
 
 	if err := s.setDashboardProvisioner(); err != nil {
@@ -154,6 +156,7 @@ type ProvisioningServiceImpl struct {
 	quotaService                 quota.Service
 	secretService                secrets.Service
 	folderService                folder.Service
+	resourcePermissions          accesscontrol.ReceiverPermissionsService
 }
 
 func (ps *ProvisioningServiceImpl) RunInitProvisioners(ctx context.Context) error {
@@ -287,6 +290,7 @@ func (ps *ProvisioningServiceImpl) ProvisionAlerting(ctx context.Context) error 
 		ps.secretService,
 		ps.SQLStore,
 		ps.log,
+		ps.resourcePermissions,
 	)
 	contactPointService := provisioning.NewContactPointService(configStore, ps.secretService,
 		st, ps.SQLStore, receiverSvc, ps.log, &st)

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -502,7 +502,7 @@ func setupEnv(t *testing.T, replStore db.ReplDB, cfg *setting.Cfg, b bus.Bus, qu
 	_, err = ngalert.ProvideService(
 		cfg, featuremgmt.WithFeatures(), nil, nil, routing.NewRouteRegister(), sqlStore, ngalertfakes.NewFakeKVStore(t), nil, nil, quotaService,
 		secretsService, nil, m, &foldertest.FakeService{}, &acmock.Mock{}, &dashboards.FakeDashboardService{}, nil, b, &acmock.Mock{},
-		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(),
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore, httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(),
 	)
 	require.NoError(t, err)
 	_, err = storesrv.ProvideService(sqlStore, featuremgmt.WithFeatures(), cfg, quotaService, storesrv.ProvideSystemUsersService())

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -294,6 +294,23 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 			expACMetadata: allACMetadata,
 			expRead:       true,
 		},
+		// Team-based access. Staff team has editor+admin but not viewer in it.
+		{
+			name:          "Admin creates, assigns admin to staff, viewer has no metadata and access",
+			creatingUser:  admin,
+			testUser:      viewer,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{TeamID: org1.Staff.ID, Permission: string(alertingac.ReceiverPermissionAdmin)}},
+			expACMetadata: nil,
+			expRead:       true,
+		},
+		{
+			name:          "Admin creates, assigns admin to staff, editor has all metadata and access",
+			creatingUser:  admin,
+			testUser:      editor,
+			assignments:   []accesscontrol.SetResourcePermissionCommand{{TeamID: org1.Staff.ID, Permission: string(alertingac.ReceiverPermissionAdmin)}},
+			expACMetadata: allACMetadata,
+			expRead:       true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			createClient := newClient(t, tc.creatingUser)

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -434,7 +436,11 @@ func (c *K8sTestHelper) createTestUsers(orgName string) OrgUsers {
 		Viewer: c.CreateUser("viewer", orgName, org.RoleViewer, nil),
 	}
 	users.Staff = c.CreateTeam("staff", "staff@"+orgName, users.Admin.Identity.GetOrgID())
-	// TODO add admin and editor to staff
+
+	// Add Admin and Editor to Staff team as Admin and Member, respectively.
+	c.AddOrUpdateTeamMember(users.Admin, users.Staff.ID, team.PermissionTypeAdmin)
+	c.AddOrUpdateTeamMember(users.Editor, users.Staff.ID, team.PermissionTypeMember)
+
 	return users
 }
 
@@ -530,6 +536,42 @@ func (c *K8sTestHelper) SetPermissions(user User, permissions []resourcepermissi
 			permission, nil)
 		require.NoError(c.t, err)
 	}
+}
+
+func (c *K8sTestHelper) AddOrUpdateTeamMember(user User, teamID int64, permission team.PermissionType) {
+	teamSvc, err := teamimpl.ProvideService(c.env.ReadReplStore, c.env.Cfg, tracing.InitializeTracerForTest())
+	require.NoError(c.t, err)
+
+	orgService, err := orgimpl.ProvideService(c.env.SQLStore, c.env.Cfg, c.env.Server.HTTPServer.QuotaService)
+	require.NoError(c.t, err)
+
+	cache := localcache.ProvideService()
+	userSvc, err := userimpl.ProvideService(
+		c.env.SQLStore, orgService, c.env.Cfg, teamSvc,
+		cache, tracing.InitializeTracerForTest(), c.env.Server.HTTPServer.QuotaService,
+		supportbundlestest.NewFakeBundleService())
+	require.NoError(c.t, err)
+
+	teampermissionSvc, err := ossaccesscontrol.ProvideTeamPermissions(
+		c.env.Cfg,
+		c.env.FeatureToggles,
+		c.env.Server.HTTPServer.RouteRegister,
+		c.env.SQLStore,
+		c.env.Server.HTTPServer.AccessControl,
+		c.env.Server.HTTPServer.License,
+		c.env.Server.HTTPServer.AlertNG.AccesscontrolService,
+		teamSvc,
+		userSvc,
+		resourcepermissions.NewActionSetService(c.env.FeatureToggles),
+	)
+	require.NoError(c.t, err)
+
+	id, err := user.Identity.GetInternalID()
+	require.NoError(c.t, err)
+
+	teamIDString := strconv.FormatInt(teamID, 10)
+	_, err = teampermissionSvc.SetUserPermission(context.Background(), user.Identity.GetOrgID(), accesscontrol.User{ID: id}, teamIDString, permission.String())
+	require.NoError(c.t, err)
 }
 
 func (c *K8sTestHelper) NewDiscoveryClient() *discovery.DiscoveryClient {


### PR DESCRIPTION
Followup to https://github.com/grafana/grafana/pull/93552
Extracted from https://github.com/grafana/grafana/pull/92885

**What is this feature?**

Adds logic to manages receiver resource permission in `receiver_svc`. This only affects the k8s receiver API, provisioning will be a in a followup. 

- `Create`: Adds default resource permissions (`Viewer: View, Editor: Edit`). If the creator is a regular user, they will also be assigned `Admin` permission on the created receiver.
- `Delete`: Removes all resource permissions associated with the receiver.
- `Update`: If the receiver's name is changed, it will also update the permissions to reflect the new UID. This is only necessary as we generate the UID based on the receiver name and will eventually be removed.

**Why do we need this feature?**

As part of per-receiver RBAC, permissions need to be maintained alongside receiver CRUD operations.

**Special notes for your reviewer:**

- We could consider being more aggressive on cache invalidation during `CopyPermissions`. Currently, if another user renames a receiver, other users who have user-assigned permission to that receiver will take some time before they can interact with it.

TODO: 
- [x] Write tests to ensure interactions between users creating receivers and assigning permissions is correct.
