### PR TITLE
K8s/Folders: Remove folder service from client

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -21,6 +21,7 @@ import (
 	folderalpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/slugify"
+	"github.com/grafana/grafana/pkg/registry/apis/folders"
 	internalfolders "github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/apiserver"
@@ -886,8 +887,10 @@ func (fk8s *folderK8sHandler) newToFolderDto(c *contextmodel.ReqContext, item un
 		return folderDTO, nil
 	}
 
-	// #TODO add support for escaped slashes
-	parentsFullPath := strings.Split(f.Fullpath, "/")
+	parentsFullPath, err := folders.GetParentTitles(f.Fullpath)
+	if err != nil {
+		return dtos.Folder{}, err
+	}
 	parentsFullPathUIDs := strings.Split(f.FullpathUIDs, "/")
 
 	// The first part of the path is the newly created folder which we don't need to include

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	folderalpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/infra/slugify"
 	internalfolders "github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/apiserver"
@@ -635,8 +636,6 @@ type folderK8sHandler struct {
 	// #TODO check if it makes more sense to move this to FolderAPIBuilder
 	accesscontrolService accesscontrol.Service
 	userService          user.Service
-	// #TODO remove after we handle the nested folder case
-	folderService folder.Service
 }
 
 //-----------------------------------------------------------------------------------------
@@ -650,7 +649,6 @@ func newFolderK8sHandler(hs *HTTPServer) *folderK8sHandler {
 		clientConfigProvider: hs.clientConfigProvider,
 		accesscontrolService: hs.accesscontrolService,
 		userService:          hs.userService,
-		folderService:        hs.folderService,
 	}
 }
 
@@ -884,54 +882,35 @@ func (fk8s *folderK8sHandler) newToFolderDto(c *contextmodel.ReqContext, item un
 		return dtos.Folder{}, err
 	}
 
-	parents := []*folder.Folder{}
-	if folderDTO.ParentUID != "" {
-		parents, err = fk8s.folderService.GetParents(
-			c.Req.Context(),
-			folder.GetParentsQuery{
-				UID:   folderDTO.UID,
-				OrgID: folderDTO.OrgID,
-			})
-		if err != nil {
-			return dtos.Folder{}, err
-		}
+	if len(f.Fullpath) == 0 || len(f.FullpathUIDs) == 0 {
+		return folderDTO, nil
 	}
 
-	// #TODO refactor so that we have just one function for converting to folder DTO
-	toParentDTO := func(fold *folder.Folder, checkCanView bool) (dtos.Folder, error) {
-		g, err := guardian.NewByFolder(c.Req.Context(), fold, c.SignedInUser.GetOrgID(), c.SignedInUser)
-		if err != nil {
-			return dtos.Folder{}, err
-		}
+	// #TODO add support for escaped slashes
+	parentsFullPath := strings.Split(f.Fullpath, "/")
+	parentsFullPathUIDs := strings.Split(f.FullpathUIDs, "/")
 
-		if checkCanView {
-			canView, _ := g.CanView()
-			if !canView {
-				return dtos.Folder{
-					UID:   REDACTED,
-					Title: REDACTED,
-				}, nil
-			}
-		}
-		metrics.MFolderIDsAPICount.WithLabelValues(metrics.NewToFolderDTO).Inc()
-
-		return dtos.Folder{
-			UID:   fold.UID,
-			Title: fold.Title,
-			URL:   fold.URL,
-		}, nil
+	// The first part of the path is the newly created folder which we don't need to include
+	// in the parents field
+	if len(parentsFullPath) < 2 || len(parentsFullPathUIDs) < 2 {
+		return folderDTO, nil
 	}
 
-	folderDTO.Parents = make([]dtos.Folder, 0, len(parents))
-	for _, f := range parents {
-		DTO, err := toParentDTO(f, true)
-		if err != nil {
-			// #TODO add logging
-			// fk8s.log.Error("failed to convert folder to DTO", "folder", f.UID, "org", f.OrgID, "error", err)
-			continue
-		}
-		folderDTO.Parents = append(folderDTO.Parents, DTO)
+	parents := []dtos.Folder{}
+	for i, v := range parentsFullPath[1:] {
+		slug := slugify.Slugify(v)
+		uid := parentsFullPathUIDs[1:][i]
+		url := dashboards.GetFolderURL(uid, slug)
+
+		parents = append(parents, dtos.Folder{
+			UID:   uid,
+			OrgID: c.SignedInUser.GetOrgID(),
+			Title: v,
+			URL:   url,
+		})
 	}
+
+	folderDTO.Parents = parents
 
 	return folderDTO, nil
 }
@@ -953,23 +932,19 @@ func (fk8s *folderK8sHandler) getFolderACMetadata(c *contextmodel.ReqContext, f 
 		return nil, nil
 	}
 
-	var err error
-	parents := []*folder.Folder{}
-	if f.ParentUID != "" {
-		parents, err = fk8s.folderService.GetParents(
-			c.Req.Context(),
-			folder.GetParentsQuery{
-				UID:   f.UID,
-				OrgID: c.SignedInUser.GetOrgID(),
-			})
-		if err != nil {
-			return nil, err
-		}
+	if len(f.FullpathUIDs) == 0 {
+		return map[string]bool{}, nil
+	}
+
+	parentsFullPathUIDs := strings.Split(f.FullpathUIDs, "/")
+	// The first part of the path is the newly created folder which we don't need to check here
+	if len(parentsFullPathUIDs) < 2 {
+		return map[string]bool{}, nil
 	}
 
 	folderIDs := map[string]bool{f.UID: true}
-	for _, p := range parents {
-		folderIDs[p.UID] = true
+	for _, uid := range parentsFullPathUIDs[1:] {
+		folderIDs[uid] = true
 	}
 
 	allMetadata := getMultiAccessControlMetadata(c, dashboards.ScopeFoldersPrefix, folderIDs)

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -21,7 +21,6 @@ import (
 	folderalpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/slugify"
-	"github.com/grafana/grafana/pkg/registry/apis/folders"
 	internalfolders "github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	grafanaapiserver "github.com/grafana/grafana/pkg/services/apiserver"
@@ -887,7 +886,7 @@ func (fk8s *folderK8sHandler) newToFolderDto(c *contextmodel.ReqContext, item un
 		return folderDTO, nil
 	}
 
-	parentsFullPath, err := folders.GetParentTitles(f.Fullpath)
+	parentsFullPath, err := internalfolders.GetParentTitles(f.Fullpath)
 	if err != nil {
 		return dtos.Folder{}, err
 	}

--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -34,6 +34,11 @@ const AnnoKeyOriginPath = "grafana.app/originPath"
 const AnnoKeyOriginHash = "grafana.app/originHash"
 const AnnoKeyOriginTimestamp = "grafana.app/originTimestamp"
 
+// #TODO revisit keeping these folder-specific annotations once we have complete support for mode 1
+
+const AnnoKeyFullPath = "grafana.app/fullPath"
+const AnnoKeyFullPathUIDs = "grafana.app/fullPathUIDs"
+
 // ResourceOriginInfo is saved in annotations.  This is used to identify where the resource came from
 // This object can model the same data as our existing provisioning table or a more general git sync
 type ResourceOriginInfo struct {
@@ -100,6 +105,11 @@ type GrafanaMetaAccessor interface {
 	// Used by the generic strategy to keep the status value unchanged on an update
 	// NOTE the type must match the existing value, or an error will be thrown
 	SetStatus(any) error
+
+	GetFullPath() string
+	SetFullPath(path string)
+	GetFullPathUIDs() string
+	SetFullPathUIDs(path string)
 
 	// Find a title in the object
 	// This will reflect the object and try to get:
@@ -596,6 +606,22 @@ func (m *grafanaMetaAccessor) SetStatus(s any) (err error) {
 		err = fmt.Errorf("unable to read status")
 	}
 	return
+}
+
+func (m *grafanaMetaAccessor) GetFullPath() string {
+	return m.get(AnnoKeyFullPath)
+}
+
+func (m *grafanaMetaAccessor) SetFullPath(path string) {
+	m.SetAnnotation(AnnoKeyFullPath, path)
+}
+
+func (m *grafanaMetaAccessor) GetFullPathUIDs() string {
+	return m.get(AnnoKeyFullPathUIDs)
+}
+
+func (m *grafanaMetaAccessor) SetFullPathUIDs(path string) {
+	m.SetAnnotation(AnnoKeyFullPathUIDs, path)
 }
 
 func (m *grafanaMetaAccessor) FindTitle(defaultTitle string) string {

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -2,6 +2,7 @@ package folders
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -233,4 +234,23 @@ func getCreated(meta utils.GrafanaMetaAccessor) (*time.Time, error) {
 		return nil, err
 	}
 	return created, nil
+}
+
+func GetParentTitles(fullPath string) ([]string, error) {
+	// Find all forward slashes which aren't escaped
+	r, err := regexp.Compile(`[^\\](/)`)
+	if err != nil {
+		return nil, err
+	}
+	indices := r.FindAllStringIndex(fullPath, -1)
+
+	var start int
+	titles := []string{}
+	for _, i := range indices {
+		titles = append(titles, string(fullPath[start:i[0]+1]))
+		start = i[0] + 2
+	}
+
+	titles = append(titles, string(fullPath[start:]))
+	return titles, nil
 }

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -247,10 +247,10 @@ func GetParentTitles(fullPath string) ([]string, error) {
 	var start int
 	titles := []string{}
 	for _, i := range indices {
-		titles = append(titles, string(fullPath[start:i[0]+1]))
+		titles = append(titles, fullPath[start:i[0]+1])
 		start = i[0] + 2
 	}
 
-	titles = append(titles, string(fullPath[start:]))
+	titles = append(titles, fullPath[start:])
 	return titles, nil
 }

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -85,10 +85,12 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) *fo
 		// #TODO add created by field if necessary
 		// CreatedBy: meta.GetCreatedBy(),
 		// UpdatedBy: meta.GetCreatedBy(),
-		URL:     getURL(meta, title),
-		Created: createdTime,
-		Updated: createdTime,
-		OrgID:   orgID,
+		URL:          getURL(meta, title),
+		Created:      createdTime,
+		Updated:      createdTime,
+		OrgID:        orgID,
+		Fullpath:     meta.GetFullPath(),
+		FullpathUIDs: meta.GetFullPathUIDs(),
 	}
 	return f
 }
@@ -182,6 +184,12 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 	}
 	if v.ParentUID != "" {
 		meta.SetFolder(v.ParentUID)
+	}
+	if v.Fullpath != "" {
+		meta.SetFullPath(v.Fullpath)
+	}
+	if v.FullpathUIDs != "" {
+		meta.SetFullPathUIDs(v.FullpathUIDs)
 	}
 	f.UID = gapiutil.CalculateClusterWideUID(f)
 	return f, nil

--- a/pkg/registry/apis/folders/conversions_test.go
+++ b/pkg/registry/apis/folders/conversions_test.go
@@ -1,0 +1,18 @@
+package folders
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetParentTitles(t *testing.T) {
+	path := "get\\/folder-folder-0/get\\/folder-folder-1/another"
+
+	titles, err := GetParentTitles(path)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(titles))
+	require.Equal(t, "get\\/folder-folder-0", titles[0])
+	require.Equal(t, "get\\/folder-folder-1", titles[1])
+	require.Equal(t, "another", titles[2])
+}

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -260,6 +260,7 @@ func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Fo
 
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) {
 		dashFolder.Fullpath = dashFolder.Title
+		dashFolder.FullpathUIDs = dashFolder.UID
 		return dashFolder, nil
 	}
 
@@ -282,7 +283,8 @@ func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Fo
 	f.Version = dashFolder.Version
 
 	if !s.features.IsEnabled(ctx, featuremgmt.FlagNestedFolders) {
-		f.Fullpath = f.Title // set full path to the folder title (unescaped)
+		f.Fullpath = f.Title   // set full path to the folder title (unescaped)
+		f.FullpathUIDs = f.UID // set full path to the folder UID
 	}
 
 	return f, err

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -690,7 +690,10 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 		if err != nil {
 			return nil, err
 		}
-		f.Fullpath = f.Title + "/" + parent.Fullpath
+		// #TODO revisit setting permissions so that we can centralise the logic for escaping slashes in titles
+		// Escape forward slashes in the title
+		title := strings.Replace(f.Title, "/", "\\/", -1)
+		f.Fullpath = title + "/" + parent.Fullpath
 		f.FullpathUIDs = f.UID + "/" + parent.FullpathUIDs
 	}
 

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -501,7 +501,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 			lps, err := librarypanels.ProvideService(cfg, db, routeRegister, elementService, serviceWithFlagOn)
 			require.NoError(t, err)
 
-			ancestors := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "getDescendantCountsOn", createCmd)
+			ancestors := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "getDescendantCountsOn", createCmd, true)
 
 			parent, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, ancestors[0].UID)
 			require.NoError(t, err)
@@ -584,7 +584,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 			lps, err := librarypanels.ProvideService(cfg, db, routeRegister, elementService, serviceWithFlagOff)
 			require.NoError(t, err)
 
-			ancestors := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "getDescendantCountsOff", createCmd)
+			ancestors := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "getDescendantCountsOff", createCmd, true)
 
 			parent, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, ancestors[0].UID)
 			require.NoError(t, err)
@@ -725,7 +725,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 				alertStore, err := ngstore.ProvideDBStore(cfg, tc.featuresFlag, db, tc.service, dashSrv, ac)
 				require.NoError(t, err)
 
-				ancestors := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, tc.depth, tc.prefix, createCmd)
+				ancestors := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, tc.depth, tc.prefix, createCmd, true)
 
 				parent, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, ancestors[0].UID)
 				require.NoError(t, err)
@@ -1536,8 +1536,8 @@ func TestIntegrationNestedFolderSharedWithMe(t *testing.T) {
 	t.Run("Should get folders shared with given user", func(t *testing.T) {
 		depth := 3
 
-		ancestorFoldersWithPermissions := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "withPermissions", createCmd)
-		ancestorFoldersWithoutPermissions := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "withoutPermissions", createCmd)
+		ancestorFoldersWithPermissions := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "withPermissions", createCmd, true)
+		ancestorFoldersWithoutPermissions := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "withoutPermissions", createCmd, true)
 
 		parent, err := serviceWithFlagOn.dashboardFolderStore.GetFolderByUID(context.Background(), orgID, ancestorFoldersWithoutPermissions[0].UID)
 		require.NoError(t, err)
@@ -1661,8 +1661,8 @@ func TestIntegrationNestedFolderSharedWithMe(t *testing.T) {
 		// tree2-folder-0
 		//  └──tree2-folder-1
 		// 	 └──tree2-folder-2
-		tree1 := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "tree1-", createCmd)
-		tree2 := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "tree2-", createCmd)
+		tree1 := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "tree1-", createCmd, true)
+		tree2 := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOn, depth, "tree2-", createCmd, true)
 
 		signedInUser.Permissions[orgID][dashboards.ActionFoldersRead] = []string{
 			// Add permission to tree1-folder-0
@@ -1928,7 +1928,7 @@ func TestFolderServiceGetFolder(t *testing.T) {
 	}
 
 	depth := 3
-	folders := CreateSubtreeInStore(t, folderSvcOn.store, &folderSvcOn, depth, "get/folder-", createCmd)
+	folders := CreateSubtreeInStore(t, folderSvcOn.store, &folderSvcOn, depth, "get/folder-", createCmd, false)
 	f := folders[1]
 
 	testCases := []struct {
@@ -2035,7 +2035,7 @@ func TestFolderServiceGetFolders(t *testing.T) {
 	})
 
 	prefix := "getfolders/ff/off"
-	folders := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOff, 5, prefix, createCmd)
+	folders := CreateSubtreeInStore(t, nestedFolderStore, serviceWithFlagOff, 5, prefix, createCmd, true)
 	f := folders[rand.Intn(len(folders))]
 
 	t.Run("when flag is off", func(t *testing.T) {
@@ -2524,14 +2524,17 @@ func TestSupportBundle(t *testing.T) {
 	}
 }
 
-func CreateSubtreeInStore(t *testing.T, store folder.Store, service *Service, depth int, prefix string, cmd folder.CreateFolderCommand) []*folder.Folder {
+func CreateSubtreeInStore(t *testing.T, store folder.Store, service *Service, depth int, prefix string, cmd folder.CreateFolderCommand, randomUID bool) []*folder.Folder {
 	t.Helper()
 
 	folders := make([]*folder.Folder, 0, depth)
 	for i := 0; i < depth; i++ {
 		title := fmt.Sprintf("%sfolder-%d", prefix, i)
 		cmd.Title = title
-		cmd.UID = fmt.Sprintf("uidfor-%d", i)
+		cmd.UID = util.GenerateShortUID()
+		if !randomUID {
+			cmd.UID = fmt.Sprintf("uidfor-%d", i)
+		}
 		cmd.OrgID = orgID
 		cmd.SignedInUser = &user.SignedInUser{OrgID: orgID, Permissions: map[int64]map[string][]string{orgID: {dashboards.ActionFoldersCreate: {dashboards.ScopeFoldersAll}}}}
 

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -1932,10 +1932,12 @@ func TestFolderServiceGetFolder(t *testing.T) {
 	f := folders[1]
 
 	testCases := []struct {
-		name             string
-		svc              *Service
-		WithFullpath     bool
-		expectedFullpath string
+		name                 string
+		svc                  *Service
+		WithFullpath         bool
+		WithFullpathUIDs     bool
+		expectedFullpath     string
+		expectedFullpathUIDs string
 	}{
 		{
 			name:             "when flag is off",
@@ -1953,6 +1955,18 @@ func TestFolderServiceGetFolder(t *testing.T) {
 			svc:              &folderSvcOn,
 			WithFullpath:     true,
 			expectedFullpath: "get\\/folder-folder-0/get\\/folder-folder-1",
+		},
+		{
+			name:                 "when flag is on and WithFullpathUIDs is false",
+			svc:                  &folderSvcOn,
+			WithFullpathUIDs:     false,
+			expectedFullpathUIDs: "",
+		},
+		{
+			name:                 "when flag is on and WithFullpathUIDs is true",
+			svc:                  &folderSvcOn,
+			WithFullpathUIDs:     true,
+			expectedFullpathUIDs: "uidfor-0/uidfor-1",
 		},
 	}
 
@@ -2517,7 +2531,7 @@ func CreateSubtreeInStore(t *testing.T, store folder.Store, service *Service, de
 	for i := 0; i < depth; i++ {
 		title := fmt.Sprintf("%sfolder-%d", prefix, i)
 		cmd.Title = title
-		cmd.UID = util.GenerateShortUID()
+		cmd.UID = fmt.Sprintf("uidfor-%d", i)
 		cmd.OrgID = orgID
 		cmd.SignedInUser = &user.SignedInUser{OrgID: orgID, Permissions: map[int64]map[string][]string{orgID: {dashboards.ActionFoldersCreate: {dashboards.ScopeFoldersAll}}}}
 

--- a/pkg/services/folder/folderimpl/sqlstore.go
+++ b/pkg/services/folder/folderimpl/sqlstore.go
@@ -201,8 +201,11 @@ func (ss *FolderStoreImpl) Get(ctx context.Context, q folder.GetFolderQuery) (*f
 		if q.WithFullpath {
 			s.WriteString(fmt.Sprintf(`, %s AS fullpath`, getFullpathSQL(ss.db.GetDialect())))
 		}
+		if q.WithFullpathUIDs {
+			s.WriteString(fmt.Sprintf(`, %s AS fullpath_uids`, getFullapathUIDsSQL(ss.db.GetDialect())))
+		}
 		s.WriteString(" FROM folder f0")
-		if q.WithFullpath {
+		if q.WithFullpath || q.WithFullpathUIDs {
 			s.WriteString(getFullpathJoinsSQL())
 		}
 		switch {
@@ -241,6 +244,7 @@ func (ss *FolderStoreImpl) Get(ctx context.Context, q folder.GetFolderQuery) (*f
 	})
 
 	foldr.Fullpath = strings.TrimLeft(foldr.Fullpath, "/")
+	foldr.FullpathUIDs = strings.TrimLeft(foldr.FullpathUIDs, "/")
 	return foldr.WithURL(), err
 }
 

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -485,6 +485,24 @@ func TestIntegrationGet(t *testing.T) {
 		assert.NotEmpty(t, ff.Updated)
 		assert.NotEmpty(t, ff.URL)
 	})
+
+	t.Run("get folder withFullpathUIDs should set fullpathUIDs as expected", func(t *testing.T) {
+		ff, err := folderStore.Get(context.Background(), folder.GetFolderQuery{
+			UID:              &subfolderWithSameName.UID,
+			OrgID:            orgID,
+			WithFullpathUIDs: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, subfolderWithSameName.UID, ff.UID)
+		assert.Equal(t, subfolderWithSameName.OrgID, ff.OrgID)
+		assert.Equal(t, subfolderWithSameName.Title, ff.Title)
+		assert.Equal(t, subfolderWithSameName.Description, ff.Description)
+		assert.Equal(t, path.Join(f.UID, subfolderWithSameName.UID), ff.FullpathUIDs)
+		assert.Equal(t, f.UID, ff.ParentUID)
+		assert.NotEmpty(t, ff.Created)
+		assert.NotEmpty(t, ff.Updated)
+		assert.NotEmpty(t, ff.URL)
+	})
 }
 
 func TestIntegrationGetParents(t *testing.T) {

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -148,11 +148,12 @@ type DeleteFolderCommand struct {
 type GetFolderQuery struct {
 	UID *string
 	// Deprecated: use FolderUID instead
-	ID           *int64
-	Title        *string
-	ParentUID    *string
-	OrgID        int64
-	WithFullpath bool
+	ID               *int64
+	Title            *string
+	ParentUID        *string
+	OrgID            int64
+	WithFullpath     bool
+	WithFullpathUIDs bool
 
 	SignedInUser identity.Requester `json:"-"`
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes legacy folder service from folder k8s client. We had added it temporarily to support the creation of subfolders (in particular to make `GetParents` calls). Using the fullpath and fullpathUIDs allows us to remove it.

**Who is this feature for?**

Search and Storage team

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/108

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
