### PR TITLE
Chore: Improve auto refresh input experience

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -296,7 +296,7 @@ export function calculateInterval(range: TimeRange, resolution: number, lowLimit
   };
 }
 
-const interval_regex = /(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])/;
+const interval_regex = /^(-?\d+(?:\.\d+)?)(ms|[Mwdhmsy])?$/;
 // histogram & trends
 const intervals_in_seconds: Record<string, number> = {
   y: 31536000,

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -187,7 +187,6 @@ export class ContextSrv {
       return intervals.filter((str) => str !== '').filter(this.isAllowedInterval);
     }
 
-    console.log(intervals);
     return intervals;
   }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -167,7 +167,12 @@ export class ContextSrv {
     if (!config.minRefreshInterval || interval === AutoRefreshInterval) {
       return true;
     }
-    return rangeUtil.intervalToMs(interval) >= rangeUtil.intervalToMs(config.minRefreshInterval);
+
+    if (rangeUtil.intervalToMs(interval) < rangeUtil.intervalToMs(config.minRefreshInterval)) {
+      throw new Error(`Intervals must be greater than or equal to "${config.minRefreshInterval}"`);
+    }
+
+    return true;
   }
 
   getValidInterval(interval: string) {
@@ -181,6 +186,8 @@ export class ContextSrv {
     if (this.minRefreshInterval) {
       return intervals.filter((str) => str !== '').filter(this.isAllowedInterval);
     }
+
+    console.log(intervals);
     return intervals;
   }
 

--- a/public/app/features/dashboard/components/DashboardSettings/AutoRefreshIntervals.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AutoRefreshIntervals.tsx
@@ -74,6 +74,7 @@ export const AutoRefreshIntervals = ({
         value={intervalsString}
         onChange={onIntervalsChange}
         onBlur={onIntervalsBlur}
+        spellCheck={false}
       />
     </Field>
   );


### PR DESCRIPTION
Some small improvements to the auto refresh interval input.

- Previously the input would silently discard interval values < min interval. An informative message is now shown to inform the user that the interval is not valid.
- Previously the input would accept strings such as "2sx" or "2s[anything-else-goes-here]" as "2s". I've tweaked the validation regex to be a bit stricter, so only "2s" would be accepted now.
- Disabled spell check on the input. Values such as "2s,1d,5m" would show a red squiggly line underneath. Disabling spellcheck prevents this.