### PR TITLE
Alerting: Update permissions to reciever and template test API

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -455,6 +455,7 @@ const (
 	ActionAlertingReceiversCreate           = "alert.notifications.receivers:create"
 	ActionAlertingReceiversUpdate           = "alert.notifications.receivers:write"
 	ActionAlertingReceiversDelete           = "alert.notifications.receivers:delete"
+	ActionAlertingReceiversTest             = "alert.notifications.receivers:test"
 	ActionAlertingReceiversPermissionsRead  = "receivers.permissions:read"
 	ActionAlertingReceiversPermissionsWrite = "receivers.permissions:write"
 

--- a/pkg/services/ngalert/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol.go
@@ -136,6 +136,7 @@ var (
 			Group:       AlertRolesGroup,
 			Permissions: []accesscontrol.Permission{
 				{Action: accesscontrol.ActionAlertingReceiversCreate},
+				{Action: accesscontrol.ActionAlertingReceiversTest},
 			},
 		},
 	}

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -212,9 +212,15 @@ func (api *API) authorize(method, path string) web.Handler {
 	case http.MethodGet + "/api/alertmanager/grafana/config/api/v1/receivers":
 		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
 	case http.MethodPost + "/api/alertmanager/grafana/config/api/v1/receivers/test":
-		eval = ac.EvalPermission(ac.ActionAlertingNotificationsWrite)
+		eval = ac.EvalAny(
+			ac.EvalPermission(ac.ActionAlertingNotificationsWrite),
+			ac.EvalPermission(ac.ActionAlertingReceiversTest),
+		)
 	case http.MethodPost + "/api/alertmanager/grafana/config/api/v1/templates/test":
-		eval = ac.EvalPermission(ac.ActionAlertingNotificationsWrite)
+		eval = ac.EvalAny(
+			ac.EvalPermission(ac.ActionAlertingNotificationsWrite),
+			ac.EvalPermission(ac.ActionAlertingNotificationsTemplatesRead),
+		)
 
 	// External Alertmanager Paths
 	case http.MethodDelete + "/api/alertmanager/{DatasourceUID}/config/api/v1/alerts":


### PR DESCRIPTION
**What is this feature?**
This PR introduces a new action `alert.notifications.receivers:test` which guards receiver testing API. The action is granted to Contact Point Creator and Writer fixed roles. Therefore reader will not be able to use it.

Also, template testing API endpoint is updated to accept `alert.notifications.templates:read`.


**Why do we need this feature?**
To grant access to required APIs to UI users when a new notifications API is enabled
