### PR TITLE
TraceView: Fix icon background after making a copy of an attribute

### DIFF
--- a/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
@@ -26,7 +26,7 @@ const getStyles = () => ({
     height: '100%',
     overflow: 'hidden',
     '&:focus': {
-      backgroundCcolor: 'rgba(255, 255, 255, 0.25)',
+      backgroundColor: 'rgba(255, 255, 255, 0.25)',
       color: 'inherit',
     },
   }),


### PR DESCRIPTION
Follow up on https://github.com/grafana/grafana/pull/87621

Fixing incorrect CSS style used to apply dark background behind the copy icon after making a copy.

![copy](https://github.com/user-attachments/assets/4d781453-a1e6-441f-a131-f9642d04a40a)
