### PR TITLE
SQLStore: Fix parseTime check

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -289,7 +289,7 @@ func (ss *SQLStore) initEngine(engine *xorm.Engine) error {
 	}
 	if engine == nil {
 		// Ensure that parseTime is enabled for MySQL
-		if ss.features.IsEnabledGlobally(featuremgmt.FlagMysqlParseTime) && ss.dbCfg.Type == migrator.MySQL && !strings.Contains(ss.dbCfg.ConnectionString, "parseTime=") {
+		if ss.features.IsEnabledGlobally(featuremgmt.FlagMysqlParseTime) && strings.Contains(ss.dbCfg.Type, migrator.MySQL) && !strings.Contains(ss.dbCfg.ConnectionString, "parseTime=") {
 			if strings.Contains(ss.dbCfg.ConnectionString, "?") {
 				ss.dbCfg.ConnectionString += "&parseTime=true"
 			} else {

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -94,6 +94,13 @@ func TestInitEngine_ParseTimeInConnectionString(t *testing.T) {
 			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&charset=utf8&parseTime=true",
 		},
 		{
+			name:               "MySQL with feature enabled",
+			connectionString:   "mysql://user:password@localhost:3306/existingparams?charset=utf8",
+			dbType:             "mysqlWithHooks",
+			featureEnabled:     true,
+			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&charset=utf8&parseTime=true",
+		},
+		{
 			name:               "MySQL with feature disabled",
 			connectionString:   "mysql://user:password@localhost:3306/disabled",
 			dbType:             "mysql",


### PR DESCRIPTION
**What is this feature?**

This PR fixes the check for cloud, where the database type is [mysqlWithHooks](https://ops.grafana-ops.net/goto/fxHC5dzNg?orgId=1).

**Why do we need this feature?**

To ensure that we are adding the parseTime flag properly whenever it is a mysql database and the feature flag is on

