### PR TITLE
Alerting: Update GettableRuleGroupConfig with missing fields supported by Prometheus

### DIFF
--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1660,10 +1660,19 @@
   },
   "GettableRuleGroupConfig": {
    "properties": {
+    "align_evaluation_time_on_interval": {
+     "type": "boolean"
+    },
+    "evaluation_delay": {
+     "type": "string"
+    },
     "interval": {
      "$ref": "#/definitions/Duration"
     },
     "name": {
+     "type": "string"
+    },
+    "query_offset": {
      "type": "string"
     },
     "rules": {
@@ -3616,10 +3625,19 @@
   },
   "RuleGroupConfigResponse": {
    "properties": {
+    "align_evaluation_time_on_interval": {
+     "type": "boolean"
+    },
+    "evaluation_delay": {
+     "type": "string"
+    },
     "interval": {
      "$ref": "#/definitions/Duration"
     },
     "name": {
+     "type": "string"
+    },
+    "query_offset": {
      "type": "string"
     },
     "rules": {

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -163,6 +163,14 @@
    ],
    "type": "object"
   },
+  "AlertRuleEditorSettings": {
+   "properties": {
+    "simplified_query_and_expressions_section": {
+     "type": "boolean"
+    }
+   },
+   "type": "object"
+  },
   "AlertRuleExport": {
    "properties": {
     "annotations": {
@@ -282,6 +290,14 @@
     "interval": {
      "format": "int64",
      "type": "integer"
+    }
+   },
+   "type": "object"
+  },
+  "AlertRuleMetadata": {
+   "properties": {
+    "editor_settings": {
+     "$ref": "#/definitions/AlertRuleEditorSettings"
     }
    },
    "type": "object"
@@ -1573,6 +1589,9 @@
     "is_paused": {
      "type": "boolean"
     },
+    "metadata": {
+     "$ref": "#/definitions/AlertRuleMetadata"
+    },
     "namespace_uid": {
      "type": "string"
     },
@@ -2794,6 +2813,9 @@
     },
     "is_paused": {
      "type": "boolean"
+    },
+    "metadata": {
+     "$ref": "#/definitions/AlertRuleMetadata"
     },
     "no_data_state": {
      "enum": [

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -2859,15 +2859,34 @@
   },
   "PostableRuleGroupConfig": {
    "properties": {
+    "align_evaluation_time_on_interval": {
+     "type": "boolean"
+    },
+    "evaluation_delay": {
+     "type": "string"
+    },
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "limit": {
+     "format": "int64",
+     "type": "integer"
+    },
     "name": {
+     "type": "string"
+    },
+    "query_offset": {
      "type": "string"
     },
     "rules": {
      "items": {
       "$ref": "#/definitions/PostableExtendedRuleNode"
+     },
+     "type": "array"
+    },
+    "source_tenants": {
+     "items": {
+      "type": "string"
      },
      "type": "array"
     }

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1688,6 +1688,10 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "limit": {
+     "format": "int64",
+     "type": "integer"
+    },
     "name": {
      "type": "string"
     },
@@ -3655,6 +3659,10 @@
     },
     "interval": {
      "$ref": "#/definitions/Duration"
+    },
+    "limit": {
+     "format": "int64",
+     "type": "integer"
     },
     "name": {
      "type": "string"

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -290,6 +290,7 @@ type GettableRuleGroupConfig struct {
 	EvaluationDelay               *model.Duration `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
 	QueryOffset                   *model.Duration `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
 	AlignEvaluationTimeOnInterval bool            `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
+	Limit                         int             `yaml:"limit,omitempty" json:"limit,omitempty"`
 }
 
 func (c *GettableRuleGroupConfig) UnmarshalJSON(b []byte) error {

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -237,6 +237,14 @@ type PostableRuleGroupConfig struct {
 	Name     string                     `yaml:"name" json:"name"`
 	Interval model.Duration             `yaml:"interval,omitempty" json:"interval,omitempty"`
 	Rules    []PostableExtendedRuleNode `yaml:"rules" json:"rules"`
+
+	// fields below are used by Mimir/Loki rulers
+
+	SourceTenants                 []string        `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
+	EvaluationDelay               *model.Duration `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
+	QueryOffset                   *model.Duration `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
+	AlignEvaluationTimeOnInterval bool            `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
+	Limit                         int             `yaml:"limit,omitempty" json:"limit,omitempty"`
 }
 
 func (c *PostableRuleGroupConfig) UnmarshalJSON(b []byte) error {
@@ -274,6 +282,10 @@ func (c *PostableRuleGroupConfig) validate() error {
 
 	if hasGrafRules && hasLotexRules {
 		return fmt.Errorf("cannot mix Grafana & Prometheus style rules")
+	}
+
+	if hasGrafRules && (len(c.SourceTenants) > 0 || c.EvaluationDelay != nil || c.QueryOffset != nil || c.AlignEvaluationTimeOnInterval || c.Limit > 0) {
+		return fmt.Errorf("Grafana managed rules cannot have source_tenants, evaluation_delay, query_offset, align_evaluation_time_on_interval or limit set")
 	}
 	return nil
 }

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -280,10 +280,16 @@ func (c *PostableRuleGroupConfig) validate() error {
 
 // swagger:model
 type GettableRuleGroupConfig struct {
-	Name          string                     `yaml:"name" json:"name"`
-	Interval      model.Duration             `yaml:"interval,omitempty" json:"interval,omitempty"`
-	SourceTenants []string                   `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
-	Rules         []GettableExtendedRuleNode `yaml:"rules" json:"rules"`
+	Name     string                     `yaml:"name" json:"name"`
+	Interval model.Duration             `yaml:"interval,omitempty" json:"interval,omitempty"`
+	Rules    []GettableExtendedRuleNode `yaml:"rules" json:"rules"`
+
+	// fields below are used by Mimir/Loki rulers
+
+	SourceTenants                 []string        `yaml:"source_tenants,omitempty" json:"source_tenants,omitempty"`
+	EvaluationDelay               *model.Duration `yaml:"evaluation_delay,omitempty" json:"evaluation_delay,omitempty"`
+	QueryOffset                   *model.Duration `yaml:"query_offset,omitempty" json:"query_offset,omitempty"`
+	AlignEvaluationTimeOnInterval bool            `yaml:"align_evaluation_time_on_interval,omitempty" json:"align_evaluation_time_on_interval,omitempty"`
 }
 
 func (c *GettableRuleGroupConfig) UnmarshalJSON(b []byte) error {

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -285,7 +285,7 @@ func (c *PostableRuleGroupConfig) validate() error {
 	}
 
 	if hasGrafRules && (len(c.SourceTenants) > 0 || c.EvaluationDelay != nil || c.QueryOffset != nil || c.AlignEvaluationTimeOnInterval || c.Limit > 0) {
-		return fmt.Errorf("Grafana managed rules cannot have source_tenants, evaluation_delay, query_offset, align_evaluation_time_on_interval or limit set")
+		return fmt.Errorf("fields source_tenants, evaluation_delay, query_offset, align_evaluation_time_on_interval and limit are not supported for Grafana rules")
 	}
 	return nil
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1660,10 +1660,19 @@
   },
   "GettableRuleGroupConfig": {
    "properties": {
+    "align_evaluation_time_on_interval": {
+     "type": "boolean"
+    },
+    "evaluation_delay": {
+     "type": "string"
+    },
     "interval": {
      "$ref": "#/definitions/Duration"
     },
     "name": {
+     "type": "string"
+    },
+    "query_offset": {
      "type": "string"
     },
     "rules": {
@@ -3616,10 +3625,19 @@
   },
   "RuleGroupConfigResponse": {
    "properties": {
+    "align_evaluation_time_on_interval": {
+     "type": "boolean"
+    },
+    "evaluation_delay": {
+     "type": "string"
+    },
     "interval": {
      "$ref": "#/definitions/Duration"
     },
     "name": {
+     "type": "string"
+    },
+    "query_offset": {
      "type": "string"
     },
     "rules": {

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -163,6 +163,14 @@
    ],
    "type": "object"
   },
+  "AlertRuleEditorSettings": {
+   "properties": {
+    "simplified_query_and_expressions_section": {
+     "type": "boolean"
+    }
+   },
+   "type": "object"
+  },
   "AlertRuleExport": {
    "properties": {
     "annotations": {
@@ -282,6 +290,14 @@
     "interval": {
      "format": "int64",
      "type": "integer"
+    }
+   },
+   "type": "object"
+  },
+  "AlertRuleMetadata": {
+   "properties": {
+    "editor_settings": {
+     "$ref": "#/definitions/AlertRuleEditorSettings"
     }
    },
    "type": "object"
@@ -1573,6 +1589,9 @@
     "is_paused": {
      "type": "boolean"
     },
+    "metadata": {
+     "$ref": "#/definitions/AlertRuleMetadata"
+    },
     "namespace_uid": {
      "type": "string"
     },
@@ -2794,6 +2813,9 @@
     },
     "is_paused": {
      "type": "boolean"
+    },
+    "metadata": {
+     "$ref": "#/definitions/AlertRuleMetadata"
     },
     "no_data_state": {
      "enum": [

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2859,15 +2859,34 @@
   },
   "PostableRuleGroupConfig": {
    "properties": {
+    "align_evaluation_time_on_interval": {
+     "type": "boolean"
+    },
+    "evaluation_delay": {
+     "type": "string"
+    },
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "limit": {
+     "format": "int64",
+     "type": "integer"
+    },
     "name": {
+     "type": "string"
+    },
+    "query_offset": {
      "type": "string"
     },
     "rules": {
      "items": {
       "$ref": "#/definitions/PostableExtendedRuleNode"
+     },
+     "type": "array"
+    },
+    "source_tenants": {
+     "items": {
+      "type": "string"
      },
      "type": "array"
     }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1688,6 +1688,10 @@
     "interval": {
      "$ref": "#/definitions/Duration"
     },
+    "limit": {
+     "format": "int64",
+     "type": "integer"
+    },
     "name": {
      "type": "string"
     },
@@ -3655,6 +3659,10 @@
     },
     "interval": {
      "$ref": "#/definitions/Duration"
+    },
+    "limit": {
+     "format": "int64",
+     "type": "integer"
     },
     "name": {
      "type": "string"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5321,6 +5321,10 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
         "name": {
           "type": "string"
         },
@@ -7289,6 +7293,10 @@
         },
         "interval": {
           "$ref": "#/definitions/Duration"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
         },
         "name": {
           "type": "string"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -6493,16 +6493,35 @@
     "PostableRuleGroupConfig": {
       "type": "object",
       "properties": {
+        "align_evaluation_time_on_interval": {
+          "type": "boolean"
+        },
+        "evaluation_delay": {
+          "type": "string"
+        },
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
         "name": {
+          "type": "string"
+        },
+        "query_offset": {
           "type": "string"
         },
         "rules": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/PostableExtendedRuleNode"
+          }
+        },
+        "source_tenants": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3794,6 +3794,14 @@
         }
       }
     },
+    "AlertRuleEditorSettings": {
+      "type": "object",
+      "properties": {
+        "simplified_query_and_expressions_section": {
+          "type": "boolean"
+        }
+      }
+    },
     "AlertRuleExport": {
       "type": "object",
       "title": "AlertRuleExport is the provisioned file export of models.AlertRule.",
@@ -3914,6 +3922,14 @@
         "interval": {
           "type": "integer",
           "format": "int64"
+        }
+      }
+    },
+    "AlertRuleMetadata": {
+      "type": "object",
+      "properties": {
+        "editor_settings": {
+          "$ref": "#/definitions/AlertRuleEditorSettings"
         }
       }
     },
@@ -5206,6 +5222,9 @@
         "is_paused": {
           "type": "boolean"
         },
+        "metadata": {
+          "$ref": "#/definitions/AlertRuleMetadata"
+        },
         "namespace_uid": {
           "type": "string"
         },
@@ -6428,6 +6447,9 @@
         },
         "is_paused": {
           "type": "boolean"
+        },
+        "metadata": {
+          "$ref": "#/definitions/AlertRuleMetadata"
         },
         "no_data_state": {
           "type": "string",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -5293,10 +5293,19 @@
     "GettableRuleGroupConfig": {
       "type": "object",
       "properties": {
+        "align_evaluation_time_on_interval": {
+          "type": "boolean"
+        },
+        "evaluation_delay": {
+          "type": "string"
+        },
         "interval": {
           "$ref": "#/definitions/Duration"
         },
         "name": {
+          "type": "string"
+        },
+        "query_offset": {
           "type": "string"
         },
         "rules": {
@@ -7250,10 +7259,19 @@
     "RuleGroupConfigResponse": {
       "type": "object",
       "properties": {
+        "align_evaluation_time_on_interval": {
+          "type": "boolean"
+        },
+        "evaluation_delay": {
+          "type": "string"
+        },
         "interval": {
           "$ref": "#/definitions/Duration"
         },
         "name": {
+          "type": "string"
+        },
+        "query_offset": {
           "type": "string"
         },
         "rules": {

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -18154,16 +18154,35 @@
     "PostableRuleGroupConfig": {
       "type": "object",
       "properties": {
+        "align_evaluation_time_on_interval": {
+          "type": "boolean"
+        },
+        "evaluation_delay": {
+          "type": "string"
+        },
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
         "name": {
+          "type": "string"
+        },
+        "query_offset": {
           "type": "string"
         },
         "rules": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/PostableExtendedRuleNode"
+          }
+        },
+        "source_tenants": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -15908,6 +15908,10 @@
         "interval": {
           "$ref": "#/definitions/Duration"
         },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
         "name": {
           "type": "string"
         },
@@ -19633,6 +19637,10 @@
         },
         "interval": {
           "$ref": "#/definitions/Duration"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
         },
         "name": {
           "type": "string"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -12388,6 +12388,14 @@
         }
       }
     },
+    "AlertRuleEditorSettings": {
+      "type": "object",
+      "properties": {
+        "simplified_query_and_expressions_section": {
+          "type": "boolean"
+        }
+      }
+    },
     "AlertRuleExport": {
       "type": "object",
       "title": "AlertRuleExport is the provisioned file export of models.AlertRule.",
@@ -12508,6 +12516,14 @@
         "interval": {
           "type": "integer",
           "format": "int64"
+        }
+      }
+    },
+    "AlertRuleMetadata": {
+      "type": "object",
+      "properties": {
+        "editor_settings": {
+          "$ref": "#/definitions/AlertRuleEditorSettings"
         }
       }
     },
@@ -15793,6 +15809,9 @@
         "is_paused": {
           "type": "boolean"
         },
+        "metadata": {
+          "$ref": "#/definitions/AlertRuleMetadata"
+        },
         "namespace_uid": {
           "type": "string"
         },
@@ -15880,10 +15899,19 @@
     "GettableRuleGroupConfig": {
       "type": "object",
       "properties": {
+        "align_evaluation_time_on_interval": {
+          "type": "boolean"
+        },
+        "evaluation_delay": {
+          "type": "string"
+        },
         "interval": {
           "$ref": "#/definitions/Duration"
         },
         "name": {
+          "type": "string"
+        },
+        "query_offset": {
           "type": "string"
         },
         "rules": {
@@ -18081,6 +18109,9 @@
         "is_paused": {
           "type": "boolean"
         },
+        "metadata": {
+          "$ref": "#/definitions/AlertRuleMetadata"
+        },
         "no_data_state": {
           "type": "string",
           "enum": [
@@ -19594,10 +19625,19 @@
     "RuleGroupConfigResponse": {
       "type": "object",
       "properties": {
+        "align_evaluation_time_on_interval": {
+          "type": "boolean"
+        },
+        "evaluation_delay": {
+          "type": "string"
+        },
         "interval": {
           "$ref": "#/definitions/Duration"
         },
         "name": {
+          "type": "string"
+        },
+        "query_offset": {
           "type": "string"
         },
         "rules": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -8386,15 +8386,34 @@
       },
       "PostableRuleGroupConfig": {
         "properties": {
+          "align_evaluation_time_on_interval": {
+            "type": "boolean"
+          },
+          "evaluation_delay": {
+            "type": "string"
+          },
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
+          },
           "name": {
+            "type": "string"
+          },
+          "query_offset": {
             "type": "string"
           },
           "rules": {
             "items": {
               "$ref": "#/components/schemas/PostableExtendedRuleNode"
+            },
+            "type": "array"
+          },
+          "source_tenants": {
+            "items": {
+              "type": "string"
             },
             "type": "array"
           }

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6140,6 +6140,10 @@
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },
@@ -9865,6 +9869,10 @@
           },
           "interval": {
             "$ref": "#/components/schemas/Duration"
+          },
+          "limit": {
+            "format": "int64",
+            "type": "integer"
           },
           "name": {
             "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -2621,6 +2621,14 @@
         ],
         "type": "object"
       },
+      "AlertRuleEditorSettings": {
+        "properties": {
+          "simplified_query_and_expressions_section": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
       "AlertRuleExport": {
         "properties": {
           "annotations": {
@@ -2740,6 +2748,14 @@
           "interval": {
             "format": "int64",
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AlertRuleMetadata": {
+        "properties": {
+          "editor_settings": {
+            "$ref": "#/components/schemas/AlertRuleEditorSettings"
           }
         },
         "type": "object"
@@ -6025,6 +6041,9 @@
           "is_paused": {
             "type": "boolean"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/AlertRuleMetadata"
+          },
           "namespace_uid": {
             "type": "string"
           },
@@ -6112,10 +6131,19 @@
       },
       "GettableRuleGroupConfig": {
         "properties": {
+          "align_evaluation_time_on_interval": {
+            "type": "boolean"
+          },
+          "evaluation_delay": {
+            "type": "string"
+          },
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
           "name": {
+            "type": "string"
+          },
+          "query_offset": {
             "type": "string"
           },
           "rules": {
@@ -8313,6 +8341,9 @@
           "is_paused": {
             "type": "boolean"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/AlertRuleMetadata"
+          },
           "no_data_state": {
             "enum": [
               "Alerting",
@@ -9826,10 +9857,19 @@
       },
       "RuleGroupConfigResponse": {
         "properties": {
+          "align_evaluation_time_on_interval": {
+            "type": "boolean"
+          },
+          "evaluation_delay": {
+            "type": "string"
+          },
           "interval": {
             "$ref": "#/components/schemas/Duration"
           },
           "name": {
+            "type": "string"
+          },
+          "query_offset": {
             "type": "string"
           },
           "rules": {


### PR DESCRIPTION
**What is this feature?**
This PR updates the models `definitions.GettableRuleGroupConfig` and `definitions.PostableRuleGroupConfig` have all fields supported in Mimir\Prometheus rulers (https://github.com/grafana/mimir/blob/1fcecee221e0e05c5cdb44cffc1e8dc8d7b26b08/vendor/github.com/prometheus/prometheus/model/rulefmt/rulefmt.go#L138-L150).

**Why do we need this feature?**
The models are shared between Grafana managed rules API and Mimir/Prometheus/Loki rules API. They miss some fields from the Mimir\Prometheus model and when Grafana "Lotex" API re-marshals the response from those rulers it fails because the response contains unknown fields.