### PR TITLE
Alerting: Change styling so query results with no labels are clearer

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1692,10 +1692,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
     "public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -4,7 +4,7 @@ import { FC, useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { DataFrame, dateTimeFormat, GrafanaTheme2, isTimeSeriesFrames, LoadingState, PanelData } from '@grafana/data';
-import { Alert, AutoSizeInput, Button, clearButtonStyles, IconButton, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, AutoSizeInput, Button, clearButtonStyles, IconButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { ClassicConditions } from 'app/features/expressions/components/ClassicConditions';
 import { Math } from 'app/features/expressions/components/Math';
 import { Reduce } from 'app/features/expressions/components/Reduce';
@@ -359,6 +359,10 @@ interface FrameProps extends Pick<ExpressionProps, 'isAlertCondition'> {
   index: number;
 }
 
+const OpeningBracket = () => <span>{'{'}</span>;
+const ClosingBracket = () => <span>{'}'}</span>;
+const Quote = () => <span>&quot;</span>;
+
 const FrameRow: FC<FrameProps> = ({ frame, index, isAlertCondition }) => {
   const styles = useStyles2(getStyles);
 
@@ -377,23 +381,26 @@ const FrameRow: FC<FrameProps> = ({ frame, index, isAlertCondition }) => {
     <div className={styles.expression.resultsRow}>
       <Stack direction="row" gap={1} alignItems="center">
         <div className={styles.expression.resultLabel} title={title}>
-          <span>{hasLabels ? '' : name}</span>
-          {hasLabels && (
-            <>
-              <span>{'{'}</span>
-              {labels.map(([key, value], index) => (
-                <span key={uniqueId()}>
-                  <span className={styles.expression.labelKey}>{key}</span>
-                  <span>=</span>
-                  <span>&quot;</span>
-                  <span className={styles.expression.labelValue}>{value}</span>
-                  <span>&quot;</span>
-                  {index < labels.length - 1 && <span>, </span>}
-                </span>
-              ))}
-              <span>{'}'}</span>
-            </>
-          )}
+          <Text variant="code">
+            {hasLabels ? (
+              <>
+                <OpeningBracket />
+                {labels.map(([key, value], index) => (
+                  <Text variant="body" key={uniqueId()}>
+                    <span className={styles.expression.labelKey}>{key}</span>
+                    <span>=</span>
+                    <Quote />
+                    <span className={styles.expression.labelValue}>{value}</span>
+                    <Quote />
+                    {index < labels.length - 1 && <span>, </span>}
+                  </Text>
+                ))}
+                <ClosingBracket />
+              </>
+            ) : (
+              <span className={styles.expression.labelKey}>{title}</span>
+            )}
+          </Text>
         </div>
         <div className={styles.expression.resultValue}>{value}</div>
         {showFiring && <AlertStateTag state={PromAlertingRuleState.Firing} size="sm" />}

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -361,7 +361,8 @@ interface FrameProps extends Pick<ExpressionProps, 'isAlertCondition'> {
 
 const OpeningBracket = () => <span>{'{'}</span>;
 const ClosingBracket = () => <span>{'}'}</span>;
-const Quote = () => <span>&quot;</span>;
+const Quote = () => <span>{'&quot;'}</span>;
+const Equals = () => <span>{'='}</span>;
 
 const FrameRow: FC<FrameProps> = ({ frame, index, isAlertCondition }) => {
   const styles = useStyles2(getStyles);
@@ -388,7 +389,7 @@ const FrameRow: FC<FrameProps> = ({ frame, index, isAlertCondition }) => {
                 {labels.map(([key, value], index) => (
                   <Text variant="body" key={uniqueId()}>
                     <span className={styles.expression.labelKey}>{key}</span>
-                    <span>=</span>
+                    <Equals />
                     <Quote />
                     <span className={styles.expression.labelValue}>{value}</span>
                     <Quote />


### PR DESCRIPTION
**What is this feature?**

Makes the display of rows in query/expression steps clearer when there are no labels - before this they can look like a table heading (e.g Series 1 at the top of the table)

**Why do we need this feature?**

Clearer UX for rows that don't have labels/are using fallback titles for the rows

**Who is this feature for?**

Alerting UI users

Screenshots - with a hack to make the first one always display as the title instead of the labels:

Before:
![Screenshot 2024-10-08 at 13 24 10](https://github.com/user-attachments/assets/6b1d737a-71e8-4651-ba93-5c6b9a447309)
![Screenshot 2024-10-08 at 13 24 25](https://github.com/user-attachments/assets/abd43762-e855-4024-8e11-f9e72d9fdef1)

After:
![Screenshot 2024-10-08 at 13 24 12](https://github.com/user-attachments/assets/606b7118-07b9-4615-bb16-d13456e49a25)

![Screenshot 2024-10-08 at 13 24 23](https://github.com/user-attachments/assets/40c03d09-ee0e-4cb8-848c-8a4793670d6a)


