### PR TITLE
Sidecar: Allow passing initial context to openAppInSideview

### DIFF
--- a/packages/grafana-data/src/context/plugins/PluginContextProvider.tsx
+++ b/packages/grafana-data/src/context/plugins/PluginContextProvider.tsx
@@ -6,6 +6,7 @@ import { Context } from './PluginContext';
 
 export type PluginContextProviderProps = {
   meta: PluginMeta;
+  initialContext?: unknown;
 };
 
 export function PluginContextProvider(props: PropsWithChildren<PluginContextProviderProps>): ReactElement {

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -50,6 +50,8 @@ export interface AppRootProps<T extends KeyValue = KeyValue> {
    * @deprecated Use react-router instead
    */
   path: string;
+
+  initialContext?: unknown;
 }
 
 export interface AppPluginMeta<T extends KeyValue = KeyValue> extends PluginMeta<T> {

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -50,8 +50,6 @@ export interface AppRootProps<T extends KeyValue = KeyValue> {
    * @deprecated Use react-router instead
    */
   path: string;
-
-  initialContext?: unknown;
 }
 
 export interface AppPluginMeta<T extends KeyValue = KeyValue> extends PluginMeta<T> {

--- a/public/app/core/context/SidecarContext.ts
+++ b/public/app/core/context/SidecarContext.ts
@@ -6,17 +6,19 @@ import { SidecarService, sidecarService } from '../services/SidecarService';
 export const SidecarContext = createContext<SidecarService>(sidecarService);
 
 export function useSidecar() {
-  const activePluginId = useObservable(sidecarService.activePluginId);
-  const context = useContext(SidecarContext);
+  const service = useContext(SidecarContext);
+  const activePluginId = useObservable(service.activePluginId);
+  const initialContext = useObservable(service.initialContext);
 
-  if (!context) {
+  if (!service) {
     throw new Error('No SidecarContext found');
   }
 
   return {
     activePluginId,
-    openApp: (pluginId: string) => context.openApp(pluginId),
-    closeApp: (pluginId: string) => context.closeApp(pluginId),
-    isAppOpened: (pluginId: string) => context.isAppOpened(pluginId),
+    initialContext,
+    openApp: (pluginId: string, context?: unknown) => service.openApp(pluginId, context),
+    closeApp: (pluginId: string) => service.closeApp(pluginId),
+    isAppOpened: (pluginId: string) => service.isAppOpened(pluginId),
   };
 }

--- a/public/app/core/services/SidecarService.ts
+++ b/public/app/core/services/SidecarService.ts
@@ -5,9 +5,11 @@ import { config, locationService } from '@grafana/runtime';
 export class SidecarService {
   // The ID of the app plugin that is currently opened in the sidecar view
   private _activePluginId: BehaviorSubject<string | undefined>;
+  private _initialContext: BehaviorSubject<unknown | undefined>;
 
   constructor() {
     this._activePluginId = new BehaviorSubject<string | undefined>(undefined);
+    this._initialContext = new BehaviorSubject<unknown | undefined>(undefined);
   }
 
   private assertFeatureEnabled() {
@@ -23,21 +25,27 @@ export class SidecarService {
     return this._activePluginId.asObservable();
   }
 
-  openApp(pluginId: string) {
+  get initialContext() {
+    return this._initialContext.asObservable();
+  }
+
+  openApp(pluginId: string, context?: unknown) {
     if (!this.assertFeatureEnabled()) {
-      return false;
+      return;
     }
 
-    return this._activePluginId.next(pluginId);
+    this._activePluginId.next(pluginId);
+    this._initialContext.next(context);
   }
 
   closeApp(pluginId: string) {
     if (!this.assertFeatureEnabled()) {
-      return false;
+      return;
     }
 
     if (this._activePluginId.getValue() === pluginId) {
-      return this._activePluginId.next(undefined);
+      this._activePluginId.next(undefined);
+      this._initialContext.next(undefined);
     }
   }
 

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -100,7 +100,7 @@ export function AppRootPage({ pluginId, pluginNavSection, initialContext }: Prop
   }
 
   const pluginRoot = plugin.root && (
-    <PluginContextProvider meta={plugin.meta}>
+    <PluginContextProvider meta={plugin.meta} initialContext={initialContext}>
       <ExtensionRegistriesProvider
         registries={{
           addedLinksRegistry: addedLinksRegistry.readOnly(),
@@ -114,7 +114,6 @@ export function AppRootPage({ pluginId, pluginNavSection, initialContext }: Prop
           onNavChanged={onNavChanged}
           query={queryParams}
           path={location.pathname}
-          initialContext={initialContext}
         />
       </ExtensionRegistriesProvider>
     </PluginContextProvider>

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -43,6 +43,7 @@ interface Props {
   // The root navModelItem for the plugin (root = lives directly under 'home'). In case app does not need a nva model,
   // for example it's in some way embedded or shown in a sideview this can be undefined.
   pluginNavSection?: NavModelItem;
+  initialContext?: unknown;
 }
 
 interface State {
@@ -55,7 +56,7 @@ interface State {
 
 const initialState: State = { loading: true, loadingError: false, pluginNav: null, plugin: null };
 
-export function AppRootPage({ pluginId, pluginNavSection }: Props) {
+export function AppRootPage({ pluginId, pluginNavSection, initialContext }: Props) {
   const { pluginId: pluginIdParam = '' } = useParams();
   pluginId = pluginId || pluginIdParam;
   const addedLinksRegistry = useAddedLinksRegistry();
@@ -113,6 +114,7 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
           onNavChanged={onNavChanged}
           query={queryParams}
           path={location.pathname}
+          initialContext={initialContext}
         />
       </ExtensionRegistriesProvider>
     </PluginContextProvider>

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -375,7 +375,7 @@ export function getLinkExtensionOnClick(
         context,
         openModal: createOpenModalFunction(pluginId),
         isAppOpened: () => isAppOpened(pluginId),
-        openAppInSideview: () => openAppInSideview(pluginId),
+        openAppInSideview: (context?: unknown) => openAppInSideview(pluginId, context),
         closeAppInSideview: () => closeAppInSideview(pluginId),
       };
 
@@ -406,7 +406,7 @@ export function getLinkExtensionPathWithTracking(pluginId: string, path: string,
   );
 }
 
-export const openAppInSideview = (pluginId: string) => sidecarService.openApp(pluginId);
+export const openAppInSideview = (pluginId: string, context?: unknown) => sidecarService.openApp(pluginId, context);
 
 export const closeAppInSideview = (pluginId: string) => sidecarService.closeApp(pluginId);
 

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -55,7 +55,7 @@ export function RouterWrapper(props: RouterWrapperProps) {
  * @constructor
  */
 export function ExperimentalSplitPaneRouterWrapper(props: RouterWrapperProps) {
-  const { activePluginId, closeApp } = useSidecar();
+  const { activePluginId, closeApp, initialContext } = useSidecar();
 
   let { containerProps, primaryProps, secondaryProps, splitterProps } = useSplitter({
     direction: 'row',
@@ -109,7 +109,7 @@ export function ExperimentalSplitPaneRouterWrapper(props: RouterWrapperProps) {
                         onClick={() => closeApp(activePluginId)}
                       />
                     </div>
-                    <AppRootPage pluginId={activePluginId} />
+                    <AppRootPage pluginId={activePluginId} initialContext={initialContext} />
                   </div>
                 </CompatRouter>
               </LocationServiceProvider>


### PR DESCRIPTION
This allows to pass some context information to the app from the app extensions.

Allows for initializing the app from information that is provided to the extensions point, possibly initializing queries/labels/timeranges etc.


https://github.com/user-attachments/assets/5cc3fa11-df18-43e9-a2e9-a360e4a0c92e

