### PR TITLE
Fix: Deduplicate OrgID in SA logins

### DIFF
--- a/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
+++ b/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
@@ -9,12 +9,16 @@ import (
 
 const (
 	AllowSameLoginCrossOrgs = "update login field with orgid to allow for multiple service accounts with same name across orgs"
+	DedupOrgInLogin         = "update service accounts login field orgid to appear only once"
 )
 
 // Service accounts login were not unique per org. this migration is part of making it unique per org
 // to be able to create service accounts that are unique per org
 func AddServiceAccountsAllowSameLoginCrossOrgs(mg *migrator.Migrator) {
 	mg.AddMigration(AllowSameLoginCrossOrgs, &ServiceAccountsSameLoginCrossOrgs{})
+	// Before it was fixed, the previous introduced the org_id again in logins that already had it.
+	// This migration removes the duplicate org_id from the login.
+	mg.AddMigration(DedupOrgInLogin, &ServiceAccountsDeduplicateOrgInLogin{})
 }
 
 var _ migrator.CodeMigration = new(ServiceAccountsSameLoginCrossOrgs)
@@ -74,5 +78,58 @@ func (p *ServiceAccountsSameLoginCrossOrgs) Exec(sess *xorm.Session, mg *migrato
 	default:
 		return fmt.Errorf("dialect not supported: %s", p.dialect)
 	}
+	return err
+}
+
+type ServiceAccountsDeduplicateOrgInLogin struct {
+	sess    *xorm.Session
+	dialect migrator.Dialect
+	migrator.MigrationBase
+}
+
+func (p *ServiceAccountsDeduplicateOrgInLogin) SQL(dialect migrator.Dialect) string {
+	return "code migration"
+}
+
+func (p *ServiceAccountsDeduplicateOrgInLogin) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
+	p.sess = sess
+	p.dialect = mg.Dialect
+	var err error
+
+	type Login struct {
+		ID    int64
+		Login string
+	}
+
+	// var logins []Login
+	switch p.dialect.DriverName() {
+	case migrator.Postgres:
+		_, err = p.sess.Exec(`
+            UPDATE "user"
+            SET login = 'sa-' || org_id::text || SUBSTRING(login FROM LENGTH('sa-' || org_id::text || '-' || org_id::text)+1)
+            WHERE login IS NOT NULL 
+              AND is_service_account = true
+              AND login LIKE 'sa-' || org_id::text || '-' || org_id::text || '-%';
+        `)
+	case migrator.MySQL:
+		_, err = p.sess.Exec(`
+            UPDATE user
+            SET login = CONCAT('sa-', org_id, SUBSTRING(login, LENGTH(CONCAT('sa-', org_id, '-', org_id))+1))
+            WHERE login IS NOT NULL
+                AND is_service_account = 1
+                AND login LIKE CONCAT('sa-', org_id, '-', org_id, '-%');
+        `)
+	case migrator.SQLite:
+		_, err = p.sess.Exec(`
+            UPDATE ` + p.dialect.Quote("user") + `
+            SET login = 'sa-' || CAST(org_id AS TEXT) || SUBSTRING(login, LENGTH('sa-'||CAST(org_id AS TEXT)||'-'||CAST(org_id AS TEXT))+1)
+            WHERE login IS NOT NULL
+                AND is_service_account = 1
+                AND login LIKE 'sa-'||CAST(org_id AS TEXT)||'-'||CAST(org_id AS TEXT)||'-%';
+        `)
+	default:
+		return fmt.Errorf("dialect not supported: %s", p.dialect)
+	}
+
 	return err
 }

--- a/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
+++ b/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
@@ -16,7 +16,7 @@ const (
 // to be able to create service accounts that are unique per org
 func AddServiceAccountsAllowSameLoginCrossOrgs(mg *migrator.Migrator) {
 	mg.AddMigration(AllowSameLoginCrossOrgs, &ServiceAccountsSameLoginCrossOrgs{})
-	// Before it was fixed, the previous introduced the org_id again in logins that already had it.
+	// Before it was fixed, the previous migration introduced the org_id again in logins that already had it.
 	// This migration removes the duplicate org_id from the login.
 	mg.AddMigration(DedupOrgInLogin, &ServiceAccountsDeduplicateOrgInLogin{})
 }

--- a/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
+++ b/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
@@ -96,11 +96,6 @@ func (p *ServiceAccountsDeduplicateOrgInLogin) Exec(sess *xorm.Session, mg *migr
 	p.dialect = mg.Dialect
 	var err error
 
-	type Login struct {
-		ID    int64
-		Login string
-	}
-
 	// var logins []Login
 	switch p.dialect.DriverName() {
 	case migrator.Postgres:


### PR DESCRIPTION
**What is this feature?**

Follow up to https://github.com/grafana/grafana/pull/94347.
Some service accounts logins were migrated even though their logins were correctly formed (`sa-<orgID>`) thus introducing a duplicated `orgID`  (`sa-<orgID>-<orgID>`).
This PR introduces a new migration that de-duplicates the `orgID`.

This is particularly necessary in the case of external service accounts as their logins is what we use to protect them against deletion and modifications.
