### PR TITLE
Limit: Prevent negative limit

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/limit.ts
+++ b/packages/grafana-data/src/transformations/transformers/limit.ts
@@ -34,6 +34,10 @@ export const limitTransformer: DataTransformerInfo<LimitTransformerOptions> = {
             limit = options.limitField;
           }
         }
+        // Prevent negative limit
+        if (limit < 0) {
+          limit = 0;
+        }
         return data.map((frame) => {
           if (frame.length > limit) {
             return {


### PR DESCRIPTION
For limit transformation, prevent negative limits, which will cause table view to crash.

Before:
![Oct-03-2024 19-20-04](https://github.com/user-attachments/assets/ab34d7e9-7def-41d2-9a79-2be3e2fae2c8)

After:
![Oct-03-2024 19-17-58](https://github.com/user-attachments/assets/49763f7b-6d8c-434c-a9d0-b04253623157)


Fixes https://github.com/grafana/support-escalations/issues/12511