### PR TITLE
VizTooltip: Update datalinks styling 

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipFooter.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { ActionModel, Field, GrafanaTheme2, LinkModel } from '@grafana/data';
 
-import { Button, ButtonProps, DataLinkButton, Stack } from '..';
+import { Button, Stack, TextLink } from '..';
 import { useStyles2 } from '../../themes';
 import { ActionButton } from '../Actions/ActionButton';
 
@@ -15,14 +15,19 @@ interface VizTooltipFooterProps {
 export const ADD_ANNOTATION_ID = 'add-annotation-button';
 
 const renderDataLinks = (dataLinks: LinkModel[]) => {
-  const buttonProps: ButtonProps = {
-    variant: 'secondary',
-  };
-
   return (
     <Stack direction="column" justifyContent="flex-start">
       {dataLinks.map((link, i) => (
-        <DataLinkButton key={i} link={link} buttonProps={buttonProps} />
+        <TextLink
+          key={i}
+          href={link.href}
+          external={link.target === '_blank'}
+          weight={'medium'}
+          inline={false}
+          variant={'bodySmall'}
+        >
+          {link.title}
+        </TextLink>
       ))}
     </Stack>
   );


### PR DESCRIPTION
This PR brings back the data links styling as the button-like links can now be easily confused with actions.

Before
![links_before](https://github.com/user-attachments/assets/296c9d1b-612b-42d6-a949-934720e79857)

After
  
![links_after2](https://github.com/user-attachments/assets/9566ed09-c2e0-4e51-b8b0-31c80565afeb)


**Special notes for your reviewer:**
- there's an 8px gap between links (coming from the `TextLink` component), probably we could address later, as we'd have to alter the component 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
