### PR TITLE
LibraryElements: export GetAllElements to service

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -1081,3 +1081,8 @@ func (l *mockLibraryElementService) DisconnectElementsFromDashboard(c context.Co
 func (l *mockLibraryElementService) DeleteLibraryElementsInFolder(c context.Context, signedInUser identity.Requester, folderUID string) error {
 	return nil
 }
+
+// GetAll gets all library elements with support to query filters.
+func (l *mockLibraryElementService) GetAllElements(c context.Context, signedInUser identity.Requester, query model.SearchLibraryElementsQuery) (model.LibraryElementSearchResult, error) {
+	return model.LibraryElementSearchResult{}, nil
+}

--- a/pkg/services/libraryelements/libraryelements.go
+++ b/pkg/services/libraryelements/libraryelements.go
@@ -40,6 +40,7 @@ type Service interface {
 	ConnectElementsToDashboard(c context.Context, signedInUser identity.Requester, elementUIDs []string, dashboardID int64) error
 	DisconnectElementsFromDashboard(c context.Context, dashboardID int64) error
 	DeleteLibraryElementsInFolder(c context.Context, signedInUser identity.Requester, folderUID string) error
+	GetAllElements(c context.Context, signedInUser identity.Requester, query model.SearchLibraryElementsQuery) (model.LibraryElementSearchResult, error)
 }
 
 // LibraryElementService is the service for the Library Element feature.
@@ -83,6 +84,11 @@ func (l *LibraryElementService) DisconnectElementsFromDashboard(c context.Contex
 // DeleteLibraryElementsInFolder deletes all elements for a specific folder.
 func (l *LibraryElementService) DeleteLibraryElementsInFolder(c context.Context, signedInUser identity.Requester, folderUID string) error {
 	return l.deleteLibraryElementsInFolderUID(c, signedInUser, folderUID)
+}
+
+// GetAll gets all library elements with support to query filters.
+func (l *LibraryElementService) GetAllElements(c context.Context, signedInUser identity.Requester, query model.SearchLibraryElementsQuery) (model.LibraryElementSearchResult, error) {
+	return l.getAllLibraryElements(c, signedInUser, query)
 }
 
 func (l *LibraryElementService) addUidToLibraryPanel(model []byte, newUid string) (json.RawMessage, error) {


### PR DESCRIPTION
**What is this feature?**

Exports `getAllLibraryElements` as `GetAllElements` in the service interface.

**Why do we need this feature?**

The Migration Assistant (aka CloudMigrations) will need this method to fetch all library elements in the DB, as there's currently no other way of fetching that info (regardless if the Library Element is connected to a Dashboard).

**Who is this feature for?**

Migration Assistant

**Which issue(s) does this PR fix?**:

Part of the work for https://github.com/grafana/grafana-operator-experience-squad/issues/972
