### PR TITLE
Explore Metrics: Add consistent maxDataPoints value across the app

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/AutoVizPanel.tsx
+++ b/public/app/features/trails/AutomaticMetricQueries/AutoVizPanel.tsx
@@ -1,7 +1,7 @@
 import { SceneObjectState, SceneObjectBase, SceneComponentProps, VizPanel, SceneQueryRunner } from '@grafana/scenes';
 import { RadioButtonGroup } from '@grafana/ui';
 
-import { trailDS } from '../shared';
+import { MDP_METRIC_OVERVIEW, trailDS } from '../shared';
 import { getMetricSceneFor } from '../utils';
 
 import { AutoQueryDef } from './types';
@@ -52,7 +52,7 @@ export class AutoVizPanel extends SceneObjectBase<AutoVizPanelState> {
       .setData(
         new SceneQueryRunner({
           datasource: trailDS,
-          maxDataPoints: 500,
+          maxDataPoints: MDP_METRIC_OVERVIEW,
           queries: def.queries,
         })
       )

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -33,7 +33,7 @@ import { MetricScene } from '../MetricScene';
 import { StatusWrapper } from '../StatusWrapper';
 import { reportExploreMetrics } from '../interactions';
 import { ALL_VARIABLE_VALUE } from '../services/variables';
-import { trailDS, VAR_FILTERS, VAR_GROUP_BY, VAR_GROUP_BY_EXP } from '../shared';
+import { MDP_METRIC_PREVIEW, trailDS, VAR_FILTERS, VAR_GROUP_BY, VAR_GROUP_BY_EXP } from '../shared';
 import { getColorByIndex, getTrailFor } from '../utils';
 
 import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
@@ -304,7 +304,7 @@ export function buildAllLayout(
       .setTitle(option.label!)
       .setData(
         new SceneQueryRunner({
-          maxDataPoints: 250,
+          maxDataPoints: MDP_METRIC_PREVIEW,
           datasource: trailDS,
           queries: [
             {
@@ -395,7 +395,7 @@ function buildNormalLayout(
   return new LayoutSwitcher({
     $data: new SceneQueryRunner({
       datasource: trailDS,
-      maxDataPoints: 300,
+      maxDataPoints: MDP_METRIC_PREVIEW,
       queries: queryDef.queries,
     }),
     breakdownLayoutOptions: [

--- a/public/app/features/trails/MetricSelect/previewPanel.ts
+++ b/public/app/features/trails/MetricSelect/previewPanel.ts
@@ -2,7 +2,7 @@ import { PromQuery } from '@grafana/prometheus';
 import { SceneCSSGridItem, SceneQueryRunner, SceneVariableSet } from '@grafana/scenes';
 
 import { getAutoQueriesForMetric } from '../AutomaticMetricQueries/AutoQueryEngine';
-import { getVariablesWithMetricConstant, trailDS } from '../shared';
+import { getVariablesWithMetricConstant, MDP_METRIC_PREVIEW, trailDS } from '../shared';
 import { getColorByIndex } from '../utils';
 
 import { SelectMetricAction } from './SelectMetricAction';
@@ -29,7 +29,7 @@ export function getPreviewPanelFor(metric: string, index: number, currentFilterC
     $behaviors: [hideEmptyPreviews(metric)],
     $data: new SceneQueryRunner({
       datasource: trailDS,
-      maxDataPoints: 200,
+      maxDataPoints: MDP_METRIC_PREVIEW,
       queries,
     }),
     body: vizPanel,

--- a/public/app/features/trails/shared.ts
+++ b/public/app/features/trails/shared.ts
@@ -37,10 +37,11 @@ export const trailDS = { uid: VAR_DATASOURCE_EXPR };
 
 // Local storage keys
 export const RECENT_TRAILS_KEY = 'grafana.trails.recent';
-
 export const TRAIL_BOOKMARKS_KEY = 'grafana.trails.bookmarks';
-
 export const TRAIL_BREAKDOWN_VIEW_KEY = 'grafana.trails.breakdown.view';
+
+export const MDP_METRIC_PREVIEW = 250;
+export const MDP_METRIC_OVERVIEW = 500;
 
 export type MakeOptional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 


### PR DESCRIPTION
**What is this feature?**

Add consistent values for `maxDataPoints` across the explore metrics app to eliminate data granularity differences. 

**Why do we need this feature?**

More consistent visualization

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/93413

