### PR TITLE
Anonymous: Fix anonymous cache ignoring device limit evaluation

### DIFF
--- a/pkg/services/anonymous/anonimpl/client.go
+++ b/pkg/services/anonymous/anonimpl/client.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	errInvalidOrg = errutil.Unauthorized("anonymous.invalid-org")
-	errInvalidID  = errutil.Unauthorized("anonymous.invalid-id")
+	errInvalidOrg  = errutil.Unauthorized("anonymous.invalid-org")
+	errInvalidID   = errutil.Unauthorized("anonymous.invalid-id")
+	errDeviceLimit = errutil.Unauthorized("anonymous.device-limit-reached", errutil.WithPublicMessage("Anonymous device limit reached. Contact Administrator"))
 )
 
 var _ authn.ContextAwareClient = new(Anonymous)
@@ -51,7 +52,7 @@ func (a *Anonymous) Authenticate(ctx context.Context, r *authn.Request) (*authn.
 
 	if err := a.anonDeviceService.TagDevice(ctx, httpReqCopy, anonymous.AnonDeviceUI); err != nil {
 		if errors.Is(err, anonstore.ErrDeviceLimitReached) {
-			return nil, err
+			return nil, errDeviceLimit.Errorf("limit reached for anonymous devices: %w", err)
 		}
 
 		a.log.Warn("Failed to tag anonymous session", "error", err)

--- a/pkg/services/anonymous/anonimpl/impl.go
+++ b/pkg/services/anonymous/anonimpl/impl.go
@@ -79,20 +79,29 @@ func (a *AnonDeviceService) usageStatFn(ctx context.Context) (map[string]any, er
 	}, nil
 }
 
-func (a *AnonDeviceService) tagDeviceUI(ctx context.Context, httpReq *http.Request, device *anonstore.Device) error {
+func (a *AnonDeviceService) tagDeviceUI(ctx context.Context, device *anonstore.Device) error {
 	key := device.CacheKey()
 
-	if _, ok := a.localCache.Get(key); ok {
+	if val, ok := a.localCache.Get(key); ok {
+		if boolVal, ok := val.(bool); ok && !boolVal {
+			return anonstore.ErrDeviceLimitReached
+		}
 		return nil
 	}
 
-	a.localCache.SetDefault(key, struct{}{})
+	a.localCache.SetDefault(key, true)
 
 	if a.cfg.Env == setting.Dev {
 		a.log.Debug("Tagging device for UI", "deviceID", device.DeviceID, "device", device, "key", key)
 	}
 
 	if err := a.anonStore.CreateOrUpdateDevice(ctx, device); err != nil {
+		if err == anonstore.ErrDeviceLimitReached {
+			a.localCache.SetDefault(key, false)
+			return err
+		}
+		// invalidate cache if there is an error
+		a.localCache.Delete(key)
 		return err
 	}
 
@@ -142,7 +151,7 @@ func (a *AnonDeviceService) TagDevice(ctx context.Context, httpReq *http.Request
 		UpdatedAt: time.Now(),
 	}
 
-	err = a.tagDeviceUI(ctx, httpReq, taggedDevice)
+	err = a.tagDeviceUI(ctx, taggedDevice)
 	if err != nil {
 		a.log.Debug("Failed to tag device for UI", "error", err)
 		return err

--- a/pkg/services/anonymous/anonimpl/impl.go
+++ b/pkg/services/anonymous/anonimpl/impl.go
@@ -2,6 +2,7 @@ package anonimpl
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -96,7 +97,7 @@ func (a *AnonDeviceService) tagDeviceUI(ctx context.Context, device *anonstore.D
 	}
 
 	if err := a.anonStore.CreateOrUpdateDevice(ctx, device); err != nil {
-		if err == anonstore.ErrDeviceLimitReached {
+		if errors.Is(err, anonstore.ErrDeviceLimitReached) {
 			a.localCache.SetDefault(key, false)
 			return err
 		}


### PR DESCRIPTION
**What is this feature?**

- Fix issue with anonymous cache ignoring device limit evaluation (Fixes https://github.com/grafana/grafana/issues/93755)
- Add 2 types of end user warnings for device limit reached

![Screenshot_20241003_163329](https://github.com/user-attachments/assets/408fd336-0b59-4a42-9d0a-edd64f5bc54b)
![Screenshot_20241003_163210](https://github.com/user-attachments/assets/b0663190-4319-46e3-8d1f-24575f83bce6)