### PR TITLE
Alerting: Remove `accesscontrol` license feature requirement for contact points RBAC

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -3,11 +3,7 @@ import { ComponentProps, ReactNode } from 'react';
 import { render, screen, userEvent, waitFor, waitForElementToBeRemoved, within } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
-import {
-  flushMicrotasks,
-  testWithFeatureToggles,
-  testWithLicenseFeatures,
-} from 'app/features/alerting/unified/test/test-utils';
+import { flushMicrotasks, testWithFeatureToggles } from 'app/features/alerting/unified/test/test-utils';
 import { K8sAnnotations } from 'app/features/alerting/unified/utils/k8s/constants';
 import { AlertManagerDataSourceJsonData, AlertManagerImplementation } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
@@ -541,24 +537,20 @@ describe('contact points', () => {
       expect(screen.queryByRole('menuitem', { name: /manage permissions/i })).not.toBeInTheDocument();
     });
 
-    describe('accesscontrol license feature enabled', () => {
-      testWithLicenseFeatures(['accesscontrol']);
+    it('shows manage permissions and allows closing', async () => {
+      const { user } = renderGrafanaContactPoints();
 
-      it('shows manage permissions and allows closing', async () => {
-        const { user } = renderGrafanaContactPoints();
+      await clickMoreActionsButton('lotsa-emails');
 
-        await clickMoreActionsButton('lotsa-emails');
+      await user.click(await screen.findByRole('menuitem', { name: /manage permissions/i }));
 
-        await user.click(await screen.findByRole('menuitem', { name: /manage permissions/i }));
+      const permissionsDialog = await screen.findByRole('dialog', { name: /drawer title manage permissions/i });
 
-        const permissionsDialog = await screen.findByRole('dialog', { name: /drawer title manage permissions/i });
+      expect(permissionsDialog).toBeInTheDocument();
+      expect(await screen.findByRole('table')).toBeInTheDocument();
 
-        expect(permissionsDialog).toBeInTheDocument();
-        expect(await screen.findByRole('table')).toBeInTheDocument();
-
-        await user.click(within(permissionsDialog).getAllByRole('button', { name: /close/i })[0]);
-        expect(permissionsDialog).not.toBeInTheDocument();
-      });
+      await user.click(within(permissionsDialog).getAllByRole('button', { name: /close/i })[0]);
+      expect(permissionsDialog).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -529,14 +529,6 @@ describe('contact points', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not show manage permissions', async () => {
-      renderGrafanaContactPoints();
-
-      await clickMoreActionsButton('lotsa-emails');
-
-      expect(screen.queryByRole('menuitem', { name: /manage permissions/i })).not.toBeInTheDocument();
-    });
-
     it('shows manage permissions and allows closing', async () => {
       const { user } = renderGrafanaContactPoints();
 

--- a/public/app/features/alerting/unified/components/contact-points/utils.ts
+++ b/public/app/features/alerting/unified/components/contact-points/utils.ts
@@ -2,7 +2,6 @@ import { difference, groupBy, take, trim, upperFirst } from 'lodash';
 import { ReactNode } from 'react';
 
 import { config } from '@grafana/runtime';
-import { contextSrv } from 'app/core/core';
 import { canAdminEntity, shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
 import {
   AlertManagerCortexConfig,
@@ -210,4 +209,4 @@ function getNotifierMetadata(notifiers: NotifierDTO[], receiver: GrafanaManagedR
 }
 
 export const showManageContactPointPermissions = (alertmanager: string, contactPoint: GrafanaManagedContactPoint) =>
-  shouldUseK8sApi(alertmanager) && contextSrv.licensedAccessControlEnabled() && canAdminEntity(contactPoint);
+  shouldUseK8sApi(alertmanager) && canAdminEntity(contactPoint);


### PR DESCRIPTION
**What is this feature?**

Removes requirement of `accesscontrol` license feature for display of "Manage permissions" in Grafana contact points

**Why do we need this feature?**

The functionality doesn't need to be hidden behind this check, as we can offer (some) functionality without the full license enabled anyway
