### PR TITLE
Auth: Fix token rotation redirect when session storage redirect is enabled

### DIFF
--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -88,7 +88,11 @@ func (hs *HTTPServer) RotateUserAuthTokenRedirect(c *contextmodel.ReqContext) re
 		return response.Redirect(hs.GetRedirectURL(c))
 	}
 
-	return response.Redirect(hs.Cfg.AppSubURL + "/")
+	redirectTo := c.Query("redirectTo")
+	if err := hs.ValidateRedirectTo(redirectTo); err != nil {
+		return response.Redirect(hs.Cfg.AppSubURL + "/")
+	}
+	return response.Redirect(hs.Cfg.AppSubURL + redirectTo)
 }
 
 // swagger:route POST /user/auth-tokens/rotate
@@ -133,7 +137,6 @@ func (hs *HTTPServer) rotateToken(c *contextmodel.ReqContext) error {
 		IP:            ip,
 		UserAgent:     c.Req.UserAgent(),
 	})
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What is this feature?**
Fixes the redirection when the `useSessionStorageForRedirection` feature is enabled.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
