### PR TITLE
Unified Storage: Logs metadata when gRPC logging enabled

### DIFF
--- a/pkg/services/grpcserver/interceptors/logging.go
+++ b/pkg/services/grpcserver/interceptors/logging.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func LoggingUnaryInterceptor(cfg *setting.Cfg, logger log.Logger) grpc.UnaryServerInterceptor {
@@ -17,11 +18,18 @@ func LoggingUnaryInterceptor(cfg *setting.Cfg, logger log.Logger) grpc.UnaryServ
 	) (resp any, err error) {
 		resp, err = handler(ctx, req)
 		if cfg.GRPCServerEnableLogging {
+			md, _ := metadata.FromIncomingContext(ctx)
+
+			// Redact grafana token from logs
+			if _, ok := md["grafana-idtoken"]; ok {
+				md["grafana-idtoken"] = []string{"REDACTED"}
+			}
+
 			ctxLogger := logger.FromContext(ctx)
 			if err != nil {
-				ctxLogger.Error("gRPC call", "method", info.FullMethod, "req", req, "err", err)
+				ctxLogger.Error("gRPC call", "method", info.FullMethod, "req", req, "err", err, "md", md)
 			} else {
-				ctxLogger.Info("gRPC call", "method", info.FullMethod, "req", req, "resp", resp)
+				ctxLogger.Info("gRPC call", "method", info.FullMethod, "req", req, "resp", resp, "md", md)
 			}
 		}
 		return resp, err


### PR DESCRIPTION
Logs metadata (while redacting the grafana token) when gRPC logging is enabled