### PR TITLE
DashboardScene: Fixes issue with updating repeated panels after coming back from panel edit

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -54,6 +54,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   private _originalLayoutElementState!: DashboardGridItemState;
   private _layoutElement!: DashboardGridItem;
   private _originalSaveModel!: Panel;
+  private _changesHaveBeenMade = false;
 
   public constructor(state: PanelEditorState) {
     super(state);
@@ -71,7 +72,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
 
     return () => {
       if (layoutElement instanceof DashboardGridItem) {
-        layoutElement.editingCompleted();
+        layoutElement.editingCompleted(this.state.isDirty || this._changesHaveBeenMade);
       }
       if (deactivateParents) {
         deactivateParents();
@@ -227,6 +228,9 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
   public dashboardSaved() {
     this.setOriginalState(this.state.panelRef);
     this.setState({ isDirty: false });
+
+    // Remember that we have done changes
+    this._changesHaveBeenMade = false;
   }
 
   public onSaveLibraryPanel = () => {

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.test.tsx
@@ -143,8 +143,8 @@ describe('PanelRepeaterGridItem', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     vizPanel.setState({ title: 'Changed' });
-    //mimic returning to dashboard from panel edit cloning panel
-    panel.setState({ body: vizPanel.clone() });
+
+    panel.editingCompleted(true);
 
     // mimic returning to dashboard
     activateFullSceneTree(scene);
@@ -214,10 +214,11 @@ describe('PanelRepeaterGridItem', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     vizPanel.setState({ title: 'Changed' });
-    //mimic returning to dashboard from panel edit cloning panel
-    panel.setState({ body: vizPanel.clone() });
+
+    panel.editingCompleted(true);
 
     const performRepeatMock = jest.spyOn(panel, 'performRepeat');
+
     // mimic returning to dashboard
     activateFullSceneTree(scene);
 

--- a/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardGridItem.tsx
@@ -41,8 +41,6 @@ export type RepeatDirection = 'v' | 'h';
 
 export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> implements SceneGridItemLike {
   private _prevRepeatValues?: VariableValueSingle[];
-  private _prevPanelState: VizPanelState | undefined;
-  private _prevGridItemState: DashboardGridItemState | undefined;
 
   protected _variableDependency = new DashboardGridItemVariableDependencyHandler(this);
 
@@ -55,14 +53,7 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
   private _activationHandler() {
     if (this.state.variableName) {
       this._subs.add(this.subscribeToState((newState, prevState) => this._handleGridResize(newState, prevState)));
-      this.clearCachedStateIfBodyOrOptionsChanged();
       this.performRepeat();
-    }
-  }
-
-  private clearCachedStateIfBodyOrOptionsChanged() {
-    if (this._prevGridItemState !== this.state || this._prevPanelState !== this.state.body.state) {
-      this._prevRepeatValues = undefined;
     }
   }
 
@@ -179,8 +170,6 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
       }
     }
 
-    this._prevGridItemState = this.state;
-    this._prevPanelState = this.state.body.state;
     this._prevRepeatValues = values;
 
     // Used from dashboard url sync
@@ -214,14 +203,18 @@ export class DashboardGridItem extends SceneObjectBase<DashboardGridItemState> i
         $variables: this.state.repeatedPanels![0].state.$variables?.clone(),
         $data: this.state.repeatedPanels![0].state.$data?.clone(),
       });
-      this._prevPanelState = this.state.body.state;
     }
   }
 
   /**
    * Going back to dashboards logic
+   * withChanges true if there where changes made while in panel edit
    */
-  public editingCompleted() {
+  public editingCompleted(withChanges: boolean) {
+    if (withChanges) {
+      this._prevRepeatValues = undefined;
+    }
+
     if (this.state.variableName && this.state.repeatDirection === 'h' && this.state.width !== GRID_COLUMN_COUNT) {
       this.setState({ width: GRID_COLUMN_COUNT });
     }


### PR DESCRIPTION
Fixes a minor issue in the panel editor refactoring with repeated panels and updates to only the data transformer or queries, this was not detected. Found a pretty simple solution since we already notify the grid item that the editing is complete we can rely on the panel edit diff tracking to let the grid item know when changes have been made or not. 