### PR TITLE
SAML: Add a screenshot for Graph API integration config

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -249,13 +249,13 @@ This app registration will be used as a Service Account to retrieve more informa
 1. Click the **Add permissions** button at the bottom of the page.
 1. In the **API permissions** section, select **Grant admin consent for <your-organization>**.
 
+The following table shows what the permissions look like from the Azure AD portal:
+
 | Permissions name | Type        | Admin consent required | Status  |
 | ---------------- | ----------- | ---------------------- | ------- |
 | `Group.Read.All` | Application | Yes                    | Granted |
 | `User.Read`      | Delegated   | No                     | Granted |
 | `User.Read.All`  | Application | Yes                    | Granted |
-
-The following table shows what the permissions look like from the Azure AD portal:
 
 {{< figure src="/media/docs/grafana/saml/graph-api-app-permissions.png" caption="Screen shot of the permissions listed in Azure AD for the App registration" >}}
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -231,20 +231,31 @@ This app registration will be used as a Service Account to retrieve more informa
 
 1. Go to the [Azure portal](https://portal.azure.com/#home) and sign in with your Azure AD account.
 1. In the left-hand navigation pane, select the Azure Active Directory service, and then select **App registrations**.
-1. Select **New registration**.
+1. Click the **New registration** button.
 1. In the **Register an application** pane, enter a name for the application.
 1. In the **Supported account types** section, select the account types that can use the application.
 1. In the **Redirect URI** section, select Web and enter `https://localhost/login/azuread`.
-1. Select **Register**.
+1. Click the **Register** button.
 
 #### Set up permissions for the application
 
 1. In the overview pane, look for **API permissions** section and select **Add a permission**.
 1. In the **Request API permissions** pane, select **Microsoft Graph**, and click **Application permissions**.
 1. In the **Select permissions** pane, under the **GroupMember** section, select **GroupMember.Read.All**.
+1. In the **Select permissions** pane, under the **User** section, select **User.Read.All**.
+1. Click the **Add permissions** button at the bottom of the page.
+1. In the **Request API permissions** pane, select **Microsoft Graph**, and click **Delegated permissions**.
 1. In the **Select permissions** pane, under the **User** section, select **User.Read**.
-1. Select **Add permissions** at the bottom of the page.
+1. Click the **Add permissions** button at the bottom of the page.
 1. In the **API permissions** section, select **Grant admin consent for <your-organization>**.
+
+| Permissions name | Type        | Admin consent required | Status  |
+| ---------------- | ----------- | ---------------------- | ------- |
+| `Group.Read.All` | Application | Yes                    | Granted |
+| `User.Read`      | Delegated   | No                     | Granted |
+| `User.Read.All`  | Application | Yes                    | Granted |
+
+{{< figure src="/media/docs/grafana/saml/graph-api-app-permissions.png" caption="Screen shot of the permissions listed in Azure AD for the App registration" >}}
 
 #### Generate a client secret
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -255,6 +255,8 @@ This app registration will be used as a Service Account to retrieve more informa
 | `User.Read`      | Delegated   | No                     | Granted |
 | `User.Read.All`  | Application | Yes                    | Granted |
 
+The following table shows what the permissions look like from the Azure AD portal:
+
 {{< figure src="/media/docs/grafana/saml/graph-api-app-permissions.png" caption="Screen shot of the permissions listed in Azure AD for the App registration" >}}
 
 #### Generate a client secret


### PR DESCRIPTION
**What is this feature?**

Adds a screenshot of the collection of permissions needed in Azure AD for the Graph API Registered App.

**Why do we need this feature?**

By acting as support for the [https://github.com/grafana/support-escalations/issues/11680] and [https://github.com/grafana/support-escalations/issues/12584#issuecomment-2373171259] escalations, it became clear that we need to update the documentation to add a missing permission - `User.Read.All`.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/962

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
