### PR TITLE
PanelSearch: Add support for rows & repeats

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
@@ -44,15 +44,23 @@ export function PanelSearchLayout({ dashboard, panelSearch = '', panelsPerRow }:
     }
   }
 
+  if (filteredPanels.length > 0) {
+    return (
+      <div
+        className={classNames(styles.grid, { [styles.perRow]: panelsPerRow !== undefined })}
+        style={{ [panelsPerRowCSSVar]: panelsPerRow } as Record<string, number>}
+      >
+        {filteredPanels.map((panel) => (
+          <PanelSearchHit key={panel.state.key} panel={panel} />
+        ))}
+      </div>
+    );
+  }
+
   return (
-    <div
-      className={classNames(styles.grid, { [styles.perRow]: panelsPerRow !== undefined })}
-      style={{ [panelsPerRowCSSVar]: panelsPerRow } as Record<string, number>}
-    >
-      {filteredPanels.map((panel) => (
-        <PanelSearchHit key={panel.state.key} panel={panel} />
-      ))}
-    </div>
+    <p className={styles.noHits}>
+      <Trans i18nKey="panel-search.no-matches">No matches found</Trans>
+    </p>
   );
 }
 
@@ -72,6 +80,10 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     perRow: css({
       gridTemplateColumns: `repeat(var(${panelsPerRowCSSVar}, 3), 1fr)`,
+    }),
+    noHits: css({
+      display: 'grid',
+      placeItems: 'center',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useEffect } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { VizPanel, sceneGraph } from '@grafana/scenes';
+import { SceneGridRow, VizPanel, sceneGraph } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
@@ -34,12 +34,11 @@ export function PanelSearchLayout({ dashboard, panelSearch = '', panelsPerRow }:
 
   for (const gridItem of bodyGrid.state.children) {
     if (gridItem instanceof DashboardGridItem) {
-      const panels = gridItem.state.repeatedPanels ?? [gridItem.state.body];
-      for (const panel of panels) {
-        const interpolatedTitle = panel.interpolate(panel.state.title, undefined, 'text').toLowerCase();
-        const interpolatedSearchString = sceneGraph.interpolate(dashboard, panelSearch).toLowerCase();
-        if (interpolatedTitle.includes(interpolatedSearchString)) {
-          filteredPanels.push(panel);
+      filterPanels(gridItem, dashboard, panelSearch, filteredPanels);
+    } else if (gridItem instanceof SceneGridRow) {
+      for (const rowItem of gridItem.state.children) {
+        if (rowItem instanceof DashboardGridItem) {
+          filterPanels(rowItem, dashboard, panelSearch, filteredPanels);
         }
       }
     }
@@ -75,4 +74,32 @@ function getStyles(theme: GrafanaTheme2) {
       gridTemplateColumns: `repeat(var(${panelsPerRowCSSVar}, 3), 1fr)`,
     }),
   };
+}
+
+function filterPanels(
+  gridItem: DashboardGridItem,
+  dashboard: DashboardScene,
+  searchString: string,
+  filteredPanels: VizPanel[]
+) {
+  const interpolatedSearchString = sceneGraph.interpolate(dashboard, searchString).toLowerCase();
+
+  // activate inactive repeat panel if one of its children will be matched
+  if (gridItem.state.variableName && !gridItem.isActive) {
+    const panel = gridItem.state.body;
+    const interpolatedTitle = panel.interpolate(panel.state.title, undefined, 'text').toLowerCase();
+    if (interpolatedTitle.includes(interpolatedSearchString)) {
+      gridItem.activate();
+    }
+  }
+
+  const panels = gridItem.state.repeatedPanels ?? [gridItem.state.body];
+  for (const panel of panels) {
+    const interpolatedTitle = panel.interpolate(panel.state.title, undefined, 'text').toLowerCase();
+    if (interpolatedTitle.includes(interpolatedSearchString)) {
+      filteredPanels.push(panel);
+    }
+  }
+
+  return filteredPanels;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1924,6 +1924,7 @@
     }
   },
   "panel-search": {
+    "no-matches": "No matches found",
     "unsupported-layout": "Unsupported layout"
   },
   "playlist-edit": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1924,6 +1924,7 @@
     }
   },
   "panel-search": {
+    "no-matches": "Ńő mäŧčĥęş ƒőūŉđ",
     "unsupported-layout": "Ůŉşūppőřŧęđ ľäyőūŧ"
   },
   "playlist-edit": {


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/94100 while the out-of-order hook issue gets tackled.

This PR adds support for searching for panels contained in rows, and repeat panels.
