### PR TITLE
Prometheus: Pass query timeout value to the upstream request

### DIFF
--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -67,6 +68,20 @@ func New(
 		httpMethod = http.MethodPost
 	}
 
+	queryTimeoutStr, err := maputil.GetStringOptional(jsonData, "queryTimeout")
+	if err != nil {
+		return nil, err
+	}
+
+	queryTimeout := 60 * time.Second
+	if queryTimeoutStr != "" {
+		queryTimeout, err = gtime.ParseDuration(queryTimeoutStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	httpClient.Timeout = queryTimeout
 	promClient := client.NewClient(httpClient, httpMethod, settings.URL)
 
 	// standard deviation sampler is the default for backwards compatibility


### PR DESCRIPTION
**What is this feature?**

In prometheus data source we also have a special timeout to control how long we should wait a response from Prometheus itself. That timeout is called "Query Timeout"
![image](https://github.com/user-attachments/assets/494571f5-6b91-45ba-b565-cb8c45f16e37)

But unfortunately that value hasn't been passed to the request. This PR is fixing this problem. 

**Who is this feature for?**

Prometheus users
