### PR TITLE
Explore metrics: Fix bug that turns off otel experience when selecting otel variables

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -381,7 +381,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     }
   }
   /**
-   *  This function is used to update state and otel variables
+   *  This function is used to update state and otel variables.
    * 
    *  1. Set the otelResources adhoc tagKey and tagValues filter functions
       2. Get the otel join query for state and variable
@@ -392,6 +392,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
         - has otel resources flag
         - isStandardOtel flag (for enabliing the otel experience toggle)
         - and useOtelExperience
+   *
+   * This function is called on start and when variables change.
+   * On start will provide the deploymentEnvironments and hasOtelResources parameters.
+   * In the variable change case, we will not provide these parameters. It is assumed that the
+   * data source has been checked for otel resources and standardization and the otel variables are enabled at this point.    
    * @param datasourceUid 
    * @param timeRange 
    * @param otelDepEnvVariable 
@@ -504,7 +509,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       this.setState({
         otelTargets,
         otelJoinQuery,
-        useOtelExperience: false,
       });
     }
   }


### PR DESCRIPTION
**What is this?**

This is a bug fix for when a user selects an otel variable and the otel variables disappear because `useOtelExperience` was being disabled. This keeps the otel variables visible when the variables change, fixing the bug.

How to test:

1. Select an OTel native Prometheus data source. (See your 1password account and search for OTel PRometheus to find credentials to set up an OTel Prometheus DS or ping me @bohandley and I will show you.)
2. Change an otel resource attribute variable selecting a resource attribute key and value.
3. See that the variable UI does not disappear.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
