### PR TITLE
Prometheus: Add series endpoint configuration

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7064,6 +7064,7 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
+      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
     "packages/grafana-prometheus/src/querybuilder/components/PromQueryCodeEditor.tsx:5381": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -7064,7 +7064,6 @@ exports[`no gf-form usage`] = {
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
-      [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"],
       [0, 0, 0, "gf-form usage has been deprecated. Use a component from @grafana/ui or custom CSS instead.", "5381"]
     ],
     "packages/grafana-prometheus/src/querybuilder/components/PromQueryCodeEditor.tsx:5381": [

--- a/packages/grafana-prometheus/src/configuration/PromSettings.test.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.test.tsx
@@ -112,5 +112,12 @@ describe('PromSettings', () => {
       fireEvent.blur(input);
       expect(queryByText(countError)).toBeInTheDocument();
     });
+
+    it('should have a series endpoint configuration element', () => {
+      const options = defaultProps;
+
+      render(<PromSettings onOptionsChange={() => {}} options={options} />);
+      expect(screen.getByText('Use series endpoint')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -492,6 +492,28 @@ export const PromSettings = (props: Props) => {
               </InlineField>
             </div>
           </div>
+          <div className="gf-form">
+            <InlineField
+              labelWidth={PROM_CONFIG_LABEL_WIDTH}
+              label="Use series endpoint"
+              tooltip={
+                <>
+                  Checking this option will favor the series endpoint with match[] parameter over the label values
+                  endpoint with match[] parameter. While the label values endpoint is considered more performant, some
+                  users may prefer the series because it has a POST method while the label values endpoint only has a
+                  GET method. {docsTip()}
+                </>
+              }
+              interactive={true}
+              disabled={options.readOnly}
+              className={styles.switchField}
+            >
+              <Switch
+                value={options.jsonData.seriesEndpoint ?? false}
+                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
+              />
+            </InlineField>
+          </div>
         </div>
       </ConfigSubSection>
 

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -492,28 +492,26 @@ export const PromSettings = (props: Props) => {
               </InlineField>
             </div>
           </div>
-          <div className="gf-form">
-            <InlineField
-              labelWidth={PROM_CONFIG_LABEL_WIDTH}
-              label="Use series endpoint"
-              tooltip={
-                <>
-                  Checking this option will favor the series endpoint with match[] parameter over the label values
-                  endpoint with match[] parameter. While the label values endpoint is considered more performant, some
-                  users may prefer the series because it has a POST method while the label values endpoint only has a
-                  GET method. {docsTip()}
-                </>
-              }
-              interactive={true}
-              disabled={options.readOnly}
-              className={styles.switchField}
-            >
-              <Switch
-                value={options.jsonData.seriesEndpoint ?? false}
-                onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
-              />
-            </InlineField>
-          </div>
+          <InlineField
+            labelWidth={PROM_CONFIG_LABEL_WIDTH}
+            label="Use series endpoint"
+            tooltip={
+              <>
+                Checking this option will favor the series endpoint with match[] parameter over the label values
+                endpoint with match[] parameter. While the label values endpoint is considered more performant, some
+                users may prefer the series because it has a POST method while the label values endpoint only has a GET
+                method. {docsTip()}
+              </>
+            }
+            interactive={true}
+            disabled={options.readOnly}
+            className={styles.switchField}
+          >
+            <Switch
+              value={options.jsonData.seriesEndpoint ?? false}
+              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'seriesEndpoint')}
+            />
+          </InlineField>
         </div>
       </ConfigSubSection>
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -111,6 +111,7 @@ export class PrometheusDatasource
   cacheLevel: PrometheusCacheLevel;
   cache: QueryCache<PromQuery>;
   metricNamesAutocompleteSuggestionLimit: number;
+  seriesEndpoint: boolean;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<PromOptions>,
@@ -136,6 +137,7 @@ export class PrometheusDatasource
     this.customQueryParameters = new URLSearchParams(instanceSettings.jsonData.customQueryParameters);
     this.datasourceConfigurationPrometheusFlavor = instanceSettings.jsonData.prometheusType;
     this.datasourceConfigurationPrometheusVersion = instanceSettings.jsonData.prometheusVersion;
+    this.seriesEndpoint = instanceSettings.jsonData.seriesEndpoint ?? false;
     this.defaultEditor = instanceSettings.jsonData.defaultEditor;
     this.disableRecordingRules = instanceSettings.jsonData.disableRecordingRules ?? false;
     this.variables = new PrometheusVariableSupport(this, this.templateSrv);
@@ -183,6 +185,12 @@ export class PrometheusDatasource
   }
 
   hasLabelsMatchAPISupport(): boolean {
+    // users may choose the series endpoint as it has a POST method
+    // while the label values is only GET
+    if (this.seriesEndpoint) {
+      return false;
+    }
+
     return (
       // https://github.com/prometheus/prometheus/releases/tag/v2.24.0
       this._isDatasourceVersionGreaterOrEqualTo('2.24.0', PromApplication.Prometheus) ||

--- a/packages/grafana-prometheus/src/types.ts
+++ b/packages/grafana-prometheus/src/types.ts
@@ -53,6 +53,7 @@ export interface PromOptions extends DataSourceJsonData {
   sigV4Auth?: boolean;
   oauthPassThru?: boolean;
   codeModeMetricNamesSuggestionLimit?: number;
+  seriesEndpoint?: boolean;
 }
 
 export type ExemplarTraceIdDestination = {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/11571
Fixes https://github.com/grafana/support-escalations/issues/12791
Fixes https://github.com/grafana/grafana/issues/94431

**What is this?**

Users can explicitly select to use the series endpoint with match[] parameter over the label values endpoint even if their data source supports the label values endpoint with match[] param.

![Screenshot 2024-10-08 at 5 35 22 PM](https://github.com/user-attachments/assets/17d86b09-57a4-464e-a3b3-de89910e019d)

**Why is this needed?**

In v11, we defaulted to use the label values with match[] param for Prometheus DS configurations that support it. The label values endpoint is more performant but it only has the GET method. The series endpoint has a POST method. Some users preferred the series even though their prometheus versions supported the more performant endpoint. [One reason was because they were using proxies that were configured to add cluster values](https://github.com/grafana/grafana/issues/90318). Switching to label values endpoint broke this for them.

How to test:

Any time that a user is using part of a metric to make a call, we need to use the match[] parameter. This occurs in the metric select in the query builder. If a user has started typing, we send the partial string as a match[] parameter like `{__name__=".*<whatever the user is typing, part of a metric name>"}`

So, to test, 

Make sure your Prometheus version supports the label values with match[] param. Anything greater than Prometheus v2.14.x will support it. NOTE: When you choose > 2.14.x we automatically only support series.
![Screenshot 2024-10-09 at 8 26 44 AM](https://github.com/user-attachments/assets/f3d13524-6a02-49f8-8e25-9136cc34bf95)

You will need to configure Prometheus and use the configuration, "Use series endpoint"
![Screenshot 2024-10-09 at 8 25 19 AM](https://github.com/user-attachments/assets/8d31e5f3-e819-46c8-b57e-fa25f21b9d5b)

Then go to the query builder metric select and start typing. Check the network requests in the browser inspector for typing a partial metric name, see that the series endpoint is called
![Screenshot 2024-10-09 at 8 24 18 AM](https://github.com/user-attachments/assets/f323eda4-d551-477c-870c-f16a7bc0a3e6)

Go back to the configuration page and turn off "Use series endpoint". 

Return to the query builder and begin typing. See that only the label values endpoint is called
![Screenshot 2024-10-09 at 8 22 45 AM](https://github.com/user-attachments/assets/7de79a8b-4a9a-4499-b74e-d1e856568637)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
