### PR TITLE
Chore: Fix levitate pipeline by removing non-generated link

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -282,7 +282,6 @@ jobs:
               "pr_link": "https://github.com/grafana/grafana/pull/${{ steps.levitate-run.outputs.pr_number }}",
               "pr_number": "${{ steps.levitate-run.outputs.pr_number }}",
               "job_link": "${{ steps.levitate-run.outputs.job_link }}",
-              "reporting_job_link": "${{ github.event.workflow_run.html_url }}",
               "message": "${{ steps.levitate-run.outputs.message }}"
             }
         env:


### PR DESCRIPTION
**What is this feature?**

Fixes an error in the community pipeline because of not generated event links

**Why do we need this feature?**

Fix failures in the pipeline

**Who is this feature for?**

All users creating pull requests in Grafana/grafana
