### PR TITLE
[v11.0.x] AzureMonitor: Fix App Insights portal URL for multi-resource trace queries

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -389,7 +389,7 @@ func addDataLinksToFields(query *AzureLogAnalyticsQuery, azurePortalBaseUrl stri
 }
 
 func addTraceDataLinksToFields(query *AzureLogAnalyticsQuery, azurePortalBaseUrl string, frame *data.Frame, dsInfo types.DatasourceInfo) error {
-	tracesUrl, err := getTracesQueryUrl(query.Resources, azurePortalBaseUrl)
+	tracesUrl, err := getTracesQueryUrl(azurePortalBaseUrl)
 	if err != nil {
 		return err
 	}
@@ -553,20 +553,12 @@ func getQueryUrl(query string, resources []string, azurePortalUrl string, timeRa
 	return portalUrl, nil
 }
 
-func getTracesQueryUrl(resources []string, azurePortalUrl string) (string, error) {
+func getTracesQueryUrl(azurePortalUrl string) (string, error) {
 	portalUrl := azurePortalUrl
 	portalUrl += "/#view/AppInsightsExtension/DetailsV2Blade/ComponentId~/"
-	resource := struct {
-		ResourceId string `json:"ResourceId"`
-	}{
-		resources[0],
-	}
-	resourceMarshalled, err := json.Marshal(resource)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal application insights resource: %s", err)
-	}
 
-	portalUrl += url.PathEscape(string(resourceMarshalled))
+	resource := "%7B%22ResourceId%22:%22${__data.fields.resource:percentencode}%22%7D"
+	portalUrl += resource
 	portalUrl += "/DataModel~/"
 
 	// We're making use of data link variables to select the necessary fields in the frontend


### PR DESCRIPTION
Backport 97a90591ca10f18af0194a5c762834e7f52c318b from #94119

---

Multi-resource trace queries originally only made use of the first resource in the list. This would lead to the Azure portal URL being correct in some cases (if the trace originated from the first resource) and incorrect in others.

This change will retrieve the resource as a part of the query and correctly set the value in the URL based on the resource value in each row.

A side-effect of this is the `resource` value is now displayed in the table view for traces but I think it actually makes sense to do so to allow users to have context on the origin of their traces.
