### PR TITLE
Plugin E2E: Add more api tests

### DIFF
--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/dashboard.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/dashboard.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
+
+test('add panel in already existing dashboard', async ({ gotoDashboardPage, page }) => {
+  const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+  await dashboardPage.addPanel();
+  await expect(page.url()).toContain('editPanel');
+});
+
+test('add panel in new dashboard', async ({ dashboardPage, page }) => {
+  const panelEditPage = await dashboardPage.addPanel();
+  await expect(panelEditPage.panel.locator).toBeVisible();
+  await expect(page.url()).toContain('editPanel');
+});

--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
@@ -1,4 +1,4 @@
-import { DashboardPage, expect, test } from '@grafana/plugin-e2e';
+import { expect, test } from '@grafana/plugin-e2e';
 
 import { formatExpectError } from '../errors';
 import { successfulDataQuery } from '../mocks/queries';
@@ -8,6 +8,7 @@ const PANEL_TITLE = 'Table panel E2E test';
 const TABLE_VIZ_NAME = 'Table';
 const STANDARD_OTIONS_CATEGORY = 'Standard options';
 const DISPLAY_NAME_LABEL = 'Display name';
+const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
 
 test.describe('query editor query data', () => {
   test('query data response should be OK when query is valid', async ({ panelEditPage }) => {
@@ -83,4 +84,10 @@ test.describe('edit panel plugin settings', () => {
       formatExpectError('Expected section to be collapsed')
     ).toBeVisible();
   });
+});
+
+test('backToDashboard method should navigate to dashboard page', async ({ gotoPanelEditPage, page }) => {
+  const panelEditPage = await gotoPanelEditPage({ dashboard: REACT_TABLE_DASHBOARD, id: '4' });
+  await panelEditPage.backToDashboard();
+  await expect(page.url()).not.toContain('editPanel');
 });

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "7.0.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "1.8.3",
+    "@grafana/plugin-e2e": "^1.8.3",
     "@grafana/tsconfig": "^2.0.0",
     "@manypkg/get-packages": "^2.2.0",
     "@playwright/test": "1.47.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "7.0.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "1.8.3-canary.1155.64c8314.0",
+    "@grafana/plugin-e2e": "1.8.3",
     "@grafana/tsconfig": "^2.0.0",
     "@manypkg/get-packages": "^2.2.0",
     "@playwright/test": "1.47.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "7.0.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "^1.8.2",
+    "@grafana/plugin-e2e": "1.8.3-canary.1155.64c8314.0",
     "@grafana/tsconfig": "^2.0.0",
     "@manypkg/get-packages": "^2.2.0",
     "@playwright/test": "1.47.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,16 +3949,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:1.8.3-canary.1155.64c8314.0":
-  version: 1.8.3-canary.1155.64c8314.0
-  resolution: "@grafana/plugin-e2e@npm:1.8.3-canary.1155.64c8314.0"
+"@grafana/plugin-e2e@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@grafana/plugin-e2e@npm:1.8.3"
   dependencies:
     semver: "npm:^7.5.4"
     uuid: "npm:^10.0.0"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@playwright/test": ^1.41.2
-  checksum: 10/dc2368cde8697c023de20660482f7829dfb6a1c2b49669885b76bfb309da42d8bcaef453b47cba20b11bbcecb9a38bbcc74a04ff961ae0770232f7c33e5f0f84
+  checksum: 10/bb13d8e9fd6dc5ebb7deb7f3e57ac31c13a6f163337c2eb744a5671a38944ea7c81298bd9c1a65b8d53e1392429a16347134ae215fbda3babc9c4d563312a0bf
   languageName: node
   linkType: hard
 
@@ -18943,7 +18943,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:0.2.6"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:1.8.3-canary.1155.64c8314.0"
+    "@grafana/plugin-e2e": "npm:1.8.3"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,7 +3949,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:1.8.3":
+"@grafana/plugin-e2e@npm:^1.8.3":
   version: 1.8.3
   resolution: "@grafana/plugin-e2e@npm:1.8.3"
   dependencies:
@@ -18943,7 +18943,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:0.2.6"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:1.8.3"
+    "@grafana/plugin-e2e": "npm:^1.8.3"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,16 +3949,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:^1.8.2":
-  version: 1.8.2
-  resolution: "@grafana/plugin-e2e@npm:1.8.2"
+"@grafana/plugin-e2e@npm:1.8.3-canary.1155.64c8314.0":
+  version: 1.8.3-canary.1155.64c8314.0
+  resolution: "@grafana/plugin-e2e@npm:1.8.3-canary.1155.64c8314.0"
   dependencies:
     semver: "npm:^7.5.4"
     uuid: "npm:^10.0.0"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@playwright/test": ^1.41.2
-  checksum: 10/33afac70ec9a926d41f2cc1a07f818f3705e63a33d5c9ce85569b19ec585fed1d8e863a9320c54ca6dc96f8c1e20699bb6ad44714e91ba895c3c937395aa9b16
+  checksum: 10/dc2368cde8697c023de20660482f7829dfb6a1c2b49669885b76bfb309da42d8bcaef453b47cba20b11bbcecb9a38bbcc74a04ff961ae0770232f7c33e5f0f84
   languageName: node
   linkType: hard
 
@@ -18943,7 +18943,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:0.2.6"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:^1.8.2"
+    "@grafana/plugin-e2e": "npm:1.8.3-canary.1155.64c8314.0"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

This PR adds a few more plugin e2e API tests. Goal is to cover as many APIs as possible so that we continuously check for breakages when Grafana changes. 

**Why do we need this feature?**

To ensure plugin-e2e is compatible with latest Grafana.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
