### PR TITLE
datasources: querier: request parsing failures are not http500

### DIFF
--- a/pkg/tests/apis/query/query_test.go
+++ b/pkg/tests/apis/query/query_test.go
@@ -143,9 +143,8 @@ func TestIntegrationSimpleQuery(t *testing.T) {
 			"apiVersion": "v1",
 			"metadata": {},
 			"status": "Failure",
-			"message": "did not execute expression [Y] due to a failure to of the dependent expression or query [X]",
-			"reason": "BadRequest",
-			"details": { "uid": "sse.dependencyError" },
+			"message": "[sse.dependencyError] did not execute expression [Y] due to a failure to of the dependent expression or query [X]",
+			"reason": "Invalid",
 			"code": 400
 		  }`, string(body))
 		// require.JSONEq(t, `{


### PR DESCRIPTION
when the ds-querier receives a request with an invalid SSE-configuration (for example, an invalid `reducer` config), it returns a HTTP500. it should return a HTTP400 instead. that's what the PR does.

you can use the following query-json to trigger the "unsupported reduce mode" error:
```json
{
  "queries": [
    {
      "refId": "A",
      "datasource": {
        "type": "prometheus",
        "uid": "uid1"
      },
      "expr": "42",
      "range": false,
      "instant": true
    },
    {
      "conditions": [
        {
          "evaluator": {
            "params": [],
            "type": "gt"
          },
          "operator": {
            "type": "and"
          },
          "query": {
            "params": []
          },
          "reducer": {
            "params": [],
            "type": "last"
          },
          "type": "query"
        }
      ],
      "datasource": {
        "type": "__expr__",
        "uid": "__expr__"
      },
      "expression": "A",
      "refId": "B",
      "settings": {
        "mode": ""
      },
      "type": "reduce"
    }
  ],
  "from": "now-1h",
  "to": "now"
}
```