### PR TITLE
LibraryElements: remove viewer check when connecting a dashboard on General folder

### DIFF
--- a/pkg/services/libraryelements/guard.go
+++ b/pkg/services/libraryelements/guard.go
@@ -58,7 +58,7 @@ func (l *LibraryElementService) requireEditPermissionsOnFolder(ctx context.Conte
 }
 
 func (l *LibraryElementService) requireViewPermissionsOnFolder(ctx context.Context, user identity.Requester, folderID int64) error {
-	if isGeneralFolder(folderID) && user.HasRole(org.RoleViewer) {
+	if isGeneralFolder(folderID) {
 		return nil
 	}
 


### PR DESCRIPTION
**What is this feature?**

Removes checking for `role=Viewer` when connecting a library panel to a dashboard on the General folder (`id=0`). We've agreed internally that this check is not adding to anything.

**Why do we need this feature?**

The token the Migration Assistant uses does not have regular roles but rather permissions (RBAC), which is not yet globally enabled for LibraryElements (currently under a feature flag), which causes the check to fail and break migration of a specific scenario of Dashboards with Library Panels on the General folder.

`requireViewPermissionsOnFolder` may be removed once the FF is productized.

**Who is this feature for?**

Cloud Migration service :)
