### PR TITLE
Auth: Fix redirection when auto_login is enabled

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -182,6 +182,9 @@ func (hs *HTTPServer) tryAutoLogin(c *contextmodel.ReqContext) bool {
 	for providerName, provider := range oauthInfos {
 		if provider.AutoLogin || hs.Cfg.OAuthAutoLogin {
 			redirectUrl := hs.Cfg.AppSubURL + "/login/" + providerName
+			if hs.Features.IsEnabledGlobally(featuremgmt.FlagUseSessionStorageForRedirection) {
+				redirectUrl += hs.getRedirectToForAutoLogin(c)
+			}
 			c.Logger.Info("OAuth auto login enabled. Redirecting to " + redirectUrl)
 			c.Redirect(redirectUrl, 307)
 			return true

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/network"
+	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -189,12 +190,30 @@ func (hs *HTTPServer) tryAutoLogin(c *contextmodel.ReqContext) bool {
 
 	if samlAutoLogin {
 		redirectUrl := hs.Cfg.AppSubURL + "/login/saml"
+		if hs.Features.IsEnabledGlobally(featuremgmt.FlagUseSessionStorageForRedirection) {
+			redirectUrl += hs.getRedirectToForAutoLogin(c)
+		}
 		c.Logger.Info("SAML auto login enabled. Redirecting to " + redirectUrl)
 		c.Redirect(redirectUrl, 307)
 		return true
 	}
 
 	return false
+}
+
+func (hs *HTTPServer) getRedirectToForAutoLogin(c *contextmodel.ReqContext) string {
+	redirectTo := c.Req.FormValue("redirectTo")
+	if hs.Cfg.AppSubURL != "" && strings.HasPrefix(redirectTo, hs.Cfg.AppSubURL) {
+		redirectTo = strings.TrimPrefix(redirectTo, hs.Cfg.AppSubURL)
+	}
+
+	if redirectTo == "/" {
+		return ""
+	}
+
+	// remove any forceLogin=true params
+	redirectTo = middleware.RemoveForceLoginParams(redirectTo)
+	return "?redirectTo=" + url.QueryEscape(redirectTo)
 }
 
 func (hs *HTTPServer) LoginAPIPing(c *contextmodel.ReqContext) response.Response {

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -98,7 +98,7 @@ func writeRedirectCookie(c *contextmodel.ReqContext) {
 	}
 
 	// remove any forceLogin=true params
-	redirectTo = removeForceLoginParams(redirectTo)
+	redirectTo = RemoveForceLoginParams(redirectTo)
 	cookies.WriteCookie(c.Resp, "redirect_to", url.QueryEscape(redirectTo), 0, nil)
 }
 
@@ -113,13 +113,13 @@ func getRedirectToQueryParam(c *contextmodel.ReqContext) string {
 	}
 
 	// remove any forceLogin=true params
-	redirectTo = removeForceLoginParams(redirectTo)
+	redirectTo = RemoveForceLoginParams(redirectTo)
 	return "?redirectTo=" + url.QueryEscape(redirectTo)
 }
 
 var forceLoginParamsRegexp = regexp.MustCompile(`&?forceLogin=true`)
 
-func removeForceLoginParams(str string) string {
+func RemoveForceLoginParams(str string) string {
 	return forceLoginParamsRegexp.ReplaceAllString(str, "")
 }
 
@@ -138,7 +138,8 @@ func CanAdminPlugins(cfg *setting.Cfg, accessControl ac.AccessControl) func(c *c
 }
 
 func RoleAppPluginAuth(accessControl ac.AccessControl, ps pluginstore.Store, features featuremgmt.FeatureToggles,
-	logger log.Logger) func(c *contextmodel.ReqContext) {
+	logger log.Logger,
+) func(c *contextmodel.ReqContext) {
 	return func(c *contextmodel.ReqContext) {
 		pluginID := web.Params(c.Req)[":id"]
 		p, exists := ps.Plugin(c.Req.Context(), pluginID)

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -352,7 +352,7 @@ func TestRemoveForceLoginparams(t *testing.T) {
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
-			require.Equal(t, tc.exp, removeForceLoginParams(tc.inp))
+			require.Equal(t, tc.exp, RemoveForceLoginParams(tc.inp))
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**
This PR fixes the redirection handling after login when `auto_login` is enabled for OAuth/SAML.

**Why do we need this feature?**

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
Enable `useSessionStorageForRedirection` feature toggle.

For both OAuth/SAML with auto_login=true/false verify the following:
- Open an incognito window
- Navigate to a dashboard url (example: http://localhost:3000/d/fdtfaa2vgdszkd/new-dashboard?orgId=1)
- Login on the IdP side
- You are being redirected to the correct dashboard


Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
