### PR TITLE
ServiceAccounts: Run migration in batches

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -55,7 +55,6 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, mg *migrato
 }
 
 func (m *orphanedServiceAccountPermissions) exec(sess *xorm.Session, mg *migrator.Migrator, ids []int64) error {
-
 	// get all service accounts from batch
 	raw := "SELECT u.id FROM " + mg.Dialect.Quote("user") + " AS u WHERE u.is_service_account AND u.id IN(?" + strings.Repeat(",?", len(ids)-1) + ")"
 	args := make([]any, 0, len(ids))

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -49,7 +49,14 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, mg *migrato
 		return nil
 	}
 
-	// Then find all existing service accounts
+	return batch(len(ids), batchSize, func(start, end int) error {
+		return m.exec(sess, mg, ids[start:end])
+	})
+}
+
+func (m *orphanedServiceAccountPermissions) exec(sess *xorm.Session, mg *migrator.Migrator, ids []int64) error {
+
+	// get all service accounts from batch
 	raw := "SELECT u.id FROM " + mg.Dialect.Quote("user") + " AS u WHERE u.is_service_account AND u.id IN(?" + strings.Repeat(",?", len(ids)-1) + ")"
 	args := make([]any, 0, len(ids))
 	for _, id := range ids {
@@ -57,7 +64,7 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, mg *migrato
 	}
 
 	var existingIDs []int64
-	err = sess.SQL(raw, args...).Find(&existingIDs)
+	err := sess.SQL(raw, args...).Find(&existingIDs)
 	if err != nil {
 		return fmt.Errorf("failed to fetch existing service accounts: %w", err)
 	}
@@ -93,4 +100,5 @@ func (m *orphanedServiceAccountPermissions) Exec(sess *xorm.Session, mg *migrato
 	}
 
 	return nil
+
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -99,5 +99,4 @@ func (m *orphanedServiceAccountPermissions) exec(sess *xorm.Session, mg *migrato
 	}
 
 	return nil
-
 }


### PR DESCRIPTION
**What is this feature?**
For instances with a lot of service accounts this migration can fail due to prepare statement limits.
To fix this we can run fetch, check and delete in batches.


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
