### PR TITLE
Alerting: Update GetTemplates to return sorted list of templates

### DIFF
--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
+	"slices"
 	"sort"
 	"unsafe"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -51,7 +51,7 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]defi
 	}
 
 	templates := make([]definitions.NotificationTemplate, 0, len(revision.Config.TemplateFiles))
-	names := maps.Keys(revision.Config.TemplateFiles)
+	names := slices.Collect(maps.Keys(revision.Config.TemplateFiles))
 	sort.Strings(names)
 	for _, name := range names {
 		content := revision.Config.TemplateFiles[name]

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"unsafe"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -48,12 +51,15 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]defi
 	}
 
 	templates := make([]definitions.NotificationTemplate, 0, len(revision.Config.TemplateFiles))
-	for name, tmpl := range revision.Config.TemplateFiles {
+	names := maps.Keys(revision.Config.TemplateFiles)
+	sort.Strings(names)
+	for _, name := range names {
+		content := revision.Config.TemplateFiles[name]
 		tmpl := definitions.NotificationTemplate{
 			UID:             legacy_storage.NameToUid(name),
 			Name:            name,
-			Template:        tmpl,
-			ResourceVersion: calculateTemplateFingerprint(tmpl),
+			Template:        content,
+			ResourceVersion: calculateTemplateFingerprint(content),
 		}
 		provenance, ok := provenances[tmpl.ResourceID()]
 		if !ok {

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -68,7 +68,7 @@ func TestGetTemplates(t *testing.T) {
 			},
 		}
 
-		require.ElementsMatch(t, expected, result)
+		require.EqualValues(t, expected, result)
 
 		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&definitions.NotificationTemplate{}).ResourceType())
 		prov.AssertExpectations(t)


### PR DESCRIPTION
**What is this feature?**
This PR updates template service to sort the template groups before returning. There is no effect on the provisioning API. 

**Why do we need this feature?**
UI would like us to guarantee the order so they can base their features on this assumption.

**Who is this feature for?**
UI 