### PR TITLE
Unified Storage /Folders: Allow Unified Storage subfolders creation

### DIFF
--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -50,7 +50,7 @@ func LegacyUpdateCommandToUnstructured(cmd folder.UpdateFolderCommand) unstructu
 	return obj
 }
 
-func UnstructuredToLegacyFolder(item unstructured.Unstructured) *folder.Folder {
+func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) *folder.Folder {
 	// #TODO reduce duplication of the different conversion functions
 	spec := item.Object["spec"].(map[string]any)
 	uid := item.GetName()
@@ -88,6 +88,7 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured) *folder.Folder {
 		URL:     getURL(meta, title),
 		Created: createdTime,
 		Updated: createdTime,
+		OrgID:   orgID,
 	}
 	return f
 }

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -51,12 +51,45 @@ func LegacyUpdateCommandToUnstructured(cmd folder.UpdateFolderCommand) unstructu
 }
 
 func UnstructuredToLegacyFolder(item unstructured.Unstructured) *folder.Folder {
+	// #TODO reduce duplication of the different conversion functions
 	spec := item.Object["spec"].(map[string]any)
-	return &folder.Folder{
-		UID:   item.GetName(),
-		Title: spec["title"].(string),
-		// #TODO add other fields
+	uid := item.GetName()
+	title := spec["title"].(string)
+
+	meta, err := utils.MetaAccessor(&item)
+	if err != nil {
+		return nil
 	}
+
+	id, err := getLegacyID(meta)
+	if err != nil {
+		return nil
+	}
+
+	created, err := getCreated(meta)
+	if err != nil {
+		return nil
+	}
+
+	// avoid panic
+	var createdTime time.Time
+	if created != nil {
+		createdTime = created.Local()
+	}
+
+	f := &folder.Folder{
+		UID:       uid,
+		Title:     title,
+		ID:        id,
+		ParentUID: meta.GetFolder(),
+		// #TODO add created by field if necessary
+		// CreatedBy: meta.GetCreatedBy(),
+		// UpdatedBy: meta.GetCreatedBy(),
+		URL:     getURL(meta, title),
+		Created: createdTime,
+		Updated: createdTime,
+	}
+	return f
 }
 
 func UnstructuredToLegacyFolderDTO(item unstructured.Unstructured) (*dtos.Folder, error) {

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -1,6 +1,9 @@
 package sql
 
 import (
+	"context"
+
+	"github.com/grafana/authlib/claims"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -29,6 +32,17 @@ func NewResourceServer(db infraDB.DB, cfg *setting.Cfg, features featuremgmt.Fea
 
 	if features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearch) {
 		opts.Index = resource.NewResourceIndexServer()
+	}
+
+	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesFolders) {
+		opts.WriteAccess = resource.WriteAccessHooks{
+			Folder: func(ctx context.Context, user claims.AuthInfo, uid string) bool {
+				// #TODO build on the logic here
+				// #TODO only enable write access when the resource being written in the folder
+				// is another folder
+				return true
+			},
+		}
 	}
 
 	return resource.NewResourceServer(opts)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allow subfolder creation when using the k8s client. For now to populate the parents field in the folder DTO we depend on the folder service. Ultimately we want to remove the dependancy on the folder service for subfolder creation (this is already the case when creating parent folders) but we want to proceed incrementally.

FYI we will stop setting all the folder DTO fields for the folders being returned in the parents field. See https://raintank-corp.slack.com/archives/C025WTVRBSN/p1728022467393959 and https://github.com/grafana/grafana/pull/94244

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # https://github.com/grafana/search-and-storage-team/issues/101

Relates to https://github.com/grafana/search-and-storage-team/issues/102

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
