### PR TITLE
Query Library: Display query text even when datasource doesn't have getQueryDisplayText

### DIFF
--- a/public/app/features/explore/QueryLibrary/QueryTemplatesTable/QueryDescriptionCell.tsx
+++ b/public/app/features/explore/QueryLibrary/QueryTemplatesTable/QueryDescriptionCell.tsx
@@ -2,6 +2,7 @@ import { cx } from '@emotion/css';
 import { CellProps } from 'react-table';
 
 import { Spinner, Tooltip } from '@grafana/ui';
+import { createQueryText } from 'app/core/utils/richHistory';
 
 import { useDatasource } from '../utils/useDatasource';
 
@@ -20,7 +21,7 @@ export function QueryDescriptionCell(props: CellProps<QueryTemplateRow>) {
     return <div>No queries</div>;
   }
   const query = props.row.original.query;
-  const queryDisplayText = datasourceApi?.getQueryDisplayText?.(query) || '';
+  const queryDisplayText = createQueryText(query, datasourceApi);
   const description = props.row.original.description;
   const dsName = datasourceApi?.name || '';
 


### PR DESCRIPTION
Some datasources like Google Spreadsheets don't have `getQueryDisplayText` implemented, and that results in not showing the query params:

![Screenshot 2024-09-24 at 6 47 51 AM](https://github.com/user-attachments/assets/8ddec0fb-0a34-4e79-a188-1376fb545a42)

Since in Query History we show query params for datasources that don't have `getQueryDisplayText` implemented, it makes sense to also show them in Query Library. 

After this fix, user will be able to see the query params:
![Screenshot 2024-09-24 at 6 49 05 AM](https://github.com/user-attachments/assets/d2315806-8ab7-4062-969c-860e7feefdb2)

Fixes #93665 

Please check that:
- [ ] It works as expected from a user's perspective.

