### PR TITLE
ServiceAccounts: Remove permissions to service account when it is deleted

### DIFF
--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -119,7 +119,8 @@ func (f *SecretsCheckerFake) CheckTokens(ctx context.Context) error {
 func TestProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
 	storeMock := newServiceAccountStoreFake()
 	acSvc := actest.FakeService{}
-	svc := ServiceAccountsService{acSvc, storeMock, log.New("test"), log.New("background.test"), &SecretsCheckerFake{}, false, 0}
+	pSvc := &actest.FakePermissionsService{}
+	svc := ServiceAccountsService{acSvc, pSvc, storeMock, log.NewNopLogger(), log.NewNopLogger(), &SecretsCheckerFake{}, false, 0}
 	testOrgId := 1
 
 	t.Run("should create service account", func(t *testing.T) {

--- a/pkg/services/serviceaccounts/manager/stats_test.go
+++ b/pkg/services/serviceaccounts/manager/stats_test.go
@@ -14,8 +14,9 @@ import (
 
 func Test_UsageStats(t *testing.T) {
 	acSvc := actest.FakeService{}
+	pSvc := actest.FakePermissionsService{}
 	storeMock := newServiceAccountStoreFake()
-	svc := ServiceAccountsService{acSvc, storeMock, log.New("test"), log.New("background-test"), &SecretsCheckerFake{}, true, 5}
+	svc := ServiceAccountsService{acSvc, &pSvc, storeMock, log.NewNopLogger(), log.NewNopLogger(), &SecretsCheckerFake{}, true, 5}
 	err := svc.DeleteServiceAccount(context.Background(), 1, 1)
 	require.NoError(t, err)
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -28,7 +28,7 @@ func (m *orphanedServiceAccountPermissions) SQL(dialect migrator.Dialect) string
 	return CodeMigrationSQL
 }
 
-func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
+func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 	var idents []string
 
 	// find all permissions that are scopes directly to a service account
@@ -45,8 +45,12 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, migrator *m
 		}
 	}
 
+	if len(ids) == 0 {
+		return nil
+	}
+
 	// Then find all existing service accounts
-	raw := "SELECT u.id FROM " + migrator.Dialect.Quote("user") + " AS u WHERE u.is_service_account AND u.id IN(?" + strings.Repeat(",?", len(ids)-1) + ")"
+	raw := "SELECT u.id FROM " + mg.Dialect.Quote("user") + " AS u WHERE u.is_service_account AND u.id IN(?" + strings.Repeat(",?", len(ids)-1) + ")"
 	args := make([]any, 0, len(ids))
 	for _, id := range ids {
 		args = append(args, id)

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -1,0 +1,92 @@
+package accesscontrol
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"xorm.io/xorm"
+)
+
+const (
+	orphanedServiceAccountsPermissions = "delete orphaned service account permissions"
+)
+
+func AddOrphanedMigrations(mg *migrator.Migrator) {
+	mg.AddMigration(orphanedServiceAccountsPermissions, &orphanedServiceAccountPermissions{})
+}
+
+var _ migrator.CodeMigration = new(alertingScopeRemovalMigrator)
+
+type orphanedServiceAccountPermissions struct {
+	migrator.MigrationBase
+}
+
+func (m *orphanedServiceAccountPermissions) SQL(dialect migrator.Dialect) string {
+	return CodeMigrationSQL
+}
+
+func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
+
+	var idents []string
+
+	// find all permissions that are scopes directly to a service account
+	err := sess.SQL("SELECT DISTINCT p.identifier FROM permission AS p WHERE p.kind  = 'serviceaccounts' AND NOT p.identifier = '*';").Find(&idents)
+	if err != nil {
+		return fmt.Errorf("failed to fetch permissinos scoped to service accounts: %w", err)
+	}
+
+	ids := make([]int64, 0, len(idents))
+	for _, id := range idents {
+		id, err := strconv.ParseInt(id, 10, 64)
+		if err == nil {
+			ids = append(ids, id)
+		}
+	}
+
+	// Then find all existing service accounts
+	raw := "SELECT u.id FROM " + migrator.Dialect.Quote("user") + " AS u WHERE u.is_service_account AND u.id IN(?" + strings.Repeat(",?", len(ids)-1) + ")"
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+
+	var existingIDs []int64
+	err = sess.SQL(raw, args...).Find(&existingIDs)
+	if err != nil {
+		return fmt.Errorf("failed to fetch existing service accounts: %w", err)
+	}
+
+	existing := make(map[int64]struct{}, len(existingIDs))
+	for _, id := range existingIDs {
+		existing[id] = struct{}{}
+	}
+
+	// filter out orphaned permissions
+	var orphaned []string
+	for _, id := range ids {
+		if _, ok := existing[id]; !ok {
+			orphaned = append(orphaned, strconv.FormatInt(id, 10))
+		}
+	}
+
+	if len(orphaned) == 0 {
+		return nil
+	}
+
+	// delete all orphaned permissions
+	rawDelete := "DELETE FROM permission AS p WHERE p.kind = 'serviceaccounts' ANd p.identifier IN(?" + strings.Repeat(",?", len(orphaned)-1) + ")"
+	deleteArgs := make([]any, 0, len(orphaned)+1)
+	deleteArgs = append(deleteArgs, rawDelete)
+	for _, id := range orphaned {
+		deleteArgs = append(deleteArgs, id)
+	}
+
+	_, err = sess.Exec(deleteArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to delete orphaned service accounts: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -29,7 +29,6 @@ func (m *orphanedServiceAccountPermissions) SQL(dialect migrator.Dialect) string
 }
 
 func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
-
 	var idents []string
 
 	// find all permissions that are scopes directly to a service account

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -32,7 +32,7 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, migrator *m
 	var idents []string
 
 	// find all permissions that are scopes directly to a service account
-	err := sess.SQL("SELECT DISTINCT p.identifier FROM permission AS p WHERE p.kind  = 'serviceaccounts' AND NOT p.identifier = '*';").Find(&idents)
+	err := sess.SQL("SELECT DISTINCT p.identifier FROM permission AS p WHERE p.kind  = 'serviceaccounts' AND NOT p.identifier = '*'").Find(&idents)
 	if err != nil {
 		return fmt.Errorf("failed to fetch permissinos scoped to service accounts: %w", err)
 	}

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -80,7 +80,7 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, mg *migrato
 	}
 
 	// delete all orphaned permissions
-	rawDelete := "DELETE FROM permission AS p WHERE p.kind = 'serviceaccounts' ANd p.identifier IN(?" + strings.Repeat(",?", len(orphaned)-1) + ")"
+	rawDelete := "DELETE FROM permission AS p WHERE p.kind = 'serviceaccounts' AND p.identifier IN(?" + strings.Repeat(",?", len(orphaned)-1) + ")"
 	deleteArgs := make([]any, 0, len(orphaned)+1)
 	deleteArgs = append(deleteArgs, rawDelete)
 	for _, id := range orphaned {

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -5,8 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"xorm.io/xorm"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
 const (

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -131,6 +131,8 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.AddReceiverActionScopesMigration(mg)
 
 	ualert.AddRuleMetadata(mg)
+
+	accesscontrol.AddOrphanedMigrations(mg)
 }
 
 func addStarMigrations(mg *Migrator) {


### PR DESCRIPTION
**What is this feature?**
Whenever a service account is deleted we deleted all permissions that service account had to other resources but we did not delete permissions to the service account itself leaving orphaned permissions.

In this pr I just add the call to clean-up all permissions to the service account itself.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
