### PR TITLE
Combobox: Measure text of longest label for dropdown width

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -88,7 +88,6 @@ const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...arg
         setIsLoading(false);
         setOptions(options);
         setValue(options[5].value);
-        console.log("I've set stuff");
       });
     }, 1000);
   }, [numberOfOptions]);

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -3,8 +3,11 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { Chance } from 'chance';
 import React, { ComponentProps, useEffect, useState } from 'react';
 
+import { useTheme2 } from '../../themes/ThemeContext';
 import { Alert } from '../Alert/Alert';
+import { Divider } from '../Divider/Divider';
 import { Field } from '../Forms/Field';
+import { Select } from '../Select/Select';
 
 import { Combobox, ComboboxOption } from './Combobox';
 
@@ -73,7 +76,6 @@ async function generateOptions(amount: number): Promise<ComboboxOption[]> {
   return Array.from({ length: amount }, (_, index) => ({
     label: chance.sentence({ words: index % 5 }),
     value: chance.guid(),
-    //description: chance.sentence(),
   }));
 }
 
@@ -106,6 +108,123 @@ const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...arg
   );
 };
 
+const SelectComparisonStory: StoryFn<typeof Combobox> = (args) => {
+  const [comboboxValue, setComboboxValue] = useState(args.value);
+  const theme = useTheme2();
+
+  return (
+    <div style={{ border: '1px solid ' + theme.colors.border.weak, padding: 16 }}>
+      <Field label="Combobox with default size">
+        <Combobox
+          id="combobox-default-size"
+          value={comboboxValue}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Field label="Select with default size">
+        <Select
+          id="select-default-size"
+          value={comboboxValue}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Divider />
+
+      <Field label="Combobox with explicit size (25)">
+        <Combobox
+          id="combobox-explicit-size"
+          width={25}
+          value={comboboxValue}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Field label="Select with explicit size (25)">
+        <Select
+          id="select-explicit-size"
+          width={25}
+          value={comboboxValue}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Divider />
+
+      <Field label="Combobox with auto width, minWidth 15">
+        <Combobox
+          id="combobox-auto-size"
+          width="auto"
+          minWidth={15}
+          value={comboboxValue}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Field label="Select with auto width">
+        <Select
+          id="select-auto-size"
+          width="auto"
+          value={comboboxValue}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Field label="Combobox with auto width, minWidth 15, empty value">
+        <Combobox
+          id="combobox-auto-size-empty"
+          width="auto"
+          minWidth={15}
+          value={null}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+
+      <Field label="Select with auto width, empty value">
+        <Select
+          id="select-auto-size-empty"
+          width="auto"
+          value={null}
+          options={args.options}
+          onChange={(val) => {
+            setComboboxValue(val?.value || null);
+            action('onChange')(val);
+          }}
+        />
+      </Field>
+    </div>
+  );
+};
+
 export const AutoSize: StoryObj<PropsAndCustomArgs> = {
   args: {
     width: 'auto',
@@ -127,6 +246,13 @@ export const CustomValue: StoryObj<PropsAndCustomArgs> = {
   args: {
     createCustomValue: true,
   },
+};
+
+export const ComparisonToSelect: StoryObj<PropsAndCustomArgs> = {
+  args: {
+    numberOfOptions: 100,
+  },
+  render: SelectComparisonStory,
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -4,6 +4,10 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 const MAX_HEIGHT = 400;
 
+// We need a px font size to accurately measure the width of items.
+// This should be in sync with the body font size in the theme.
+export const MENU_ITEM_FONT_SIZE = 14;
+
 export const getComboboxStyles = (theme: GrafanaTheme2) => {
   return {
     menuClosed: css({
@@ -53,6 +57,9 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
       label: 'grafana-select-option-label',
       textOverflow: 'ellipsis',
       overflow: 'hidden',
+      fontSize: MENU_ITEM_FONT_SIZE,
+      fontWeight: 500,
+      letterSpacing: 0, // pr todo: text in grafana has a slightly different letter spacing, which causes measureText() to be ~5% off
     }),
     optionDescription: css({
       label: 'grafana-select-option-description',

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -7,6 +7,8 @@ const MAX_HEIGHT = 400;
 // We need a px font size to accurately measure the width of items.
 // This should be in sync with the body font size in the theme.
 export const MENU_ITEM_FONT_SIZE = 14;
+export const MENU_ITEM_FONT_WEIGHT = 500;
+export const MENU_ITEM_PADDING_X = 8;
 
 export const getComboboxStyles = (theme: GrafanaTheme2) => {
   return {
@@ -28,7 +30,7 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
     }),
     option: css({
       label: 'grafana-select-option',
-      padding: '8px',
+      padding: MENU_ITEM_PADDING_X,
       position: 'absolute',
       display: 'flex',
       alignItems: 'center',
@@ -58,7 +60,7 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       fontSize: MENU_ITEM_FONT_SIZE,
-      fontWeight: 500,
+      fontWeight: MENU_ITEM_FONT_WEIGHT,
       letterSpacing: 0, // pr todo: text in grafana has a slightly different letter spacing, which causes measureText() to be ~5% off
     }),
     optionDescription: css({

--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -9,12 +9,6 @@ import { MENU_ITEM_FONT_SIZE } from './getComboboxStyles';
 // Only consider the first n items when calculating the width of the popover.
 const WIDTH_CALCULATION_LIMIT_ITEMS = 1000;
 
-// // On every 100th index we will recalculate the width of the popover.
-// const INDEX_WIDTH_CALCULATION = 100;
-
-// // A multiplier guesstimate times the amount of characters. If any padding or image support etc. is added this will need to be updated.
-// const WIDTH_MULTIPLIER = 7.3;
-
 /**
  * Used with Downshift to get the height of each item
  */

--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -7,7 +7,7 @@ import { ComboboxOption } from './Combobox';
 import { MENU_ITEM_FONT_SIZE, MENU_ITEM_FONT_WEIGHT, MENU_ITEM_PADDING_X } from './getComboboxStyles';
 
 // Only consider the first n items when calculating the width of the popover.
-const WIDTH_CALCULATION_LIMIT_ITEMS = 1000;
+const WIDTH_CALCULATION_LIMIT_ITEMS = 100_000;
 
 /**
  * Used with Downshift to get the height of each item

--- a/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
+++ b/packages/grafana-ui/src/components/Combobox/useComboboxFloat.ts
@@ -4,7 +4,7 @@ import { useMemo, useRef, useState } from 'react';
 import { measureText } from '../../utils';
 
 import { ComboboxOption } from './Combobox';
-import { MENU_ITEM_FONT_SIZE } from './getComboboxStyles';
+import { MENU_ITEM_FONT_SIZE, MENU_ITEM_FONT_WEIGHT, MENU_ITEM_PADDING_X } from './getComboboxStyles';
 
 // Only consider the first n items when calculating the width of the popover.
 const WIDTH_CALCULATION_LIMIT_ITEMS = 1000;
@@ -24,6 +24,8 @@ export const useComboboxFloat = (
   const inputRef = useRef<HTMLInputElement>(null);
   const floatingRef = useRef<HTMLDivElement>(null);
   const [popoverMaxWidth, setPopoverMaxWidth] = useState<number | undefined>(undefined);
+
+  const scrollbarWidth = useMemo(() => getScrollbarWidth(), []);
 
   // the order of middleware is important!
   const middleware = [
@@ -57,12 +59,10 @@ export const useComboboxFloat = (
       longestItem = itemLabel.length > longestItem.length ? itemLabel : longestItem;
     }
 
-    // pr todo: get weight from theme/styles
-    const size = measureText(longestItem, MENU_ITEM_FONT_SIZE, 500).width;
+    const size = measureText(longestItem, MENU_ITEM_FONT_SIZE, MENU_ITEM_FONT_WEIGHT).width;
 
-    // pr todo: ideally we want to remove these magic numbers from here, or derive them from the styles
-    return size + 16 /* padding */ + 17 /* chrome fixed scrollbar width */;
-  }, [items]);
+    return size + MENU_ITEM_PADDING_X * 2 + scrollbarWidth;
+  }, [items, scrollbarWidth]);
 
   const floatStyles = {
     ...floatingStyles,
@@ -73,3 +73,20 @@ export const useComboboxFloat = (
 
   return { inputRef, floatingRef, floatStyles };
 };
+
+// Creates a temporary div with a scrolling inner div to calculate the width of the scrollbar
+function getScrollbarWidth(): number {
+  const outer = document.createElement('div');
+  outer.style.visibility = 'hidden';
+  outer.style.overflow = 'scroll';
+  document.body.appendChild(outer);
+
+  const inner = document.createElement('div');
+  outer.appendChild(inner);
+
+  const scrollbarWidth = outer.offsetWidth - inner.offsetWidth;
+
+  outer.parentNode?.removeChild(outer);
+
+  return scrollbarWidth;
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/92586

Changes combobox to use `measureText()` to size the dropdown menu more accurately. We assume (but have not measured) that `measureText()` is slow enough to not measure every item, so for optimisation we only measure the text of the longest item in the first 1000 options.

Tbh, we can probably look at many more items. on my (fast) computer, it takes me 600ms to look over 8 billion items. we can probably find a middleground in there somewhere.

By measuring only one item, if there a bunch of labels with similar length but different width, we may get truncated labels. Would be nice to _measure_ measureText() to see if it's worth looking at more items.