### PR TITLE
Alerting: refactor InstanceStore to support saving multiple alert instances 

### DIFF
--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -215,9 +215,7 @@ func TestWarmStateCache(t *testing.T) {
 		Labels:            labels,
 		ResultFingerprint: data.Fingerprint(2).String(),
 	})
-	for _, instance := range instances {
-		_ = dbstore.SaveAlertInstance(ctx, instance)
-	}
+	_ = dbstore.SaveAlertInstances(ctx, instances)
 
 	cfg := state.ManagerCfg{
 		Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
@@ -1750,9 +1748,7 @@ func TestStaleResultsHandler(t *testing.T) {
 		},
 	}
 
-	for _, instance := range instances {
-		_ = dbstore.SaveAlertInstance(ctx, instance)
-	}
+	_ = dbstore.SaveAlertInstances(ctx, instances)
 
 	testCases := []struct {
 		desc               string
@@ -2008,9 +2004,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 		},
 	}
 
-	for _, instance := range instances {
-		_ = dbstore.SaveAlertInstance(ctx, instance)
-	}
+	_ = dbstore.SaveAlertInstances(ctx, instances)
 
 	testCases := []struct {
 		desc          string
@@ -2150,9 +2144,7 @@ func TestResetStateByRuleUID(t *testing.T) {
 		},
 	}
 
-	for _, instance := range instances {
-		_ = dbstore.SaveAlertInstance(ctx, instance)
-	}
+	_ = dbstore.SaveAlertInstances(ctx, instances)
 
 	testCases := []struct {
 		desc          string

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -11,7 +11,7 @@ import (
 type InstanceStore interface {
 	FetchOrgIds(ctx context.Context) ([]int64, error)
 	ListAlertInstances(ctx context.Context, cmd *models.ListAlertInstancesQuery) ([]*models.AlertInstance, error)
-	SaveAlertInstance(ctx context.Context, instance models.AlertInstance) error
+	SaveAlertInstances(ctx context.Context, instances []models.AlertInstance) error
 	DeleteAlertInstances(ctx context.Context, keys ...models.AlertInstanceKey) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error
 	FullSync(ctx context.Context, instances []models.AlertInstance) error

--- a/pkg/services/ngalert/state/persister_sync.go
+++ b/pkg/services/ngalert/state/persister_sync.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 type SyncStatePersister struct {
@@ -54,7 +54,7 @@ func (a *SyncStatePersister) deleteAlertStates(ctx context.Context, states []Sta
 	}
 	logger := a.log.FromContext(ctx)
 	logger.Debug("Deleting alert states", "count", len(states))
-	toDelete := make([]ngModels.AlertInstanceKey, 0, len(states))
+	toDelete := make([]models.AlertInstanceKey, 0, len(states))
 
 	for _, s := range states {
 		key, err := s.GetAlertInstanceKey()
@@ -94,10 +94,10 @@ func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...Stat
 			logger.Error("Failed to create a key for alert state to save it to database. The state will be ignored ", "cacheID", s.CacheID, "error", err, "labels", s.Labels.String())
 			return nil
 		}
-		instance := ngModels.AlertInstance{
+		instance := models.AlertInstance{
 			AlertInstanceKey:  key,
-			Labels:            ngModels.InstanceLabels(s.Labels),
-			CurrentState:      ngModels.InstanceStateType(s.State.State.String()),
+			Labels:            models.InstanceLabels(s.Labels),
+			CurrentState:      models.InstanceStateType(s.State.State.String()),
 			CurrentReason:     s.StateReason,
 			LastEvalTime:      s.LastEvaluationTime,
 			CurrentStateSince: s.StartsAt,
@@ -107,7 +107,7 @@ func (a *SyncStatePersister) saveAlertStates(ctx context.Context, states ...Stat
 			ResultFingerprint: s.ResultFingerprint.String(),
 		}
 
-		err = a.store.SaveAlertInstance(ctx, instance)
+		err = a.store.SaveAlertInstances(ctx, []models.AlertInstance{instance})
 		if err != nil {
 			logger.Error("Failed to save alert state", "labels", s.Labels.String(), "state", s.State, "error", err)
 			return nil

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -35,10 +35,12 @@ func (f *FakeInstanceStore) ListAlertInstances(_ context.Context, q *models.List
 	return nil, nil
 }
 
-func (f *FakeInstanceStore) SaveAlertInstance(_ context.Context, q models.AlertInstance) error {
+func (f *FakeInstanceStore) SaveAlertInstances(_ context.Context, q []models.AlertInstance) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
-	f.recordedOps = append(f.recordedOps, q)
+	for _, instance := range q {
+		f.recordedOps = append(f.recordedOps, instance)
+	}
 	return nil
 }
 

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -48,9 +48,7 @@ func BenchmarkAlertInstanceOperations(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		for _, instance := range instances {
-			_ = dbstore.SaveAlertInstance(ctx, instance)
-		}
+		_ = dbstore.SaveAlertInstances(ctx, instances)
 		_ = dbstore.DeleteAlertInstances(ctx, keys...)
 	}
 }
@@ -99,7 +97,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			CurrentReason: string(models.InstanceStateError),
 			Labels:        labels,
 		}
-		err := dbstore.SaveAlertInstance(ctx, instance)
+		err := dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance})
 		require.NoError(t, err)
 
 		listCmd := &models.ListAlertInstancesQuery{
@@ -128,7 +126,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			CurrentState: models.InstanceStateNormal,
 			Labels:       labels,
 		}
-		err := dbstore.SaveAlertInstance(ctx, instance)
+		err := dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance})
 		require.NoError(t, err)
 
 		listCmd := &models.ListAlertInstancesQuery{
@@ -158,7 +156,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			Labels:       labels,
 		}
 
-		err := dbstore.SaveAlertInstance(ctx, instance1)
+		err := dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance1})
 		require.NoError(t, err)
 
 		labels = models.InstanceLabels{"test": "testValue2"}
@@ -172,7 +170,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			CurrentState: models.InstanceStateFiring,
 			Labels:       labels,
 		}
-		err = dbstore.SaveAlertInstance(ctx, instance2)
+		err = dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance2})
 		require.NoError(t, err)
 
 		listQuery := &models.ListAlertInstancesQuery{
@@ -219,9 +217,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			CurrentReason: models.StateReasonError,
 			Labels:        labels,
 		}
-		err := dbstore.SaveAlertInstance(ctx, instance1)
+		err := dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance1})
 		require.NoError(t, err)
-		err = dbstore.SaveAlertInstance(ctx, instance2)
+		err = dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance2})
 		require.NoError(t, err)
 
 		listQuery := &models.ListAlertInstancesQuery{
@@ -264,7 +262,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			Labels:       labels,
 		}
 
-		err := dbstore.SaveAlertInstance(ctx, instance1)
+		err := dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance1})
 		require.NoError(t, err)
 
 		instance2 := models.AlertInstance{
@@ -276,7 +274,7 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 			CurrentState: models.InstanceStateNormal,
 			Labels:       instance1.Labels,
 		}
-		err = dbstore.SaveAlertInstance(ctx, instance2)
+		err = dbstore.SaveAlertInstances(ctx, []models.AlertInstance{instance2})
 		require.NoError(t, err)
 
 		listQuery := &models.ListAlertInstancesQuery{


### PR DESCRIPTION
**What is this feature?**

Refactored SaveAlertInstance to SaveAlertInstance**s**, which accepts a list of instances to save.

**Why do we need this feature?**

It allows us to refactor things like `SyncStatePersister` (and write new persisters) to save multiple alert instances. For example, the whole state of the rule can be saved as a single data blob, etc.

Related PR: https://github.com/grafana/grafana-enterprise/pull/7279