### PR TITLE
Correlations: Handle special field for loki labels (using data plane)

### DIFF
--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -19,11 +19,13 @@ import {
   DataLinkPostProcessor,
   ExploreUrlState,
   urlUtil,
+  DataFrameType,
 } from '@grafana/data';
 import { getTemplateSrv, reportInteraction, VariableInterpolation } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getTransformationVars } from 'app/features/correlations/transformations';
+import { parseDataplaneLogsFrame } from 'app/features/logs/logsFrame';
 import { ExploreItemState } from 'app/types/explore';
 
 import { getLinkSrv } from '../../panel/panellinks/link_srv';
@@ -136,6 +138,18 @@ export const getFieldLinksForExplore = (options: {
       },
       text: 'Data',
     };
+
+    if (dataFrame.meta?.type === DataFrameType.LogLines) {
+      const dataPlane = parseDataplaneLogsFrame(dataFrame);
+      const labels = dataPlane?.getLogFrameLabels();
+      if (labels != null) {
+        Object.entries(labels[rowIndex]).forEach((value) => {
+          scopedVars[value[0]] = {
+            value: value[1],
+          };
+        });
+      }
+    }
 
     dataFrame.fields.forEach((f) => {
       if (fieldDisplayValuesProxy && fieldDisplayValuesProxy[f.name]) {

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -45,7 +45,7 @@ export function logFrameLabelsToLabels(logFrameLabels: LogFrameLabels): Labels {
   return result;
 }
 
-function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
+export function parseDataplaneLogsFrame(frame: DataFrame): LogsFrame | null {
   const cache = new FieldCache(frame);
 
   const timestampField = getField(cache, DATAPLANE_TIMESTAMP_NAME, FieldType.time);


### PR DESCRIPTION
**What is this feature?**

Loki has a special type of field in Grafana where the data is JSON. Importantly, it's a list of labels in a key/value object. These labels are popular places to use for Correlations, but because they don't follow the standard Field structure, we cannot use the standard `getFieldDisplayValuesProxy` and `displayProcessor` path in `grafana-data` to get the value out for interpolation. 

This adds logic where if the field to create a correlation on is one of these special fields using the data plane it looks for labels and then attaches the labels as variables to be able to be used.

This does mean the normal paradigm for correlations is a bit different. You will need to make the correlations on the `labels` field but then can use any of the label keys in the correlation itself. It will be overwritten by any fields that share the same name. 

**Why do we need this feature?**

To make labels accessible for correlations.

**Which issue(s) does this PR fix?**:

Fixes #94005 

**Special notes for your reviewer:**

Replication Steps:

Using gdev-loki

1. Create a correlation named whatever you'd like
2. Type: external, Target `https://www.google.com/search?q=${compose_project}`
3. Source: `gdev-loki`, results field: `labels`
4. Save
5. In explore, select 'gdev-loki' and run `{compose_project="devenv"} `
6. Expand a log line to see the "labels" field shows with a button with the name entered in step 1
7. Clicking the button will take you to `https://www.google.com/search?q=devenv`

Special Note: 
This will only function if the `lokiLogsDataplane` feature flag is on.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
