### PR TITLE
Plugins: Add state logs for plugin client retrieval

### DIFF
--- a/pkg/plugins/backendplugin/grpcplugin/client_proto.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_proto.go
@@ -29,7 +29,7 @@ type ProtoClient interface {
 
 	PID(context.Context) (string, error)
 	PluginID() string
-	PluginJSON() plugins.JSONData
+	PluginVersion() string
 	Backend() backendplugin.Plugin
 }
 
@@ -73,8 +73,8 @@ func (r *protoClient) PluginID() string {
 	return r.plugin.descriptor.pluginID
 }
 
-func (r *protoClient) PluginJSON() plugins.JSONData {
-	return r.pluginJSON
+func (r *protoClient) PluginVersion() string {
+	return r.pluginJSON.Info.Version
 }
 
 func (r *protoClient) Backend() backendplugin.Plugin {

--- a/pkg/plugins/backendplugin/grpcplugin/client_proto.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_proto.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	errClientNotAvailable = errors.New("plugin client is not available")
+	errClientNotAvailable = errors.New("plugin client not available")
 )
 
 var _ ProtoClient = (*protoClient)(nil)

--- a/pkg/plugins/backendplugin/grpcplugin/client_proto.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_proto.go
@@ -3,6 +3,7 @@ package grpcplugin
 import (
 	"context"
 	"errors"
+
 	"google.golang.org/grpc"
 
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
@@ -13,7 +14,7 @@ import (
 )
 
 var (
-	errClientNotStarted = errors.New("plugin client has not been started")
+	errClientNotAvailable = errors.New("plugin client is not available")
 )
 
 var _ ProtoClient = (*protoClient)(nil)
@@ -63,7 +64,7 @@ func NewProtoClient(opts ProtoClientOpts) (ProtoClient, error) {
 
 func (r *protoClient) PID(ctx context.Context) (string, error) {
 	if _, exists := r.client(ctx); !exists {
-		return "", errClientNotStarted
+		return "", errClientNotAvailable
 	}
 	return r.plugin.client.ID(), nil
 }
@@ -91,7 +92,7 @@ func (r *protoClient) client(ctx context.Context) (*ClientV2, bool) {
 func (r *protoClient) QueryData(ctx context.Context, in *pluginv2.QueryDataRequest, opts ...grpc.CallOption) (*pluginv2.QueryDataResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.DataClient.QueryData(ctx, in, opts...)
 }
@@ -99,7 +100,7 @@ func (r *protoClient) QueryData(ctx context.Context, in *pluginv2.QueryDataReque
 func (r *protoClient) CallResource(ctx context.Context, in *pluginv2.CallResourceRequest, opts ...grpc.CallOption) (pluginv2.Resource_CallResourceClient, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.ResourceClient.CallResource(ctx, in, opts...)
 }
@@ -107,7 +108,7 @@ func (r *protoClient) CallResource(ctx context.Context, in *pluginv2.CallResourc
 func (r *protoClient) CheckHealth(ctx context.Context, in *pluginv2.CheckHealthRequest, opts ...grpc.CallOption) (*pluginv2.CheckHealthResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.DiagnosticsClient.CheckHealth(ctx, in, opts...)
 }
@@ -115,7 +116,7 @@ func (r *protoClient) CheckHealth(ctx context.Context, in *pluginv2.CheckHealthR
 func (r *protoClient) CollectMetrics(ctx context.Context, in *pluginv2.CollectMetricsRequest, opts ...grpc.CallOption) (*pluginv2.CollectMetricsResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.DiagnosticsClient.CollectMetrics(ctx, in, opts...)
 }
@@ -123,7 +124,7 @@ func (r *protoClient) CollectMetrics(ctx context.Context, in *pluginv2.CollectMe
 func (r *protoClient) SubscribeStream(ctx context.Context, in *pluginv2.SubscribeStreamRequest, opts ...grpc.CallOption) (*pluginv2.SubscribeStreamResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.StreamClient.SubscribeStream(ctx, in, opts...)
 }
@@ -131,7 +132,7 @@ func (r *protoClient) SubscribeStream(ctx context.Context, in *pluginv2.Subscrib
 func (r *protoClient) RunStream(ctx context.Context, in *pluginv2.RunStreamRequest, opts ...grpc.CallOption) (pluginv2.Stream_RunStreamClient, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.StreamClient.RunStream(ctx, in, opts...)
 }
@@ -139,7 +140,7 @@ func (r *protoClient) RunStream(ctx context.Context, in *pluginv2.RunStreamReque
 func (r *protoClient) PublishStream(ctx context.Context, in *pluginv2.PublishStreamRequest, opts ...grpc.CallOption) (*pluginv2.PublishStreamResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.StreamClient.PublishStream(ctx, in, opts...)
 }
@@ -147,7 +148,7 @@ func (r *protoClient) PublishStream(ctx context.Context, in *pluginv2.PublishStr
 func (r *protoClient) ValidateAdmission(ctx context.Context, in *pluginv2.AdmissionRequest, opts ...grpc.CallOption) (*pluginv2.ValidationResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.AdmissionClient.ValidateAdmission(ctx, in, opts...)
 }
@@ -155,7 +156,7 @@ func (r *protoClient) ValidateAdmission(ctx context.Context, in *pluginv2.Admiss
 func (r *protoClient) MutateAdmission(ctx context.Context, in *pluginv2.AdmissionRequest, opts ...grpc.CallOption) (*pluginv2.MutationResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.AdmissionClient.MutateAdmission(ctx, in, opts...)
 }
@@ -163,7 +164,7 @@ func (r *protoClient) MutateAdmission(ctx context.Context, in *pluginv2.Admissio
 func (r *protoClient) ConvertObjects(ctx context.Context, in *pluginv2.ConversionRequest, opts ...grpc.CallOption) (*pluginv2.ConversionResponse, error) {
 	c, exists := r.client(ctx)
 	if !exists {
-		return nil, errClientNotStarted
+		return nil, errClientNotAvailable
 	}
 	return c.ConversionClient.ConvertObjects(ctx, in, opts...)
 }

--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -14,16 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/log"
 )
 
-type pluginClient interface {
-	backend.CollectMetricsHandler
-	backend.CheckHealthHandler
-	backend.QueryDataHandler
-	backend.CallResourceHandler
-	backend.AdmissionHandler
-	backend.ConversionHandler
-	backend.StreamHandler
-}
-
 type grpcPlugin struct {
 	descriptor     PluginDescriptor
 	clientFactory  func() *plugin.Client
@@ -32,7 +22,18 @@ type grpcPlugin struct {
 	logger         log.Logger
 	mutex          sync.RWMutex
 	decommissioned bool
+	state          pluginState
 }
+
+type pluginState int
+
+const (
+	pluginStateNotStarted pluginState = iota
+	pluginStateStartInit
+	pluginStateStartSuccess
+	pluginStateStartFail
+	pluginStateStopped
+)
 
 // newPlugin allocates and returns a new gRPC (external) backendplugin.Plugin.
 func newPlugin(descriptor PluginDescriptor) backendplugin.PluginFactoryFunc {
@@ -48,6 +49,7 @@ func newGrpcPlugin(descriptor PluginDescriptor, logger log.Logger, env func() []
 		clientFactory: func() *plugin.Client {
 			return plugin.NewClient(newClientConfig(descriptor.executablePath, descriptor.executableArgs, env(), descriptor.skipHostEnvVars, logger, descriptor.versionedPlugins))
 		},
+		state: pluginStateNotStarted,
 	}
 }
 
@@ -63,9 +65,12 @@ func (p *grpcPlugin) Start(_ context.Context) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
+	p.state = pluginStateStartInit
+
 	p.client = p.clientFactory()
 	rpcClient, err := p.client.Client()
 	if err != nil {
+		p.state = pluginStateStartFail
 		return err
 	}
 
@@ -74,10 +79,12 @@ func (p *grpcPlugin) Start(_ context.Context) error {
 	}
 	p.pluginClient, err = newClientV2(p.descriptor, p.logger, rpcClient)
 	if err != nil {
+		p.state = pluginStateStartFail
 		return err
 	}
 
 	if p.pluginClient == nil {
+		p.state = pluginStateStartFail
 		return errors.New("no compatible plugin implementation found")
 	}
 
@@ -89,6 +96,7 @@ func (p *grpcPlugin) Start(_ context.Context) error {
 		p.logger.Warn("Plugin process is running with elevated privileges. This is not recommended")
 	}
 
+	p.state = pluginStateStartSuccess
 	return nil
 }
 
@@ -99,6 +107,7 @@ func (p *grpcPlugin) Stop(_ context.Context) error {
 	if p.client != nil {
 		p.client.Kill()
 	}
+	p.state = pluginStateStopped
 	return nil
 }
 
@@ -134,94 +143,111 @@ func (p *grpcPlugin) Target() backendplugin.Target {
 	return backendplugin.TargetLocal
 }
 
-func (p *grpcPlugin) getPluginClient() (pluginClient, bool) {
+func (p *grpcPlugin) getPluginClient(ctx context.Context) (*ClientV2, bool) {
 	p.mutex.RLock()
-	if p.client == nil || p.client.Exited() || p.pluginClient == nil {
+	if p.client != nil && !p.client.Exited() && p.pluginClient != nil {
 		p.mutex.RUnlock()
-		return nil, false
+		return p.pluginClient, false
 	}
-	pluginClient := p.pluginClient
+
+	logger := p.Logger().FromContext(ctx)
+	if p.state == pluginStateNotStarted {
+		logger.Debug("Plugin client has not been started yet")
+	}
+
+	if p.state == pluginStateStartInit {
+		logger.Debug("Plugin client is starting")
+	}
+
+	if p.state == pluginStateStartFail {
+		logger.Debug("Plugin client failed to start")
+	}
+
+	if p.state == pluginStateStopped {
+		logger.Debug("Plugin client has stopped")
+	}
+
 	p.mutex.RUnlock()
-	return pluginClient, true
+	return nil, false
 }
 
 func (p *grpcPlugin) CollectMetrics(ctx context.Context, req *backend.CollectMetricsRequest) (*backend.CollectMetricsResult, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.CollectMetrics(ctx, req)
+	return pc.CollectMetrics(ctx, req)
 }
 
 func (p *grpcPlugin) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.CheckHealth(ctx, req)
+	return pc.CheckHealth(ctx, req)
 }
 
 func (p *grpcPlugin) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
 
-	return pluginClient.QueryData(ctx, req)
+	return pc.QueryData(ctx, req)
 }
 
 func (p *grpcPlugin) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return plugins.ErrPluginUnavailable
 	}
-	return pluginClient.CallResource(ctx, req, sender)
+	return pc.CallResource(ctx, req, sender)
 }
 
 func (p *grpcPlugin) SubscribeStream(ctx context.Context, request *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.SubscribeStream(ctx, request)
+	return pc.SubscribeStream(ctx, request)
 }
 
 func (p *grpcPlugin) PublishStream(ctx context.Context, request *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.PublishStream(ctx, request)
+	return pc.PublishStream(ctx, request)
 }
 
 func (p *grpcPlugin) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return plugins.ErrPluginUnavailable
 	}
-	return pluginClient.RunStream(ctx, req, sender)
+	return pc.RunStream(ctx, req, sender)
 }
 
 func (p *grpcPlugin) ValidateAdmission(ctx context.Context, request *backend.AdmissionRequest) (*backend.ValidationResponse, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.ValidateAdmission(ctx, request)
+	return pc.ValidateAdmission(ctx, request)
 }
 
 func (p *grpcPlugin) MutateAdmission(ctx context.Context, request *backend.AdmissionRequest) (*backend.MutationResponse, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.MutateAdmission(ctx, request)
+	return pc.MutateAdmission(ctx, request)
 }
 
 func (p *grpcPlugin) ConvertObjects(ctx context.Context, request *backend.ConversionRequest) (*backend.ConversionResponse, error) {
-	pluginClient, ok := p.getPluginClient()
+	pc, ok := p.getPluginClient(ctx)
 	if !ok {
 		return nil, plugins.ErrPluginUnavailable
 	}
-	return pluginClient.ConvertObjects(ctx, request)
+	return pc.ConvertObjects(ctx, request)
 }

--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -75,6 +75,7 @@ func (p *grpcPlugin) Start(_ context.Context) error {
 	}
 
 	if p.client.NegotiatedVersion() < 2 {
+		p.state = pluginStateStartFail
 		return errors.New("plugin protocol version not supported")
 	}
 	p.pluginClient, err = newClientV2(p.descriptor, p.logger, rpcClient)
@@ -147,7 +148,7 @@ func (p *grpcPlugin) getPluginClient(ctx context.Context) (*ClientV2, bool) {
 	p.mutex.RLock()
 	if p.client != nil && !p.client.Exited() && p.pluginClient != nil {
 		p.mutex.RUnlock()
-		return p.pluginClient, false
+		return p.pluginClient, true
 	}
 
 	logger := p.Logger().FromContext(ctx)

--- a/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
+++ b/pkg/plugins/backendplugin/grpcplugin/grpc_plugin.go
@@ -146,8 +146,8 @@ func (p *grpcPlugin) Target() backendplugin.Target {
 
 func (p *grpcPlugin) getPluginClient(ctx context.Context) (*ClientV2, bool) {
 	p.mutex.RLock()
+	defer p.mutex.RUnlock()
 	if p.client != nil && !p.client.Exited() && p.pluginClient != nil {
-		p.mutex.RUnlock()
 		return p.pluginClient, true
 	}
 
@@ -168,7 +168,6 @@ func (p *grpcPlugin) getPluginClient(ctx context.Context) (*ClientV2, bool) {
 		logger.Debug("Plugin client has stopped")
 	}
 
-	p.mutex.RUnlock()
 	return nil, false
 }
 


### PR DESCRIPTION
**What is this feature?**

- Simplifies proto client
- Adds logs for the plugin client fetching 
- Updates error messaging

**Why do we need this feature?**

In order to get better insight into what state the plugin is in when the client is requested.

