### PR TITLE
[v11.1.x] Annotations: Fix composite store read

### DIFF
--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -39,7 +39,7 @@ func NewAuthService(db db.DB, features featuremgmt.FeatureToggles) *AuthService 
 }
 
 // Authorize checks if the user has permission to read annotations, then returns a struct containing dashboards and scope types that the user has access to.
-func (authz *AuthService) Authorize(ctx context.Context, query *annotations.ItemQuery) (*AccessResources, error) {
+func (authz *AuthService) Authorize(ctx context.Context, query annotations.ItemQuery) (*AccessResources, error) {
 	user := query.SignedInUser
 	if user == nil || user.IsNil() {
 		return nil, ErrReadForbidden.Errorf("missing user")
@@ -80,7 +80,7 @@ func (authz *AuthService) Authorize(ctx context.Context, query *annotations.Item
 	}, nil
 }
 
-func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *annotations.ItemQuery) (int64, error) {
+func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query annotations.ItemQuery) (int64, error) {
 	var items []annotations.Item
 	params := make([]any, 0)
 	err := authz.db.WithDbSession(ctx, func(sess *db.Session) error {
@@ -106,7 +106,7 @@ func (authz *AuthService) getAnnotationDashboard(ctx context.Context, query *ann
 	return items[0].DashboardID, nil
 }
 
-func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, query *annotations.ItemQuery) (map[string]int64, error) {
+func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, query annotations.ItemQuery) (map[string]int64, error) {
 	recursiveQueriesSupported, err := authz.db.RecursiveQueriesAreSupported()
 	if err != nil {
 		return nil, err

--- a/pkg/services/annotations/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol_test.go
@@ -175,7 +175,7 @@ func TestIntegrationAuthorize(t *testing.T) {
 
 			authz := NewAuthService(sql, featuremgmt.WithFeatures(tc.featureToggle))
 
-			query := &annotations.ItemQuery{SignedInUser: u, OrgID: 1}
+			query := annotations.ItemQuery{SignedInUser: u, OrgID: 1}
 			resources, err := authz.Authorize(context.Background(), query)
 			require.NoError(t, err)
 

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -75,7 +75,7 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 	// Search without dashboard UID filter is expensive, so check without access control first
 	if query.DashboardID == 0 && query.DashboardUID == "" {
 		// Return early if no annotations found, it's not necessary to perform expensive access control filtering
-		res, err := r.reader.Get(ctx, query, &accesscontrol.AccessResources{
+		res, err := r.reader.Get(ctx, *query, &accesscontrol.AccessResources{
 			SkipAccessControlFilter: true,
 		})
 		if err != nil || len(res) == 0 {
@@ -93,12 +93,12 @@ func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery)
 	// Iterate over available annotations until query limit is reached
 	// or all available dashboards are checked
 	for len(results) < int(query.Limit) {
-		resources, err := r.authZ.Authorize(ctx, query)
+		resources, err := r.authZ.Authorize(ctx, *query)
 		if err != nil {
 			return nil, err
 		}
 
-		res, err := r.reader.Get(ctx, query, resources)
+		res, err := r.reader.Get(ctx, *query, resources)
 		if err != nil {
 			return nil, err
 		}
@@ -119,5 +119,5 @@ func (r *RepositoryImpl) Delete(ctx context.Context, params *annotations.DeleteP
 }
 
 func (r *RepositoryImpl) FindTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
-	return r.reader.GetTags(ctx, query)
+	return r.reader.GetTags(ctx, *query)
 }

--- a/pkg/services/annotations/annotationsimpl/composite_store.go
+++ b/pkg/services/annotations/annotationsimpl/composite_store.go
@@ -31,7 +31,7 @@ func (c *CompositeStore) Type() string {
 }
 
 // Get returns annotations from all stores, and combines the results.
-func (c *CompositeStore) Get(ctx context.Context, query *annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
+func (c *CompositeStore) Get(ctx context.Context, query annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
 	itemCh := make(chan []*annotations.ItemDTO, len(c.readers))
 
 	err := concurrency.ForEachJob(ctx, len(c.readers), len(c.readers), func(ctx context.Context, i int) (err error) {
@@ -56,7 +56,7 @@ func (c *CompositeStore) Get(ctx context.Context, query *annotations.ItemQuery, 
 }
 
 // GetTags returns tags from all stores, and combines the results.
-func (c *CompositeStore) GetTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+func (c *CompositeStore) GetTags(ctx context.Context, query annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	resCh := make(chan annotations.FindTagsResult, len(c.readers))
 
 	err := concurrency.ForEachJob(ctx, len(c.readers), len(c.readers), func(ctx context.Context, i int) (err error) {

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store.go
@@ -8,24 +8,21 @@ import (
 	"sort"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/constraints"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/annotations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert"
-
-	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/log"
 	ngmetrics "github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/state/historian"
 	historymodel "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errutil"
 )

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store.go
@@ -8,11 +8,12 @@ import (
 	"sort"
 	"time"
 
+	"golang.org/x/exp/constraints"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/annotations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert"
-	"golang.org/x/exp/constraints"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -73,7 +74,7 @@ func (r *LokiHistorianStore) Type() string {
 	return "loki"
 }
 
-func (r *LokiHistorianStore) Get(ctx context.Context, query *annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
+func (r *LokiHistorianStore) Get(ctx context.Context, query annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
 	if query.Type == "annotation" {
 		return make([]*annotations.ItemDTO, 0), nil
 	}
@@ -96,7 +97,7 @@ func (r *LokiHistorianStore) Get(ctx context.Context, query *annotations.ItemQue
 		}
 	}
 
-	logQL, err := historian.BuildLogQuery(buildHistoryQuery(query, accessResources.Dashboards, rule.UID))
+	logQL, err := historian.BuildLogQuery(buildHistoryQuery(&query, accessResources.Dashboards, rule.UID))
 	if err != nil {
 		return make([]*annotations.ItemDTO, 0), ErrLokiStoreInternal.Errorf("failed to build loki query: %w", err)
 	}
@@ -178,7 +179,7 @@ func (r *LokiHistorianStore) annotationsFromStream(stream historian.Stream, ac a
 	return items
 }
 
-func (r *LokiHistorianStore) GetTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+func (r *LokiHistorianStore) GetTags(ctx context.Context, query annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	return annotations.FindTagsResult{Tags: []*annotations.TagsDTO{}}, nil
 }
 

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -29,8 +30,6 @@ import (
 	historymodel "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/loki/historian_store_test.go
@@ -94,7 +94,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,
@@ -120,7 +120,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,
@@ -144,7 +144,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,
@@ -170,7 +170,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,
@@ -200,7 +200,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,
@@ -229,7 +229,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,
@@ -263,7 +263,7 @@ func TestIntegrationAlertStateHistoryStore(t *testing.T) {
 			}
 			res, err := store.Get(
 				context.Background(),
-				&query,
+				query,
 				&annotation_ac.AccessResources{
 					Dashboards: map[string]int64{
 						dashboard1.UID: dashboard1.ID,

--- a/pkg/services/annotations/annotationsimpl/store.go
+++ b/pkg/services/annotations/annotationsimpl/store.go
@@ -20,8 +20,8 @@ type commonStore interface {
 
 type readStore interface {
 	commonStore
-	Get(ctx context.Context, query *annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error)
-	GetTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error)
+	Get(ctx context.Context, query annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error)
+	GetTags(ctx context.Context, query annotations.TagsQuery) (annotations.FindTagsResult, error)
 }
 
 type writeStore interface {

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -245,7 +245,7 @@ func tagSet[T any](fn func(T) int64, list []T) map[int64]struct{} {
 	return set
 }
 
-func (r *xormRepositoryImpl) Get(ctx context.Context, query *annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
+func (r *xormRepositoryImpl) Get(ctx context.Context, query annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
 	var sql bytes.Buffer
 	params := make([]interface{}, 0)
 	items := make([]*annotations.ItemDTO, 0)
@@ -446,7 +446,7 @@ func (r *xormRepositoryImpl) Delete(ctx context.Context, params *annotations.Del
 	})
 }
 
-func (r *xormRepositoryImpl) GetTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+func (r *xormRepositoryImpl) GetTags(ctx context.Context, query annotations.TagsQuery) (annotations.FindTagsResult, error) {
 	var items []*annotations.Tag
 	err := r.db.WithDbSession(ctx, func(dbSession *db.Session) error {
 		if query.Limit == 0 {

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -133,7 +133,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		assert.Greater(t, organizationAnnotation2.ID, int64(0))
 
 		t.Run("Can query for annotation by dashboard id", func(t *testing.T) {
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  dashboard.ID,
 				From:         0,
@@ -182,7 +182,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 			err := store.AddMany(context.Background(), items)
 
 			require.NoError(t, err)
-			query := &annotations.ItemQuery{OrgID: 100, SignedInUser: testUser}
+			query := annotations.ItemQuery{OrgID: 100, SignedInUser: testUser}
 			accRes := &annotation_ac.AccessResources{CanAccessOrgAnnotations: true}
 			inserted, err := store.Get(context.Background(), query, accRes)
 			require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 			err := store.AddMany(context.Background(), items)
 
 			require.NoError(t, err)
-			query := &annotations.ItemQuery{OrgID: 101, SignedInUser: testUser}
+			query := annotations.ItemQuery{OrgID: 101, SignedInUser: testUser}
 			accRes := &annotation_ac.AccessResources{CanAccessOrgAnnotations: true}
 			inserted, err := store.Get(context.Background(), query, accRes)
 			require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Can query for annotation by id", func(t *testing.T) {
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				AnnotationID: annotation2.ID,
 				SignedInUser: testUser,
@@ -237,7 +237,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 				Dashboards:               map[string]int64{"foo": 1},
 				CanAccessDashAnnotations: true,
 			}
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         12,
@@ -253,7 +253,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 				Dashboards:               map[string]int64{"foo": 1},
 				CanAccessDashAnnotations: true,
 			}
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         1,
@@ -270,7 +270,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 				Dashboards:               map[string]int64{"foo": 1},
 				CanAccessDashAnnotations: true,
 			}
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         1,
@@ -287,7 +287,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 				Dashboards:               map[string]int64{"foo": 1},
 				CanAccessDashAnnotations: true,
 			}
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         1,
@@ -301,7 +301,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 
 		t.Run("Should find two annotations using partial match", func(t *testing.T) {
 			accRes := &annotation_ac.AccessResources{CanAccessOrgAnnotations: true}
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				From:         1,
 				To:           25,
@@ -318,7 +318,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 				Dashboards:               map[string]int64{"foo": 1},
 				CanAccessDashAnnotations: true,
 			}
-			items, err := store.Get(context.Background(), &annotations.ItemQuery{
+			items, err := store.Get(context.Background(), annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         1,
@@ -331,7 +331,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Can update annotation and remove all tags", func(t *testing.T) {
-			query := &annotations.ItemQuery{
+			query := annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         0,
@@ -366,7 +366,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Can update annotation with new tags", func(t *testing.T) {
-			query := &annotations.ItemQuery{
+			query := annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         0,
@@ -399,7 +399,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Can update annotation with additional tags", func(t *testing.T) {
-			query := &annotations.ItemQuery{
+			query := annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         0,
@@ -432,7 +432,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Can update annotations with data", func(t *testing.T) {
-			query := &annotations.ItemQuery{
+			query := annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         0,
@@ -468,7 +468,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Can delete annotation", func(t *testing.T) {
-			query := &annotations.ItemQuery{
+			query := annotations.ItemQuery{
 				OrgID:        1,
 				DashboardID:  1,
 				From:         0,
@@ -512,7 +512,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 				CanAccessDashAnnotations: true,
 			}
 
-			query := &annotations.ItemQuery{
+			query := annotations.ItemQuery{
 				OrgID:        1,
 				AnnotationID: annotation3.ID,
 				SignedInUser: testUser,
@@ -531,7 +531,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Should find tags by key", func(t *testing.T) {
-			result, err := store.GetTags(context.Background(), &annotations.TagsQuery{
+			result, err := store.GetTags(context.Background(), annotations.TagsQuery{
 				OrgID: 1,
 				Tag:   "server",
 			})
@@ -542,7 +542,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Should find tags by value", func(t *testing.T) {
-			result, err := store.GetTags(context.Background(), &annotations.TagsQuery{
+			result, err := store.GetTags(context.Background(), annotations.TagsQuery{
 				OrgID: 1,
 				Tag:   "outage",
 			})
@@ -555,7 +555,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Should not find tags in other org", func(t *testing.T) {
-			result, err := store.GetTags(context.Background(), &annotations.TagsQuery{
+			result, err := store.GetTags(context.Background(), annotations.TagsQuery{
 				OrgID: 0,
 				Tag:   "server-1",
 			})
@@ -564,7 +564,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		})
 
 		t.Run("Should not find tags that do not exist", func(t *testing.T) {
-			result, err := store.GetTags(context.Background(), &annotations.TagsQuery{
+			result, err := store.GetTags(context.Background(), annotations.TagsQuery{
 				OrgID: 0,
 				Tag:   "unknown:tag",
 			})
@@ -650,7 +650,7 @@ func benchmarkFindTags(b *testing.B, numAnnotations int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result, err := store.GetTags(context.Background(), &annotations.TagsQuery{
+		result, err := store.GetTags(context.Background(), annotations.TagsQuery{
 			OrgID: 1,
 			Tag:   "outage",
 		})


### PR DESCRIPTION
Backport bd1741653d66509c8464472608df38ea0ef19d99 from #94158

---

**What is this feature?**

This PR fixes race condition in annotations query when composite store is used. Root cause was that `query` param was passed by reference, and then loki store set default time range to `From:now To:-6h`, so grafana db query was affected by this modification. Solution is not to pass query by ref, but instead pass it by value (I haven't found any reason why it should be passed as a ref).

Race condition started to appear after https://github.com/grafana/grafana/pull/93547 since extra `reader.Get()` was introduced inside `Find()` function for optimization purpose.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
