### PR TITLE
Chore: add GIT_BASE variable to Makefile to allow configuring lint-go-diff target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GO_RACE_FLAG := $(if $(GO_RACE),-race)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 GO_BUILD_FLAGS += $(GO_RACE_FLAG)
+GIT_BASE = remotes/origin/main
 
 # GNU xargs has flag -r, and BSD xargs (e.g. MacOS) has that behaviour by default
 XARGSR = $(shell xargs --version 2>&1 | grep -q GNU && echo xargs -r || echo xargs)
@@ -308,7 +309,7 @@ lint-go: golangci-lint ## Run all code checks for backend. You can use GO_LINT_F
 
 .PHONY: lint-go-diff
 lint-go-diff: $(GOLANGCI_LINT)
-	git diff --name-only remotes/origin/main | \
+	git diff --name-only $(GIT_BASE) | \
 		grep '\.go$$' | \
 		$(XARGSR) dirname | \
 		sort -u | \


### PR DESCRIPTION
**What is this feature?**

Allows configuring the git base with which to compare changes in the `lint-go-diff` Makefile target introduced in https://github.com/grafana/grafana/pull/94228. The default remains `remotes/origin/main`, which is what we want for most cases.

But for the case where we want to merge to a different branch, then comparing to that branch may be inconvenient. That could be the case for working to add a fix to a backport branch.

**Why do we need this feature?**

Make it easier and faster to lint Go code in branches that are meant to be merged to a different branch.

**Who is this feature for?**

Go developers.