### PR TITLE
Dashboards: Fixes view & edit keyboard shortcuts when grafana is behind a subpath

### DIFF
--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { SetPanelAttentionEvent } from '@grafana/data';
+import { locationUtil, SetPanelAttentionEvent } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { sceneGraph, VizPanel } from '@grafana/scenes';
 import appEvents from 'app/core/app_events';
@@ -43,7 +43,8 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     key: 'v',
     onTrigger: withFocusedPanel(scene, (vizPanel: VizPanel) => {
       if (!scene.state.viewPanelScene) {
-        locationService.push(getViewPanelUrl(vizPanel));
+        const url = locationUtil.stripBaseFromUrl(getViewPanelUrl(vizPanel));
+        locationService.push(url);
       }
     }),
   });
@@ -173,7 +174,8 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
         if (sceneRoot instanceof DashboardScene) {
           const panelId = getPanelIdForVizPanel(vizPanel);
           if (!scene.state.editPanel) {
-            locationService.push(getEditPanelUrl(panelId));
+            const url = locationUtil.stripBaseFromUrl(getEditPanelUrl(panelId));
+            locationService.push(url);
           }
         }
       }),


### PR DESCRIPTION
Was running Grafana behind a subpath (I used to do this always but haven't recently). 

Noticed that view & edit panel shortcuts resulted in "Page not found", this fixes it. Super annoying that we have to add/remove subpath like this everywhere :( 