### PR TITLE
Explore Logs: Preinstall for onprem Grafana instances

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1740,7 +1740,7 @@ hide_angular_deprecation =
 # Comma separated list of plugin ids for which environment variables should be forwarded. Used only when feature flag pluginsSkipHostEnvVars is enabled.
 forward_host_env_vars =
 # Comma separated list of plugin ids to install as part of the startup process.
-preinstall =
+preinstall = grafana-lokiexplore-app
 # Controls whether preinstall plugins asynchronously (in the background) or synchronously (blocking). Useful when preinstalled plugins are used with provisioning.
 preinstall_async = true
 # Disables preinstall feature. It has the same effect as setting preinstall to an empty list.


### PR DESCRIPTION
**What is this feature?**

This PR will preinstall Explore Logs (https://grafana.com/grafana/plugins/grafana-lokiexplore-app/) on all onprem Grafana instances.