### PR TITLE
CloudMigrations: wire ngalert to cloud migration service and add slicesext.Map helper

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/gcom"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/ngalert"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	secretskv "github.com/grafana/grafana/pkg/services/secrets/kvstore"
@@ -62,6 +63,7 @@ type Service struct {
 	secretsService         secrets.Service
 	kvStore                *kvstore.NamespacedKVStore
 	libraryElementsService libraryelements.Service
+	ngAlert                *ngalert.AlertNG
 
 	api     *api.CloudMigrationAPI
 	tracer  tracing.Tracer
@@ -96,6 +98,7 @@ func ProvideService(
 	pluginStore pluginstore.Store,
 	kvStore kvstore.KVStore,
 	libraryElementsService libraryelements.Service,
+	ngAlert *ngalert.AlertNG,
 ) (cloudmigration.Service, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagOnPremToCloudMigrations) {
 		return &NoopServiceImpl{}, nil
@@ -115,6 +118,7 @@ func ProvideService(
 		pluginStore:            pluginStore,
 		kvStore:                kvstore.WithNamespace(kvStore, 0, "cloudmigration"),
 		libraryElementsService: libraryElementsService,
+		ngAlert:                ngAlert,
 	}
 	s.api = api.RegisterApi(routeRegister, s, tracer)
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/cloudmigration"
 	"github.com/grafana/grafana/pkg/services/cloudmigration/gmsclient"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
@@ -26,7 +30,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	libraryelementsfake "github.com/grafana/grafana/pkg/services/libraryelements/fake"
 	libraryelements "github.com/grafana/grafana/pkg/services/libraryelements/model"
+	"github.com/grafana/grafana/pkg/services/ngalert"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
+	ngalertfakes "github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	secretsfakes "github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretskv "github.com/grafana/grafana/pkg/services/secrets/kvstore"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -642,6 +651,26 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 		},
 	}
 
+	featureToggles := featuremgmt.WithFeatures(featuremgmt.FlagOnPremToCloudMigrations, featuremgmt.FlagDashboardRestore)
+
+	kvStore := kvstore.ProvideService(sqlStore)
+
+	bus := bus.ProvideBus(tracer)
+	fakeAccessControl := actest.FakeAccessControl{}
+	fakeAccessControlService := actest.FakeService{}
+	alertMetrics := metrics.NewNGAlert(prometheus.NewRegistry())
+
+	ruleStore, err := ngalertstore.ProvideDBStore(cfg, featureToggles, sqlStore, mockFolder, dashboardService, fakeAccessControl)
+	require.NoError(t, err)
+
+	ng, err := ngalert.ProvideService(
+		cfg, featureToggles, nil, nil, rr, sqlStore, kvStore, nil, nil, quotatest.New(false, nil),
+		secretsService, nil, alertMetrics, mockFolder, fakeAccessControl, dashboardService, nil, bus, fakeAccessControlService,
+		annotationstest.NewFakeAnnotationsRepo(), &pluginstore.FakePluginStore{}, tracer, ruleStore,
+		httpclient.NewProvider(), ngalertfakes.NewFakeReceiverPermissionsService(),
+	)
+	require.NoError(t, err)
+
 	s, err := ProvideService(
 		cfg,
 		featuremgmt.WithFeatures(
@@ -659,6 +688,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 		&pluginstore.FakePluginStore{},
 		kvstore.ProvideService(sqlStore),
 		&libraryelementsfake.LibraryElementService{},
+		ng,
 	)
 	require.NoError(t, err)
 

--- a/pkg/services/cloudmigration/slicesext/slicesext.go
+++ b/pkg/services/cloudmigration/slicesext/slicesext.go
@@ -1,0 +1,11 @@
+package slicesext
+
+func Map[T any, U any](xs []T, f func(T) U) []U {
+	out := make([]U, 0, len(xs))
+
+	for _, x := range xs {
+		out = append(out, f(x))
+	}
+
+	return out
+}

--- a/pkg/services/cloudmigration/slicesext/slicesext_test.go
+++ b/pkg/services/cloudmigration/slicesext/slicesext_test.go
@@ -1,0 +1,36 @@
+package slicesext_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/cloudmigration/slicesext"
+)
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mapping a nil slice does nothing and returns an empty slice", func(t *testing.T) {
+		t.Parallel()
+
+		require.Empty(t, slicesext.Map[any, any](nil, nil))
+	})
+
+	t.Run("mapping a non-nil slice with a nil function panics", func(t *testing.T) {
+		t.Parallel()
+
+		require.Panics(t, func() { slicesext.Map[int, any]([]int{1, 2, 3}, nil) })
+	})
+
+	t.Run("mapping a non-nil slice with a non-nil function returns the mapped slice", func(t *testing.T) {
+		t.Parallel()
+
+		original := []int{1, 2, 3}
+		expected := []string{"1", "2", "3"}
+		fn := func(i int) string { return strconv.Itoa(i) }
+
+		require.ElementsMatch(t, expected, slicesext.Map(original, fn))
+	})
+}


### PR DESCRIPTION
**What is this feature?**

- Wires `ngalert` service to `CloudMigrations`.
- Adds `slicesext.Map` function to help with converting Alerts types.

**Why do we need this feature?**

Required in order to support Alerts migration, wiring the `ngalert` service which will be used to fetch the different Alert-related resources data, then convert some of the data types with `slicesext.Map` into the objects we need to create the snapshot with.

**Who is this feature for?**

Migration Assistant

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947