### PR TITLE
Chore: uPlot v1.6.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -406,7 +406,7 @@
     "tslib": "2.7.0",
     "tween-functions": "^1.2.0",
     "type-fest": "^4.18.2",
-    "uplot": "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c",
+    "uplot": "1.6.31",
     "uuid": "9.0.1",
     "visjs-network": "4.25.0",
     "whatwg-fetch": "3.6.20",

--- a/package.json
+++ b/package.json
@@ -406,7 +406,7 @@
     "tslib": "2.7.0",
     "tween-functions": "^1.2.0",
     "type-fest": "^4.18.2",
-    "uplot": "1.6.30",
+    "uplot": "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c",
     "uuid": "9.0.1",
     "visjs-network": "4.25.0",
     "whatwg-fetch": "3.6.20",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -57,7 +57,7 @@
     "string-hash": "^1.1.3",
     "tinycolor2": "1.6.0",
     "tslib": "2.7.0",
-    "uplot": "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c",
+    "uplot": "1.6.31",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -57,7 +57,7 @@
     "string-hash": "^1.1.3",
     "tinycolor2": "1.6.0",
     "tslib": "2.7.0",
-    "uplot": "1.6.30",
+    "uplot": "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -111,7 +111,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.6.0",
     "tslib": "2.7.0",
-    "uplot": "1.6.30",
+    "uplot": "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -111,7 +111,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.6.0",
     "tslib": "2.7.0",
-    "uplot": "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c",
+    "uplot": "1.6.31",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,7 +3643,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.7.0"
     typescript: "npm:5.5.4"
-    uplot: "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c"
+    uplot: "npm:1.6.31"
     xss: "npm:^1.0.14"
   peerDependencies:
     react: ^18.0.0
@@ -4390,7 +4390,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.7.0"
     typescript: "npm:5.5.4"
-    uplot: "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c"
+    uplot: "npm:1.6.31"
     uuid: "npm:9.0.1"
     webpack: "npm:5.95.0"
   peerDependencies:
@@ -19248,7 +19248,7 @@ __metadata:
     tween-functions: "npm:^1.2.0"
     type-fest: "npm:^4.18.2"
     typescript: "npm:5.5.4"
-    uplot: "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c"
+    uplot: "npm:1.6.31"
     uuid: "npm:9.0.1"
     visjs-network: "npm:4.25.0"
     webpack: "npm:5.95.0"
@@ -32337,10 +32337,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c":
+"uplot@npm:1.6.31":
   version: 1.6.31
-  resolution: "uplot@https://github.com/leeoniya/uPlot.git#commit=f98d1d34d92a128f18fbaac9293910eed85ea19c"
-  checksum: 10/308d9d43074454fca85a75025261addf7830a8fb109c23f023ac286918c150aa4c9d230db9b0813ebdf1fa57be00ebe1ef1920efd9a367ea4b2d83828f369c54
+  resolution: "uplot@npm:1.6.31"
+  checksum: 10/8a24bed5c56aa45928102ff964a6a42e3ec806369278ce52dbc65d65e453a7e4b1ee73d525c53618223b712207266f7be752853284c7e5d5bc04c2d23bcc85b1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,7 +3643,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.7.0"
     typescript: "npm:5.5.4"
-    uplot: "npm:1.6.30"
+    uplot: "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c"
     xss: "npm:^1.0.14"
   peerDependencies:
     react: ^18.0.0
@@ -4390,7 +4390,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.7.0"
     typescript: "npm:5.5.4"
-    uplot: "npm:1.6.30"
+    uplot: "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c"
     uuid: "npm:9.0.1"
     webpack: "npm:5.95.0"
   peerDependencies:
@@ -19248,7 +19248,7 @@ __metadata:
     tween-functions: "npm:^1.2.0"
     type-fest: "npm:^4.18.2"
     typescript: "npm:5.5.4"
-    uplot: "npm:1.6.30"
+    uplot: "leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c"
     uuid: "npm:9.0.1"
     visjs-network: "npm:4.25.0"
     webpack: "npm:5.95.0"
@@ -32337,10 +32337,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.30":
-  version: 1.6.30
-  resolution: "uplot@npm:1.6.30"
-  checksum: 10/08ad2f9441b8cfa26d9219362cdbb6f2dc6e5ec9403382df71798ed3e9d3666e7712c8a245e652ebb4a25c5d911cbdc614b52dfd891c0f7ce8705320d2eff81f
+"uplot@leeoniya/uPlot#f98d1d34d92a128f18fbaac9293910eed85ea19c":
+  version: 1.6.31
+  resolution: "uplot@https://github.com/leeoniya/uPlot.git#commit=f98d1d34d92a128f18fbaac9293910eed85ea19c"
+  checksum: 10/308d9d43074454fca85a75025261addf7830a8fb109c23f023ac286918c150aa4c9d230db9b0813ebdf1fa57be00ebe1ef1920efd9a367ea4b2d83828f369c54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/89570
Fixes https://github.com/grafana/grafana/issues/92719

- Better axis tick handling with values < 1e-14 (above issues, log and linear)
- New `cursor.points.one` setting to avoid creating 1,000 dynamic dom elements for 1,000 series (https://github.com/grafana/support-escalations/issues/9547)
- Custom scales support (Weibull, etc) - https://leeoniya.github.io/uPlot/demos/custom-scales.html
- [Fix for possible prototype pollution](https://github.com/leeoniya/uPlot/commit/5756e3e9b91270b303157e14bd0174311047d983)