### PR TITLE
LBAC for datasources: Add `lbac_enabled` to disable on-prem

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -455,6 +455,8 @@ datasource_limit = 5000
 # Check datasource documentations for enabling concurrency.
 concurrent_query_count = 10
 
+# Enable LBAC for datasources
+lbac_enabled = false
 
 ################################### SQL Data Sources #####################
 [sql_datasources]

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -235,6 +235,7 @@ export interface GrafanaConfig {
   listScopesEndpoint?: string;
   reportingStaticContext?: Record<string, string>;
   exploreDefaultTimeOffset?: string;
+  datasourceLBACEnabled?: boolean;
 
   // The namespace to use for kubernetes apiserver requests
   namespace: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -1,6 +1,7 @@
 import { merge } from 'lodash';
 
 import {
+  AngularMeta,
   AuthSettings,
   BootData,
   BuildInfo,
@@ -13,12 +14,12 @@ import {
   MapLayerOptions,
   OAuthSettings,
   PanelPluginMeta,
-  systemDateFormats,
+  PluginLoadingStrategy,
   SystemDateFormatSettings,
   getThemeById,
-  AngularMeta,
-  PluginLoadingStrategy,
+  systemDateFormats,
 } from '@grafana/data';
+
 
 export interface AzureSettings {
   cloud?: string;
@@ -149,6 +150,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   };
   geomapDefaultBaseLayerConfig?: MapLayerOptions;
   geomapDisableCustomBaseLayer?: boolean;
+  datasourceLBACEnabled?: boolean;
   unifiedAlertingEnabled = false;
   unifiedAlerting = {
     minInterval: '',

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -266,6 +266,8 @@ type FrontendSettingsDTO struct {
 
 	LoginError string `json:"loginError,omitempty"`
 
+	DatasourceLBACEnabled bool `json:"datasourceLBACEnabled"`
+
 	// The K8s namespace to use for this user
 	Namespace string `json:"namespace,omitempty"`
 

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -372,6 +372,8 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		frontendSettings.GeomapDisableCustomBaseLayer = true
 	}
 
+	frontendSettings.DatasourceLBACEnabled = hs.Cfg.DatasourceLBACEnabled
+
 	// Set the kubernetes namespace
 	frontendSettings.Namespace = hs.namespacer(c.SignedInUser.OrgID)
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -331,7 +331,8 @@ type Cfg struct {
 	// Data sources
 	DataSourceLimit int
 	// Number of queries to be executed concurrently. Only for the datasource supports concurrency.
-	ConcurrentQueryCount int
+	ConcurrentQueryCount  int
+	DatasourceLBACEnabled bool
 
 	// IP range access control
 	IPRangeACEnabled     bool
@@ -1973,6 +1974,7 @@ func (cfg *Cfg) readDataSourcesSettings() {
 	datasources := cfg.Raw.Section("datasources")
 	cfg.DataSourceLimit = datasources.Key("datasource_limit").MustInt(5000)
 	cfg.ConcurrentQueryCount = datasources.Key("concurrent_query_count").MustInt(10)
+	cfg.DatasourceLBACEnabled = datasources.Key("lbac_enabled").MustBool(false)
 }
 
 func (cfg *Cfg) readDataSourceSecuritySettings() {


### PR DESCRIPTION
This adds a configuration option `lbac_enabled`
- to be able to disable the on-prem until we can support on-prem.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds configuration option for `lbac_enabled`

**Why do we need this feature?**
 to disable not yet supported on-prem  feature `teamHttpHeaders`.

**Who is this feature for?**

Enterprise

