### PR TITLE
make gen-feature-toggles should run even with merge conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,14 @@ gen-cue: ## Do all CUE/Thema code generation
 gen-feature-toggles:
 ## First go test run fails because it will re-generate the feature toggles.
 ## Second go test run will compare the generated files and pass.
+	# If toggles_gen.go has conflict markers, then the test won't run because of the invalid syntax
+	if git ls-files -u | grep -q "pkg/services/featuremgmt/toggles_gen.go"; then \
+		echo "File pkg/services/featuremgmt/toggles_gen.go is conflicting, checking out from origin/main"; \
+		git checkout origin/main -- pkg/services/featuremgmt/toggles_gen.go; \
+	fi
+
 	@echo "generate feature toggles"
+	# Run the tests
 	go test -v ./pkg/services/featuremgmt/... > /dev/null 2>&1; \
 	if [ $$? -eq 0 ]; then \
 		echo "feature toggles already up-to-date"; \

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1,10 +1,7 @@
-// To change feature flags, edit:
-//  pkg/services/featuremgmt/registry.go
-// Then run tests in:
-//  pkg/services/featuremgmt/toggles_gen_test.go
-// twice to generate and validate the feature flag files
+// To change feature toggles, edit this file and run `make gen-feature-toggles`
 //
-// Alternatively, use `make gen-feature-toggles`
+// Alternatively, run the tests in `pkg/services/featuremgmt/toggles_gen_test.go` twice
+// to generate and validate the feature flag files
 
 package featuremgmt
 


### PR DESCRIPTION
`make gen-feature-toggles` is great to generate the feature toggle files, but unfortunately it fails when you have a golang syntax error in the generated `toggles_gen.go` file, commonly from a merge conflict.

I've updated the make task to just reset that file back to main, and then regenerate it with whats in your branch. Hopefully this makes things easier for development :)