### PR TITLE
Chore: Fix flaky cloud migration test

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -617,7 +617,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 			featuremgmt.FlagDashboardRestore),
 		sqlStore,
 		dsService,
-		secretskv.NewFakeSQLSecretsKVStore(t),
+		secretskv.NewFakeSQLSecretsKVStore(t, sqlStore),
 		secretsService,
 		rr,
 		prometheus.DefaultRegisterer,

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -228,7 +228,7 @@ func Test_SnapshotResources(t *testing.T) {
 }
 
 func TestGetSnapshotList(t *testing.T) {
-	t.Skip("FLAKY test: disabled until fixed")
+	//t.Skip("FLAKY test: disabled until fixed")
 
 	_, s := setUpTest(t)
 	// Taken from setUpTest
@@ -322,7 +322,7 @@ func setUpTest(t *testing.T) (*sqlstore.SQLStore, *sqlStore) {
 	s := &sqlStore{
 		db:             testDB,
 		secretsService: fakeSecrets.FakeSecretsService{},
-		secretsStore:   secretskv.NewFakeSQLSecretsKVStore(t),
+		secretsStore:   secretskv.NewFakeSQLSecretsKVStore(t, testDB),
 	}
 	ctx := context.Background()
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -228,8 +228,6 @@ func Test_SnapshotResources(t *testing.T) {
 }
 
 func TestGetSnapshotList(t *testing.T) {
-	//t.Skip("FLAKY test: disabled until fixed")
-
 	_, s := setUpTest(t)
 	// Taken from setUpTest
 	sessionUID := "qwerty"

--- a/pkg/services/secrets/kvstore/migrations/to_plugin_mig_test.go
+++ b/pkg/services/secrets/kvstore/migrations/to_plugin_mig_test.go
@@ -100,12 +100,13 @@ func setupTestMigrateToPluginService(t *testing.T) (*MigrateToPluginService, sec
 	raw, err := ini.Load([]byte(rawCfg))
 	require.NoError(t, err)
 	cfg := &setting.Cfg{Raw: raw}
+	sqlStore := db.InitTestDB(t)
+
 	// this would be the plugin - mocked at the moment
-	fallbackStore := secretskvs.WithCache(secretskvs.NewFakeSQLSecretsKVStore(t), time.Minute*5, time.Minute*5)
+	fallbackStore := secretskvs.WithCache(secretskvs.NewFakeSQLSecretsKVStore(t, sqlStore), time.Minute*5, time.Minute*5)
 	secretsStoreForPlugin := secretskvs.WithCache(secretskvs.NewFakePluginSecretsKVStore(t, featuremgmt.WithFeatures(), fallbackStore), time.Minute*5, time.Minute*5)
 
 	// this is to init the sql secret store inside the migration
-	sqlStore := db.InitTestDB(t)
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	manager := secretskvs.NewFakeSecretsPluginManager(t, false)
 	migratorService := ProvideMigrateToPluginService(

--- a/pkg/services/secrets/kvstore/test_helpers.go
+++ b/pkg/services/secrets/kvstore/test_helpers.go
@@ -20,12 +20,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsmng "github.com/grafana/grafana/pkg/services/secrets/manager"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func NewFakeSQLSecretsKVStore(t *testing.T) *SecretsKVStoreSQL {
+func NewFakeSQLSecretsKVStore(t *testing.T, sqlStore *sqlstore.SQLStore) *SecretsKVStoreSQL {
 	t.Helper()
-	sqlStore := db.InitTestDB(t)
 	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
 	return NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))
 }


### PR DESCRIPTION
The TestDB initializer in this unit test was being called twice, once by the top level unit test, and once in the test secret kv store initializer. I noticed that in both instances the memory address was the same. I'm still not entirely sure where the race condition is, but we can make the issue moot by just explicitly having the services share a DB instance.

Fixes: https://github.com/grafana/grafana-operator-experience-squad/issues/989