### PR TITLE
CloudMigrations: Fix OrderBy clause in GetSnapshotList sql handler

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store.go
@@ -278,7 +278,7 @@ func (ss *sqlStore) GetSnapshotList(ctx context.Context, query cloudmigration.Li
 			offset := (query.Page - 1) * query.Limit
 			sess.Limit(query.Limit, offset)
 		}
-		sess.OrderBy("created DESC")
+		sess.OrderBy("cloud_migration_snapshot.created DESC")
 		return sess.Find(&snapshots, &cloudmigration.CloudMigrationSnapshot{
 			SessionUID: query.SessionUID,
 		})


### PR DESCRIPTION
**What is this feature?**

Both the `cloud_migration_snapshot` and `cloud_migration_session` tables have a `created` column, and the inner join makes the `OrderBy("created DESC")` clause ambiguous in mysql.

Tested in MySQL, Sqlite, and Postgres.