### PR TITLE
FIX: typo in generic oauth org mapping json

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -313,7 +313,7 @@ Payload:
         "roles": [
             "org_foo",
             "org_bar",
-            "another_org'
+            "another_org"
         ],
         ...
     },


### PR DESCRIPTION
**What is this feature?**

Documentation typo fix

**Why do we need this feature?**

Fixes example documentation to be valid json

**Who is this feature for?**

Readers of org mapping documentation

**Which issue(s) does this PR fix?**:

No known open issue. I can edit this PR with a link to the issue if there is a related issue.

Related PR: #87394

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
