### PR TITLE
AuthN: Set access token name

### DIFF
--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -185,10 +185,10 @@ func (s *ExtendedJWT) authenticateAsService(accessTokenClaims authlib.Claims[aut
 	return &authn.Identity{
 		ID:                         id,
 		UID:                        id,
+		Name:                       id,
 		Type:                       t,
 		OrgID:                      s.cfg.DefaultOrgID(),
 		AccessTokenClaims:          &accessTokenClaims,
-		IDTokenClaims:              nil,
 		AuthenticatedBy:            login.ExtendedJWTModule,
 		AuthID:                     accessTokenClaims.Subject,
 		AllowedKubernetesNamespace: accessTokenClaims.Rest.Namespace,

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -228,6 +228,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			want: &authn.Identity{
 				ID:                         "this-uid",
 				UID:                        "this-uid",
+				Name:                       "this-uid",
 				Type:                       claims.TypeAccessPolicy,
 				OrgID:                      1,
 				AccessTokenClaims:          &validAccessTokenClaims,
@@ -246,6 +247,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			want: &authn.Identity{
 				ID:                         "this-uid",
 				UID:                        "this-uid",
+				Name:                       "this-uid",
 				Type:                       claims.TypeAccessPolicy,
 				OrgID:                      1,
 				AccessTokenClaims:          &validAccessTokenClaimsWildcard,
@@ -343,6 +345,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			want: &authn.Identity{
 				ID:                         "this-uid",
 				UID:                        "this-uid",
+				Name:                       "this-uid",
 				Type:                       claims.TypeAccessPolicy,
 				OrgID:                      1,
 				AccessTokenClaims:          &validAccessTokenClaimsWithStackSet,
@@ -369,6 +372,7 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 			want: &authn.Identity{
 				ID:                         "this-uid",
 				UID:                        "this-uid",
+				Name:                       "this-uid",
 				Type:                       claims.TypeAccessPolicy,
 				OrgID:                      1,
 				AccessTokenClaims:          &validAccessTokenClaimsWithDeprecatedStackClaimSet,


### PR DESCRIPTION
**What is this feature?**
I noticed authorization errors and logs uses `GetName` when going through k8s api. So we should set something for when calling grafana with access tokens otherwise it will be empty. I used the subject for this for now.

**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
