### PR TITLE
CloudMigrations: Avoid building GMS base path when provided

### DIFF
--- a/pkg/services/cloudmigration/gmsclient/gms_client.go
+++ b/pkg/services/cloudmigration/gmsclient/gms_client.go
@@ -297,7 +297,7 @@ func (c *gmsClientImpl) ReportEvent(ctx context.Context, session cloudmigration.
 
 func (c *gmsClientImpl) buildBasePath(clusterSlug string) string {
 	domain := c.cfg.CloudMigration.GMSDomain
-	if strings.HasPrefix(domain, "http://localhost") {
+	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
 		return domain
 	}
 	return fmt.Sprintf("https://cms-%s.%s/cloud-migrations", clusterSlug, domain)

--- a/pkg/services/cloudmigration/gmsclient/gms_client_test.go
+++ b/pkg/services/cloudmigration/gmsclient/gms_client_test.go
@@ -35,13 +35,19 @@ func Test_buildBasePath(t *testing.T) {
 		expected    string
 	}{
 		{
-			description: "domain starts with http://localhost, should return domain",
-			domain:      "http://localhost:8080",
+			description: "domain starts with http://, should return domain",
+			domain:      "http://some-domain:8080",
 			clusterSlug: "anything",
-			expected:    "http://localhost:8080",
+			expected:    "http://some-domain:8080",
 		},
 		{
-			description: "domain doesn't start with http://localhost, should build a string using the domain and clusterSlug",
+			description: "domain starts with https://, should return domain",
+			domain:      "https://some-domain:8080",
+			clusterSlug: "anything",
+			expected:    "https://some-domain:8080",
+		},
+		{
+			description: "domain doesn't start with http or https, should build a string using the domain and clusterSlug",
 			domain:      "gms-dev",
 			clusterSlug: "us-east-1",
 			expected:    "https://cms-us-east-1.gms-dev/cloud-migrations",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Modify the behavior to check if a complete GMS URL is already provided. If so, use that URL directly instead of constructing it. This change allows operators to explicitly configure the GMS URL without needing to understand the internal URL construction logic. If no complete URL is provided, then proceed with the current path-building process.

**Why do we need this feature?**

The Cloud Migration Service is encountering difficulties when running Grafana locally with Docker and attempting to connect to a mock gateway running on the host.

The following Docker command is used to start Grafana:

```
docker run -p 3000:3000 --name grafana \
  -e "GF_FEATURE_TOGGLES_ENABLE=onPremToCloudMigrations" \
  -e "GF_CLOUD_MIGRATION_DOMAIN=http://host.docker.internal:9002" \
  -e "GF_LOG_LEVEL=debug" \
  grafana/grafana:latest
```

The use of `host.docker.internal` is intended to facilitate communication between the mock gateway running on the host and Grafana within the container.

Grafana produces the following error:

```
console logger=cloudmigration.gmsclient t=2024-09-25T10:54:45.300413419Z level=error msg="error sending http request for token validation" err="Post \"&lt;https://cms-dev-us-central-0.http//host.docker.internal:9002/cloud-migr&gt;
```

**Who is this feature for?**

It's for anybody enabling CloudMigration in Grafana, specially those running grafana locally.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/985

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
