### PR TITLE
AutoSizeInput: Forward onChange event

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
@@ -15,6 +15,16 @@ jest.mock('../../utils/measureText', () => {
 });
 
 describe('AutoSizeInput', () => {
+  it('should support default Input API', () => {
+    const onChange = jest.fn();
+    render(<AutoSizeInput onChange={onChange} value="" />);
+
+    const input: HTMLInputElement = screen.getByTestId('autosize-input');
+    fireEvent.change(input, { target: { value: 'foo' } });
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
   it('should have default minWidth when empty', () => {
     render(<AutoSizeInput />);
 

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -20,6 +20,7 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
     minWidth = 10,
     maxWidth,
     onCommitChange,
+    onChange,
     onKeyDown,
     onBlur,
     value: controlledValue,
@@ -48,6 +49,9 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
       ref={ref}
       value={value.toString()}
       onChange={(event) => {
+        if (onChange) {
+          onChange(event);
+        }
         setValue(event.currentTarget.value);
       }}
       width={inputWidth}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The onChange prop is forwarded


**Why do we need this feature?**

To be able to use AuotSizeInput as a drop in replacement for Input whenever it makes sense

**Who is this feature for?**

The main use case here is simpler support for Combobox

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/pull/93937#discussion_r1793072829

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
