### PR TITLE
[v10.4.x] TraceView: Fix for toString() usage in span filters

### DIFF
--- a/public/app/features/explore/TraceView/components/utils/filter-spans.tsx
+++ b/public/app/features/explore/TraceView/components/utils/filter-spans.tsx
@@ -76,7 +76,7 @@ export function getQueryMatches(query: string, spans: TraceSpan[] | TNil) {
   const isTextInKeyValues = (kvs: TraceKeyValuePair[]) =>
     kvs
       ? kvs.some((kv) => {
-          return isTextInQuery(queryParts, kv.key) || isTextInQuery(queryParts, kv.value.toString());
+          return isTextInQuery(queryParts, kv.key) || isTextInQuery(queryParts, getStringValue(kv.value));
         })
       : false;
 
@@ -157,11 +157,15 @@ const checkKeyForMatch = (tagKey: string, key: string) => {
 };
 
 const checkKeyAndValueForMatch = (tag: Tag, kv: TraceKeyValuePair) => {
-  return tag.key === kv.key.toString() && tag.value === kv.value.toString() ? true : false;
+  return tag.key === kv.key && tag.value === getStringValue(kv.value);
 };
 
 const getReturnValue = (operator: string, found: boolean) => {
   return operator === '=' ? found : !found;
+};
+
+const getStringValue = (value: string | number | boolean | undefined) => {
+  return value ? value.toString() : '';
 };
 
 const getServiceNameMatches = (spans: TraceSpan[], searchProps: SearchProps) => {


### PR DESCRIPTION
Backport d30dc3ad50026284b9d9c07474bceb62ef6bb201 from #93648

---

**What is this feature?**

Fix for `toString()` usage int he trace view span filters.

**Why do we need this feature?**

`toString()` should not be used if there is no value to convert to a string.

**Who is this feature for?**

Trace view users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/93435
