### PR TITLE
Prometheus: Add resource for suggestions that include scopes/adhoc filters

### DIFF
--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/variableEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/variableEditPage.spec.ts
@@ -5,6 +5,7 @@ import { prometheusLabels } from '../mocks/resources';
 
 test('variable query with mocked response', async ({ variableEditPage, page }) => {
   variableEditPage.mockResourceResponse('api/v1/labels?*', prometheusLabels);
+  variableEditPage.mockResourceResponse('suggestions*', prometheusLabels);
   await variableEditPage.datasource.set('gdev-prometheus');
   await variableEditPage.getByGrafanaSelector('Query type').fill('Label names');
   await page.keyboard.press('Tab');

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -79,7 +79,7 @@ const GET_AND_POST_METADATA_ENDPOINTS = [
   'api/v1/query_range',
   'api/v1/series',
   'api/v1/labels',
-  'resources',
+  'suggestions',
 ];
 
 export const InstantQueryRefIdIndex = '-Instant';
@@ -655,9 +655,7 @@ export class PrometheusDatasource
           undefined,
           requestId
         )
-      )
-        .filter((v) => !!v)
-        .map((v) => ({ value: v, text: v }));
+      ).map((v) => ({ value: v, text: v }));
     }
 
     const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -615,9 +615,9 @@ export class PrometheusDatasource
         options.filters
       );
 
-      // filter out already used labels
+      // filter out already used labels and empty labels
       return suggestions
-        .filter((labelName) => !options.filters.find((filter) => filter.key === labelName))
+        .filter((labelName) => !!labelName && !options.filters.find((filter) => filter.key === labelName))
         .map((k) => ({ value: k, text: k }));
     }
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -652,6 +652,7 @@ export class PrometheusDatasource
           options.scopes,
           options.filters,
           options.key,
+          undefined,
           requestId
         )
       )

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -607,26 +607,54 @@ export class PrometheusDatasource
   // it is used in metric_find_query.ts
   // and in Tempo here grafana/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
   async getTagKeys(options: DataSourceGetTagKeysOptions<PromQuery>): Promise<MetricFindValue[]> {
-    if (!options || (options.filters.length === 0 && (options.scopes?.length ?? 0) === 0)) {
+    if (config.featureToggles.promQLScope && !!options) {
+      const suggestions = await this.languageProvider.fetchSuggestions(
+        options.timeRange,
+        options.queries,
+        options.scopes,
+        options.filters
+      );
+
+      // filter out already used labels
+      return suggestions
+        .filter((labelName) => !options.filters.find((filter) => filter.key === labelName))
+        .map((k) => ({ value: k, text: k }));
+    }
+
+    if (!options || options.filters.length === 0) {
       await this.languageProvider.fetchLabels(options.timeRange, options.queries);
       return this.languageProvider.getLabelKeys().map((k) => ({ value: k, text: k }));
     }
 
-    const suggestions = await this.languageProvider.fetchSuggestions(
-      options.timeRange,
-      options.queries,
-      options.scopes,
-      options.filters
-    );
+    const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({
+      label: f.key,
+      value: f.value,
+      op: f.operator,
+    }));
+    const expr = promQueryModeller.renderLabels(labelFilters);
+
+    let labelsIndex: Record<string, string[]> = await this.languageProvider.fetchLabelsWithMatch(expr);
 
     // filter out already used labels
-    return suggestions
+    return Object.keys(labelsIndex)
       .filter((labelName) => !options.filters.find((filter) => filter.key === labelName))
       .map((k) => ({ value: k, text: k }));
   }
 
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   async getTagValues(options: DataSourceGetTagValuesOptions<PromQuery>) {
+    if (config.featureToggles.promQLScope) {
+      return (
+        await this.languageProvider.fetchSuggestions(
+          options.timeRange,
+          options.queries,
+          options.scopes,
+          options.filters,
+          options.key
+        )
+      ).map((k) => ({ value: k, text: k }));
+    }
+
     const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({
       label: f.key,
       value: f.value,

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -6,8 +6,12 @@ import {
   AbstractLabelMatcher,
   AbstractLabelOperator,
   AbstractQuery,
+  AdHocVariableFilter,
   getDefaultTimeRange,
   LanguageProvider,
+  Scope,
+  scopeFilterOperatorMap,
+  ScopeSpecFilter,
   TimeRange,
 } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
@@ -407,6 +411,58 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const values = await Promise.all(DEFAULT_KEYS.map((key) => this.fetchLabelValues(key)));
     return DEFAULT_KEYS.reduce((acc, key, i) => ({ ...acc, [key]: values[i] }), {});
   });
+
+  /**
+   * Fetch labels or values for a label based on the queries, scopes, filters and time range
+   * @param timeRange
+   * @param queries
+   * @param scopes
+   * @param adhocFilters
+   * @param labelName
+   */
+  fetchSuggestions = async (
+    timeRange?: TimeRange,
+    queries?: PromQuery[],
+    scopes?: Scope[],
+    adhocFilters?: AdHocVariableFilter[],
+    labelName?: string
+  ): Promise<string[]> => {
+    if (timeRange) {
+      this.timeRange = timeRange;
+    }
+
+    const url = '/suggestions';
+    const timeParams = this.datasource.getAdjustedInterval(this.timeRange);
+    const value = await this.request(
+      url,
+      [],
+      {
+        labelName,
+        queries: queries?.map((q) => q.expr),
+        scopes: scopes?.reduce<ScopeSpecFilter[]>((acc, scope) => {
+          acc.push(...scope.spec.filters);
+
+          return acc;
+        }, []),
+        adhocFilters: adhocFilters?.map((filter) => ({
+          key: filter.key,
+          operator: scopeFilterOperatorMap[filter.operator],
+          value: filter.value,
+          values: filter.values,
+        })),
+        ...timeParams,
+      },
+      {
+        headers: {
+          ...this.getDefaultCacheHeaders()?.headers,
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      }
+    );
+
+    return value ?? [];
+  };
 }
 
 function getNameLabelValue(promQuery: string, tokens: Array<string | Prism.Token>): string {

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -419,13 +419,15 @@ export default class PromQlLanguageProvider extends LanguageProvider {
    * @param scopes
    * @param adhocFilters
    * @param labelName
+   * @param requestId
    */
   fetchSuggestions = async (
     timeRange?: TimeRange,
     queries?: PromQuery[],
     scopes?: Scope[],
     adhocFilters?: AdHocVariableFilter[],
-    labelName?: string
+    labelName?: string,
+    requestId?: string
   ): Promise<string[]> => {
     if (timeRange) {
       this.timeRange = timeRange;
@@ -453,6 +455,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
         ...timeParams,
       },
       {
+        ...(requestId && { requestId }),
         headers: {
           ...this.getDefaultCacheHeaders()?.headers,
           'Content-Type': 'application/json',

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -419,6 +419,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
    * @param scopes
    * @param adhocFilters
    * @param labelName
+   * @param limit
    * @param requestId
    */
   fetchSuggestions = async (
@@ -427,6 +428,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     scopes?: Scope[],
     adhocFilters?: AdHocVariableFilter[],
     labelName?: string,
+    limit?: number,
     requestId?: string
   ): Promise<string[]> => {
     if (timeRange) {
@@ -452,6 +454,7 @@ export default class PromQlLanguageProvider extends LanguageProvider {
           value: filter.value,
           values: filter.values,
         })),
+        limit,
         ...timeParams,
       },
       {

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/grafana/pkg/promlib
 go 1.23.1
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/grafana/dskit v0.0.0-20240805174438-dfa83b4ed2d3
 	github.com/grafana/grafana-plugin-sdk-go v0.251.0
 	github.com/json-iterator/go v1.1.12
@@ -31,7 +32,6 @@ require (
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/chromedp/cdproto v0.0.0-20240810084448-b931b754e476 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/elazarl/goproxy v0.0.0-20240726154733-8b0c20506380 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -3,7 +3,6 @@ module github.com/grafana/grafana/pkg/promlib
 go 1.23.1
 
 require (
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/grafana/dskit v0.0.0-20240805174438-dfa83b4ed2d3
 	github.com/grafana/grafana-plugin-sdk-go v0.251.0
 	github.com/json-iterator/go v1.1.12
@@ -32,6 +31,7 @@ require (
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/chromedp/cdproto v0.0.0-20240810084448-b931b754e476 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/elazarl/goproxy v0.0.0-20240726154733-8b0c20506380 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -110,7 +110,6 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	}
 
 	switch {
-
 	case strings.EqualFold(req.Path, "version-detect"):
 		versionObj, found := i.versionCache.Get("version")
 		if found {

--- a/pkg/promlib/library.go
+++ b/pkg/promlib/library.go
@@ -109,7 +109,9 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		return err
 	}
 
-	if strings.EqualFold(req.Path, "version-detect") {
+	switch {
+
+	case strings.EqualFold(req.Path, "version-detect"):
 		versionObj, found := i.versionCache.Get("version")
 		if found {
 			return sender.Send(versionObj.(*backend.CallResourceResponse))
@@ -121,6 +123,13 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 		}
 		i.versionCache.Set("version", vResp, cache.DefaultExpiration)
 		return sender.Send(vResp)
+
+	case strings.EqualFold(req.Path, "suggestions"):
+		resp, err := i.resource.GetSuggestions(ctx, req)
+		if err != nil {
+			return err
+		}
+		return sender.Send(resp)
 	}
 
 	resp, err := i.resource.Execute(ctx, req)

--- a/pkg/promlib/library_test.go
+++ b/pkg/promlib/library_test.go
@@ -117,6 +117,19 @@ func TestService(t *testing.T) {
 		err := service.CallResource(context.Background(), req, sender)
 		require.NoError(t, err)
 	})
+
+	t.Run("suggest resource", func(t *testing.T) {
+		f := &fakeHTTPClientProvider{}
+		httpProvider := getMockPromTestSDKProvider(f)
+		l := backend.NewLoggerWith("logger", "test")
+		service := NewService(httpProvider, l, mockExtendTransportOptions)
+
+		req := mockSuggestResource()
+		sender := &fakeSender{}
+		err := service.CallResource(context.Background(), req, sender)
+		require.NoError(t, err)
+		require.Equal(t, `http://localhost:9090/api/v1/labels?end=2022-06-01T12%3A00%3A00Z&limit=10&match%5B%5D=go_cgo_go_to_c_calls_calls_total%7Bjob%3D~%22.%2B%22%7D&match%5B%5D=up%7Bjob%3D~%22.%2B%22%7D&start=2022-06-01T00%3A00%3A00Z`, f.Roundtripper.Req.URL.String())
+	})
 }
 
 func mockRequest() *backend.CallResourceRequest {
@@ -144,5 +157,44 @@ func mockRequest() *backend.CallResourceRequest {
 		Method: http.MethodPost,
 		URL:    "/api/v1/series",
 		Body:   []byte("match%5B%5D: ALERTS\nstart: 1655271408\nend: 1655293008"),
+	}
+}
+
+func mockSuggestResource() *backend.CallResourceRequest {
+	return &backend.CallResourceRequest{
+		PluginContext: backend.PluginContext{
+			OrgID:               0,
+			PluginID:            "prometheus",
+			User:                nil,
+			AppInstanceSettings: nil,
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				ID:               0,
+				UID:              "",
+				Type:             "prometheus",
+				Name:             "test-prom",
+				URL:              "http://localhost:9090",
+				User:             "",
+				Database:         "",
+				BasicAuthEnabled: true,
+				BasicAuthUser:    "admin",
+				Updated:          time.Time{},
+				JSONData:         []byte("{}"),
+			},
+		},
+		Path:   "suggestions",
+		URL:    "suggestions",
+		Method: http.MethodPost,
+		Body: []byte(`
+			{
+				"queries": ["up + 1", "go_cgo_go_to_c_calls_calls_total + 2"],
+				"scopes": [{
+					"key": "job",
+					"value": ".+",
+					"operator": "regex-match"
+				}],
+				"start": "2022-06-01T00:00:00Z",
+				"end": "2022-06-01T12:00:00Z",
+				"limit": 10
+			}`),
 	}
 }

--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -15,7 +15,7 @@ func ApplyFiltersAndGroupBy(rawExpr string, scopeFilters, adHocFilters []ScopeFi
 		return "", err
 	}
 
-	matchers, err := filtersToMatchers(scopeFilters, adHocFilters)
+	matchers, err := FiltersToMatchers(scopeFilters, adHocFilters)
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +70,7 @@ func ApplyFiltersAndGroupBy(rawExpr string, scopeFilters, adHocFilters []ScopeFi
 	return expr.String(), nil
 }
 
-func filtersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matcher, error) {
+func FiltersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matcher, error) {
 	filterMap := make(map[string]*labels.Matcher)
 
 	for _, filter := range append(scopeFilters, adhocFilters...) {

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -124,7 +124,7 @@ type SuggestionRequest struct {
 	Queries []string `json:"queries"`
 
 	Scopes       []models.ScopeFilter `json:"scopes"`
-	AdhocFilters []models.ScopeFilter `json:"AdhocFilters"`
+	AdhocFilters []models.ScopeFilter `json:"adhocFilters"`
 
 	// Start and End are proxied directly to the prometheus endpoint (which is rfc3339 | unix_timestamp)
 	Start string `json:"start"`

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -118,7 +118,7 @@ func getSelectors(expr string) ([]string, error) {
 
 // SuggestionRequest is the request body for the GetSuggestions resource.
 type SuggestionRequest struct {
-	// LabelName, if provides, will results in label values being returned for the given label name.
+	// LabelName, if provided, will result in label values being returned for the given label name.
 	LabelName string `json:"labelName"`
 
 	Queries []string `json:"queries"`


### PR DESCRIPTION
**What is this feature?**

Resource that takes a "Suggestion Request" that includes prometheus expressions, and filters from scopes or adhoc variables - and creates a request to the prometheus labels or label values API to get suggestions.

**Special notes for your reviewer:**

Input:
```go
// SuggestionRequest is the request body for the GetSuggestions resource.
type SuggestionRequest struct {
	// LabelName, if provided, will result in label values being returned for the given label name.
	LabelName string `json:"labelName"`

	Queries []string `json:"queries"`

	Scopes       []models.ScopeFilter `json:"scopes"`
	AdhocFilters []models.ScopeFilter `json:"adhocFilters"`

	// Start and End are proxied directly to the prometheus endpoint (which is rfc3339 | unix_timestamp)
	Start string `json:"start"`
	End   string `json:"end"`

	// Limit is the maximum number of suggestions to return and is proxied directly to the prometheus endpoint.
	Limit int64 `json:"limit"`
}
```


*Example 1:*
```http
POST http://admin:admin@localhost:3000/api/datasources/uid/gdev-prometheus/resources/suggestions

{
    "queries": ["up + 1", "go_cgo_go_to_c_calls_calls_total + 2"],
    "scopes": [{
        "key": "job",
        "value": ".+",
        "operator": "regex-match"
    }]
}
```

translates to:
```URL="/api/v1/labels?match%5B%5D=go_cgo_go_to_c_calls_calls_total%7Bjob%3D~%22.%2B%22%7D&match%5B%5D=up%7Bjob%3D~%22.%2B%22%7D"```


returns:

```json
{
  "status": "success",
  "data": [
    "__name__",
    "instance",
    "job"
  ]
}
```

*Example 2:*
```http
POST http://admin:admin@localhost:3000/api/datasources/uid/gdev-prometheus/resources/suggestions

{
    "queries": ["up + 1", "go_cgo_go_to_c_calls_calls_total + 2"],
    "labelName": "job",
    "scopes": [{
        "key": "job",
        "value": ".+",
        "operator": "regex-match"
    }]
}
```

translates to:
```URL="/api/v1/label/job/values?match%5B%5D=go_cgo_go_to_c_calls_calls_total%7Bjob%3D~%22.%2B%22%7D&match%5B%5D=up%7Bjob%3D~%22.%2B%22%7D"```

returns:

```json
{
  "status": "success",
  "data": [
    "grafana"
  ]
}
```



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
