### PR TITLE
Devenv: Add serve_from_sub_path scenario to nginx devenv

### DIFF
--- a/devenv/docker/blocks/auth/nginx_proxy/nginx_serve_from_sub_path.conf
+++ b/devenv/docker/blocks/auth/nginx_proxy/nginx_serve_from_sub_path.conf
@@ -1,0 +1,39 @@
+events { worker_connections 1024; }
+
+http {
+  # This is required to proxy Grafana Live WebSocket connections.
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+  }
+
+  upstream grafana {
+    server host.docker.internal:3000;
+  }
+
+  server {
+    listen 8090;
+
+    location / {
+      root /var/www/html;
+    }
+
+    # Set the followings in grafana.ini:
+    # [server]
+    # root_url = http://localhost:8090/grafana/
+    # serve_from_sub_path = true
+    location /grafana/ {
+      proxy_set_header Host $host;
+      proxy_pass http://grafana;
+    }
+
+    # Proxy Grafana Live WebSocket connections.
+    location /grafana/api/live/ {
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_set_header Host $host;
+      proxy_pass http://grafana;
+    }
+  }
+}


### PR DESCRIPTION
**What is this feature?**
This PR adds a new nginx config file for making it simpler to test Grafana with the `serve_from_sub_path = true` scenario.

**Why do we need this feature?**

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
