### PR TITLE
Elasticsearch: Use templateSrv.getVariables instead of dashboard.getVariables

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6095,6 +6095,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "1"],
       [0, 0, 0, "Styles should be written using objects.", "2"]
     ],
+    "public/app/plugins/datasource/elasticsearch/datasource.test.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
     "public/app/plugins/datasource/elasticsearch/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -6095,9 +6095,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Styles should be written using objects.", "1"],
       [0, 0, 0, "Styles should be written using objects.", "2"]
     ],
-    "public/app/plugins/datasource/elasticsearch/datasource.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/plugins/datasource/elasticsearch/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -938,23 +938,13 @@ describe('ElasticDatasource', () => {
 
       it('should process annotation request using dashboard adhoc variables', async () => {
         const ds = createElasticDatasource({
-          getVariables: () =>
-            [
-              {
-                type: 'adhoc',
-                datasource: {
-                  type: 'elasticsearch',
-                  uid: 'gdev-elasticsearch',
-                },
-                filters: [
-                  {
-                    key: 'abc_key',
-                    operator: '=',
-                    value: 'abc_value',
-                  },
-                ],
-              },
-            ] as any[],
+          getAdhocFilters: () => [
+            {
+              key: 'abc_key',
+              operator: '=',
+              value: 'abc_value',
+            },
+          ],
         });
         const postResourceRequestMock = jest.spyOn(ds, 'postResourceRequest').mockResolvedValue({
           responses: [

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -937,7 +937,25 @@ describe('ElasticDatasource', () => {
       });
 
       it('should process annotation request using dashboard adhoc variables', async () => {
-        const ds = createElasticDatasource();
+        const ds = createElasticDatasource({
+          getVariables: () =>
+            [
+              {
+                type: 'adhoc',
+                datasource: {
+                  type: 'elasticsearch',
+                  uid: 'gdev-elasticsearch',
+                },
+                filters: [
+                  {
+                    key: 'abc_key',
+                    operator: '=',
+                    value: 'abc_value',
+                  },
+                ],
+              },
+            ] as any[],
+        });
         const postResourceRequestMock = jest.spyOn(ds, 'postResourceRequest').mockResolvedValue({
           responses: [
             {
@@ -964,24 +982,7 @@ describe('ElasticDatasource', () => {
               uid: 'gdev-elasticsearch',
             },
           },
-          dashboard: {
-            getVariables: () => [
-              {
-                type: 'adhoc',
-                datasource: {
-                  type: 'elasticsearch',
-                  uid: 'gdev-elasticsearch',
-                },
-                filters: [
-                  {
-                    key: 'abc_key',
-                    operator: '=',
-                    value: 'abc_value',
-                  },
-                ],
-              },
-            ],
-          },
+          dashboard: {},
           range: {
             from: dateTime(1683291160012),
             to: dateTime(1683291460012),

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -37,16 +37,16 @@ import {
   DataSourceGetTagValuesOptions,
   AdHocVariableFilter,
   DataSourceWithQueryModificationSupport,
-  AdHocVariableModel,
   TypedVariableModel,
 } from '@grafana/data';
 import {
   DataSourceWithBackend,
   getDataSourceSrv,
   BackendSrvRequest,
-  TemplateSrv,
+  TemplateSrv as BaseTemplateSrv,
   getTemplateSrv,
 } from '@grafana/runtime';
+import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { IndexPattern, intervalMap } from './IndexPattern';
 import LanguageProvider from './LanguageProvider';
@@ -130,7 +130,7 @@ export class ElasticDatasource
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
-    private readonly templateSrv: TemplateSrv = getTemplateSrv()
+    private readonly templateSrv: BaseTemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
     this.basicAuth = instanceSettings.basicAuth;
@@ -272,9 +272,7 @@ export class ElasticDatasource
     const timeEndField = annotation.timeEndField || null;
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const adhocVariables = this.templateSrv.getVariables().filter((v) => v.type === 'adhoc') as AdHocVariableModel[];
-    const annotationRelatedVariables = adhocVariables.filter((v) => v.datasource?.uid === annotation.datasource.uid);
-    const filters = annotationRelatedVariables.map((v) => v.filters).flat();
+    const filters = (this.templateSrv as TemplateSrv).getAdhocFilters(this.name, true);
 
     // the `target.query` is the "new" location for the query.
     // normally we would write this code as

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -270,10 +270,9 @@ export class ElasticDatasource
     const annotation = options.annotation;
     const timeField = annotation.timeField || '@timestamp';
     const timeEndField = annotation.timeEndField || null;
-    const dashboard = options.dashboard;
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const adhocVariables = dashboard.getVariables().filter((v) => v.type === 'adhoc') as AdHocVariableModel[];
+    const adhocVariables = this.templateSrv.getVariables().filter((v) => v.type === 'adhoc') as AdHocVariableModel[];
     const annotationRelatedVariables = adhocVariables.filter((v) => v.datasource?.uid === annotation.datasource.uid);
     const filters = annotationRelatedVariables.map((v) => v.filters).flat();
 

--- a/public/app/plugins/datasource/elasticsearch/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/mocks.ts
@@ -1,13 +1,23 @@
-import { CoreApp, DataQueryRequest, DataSourceInstanceSettings, FieldType, PluginType, dateTime } from '@grafana/data';
+import {
+  CoreApp,
+  DataQueryRequest,
+  DataSourceInstanceSettings,
+  FieldType,
+  PluginType,
+  TypedVariableModel,
+  dateTime,
+} from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 import { ElasticDatasource } from './datasource';
 import { ElasticsearchOptions, ElasticsearchQuery } from './types';
 
 export function createElasticDatasource(
-  settings: Partial<DataSourceInstanceSettings<Partial<ElasticsearchOptions>>> = {}
+  settings: Partial<DataSourceInstanceSettings<Partial<ElasticsearchOptions>>> & {
+    getVariables?: () => TypedVariableModel[];
+  } = {}
 ) {
-  const { jsonData, ...rest } = settings;
+  const { jsonData, getVariables = () => [], ...rest } = settings;
 
   const instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions> = {
     id: 1,
@@ -48,7 +58,7 @@ export function createElasticDatasource(
   };
 
   const templateSrv: TemplateSrv = {
-    getVariables: () => [],
+    getVariables,
     replace: (text?: string) => {
       if (text?.startsWith('$')) {
         return `resolvedVariable`;

--- a/public/app/plugins/datasource/elasticsearch/mocks.ts
+++ b/public/app/plugins/datasource/elasticsearch/mocks.ts
@@ -1,23 +1,24 @@
 import {
+  AdHocVariableFilter,
   CoreApp,
   DataQueryRequest,
   DataSourceInstanceSettings,
   FieldType,
   PluginType,
-  TypedVariableModel,
   dateTime,
 } from '@grafana/data';
-import { TemplateSrv } from '@grafana/runtime';
+import { TemplateSrv as BaseTemplateSrv } from '@grafana/runtime';
+import type { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { ElasticDatasource } from './datasource';
 import { ElasticsearchOptions, ElasticsearchQuery } from './types';
 
 export function createElasticDatasource(
   settings: Partial<DataSourceInstanceSettings<Partial<ElasticsearchOptions>>> & {
-    getVariables?: () => TypedVariableModel[];
+    getAdhocFilters?: (dsName: string, ignoreWarnings?: boolean) => AdHocVariableFilter[];
   } = {}
 ) {
-  const { jsonData, getVariables = () => [], ...rest } = settings;
+  const { jsonData, getAdhocFilters = (dsName: string) => [], ...rest } = settings;
 
   const instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions> = {
     id: 1,
@@ -57,8 +58,9 @@ export function createElasticDatasource(
     ...rest,
   };
 
-  const templateSrv: TemplateSrv = {
-    getVariables,
+  const templateSrv: BaseTemplateSrv & Pick<TemplateSrv, 'getAdhocFilters'> = {
+    getVariables: () => [],
+    getAdhocFilters,
     replace: (text?: string) => {
       if (text?.startsWith('$')) {
         return `resolvedVariable`;


### PR DESCRIPTION
Fix for the following escalation: https://github.com/grafana/support-escalations/issues/12768

Under scenes, elasticsearch annotation queries would fail when attempting to call `dashboard.getVariables`:
https://github.com/grafana/grafana/blob/4623a6471bf77036ea3f0f17b0ff4e94272bb01a/public/app/plugins/datasource/elasticsearch/datasource.ts#L276

This is because the "dashboard" provided when `executeAnnotationQuery` is called from scenes is just an empty object:

https://github.com/grafana/scenes/blob/3c528dc05aa5b7e96aa312d7dfaa7e82fcc3250b/packages/scenes/src/querying/layers/annotations/standardAnnotationQuery.ts#L48-L53

Initially we had the idea of populating the object with a `getVariables` method that called `getVariablesCompatibility`, but all of that code exists in the grafana repo, and moving it to the scenes repo seemed like a mismatch.

With that said, in this PR I've changed the elasticsearch datasource implementation itself to call `this.templateSrv.getVariables` rather than `dashboard.getVariables`. Tests still seem to pass and some brief manual testing left the impression that it doesn't break things, but this datasource isn't my bread and butter, so if someone from @grafana/aws-datasources can double-check that this makes sense I'd really appreciate it. :)
