### PR TITLE
Explore metrics: set options directly because of scenes error when options not set

### DIFF
--- a/public/app/features/trails/AutomaticMetricQueries/graph-builders/percentiles.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/graph-builders/percentiles.ts
@@ -1,4 +1,6 @@
 import { PanelBuilders } from '@grafana/scenes';
+import { SortOrder } from '@grafana/schema/dist/esm/index';
+import { TooltipDisplayMode } from '@grafana/ui';
 
 import { CommonVizParams } from './types';
 
@@ -6,5 +8,7 @@ export function percentilesGraphBuilder({ title, unit }: CommonVizParams) {
   return PanelBuilders.timeseries() //
     .setTitle(title)
     .setUnit(unit)
-    .setCustomFieldConfig('fillOpacity', 9);
+    .setCustomFieldConfig('fillOpacity', 9)
+    .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
+    .setOption('legend', { showLegend: false });
 }

--- a/public/app/features/trails/AutomaticMetricQueries/graph-builders/percentiles.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/graph-builders/percentiles.ts
@@ -1,5 +1,5 @@
 import { PanelBuilders } from '@grafana/scenes';
-import { SortOrder } from '@grafana/schema/dist/esm/index';
+import { SortOrder } from '@grafana/schema';
 import { TooltipDisplayMode } from '@grafana/ui';
 
 import { CommonVizParams } from './types';

--- a/public/app/features/trails/AutomaticMetricQueries/graph-builders/percentiles.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/graph-builders/percentiles.ts
@@ -5,7 +5,7 @@ import { TooltipDisplayMode } from '@grafana/ui';
 import { CommonVizParams } from './types';
 
 export function percentilesGraphBuilder({ title, unit }: CommonVizParams) {
-  return PanelBuilders.timeseries() //
+  return PanelBuilders.timeseries()
     .setTitle(title)
     .setUnit(unit)
     .setCustomFieldConfig('fillOpacity', 9)

--- a/public/app/features/trails/AutomaticMetricQueries/graph-builders/simple.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/graph-builders/simple.ts
@@ -1,5 +1,5 @@
 import { PanelBuilders } from '@grafana/scenes';
-import { SortOrder } from '@grafana/schema/dist/esm/index';
+import { SortOrder } from '@grafana/schema';
 import { TooltipDisplayMode } from '@grafana/ui';
 
 import { CommonVizParams } from './types';

--- a/public/app/features/trails/AutomaticMetricQueries/graph-builders/simple.ts
+++ b/public/app/features/trails/AutomaticMetricQueries/graph-builders/simple.ts
@@ -1,4 +1,6 @@
 import { PanelBuilders } from '@grafana/scenes';
+import { SortOrder } from '@grafana/schema/dist/esm/index';
+import { TooltipDisplayMode } from '@grafana/ui';
 
 import { CommonVizParams } from './types';
 
@@ -7,5 +9,6 @@ export function simpleGraphBuilder({ title, unit }: CommonVizParams) {
     .setTitle(title)
     .setUnit(unit)
     .setOption('legend', { showLegend: false })
+    .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
     .setCustomFieldConfig('fillOpacity', 9);
 }

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -411,7 +411,11 @@ function buildNormalLayout(
         children: [
           new SceneFlexItem({
             minHeight: 300,
-            body: PanelBuilders.timeseries().setTitle('$metric').build(),
+            body: PanelBuilders.timeseries()
+              .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
+              .setOption('legend', { showLegend: false })
+              .setTitle('$metric')
+              .build(),
           }),
         ],
       }),

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -21,7 +21,7 @@ import {
   VariableDependencyConfig,
   VizPanel,
 } from '@grafana/scenes';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 import { Button, Field, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
@@ -300,6 +300,7 @@ export function buildAllLayout(
     const unit = queryDef.unit;
 
     const vizPanel = PanelBuilders.timeseries()
+      .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
       .setOption('legend', { showLegend: false })
       .setTitle(option.label!)
       .setData(

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -39,7 +39,6 @@ import { AddToFiltersGraphAction } from './AddToFiltersGraphAction';
 import { BreakdownSearchReset, BreakdownSearchScene } from './BreakdownSearchScene';
 import { ByFrameRepeater } from './ByFrameRepeater';
 import { LayoutSwitcher } from './LayoutSwitcher';
-import { breakdownPanelOptions } from './panelConfigs';
 import { BreakdownLayoutChangeCallback, BreakdownLayoutType } from './types';
 import { getLabelOptions } from './utils';
 import { BreakdownAxisChangeEvent, yAxisSyncBehavior } from './yAxisSyncBehavior';
@@ -321,10 +320,6 @@ export function buildAllLayout(
       .setBehaviors([fixLegendForUnspecifiedLabelValueBehavior])
       .build();
 
-    vizPanel.addActivationHandler(() => {
-      vizPanel.onOptionsChange(breakdownPanelOptions);
-    });
-
     children.push(
       new SceneCSSGridItem({
         $behaviors: [yAxisSyncBehavior],
@@ -382,10 +377,6 @@ function buildNormalLayout(
       $behaviors: [yAxisSyncBehavior],
       body: vizPanel,
       isHidden,
-    });
-
-    vizPanel.addActivationHandler(() => {
-      vizPanel.onOptionsChange(breakdownPanelOptions);
     });
 
     return item;

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -300,6 +300,7 @@ export function buildAllLayout(
     const unit = queryDef.unit;
 
     const vizPanel = PanelBuilders.timeseries()
+      .setOption('legend', { showLegend: false })
       .setTitle(option.label!)
       .setData(
         new SceneQueryRunner({

--- a/public/app/features/trails/Breakdown/panelConfigs.ts
+++ b/public/app/features/trails/Breakdown/panelConfigs.ts
@@ -1,8 +1,0 @@
-import { PanelOptionsBuilders } from '@grafana/scenes';
-import { SortOrder } from '@grafana/schema/dist/esm/index';
-import { TooltipDisplayMode } from '@grafana/ui';
-
-export const breakdownPanelOptions = PanelOptionsBuilders.timeseries()
-  .setOption('tooltip', { mode: TooltipDisplayMode.Multi, sort: SortOrder.Descending })
-  .setOption('legend', { showLegend: false })
-  .build();


### PR DESCRIPTION
Fixes bug when using `PanelBuilders.timeseries()` without setting options directly.

See here for more context https://raintank-corp.slack.com/archives/C02UC0KCSF4/p1728064725662419

![image](https://github.com/user-attachments/assets/d2c44bb3-7310-465a-895a-3b8396b064e6)

![image](https://github.com/user-attachments/assets/9913ef63-3487-4133-b994-62ff13668c53)


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
