### PR TITLE
Prometheus: Fix e2e selector by using "data-test-id" instead of "id"

### DIFF
--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -1,5 +1,3 @@
-import { selectors } from '@grafana/e2e-selectors';
-
 import { e2e } from '../utils';
 
 import { getResources } from './helpers/prometheus-helpers';
@@ -45,17 +43,17 @@ function navigateToEditor(editorType: editorType, name: string): void {
 }
 
 describe('Prometheus query editor', () => {
-  it('should have a kickstart component', () => {
+  xit('should have a kickstart component', () => {
     navigateToEditor('Code', 'prometheus');
     e2e.components.QueryBuilder.queryPatterns().scrollIntoView().should('exist');
   });
 
-  it('should have an explain component', () => {
+  xit('should have an explain component', () => {
     navigateToEditor('Code', 'prometheus');
     e2e.components.DataSource.Prometheus.queryEditor.explain().scrollIntoView().should('exist');
   });
 
-  it('should have an editor toggle component', () => {
+  xit('should have an editor toggle component', () => {
     navigateToEditor('Code', 'prometheus');
     e2e.components.DataSource.Prometheus.queryEditor.editorToggle().scrollIntoView().should('exist');
   });
@@ -67,12 +65,12 @@ describe('Prometheus query editor', () => {
     // check options
     e2e.components.DataSource.Prometheus.queryEditor.legend().scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.format().scrollIntoView().should('exist');
-    cy.get(`#${selectors.components.DataSource.Prometheus.queryEditor.step}`).scrollIntoView().should('exist');
+    cy.get(`[data-test-id="prometheus-step"]`).scrollIntoView().should('exist');
     e2e.components.DataSource.Prometheus.queryEditor.type().scrollIntoView().should('exist');
-    cy.get(`#${selectors.components.DataSource.Prometheus.queryEditor.exemplars}`).scrollIntoView().should('exist');
+    cy.get(`[data-test-id="prometheus-exemplars"]`).scrollIntoView().should('exist');
   });
 
-  describe('Code editor', () => {
+  describe.skip('Code editor', () => {
     it('navigates to the code editor with editor type as code', () => {
       navigateToEditor('Code', 'prometheusCode');
     });
@@ -122,7 +120,7 @@ describe('Prometheus query editor', () => {
     });
   });
 
-  describe('Query builder', () => {
+  describe.skip('Query builder', () => {
     it('navigates to the query builder with editor type as code', () => {
       navigateToEditor('Builder', 'prometheusBuilder');
     });

--- a/e2e/various-suite/prometheus-editor.spec.ts
+++ b/e2e/various-suite/prometheus-editor.spec.ts
@@ -43,17 +43,17 @@ function navigateToEditor(editorType: editorType, name: string): void {
 }
 
 describe('Prometheus query editor', () => {
-  xit('should have a kickstart component', () => {
+  it('should have a kickstart component', () => {
     navigateToEditor('Code', 'prometheus');
     e2e.components.QueryBuilder.queryPatterns().scrollIntoView().should('exist');
   });
 
-  xit('should have an explain component', () => {
+  it('should have an explain component', () => {
     navigateToEditor('Code', 'prometheus');
     e2e.components.DataSource.Prometheus.queryEditor.explain().scrollIntoView().should('exist');
   });
 
-  xit('should have an editor toggle component', () => {
+  it('should have an editor toggle component', () => {
     navigateToEditor('Code', 'prometheus');
     e2e.components.DataSource.Prometheus.queryEditor.editorToggle().scrollIntoView().should('exist');
   });
@@ -70,7 +70,7 @@ describe('Prometheus query editor', () => {
     cy.get(`[data-test-id="prometheus-exemplars"]`).scrollIntoView().should('exist');
   });
 
-  describe.skip('Code editor', () => {
+  describe('Code editor', () => {
     it('navigates to the code editor with editor type as code', () => {
       navigateToEditor('Code', 'prometheusCode');
     });
@@ -120,7 +120,7 @@ describe('Prometheus query editor', () => {
     });
   });
 
-  describe.skip('Query builder', () => {
+  describe('Query builder', () => {
     it('navigates to the query builder with editor type as code', () => {
       navigateToEditor('Builder', 'prometheusBuilder');
     });

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -92,7 +92,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
                 minWidth={10}
                 onCommitChange={onChangeStep}
                 defaultValue={query.interval}
-                id={selectors.components.DataSource.Prometheus.queryEditor.step}
+                data-test-id="prometheus-step"
               />
             </EditorField>
             <EditorField label="Format">
@@ -112,7 +112,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
                 <EditorSwitch
                   value={query.exemplar || false}
                   onChange={onExemplarChange}
-                  id={selectors.components.DataSource.Prometheus.queryEditor.exemplars}
+                  data-test-id="prometheus-exemplars"
                 />
               </EditorField>
             )}


### PR DESCRIPTION
**What is this feature?**

Prefer `data-test-id` instead of `id` to prevent mis-referenced the components. 
When we have two queries in the panel and try to enable exemplars for the second one, the first one's exemplar switch is enabled. This is because all exemplar switches have the same id. We were using `id`s for e2e tests. So I removed `id` and use `data-test-id`. 
