### PR TITLE
docs: linked to Explore Apps in relevant places

### DIFF
--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -158,3 +158,7 @@ Grafana lists these variables in dropdown select boxes at the top of the dashboa
 Grafana refers to such variables as template variables.
 
 For details, see the [template variables documentation]({{< relref "./template-variables" >}}).
+
+## Try Explore Logs
+
+Try our new [simplified queryless Explore experiences]({{< relref "../../explore/simplified-exploration/logs" >}}) for Loki.

--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -161,4 +161,4 @@ For details, see the [template variables documentation]({{< relref "./template-v
 
 ## Try Explore Logs
 
-Try our new [simplified queryless Explore experiences]({{< relref "../../explore/simplified-exploration/logs" >}}) for Loki.
+Try our [simplified queryless Explore experiences]({{< relref "../../explore/simplified-exploration/logs" >}}) for Loki.

--- a/docs/sources/datasources/loki/_index.md
+++ b/docs/sources/datasources/loki/_index.md
@@ -161,4 +161,4 @@ For details, see the [template variables documentation]({{< relref "./template-v
 
 ## Try Explore Logs
 
-Try our [simplified queryless Explore experiences]({{< relref "../../explore/simplified-exploration/logs" >}}) for Loki.
+Try [Explore Logs]({{< relref "../../explore/simplified-exploration/logs" >}}) for a simplified, queryless Explore experience.

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -47,6 +47,9 @@ cards:
       href: ./correlations-editor-in-explore/
       description: Learn how to create and use Correlations.
       height: 24
+    - title: "NEW: Explore Apps"
+      href: ./simplified-exploration/
+      description: Try our new suite of queryless apps built for experts and non-experts alike.
 ---
 
 {{< docs/hero-simple key="hero" >}}
@@ -56,6 +59,10 @@ cards:
 ## Overview
 
 Explore is your starting point for querying, analyzing, and aggregating data in Grafana. You can quickly begin creating queries to start analyzing data without having to create a dashboard or customize a visualization.
+
+{{% admonition type="note" %}}
+If you're using Mimir, Loki, Tempo or Pyroscope, be sure to try our new [simplified queryless Explore experiences]({{< relref "simplified-exploration" >}}).
+{{% /admonition %}}
 
 ## Explore
 

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -47,9 +47,9 @@ cards:
       href: ./correlations-editor-in-explore/
       description: Learn how to create and use Correlations.
       height: 24
-    - title: "NEW: Explore Apps"
+    - title: "Explore Apps"
       href: ./simplified-exploration/
-      description: Try our new suite of queryless apps built for experts and non-experts alike.
+      description: Try our suite of queryless apps built for experts and non-experts alike.
 ---
 
 {{< docs/hero-simple key="hero" >}}
@@ -61,7 +61,7 @@ cards:
 Explore is your starting point for querying, analyzing, and aggregating data in Grafana. You can quickly begin creating queries to start analyzing data without having to create a dashboard or customize a visualization.
 
 {{% admonition type="note" %}}
-If you're using Mimir, Loki, Tempo or Pyroscope, be sure to try our new [simplified queryless Explore experiences]({{< relref "simplified-exploration" >}}).
+If you're using Mimir, Loki, Tempo or Pyroscope, be sure to try our [simplified queryless Explore experiences]({{< relref "simplified-exploration" >}}).
 {{% /admonition %}}
 
 ## Explore

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -61,7 +61,7 @@ cards:
 Explore is your starting point for querying, analyzing, and aggregating data in Grafana. You can quickly begin creating queries to start analyzing data without having to create a dashboard or customize a visualization.
 
 {{% admonition type="note" %}}
-If you're using Mimir, Loki, Tempo or Pyroscope, be sure to try our [simplified queryless Explore experiences]({{< relref "simplified-exploration" >}}).
+If you're using Mimir, Loki, Tempo, or Pyroscope, try the [queryless Explore experiences]({{< relref "simplified-exploration" >}}).
 {{% /admonition %}}
 
 ## Explore

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -22,7 +22,7 @@ The following sections provide an overview of Grafana features and links to prod
 
 ## Explore metrics, logs, traces and profiles
 
-Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore" >}}) for more information. Or use our new suite of [Explore Apps for simplified exploration]({{< relref "../explore/simplified-exploration/" >}}) to browse your telemetry data without writing queries.
+Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore" >}}) for more information. Or use our new suite of [Explore Apps for simplified exploration]({{< relref "../explore/simplified-exploration" >}}) to browse your telemetry data without writing queries.
 
 ## Alerts
 

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -20,9 +20,9 @@ After you have [installed Grafana]({{< relref "../setup-grafana/installation" >}
 
 The following sections provide an overview of Grafana features and links to product documentation to help you learn more. For more guidance and ideas, check out our [Grafana Community forums](https://community.grafana.com/).
 
-## Explore metrics, logs, and traces
+## Explore metrics, logs, traces and profiles
 
-Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore" >}}) for more information.
+Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore" >}}) for more information. Or use our new suite of [Explore Apps for simplified exploration]({{< relref "../explore/simplified-exploration/" >}}) to browse your telemetry data without writing queries.
 
 ## Alerts
 

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -22,7 +22,11 @@ The following sections provide an overview of Grafana features and links to prod
 
 ## Explore metrics, logs, traces and profiles
 
-Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore" >}}) for more information. Or use our new suite of [Explore Apps for simplified exploration]({{< relref "../explore/simplified-exploration" >}}) to browse your telemetry data without writing queries.
+Use Grafana Explore to examine your data using ad-hoc queries and dynamic drilldown.
+Split view and compare different time ranges, queries and data sources side by side. 
+Refer to [Explore]({{< relref "../explore" >}}) for more information. 
+
+You can also use one of the [Explore Apps for simplified exploration]({{< relref "../explore/simplified-exploration" >}}) to browse your telemetry data without writing queries.
 
 ## Alerts
 

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -20,7 +20,7 @@ After you have [installed Grafana]({{< relref "../setup-grafana/installation" >}
 
 The following sections provide an overview of Grafana features and links to product documentation to help you learn more. For more guidance and ideas, check out our [Grafana Community forums](https://community.grafana.com/).
 
-## Explore metrics, logs, traces and profiles
+## Explore telemetry data
 
 Use Grafana Explore to examine your data using ad-hoc queries and dynamic drilldown.
 Split view and compare different time ranges, queries and data sources side by side. 

--- a/docs/sources/shared/basics/what-is-grafana.md
+++ b/docs/sources/shared/basics/what-is-grafana.md
@@ -22,6 +22,10 @@ Grafana Tempo is an open source, easy-to-use and high-volume distributed tracing
 
 Grafana Mimir is an open source software project that provides a scalable long-term storage for Prometheus. For more information about Grafana Mimir, refer to [Grafana Mimir documentation](/docs/mimir/latest/).
 
-### Grafana Oncall
+### Grafana OnCall
 
 Grafana OnCall is an open source incident response management tool built to help teams improve their collaboration and resolve incidents faster. For more information about Grafana OnCall, refer to [Grafana OnCall documentation](/docs/oncall/latest/).
+
+### Explore Apps
+
+Our new suite of apps provides queryless point-and-click experiences for working with Mimir, Loki, Tempo and Pyroscope data. Diagnose issues and understand your systems faster than ever regardless of your level of expertise. For more information, check out [Explore Apps simplified exploration documentation](/docs/grafana/latest/explore/simplified-exploration/).

--- a/docs/sources/shared/basics/what-is-grafana.md
+++ b/docs/sources/shared/basics/what-is-grafana.md
@@ -28,4 +28,6 @@ Grafana OnCall is an open source incident response management tool built to help
 
 ### Explore Apps
 
-Our new suite of apps provides queryless point-and-click experiences for working with Mimir, Loki, Tempo and Pyroscope data. Diagnose issues and understand your systems faster than ever regardless of your level of expertise. For more information, check out [Explore Apps simplified exploration documentation](/docs/grafana/latest/explore/simplified-exploration/).
+The Explore Apps provides queryless point-and-click experiences for working with Mimir, Loki, Tempo, and Pyroscope data.
+You can diagnose issues and understand your systems faster regardless of your level of expertise.
+For more information, refer to the [Explore apps documentation](/docs/grafana/latest/explore/simplified-exploration/).


### PR DESCRIPTION

**What is this feature?**

I have linked to Explore Apps (the simplified exploration docs) in a few relevant places to assist with discovery.

**Why do we need this feature?**

We should make people aware of Explore Apps as an option early in their learning process.

**Who is this feature for?**

This is for non-expert SREs who may want to skip learning query languages in favour of a point-and-click experience.
