### PR TITLE
DataTrail: Remove newFiltersUI feature toggle usage from explore metrics

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -10,7 +10,7 @@ import {
   VariableHide,
   urlUtil,
 } from '@grafana/data';
-import { config, locationService, useChromeHeaderHeight } from '@grafana/runtime';
+import { locationService, useChromeHeaderHeight } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   ConstantVariable,
@@ -648,7 +648,7 @@ function getVariableSet(
         addFilterButtonText: 'Add label',
         datasource: trailDS,
         hide: VariableHide.hideLabel,
-        layout: config.featureToggles.newFiltersUI ? 'combobox' : 'vertical',
+        layout: 'vertical',
         filters: initialFilters ?? [],
         baseFilters: getBaseFiltersForMetric(metric),
         applyMode: 'manual',


### PR DESCRIPTION
Remove `newFiltersUI` feature toggle usage from explore metrics