### PR TITLE
Alerting docs: Move the `Condition operators` to the Classic condition section

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rule-evaluation/_index.md
@@ -53,19 +53,6 @@ The pending period specifies how long the condition must be met before firing, e
 
 You can also set the pending period to zero to skip it and have the alert fire immediately once the condition is met.
 
-## Condition operator
-
-There are several condition operators available.
-
-- **and**: Two conditions before and after must be true for the overall condition to be true.
-- **or**: If one of conditions before and after are true, the overall condition is true.
-- **logic-or**: If the condition before logic-or is true, the overall condition is immediately true, without evaluating subsequent conditions.
-
-Here are some examples of operators.
-
-- `TRUE and TRUE or FALSE and FALSE` evaluate to `FALSE`, because last two conditions return `FALSE`.
-- `TRUE and TRUE logic-or FALSE and FALSE` evaluate to `TRUE`, because the preceding condition returns `TRUE`.
-
 ## Evaluation example
 
 Keep in mind:

--- a/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/queries-conditions.md
@@ -111,6 +111,12 @@ Classic conditions exist mainly for compatibility reasons and should be avoided 
 
 Classic condition checks if any time series data matches the alert condition. It always produce one alert instance only, no matter how many time series meet the condition.
 
+| Condition operators | How it works                                                                                                                                                                                                                                                |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| and                 | Two conditions before and after must be true for the overall condition to be true.                                                                                                                                                                          |
+| or                  | If one of conditions before and after are true, the overall condition is true.                                                                                                                                                                              |
+| logic-or            | If the condition before `logic-or` is true, the overall condition is immediately true, without evaluating subsequent conditions. For instance, `TRUE and TRUE logic-or FALSE and FALSE` evaluate to `TRUE`, because the preceding condition returns `TRUE`. |
+
 ## Aggregations
 
 Grafana Alerting provides the following aggregation functions to enable you to further refine your query.


### PR DESCRIPTION
Continuation of https://github.com/grafana/grafana/pull/89258. Upon review, it appears that condition operators such as `LogicOr`  are exclusively part of the Classic (legacy) condition expression. 

![Screenshot 2024-09-30 at 13 00 05](https://github.com/user-attachments/assets/39ea3ebf-bcd2-4d63-b0ff-ec67789a7686)

This doc PR moves the list of these condition operators to the appropriate section 




