### PR TITLE
Build: Reduce repetition in rollup configs

### DIFF
--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -1,53 +1,15 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { entryPoint, plugins, esmOutput, cjsOutput, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-data/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins,
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-data')],
   },
-  {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-e2e-selectors/rollup.config.ts
+++ b/packages/grafana-e2e-selectors/rollup.config.ts
@@ -1,53 +1,15 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-e2e-selectors/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins,
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-e2e-selectors')],
   },
-  {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-flamegraph/rollup.config.ts
+++ b/packages/grafana-flamegraph/rollup.config.ts
@@ -1,53 +1,15 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-ui/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins,
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-flamegraph')],
   },
-  {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-icons/package.json
+++ b/packages/grafana-icons/package.json
@@ -16,6 +16,7 @@
   "types": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
+    "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "access": "public"
   },

--- a/packages/grafana-icons/rollup.config.ts
+++ b/packages/grafana-icons/rollup.config.ts
@@ -1,45 +1,15 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
-    output: [
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        preserveModules: true,
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins,
+    output: esmOutput(pkg, 'grafana-icons'),
   },
-  {
-    input: 'src/index.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg, { input: 'src/index.ts' }),
 ];

--- a/packages/grafana-prometheus/rollup.config.ts
+++ b/packages/grafana-prometheus/rollup.config.ts
@@ -1,55 +1,16 @@
 import image from '@rollup/plugin-image';
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-      image(),
-    ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-prometheus/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins: [...plugins, image()],
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-prometheus')],
   },
-  {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-runtime/rollup.config.ts
+++ b/packages/grafana-runtime/rollup.config.ts
@@ -1,53 +1,15 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-runtime/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins,
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-runtime')],
   },
-  {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg),
 ];

--- a/packages/grafana-schema/rollup.config.ts
+++ b/packages/grafana-schema/rollup.config.ts
@@ -1,57 +1,22 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { glob } from 'glob';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'path';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
+
+import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
+const [_, noderesolve, esbuild] = plugins;
 
 export default [
   {
-    input: 'src/index.ts',
-    plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-schema/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    input: entryPoint,
+    plugins,
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-schema')],
   },
-  {
-    input: './dist/esm/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg, { input: './dist/esm/index.d.ts' }),
   {
     input: Object.fromEntries(
       glob
@@ -61,13 +26,7 @@ export default [
           fileURLToPath(new URL(file, import.meta.url)),
         ])
     ),
-    plugins: [
-      resolve(),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
-    ],
+    plugins: [noderesolve, esbuild],
     output: {
       format: 'esm',
       dir: path.dirname(pkg.publishConfig.module),

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -1,11 +1,8 @@
-import resolve from '@rollup/plugin-node-resolve';
 import { createRequire } from 'node:module';
-import path from 'path';
 import copy from 'rollup-plugin-copy';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
-import { nodeExternals } from 'rollup-plugin-node-externals';
 import svg from 'rollup-plugin-svg-import';
+
+import { cjsOutput, entryPoint, esmOutput, plugins, tsDeclarationOutput } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const icons = rq('../../public/app/core/icons/cached.json');
@@ -15,51 +12,18 @@ const iconSrcPaths = icons.map((iconSubPath) => {
   return `../../public/img/icons/${iconSubPath}.svg`;
 });
 
-const legacyOutputDefaults = {
-  esModule: true,
-  interop: 'compat',
-};
-
 export default [
   {
-    input: 'src/index.ts',
+    input: entryPoint,
     plugins: [
-      nodeExternals({ deps: true, packagePath: './package.json' }),
+      ...plugins,
       svg({ stringify: true }),
-      resolve(),
       copy({
         targets: [{ src: iconSrcPaths, dest: './dist/public/' }],
         flatten: false,
       }),
-      esbuild({
-        target: 'es2018',
-        tsconfig: 'tsconfig.build.json',
-      }),
     ],
-    output: [
-      {
-        format: 'cjs',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
-        ...legacyOutputDefaults,
-      },
-      {
-        format: 'esm',
-        sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
-        preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-ui/src`),
-        ...legacyOutputDefaults,
-      },
-    ],
+    output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-ui')],
   },
-  {
-    input: './compiled/index.d.ts',
-    plugins: [dts()],
-    output: {
-      file: pkg.publishConfig.types,
-      format: 'es',
-    },
-  },
+  tsDeclarationOutput(pkg),
 ];

--- a/packages/rollup.config.parts.ts
+++ b/packages/rollup.config.parts.ts
@@ -1,0 +1,58 @@
+// This file contains the common parts of the rollup configuration that are shared across multiple packages.
+import nodeResolve from '@rollup/plugin-node-resolve';
+import { dirname, resolve } from 'node:path';
+import dts from 'rollup-plugin-dts';
+import esbuild from 'rollup-plugin-esbuild';
+import { nodeExternals } from 'rollup-plugin-node-externals';
+
+// This is the path to the root of the grafana project
+// Prefer PROJECT_CWD env var set by yarn berry
+const projectCwd = process.env.PROJECT_CWD ?? '../../';
+
+export const entryPoint = 'src/index.ts';
+
+// Plugins that are shared across all rollup configurations. Their order can affect build output.
+// Externalising and resolving modules should happen before transformation.
+export const plugins = [
+  nodeExternals({ deps: true, packagePath: './package.json' }),
+  nodeResolve(),
+  esbuild({
+    target: 'es2018',
+    tsconfig: 'tsconfig.build.json',
+  }),
+];
+
+// Generates a rollup configuration for commonjs output.
+export function cjsOutput(pkg) {
+  return {
+    format: 'cjs',
+    sourcemap: true,
+    dir: dirname(pkg.publishConfig.main),
+    esModule: true,
+    interop: 'compat',
+  };
+}
+
+// Generate a rollup configuration for es module output.
+export function esmOutput(pkg, pkgName) {
+  return {
+    format: 'esm',
+    sourcemap: true,
+    dir: dirname(pkg.publishConfig.module),
+    preserveModules: true,
+    preserveModulesRoot: resolve(projectCwd, `packages/${pkgName}/src`),
+  };
+}
+
+// Generate a rollup configuration for rolling up typescript declaration files into a single file.
+export function tsDeclarationOutput(pkg, overrides = {}) {
+  return {
+    input: './compiled/index.d.ts',
+    plugins: [dts()],
+    output: {
+      file: pkg.publishConfig.types,
+      format: 'es',
+    },
+    ...overrides,
+  };
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a rollup.config.parts file that contains pieces of generic config. Each package can import the pieces it needs to be built.

**Why do we need this feature?**

We don't _need_ this but I find the amount of repetition in all these configs to be quite annoying when a change needs to be made.

**Who is this feature for?**

Grafana developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
