### PR TITLE
Docs: grafana image renderer instructions custom cert in container

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
+++ b/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
@@ -125,6 +125,18 @@ If this happens, then you have to add the certificate to the trust store. If you
 certutil –addstore "Root" <path>/internal-root-ca.crt.pem
 ```
 
+**Container:**
+
+```Dockerfile
+FROM grafana/grafana-image-renderer:latest
+USER root
+RUN apk add --no-cache nss-tools
+USER grafana
+COPY internal-root-ca.crt.pem /etc/pki/tls/certs/internal-root-ca.crt.pem
+RUN mkdir -p /home/grafana/.pki/nssdb
+RUN certutil -d sql:/home/grafana/.pki/nssdb -A -n internal-root-ca -t C -i /etc/pki/tls/certs/internal-root-ca.crt.pem
+```
+
 ## Custom Chrome/Chromium
 
 As a last resort, if you already have [Chrome](https://www.google.com/chrome/) or [Chromium](https://www.chromium.org/)

--- a/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
+++ b/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
@@ -129,9 +129,13 @@ certutil –addstore "Root" <path>/internal-root-ca.crt.pem
 
 ```Dockerfile
 FROM grafana/grafana-image-renderer:latest
+
 USER root
+
 RUN apk add --no-cache nss-tools
+
 USER grafana
+
 COPY internal-root-ca.crt.pem /etc/pki/tls/certs/internal-root-ca.crt.pem
 RUN mkdir -p /home/grafana/.pki/nssdb
 RUN certutil -d sql:/home/grafana/.pki/nssdb -A -n internal-root-ca -t C -i /etc/pki/tls/certs/internal-root-ca.crt.pem


### PR DESCRIPTION
**What is this feature?**

adding instructions on how to add a custom TLS certificte to the grafana image render container

**Why do we need this feature?**

Help users setting up Grafana image render with containers.

**Who is this feature for?**

Users running Grafana image render in a container and needing to add a custom TLS certificate

