### PR TITLE
DS-Query Service: do not return a 500 if the datasource uid and type are missing

### DIFF
--- a/pkg/registry/apis/query/parser.go
+++ b/pkg/registry/apis/query/parser.go
@@ -13,6 +13,7 @@ import (
 	query "github.com/grafana/grafana/pkg/apis/query/v0alpha1"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/service"
 )
 
@@ -206,7 +207,7 @@ func (p *queryParser) getValidDataSourceRef(ctx context.Context, ds *data.DataSo
 	}
 	if ds.Type == "" {
 		if ds.UID == "" {
-			return nil, fmt.Errorf("missing name/uid in data source reference")
+			return nil, datasources.ErrDatasourceMissingInfo
 		}
 		if ds.UID == expr.DatasourceType {
 			return ds, nil

--- a/pkg/services/datasources/errors.go
+++ b/pkg/services/datasources/errors.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	ErrDatasourceMissingInfo             = errors.New("datasource type and uid missing")
 	ErrDataSourceNotFound                = errors.New("data source not found")
 	ErrDataSourceNameExists              = errors.New("data source with the same name already exists")
 	ErrDataSourceUidExists               = errors.New("data source with the same uid already exists")


### PR DESCRIPTION
**What is this feature?**

Right now if a request is made to the new query service and the uid and type are missing from the datasource request we return a 500. However users can alert query objects more or less however they like by directly editing query json, including removing uids and datasource types. This kind of error is to be expected and not exceptional and does not indicate something wrong on a service-level, rather the issue is in the format of the request so a 400 would be more appropriate than a 500. 

**Why do we need this feature?**

As we gear up to move more traffic to the query service, it is important we only return 500s in unexpected/exceptional events (such as a service being down). 

**Who is this feature for?**

internal grafana devs for now

**Which issue(s) does this PR fix?**:

relates to https://github.com/grafana/grafana-enterprise/issues/7227

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
