### PR TITLE
E2E: Build test plugins before running the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:enterprise:dev": "./e2e/start-and-run-suite enterprise dev",
     "e2e:enterprise:debug": "./e2e/start-and-run-suite enterprise debug",
     "e2e:playwright": "yarn playwright test",
-    "e2e:playwright:server": "./e2e/plugin-e2e/start-and-run-suite",
+    "e2e:playwright:server": "yarn e2e:plugin:build && ./e2e/plugin-e2e/start-and-run-suite",
     "e2e:storybook": "PORT=9001 ./e2e/run-suite storybook true",
     "e2e:plugin:build": "nx run-many -t build --projects='@test-plugins/*'",
     "e2e:plugin:build:dev": "nx run-many -t dev --projects='@test-plugins/*' --maxParallel=100",


### PR DESCRIPTION
**What is this feature?**

Some playwright tests rely on the test plugins. This PR ensure the test plugins are being built before the tests are executed. 

