### PR TITLE
BrowseDashboards: Limit the type for folder parents to just a few fields

### DIFF
--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -3,7 +3,7 @@ import { config } from '@grafana/runtime';
 import { t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getNavSubTitle } from 'app/core/utils/navBarItem-translations';
-import { AccessControlAction, FolderDTO } from 'app/types';
+import { AccessControlAction, FolderDTO, FolderParent } from 'app/types';
 
 export const FOLDER_ID = 'manage-folder';
 
@@ -13,7 +13,9 @@ export const getAlertingTabID = (folderUID: string) => `folder-alerting-${folder
 export const getPermissionsTabID = (folderUID: string) => `folder-permissions-${folderUID}`;
 export const getSettingsTabID = (folderUID: string) => `folder-settings-${folderUID}`;
 
-export function buildNavModel(folder: FolderDTO, parents = folder.parents): NavModelItem {
+export function buildNavModel(folder: FolderDTO | FolderParent, parentsArg?: FolderParent[]): NavModelItem {
+  const parents = parentsArg ?? ('parents' in folder ? folder.parents : undefined);
+
   const model: NavModelItem = {
     icon: 'folder',
     id: FOLDER_ID,

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -15,7 +15,9 @@ export interface FolderDTO extends WithAccessControlMetadata {
   hasAcl: boolean;
   id: number;
   parentUid?: string;
-  parents?: FolderDTO[];
+
+  // The API does actually return a full FolderDTO here, but we want to restrict it to just a few properties
+  parents?: Array<Pick<FolderDTO, 'title' | 'uid' | 'url'>>;
   title: string;
   uid: string;
   updated: string;

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -5,6 +5,8 @@ export interface FolderListItemDTO {
   title: string;
 }
 
+export type FolderParent = Pick<FolderDTO, 'title' | 'uid' | 'url'>;
+
 export interface FolderDTO extends WithAccessControlMetadata {
   canAdmin: boolean;
   canDelete: boolean;
@@ -17,7 +19,7 @@ export interface FolderDTO extends WithAccessControlMetadata {
   parentUid?: string;
 
   // The API does actually return a full FolderDTO here, but we want to restrict it to just a few properties
-  parents?: Array<Pick<FolderDTO, 'title' | 'uid' | 'url'>>;
+  parents?: FolderParent[];
   title: string;
   uid: string;
   updated: string;


### PR DESCRIPTION
A full folder DTO is returned for folder parents, but we should use anything other than title and url. It's possible this API will change in the future, so lets lock it down now.

https://raintank-corp.slack.com/archives/C025WTVRBSN/p1728022467393959 