### PR TITLE
refactor(alerting): remove transformation that is now done by the querier

### DIFF
--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var logger = log.New("ngalert.eval")
@@ -705,13 +704,6 @@ func evaluateExecutionResult(execResults ExecutionResults, ts time.Time) Results
 			continue
 		}
 
-		// The query service returns instant vectors from prometheus as scalars. We need to handle them accordingly.
-		if val, ok := scalarInstantVector(f); ok {
-			r := buildResult(f, val, ts)
-			evalResults = append(evalResults, r)
-			continue
-		}
-
 		if len(f.TypeIndices(data.FieldTypeTime, data.FieldTypeNullableTime)) > 0 {
 			appendErrRes(&invalidEvalResultFormatError{refID: f.RefID, reason: "looks like time series data, only reduced data can be alerted on."})
 			continue
@@ -787,23 +779,6 @@ func buildResult(f *data.Frame, val *float64, ts time.Time) Result {
 		r.State = Alerting
 	}
 	return r
-}
-
-func scalarInstantVector(f *data.Frame) (*float64, bool) {
-	if len(f.Fields) != 2 {
-		return nil, false
-	}
-	if f.Fields[0].Len() > 1 || (f.Fields[0].Type() != data.FieldTypeNullableTime && f.Fields[0].Type() != data.FieldTypeTime) {
-		return nil, false
-	}
-	switch f.Fields[1].Type() {
-	case data.FieldTypeFloat64:
-		return util.Pointer(f.Fields[1].At(0).(float64)), true
-	case data.FieldTypeNullableFloat64:
-		return f.Fields[1].At(0).(*float64), true
-	default:
-		return nil, true
-	}
 }
 
 // AsDataFrame forms the EvalResults in Frame suitable for displaying in the table panel of the front end.

--- a/pkg/services/ngalert/eval/eval_test.go
+++ b/pkg/services/ngalert/eval/eval_test.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -55,52 +54,6 @@ func TestEvaluateExecutionResult(t *testing.T) {
 				Condition: []*data.Frame{
 					data.NewFrame("", data.NewField("", nil, []*float64{util.Pointer(1.0)})),
 				},
-			},
-			expectResultLength: 1,
-			expectResults: Results{
-				{
-					State: Alerting,
-				},
-			},
-		},
-		{
-			desc: "query service dataframe works as instant vector",
-			execResults: ExecutionResults{
-				Condition: func() []*data.Frame {
-					f := data.NewFrame("",
-						data.NewField("", nil, []*time.Time{util.Pointer(time.Now())}),
-						data.NewField("", nil, []*float64{util.Pointer(0.0)}),
-					)
-					f.Meta = &data.FrameMeta{
-						Custom: map[string]any{
-							"resultType": "scalar",
-						},
-					}
-					return []*data.Frame{f}
-				}(),
-			},
-			expectResultLength: 1,
-			expectResults: Results{
-				{
-					State: Normal,
-				},
-			},
-		},
-		{
-			desc: "query service dataframe works as instant vector when alerting",
-			execResults: ExecutionResults{
-				Condition: func() []*data.Frame {
-					f := data.NewFrame("",
-						data.NewField("", nil, []*time.Time{util.Pointer(time.Now())}),
-						data.NewField("", nil, []*float64{util.Pointer(1.0)}),
-					)
-					f.Meta = &data.FrameMeta{
-						Custom: map[string]any{
-							"resultType": "scalar",
-						},
-					}
-					return []*data.Frame{f}
-				}(),
 			},
 			expectResultLength: 1,
 			expectResults: Results{
@@ -1341,76 +1294,6 @@ func TestCreate(t *testing.T) {
 
 		require.Equal(t, expectedHeaders, request.Headers)
 	})
-}
-
-func TestQueryServiceResponse(t *testing.T) {
-	data := `
-{
-    "results": {
-        "A": {
-            "status": 200,
-            "frames": [
-                {
-                    "schema": {
-                        "refId": "A",
-                        "meta": {
-                            "type": "numeric-multi",
-                            "typeVersion": [
-                                0,
-                                1
-                            ],
-                            "custom": {
-                                "resultType": "scalar"
-                            },
-                            "executedQueryString": "Expr: 1\nStep: 15s"
-                        },
-                        "fields": [
-                            {
-                                "name": "Time",
-                                "type": "time",
-                                "typeInfo": {
-                                    "frame": "time.Time"
-                                },
-                                "config": {
-                                    "interval": 15000
-                                }
-                            },
-                            {
-                                "name": "Value",
-                                "type": "number",
-                                "typeInfo": {
-                                    "frame": "float64"
-                                },
-                                "labels": {},
-                                "config": {
-                                    "displayNameFromDS": "1"
-                                }
-                            }
-                        ]
-                    },
-                    "data": {
-                        "values": [
-                            [
-                                1719855251019
-                            ],
-                            [
-                                1
-                            ]
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-}
-`
-	var s backend.QueryDataResponse
-	err := json.Unmarshal([]byte(data), &s)
-	require.NoError(t, err)
-	res := EvaluateAlert(&s, models.Condition{Condition: "A"}, time.Time{})
-
-	require.Equal(t, 1, len(res))
-	require.Equal(t, Alerting, res[0].State)
 }
 
 type fakeExpressionService struct {


### PR DESCRIPTION
This has been surpassed by a change we did in the querier, also it causes some errors when the array was empty. https://github.com/grafana/grafana/pull/93497