### PR TITLE
Dashboard: Annotations - Fix issue of `angularEditorLoader` when angular is not supported

### DIFF
--- a/public/app/features/dashboard-scene/settings/annotations/AngularEditorLoader.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AngularEditorLoader.tsx
@@ -1,7 +1,7 @@
 import { PureComponent } from 'react';
 
 import { AnnotationQuery, DataSourceApi } from '@grafana/data';
-import { AngularComponent, getAngularLoader } from '@grafana/runtime';
+import { AngularComponent, config, getAngularLoader } from '@grafana/runtime';
 
 export interface Props {
   annotation: AnnotationQuery;
@@ -29,7 +29,9 @@ export class AngularEditorLoader extends PureComponent<Props> {
   }
 
   componentDidMount() {
-    if (this.ref) {
+    // check if angular support is enabled in the instance
+    const isAngularEnabled = config.angularSupportEnabled;
+    if (this.ref && isAngularEnabled) {
       this.loadAngular();
     }
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In this [PR](https://github.com/grafana/grafana/pull/92504)  I forgot to add a condition when angular support is not enabled in the instance. This property `angularSupportEnabled` is configured in the Grafana config (custom.ini or grafana.ini).


#### Screenshot with `angularSupportEnabled=false`
![image](https://github.com/user-attachments/assets/dc1e18cc-b438-4a49-b14c-9edfa05117ef)

**How to test this PR?**

- In your grafana configuration `custom.ini` or `grafana.ini` add `angular_support_enabled = false`
- Make `default` a datasource that does not support annotations (zipkin, influxdata-flightsql-datasource)
- Go to a dashboard --> Settings --> Click "Add Annotation Query"
- You should see an inline error with the annotation not supported, and not runtime error should appear

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/support-escalations/issues/11948

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
