### PR TITLE
DashboardScene: Fixes url issue with subpath when exiting edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -1,4 +1,4 @@
-import { CoreApp, LoadingState, getDefaultTimeRange, store } from '@grafana/data';
+import { CoreApp, GrafanaConfig, LoadingState, getDefaultTimeRange, locationUtil, store } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import {
   sceneGraph,
@@ -76,6 +76,12 @@ jest.mock('app/features/manage-dashboards/state/actions', () => ({
   deleteDashboard: jest.fn().mockResolvedValue({}),
 }));
 
+locationUtil.initialize({
+  config: { appSubUrl: '/subUrl' } as GrafanaConfig,
+  getVariablesUrlParams: jest.fn(),
+  getTimeRangeForUrl: jest.fn(),
+});
+
 const worker = createWorker();
 mockResultsOfDetectChangesWorker({ hasChanges: true, hasTimeChanges: false, hasVariableValueChanges: false });
 
@@ -134,6 +140,7 @@ describe('DashboardScene', () => {
 
       beforeEach(() => {
         scene = buildTestScene();
+        locationService.push('/d/dash-1');
         deactivateScene = scene.activate();
         scene.onEnterEditMode();
         jest.clearAllMocks();
@@ -141,6 +148,11 @@ describe('DashboardScene', () => {
 
       it('Should set isEditing to true', () => {
         expect(scene.state.isEditing).toBe(true);
+      });
+
+      it('Can exit edit mode', () => {
+        scene.exitEditMode({ skipConfirm: true });
+        expect(locationService.getLocation().pathname).toBe('/d/dash-1');
       });
 
       it('Exiting already saved dashboard should not restore initial state', () => {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -301,15 +301,15 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
     // We are updating url and removing editview and editPanel.
     // The initial url may be including edit view, edit panel or inspect query params if the user pasted the url,
     // hence we need to cleanup those query params to get back to the dashboard view. Otherwise url sync can trigger overlays.
-    locationService.replace(
-      locationUtil.getUrlForPartial(this._initialUrlState!, {
-        editPanel: null,
-        editview: null,
-        inspect: null,
-        inspectTab: null,
-        shareView: null,
-      })
-    );
+    const url = locationUtil.getUrlForPartial(this._initialUrlState!, {
+      editPanel: null,
+      editview: null,
+      inspect: null,
+      inspectTab: null,
+      shareView: null,
+    });
+
+    locationService.replace(locationUtil.stripBaseFromUrl(url));
 
     if (this._fromExplore) {
       this.cleanupStateFromExplore();


### PR DESCRIPTION
another bug with grafana under subpath, super annoying / bad that we still have these bugs and have to fix/think about this this everywhere

similar to  
https://github.com/grafana/grafana/pull/93955

