### PR TITLE
CloudMigrations: cover cases where library panel has no folder

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -672,6 +672,7 @@ func TestGetParentNames(t *testing.T) {
 			},
 			libraryElements: []libraryElement{
 				{UID: "libraryElementUID-0", FolderUID: &libraryElementFolderUID},
+				{UID: "libraryElementUID-1"},
 			},
 			expectedDashParentNames: []string{"", "Folder A", "Folder B"},
 			expectedFoldParentNames: []string{"Folder A"},

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -588,7 +588,9 @@ func (s *Service) getParentNames(ctx context.Context, signedInUser *user.SignedI
 		parentFolderUIDsSet[f.ParentUID] = struct{}{}
 	}
 	for _, libraryElement := range libraryElements {
-		parentFolderUIDsSet[*libraryElement.FolderUID] = struct{}{}
+		if libraryElement.FolderUID != nil {
+			parentFolderUIDsSet[*libraryElement.FolderUID] = struct{}{}
+		}
 	}
 	parentFolderUIDsSlice := make([]string, 0, len(parentFolderUIDsSet))
 	for parentFolderUID := range parentFolderUIDsSet {
@@ -610,7 +612,9 @@ func (s *Service) getParentNames(ctx context.Context, signedInUser *user.SignedI
 		parentNamesByType[cloudmigration.FolderDataType][f.UID] = foldersUIDsToFolderName[f.ParentUID]
 	}
 	for _, libraryElement := range libraryElements {
-		parentNamesByType[cloudmigration.LibraryElementDataType][libraryElement.UID] = foldersUIDsToFolderName[*libraryElement.FolderUID]
+		if libraryElement.FolderUID != nil {
+			parentNamesByType[cloudmigration.LibraryElementDataType][libraryElement.UID] = foldersUIDsToFolderName[*libraryElement.FolderUID]
+		}
 	}
 
 	return parentNamesByType, err


### PR DESCRIPTION
**What is this feature?**

Adds a nil pointer check before dereferencing `folderUID` from a `libraryElement` as it can be `nil`.

**Why do we need this feature?**

Otherwise it panics when trying to create a snapshot with Library Panels in the "root" folder.

**Who is this feature for?**

Cloud Migration Assistant.

**Which issue(s) does this PR fix?**:

N/A