### PR TITLE
Alerting docs: relocate `Intro>Notifications>Templates`

### DIFF
--- a/docs/sources/alerting/fundamentals/templates.md
+++ b/docs/sources/alerting/fundamentals/templates.md
@@ -1,10 +1,11 @@
 ---
 aliases:
-  - ../../contact-points/message-templating/ # /docs/grafana/<GRAFANA_VERSION>/alerting/contact-points/message-templating/
-  - ../../alert-rules/message-templating/ # /docs/grafana/<GRAFANA_VERSION>/alerting/alert-rules/message-templating/
-  - ../../unified-alerting/message-templating/ # /docs/grafana/<GRAFANA_VERSION>/alerting/unified-alerting/message-templating/
+  - ../fundamentals/notifications/templates/ # /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/templates/
+  - ../contact-points/message-templating/ # /docs/grafana/<GRAFANA_VERSION>/alerting/contact-points/message-templating/
+  - ../alert-rules/message-templating/ # /docs/grafana/<GRAFANA_VERSION>/alerting/alert-rules/message-templating/
+  - ../unified-alerting/message-templating/ # /docs/grafana/<GRAFANA_VERSION>/alerting/unified-alerting/message-templating/
 canonical: https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/templates/
-description: Learn about templates
+description: Use templating to customize, format, and reuse alert notification messages. Create more flexible and informative alert notification messages by incorporating dynamic content, such as metric values, labels, and other contextual information.
 keywords:
   - grafana
   - alerting
@@ -16,7 +17,7 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Templates
+title: Alert message templates
 meta_image: /media/docs/alerting/how-notification-templates-works.png
 weight: 115
 refs:
@@ -52,7 +53,7 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/create-notification-templates/
 ---
 
-# Templates
+# Alert message templates
 
 Use templating to customize, format, and reuse alert notification messages. Create more flexible and informative alert notification messages by incorporating dynamic content, such as metric values, labels, and other contextual information.
 

--- a/docs/sources/alerting/fundamentals/templates.md
+++ b/docs/sources/alerting/fundamentals/templates.md
@@ -17,7 +17,7 @@ labels:
     - cloud
     - enterprise
     - oss
-title: Alert message templates
+title: Templates
 meta_image: /media/docs/alerting/how-notification-templates-works.png
 weight: 115
 refs:
@@ -53,7 +53,7 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/configure-notifications/template-notifications/create-notification-templates/
 ---
 
-# Alert message templates
+# Templates
 
 Use templating to customize, format, and reuse alert notification messages. Create more flexible and informative alert notification messages by incorporating dynamic content, such as metric values, labels, and other contextual information.
 


### PR DESCRIPTION
Continuation of https://github.com/grafana/grafana/pull/93935

Suggested by @brendamuir -   Templates don't belong only to Notifications, let's pull it out a level in the Intro structure.


**Before**
![Screenshot 2024-10-01 at 11 51 06](https://github.com/user-attachments/assets/ed2104c9-60cd-44be-adaf-607643c2017c)


**After**
![Screenshot 2024-10-01 at 11 50 55](https://github.com/user-attachments/assets/17af09d1-8ad4-48ad-afb2-6ce3155991e9)

![Screenshot 2024-10-01 at 12 01 17](https://github.com/user-attachments/assets/be6c5f45-83f5-4330-ba71-d0365d96c937)


