### PR TITLE
CloudMigrations: Add data types for alerts resources

### DIFF
--- a/pkg/services/cloudmigration/api/dtos.go
+++ b/pkg/services/cloudmigration/api/dtos.go
@@ -120,10 +120,15 @@ type MigrateDataResponseItemDTO struct {
 type MigrateDataType string
 
 const (
-	DashboardDataType      MigrateDataType = "DASHBOARD"
-	DatasourceDataType     MigrateDataType = "DATASOURCE"
-	FolderDataType         MigrateDataType = "FOLDER"
-	LibraryElementDataType MigrateDataType = "LIBRARY_ELEMENT"
+	DashboardDataType        MigrateDataType = "DASHBOARD"
+	DatasourceDataType       MigrateDataType = "DATASOURCE"
+	FolderDataType           MigrateDataType = "FOLDER"
+	LibraryElementDataType   MigrateDataType = "LIBRARY_ELEMENT"
+	AlertRuleType            MigrateDataType = "ALERT_RULE"
+	ContactPointType         MigrateDataType = "CONTACT_POINT"
+	NotificationPolicyType   MigrateDataType = "NOTIFICATION_POLICY"
+	NotificationTemplateType MigrateDataType = "NOTIFICATION_TEMPLATE"
+	MuteTimingType           MigrateDataType = "MUTE_TIMING"
 )
 
 // swagger:enum ItemStatus

--- a/pkg/services/cloudmigration/model.go
+++ b/pkg/services/cloudmigration/model.go
@@ -80,10 +80,15 @@ type CloudMigrationResource struct {
 type MigrateDataType string
 
 const (
-	DashboardDataType      MigrateDataType = "DASHBOARD"
-	DatasourceDataType     MigrateDataType = "DATASOURCE"
-	FolderDataType         MigrateDataType = "FOLDER"
-	LibraryElementDataType MigrateDataType = "LIBRARY_ELEMENT"
+	DashboardDataType        MigrateDataType = "DASHBOARD"
+	DatasourceDataType       MigrateDataType = "DATASOURCE"
+	FolderDataType           MigrateDataType = "FOLDER"
+	LibraryElementDataType   MigrateDataType = "LIBRARY_ELEMENT"
+	AlertRuleType            MigrateDataType = "ALERT_RULE"
+	ContactPointType         MigrateDataType = "CONTACT_POINT"
+	NotificationPolicyType   MigrateDataType = "NOTIFICATION_POLICY"
+	NotificationTemplateType MigrateDataType = "NOTIFICATION_TEMPLATE"
+	MuteTimingType           MigrateDataType = "MUTE_TIMING"
 )
 
 type ItemStatus string

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -16928,7 +16928,12 @@
             "DASHBOARD",
             "DATASOURCE",
             "FOLDER",
-            "LIBRARY_ELEMENT"
+            "LIBRARY_ELEMENT",
+            "ALERT_RULE",
+            "CONTACT_POINT",
+            "NOTIFICATION_POLICY",
+            "NOTIFICATION_TEMPLATE",
+            "MUTE_TIMING"
           ]
         }
       }

--- a/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
+++ b/public/app/features/migrate-to-cloud/api/endpoints.gen.ts
@@ -168,7 +168,16 @@ export type MigrateDataResponseItemDto = {
   name?: string;
   refId: string;
   status: 'OK' | 'WARNING' | 'ERROR' | 'PENDING' | 'UNKNOWN';
-  type: 'DASHBOARD' | 'DATASOURCE' | 'FOLDER' | 'LIBRARY_ELEMENT';
+  type:
+    | 'DASHBOARD'
+    | 'DATASOURCE'
+    | 'FOLDER'
+    | 'LIBRARY_ELEMENT'
+    | 'ALERT_RULE'
+    | 'CONTACT_POINT'
+    | 'NOTIFICATION_POLICY'
+    | 'NOTIFICATION_TEMPLATE'
+    | 'MUTE_TIMING';
 };
 export type SnapshotResourceStats = {
   statuses?: {

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -37,6 +37,16 @@ function ResourceInfo({ data }: { data: ResourceTableItem }) {
       return <FolderInfo data={data} />;
     case 'LIBRARY_ELEMENT':
       return <LibraryElementInfo data={data} />;
+    case 'ALERT_RULE':
+      return null;
+    case 'CONTACT_POINT':
+      return null;
+    case 'NOTIFICATION_POLICY':
+      return null;
+    case 'NOTIFICATION_TEMPLATE':
+      return null;
+    case 'MUTE_TIMING':
+      return null;
   }
 }
 

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7148,7 +7148,12 @@
               "DASHBOARD",
               "DATASOURCE",
               "FOLDER",
-              "LIBRARY_ELEMENT"
+              "LIBRARY_ELEMENT",
+              "ALERT_RULE",
+              "CONTACT_POINT",
+              "NOTIFICATION_POLICY",
+              "NOTIFICATION_TEMPLATE",
+              "MUTE_TIMING"
             ],
             "type": "string"
           }


### PR DESCRIPTION
**What is this feature?**

Adds data types constants for alerts in CloudMigrations.

**Why do we need this feature?**

Required in order to support Alerts migration

**Who is this feature for?**

Migration Assistant

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947