### PR TITLE
DashboardScene: Update matcher options immutably

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -106,8 +106,10 @@ export function getFieldOverrideCategories(
     });
 
     const onMatcherConfigChange = (options: unknown) => {
-      override.matcher.options = options;
-      onOverrideChange(idx, override);
+      onOverrideChange(idx, {
+        ...override,
+        matcher: { ...override.matcher, options },
+      });
     };
 
     const onDynamicConfigValueAdd = (override: ConfigOverrideRule, value: SelectableValue<string>) => {


### PR DESCRIPTION
A follow-up to the panel edit refactor where if we do state changes immutably it will make the change detection not detect a change as we compare against an original clone of the state tree. 

