### PR TITLE
GRPC/Authn: Remove org name header

### DIFF
--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/grafana/authlib/authn"
-	authClaims "github.com/grafana/authlib/claims"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/authlib/authn"
+	authClaims "github.com/grafana/authlib/claims"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
@@ -18,7 +19,6 @@ const (
 	mdLogin   = "grafana-login"
 	mdUserID  = "grafana-user-id"
 	mdUserUID = "grafana-user-uid"
-	mdOrgName = "grafana-org-name"
 	mdOrgID   = "grafana-org-id"
 	mdOrgRole = "grafana-org-role"
 )
@@ -105,7 +105,6 @@ func (f *Authenticator) decodeMetadata(ctx context.Context, meta metadata.MD) (i
 	}
 	user.UserUID = id
 
-	user.OrgName = getter(mdOrgName)
 	user.OrgID, err = strconv.ParseInt(getter(mdOrgID), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("invalid org id: %w", err)
@@ -154,7 +153,6 @@ func encodeIdentityInMetadata(user identity.Requester) metadata.MD {
 		// Or we can create it directly
 		mdUserID, user.GetID(),
 		mdUserUID, user.GetUID(),
-		mdOrgName, user.GetOrgName(),
 		mdOrgID, strconv.FormatInt(user.GetOrgID(), 10),
 		mdOrgRole, string(user.GetOrgRole()),
 		mdLogin, user.GetLogin(),

--- a/pkg/storage/unified/resource/grpc/authenticator_test.go
+++ b/pkg/storage/unified/resource/grpc/authenticator_test.go
@@ -17,7 +17,6 @@ func TestBasicEncodeDecode(t *testing.T) {
 		Login:   "test",
 		Type:    claims.TypeUser,
 		OrgID:   456,
-		OrgName: "org",
 		OrgRole: identity.RoleAdmin,
 	}
 


### PR DESCRIPTION
The GRPC auth will soon be replaced with https://github.com/grafana/authlib/blob/main/authn/grpc_authenticator.go

however we are currently seeing a few errors with the org name header.  This PR just removes the org name since it is not used in the result context anyway