### PR TITLE
Fix: Prevent import errors in frontend packages

### DIFF
--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -8,6 +8,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -24,6 +29,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -32,6 +38,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-data/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-e2e-selectors/rollup.config.ts
+++ b/packages/grafana-e2e-selectors/rollup.config.ts
@@ -8,6 +8,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -24,6 +29,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -32,6 +38,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-e2e-selectors/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-flamegraph/rollup.config.ts
+++ b/packages/grafana-flamegraph/rollup.config.ts
@@ -8,6 +8,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -24,6 +29,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -32,6 +38,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-ui/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-icons/rollup.config.ts
+++ b/packages/grafana-icons/rollup.config.ts
@@ -8,6 +8,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -25,6 +30,7 @@ export default [
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
         preserveModules: true,
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-prometheus/rollup.config.ts
+++ b/packages/grafana-prometheus/rollup.config.ts
@@ -9,6 +9,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -26,6 +31,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -34,6 +40,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-prometheus/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-runtime/rollup.config.ts
+++ b/packages/grafana-runtime/rollup.config.ts
@@ -8,6 +8,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -24,6 +29,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -32,6 +38,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-runtime/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-schema/rollup.config.ts
+++ b/packages/grafana-schema/rollup.config.ts
@@ -10,6 +10,11 @@ import { nodeExternals } from 'rollup-plugin-node-externals';
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -26,6 +31,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -34,6 +40,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-schema/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -15,6 +15,11 @@ const iconSrcPaths = icons.map((iconSubPath) => {
   return `../../public/img/icons/${iconSubPath}.svg`;
 });
 
+const legacyOutputDefaults = {
+  esModule: true,
+  interop: 'compat',
+};
+
 export default [
   {
     input: 'src/index.ts',
@@ -36,6 +41,7 @@ export default [
         format: 'cjs',
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.main),
+        ...legacyOutputDefaults,
       },
       {
         format: 'esm',
@@ -44,6 +50,7 @@ export default [
         preserveModules: true,
         // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
         preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-ui/src`),
+        ...legacyOutputDefaults,
       },
     ],
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes errors caused by the [rollup v4 update](https://github.com/grafana/grafana/pull/93731). The additional options make sure to inject `Object.defineProperty(exports, '__esModule', { value: true });` in the bundled output and provide a more compatible interop - which controls how Rollup handles default, namespace and dynamic imports from external dependencies.

Without these changes consumers will see errors in jest tests like the following as the import no longer resolves to the actual module but most likely `{ default: theImportedModule }`.

```Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.```

**Why do we need this feature?**

So consumers of our `@grafana` packages that live in this repo can continue to use the packages.

**Who is this feature for?**

Plugin devs / everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I will open a further PR that cleans up all these rollup configs. There's so much repetition.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
