### PR TITLE
Prometheus: WIP add limit to metric names calls and use regex filtering in the monaco code editor

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/MonacoQueryField.tsx
@@ -175,7 +175,7 @@ const MonacoQueryField = (props: Props) => {
               }
               return await debounce(
                 () => completionProvider.provideCompletionItems(model, position, context, token),
-                300
+                200
               )();
             },
           };

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -54,7 +54,7 @@ async function getAllMetricNamesCompletions(dataProvider: DataProvider): Promise
   let metricNames: string[] = [];
   if (dataProvider.languageProvider.datasource.hasLabelsMatchAPISupport()) {
     // use the metric regex with match[] param for partial typing of metric name to filter metric names
-    metricNames = await debounce(() => dataProvider.getLimitedMetricNames(dataProvider.inputInRange), 300)();
+    metricNames = await debounce(() => dataProvider.getLimitedMetricNames(dataProvider.inputInRange), 50)();
   } else {
     metricNames = dataProvider.getAllMetricNames();
   }

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -46,8 +46,9 @@ export class DataProvider {
    *
    * @remarks
    * This is useful with fuzzy searching items to provide as Monaco autocomplete suggestions.
+   * Making dataProvider.inputInRange public because it works better than monacoSettings.inputInRange for debouncing the input because it is updated more regularly
    */
-  private inputInRange: string;
+  inputInRange: string;
   private suggestionsIncomplete: boolean;
 
   constructor(params: DataProviderParams) {
@@ -68,6 +69,10 @@ export class DataProvider {
 
   getAllMetricNames(): string[] {
     return this.languageProvider.metrics;
+  }
+
+  getLimitedMetricNames(m: string): Promise<string[]> {
+    return this.languageProvider.getLimitedMetrics(m);
   }
 
   metricNamesToMetrics(metricNames: string[]): Metric[] {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -656,6 +656,7 @@ export class PrometheusDatasource
 
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   async getTagValues(options: DataSourceGetTagValuesOptions<PromQuery>) {
+    // DO NOT USE FOR METRIC NAMES
     const requestId = `[${this.uid}][${options.key}]`;
     if (config.featureToggles.promQLScope) {
       return (

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -12,6 +12,7 @@ import {
   Scope,
   scopeFilterOperatorMap,
   ScopeSpecFilter,
+  MetricFindValue,
   TimeRange,
 } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
@@ -140,6 +141,37 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     return Promise.all([this.loadMetricsMetadata(), this.fetchLabels()]);
   };
 
+  /**
+   * Only used for getting metrics from a data source that
+   * supports the match[] parameter
+   * where we can get a list of metrics based on user input
+   * that is passed to the label values endpoint
+   * with the extra param to match on series that contain the input
+   * as regex for the __name__ label
+   *
+   * Also takes a limit param to limit the number of metrics returned
+   *
+   * @param metricRegex
+   * @param limit
+   * @returns
+   */
+  async getLimitedMetrics(metricRegex: string): Promise<string[]> {
+    const limit = this.datasource.metricNamesAutocompleteSuggestionLimit.toString();
+
+    const options = {
+      key: '__name__',
+      filters: [{ key: '__name__', value: '.*' + metricRegex + '.*', operator: '=~' }],
+      limit,
+    };
+    const metricNames = await this.datasource.getTagValues(options);
+    // metrics should only be strings but MetricFindValue from getTagKeys is a (string|number|undefined)
+    if (metricNames.every((el: MetricFindValue) => typeof el.value === 'string')) {
+      return metricNames.map((m: { text: string }) => m.text);
+    }
+
+    return [];
+  }
+
   async loadMetricsMetadata() {
     const headers = buildCacheHeaders(this.datasource.getDaysToCacheMetadata() * secondsInDay);
     this.metricsMetadata = fixSummariesMetadata(
@@ -203,18 +235,43 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   }
 
   /**
+   * Used to fetch label values and to fetch metrics with the label key __name__
+   * Used in
+   * - languageProvider.start()
+   * - languageProvider.getLabelValues()
+   * - languageProvider.fetchDefaultSeries()
+   *
    * @param key
    */
-  fetchLabelValues = async (key: string): Promise<string[]> => {
-    const params = this.datasource.getAdjustedInterval(this.timeRange);
+  fetchLabelValues = async (key: string, fromQueryBuilder?: boolean): Promise<string[]> => {
+    let params: UrlParamsType = this.datasource.getAdjustedInterval(this.timeRange);
+
+    // Do not limit the query builder metric suggestions
+    // Limit metrics from the code editor and metrics browser
+    // metric names come from the label __name__
+    if (!fromQueryBuilder && this.datasource.metricNamesAutocompleteSuggestionLimit && key === '__name__') {
+      const limit = this.datasource.metricNamesAutocompleteSuggestionLimit.toString();
+      // add limit to the params
+      params = { ...params, limit };
+    }
+
     const interpolatedName = this.datasource.interpolateString(key);
     const url = `/api/v1/label/${interpolatedName}/values`;
     const value = await this.request(url, [], params, this.getDefaultCacheHeaders());
     return value ?? [];
   };
 
-  async getLabelValues(key: string): Promise<string[]> {
-    return await this.fetchLabelValues(key);
+  /**
+   * This function is used to retrieve label values in completions.ts in Monaco editor
+   * and used for general label values in the query builder
+   * Extra: it is also used in the query builder to load initial metrics when there are no label filters
+   *
+   * @param key
+   * @param fromQueryBuilder
+   * @returns
+   */
+  async getLabelValues(key: string, fromQueryBuilder?: boolean): Promise<string[]> {
+    return await this.fetchLabelValues(key, fromQueryBuilder);
   }
 
   /**
@@ -270,6 +327,11 @@ export default class PromQlLanguageProvider extends LanguageProvider {
 
   /**
    * Fetches all values for a label, with optional match[]
+   * Used in the following locations
+   * - datasource.getTagValues() for adhoc label values and metrics here languageProvider.getLimitedMetrics which calls getTagValues()
+   * - languageProvider.getSeriesValues()
+   * - MetricsLabelsSection.tsx, getLabelValuesFromLabelValuesAPI() for labels
+   *
    * @param name
    * @param match
    * @param timeRange
@@ -284,10 +346,17 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const interpolatedName = name ? this.datasource.interpolateString(name) : null;
     const interpolatedMatch = match ? this.datasource.interpolateString(match) : null;
     const range = this.datasource.getAdjustedInterval(timeRange);
-    const urlParams = {
+    let urlParams: UrlParamsType = {
       ...range,
       ...(interpolatedMatch && { 'match[]': interpolatedMatch }),
     };
+
+    // only use the limit if calling for metrics and the limit has been set in the config
+    if (this.datasource.metricNamesAutocompleteSuggestionLimit && interpolatedName === '__name__') {
+      const limit = this.datasource.metricNamesAutocompleteSuggestionLimit.toString();
+      urlParams = { ...urlParams, limit };
+    }
+
     let requestOptions: Partial<BackendSrvRequest> | undefined = {
       ...this.getDefaultCacheHeaders(),
       ...(requestId && { requestId }),

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -28,6 +28,7 @@ import {
   toPromLikeQuery,
 } from './language_utils';
 import PromqlSyntax from './promql';
+import { formatKeyValueStringsForLabelValuesQuery } from './querybuilder/components/MetricSelect';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 import { PrometheusCacheLevel, PromMetricsMetadata, PromQuery } from './types';
 
@@ -156,14 +157,18 @@ export default class PromQlLanguageProvider extends LanguageProvider {
    * @returns
    */
   async getLimitedMetrics(metricRegex: string): Promise<string[]> {
-    const limit = this.datasource.metricNamesAutocompleteSuggestionLimit.toString();
+    // need time range
+    // need match params for metric match[]
+    // need label filters if used in the query builder
+    // pass in limit into metricFindQuery?
+    // pass in tome range into metricFindQuery?
 
-    const options = {
-      key: '__name__',
-      filters: [{ key: '__name__', value: '.*' + metricRegex + '.*', operator: '=~' }],
-      limit,
-    };
-    const metricNames = await this.datasource.getTagValues(options);
+    // const limit = this.datasource.metricNamesAutocompleteSuggestionLimit.toString();
+
+    const metricNames = await this.datasource.metricFindQuery(
+      formatKeyValueStringsForLabelValuesQuery(metricRegex, [])
+    );
+
     // metrics should only be strings but MetricFindValue from getTagKeys is a (string|number|undefined)
     if (metricNames.every((el: MetricFindValue) => typeof el.value === 'string')) {
       return metricNames.map((m: { text: string }) => m.text);

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -39,6 +39,7 @@ export function MetricCombobox({
    */
   const getMetricLabels = useCallback(
     async (query: string) => {
+      // METRIC NAMES
       const results = await datasource.metricFindQuery(formatKeyValueStringsForLabelValuesQuery(query, labelsFilters));
 
       const resultsOptions = results.map((result) => {

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx
@@ -125,21 +125,10 @@ export function MetricSelect({
   );
 
   /**
-   * Reformat the query string and label filters to return all valid results for current query editor state
-   */
-  const formatKeyValueStringsForLabelValuesQuery = (
-    query: string,
-    labelsFilters?: QueryBuilderLabelFilter[]
-  ): string => {
-    const queryString = regexifyLabelValuesQueryString(query);
-
-    return formatPrometheusLabelFiltersToString(queryString, labelsFilters);
-  };
-
-  /**
    * Gets label_values response from prometheus API for current autocomplete query string and any existing labels filters
    */
   const getMetricLabels = (query: string) => {
+    // METRIC NAMES
     // Since some customers can have millions of metrics, whenever the user changes the autocomplete text we want to call the backend and request all metrics that match the current query string
     const results = datasource.metricFindQuery(formatKeyValueStringsForLabelValuesQuery(query, labelsFilters));
     return results.then((results) => {
@@ -423,4 +412,16 @@ export const formatPrometheusLabelFilters = (labelsFilters: QueryBuilderLabelFil
   return labelsFilters.map((label) => {
     return `,${label.label}="${label.value}"`;
   });
+};
+
+/**
+ * Reformat the query string and label filters to return all valid results for current query editor state
+ */
+export const formatKeyValueStringsForLabelValuesQuery = (
+  query: string,
+  labelsFilters?: QueryBuilderLabelFilter[]
+): string => {
+  const queryString = regexifyLabelValuesQueryString(query);
+
+  return formatPrometheusLabelFiltersToString(queryString, labelsFilters);
 };

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
@@ -247,7 +247,7 @@ async function getMetrics(
     const expr = promQueryModeller.renderLabels(query.labels);
     metrics = (await datasource.languageProvider.getSeries(expr, true))['__name__'] ?? [];
   } else {
-    metrics = (await datasource.languageProvider.getLabelValues('__name__')) ?? [];
+    metrics = (await datasource.languageProvider.getLabelValues('__name__', true)) ?? [];
   }
 
   return metrics.map((m) => ({


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/85444

WIP

**What is this?**

This adds a limit for metrics names calls. 
When users type in the monaco code editor, user typing input is debounced to call the label values http endpoint with the input to get a new autocomplete list. [See this comment for example](https://github.com/grafana/grafana/issues/85444#issuecomment-2148599086)

**Why do we need this?**

Users with 100,000+ metric names have slow performance in the monaco code editor. Depending on the amount customers have, the UI is slow or crashes. Calls to server timeout sometimes too.

**Concerns and questions:**

- [x] Limit initial metrics in language provider code
Used for Monaco code editor and for Metrics browser
- [ ] When user begins typing in the code editor we debounce the metrics regex search and load metrics from the label values matching on the user typing input
- [ ] Do we need a feature toggle? For safety, maybe
- [ ] Should we implement this for the Metrics Browser? confirm with @taleena) We can limit the initial list, and use the regex input to call label values to show more metrics… Is this needed? Or just the code editor?
- [ ] Do not limit for query builder (confirm with @taleena)
- [ ] Do we need a new Prometheus configuration element or can we use Nick’s Metrics names suggestion limit?
    - His is specific for the code editor and is only client side
    - If we create a new CONFIG client side metric limit for Prom Config page, customers might assume it is applied to all 
      - metric searches
      - Code editor
      - Metrics Browser
      - Query builder
      - (not the Metrics Explorer though)
- [x] Not in scope: refactoring the multiple functions to call label values endpoint
    - Some label values function are called getSeries
    - Each UI for the query editor uses different functions
    - The caching is different for each of these resource calls
    - They all do similar things
      - Call label values
      - Get metrics
      - Use metric regex match[] param
      - Can use limits

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
