### PR TITLE
Chore: Add Makefile target to efficiently lint only locally changed Go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 GO_BUILD_FLAGS += $(GO_RACE_FLAG)
 
+# GNU xargs has flag -r, and BSD xargs (e.g. MacOS) has that behaviour by default
+XARGSR = $(shell xargs --version 2>&1 | grep -q GNU && echo xargs -r || echo xargs)
+
 targets := $(shell echo '$(sources)' | tr "," " ")
 
 GO_INTEGRATION_TESTS := $(shell find ./pkg -type f -name '*_test.go' -exec grep -l '^func TestIntegration' '{}' '+' | grep -o '\(.*\)/' | sort -u)
@@ -306,10 +309,11 @@ lint-go: golangci-lint ## Run all code checks for backend. You can use GO_LINT_F
 .PHONY: lint-go-diff
 lint-go-diff: $(GOLANGCI_LINT)
 	git diff --name-only remotes/origin/main | \
-		xargs dirname | \
+		grep '\.go$$' | \
+		$(XARGSR) dirname | \
 		sort -u | \
 		sed 's,^,./,' | \
-		xargs $(GOLANGCI_LINT) run --config .golangci.toml
+		$(XARGSR) $(GOLANGCI_LINT) run --config .golangci.toml
 
 # with disabled SC1071 we are ignored some TCL,Expect `/usr/bin/env expect` scripts
 .PHONY: shellcheck

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,14 @@ golangci-lint: $(GOLANGCI_LINT)
 .PHONY: lint-go
 lint-go: golangci-lint ## Run all code checks for backend. You can use GO_LINT_FILES to specify exact files to check
 
+.PHONY: lint-go-diff
+lint-go-diff: $(GOLANGCI_LINT)
+	git diff --name-only remotes/origin/main | \
+		xargs dirname | \
+		sort -u | \
+		sed 's,^,./,' | \
+		xargs $(GOLANGCI_LINT) run --config .golangci.toml
+
 # with disabled SC1071 we are ignored some TCL,Expect `/usr/bin/env expect` scripts
 .PHONY: shellcheck
 shellcheck: $(SH_FILES) ## Run checks for shell scripts.


### PR DESCRIPTION
**What is this feature?**

Add Makefile target to efficiently lint only the directories where Go files where changed. To use it, run the following in the repo root: `make lint-go-diff`

I don't see how this could not produce the same as `make lint-go`, but will not replace that target and will not change any pipeline just in case.

**Why do we need this feature?**

To improve Go development experience.

**Who is this feature for?**

Go developers.