### PR TITLE
Navigation: Fix wrong active item shown when parent is bookmarked

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -6,6 +6,18 @@ import { enrichHelpItem, getActiveItem, findByUrl } from './utils';
 const starredDashboardUid = 'foo';
 const mockNavTree: NavModelItem[] = [
   {
+    text: 'Bookmarks',
+    url: '/bookmarks',
+    id: 'bookmarks',
+    children: [
+      {
+        text: 'Item with children',
+        url: '/itemWithChildren',
+        id: 'item-with-children',
+      },
+    ],
+  },
+  {
     text: 'Item',
     url: '/item',
     id: 'item',
@@ -112,6 +124,10 @@ describe('getActiveItem', () => {
     const mockPage: NavModelItem = {
       text: 'Some child page',
       id: 'child',
+      parentItem: {
+        text: 'Item with children',
+        id: 'item-with-children',
+      },
     };
     expect(getActiveItem(mockNavTree, mockPage)?.id).toEqual('child');
   });

--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -14,6 +14,10 @@ const mockNavTree: NavModelItem[] = [
         text: 'Item with children',
         url: '/itemWithChildren',
         id: 'item-with-children',
+        parentItem: {
+          text: 'Bookmarks',
+          id: 'bookmarks',
+        },
       },
     ],
   },

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -98,7 +98,9 @@ export const getActiveItem = (
     }
   }
 
-  if (parentItem) {
+  // Do not search for the parent in the bookmarks section
+  const isInBookmarksSection = navTree[0]?.parentItem?.id === 'bookmarks';
+  if (parentItem && !isInBookmarksSection) {
     return getActiveItem(navTree, parentItem);
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently if the parent of the current page is bookmarked, that is displayed as the active item in the navigation:


https://github.com/user-attachments/assets/3b278c64-c0c3-44b3-af3a-1ef8de23e84e

This happens because the `getActiveItem` function goes through each navigation section and tries to find either the current page or any of its parents, so if that parent is bookmarked, the function will consider that the active item.

**Why do we need this feature?**

So that the correct active item is displayed:


https://github.com/user-attachments/assets/9a320086-332e-4bdb-9ae3-506f268a1886



**Who is this feature for?**

Users that have bookmarked something.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
