### PR TITLE
GrafanaUI: Make Drawer extend to full height

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -256,17 +256,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: 'relative',
     }),
     drawer: css({
-      '.main-view &': {
-        top: 80,
-      },
-
-      '.main-view--search-bar-hidden &': {
-        top: 40,
-      },
-
-      '.main-view--chrome-hidden &': {
-        top: 0,
-      },
+      top: 0,
 
       '.rc-drawer-content-wrapper': {
         boxShadow: theme.shadows.z3,
@@ -307,18 +297,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         left: 0,
         position: 'fixed',
         right: 0,
-
-        '.main-view &': {
-          top: 80,
-        },
-
-        '.main-view--search-bar-hidden &': {
-          top: 40,
-        },
-
-        '.main-view--chrome-hidden &': {
-          top: 0,
-        },
+        top: 0,
       },
     }),
     maskMotion: css({


### PR DESCRIPTION
A while back we changed the drawer to sit under the topnav https://github.com/grafana/grafana/pull/67824. This PR reverts that change.

While reviewing [upcoming topnav changes](https://github.com/grafana/grafana/pull/93694), I was bothered at having to tweak the Drawer position every time we change Grafana navigation, especially in `@grafana/ui` based on feature toggles.

I think it's also a bit weird how the nav remains fully visibile, but it can't actually be interacted with. I don't think the 'quirk' of having the drawer sit under the nav is really worth this complexity.

Here’s the GitHub-flavored markdown table you requested:


| Title               | Photo                                                                 |
|---------------------|----------------------------------------------------------------------|
| Before              | ![image](https://github.com/user-attachments/assets/34254097-a5e0-4b38-864b-906da450d33b) |
| After               | ![image](https://github.com/user-attachments/assets/7bacca55-eabb-4424-b427-c2e140a956c9) |
| After w/Collapsed nav      | ![image](https://github.com/user-attachments/assets/abbddf75-4c9b-44b6-8afe-09e6957c2892) |
| After w/Kiosk mode        | ![image](https://github.com/user-attachments/assets/80eb31ad-f7e5-44ef-92c6-84ade8a2914b) |




