### PR TITLE
[DOC] Add videos to Explore docs

### DIFF
--- a/docs/sources/datasources/tempo/query-editor/_index.md
+++ b/docs/sources/datasources/tempo/query-editor/_index.md
@@ -46,6 +46,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/explore/explore-inspector/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana/<GRAFANA_VERSION>/explore/explore-inspector/
+  explore-traces-app:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/simplified-exploration/traces/
 ---
 
 # Query tracing data
@@ -54,6 +59,10 @@ The Tempo data source's query editor helps you query and display traces from Tem
 The queries use [TraceQL](/docs/tempo/latest/traceql), the query language designed specifically for tracing.
 
 For general documentation on querying data sources in Grafana, refer to [Query and transform data](ref:query-transform-data).
+
+{{% admonition type="tip"}}
+Don't know TraceQL? Try [Explore Traces](ref:explore-traces-app), an intuitive, queryless app that lets you explore your tracing data using RED metrics.
+{{% /admonition %}}
 
 ## Before you begin
 

--- a/docs/sources/datasources/tempo/query-editor/_index.md
+++ b/docs/sources/datasources/tempo/query-editor/_index.md
@@ -60,9 +60,9 @@ The queries use [TraceQL](/docs/tempo/latest/traceql), the query language design
 
 For general documentation on querying data sources in Grafana, refer to [Query and transform data](ref:query-transform-data).
 
-{{% admonition type="tip"}}
+{{< admonition type="tip" >}}
 Don't know TraceQL? Try [Explore Traces](ref:explore-traces-app), an intuitive, queryless app that lets you explore your tracing data using RED metrics.
-{{% /admonition %}}
+{{< /admonition >}}
 
 ## Before you begin
 

--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -40,4 +40,8 @@ The Grafana Explore apps are designed for effortless data exploration through in
 
 Easily explore telemetry signals with these specialized tools, tailored specifically for the Grafana databases to provide quick and accurate insights.
 
+To learn more, read [A queryless experience for exploring metrics, logs, traces, and profiles: Introducing the Explore apps suite for Grafana](https://grafana.com/blog/2024/09/24/queryless-metrics-logs-traces-profiles/).
+
+{{< youtube id="MSHeWWsHaIA" >}}
+
 {{< card-grid key="cards" type="simple" >}}


### PR DESCRIPTION
Adds the new video introducing the Explore apps to the Simplified exploration page. 
Adds information about the Explore apps to the query editor documentation in the Tempo doc.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
