### PR TITLE
update 'Simplified exploration' page

### DIFF
--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -36,10 +36,8 @@ cards:
 
 # Simplified exploration
 
-Introducing the Grafana Explore apps, designed for effortless data exploration through intuitive, queryless interactions.
+The Grafana Explore apps are designed for effortless data exploration through intuitive, queryless interactions.
 
-Easily explore telemetry signals with these specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
-
-## Explore
+Easily explore telemetry signals with specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
 
 {{< card-grid key="cards" type="simple" >}}

--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -38,6 +38,6 @@ cards:
 
 The Grafana Explore apps are designed for effortless data exploration through intuitive, queryless interactions.
 
-Easily explore telemetry signals with specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
+Easily explore telemetry signals with these specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
 
 {{< card-grid key="cards" type="simple" >}}


### PR DESCRIPTION
* removed extra 'Explore' heading, which is a little confusing in this context
* simplified the intro text to sound more like the rest of the docs
