### PR TITLE
Fix deps on panel options

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptions.tsx
@@ -47,7 +47,7 @@ export const PanelOptions = React.memo<Props>(({ vizManager, searchQuery, listMo
       instanceState: _pluginInstanceState,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [panel, options, fieldConfig, _pluginInstanceState]);
+  }, [data, panel, options, fieldConfig, _pluginInstanceState]);
 
   const libraryPanelOptions = useMemo(() => {
     if (panel instanceof VizPanel && isLibraryPanel(panel)) {


### PR DESCRIPTION
Fixes an issue where the panel options would not populate correctly when opening a dashboard straight into panel edit. E.g.: field picker inputs would not be properly populated because data would not be loaded yet and the panel options didn't refresh on data load.

This PR makes sure the options refresh on data load.

Fixes https://github.com/grafana/grafana/issues/93252