### PR TITLE
ExploreMetrics: Ensure compatibility with Incremental Querying

### DIFF
--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -22,8 +22,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
-import { Button, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
-import { Field } from '@grafana/ui/';
+import { Button, Field, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
 import { getAutoQueriesForMetric } from '../AutomaticMetricQueries/AutoQueryEngine';
@@ -230,7 +229,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       <div className={styles.container}>
         <StatusWrapper {...{ isLoading: loading, blockingMessage }}>
           <div className={styles.controls}>
-            {!loading && labels.length && (
+            {!loading && Boolean(labels.length) && (
               <Field label={useOtelExperience ? 'By metric attribute' : 'By label'}>
                 <BreakdownLabelSelector options={labels} value={value} onChange={model.onChange} />
               </Field>
@@ -308,8 +307,8 @@ export function buildAllLayout(
           datasource: trailDS,
           queries: [
             {
-              refId: 'A',
-              expr: expr,
+              refId: `A-${option.label}`,
+              expr,
               legendFormat: `{{${option.label}}}`,
             },
           ],


### PR DESCRIPTION
## What is this change?

This PR ensures that in the [Explore Metrics](https://grafana.com/blog/2024/05/14/how-to-explore-metrics-without-promql-queries-in-grafana) breakdown tab, the queries that supply data to each label's panel use a unique [RefID](https://grafana.com/docs/grafana/latest/panels-visualizations/query-transform-data/expression-queries).

## Why do we need this change?

To ensure that the Explore Metrics' breakdown panels are correct when [incremental querying](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/#performance) is enabled (see https://github.com/grafana/grafana/issues/91510).

## Who is this feature for?

Explore Metrics users.

## Which issue(s) does this PR fix?

Fixes #91510 

## Demo

### Before fix

The panel for the **cluster** label contains series belonging to other panels in the Breakdown tab (such as **address**):

![demo before fix cluster contains other labels](https://github.com/user-attachments/assets/7761508e-bb00-43e1-8cea-532e7f3cf6b0)

### After fix

The panel for the **cluster** label contains only the expected series:

![demo after fix cluster contains only cluster](https://github.com/user-attachments/assets/c3f54558-be83-48aa-856a-3f02ed2a9509)

## Housekeeping

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
