### PR TITLE
[bugfix] Fix missing URI in breadcrumbs in Teams view

### DIFF
--- a/public/app/features/teams/state/navModel.ts
+++ b/public/app/features/teams/state/navModel.ts
@@ -23,7 +23,7 @@ export function buildNavModel(team: Team): NavModelItem {
     img: team.avatarUrl,
     id: 'team-' + team.id,
     subTitle: 'Manage members and settings',
-    url: '',
+    url: `org/teams/edit/${team.id}`,
     text: team.name,
     children: [
       // With RBAC this tab will always be available (but not always editable)


### PR DESCRIPTION
**What is this feature?**

This PR fixes a missing link in Teams view breadcrumbs.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
