### PR TITLE
Tempo: Update lezer-traceql version

### DIFF
--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -9,7 +9,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "1.8.0",
     "@grafana/lezer-logql": "0.2.6",
-    "@grafana/lezer-traceql": "0.0.18",
+    "@grafana/lezer-traceql": "0.0.19",
     "@grafana/monaco-logql": "^0.0.7",
     "@grafana/o11y-ds-frontend": "workspace:*",
     "@grafana/runtime": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,7 +3485,7 @@ __metadata:
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/experimental": "npm:1.8.0"
     "@grafana/lezer-logql": "npm:0.2.6"
-    "@grafana/lezer-traceql": "npm:0.0.18"
+    "@grafana/lezer-traceql": "npm:0.0.19"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
     "@grafana/plugin-configs": "npm:11.3.0-pre"
@@ -3875,12 +3875,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-traceql@npm:0.0.18":
-  version: 0.0.18
-  resolution: "@grafana/lezer-traceql@npm:0.0.18"
+"@grafana/lezer-traceql@npm:0.0.19":
+  version: 0.0.19
+  resolution: "@grafana/lezer-traceql@npm:0.0.19"
   peerDependencies:
     "@lezer/lr": ^1.3.0
-  checksum: 10/2695c7287f933abe1c3885be8519142d4eaa2675dcc47b92883962a556c0cc3f5dfc644788c8f8994e373b7b00e0e617015c0855452612c3dab9f6ab4b7827ae
+  checksum: 10/e4ca2512c215ad94f6bf926d87b044e2c83ed7196cfbe770a5e75b62a97273925e4187ddec8bd57470fc6ed645185b6298f3bddf7591da5af2671158aa7aefc7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Updates Tempo lezer-traceql version.

**Why do we need this feature?**

To get access to [latest Tempo intrinsics](https://github.com/grafana/tempo/blob/main/docs/sources/tempo/traceql/_index.md#intrinsic-fields), added in this [PR](https://github.com/grafana/lezer-traceql/pull/22).

**Who is this feature for?**

Tempo users.
