### PR TITLE
TimeSeries: Recalculate displayName to ensure panel opts are interpolated

### DIFF
--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -300,7 +300,7 @@ export function prepareTimelineFields(
     return { warn: 'No data in response' };
   }
 
-  cacheFieldDisplayNames(series);
+  cacheFieldDisplayNames(series, true);
 
   let hasTimeseries = false;
   const frames: DataFrame[] = [];

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -62,7 +62,7 @@ export function prepSeries(
     return { series: [], _rest: [], warn: 'No data in response' };
   }
 
-  cacheFieldDisplayNames(frames);
+  cacheFieldDisplayNames(frames, true);
   decoupleHideFromState(frames, fieldConfig);
 
   let frame: DataFrame | undefined = { ...frames[0] };

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -89,7 +89,7 @@ export function prepareHeatmapData({
     return {};
   }
 
-  cacheFieldDisplayNames(frames);
+  cacheFieldDisplayNames(frames, true);
 
   const exemplars = annotations?.find((f) => f.name === 'exemplar');
 

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -81,7 +81,7 @@ export function prepareGraphableFields(
     return null;
   }
 
-  cacheFieldDisplayNames(series);
+  cacheFieldDisplayNames(series, true);
 
   let useNumericX = xNumFieldIdx != null;
 

--- a/public/app/plugins/panel/xychart/v2/utils.ts
+++ b/public/app/plugins/panel/xychart/v2/utils.ts
@@ -42,7 +42,7 @@ export function prepSeries(
   frames: DataFrame[],
   fieldConfig: FieldConfigSource
 ) {
-  cacheFieldDisplayNames(frames);
+  cacheFieldDisplayNames(frames, true);
   decoupleHideFromState(frames, fieldConfig);
 
   let series: XYSeries[] = [];


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/12460

**IMPORTANT**: I don't believe this PR to be the correct fix. it's more of a work-around fix for what appears to be a Dashboard bug with either the `__field` data macro or `applyFieldOverrides()`.

simple repro:


<details><summary>displayName-bug.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 366,
  "links": [],
  "panels": [
    {
      "datasource": {
        "default": true,
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "displayName": "${__field.displayName} ${__field.labels}",
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 17,
        "w": 14,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "maxDataPoints": 5,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"config\": {}\n        },\n        {\n          \"name\": \"Value\",\n          \"type\": \"number\",\n          \"labels\": {\n            \"bar\": \"baz\"\n          },\n          \"config\": {\n            \"displayNameFromDS\": \"foooooo\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1727100877705,\n          1727105197705,\n          1727109517705,\n          1727113837705,\n          1727118157705,\n          1727122477705\n        ],\n        [\n          1,\n          20,\n          90,\n          30,\n          5,\n          0\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "schemaVersion": 39,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2024-09-23T14:10:10.373Z",
    "to": "2024-09-23T20:19:48.401Z"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "displayName-bug",
  "uid": "ddysr3t3mlblsa",
  "version": 1,
  "weekStart": ""
}
```
</details>

as @kaydelaney's git bisect showed, this broke after https://github.com/grafana/grafana/pull/82985, but i think that PR simply revealed a bug that existed previously and was masked by the fact that we were always clearing `field.state.displayName` cache during internal `join()` of the DataFrames.

you can see that at the top of the panel the `Value` field in `data.series` has an incorrectly calculated `field.state.displayName`:

![image](https://github.com/user-attachments/assets/16f1d5cd-e965-46de-b890-f445c20da378)

i expect that `field.state.displayName` is properly populated with `"foooooo bar=\"baz\""` after field overrides are applied and the fieldConfig option is interpolated into the final displayName:

![image](https://github.com/user-attachments/assets/def103db-4bbf-45c7-be3b-a7f60dd917b3)

![image](https://github.com/user-attachments/assets/174b3cfe-19a3-4e97-a1d9-13abeb55a360)


this field state has always acted as an internal memoization cache, to avoid recalculating field names when calling `getFieldDisplayName()` all over the codebase:

![image](https://github.com/user-attachments/assets/ef1a50a8-81c1-467b-a659-4913c07a7635)