### PR TITLE
PanelEdit: Hide overflow for query options in small viewports

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
@@ -111,6 +111,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     label: Column;
     display: flex;
     align-items: center;
+    overflow: hidden;
   `,
   dragIcon: css`
     cursor: grab;


### PR DESCRIPTION
**What is this feature?**

Before:
![image](https://github.com/user-attachments/assets/71593742-cdc9-440a-a6cc-b4bc9ab5f538)
After: 
![image](https://github.com/user-attachments/assets/9768613c-bdb2-41cd-b368-e9453c4d65aa)

This has bothered me for a while. Going for a quick fix that makes it look less broken, for now.

**Which issue(s) does this PR fix?**:

Fixes #93698
