### PR TITLE
Docs:change cli user for operation consistency with UI operation

### DIFF
--- a/docs/sources/cli.md
+++ b/docs/sources/cli.md
@@ -30,7 +30,7 @@ grafana cli -h
 To invoke Grafana CLI, add the path to the grafana binaries in your `PATH` environment variable. Alternately, if your current directory is the `bin` directory, use `./grafana cli`. Otherwise, you can specify full path to the CLI. For example, on Linux `/usr/share/grafana/bin/grafana` and on Windows `C:\Program Files\GrafanaLabs\grafana\bin\grafana.exe`, and invoke it with `grafana cli`.
 
 {{% admonition type="note" %}}
-Some commands, such as installing or removing plugins, require `sudo` on Linux. If you are on Windows, run Windows PowerShell as Administrator.
+Some commands, such as installing or removing plugins, you should run as grafana process user (like `sudo -u grafana`)on Linux. If you are on Windows, run Windows PowerShell as Administrator.
 {{% /admonition %}}
 
 ## Grafana CLI command syntax


### PR DESCRIPTION
Current docs require root user to install plugins through grafana-cli on Linux.

However, if you install some plugins *before* any plugin has been installed through Grafana Web UI, the owner for `/var/lib/grafana/plugins` would be `root` and can't be modified any other users including `grafana` user.

Because of that and this change https://github.com/grafana/grafana/pull/88863
, `/var/lib/grafana/plugins` is no longer readable from `grafana` user so the installed plugin would never work.


```
$ sudo ls -la /var/lib/grafana/
total 12
drwxr-xr-x  3 grafana grafana 4096 Sep  3 15:04 .
drwxr-xr-x 50 root    root    4096 Sep 17 11:01 ..
drwxr-x--- 15 root    root    4096 Sep  3 15:06 plugins
```

To make the cli operation much consistent, this PR change the Linux user for cli operation.

Note: I have no idea about cli operation on Windows, so this PR intend to modify document for Linux users.