### PR TITLE
Alerting: Pluralize error tag

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -1,7 +1,7 @@
 import { isUndefined, omitBy, pick, sum } from 'lodash';
 import pluralize from 'pluralize';
-import { Fragment, useDeferredValue, useMemo } from 'react';
 import * as React from 'react';
+import { Fragment, useDeferredValue, useMemo } from 'react';
 
 import { Badge, Stack } from '@grafana/ui';
 import {
@@ -121,7 +121,7 @@ export function getComponentsFromStats(
   }
 
   if (stats.error) {
-    statsComponents.push(<Badge color="red" key="errors" text={`${stats.error} errors`} />);
+    statsComponents.push(<Badge color="red" key="errors" text={`${stats.error} ${pluralize('error', stats.error)}`} />);
   }
 
   if (stats.nodata) {


### PR DESCRIPTION
**What is this feature?**

This small PR fixes erro tag not pluralising correctly. When having only 1 error we were rendering the word `errors`

**Who is this feature for?**

All users

**Special notes for your reviewer:**

Before: 

<img width="516" alt="Screenshot 2024-10-02 at 16 51 20" src="https://github.com/user-attachments/assets/a4b4d90b-a7a9-4da7-9967-842961b71575">

After:

<img width="552" alt="Screenshot 2024-10-02 at 16 51 48" src="https://github.com/user-attachments/assets/52f933da-9931-4f84-b302-3e5dc6b01c59">


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
