### PR TITLE
[v11.2.x] Chore: uPlot v1.6.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,7 +400,7 @@
     "tslib": "2.6.3",
     "tween-functions": "^1.2.0",
     "type-fest": "^4.18.2",
-    "uplot": "1.6.30",
+    "uplot": "1.6.31",
     "uuid": "9.0.1",
     "visjs-network": "4.25.0",
     "whatwg-fetch": "3.6.20",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -57,7 +57,7 @@
     "string-hash": "^1.1.3",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.3",
-    "uplot": "1.6.30",
+    "uplot": "1.6.31",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -110,7 +110,7 @@
     "slate-react": "0.22.10",
     "tinycolor2": "1.6.0",
     "tslib": "2.6.3",
-    "uplot": "1.6.30",
+    "uplot": "1.6.31",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,7 +3225,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.6.3"
     typescript: "npm:5.4.5"
-    uplot: "npm:1.6.30"
+    uplot: "npm:1.6.31"
     xss: "npm:^1.0.14"
   peerDependencies:
     react: ^18.0.0
@@ -3963,7 +3963,7 @@ __metadata:
     tinycolor2: "npm:1.6.0"
     tslib: "npm:2.6.3"
     typescript: "npm:5.4.5"
-    uplot: "npm:1.6.30"
+    uplot: "npm:1.6.31"
     uuid: "npm:9.0.1"
     webpack: "npm:5.91.0"
   peerDependencies:
@@ -17791,7 +17791,7 @@ __metadata:
     tween-functions: "npm:^1.2.0"
     type-fest: "npm:^4.18.2"
     typescript: "npm:5.4.5"
-    uplot: "npm:1.6.30"
+    uplot: "npm:1.6.31"
     uuid: "npm:9.0.1"
     visjs-network: "npm:4.25.0"
     webpack: "npm:5.91.0"
@@ -30191,10 +30191,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.30":
-  version: 1.6.30
-  resolution: "uplot@npm:1.6.30"
-  checksum: 10/08ad2f9441b8cfa26d9219362cdbb6f2dc6e5ec9403382df71798ed3e9d3666e7712c8a245e652ebb4a25c5d911cbdc614b52dfd891c0f7ce8705320d2eff81f
+"uplot@npm:1.6.31":
+  version: 1.6.31
+  resolution: "uplot@npm:1.6.31"
+  checksum: 10/8a24bed5c56aa45928102ff964a6a42e3ec806369278ce52dbc65d65e453a7e4b1ee73d525c53618223b712207266f7be752853284c7e5d5bc04c2d23bcc85b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport 165ca3b4e8411cebc73dcc8a396836038e3f064c from #93952

https://security.snyk.io/vuln/SNYK-JS-UPLOT-6209224