### PR TITLE
Alerting: Don't suppress translation errors in PointsFromFrames

### DIFF
--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -66,9 +66,15 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 
 	points := make([]Point, 0, len(col.Refs))
 	for _, ref := range col.Refs {
-		fp, empty, _ := ref.NullableFloat64Value()
-		if empty || fp == nil {
-			return nil, fmt.Errorf("unable to read float64 value")
+		fp, empty, err := ref.NullableFloat64Value()
+		if empty {
+			return nil, fmt.Errorf("empty frame")
+		}
+		if fp == nil {
+			return nil, fmt.Errorf("nil frame")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("unable to read float64 value: %w", err)
 		}
 
 		metric := Metric{

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -73,6 +73,9 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 		if empty {
 			return nil, fmt.Errorf("empty frame")
 		}
+		if fp == nil {
+			return nil, fmt.Errorf("nil frame")
+		}
 
 		metric := Metric{
 			T: t,

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -67,14 +67,11 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 	points := make([]Point, 0, len(col.Refs))
 	for _, ref := range col.Refs {
 		fp, empty, err := ref.NullableFloat64Value()
-		if empty {
-			return nil, fmt.Errorf("empty frame")
-		}
-		if fp == nil {
-			return nil, fmt.Errorf("nil frame")
-		}
 		if err != nil {
 			return nil, fmt.Errorf("unable to read float64 value: %w", err)
+		}
+		if empty {
+			return nil, fmt.Errorf("empty frame")
 		}
 
 		metric := Metric{


### PR DESCRIPTION
**What is this feature?**

PointsFromFrames suppresses any errors reading frames, replacing them with a generic string `unable to read float64 value`.

Wrap the actual error instead, so logs and users can see the core problem.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
