### PR TITLE
DashboardScene: Fixes issue with dashboard starting with auto refresh set 

### DIFF
--- a/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModel.test.ts.snap
+++ b/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModel.test.ts.snap
@@ -280,7 +280,7 @@ exports[`transformSceneToSaveModel Given a scene with rows Should transform back
   ],
   "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [
     "templating",
     "gdev",
@@ -548,7 +548,7 @@ exports[`transformSceneToSaveModel Given a simple scene with custom settings Sho
   ],
   "preload": false,
   "refresh": "5m",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [
     "tag1",
     "tag2",
@@ -906,7 +906,7 @@ exports[`transformSceneToSaveModel Given a simple scene with variables Should tr
   ],
   "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [
     "gdev",
     "graph-ng",

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -2413,6 +2413,21 @@ describe('when migrating table cell display mode to cell options', () => {
   });
 });
 
+describe('when migrating variable refresh to on dashboard load', () => {
+  let model: DashboardModel;
+
+  beforeEach(() => {
+    model = new DashboardModel({
+      //@ts-ignore
+      refresh: false,
+    });
+  });
+
+  it('should migrate to empty string', () => {
+    expect(model.refresh).toBe('');
+  });
+});
+
 function createRow(options: any, panelDescriptions: any[]) {
   const PANEL_HEIGHT_STEP = GRID_CELL_HEIGHT + GRID_CELL_VMARGIN;
   const { collapse, showTitle, title, repeat, repeatIteration } = options;

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -81,7 +81,7 @@ type PanelSchemeUpgradeHandler = (panel: PanelModel) => PanelModel;
  * kinds/dashboard/dashboard_kind.cue
  * Example PR: #87712
  */
-export const DASHBOARD_SCHEMA_VERSION = 39;
+export const DASHBOARD_SCHEMA_VERSION = 40;
 export class DashboardMigrator {
   dashboard: DashboardModel;
 
@@ -902,6 +902,13 @@ export class DashboardMigrator {
 
         return panel;
       });
+    }
+
+    if (oldVersion < 40) {
+      // In old ashboards refresh property can be a boolean
+      if (typeof this.dashboard.refresh !== 'string') {
+        this.dashboard.refresh = '';
+      }
     }
 
     /**


### PR DESCRIPTION
This is quite a severe bug, where old dashboards have refresh set to false (boolean), a bunch of our gdev dashboards have this. This violates our schema but it appears our schema has been wrong in regards to the typing of this property. 

For example: 
http://localhost:3000/d/TkZXxlNG3/panel-tests-graph-ng 

When initiated with boolean false, this get's added to URL, and then in updateFromUrl SceneRefreshPicker will treat 'false' as an invalid interval and then set the auto refresh to the first valid interval. 

Fixing this by migrating the false to en empty string (if you open a dashboard in the old architecture and enable and disable auto refresh then it will also be set to an empty string), and string is the only type allowed by the schema definition so think that is the best way to solve this. 

think this bug was introduced by https://github.com/grafana/grafana/pull/92950 (when we started initiating the URL with the current state) 