### PR TITLE
RestoreDashboards: Improve tracking

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { Alert, ConfirmModal, Text, Space } from '@grafana/ui';
 import { Trans, t } from 'app/core/internationalization';
 
@@ -21,6 +21,14 @@ export const DeleteModal = ({ onConfirm, onDismiss, selectedItems, ...props }: P
   const deleteIsInvalid = Boolean(data && (data.alertRule || data.libraryPanel));
   const [isDeleting, setIsDeleting] = useState(false);
   const onDelete = async () => {
+    reportInteraction('grafana_manage_dashboards_delete_clicked', {
+      item_counts: {
+        dashboard: Object.keys(selectedItems.dashboard).length,
+        folder: Object.keys(selectedItems.folder).length,
+      },
+      source: 'browse_dashboards',
+      restore_enabled: config.featureToggles.dashboardRestoreUI,
+    });
     setIsDeleting(true);
     try {
       await onConfirm();


### PR DESCRIPTION
**What is this feature?**
Add tracking to DeleteModal in browse dashboards view.

I checked all the other tracking events in the workflows related to RestoreDashboards and they are working (data available).
- `public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx` and `public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx` using the same label as `public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx` but with different payload data
- `public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx` => events for opening the restore and permanently delete modal
- `public/app/features/browse-dashboards/components/RestoreModal.tsx` => event for restoring
- `public/app/features/browse-dashboards/components/PermanentlyDeleteModal.tsx` => event for permanently deleting

**Which issue(s) does this PR fix?**:
Fixes #93149

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
