### PR TITLE
CloudMigrations: add Library Element as a valid migration resource type

### DIFF
--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -119,9 +119,10 @@ type MigrateDataResponseItemDTO struct {
 type MigrateDataType string
 
 const (
-	DashboardDataType  MigrateDataType = "DASHBOARD"
-	DatasourceDataType MigrateDataType = "DATASOURCE"
-	FolderDataType     MigrateDataType = "FOLDER"
+	DashboardDataType      MigrateDataType = "DASHBOARD"
+	DatasourceDataType     MigrateDataType = "DATASOURCE"
+	FolderDataType         MigrateDataType = "FOLDER"
+	LibraryElementDataType MigrateDataType = "LIBRARY_ELEMENT"
 )
 
 // swagger:enum ItemStatus

--- a/pkg/services/cloudmigration/gmsclient/dtos.go
+++ b/pkg/services/cloudmigration/gmsclient/dtos.go
@@ -4,12 +4,6 @@ import "time"
 
 type MigrateDataType string
 
-const (
-	DashboardDataType  MigrateDataType = "DASHBOARD"
-	DatasourceDataType MigrateDataType = "DATASOURCE"
-	FolderDataType     MigrateDataType = "FOLDER"
-)
-
 type MigrateDataRequestDTO struct {
 	Items []MigrateDataRequestItemDTO `json:"items"`
 }

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -79,9 +79,10 @@ type CloudMigrationResource struct {
 type MigrateDataType string
 
 const (
-	DashboardDataType  MigrateDataType = "DASHBOARD"
-	DatasourceDataType MigrateDataType = "DATASOURCE"
-	FolderDataType     MigrateDataType = "FOLDER"
+	DashboardDataType      MigrateDataType = "DASHBOARD"
+	DatasourceDataType     MigrateDataType = "DATASOURCE"
+	FolderDataType         MigrateDataType = "FOLDER"
+	LibraryElementDataType MigrateDataType = "LIBRARY_ELEMENT"
 )
 
 type ItemStatus string

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -5434,7 +5434,8 @@
           "enum": [
             "DASHBOARD",
             "DATASOURCE",
-            "FOLDER"
+            "FOLDER",
+            "LIBRARY_ELEMENT"
           ]
         }
       }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -16886,7 +16886,8 @@
           "enum": [
             "DASHBOARD",
             "DATASOURCE",
-            "FOLDER"
+            "FOLDER",
+            "LIBRARY_ELEMENT"
           ]
         }
       }

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -157,7 +157,7 @@ export type MigrateDataResponseItemDto = {
   message?: string;
   refId: string;
   status: 'OK' | 'WARNING' | 'ERROR' | 'PENDING' | 'UNKNOWN';
-  type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER';
+  type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER' | 'LIBRARY_ELEMENT';
 };
 export type SnapshotResourceStats = {
   statuses?: {

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -35,6 +35,8 @@ function ResourceInfo({ data }: { data: ResourceTableItem }) {
       return <DatasourceInfo data={data} />;
     case 'FOLDER':
       return <FolderInfo data={data} />;
+    case 'LIBRARY_ELEMENT':
+      return null;
   }
 }
 

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7112,7 +7112,8 @@
             "enum": [
               "DASHBOARD",
               "DATASOURCE",
-              "FOLDER"
+              "FOLDER",
+              "LIBRARY_ELEMENT"
             ],
             "type": "string"
           }


### PR DESCRIPTION
**What is this feature?**

Simply adding some constants related to the new resource type Library Elements.

**Why do we need this feature?**

Initial work for supporting migration of Library Elements from on-prem to cloud.

**Who is this feature for?**

Migration Assistant

**Which issue(s) does this PR fix?**:

Part of the work for https://github.com/grafana/grafana-operator-experience-squad/issues/972