### PR TITLE
Transformations: Add description to what is searched

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/TransformationsDrawer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/TransformationsDrawer.tsx
@@ -51,7 +51,10 @@ export function TransformationsDrawer(props: TransformationsDrawerProps) {
     ) {
       return false;
     }
-    return t.name.toLocaleLowerCase().includes(drawerState.search.toLocaleLowerCase());
+    return (
+      t.name.toLocaleLowerCase().includes(drawerState.search.toLocaleLowerCase()) ||
+      t.description?.toLocaleLowerCase().includes(drawerState.search.toLocaleLowerCase())
+    );
   });
 
   const searchBoxSuffix = (


### PR DESCRIPTION
**What is this feature?**

Doing a transformation search currently only looks at the transformation name. The description often has valuable information about the transformation as well and adding it to the search will help finding transformations.

**Why do we need this feature?**

Because when I want to hide a column, I will type "hide" to find the transformation that hides columns and it will not show, and then I lose my mind a little bit. 

**Special notes for your reviewer:**

Maybe theres a reason we only want to search by name and we should add like hidden search tags for matching - maybe the description is going to vague? We can close this if its more annoying to have it.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
