### PR TITLE
Alerting: skip flaky test TestBroadcastAndHandleMessages 

### DIFF
--- a/pkg/services/ngalert/notifier/redis_channel_test.go
+++ b/pkg/services/ngalert/notifier/redis_channel_test.go
@@ -29,6 +29,8 @@ func TestNewRedisChannel(t *testing.T) {
 }
 
 func TestBroadcastAndHandleMessages(t *testing.T) {
+	t.Skip() // TODO fix the flaky test https://github.com/grafana/grafana/issues/94037
+
 	const channelName = "testChannel"
 
 	mr, err := miniredis.Run()


### PR DESCRIPTION
Temporarily skip the test TestBroadcastAndHandleMessages . 

Related to: https://github.com/grafana/grafana/issues/94037