### PR TITLE
Loki: Add UI support for `detected_level`

### DIFF
--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, Labels } from '@grafana/data';
 import { Tooltip, useStyles2 } from '@grafana/ui';
 
 // Levels are already encoded in color, filename is a Loki-ism
-const HIDDEN_LABELS = ['level', 'lvl', 'filename'];
+const HIDDEN_LABELS = ['detected_level', 'level', 'lvl', 'filename'];
 
 interface Props {
   labels: Labels;

--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -45,7 +45,7 @@ export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
   }
 
   const timeNanosecondField = cache.getFieldByName('tsNs') ?? null;
-  const severityField = cache.getFieldByName('level') ?? null;
+  const severityField = cache.getFieldByName('detected_level') ?? cache.getFieldByName('level') ?? null;
   const idField = cache.getFieldByName('id') ?? null;
 
   // extracting the labels is done very differently for old-loki-style and simple-style

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -424,7 +424,7 @@ export function logSeriesToLogsModel(
       }
 
       let logLevel = LogLevel.unknown;
-      const logLevelKey = (logLevelField && logLevelField.values[j]) || (labels && labels['level']);
+      const logLevelKey = (logLevelField && logLevelField.values[j]) || (labels?.detected_level ?? labels?.level);
       if (typeof logLevelKey === 'number' || typeof logLevelKey === 'string') {
         logLevel = getLogLevelFromKey(logLevelKey);
       } else {
@@ -633,7 +633,7 @@ function defaultExtractLevel(dataFrame: DataFrame): LogLevel {
 }
 
 function getLogLevelFromLabels(labels: Labels): LogLevel {
-  const level = labels['level'] ?? labels['lvl'] ?? labels['loglevel'] ?? '';
+  const level = labels['detected_level'] ?? labels['level'] ?? labels['lvl'] ?? labels['loglevel'] ?? '';
   return level ? getLogLevelFromKey(level) : LogLevel.unknown;
 }
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1429,11 +1429,10 @@ describe('LokiDatasource', () => {
             }
           )
         ).toEqual({
-          expr: 'sum by (level) (count_over_time({label="value"} | drop __error__[$__auto]))',
+          expr: 'sum by (level, detected_level) (count_over_time({label="value"} | drop __error__[$__auto]))',
           queryType: LokiQueryType.Range,
           refId: 'log-volume-A',
           supportingQueryType: SupportingQueryType.LogsVolume,
-          legendFormat: '{{ level }}',
         });
       });
 
@@ -1448,11 +1447,10 @@ describe('LokiDatasource', () => {
             }
           )
         ).toEqual({
-          expr: 'sum by (level) (count_over_time({label="value"} | drop __error__[$__auto]))',
+          expr: 'sum by (level, detected_level) (count_over_time({label="value"} | drop __error__[$__auto]))',
           queryType: LokiQueryType.Range,
           refId: 'log-volume-A',
           supportingQueryType: SupportingQueryType.LogsVolume,
-          legendFormat: '{{ level }}',
         });
       });
 
@@ -1468,8 +1466,7 @@ describe('LokiDatasource', () => {
             }
           )
         ).toEqual({
-          expr: 'sum by (level) (count_over_time({label="value"} | drop __error__[$__auto]))',
-          legendFormat: '{{ level }}',
+          expr: 'sum by (level, detected_level) (count_over_time({label="value"} | drop __error__[$__auto]))',
           queryType: 'range',
           refId: 'log-volume-A',
           supportingQueryType: 'logsVolume',
@@ -1510,7 +1507,9 @@ describe('LokiDatasource', () => {
             refId: 'A',
           }
         );
-        expect(query?.expr).toEqual('sum by (level) (count_over_time({label="value"} | drop __error__[$__auto]))');
+        expect(query?.expr).toEqual(
+          'sum by (level, detected_level) (count_over_time({label="value"} | drop __error__[$__auto]))'
+        );
       });
     });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -217,7 +217,7 @@ export class LokiDatasource
         }
 
         const dropErrorExpression = `${expr} | drop __error__`;
-        const field = options.field || 'level';
+        const field = options.field || 'level, detected_level';
         if (isQueryWithError(this.interpolateString(dropErrorExpression, placeHolderScopedVars)) === false) {
           expr = dropErrorExpression;
         }
@@ -228,7 +228,6 @@ export class LokiDatasource
           queryType: LokiQueryType.Range,
           supportingQueryType: SupportingQueryType.LogsVolume,
           expr: `sum by (${field}) (count_over_time(${expr}[$__auto]))`,
-          legendFormat: `{{ ${field} }}`,
         };
 
       case SupplementaryQueryType.LogsSample:

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -130,6 +130,11 @@ describe('extractLevelLikeLabelFromDataFrame', () => {
     input.fields[1].values = [{ error_level: 'info' }];
     expect(extractLevelLikeLabelFromDataFrame(input)).toBe('error_level');
   });
+  it('returns label if detected_level label is present', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = [{ detected_level: 'info' }];
+    expect(extractLevelLikeLabelFromDataFrame(input)).toBe('detected_level');
+  });
   it('returns undefined if no level-like label is present', () => {
     const input = cloneDeep(frame);
     input.fields[1].values = [{ foo: 'info' }];

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -121,7 +121,9 @@ export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | n
 
   // Find first level-like label
   for (let labels of labelsArray) {
-    const label = Object.keys(labels).find((label) => label === 'lvl' || label.includes('level'));
+    const label = Object.keys(labels).find(
+      (label) => label === 'detected_level' || label === 'level' || label === 'lvl' || label.includes('level')
+    );
     if (label) {
       levelLikeLabel = label;
       break;


### PR DESCRIPTION
**What is this feature?**

Loki added a level detection using the `detected_level` label. This PR adds support for using that label, without breaking backwards compatibility when `detected_level` is not present. Additionally, the PR streamlines the colors using the the LogsPanel with using the `detected_level` label.

**Which issue(s) does this PR fix?**:

Fixes #87564
