### PR TITLE
Navigation: Don't show "add new connection" if user has no permissions

### DIFF
--- a/pkg/services/datasources/accesscontrol.go
+++ b/pkg/services/datasources/accesscontrol.go
@@ -25,7 +25,6 @@ var (
 var (
 	// ConfigurationPageAccess is used to protect the "Configure > Data sources" tab access
 	ConfigurationPageAccess = accesscontrol.EvalAny(
-		accesscontrol.EvalPermission(accesscontrol.ActionDatasourcesExplore),
 		accesscontrol.EvalPermission(ActionCreate),
 		accesscontrol.EvalAll(
 			accesscontrol.EvalPermission(ActionRead),


### PR DESCRIPTION
**What is this feature?**

Hide "Add new connection" navigation tab if user cannot create new data source. Currently it's possible to see this tab if user has "explore" permission, it was introduced [here](https://github.com/grafana/grafana/pull/60725). But now nav menu structure changed a bit, so makes less sense now.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
