### PR TITLE
Playlists: Check if playlist is playing before reloading for assets

### DIFF
--- a/public/app/core/services/NewFrontendAssetsChecker.test.ts
+++ b/public/app/core/services/NewFrontendAssetsChecker.test.ts
@@ -1,4 +1,7 @@
+import { Location } from 'history';
+
 import { locationService, setBackendSrv, BackendSrv } from '@grafana/runtime';
+import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 
 import { NewFrontendAssetsChecker } from './NewFrontendAssetsChecker';
 
@@ -46,4 +49,28 @@ describe('NewFrontendAssetsChecker', () => {
 
     expect(backendApiGet).toHaveBeenCalledTimes(2);
   });
+
+  it('should skip reloading if we are playing a playlist', () => {
+    const checker = new NewFrontendAssetsCheckerExposedLocationUpdate();
+    const reloadMock = jest.fn();
+    checker.reloadIfUpdateDetected = reloadMock;
+    playlistSrv.state.isPlaying = true;
+    checker.doLocationUpdated({ hash: 'foo', pathname: '/d/dashboarduid', state: {}, search: '' });
+    expect(reloadMock).not.toHaveBeenCalled();
+    playlistSrv.state.isPlaying = false;
+  });
+
+  it('should reload if we are accessing a dashboard', () => {
+    const checker = new NewFrontendAssetsCheckerExposedLocationUpdate();
+    const reloadMock = jest.fn();
+    checker.reloadIfUpdateDetected = reloadMock;
+    checker.doLocationUpdated({ hash: 'foo', pathname: '/d/dashboarduid', state: {}, search: '' });
+    expect(reloadMock).toHaveBeenCalled();
+  });
 });
+
+class NewFrontendAssetsCheckerExposedLocationUpdate extends NewFrontendAssetsChecker {
+  public doLocationUpdated(location: Location) {
+    this.locationUpdated(location);
+  }
+}

--- a/public/app/core/services/NewFrontendAssetsChecker.ts
+++ b/public/app/core/services/NewFrontendAssetsChecker.ts
@@ -2,6 +2,7 @@ import { Location } from 'history';
 import { isEqual } from 'lodash';
 
 import { getBackendSrv, getGrafanaLiveSrv, locationService, reportInteraction } from '@grafana/runtime';
+import { playlistSrv } from 'app/features/playlist/PlaylistSrv';
 
 export class NewFrontendAssetsChecker {
   private hasUpdates = false;
@@ -47,7 +48,7 @@ export class NewFrontendAssetsChecker {
       this.reloadIfUpdateDetected();
     }
     // Moving to dashboard (or changing dashboards)
-    else if (newLocationSegments[1] === 'd') {
+    else if (newLocationSegments[1] === 'd' && !playlistSrv.state.isPlaying) {
       this.reloadIfUpdateDetected();
     }
     // Track potential page change

--- a/public/app/core/services/NewFrontendAssetsChecker.ts
+++ b/public/app/core/services/NewFrontendAssetsChecker.ts
@@ -36,7 +36,7 @@ export class NewFrontendAssetsChecker {
   /**
    * Tries to detect some navigation events where it's safe to trigger a reload
    */
-  private locationUpdated(location: Location) {
+  protected locationUpdated(location: Location) {
     if (this.prevLocationPath === location.pathname) {
       return;
     }
@@ -47,7 +47,7 @@ export class NewFrontendAssetsChecker {
     if (newLocationSegments[1] === '/' && this.prevLocationPath !== '/') {
       this.reloadIfUpdateDetected();
     }
-    // Moving to dashboard (or changing dashboards)
+    // Moving to dashboard (or changing dashboards, except when we're playing a playlist)
     else if (newLocationSegments[1] === 'd' && !playlistSrv.state.isPlaying) {
       this.reloadIfUpdateDetected();
     }


### PR DESCRIPTION
**What is this feature?**

This fixes an issue where updated assets causes playlists to stop playing.

**Special notes for your reviewer:**

To reproduce this issue without the PR applied:

1. Create a playlist that has a 1 minute interval or less. Add at least 10 dashboards to it.
2. Start the playlist
3. Add a feature flag in the `[feature_toggles]
enable= ` entry and save it. This will temporarily disconnect the web socket giving a warning, and the next dashboard might fail to fetch, this is not a problem.
4. Wait 5 minutes until the asset checker discovers the flags have changed.
5. The next dashboard in the playlist will trigger a full reload and stop the dashboard.

With this fix, we will not reload if we're playing a playlist. This might lead to the assets being stale for a long time. Ideally this should be adressed in the future.

