### PR TITLE
Explore metrics: Fix warning message for limiting metrics

### DIFF
--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -287,8 +287,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
       }
 
       if (missingOtelTargets) {
-        metricNamesWarning +=
-          'The list of metrics is not complete. Select more OTel resource attributes to see a full list of metrics.';
+        metricNamesWarning = `${metricNamesWarning ?? ''} The list of metrics is not complete. Select more OTel resource attributes to see a full list of metrics.`;
       }
 
       let bodyLayout = this.state.body;


### PR DESCRIPTION
What is this?

When the OTel limit warning message is displayed, the regular warning is undefined and we see `undefined` in the warning box. This fixes that.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
