### PR TITLE
QueryLibrary: Don't use description when generating name

### DIFF
--- a/public/app/features/query-library/api/mappers.ts
+++ b/public/app/features/query-library/api/mappers.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { AddQueryTemplateCommand, QueryTemplate } from '../types';
 
 import { API_VERSION, QueryTemplateKinds } from './query';
@@ -48,7 +50,11 @@ export const convertAddQueryTemplateCommandToDataQuerySpec = (
     apiVersion: API_VERSION,
     kind: QueryTemplateKinds.QueryTemplate,
     metadata: {
-      generateName: 'A' + title.replaceAll(' ', '-'),
+      /**
+       * Server will append to whatever is passed here, but just to be safe we generate a uuid
+       * More info https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency
+       */
+      generateName: uuidv4(),
     },
     spec: {
       title: title,


### PR DESCRIPTION
When creating a query template, we were using whatever was in description and passing it to generateName. This causes an error when we have special characters like ' or ? in description because names in k8s can't have special characters. 

More info:
Name https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
Generate Name https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#idempotency

The confusing thing is that description is actually `title` in the backend spec. We could probably change this in the future.

The issue:


https://github.com/user-attachments/assets/1ee49236-a861-4319-9d84-027f4b98325c


After:

https://github.com/user-attachments/assets/be4749f1-d6a5-4ced-a0b8-07c5c9e962dc



Fixes #94235 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.

