### PR TITLE
Auth: Replace jmespath/go-jmespath with jmespath-community/go-jmespath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/huandu/xstrings v1.3.3 // @grafana/partner-datasources
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0 // @grafana/observability-metrics
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
-	github.com/jmespath/go-jmespath v0.4.0 // @grafana/grafana-backend-group
+	github.com/jmespath/go-jmespath v0.4.0 // indirect; @grafana/grafana-backend-group
 	github.com/jmoiron/sqlx v1.3.5 // @grafana/grafana-backend-group
 	github.com/json-iterator/go v1.1.12 // @grafana/grafana-backend-group
 	github.com/lib/pq v1.10.9 // @grafana/grafana-backend-group
@@ -477,6 +477,8 @@ require (
 	github.com/getkin/kin-openapi v0.127.0 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana/apps/playlist v0.0.0-20240917082838-e2bce38a7990 // @grafana/grafana-app-platform-squad
 )
+
+require github.com/jmespath-community/go-jmespath v1.1.1 // @grafana/identity-access-team
 
 require (
 	cloud.google.com/go/longrunning v0.5.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2524,6 +2524,8 @@ github.com/jhump/protoreflect v1.11.0/go.mod h1:U7aMIjN0NWq9swDP7xDdoMfRHb35uiuT
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/jmattheis/goverter v1.4.0/go.mod h1:iVIl/4qItWjWj2g3vjouGoYensJbRqDHpzlEVMHHFeY=
+github.com/jmespath-community/go-jmespath v1.1.1 h1:bFikPhsi/FdmlZhVgSCd2jj1e7G/rw+zyQfyg5UF+L4=
+github.com/jmespath-community/go-jmespath v1.1.1/go.mod h1:4gOyFJsR/Gk+05RgTKYrifT7tBPWD8Lubtb5jRrfy9I=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -3,7 +3,7 @@ package util
 import (
 	"encoding/json"
 
-	"github.com/jmespath/go-jmespath"
+	"github.com/jmespath-community/go-jmespath"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 )
@@ -86,7 +86,7 @@ func searchJSONForAttr(attributePath string, data any) (any, error) {
 	}
 
 	// Copy the data to a new variable
-	var jsonData = data
+	jsonData := data
 
 	// If the data is a byte slice, try to unmarshal it into a JSON object
 	if dataBytes, ok := data.([]byte); ok {

--- a/pkg/util/json_test.go
+++ b/pkg/util/json_test.go
@@ -153,3 +153,34 @@ func TestSearchJSONForEmail(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchJSONForStringAttr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		Name           string
+		SearchObject   any
+		AttributePath  string
+		ExpectedResult string
+	}{
+		{
+			Name: "Case insensitive contains using lower function from works correctly",
+			SearchObject: map[string]any{
+				"groups": []string{
+					"fOO",
+				},
+			},
+			AttributePath:  "contains(groups[*].lower(@) ,lower('FOO')) && 'success' || 'failure'",
+			ExpectedResult: "success",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			actualResult, err := util.SearchJSONForStringAttr(test.AttributePath, test.SearchObject)
+			require.NoError(t, err)
+			require.Equal(t, test.ExpectedResult, actualResult)
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**
Replaces `github.com/jmespath/go-jmespath` with `github.com/jmespath-community/go-jmespath`.

**Why do we need this feature?**
`github.com/jmespath-community/go-jmespath` is up to date and supports the lates specification of JMESPath (including functions like `lower()`)

**Who is this feature for?**
Anyone who would like to use more advanced queries for OAuth role mapping (using the `role_attribute_path` config).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
