### PR TITLE
Alerting: Add missing rule group fields to GettableRuleGroupConfig

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -284,6 +284,12 @@ type GettableRuleGroupConfig struct {
 	Interval      model.Duration             `yaml:"interval,omitempty" json:"interval,omitempty"`
 	SourceTenants []string                   `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
 	Rules         []GettableExtendedRuleNode `yaml:"rules" json:"rules"`
+
+	EvaluationDelay model.Duration `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
+	QueryOffset     model.Duration `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
+
+	Limit                         int  `yaml:"limit,omitempty" json:"limit,omitempty"`
+	AlignEvaluationTimeOnInterval bool `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
 }
 
 func (c *GettableRuleGroupConfig) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
**What is this feature?**

Add missing rule group fields (Prometheus rule definition in [Mimir](https://github.com/grafana/mimir/blob/456bbfde5745fcb711cee460d208c4e073aa5974/vendor/github.com/prometheus/prometheus/model/rulefmt/rulefmt.go#L138)) to GettableRuleGroupConfig.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
