### PR TITLE
Explore metrics: Add limit for adhoc filters options in providers functions

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -58,7 +58,7 @@ import {
   VAR_OTEL_JOIN_QUERY,
   VAR_OTEL_RESOURCES,
 } from './shared';
-import { getTrailFor } from './utils';
+import { getTrailFor, limitAdhocProviders } from './utils';
 
 export interface DataTrailState extends SceneObjectState {
   topScene?: SceneObject;
@@ -570,21 +570,27 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
         const otelResourcesVariable = sceneGraph.lookupVariable(VAR_OTEL_RESOURCES, model);
         const otelDepEnvVariable = sceneGraph.lookupVariable(VAR_OTEL_DEPLOYMENT_ENV, model);
         const otelJoinQueryVariable = sceneGraph.lookupVariable(VAR_OTEL_JOIN_QUERY, model);
-        const filtersvariable = sceneGraph.lookupVariable(VAR_FILTERS, model);
+        const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model);
 
         if (
           otelResourcesVariable instanceof AdHocFiltersVariable &&
           otelDepEnvVariable instanceof CustomVariable &&
           otelJoinQueryVariable instanceof ConstantVariable &&
-          filtersvariable instanceof AdHocFiltersVariable
+          filtersVariable instanceof AdHocFiltersVariable
         ) {
-          model.resetOtelExperience(otelResourcesVariable, otelDepEnvVariable, otelJoinQueryVariable, filtersvariable);
+          model.resetOtelExperience(otelResourcesVariable, otelDepEnvVariable, otelJoinQueryVariable, filtersVariable);
         }
       } else {
         // if experience is enabled, check standardization and update the otel variables
         model.checkDataSourceForOTelResources();
       }
     }, [model, hasOtelResources, useOtelExperience]);
+
+    useEffect(() => {
+      const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model);
+      const datasourceHelper = model.datasourceHelper;
+      limitAdhocProviders(filtersVariable, datasourceHelper);
+    }, [model]);
 
     return (
       <div className={styles.container}>

--- a/public/app/features/trails/utils.test.ts
+++ b/public/app/features/trails/utils.test.ts
@@ -1,0 +1,56 @@
+import { AdHocFiltersVariable } from '@grafana/scenes';
+
+import { MetricDatasourceHelper } from './helpers/MetricDatasourceHelper';
+import { limitAdhocProviders } from './utils';
+
+describe('limitAdhocProviders', () => {
+  let filtersVariable: AdHocFiltersVariable;
+  let datasourceHelper: MetricDatasourceHelper;
+
+  beforeEach(() => {
+    // disable console.log called in Scenes for this test
+    // called in scenes/packages/scenes/src/variables/adhoc/patchGetAdhocFilters.ts
+    jest.spyOn(console, 'log').mockImplementation(jest.fn());
+
+    filtersVariable = new AdHocFiltersVariable({
+      name: 'testVariable',
+      label: 'Test Variable',
+      type: 'adhoc',
+    });
+
+    datasourceHelper = {
+      getTagKeys: jest.fn().mockResolvedValue(Array(20000).fill({ text: 'key' })),
+      getTagValues: jest.fn().mockResolvedValue(Array(20000).fill({ text: 'value' })),
+    } as unknown as MetricDatasourceHelper;
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should limit the number of tag keys returned in the variable to 10000', async () => {
+    limitAdhocProviders(filtersVariable, datasourceHelper);
+
+    if (filtersVariable instanceof AdHocFiltersVariable && filtersVariable.state.getTagKeysProvider) {
+      console.log = jest.fn();
+
+      const result = await filtersVariable.state.getTagKeysProvider(filtersVariable, null);
+      expect(result.values).toHaveLength(10000);
+      expect(result.replace).toBe(true);
+    }
+  });
+
+  it('should limit the number of tag values returned in the variable to 10000', async () => {
+    limitAdhocProviders(filtersVariable, datasourceHelper);
+
+    if (filtersVariable instanceof AdHocFiltersVariable && filtersVariable.state.getTagValuesProvider) {
+      const result = await filtersVariable.state.getTagValuesProvider(filtersVariable, {
+        key: 'testKey',
+        operator: '=',
+        value: 'testValue',
+      });
+      expect(result.values).toHaveLength(10000);
+      expect(result.replace).toBe(true);
+    }
+  });
+});

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -136,34 +136,36 @@ export function limitAdhocProviders(
   filtersVariable: SceneVariable<SceneVariableState> | null,
   datasourceHelper: MetricDatasourceHelper
 ) {
-  if (filtersVariable instanceof AdHocFiltersVariable) {
-    filtersVariable.setState({
-      getTagKeysProvider: async (
-        variable: AdHocFiltersVariable,
-        currentKey: string | null
-      ): Promise<{
-        replace?: boolean;
-        values: GetTagResponse | MetricFindValue[];
-      }> => {
-        const filters = filtersVariable.state.filters;
-        const values = (await datasourceHelper.getTagKeys({ filters })).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
-        return { replace: true, values };
-      },
-      getTagValuesProvider: async (
-        variable: AdHocFiltersVariable,
-        filter: AdHocVariableFilter
-      ): Promise<{
-        replace?: boolean;
-        values: GetTagResponse | MetricFindValue[];
-      }> => {
-        const filtersValues = filtersVariable.state.filters;
-        const filters = filtersValues.filter((f) => f.key !== filter.key);
-        const values = (await datasourceHelper.getTagValues({ key: filter.key, filters })).slice(
-          0,
-          MAX_ADHOC_VARIABLE_OPTIONS
-        );
-        return { replace: true, values };
-      },
-    });
+  if (!(filtersVariable instanceof AdHocFiltersVariable)) {
+    return;
   }
+
+  filtersVariable.setState({
+    getTagKeysProvider: async (
+      variable: AdHocFiltersVariable,
+      currentKey: string | null
+    ): Promise<{
+      replace?: boolean;
+      values: GetTagResponse | MetricFindValue[];
+    }> => {
+      const filters = filtersVariable.state.filters;
+      const values = (await datasourceHelper.getTagKeys({ filters })).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
+      return { replace: true, values };
+    },
+    getTagValuesProvider: async (
+      variable: AdHocFiltersVariable,
+      filter: AdHocVariableFilter
+    ): Promise<{
+      replace?: boolean;
+      values: GetTagResponse | MetricFindValue[];
+    }> => {
+      const filtersValues = filtersVariable.state.filters;
+      const filters = filtersValues.filter((f) => f.key !== filter.key);
+      const values = (await datasourceHelper.getTagValues({ key: filter.key, filters })).slice(
+        0,
+        MAX_ADHOC_VARIABLE_OPTIONS
+      );
+      return { replace: true, values };
+    },
+  });
 }

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -148,8 +148,15 @@ export function limitAdhocProviders(
       replace?: boolean;
       values: GetTagResponse | MetricFindValue[];
     }> => {
+      // For the Prometheus label names endpoint, '/api/v1/labels'
+      // get the previously selected filters from the variable
+      // to use in the query to filter the response
+      // using filters, e.g. {previously_selected_label:"value"},
+      // as the series match[] parameter in Prometheus labels endpoint
       const filters = filtersVariable.state.filters;
+      // call getTagKeys and truncate the response
       const values = (await datasourceHelper.getTagKeys({ filters })).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
+      // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };
     },
     getTagValuesProvider: async (
@@ -159,12 +166,20 @@ export function limitAdhocProviders(
       replace?: boolean;
       values: GetTagResponse | MetricFindValue[];
     }> => {
+      // For the Prometheus label values endpoint, /api/v1/label/${interpolatedName}/values
+      // get the previously selected filters from the variable
+      // to use in the query to filter the response
+      // using filters, e.g. {previously_selected_label:"value"},
+      // as the series match[] parameter in Prometheus label values endpoint
       const filtersValues = filtersVariable.state.filters;
+      // remove current selected filter if updating a chosen filter
       const filters = filtersValues.filter((f) => f.key !== filter.key);
+      // call getTagValues and truncate the response
       const values = (await datasourceHelper.getTagValues({ key: filter.key, filters })).slice(
         0,
         MAX_ADHOC_VARIABLE_OPTIONS
       );
+      // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };
     },
   });

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -122,6 +122,16 @@ export function getFilters(scene: SceneObject) {
 // frontend hardening limit
 const MAX_ADHOC_VARIABLE_OPTIONS = 10000;
 
+/**
+ * Add custom providers for the adhoc filters variable that limit the responses for labels keys and label values.
+ * Currently hard coded to 10000.
+ *
+ * The current provider functions for adhoc filter variables are the functions getTagKeys and getTagValues in the data source.
+ * This function still uses these functions from inside the data source helper.
+ *
+ * @param filtersVariable
+ * @param datasourceHelper
+ */
 export function limitAdhocProviders(
   filtersVariable: SceneVariable<SceneVariableState> | null,
   datasourceHelper: MetricDatasourceHelper


### PR DESCRIPTION
**What is this?**

This is to harden the frontend of explore metrics by providing a limit on the adhoc filters variable to display options. 

The list of options for label keys and label values should not exceed 10,000 items.

![Screenshot 2024-09-30 at 4 46 42 PM](https://github.com/user-attachments/assets/eb1bceb4-d9ae-41d7-b59b-9abee12961a1)

**Why do we need it?**

[This is a list of work that is of concern for Explore metrics around frontend hardening.](https://docs.google.com/document/d/1ojZh9Lm9ZZ2MH9HCmkQFW_Ka9NIXAR5KZvbAf2q6WOo/edit)This is part of the [Aw Snap project](https://docs.google.com/document/d/1ZlXsF7qrXVrElV2X60-VCcn8CKVx_oXWA0Hpyqup0i8/edit) to provide frontend limits to prevent browser crashes when data sources load large amounts of data. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
