### PR TITLE
Chore: Change VariableEditorList overflow styling & tidy markup

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorList.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorList.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
+import classNames from 'classnames';
 import { ReactElement } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -30,76 +31,66 @@ export function VariableEditorList({
   onEdit,
 }: Props): ReactElement {
   const styles = useStyles2(getStyles);
+
   const onDragEnd = (result: DropResult) => {
     if (!result.destination || !result.source) {
       return;
     }
+
     reportInteraction('Variable drag and drop');
     onChangeOrder(result.source.index, result.destination.index);
   };
 
-  return (
-    <div>
-      <div>
-        {variables.length === 0 && <EmptyVariablesList onAdd={onAdd} />}
-
-        {variables.length > 0 && (
-          <Stack direction="column" gap={3}>
-            <div className={styles.tableContainer}>
-              <table
-                className="filter-table filter-table--hover"
-                data-testid={selectors.pages.Dashboard.Settings.Variables.List.table}
-                role="grid"
-              >
-                <thead>
-                  <tr>
-                    <th>Variable</th>
-                    <th>Definition</th>
-                    <th colSpan={5} />
-                  </tr>
-                </thead>
-                <DragDropContext onDragEnd={onDragEnd}>
-                  <Droppable droppableId="variables-list" direction="vertical">
-                    {(provided) => (
-                      <tbody ref={provided.innerRef} {...provided.droppableProps}>
-                        {variables.map((variableScene, index) => {
-                          const variableState = variableScene.state;
-                          return (
-                            <VariableEditorListRow
-                              index={index}
-                              key={`${variableState.name}-${index}`}
-                              variable={variableScene}
-                              onDelete={onDelete}
-                              onDuplicate={onDuplicate}
-                              onEdit={onEdit}
-                            />
-                          );
-                        })}
-                        {provided.placeholder}
-                      </tbody>
-                    )}
-                  </Droppable>
-                </DragDropContext>
-              </table>
-            </div>
-            <Stack>
-              <VariablesDependenciesButton variables={variables} />
-              <Button
-                data-testid={selectors.pages.Dashboard.Settings.Variables.List.newButton}
-                onClick={onAdd}
-                icon="plus"
-              >
-                New variable
-              </Button>
-            </Stack>
-          </Stack>
-        )}
-      </div>
-    </div>
+  return variables.length <= 0 ? (
+    <EmptyVariablesList onAdd={onAdd} />
+  ) : (
+    <Stack direction="column" gap={3}>
+      <table
+        className={classNames('filter-table', 'filter-table--hover', styles.tableContainer)}
+        data-testid={selectors.pages.Dashboard.Settings.Variables.List.table}
+        role="grid"
+      >
+        <thead>
+          <tr>
+            <th>Variable</th>
+            <th>Definition</th>
+            <th colSpan={5} />
+          </tr>
+        </thead>
+        <DragDropContext onDragEnd={onDragEnd}>
+          <Droppable droppableId="variables-list" direction="vertical">
+            {(provided) => (
+              <tbody ref={provided.innerRef} {...provided.droppableProps}>
+                {variables.map((variableScene, index) => {
+                  const variableState = variableScene.state;
+                  return (
+                    <VariableEditorListRow
+                      index={index}
+                      key={`${variableState.name}-${index}`}
+                      variable={variableScene}
+                      onDelete={onDelete}
+                      onDuplicate={onDuplicate}
+                      onEdit={onEdit}
+                    />
+                  );
+                })}
+                {provided.placeholder}
+              </tbody>
+            )}
+          </Droppable>
+        </DragDropContext>
+      </table>
+      <Stack>
+        <VariablesDependenciesButton variables={variables} />
+        <Button data-testid={selectors.pages.Dashboard.Settings.Variables.List.newButton} onClick={onAdd} icon="plus">
+          New variable
+        </Button>
+      </Stack>
+    </Stack>
   );
 }
 
-function EmptyVariablesList({ onAdd }: { onAdd: () => void }): ReactElement {
+function EmptyVariablesList({ onAdd }: { onAdd: () => void }) {
   return (
     <Stack direction="column">
       <EmptyState
@@ -138,7 +129,6 @@ function EmptyVariablesList({ onAdd }: { onAdd: () => void }): ReactElement {
 
 const getStyles = () => ({
   tableContainer: css({
-    overflow: 'scroll',
-    width: '100%',
+    overflow: 'auto',
   }),
 });


### PR DESCRIPTION
Changes overflow styling on `VariableEditorList` from `scroll` to `auto` so empty scrollbars aren't always shown.
Also some of the extraneous wrapper `div`s have been removed.

Old:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/f200c4b7-71a4-4415-8c03-bb027f8e8a14">


New:
<img width="792" alt="image" src="https://github.com/user-attachments/assets/c9eef43d-dfa1-4b8e-bd3b-f4ff9e7f847b">
