### PR TITLE
ExploreMetrics: Keep gaps consistent between sticky elements

### DIFF
--- a/public/app/features/trails/MetricGraphScene.tsx
+++ b/public/app/features/trails/MetricGraphScene.tsx
@@ -62,6 +62,8 @@ function getStyles(theme: GrafanaTheme2, chromeHeaderHeight: number) {
       flexDirection: 'row',
       background: theme.isLight ? theme.colors.background.primary : theme.colors.background.canvas,
       position: 'sticky',
+      paddingTop: theme.spacing(1),
+      marginTop: `-${theme.spacing(1)}`,
       top: `${chromeHeaderHeight + 70}px`,
       zIndex: 10,
     }),


### PR DESCRIPTION
## What is this change?

A style change in Explore Metrics. It's most visible when the Breakdown tab is selected.

### How it works

In the Data Trail scene, the history, controls, and the "top scene" are separated by:

https://github.com/grafana/grafana/blob/a3764ebeba5dc1ff02bc7a73f7ab8628d981f473/public/app/features/trails/DataTrail.tsx#L680

As we scroll, the gap between the sticky controls and top scene elements shrinks. To maintain the illusion that this gap doesn't change in size, we can introduce padding and negative margin of the same height, in the top scene.

## Why do we need this feature?

See https://github.com/grafana/grafana/issues/92415.

## Who is this feature for?

Explore Metrics users.

## Which issue(s) does this PR fix?

Fixes #92415.

## Demo

### Before fix

Notice how the gap between the data source selector and ALERTS panel shrinks as we scroll:

https://github.com/user-attachments/assets/73fa210a-c23e-40a8-97b9-8c2ff71f6f98

### After fix

The gap between the data source selector and ALERTS panel stays constant as we scroll:

https://github.com/user-attachments/assets/331a1bbd-fde7-4157-be10-8c59f074322f

## Housekeeping

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
