### PR TITLE
Cfg: Deduplicate `DefaultOrgID` code

### DIFF
--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -92,10 +92,7 @@ func (m *OrgRoleMapper) getDefaultOrgMapping(strictRoleMapping bool, directlyMap
 	}
 	orgRoles := make(map[int64]org.RoleType, 0)
 
-	orgID := int64(1)
-	if m.cfg.AutoAssignOrg && m.cfg.AutoAssignOrgId > 0 {
-		orgID = int64(m.cfg.AutoAssignOrgId)
-	}
+	orgID := m.cfg.DefaultOrgID()
 
 	orgRoles[orgID] = directlyMappedRole
 	if !directlyMappedRole.IsValid() {

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -101,7 +101,7 @@ func (s *ExtendedJWT) authenticateAsUser(
 	accessTokenClaims authlib.Claims[authlib.AccessTokenClaims],
 ) (*authn.Identity, error) {
 	// Only allow id tokens signed for namespace configured for this instance.
-	if allowedNamespace := s.namespaceMapper(s.getDefaultOrgID()); !claims.NamespaceMatches(authlib.NewIdentityClaims(idTokenClaims), allowedNamespace) {
+	if allowedNamespace := s.namespaceMapper(s.cfg.DefaultOrgID()); !claims.NamespaceMatches(authlib.NewIdentityClaims(idTokenClaims), allowedNamespace) {
 		return nil, errExtJWTDisallowedNamespaceClaim.Errorf("unexpected id token namespace: %s", idTokenClaims.Rest.Namespace)
 	}
 
@@ -138,7 +138,7 @@ func (s *ExtendedJWT) authenticateAsUser(
 	return &authn.Identity{
 		ID:                         id,
 		Type:                       t,
-		OrgID:                      s.getDefaultOrgID(),
+		OrgID:                      s.cfg.DefaultOrgID(),
 		AccessTokenClaims:          &accessTokenClaims,
 		IDTokenClaims:              &idTokenClaims,
 		AuthenticatedBy:            login.ExtendedJWTModule,
@@ -155,7 +155,7 @@ func (s *ExtendedJWT) authenticateAsUser(
 
 func (s *ExtendedJWT) authenticateAsService(accessTokenClaims authlib.Claims[authlib.AccessTokenClaims]) (*authn.Identity, error) {
 	// Allow access tokens with that has a wildcard namespace or a namespace matching this instance.
-	if allowedNamespace := s.namespaceMapper(s.getDefaultOrgID()); !claims.NamespaceMatches(authlib.NewAccessClaims(accessTokenClaims), allowedNamespace) {
+	if allowedNamespace := s.namespaceMapper(s.cfg.DefaultOrgID()); !claims.NamespaceMatches(authlib.NewAccessClaims(accessTokenClaims), allowedNamespace) {
 		return nil, errExtJWTDisallowedNamespaceClaim.Errorf("unexpected access token namespace: %s", accessTokenClaims.Rest.Namespace)
 	}
 
@@ -186,7 +186,7 @@ func (s *ExtendedJWT) authenticateAsService(accessTokenClaims authlib.Claims[aut
 		ID:                         id,
 		UID:                        id,
 		Type:                       t,
-		OrgID:                      s.getDefaultOrgID(),
+		OrgID:                      s.cfg.DefaultOrgID(),
 		AccessTokenClaims:          &accessTokenClaims,
 		IDTokenClaims:              nil,
 		AuthenticatedBy:            login.ExtendedJWTModule,
@@ -246,12 +246,4 @@ func (s *ExtendedJWT) retrieveAuthorizationToken(httpRequest *http.Request) stri
 
 	// Strip the 'Bearer' prefix if it exists.
 	return strings.TrimPrefix(jwtToken, "Bearer ")
-}
-
-func (s *ExtendedJWT) getDefaultOrgID() int64 {
-	orgID := int64(1)
-	if s.cfg.AutoAssignOrg && s.cfg.AutoAssignOrgId > 0 {
-		orgID = int64(s.cfg.AutoAssignOrgId)
-	}
-	return orgID
 }

--- a/pkg/services/authn/clients/utils.go
+++ b/pkg/services/authn/clients/utils.go
@@ -20,11 +20,7 @@ func getRoles(cfg *setting.Cfg, extract roleExtractor) (map[int64]org.RoleType, 
 		return orgRoles, nil, nil
 	}
 
-	orgID := int64(1)
-	if cfg.AutoAssignOrg && cfg.AutoAssignOrgId > 0 {
-		orgID = int64(cfg.AutoAssignOrgId)
-	}
-	orgRoles[orgID] = role
+	orgRoles[cfg.DefaultOrgID()] = role
 
 	return orgRoles, isGrafanaAdmin, nil
 }

--- a/pkg/services/extsvcauth/models.go
+++ b/pkg/services/extsvcauth/models.go
@@ -4,20 +4,11 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 const (
 	ServiceAccounts AuthProvider = "ServiceAccounts"
 )
-
-func DefaultOrgID(cfg *setting.Cfg) int64 {
-	orgID := int64(1)
-	if cfg.AutoAssignOrg && cfg.AutoAssignOrgId > 0 {
-		orgID = int64(cfg.AutoAssignOrgId)
-	}
-	return orgID
-}
 
 type AuthProvider string
 

--- a/pkg/services/serviceaccounts/extsvcaccounts/service.go
+++ b/pkg/services/serviceaccounts/extsvcaccounts/service.go
@@ -40,7 +40,7 @@ func ProvideExtSvcAccountsService(acSvc ac.Service, cfg *setting.Cfg, bus bus.Bu
 	logger := log.New("serviceauth.extsvcaccounts")
 	esa := &ExtSvcAccountsService{
 		acSvc:        acSvc,
-		defaultOrgID: extsvcauth.DefaultOrgID(cfg),
+		defaultOrgID: cfg.DefaultOrgID(),
 		logger:       logger,
 		saSvc:        saSvc,
 		features:     features,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -2051,3 +2051,10 @@ func (cfg *Cfg) readPublicDashboardsSettings() {
 	publicDashboards := cfg.Raw.Section("public_dashboards")
 	cfg.PublicDashboardsEnabled = publicDashboards.Key("enabled").MustBool(true)
 }
+
+func (cfg *Cfg) DefaultOrgID() int64 {
+	if cfg.AutoAssignOrg && cfg.AutoAssignOrgId > 0 {
+		return int64(cfg.AutoAssignOrgId)
+	}
+	return int64(1)
+}


### PR DESCRIPTION
**What is this feature?**

This PR refactors the codebase to eliminate duplicate logic for retrieving the `DefaultOrgID`.  Instead of having multiple instances of similar code, a new shared function centralizes this functionality. 