### PR TITLE
chore: enforce the validationMessageHorizontalOverflow for InlineField

### DIFF
--- a/packages/grafana-ui/src/components/Forms/InlineField.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.tsx
@@ -45,6 +45,7 @@ export const InlineField = ({
   error,
   transparent,
   interactive,
+  validationMessageHorizontalOverflow,
   ...htmlProps
 }: Props) => {
   const theme = useTheme2();
@@ -72,7 +73,11 @@ export const InlineField = ({
       <div className={styles.childContainer}>
         {cloneElement(children, { invalid, disabled, loading })}
         {invalid && error && (
-          <div className={cx(styles.fieldValidationWrapper)}>
+          <div
+            className={cx(styles.fieldValidationWrapper, {
+              [styles.validationMessageHorizontalOverflow]: !!validationMessageHorizontalOverflow,
+            })}
+          >
             <FieldValidationMessage>{error}</FieldValidationMessage>
           </div>
         )}
@@ -99,6 +104,14 @@ const getStyles = (theme: GrafanaTheme2, grow?: boolean, shrink?: boolean) => {
     }),
     fieldValidationWrapper: css({
       marginTop: theme.spacing(0.5),
+    }),
+    validationMessageHorizontalOverflow: css({
+      width: 0,
+      overflowX: 'visible',
+
+      '& > *': {
+        whiteSpace: 'nowrap',
+      },
     }),
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add css to the `InlineField` component for `validationMessageHorizontalOverflow

**Why do we need this feature?**

The `InlineField` component's validation message push out horizontal component that is next to it. Storybook has a prop under `InlineField` for `validationMessageHorizontalOverflow` but it is not being enforced in the code base. This PR adds that css piece to the `InlineField` component

**Who is this feature for?**

Any user who are integrating `grafana/ui` in their repo.

**Which issue(s) does this PR fix?**:
The `InlineField` component's validation message push out horizontal component that is next to it. 
Before:
<img width="815" alt="Screenshot 2024-09-26 at 2 47 32 PM" src="https://github.com/user-attachments/assets/9f559857-e154-4a5d-af59-bc953fa7c7d4">
After:
<img width="697" alt="Screenshot 2024-09-26 at 2 47 06 PM" src="https://github.com/user-attachments/assets/0fc422cf-f041-4cb0-9a56-7a45fa64a302">



<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
