### PR TITLE
UI/AutoSizeInput: Fixes issue where controlledValue being null caused crash

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -32,7 +32,7 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
 
   // Update internal state when controlled `value` prop changes
   useEffect(() => {
-    if (controlledValue !== undefined) {
+    if (controlledValue) {
       setValue(controlledValue);
     }
   }, [controlledValue]);


### PR DESCRIPTION
If `controlledValue` was null, trying to call the `toString` method caused a crash. This PR should prevent that.