### PR TITLE
Scenes: add clearSceneCache to DashboardScenePageStateManager

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -289,6 +289,10 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
     this.cache[cacheKey] = scene;
   }
 
+  public clearSceneCache() {
+    this.cache = {};
+  }
+
   public getCacheKey(cacheKey: string): string {
     const scopesCacheKey = getSelectedScopesNames().sort().join('__scp__');
 


### PR DESCRIPTION
**What is this feature?**
Adds a function to clear the cache of DashboardScenePageStateManager

**Why do we need this feature?**
This is the only solution I found to make [my tests on the reporting page](https://github.com/grafana/grafana-enterprise/pull/6809) work. If there is another way to do it, I'm OK to close this. 

