### PR TITLE
Explore metrics: Fix bug when switching from OTel enabled Prometheus DS to non OTel PRometheus DS

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -504,6 +504,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       this.setState({
         otelTargets,
         otelJoinQuery,
+        useOtelExperience: false,
       });
     }
   }
@@ -550,6 +551,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       this.setState({
         otelTargets: { jobs: [], instances: [] },
         otelJoinQuery: '',
+        useOtelExperience: false,
       });
     }
   }


### PR DESCRIPTION
**What is this?**

This fixes a bug when switching data sources in Explore metrics for the OTel experience.

Before the fix:
1. Navigate to explore metrics.
2. Choose an OTel data source where the OTel experience is enabled.
3. Change the data source to one that does not have `target_info` and is not OTel native (e.g. vanilla Prometheus or gdev-prometheus)
4. UseOtelExperience is still enabled and no metrics show or the metric preview panel shows all errors.

After the fix:
Switching to a non OTel native Prometheus data source, the metrics load and the metric previews work.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
