### PR TITLE
Remove buildstamp from build hash. Version and commit should be enough

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -41,7 +41,6 @@ func (hs *HTTPServer) GetFrontendAssets(c *contextmodel.ReqContext) {
 	hash.Reset()
 	_, _ = hash.Write([]byte(setting.BuildVersion))
 	_, _ = hash.Write([]byte(setting.BuildCommit))
-	_, _ = hash.Write([]byte(fmt.Sprintf("%d", setting.BuildStamp)))
 	keys["version"] = fmt.Sprintf("%x", hash.Sum(nil))
 
 	// Plugin configs


### PR DESCRIPTION
We noticed at times the buildstamp of grafana differs, even though grafana version and commit version is the same. This is causing the grafana version hash to fluctuate, probably depending on which server we hit.