### PR TITLE
Docs: update grafana-renderer auth token documentation

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -82,8 +82,10 @@ AUTH_TOKEN=-
 
 ```json
 {
-  "security": {
-    "authToken": "-"
+  "service": {
+    "security": {
+      "authToken": "-"
+    }
   }
 }
 ```


### PR DESCRIPTION
**What is this feature?**

The configuration example on setting the authtoken for Grafana image renderer is incomplete and is not showing that the config is below the service hierarchy. This can be verified by checking the [default configuration](https://github.com/grafana/grafana-image-renderer/blob/754b22c375f650bb87ceff2cd8682909243b41fa/default.json) or the[ code to load the settings](https://github.com/grafana/grafana-image-renderer/blob/614dc6ba9e24d05f6306ee8d6e88e5827e09f967/src/service/config.ts#L54).

**Why do we need this feature?**

The documentation is incomplete and misleading.

**Who is this feature for?**

Users setting up Grafana Renderer with authentication token.

**Which issue(s) does this PR fix?**:
N/A
