### PR TITLE
Prometheus: Show notice when there is no data

### DIFF
--- a/pkg/promlib/converter/prom.go
+++ b/pkg/promlib/converter/prom.go
@@ -91,6 +91,10 @@ l1Fields:
 	}
 
 	if len(warnings) > 0 {
+		if len(rsp.Frames) == 0 {
+			rsp.Frames = append(rsp.Frames, data.NewFrame("Warnings"))
+		}
+
 		for _, frame := range rsp.Frames {
 			if frame.Meta == nil {
 				frame.Meta = &data.FrameMeta{}

--- a/pkg/promlib/converter/prom_test.go
+++ b/pkg/promlib/converter/prom_test.go
@@ -28,6 +28,7 @@ var files = []string{
 	"prom-scalar",
 	"prom-series",
 	"prom-warnings",
+	"prom-warnings-no-data",
 	"prom-error",
 	"prom-exemplars-a",
 	"prom-exemplars-b",
@@ -57,6 +58,19 @@ func runScenario(name string, opts Options) func(t *testing.T) {
 			require.Error(t, rsp.Error)
 			return
 		}
+
+		if strings.Contains(name, "warnings") {
+			hasWarning := false
+			for _, frame := range rsp.Frames {
+				if len(frame.Meta.Notices) > 0 {
+					hasWarning = true
+					break
+				}
+			}
+
+			require.True(t, hasWarning)
+		}
+
 		require.NoError(t, rsp.Error)
 
 		fname := name + "-frame"

--- a/pkg/promlib/converter/testdata/prom-warnings-no-data-frame.jsonc
+++ b/pkg/promlib/converter/testdata/prom-warnings-no-data-frame.jsonc
@@ -1,0 +1,55 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "notices": [
+//          {
+//              "severity": "warning",
+//              "text": "warning 1"
+//          },
+//          {
+//              "severity": "warning",
+//              "text": "warning 2"
+//          }
+//      ]
+//  }
+//  Name: Warnings
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Warnings",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "notices": [
+            {
+              "severity": "warning",
+              "text": "warning 1"
+            },
+            {
+              "severity": "warning",
+              "text": "warning 2"
+            }
+          ]
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
+      }
+    }
+  ]
+}

--- a/pkg/promlib/converter/testdata/prom-warnings-no-data.json
+++ b/pkg/promlib/converter/testdata/prom-warnings-no-data.json
@@ -1,0 +1,8 @@
+{
+    "status" : "success",
+    "data" : {
+       "resultType" : "vector",
+       "result" : []
+    },
+    "warnings" : ["warning 1", "warning 2"]
+ }


### PR DESCRIPTION
**What is this feature?**
Warnings are set as Notices for each frame.
If there are no frames, warnings are not currently displayed
on a panel.

A fix is added to always show warnings if present.

**Why do we need this feature?**
Show warnings from prometheus data source even if the source
returns no data.

**Who is this feature for?**
All prometheus users.