### PR TITLE
Alerting: Fix Grafana recording rules expressions

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -601,7 +601,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
               />
             )}
             {/* Expression Queries */}
-            {isAdvancedMode && isGrafanaAlertingType && (
+            {isAdvancedMode && (
               <>
                 <Stack direction="column" gap={0}>
                   <Text element="h5">Expressions</Text>


### PR DESCRIPTION
**What is this feature?**

This PR fixes a regression after merging [simplification mode for alert rule form](https://github.com/grafana/grafana/pull/93022).

The bug was expressions not being shown in the alert rule form.

**Why do we need this feature?**

**Who is this feature for?**

All users.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
