### PR TITLE
Correlations: Handle special field for loki labels

### DIFF
--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -19,6 +19,7 @@ import {
   DataLinkPostProcessor,
   ExploreUrlState,
   urlUtil,
+  FieldType,
 } from '@grafana/data';
 import { getTemplateSrv, reportInteraction, VariableInterpolation } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
@@ -136,6 +137,21 @@ export const getFieldLinksForExplore = (options: {
       },
       text: 'Data',
     };
+
+    if (field.type === FieldType.other && field.hasOwnProperty('typeInfo')) {
+      // handle special datasource stuff here
+      const specialField: Field & {
+        typeInfo?: { frame: string };
+      } = field;
+
+      if (specialField.typeInfo?.frame === 'json.RawMessage') {
+        Object.entries(field.values[rowIndex]).forEach((value) => {
+          scopedVars[value[0]] = {
+            value: value[1],
+          };
+        });
+      }
+    }
 
     dataFrame.fields.forEach((f) => {
       if (fieldDisplayValuesProxy && fieldDisplayValuesProxy[f.name]) {


### PR DESCRIPTION
**What is this feature?**

Loki has a special type of field in Grafana where the data is JSON. Importantly, it's a list of labels in a key/value object. These labels are popular places to use for Correlations, but because they don't follow the standard Field structure, we cannot use the standard `getFieldDisplayValuesProxy` and `displayProcessor` path in `grafana-data` to get the value out for interpolation. 

This adds logic where if the field to create a correlation on is one of these special fields - meaning the `type` is `other` and the `typeInfo` is `json.RawMessage`, it will add the data from that field as a list of variables. 

This does mean the normal paradigm for correlations is a bit different. You will need to make the correlations on the `labels` field but then can use any of the label keys in the correlation itself. It will be overwritten by any fields that share the same name. 

**Why do we need this feature?**

To make labels accessible for correlations.

**Who is this feature for?**

For folks who want to use loki labels in correlations.

**Which issue(s) does this PR fix?**:

Fixes #94005 

**Special notes for your reviewer:**

Replication Steps:

Using gdev-loki

1. Create a correlation named whatever you'd like
2. Type: external, Target `https://www.google.com/search?q=${compose_project}`
3. Source: `gdev-loki`, results field: `labels`
4. Save
5. In explore, select 'gdev-loki' and run `{compose_project="devenv"} `
6. Expand a log line to see the "labels" field shows with a button with the name entered in step 1
7. Clicking the button will take you to `https://www.google.com/search?q=devenv`

Special Note: 
One other option I saw was adding all fields in the dataframe that had the Other / json.RawMessage format to be variables. This will not work without more custom code. Loki has two fields with this data - `labels` and `labelTypes` that have the exact same keys, but the data in `labels` is valuable and the data in `labelTypes` is not. 

For example, in one row of a Loki Log, it has
labels = `{compose_project: "devenv", compose_service:  "loki"}`
labelTypes = `{compose_project: "I", compose_service:  "I"}`

If we add all the fields in the data frame with other/json.RawMessage, the useful data in "labels" is overwritten by the useless data in "labelTypes" There is a custom config value that says "labelTypes" should be hidden that we can use if we want to, but I would rather make the user specify the field that should be parsed.

TL;DR: In the choice between more "magic" vs less custom code, I went with less custom code.

Special Note 2: In asking the logs folks about this, they let me know the data plane may be a better approach. The PR for that is https://github.com/grafana/grafana/pull/94033 but requires a feature flag.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
