### PR TITLE
Dashboard Scene: Add sceneGraph missing dependency

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -12,6 +12,7 @@ import {
 } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import {
+  sceneGraph,
   SceneGridRow,
   SceneObject,
   SceneObjectBase,


### PR DESCRIPTION
Something went wrong during this merge https://github.com/grafana/grafana/pull/93670 and `sceneGraph` is missing, now we get a runtime error