### PR TITLE
CloudMigrations: Add support for migration of Library Elements (Panels) resources

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -3,6 +3,7 @@ package cloudmigrationimpl
 import (
 	"context"
 	cryptoRand "crypto/rand"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -185,11 +186,19 @@ func (s *Service) getDashboardAndFolderCommands(ctx context.Context, signedInUse
 	return dashboardCmds, folderCmds, nil
 }
 
+type libraryElement struct {
+	FolderUID *string         `json:"folderUid"`
+	Name      string          `json:"name"`
+	UID       string          `json:"uid"`
+	Model     json.RawMessage `json:"model"`
+	Kind      int64           `json:"kind"`
+}
+
 // getLibraryElementsCommands returns the json payloads required by the library elements creation API
-func (s *Service) getLibraryElementsCommands(ctx context.Context, signedInUser *user.SignedInUser) ([]libraryelements.CreateLibraryElementCommand, error) {
+func (s *Service) getLibraryElementsCommands(ctx context.Context, signedInUser *user.SignedInUser) ([]libraryElement, error) {
 	const perPage = 100
 
-	cmds := make([]libraryelements.CreateLibraryElementCommand, 0)
+	cmds := make([]libraryElement, 0)
 
 	page := 1
 	count := 0
@@ -211,7 +220,7 @@ func (s *Service) getLibraryElementsCommands(ctx context.Context, signedInUser *
 				folderUID = &element.FolderUID
 			}
 
-			cmds = append(cmds, libraryelements.CreateLibraryElementCommand{
+			cmds = append(cmds, libraryElement{
 				FolderUID: folderUID,
 				Name:      element.Name,
 				Model:     element.Model,

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -56,6 +56,9 @@ const injectedRtkApi = api.injectEndpoints({
     getDashboardByUid: build.query<GetDashboardByUidApiResponse, GetDashboardByUidApiArg>({
       query: (queryArg) => ({ url: `/dashboards/uid/${queryArg.uid}` }),
     }),
+    getLibraryElementByUid: build.query<GetLibraryElementByUidApiResponse, GetLibraryElementByUidApiArg>({
+      query: (queryArg) => ({ url: `/library-elements/${queryArg.libraryElementUid}` }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -128,6 +131,11 @@ export type GetDashboardByUidApiResponse = /** status 200 (empty) */ DashboardFu
 export type GetDashboardByUidApiArg = {
   uid: string;
 };
+export type GetLibraryElementByUidApiResponse =
+  /** status 200 (empty) */ LibraryElementResponseIsAResponseStructForLibraryElementDto;
+export type GetLibraryElementByUidApiArg = {
+  libraryElementUid: string;
+};
 export type CloudMigrationSessionResponseDto = {
   created?: string;
   slug?: string;
@@ -155,6 +163,7 @@ export type CreateSnapshotResponseDto = {
 };
 export type MigrateDataResponseItemDto = {
   message?: string;
+  name?: string;
   refId: string;
   status: 'OK' | 'WARNING' | 'ERROR' | 'PENDING' | 'UNKNOWN';
   type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER' | 'LIBRARY_ELEMENT';
@@ -261,6 +270,39 @@ export type DashboardFullWithMeta = {
   dashboard?: Json;
   meta?: DashboardMeta;
 };
+export type LibraryElementDtoMetaUserDefinesModelForLibraryElementDtoMetaUser = {
+  avatarUrl?: string;
+  id?: number;
+  name?: string;
+};
+export type LibraryElementDtoMetaIsTheMetaInformationForLibraryElementDto = {
+  connectedDashboards?: number;
+  created?: string;
+  createdBy?: LibraryElementDtoMetaUserDefinesModelForLibraryElementDtoMetaUser;
+  folderName?: string;
+  folderUid?: string;
+  updated?: string;
+  updatedBy?: LibraryElementDtoMetaUserDefinesModelForLibraryElementDtoMetaUser;
+};
+export type LibraryElementDtoIsTheFrontendDtoForEntities = {
+  description?: string;
+  /** Deprecated: use FolderUID instead */
+  folderId?: number;
+  folderUid?: string;
+  id?: number;
+  kind?: number;
+  meta?: LibraryElementDtoMetaIsTheMetaInformationForLibraryElementDto;
+  model?: object;
+  name?: string;
+  orgId?: number;
+  schemaVersion?: number;
+  type?: string;
+  uid?: string;
+  version?: number;
+};
+export type LibraryElementResponseIsAResponseStructForLibraryElementDto = {
+  result?: LibraryElementDtoIsTheFrontendDtoForEntities;
+};
 export const {
   useGetSessionListQuery,
   useCreateSessionMutation,
@@ -275,4 +317,5 @@ export const {
   useCreateCloudMigrationTokenMutation,
   useDeleteCloudMigrationTokenMutation,
   useGetDashboardByUidQuery,
+  useGetLibraryElementByUidQuery,
 } = injectedRtkApi;

--- a/public/app/features/migrate-to-cloud/api/index.ts
+++ b/public/app/features/migrate-to-cloud/api/index.ts
@@ -47,6 +47,7 @@ export const cloudMigrationAPI = generatedAPI.enhanceEndpoints({
     },
 
     getDashboardByUid: suppressErrorsOnQuery,
+    getLibraryElementByUid: suppressErrorsOnQuery,
   },
 });
 

--- a/public/app/features/migrate-to-cloud/fixtures/migrationItems.ts
+++ b/public/app/features/migrate-to-cloud/fixtures/migrationItems.ts
@@ -29,3 +29,17 @@ export function wellFormedDashboardMigrationItem(
     ...partial,
   };
 }
+
+export function wellFormedLibraryElementMigrationItem(
+  seed = 1,
+  partial: Partial<MigrateDataResponseItemDto> = {}
+): MigrateDataResponseItemDto {
+  const random = Chance(seed);
+
+  return {
+    type: 'LIBRARY_ELEMENT',
+    refId: random.guid(),
+    status: random.pickone(['OK', 'ERROR']),
+    ...partial,
+  };
+}

--- a/public/app/features/migrate-to-cloud/fixtures/mswAPI.ts
+++ b/public/app/features/migrate-to-cloud/fixtures/mswAPI.ts
@@ -27,6 +27,28 @@ function createMockAPI(): SetupServer {
       });
     }),
 
+    http.get('/api/library-elements/:uid', ({ request, params }) => {
+      if (params.uid === 'library-element-404') {
+        return HttpResponse.json(
+          {
+            message: 'Library element not found',
+          },
+          {
+            status: 404,
+          }
+        );
+      }
+
+      return HttpResponse.json({
+        result: {
+          name: 'My Library Element',
+          meta: {
+            folderName: 'FolderName',
+          },
+        },
+      });
+    }),
+
     http.post('/api/cloudmigration/migration', async ({ request }) => {
       const data = await request.json();
       const authToken = typeof data === 'object' && data && data.authToken;

--- a/public/app/features/migrate-to-cloud/onprem/ResourcesTable.test.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/ResourcesTable.test.tsx
@@ -4,7 +4,11 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { setBackendSrv, config } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 
-import { wellFormedDashboardMigrationItem, wellFormedDatasourceMigrationItem } from '../fixtures/migrationItems';
+import {
+  wellFormedDashboardMigrationItem,
+  wellFormedDatasourceMigrationItem,
+  wellFormedLibraryElementMigrationItem,
+} from '../fixtures/migrationItems';
 import { registerMockAPI } from '../fixtures/mswAPI';
 import { wellFormedDatasource } from '../fixtures/others';
 
@@ -84,6 +88,28 @@ describe('ResourcesTable', () => {
 
     expect(await screen.findByText('Unable to load dashboard')).toBeInTheDocument();
     expect(await screen.findByText('Dashboard dashboard-404')).toBeInTheDocument();
+  });
+
+  it('renders library elements', async () => {
+    const resources = [wellFormedLibraryElementMigrationItem(1)];
+
+    render({ resources });
+
+    expect(await screen.findByText('My Library Element')).toBeInTheDocument();
+    expect(await screen.findByText('FolderName')).toBeInTheDocument();
+  });
+
+  it('renders library elements when their data is missing', async () => {
+    const resources = [
+      wellFormedLibraryElementMigrationItem(2, {
+        refId: 'library-element-404',
+      }),
+    ];
+
+    render({ resources });
+
+    expect(await screen.findByText('Unable to load library element')).toBeInTheDocument();
+    expect(await screen.findByText('Library Element library-element-404')).toBeInTheDocument();
   });
 
   it('renders the success status correctly', () => {

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -11,6 +11,8 @@ export function prettyTypeName(type: ResourceTableItem['type']) {
       return t('migrate-to-cloud.resource-type.dashboard', 'Dashboard');
     case 'FOLDER':
       return t('migrate-to-cloud.resource-type.folder', 'Folder');
+    case 'LIBRARY_ELEMENT':
+      return t('migrate-to-cloud.resource-type.library_element', 'Library Element');
     default:
       return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
   }

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -45,6 +45,8 @@ function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
       types.push(t('migrate-to-cloud.migrated-counts.datasources', 'data sources'));
     } else if (type === 'FOLDER') {
       types.push(t('migrate-to-cloud.migrated-counts.folders', 'folders'));
+    } else if (type === 'LIBRARY_ELEMENT') {
+      types.push(t('migrate-to-cloud.migrated-counts.library_elements', 'library elements'));
     }
   }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1360,7 +1360,8 @@
     "migrated-counts": {
       "dashboards": "dashboards",
       "datasources": "data sources",
-      "folders": "folders"
+      "folders": "folders",
+      "library_elements": "library elements"
     },
     "migration-token": {
       "delete-button": "Delete token",
@@ -1432,6 +1433,8 @@
       "warning-details-button": "Details"
     },
     "resource-table": {
+      "error-library-element-sub": "Library Element {uid}",
+      "error-library-element-title": "Unable to load library element",
       "unknown-datasource-title": "Data source {{datasourceUID}}",
       "unknown-datasource-type": "Unknown data source"
     },
@@ -1439,6 +1442,7 @@
       "dashboard": "Dashboard",
       "datasource": "Data source",
       "folder": "Folder",
+      "library_element": "Library Element",
       "unknown": "Unknown"
     },
     "summary": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1360,7 +1360,8 @@
     "migrated-counts": {
       "dashboards": "đäşĥþőäřđş",
       "datasources": "đäŧä şőūřčęş",
-      "folders": "ƒőľđęřş"
+      "folders": "ƒőľđęřş",
+      "library_elements": "ľįþřäřy ęľęmęŉŧş"
     },
     "migration-token": {
       "delete-button": "Đęľęŧę ŧőĸęŉ",
@@ -1432,6 +1433,8 @@
       "warning-details-button": "Đęŧäįľş"
     },
     "resource-table": {
+      "error-library-element-sub": "Ŀįþřäřy Ēľęmęŉŧ {ūįđ}",
+      "error-library-element-title": "Ůŉäþľę ŧő ľőäđ ľįþřäřy ęľęmęŉŧ",
       "unknown-datasource-title": "Đäŧä şőūřčę {{datasourceUID}}",
       "unknown-datasource-type": "Ůŉĸŉőŵŉ đäŧä şőūřčę"
     },
@@ -1439,6 +1442,7 @@
       "dashboard": "Đäşĥþőäřđ",
       "datasource": "Đäŧä şőūřčę",
       "folder": "Főľđęř",
+      "library_element": "Ŀįþřäřy Ēľęmęŉŧ",
       "unknown": "Ůŉĸŉőŵŉ"
     },
     "summary": {

--- a/scripts/generate-rtk-apis.ts
+++ b/scripts/generate-rtk-apis.ts
@@ -28,6 +28,7 @@ const config: ConfigFile = {
         'getCloudMigrationToken',
 
         'getDashboardByUid',
+        'getLibraryElementByUid',
       ],
     },
     '../public/app/features/preferences/api/user/endpoints.gen.ts': {


### PR DESCRIPTION
**What is this feature?**

Creates snapshot of all Library Elements and renders them in the `Migrate to Grafana Cloud` page resource list.

![Screenshot 2024-09-27 at 12 10 31](https://github.com/user-attachments/assets/0ca08638-c6f7-43bb-ba88-07ff00db0210)


**Why do we need this feature?**

Some Dashboards uses Library Elements (panel kind) and we need to migrate these resources and afterwards migrate those Dashboards with connected panels.

**Who is this feature for?**

Cloud Migration Assistant users :)

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/972

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
