### PR TITLE
State Timeline: Align left text to 0 when rectangle is left-truncated

### DIFF
--- a/public/app/core/components/TimelineChart/timeline.ts
+++ b/public/app/core/components/TimelineChart/timeline.ts
@@ -321,7 +321,11 @@ export function getConfig(opts: TimelineCoreOptions) {
                     continue;
                   }
 
-                  let maxChars = Math.floor(boxRect?.w / pxPerChar);
+                  // if x placement is negative, rect is left truncated, remove it from width for calculating how many chars will display
+                  // right truncation happens automatically
+                  const displayedBoxWidth = boxRect.x < 0 ? boxRect?.w + boxRect.x : boxRect?.w;
+
+                  let maxChars = Math.floor(displayedBoxWidth / pxPerChar);
 
                   if (showValue === VisibilityMode.Auto && maxChars < 2) {
                     continue;
@@ -333,7 +337,7 @@ export function getConfig(opts: TimelineCoreOptions) {
                   let x = round(boxRect.x + xOff + boxRect.w / 2);
                   if (mode === TimelineMode.Changes) {
                     if (alignValue === 'left') {
-                      x = round(boxRect.x + xOff + strokeWidth + textPadding);
+                      x = round(Math.max(boxRect.x, 0) + xOff + strokeWidth + textPadding);
                     } else if (alignValue === 'right') {
                       x = round(boxRect.x + xOff + boxRect.w - strokeWidth - textPadding);
                     }


### PR DESCRIPTION
**What is this feature?**

With left truncated rectangles in the visualization, the x value is a negative number and the width of the rectangle is maintained. This means the left aligned text would display at the negative x value and would be cut off.

Instead, align the text at 0 if the x value is negative. Also use the display width of the rectangle , which might be the actual width minus the x value, to calculate how many characters should display.

**Why do we need this feature?**

To be better about showing all the value data we can.

**Which issue(s) does this PR fix?**:

Customer escalation

Fixes https://github.com/grafana/support-escalations/issues/12760

**Special notes for your reviewer:**

1. Create a panel with the state timeline visualization 
2. Use gdev-prometheus
3. Use `rate(go_gc_duration_seconds_count{instance="localhost:9090"}[$__rate_interval])`
4. Set threshhold to show red at 0.01
5. Set visualization to auto refresh every 5 seconds

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
