### PR TITLE
Auth: Only apply redirection if the user is signed in (session storage redirection)

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -399,7 +399,6 @@ function handleRedirectTo(): void {
   }
 
   if (!contextSrv.user.isSignedIn) {
-    locationService.replace('/login');
     return;
   }
 


### PR DESCRIPTION
**What is this feature?**
Redirect the user only if the user has signed in to prevent unexpected redirection for public-dashboards.

**Why do we need this feature?**
Currently public-dashboards are inaccessible if the `useSessionStorageForRedirection` feature toggle is enabled.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
