### PR TITLE
Bump scenes to 5.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "5.18.3",
+    "@grafana/scenes": "5.19.1",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,9 +4117,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:5.18.3":
-  version: 5.18.3
-  resolution: "@grafana/scenes@npm:5.18.3"
+"@grafana/scenes@npm:5.19.1":
+  version: 5.19.1
+  resolution: "@grafana/scenes@npm:5.19.1"
   dependencies:
     "@floating-ui/react": "npm:0.26.16"
     "@grafana/e2e-selectors": "npm:^11.0.0"
@@ -4136,7 +4136,7 @@ __metadata:
     "@grafana/ui": ">=10.4"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/fb1179db5b53d709b859facc7742473dbd13947c2ec9593035e617f32166716de20b712002c14e1eec7cf90a80e58c60cdc039a5252a54c7ab1f8659bba64476
+  checksum: 10/b27dcae3ae03f4ad49815bcf445ef27f5ccf66099b837001b4e255cb37a637cd7f563dd99e4f00290668e60b8cc57a5f75c97d5577690034543fe4cfb0830c4a
   languageName: node
   linkType: hard
 
@@ -18922,7 +18922,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:5.18.3"
+    "@grafana/scenes": "npm:5.19.1"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^2.0.0"


### PR DESCRIPTION
This version of scenes contains an important fix for dashboards that have refresh_interval set to `[""]`