### PR TITLE
[Plugins]create plugins dir on install time to prevent permission problem with grafana-cli

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -23,9 +23,9 @@ if [ "$1" = configure ]; then
   fi
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
-  mkdir -p /var/log/grafana /var/lib/grafana
+  mkdir -p /var/log/grafana /var/lib/grafana /var/lib/grafana/plugins
   chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
-  chmod 755 /var/log/grafana /var/lib/grafana
+  chmod 755 /var/log/grafana /var/lib/grafana /var/lib/grafana/plugins
 
   # copy user config files
   if [ ! -f $CONF_FILE ]; then

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -40,9 +40,9 @@ if [ $1 -eq 1 ] ; then
   fi
 
   # Set user permissions on /var/log/grafana, /var/lib/grafana
-  mkdir -p /var/log/grafana /var/lib/grafana
+  mkdir -p /var/log/grafana /var/lib/grafana /var/lib/grafana/plugins
   chown -R $GRAFANA_USER:$GRAFANA_GROUP /var/log/grafana /var/lib/grafana
-  chmod 755 /var/log/grafana /var/lib/grafana
+  chmod 755 /var/log/grafana /var/lib/grafana /var/lib/grafana/plugins
 
   # copy user config files
   if [ ! -f $CONF_FILE ]; then


### PR DESCRIPTION
**What is this feature?**

This PR ensures that `/var/lib/grafana/plugins` is owned by `grafana` with 755 permission for deb/rpm package users.

Related to https://github.com/grafana/grafana/pull/94134

**Why do we need this feature?**

To solve the permission issue with using grafana-cli.
Since the current documentation recommends the `root` user for CLI operations during plugin installation, /var/lib/grafana/plugins would be owned by the root user, preventing future installations through the WebUI by the `grafana` user.

If `/var/lib/grafana/plugins` is created and owned by `grafana` in advance, it ensures both Grafana Web UI and grafana-cli(with root user) can install plugins.
Of course, there is still a problem that once plugins installed by `root` user can't be modified by `grafana` user, it's better than current situation.

Note:
https://github.com/grafana/grafana/blob/c4fa268aeac616cb825874b3ebe52609652ef68b/pkg/cmd/grafana-cli/commands/install_command.go#L57

Current plugins dir permission seems to be intended to set to 777, though it would be 775 or 755 in most cases based on umask setting.
see: #94134 for more details.


**Who is this feature for?**

deb/rpm users who use grafana-cli.

**Which issue(s) does this PR fix?**:

I can't find any related issues.

**Special notes for your reviewer:**

IMO, ideally if grafana-server has responsibility to mange plugins through API and grafana-cli just interacts with the server based on Grafana's permission model instead of modifying plugins dir directly, this kind of problem won't happen.
But I know it's difficult to switch to this model.
So this PR is intended to mitigate the problem for now, and another option (recommend `grafana` user rather than `root` user is in another PR I mentioned.

My honest opinion for that are:
1) use `grafana` user rather than `root` user is best option for now
2) create plugins dir owned by `grafana` user is a better option not as good as 1) though.
3) Either way, plugins dir should not be 777 to protect plugin installation from someone else.

Thank you for checking this PR.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
