### PR TITLE
Prometheus: Suggestions - log parse errors and continue

### DIFF
--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -161,7 +161,8 @@ func (r *Resource) GetSuggestions(ctx context.Context, req *backend.CallResource
 		)
 		s, err := getSelectors(interpolatedQuery)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing selectors: %v", err)
+			r.log.Warn("error parsing selectors", "error", err, "query", query)
+			continue
 		}
 		selectorList = append(selectorList, s...)
 	}

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -161,7 +161,7 @@ func (r *Resource) GetSuggestions(ctx context.Context, req *backend.CallResource
 		)
 		s, err := getSelectors(interpolatedQuery)
 		if err != nil {
-			r.log.Warn("error parsing selectors", "error", err, "query", query)
+			r.log.Warn("error parsing selectors", "error", err, "query", interpolatedQuery)
 			continue
 		}
 		selectorList = append(selectorList, s...)


### PR DESCRIPTION
**What is this feature?**

For now, when parsing a query in the suggest resource, log an error and continue instead of returning the error.

**Why do we need this feature?**

Make it stop 500 for now.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
