### PR TITLE
CloudMigrations: document and re-generate api for syncing

### DIFF
--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -313,6 +313,11 @@ type GetSnapshotListParams struct {
 	// Session UID of a session
 	// in: path
 	UID string `json:"uid"`
+
+	// Sort with value latest to return results sorted in descending order.
+	// in:query
+	// required:false
+	Sort string `json:"sort"`
 }
 
 // swagger:response snapshotListResponse

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2600,6 +2600,12 @@
             "name": "uid",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "description": "Sort with value latest to return results sorted in descending order.",
+            "name": "sort",
+            "in": "query"
           }
         ],
         "responses": {

--- a/public/app/features/migrate-to-cloud/api/README.md
+++ b/public/app/features/migrate-to-cloud/api/README.md
@@ -1,0 +1,6 @@
+## Migrate to Cloud API
+
+The [`endpoints.gen.ts`](./endpoints.gen.ts) file is machine generated. In order to update it, follow these steps:
+
+- Run: `make swagger-clean && make openapi3-gen`
+- Run: `yarn generate-apis`

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -112,10 +112,10 @@ export type GetShapshotListApiArg = {
   page?: number;
   /** Max limit for results returned. */
   limit?: number;
-  /** Sort with value latest to return results sorted in descending order */
-  sort?: string;
   /** Session UID of a session */
   uid: string;
+  /** Sort with value latest to return results sorted in descending order. */
+  sort?: string;
 };
 export type GetCloudMigrationTokenApiResponse = /** status 200 (empty) */ GetAccessTokenResponseDto;
 export type GetCloudMigrationTokenApiArg = void;
@@ -157,6 +157,7 @@ export type CreateSnapshotResponseDto = {
 };
 export type MigrateDataResponseItemDto = {
   message?: string;
+  name?: string;
   refId: string;
   status: 'OK' | 'WARNING' | 'ERROR' | 'PENDING' | 'UNKNOWN';
   type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER' | 'LIBRARY_ELEMENT';

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -15802,6 +15802,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Sort with value latest to return results sorted in descending order.",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
**What is this feature?**

Document how the `endpoints.gen.ts` file in the `cloudmigration` FE API shim is machine-generated and steps on how to re-generate it.

Also run a re-run to sync the file back again.

**Why do we need this feature?**

This file should not be edited manually because it will go out of sync.

**Who is this feature for?**

Developers! Developers! Developers!
