### PR TITLE
Docs: document the `managed_service_accounts_enabled` configuration option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -616,6 +616,7 @@ id_response_header_prefix = X-Grafana
 id_response_header_namespaces = user api-key service-account
 
 # Enables the use of managed service accounts for plugin authentication
+# This feature currently **only supports single-organization deployments**
 managed_service_accounts_enabled = false
 
 #################################### SSO Settings ###########################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -620,6 +620,7 @@
 ;id_response_header_namespaces = user api-key service-account
 
 # Enables the use of managed service accounts for plugin authentication
+# This feature currently **only supports single-organization deployments**
 ; managed_service_accounts_enabled = false
 
 #################################### Anonymous Auth ######################

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1094,7 +1094,7 @@ Set to `true` to enable verbose request signature logging when AWS Signature Ver
 
 > Only available in Grafana 11.3+.
 
-Enables the use of managed service accounts for plugin authentication.
+Set to `true` to enable the use of managed service accounts for plugin authentication. Default is `false`.
 
 > **Limitations:**
 > This feature currently **only supports single-organization deployments**.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1090,6 +1090,16 @@ Set to `true` to enable verbose request signature logging when AWS Signature Ver
 
 <hr />
 
+### managed_service_accounts_enabled
+
+> Only available in Grafana 11.3+.
+
+Enables the use of managed service accounts for plugin authentication.
+
+> **Limitations:**
+> This feature currently **only supports single-organization deployments**.
+> The plugin's service account is automatically created in the default organization. This means the plugin can only access data and resources within that specific organization.
+
 ## [auth.anonymous]
 
 Refer to [Anonymous authentication]({{< relref "../configure-security/configure-authentication/grafana#anonymous-authentication" >}}) for detailed instructions.


### PR DESCRIPTION
**What is this feature?**

This PR documents the `managed_service_accounts_enabled` configuration option.

Following #91844, I thought we could make it extra clear that we only support single organization setups.
