### PR TITLE
Alerting: Add SaveAlertInstancesForRule instance store method

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -464,6 +464,11 @@ type AlertRuleKeyWithVersion struct {
 	AlertRuleKey `xorm:"extends"`
 }
 
+type AlertRuleKeyWithGroup struct {
+	RuleGroup    string
+	AlertRuleKey `xorm:"extends"`
+}
+
 type AlertRuleKeyWithId struct {
 	AlertRuleKey
 	ID int64
@@ -515,6 +520,11 @@ func (s AlertRuleGroupKeySorter) Less(i, j int) bool { return s.by(&s.keys[i], &
 // GetKey returns the alert definitions identifier
 func (alertRule *AlertRule) GetKey() AlertRuleKey {
 	return AlertRuleKey{OrgID: alertRule.OrgID, UID: alertRule.UID}
+}
+
+// GetKeyWithGroup returns the alert definitions identifier
+func (alertRule *AlertRule) GetKeyWithGroup() AlertRuleKeyWithGroup {
+	return AlertRuleKeyWithGroup{AlertRuleKey: alertRule.GetKey(), RuleGroup: alertRule.RuleGroup}
 }
 
 // GetGroupKey returns the identifier of a group the rule belongs to

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -884,3 +884,27 @@ func TestTimeRangeYAML(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, yamlRaw, string(serialized))
 }
+
+func TestAlertRuleGetKey(t *testing.T) {
+	t.Run("should return correct key", func(t *testing.T) {
+		rule := RuleGen.GenerateRef()
+		expected := AlertRuleKey{
+			OrgID: rule.OrgID,
+			UID:   rule.UID,
+		}
+		require.Equal(t, expected, rule.GetKey())
+	})
+}
+
+func TestAlertRuleGetKeyWithGroup(t *testing.T) {
+	t.Run("should return correct key", func(t *testing.T) {
+		rule := RuleGen.With(
+			RuleMuts.WithUniqueGroupIndex(),
+		).GenerateRef()
+		expected := AlertRuleKeyWithGroup{
+			AlertRuleKey: rule.GetKey(),
+			RuleGroup:    rule.RuleGroup,
+		}
+		require.Equal(t, expected, rule.GetKeyWithGroup())
+	})
+}

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -587,6 +587,14 @@ func GenerateRuleKey(orgID int64) AlertRuleKey {
 	}
 }
 
+// GenerateRuleKeyWithGroup generates a random alert rule key with group
+func GenerateRuleKeyWithGroup(orgID int64) AlertRuleKeyWithGroup {
+	return AlertRuleKeyWithGroup{
+		AlertRuleKey: GenerateRuleKey(orgID),
+		RuleGroup:    util.GenerateShortUID(),
+	}
+}
+
 // GenerateGroupKey generates a random group key
 func GenerateGroupKey(orgID int64) AlertRuleGroupKey {
 	return AlertRuleGroupKey{

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -39,7 +39,7 @@ func TestAlertRule(t *testing.T) {
 
 	t.Run("when rule evaluation is not stopped", func(t *testing.T) {
 		t.Run("update should send to updateCh", func(t *testing.T) {
-			r := blankRuleForTests(context.Background(), models.GenerateRuleKey(1))
+			r := blankRuleForTests(context.Background(), models.GenerateRuleKeyWithGroup(1))
 			resultCh := make(chan bool)
 			go func() {
 				resultCh <- r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false})
@@ -52,7 +52,7 @@ func TestAlertRule(t *testing.T) {
 			}
 		})
 		t.Run("update should drop any concurrent sending to updateCh", func(t *testing.T) {
-			r := blankRuleForTests(context.Background(), models.GenerateRuleKey(1))
+			r := blankRuleForTests(context.Background(), models.GenerateRuleKeyWithGroup(1))
 			version1 := RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}
 			version2 := RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}
 
@@ -79,7 +79,7 @@ func TestAlertRule(t *testing.T) {
 		})
 		t.Run("eval should send to evalCh", func(t *testing.T) {
 			ruleSpec := gen.GenerateRef()
-			r := blankRuleForTests(context.Background(), ruleSpec.GetKey())
+			r := blankRuleForTests(context.Background(), ruleSpec.GetKeyWithGroup())
 			expected := time.Now()
 			resultCh := make(chan evalResponse)
 			data := &Evaluation{
@@ -103,7 +103,7 @@ func TestAlertRule(t *testing.T) {
 		})
 		t.Run("eval should drop any concurrent sending to evalCh", func(t *testing.T) {
 			ruleSpec := gen.GenerateRef()
-			r := blankRuleForTests(context.Background(), ruleSpec.GetKey())
+			r := blankRuleForTests(context.Background(), ruleSpec.GetKeyWithGroup())
 			time1 := time.UnixMilli(rand.Int63n(math.MaxInt64))
 			time2 := time.UnixMilli(rand.Int63n(math.MaxInt64))
 			resultCh1 := make(chan evalResponse)
@@ -150,7 +150,7 @@ func TestAlertRule(t *testing.T) {
 		})
 		t.Run("eval should exit when context is cancelled", func(t *testing.T) {
 			ruleSpec := gen.GenerateRef()
-			r := blankRuleForTests(context.Background(), ruleSpec.GetKey())
+			r := blankRuleForTests(context.Background(), ruleSpec.GetKeyWithGroup())
 			resultCh := make(chan evalResponse)
 			data := &Evaluation{
 				scheduledAt: time.Now(),
@@ -174,14 +174,14 @@ func TestAlertRule(t *testing.T) {
 	})
 	t.Run("when rule evaluation is stopped", func(t *testing.T) {
 		t.Run("Update should do nothing", func(t *testing.T) {
-			r := blankRuleForTests(context.Background(), models.GenerateRuleKey(1))
+			r := blankRuleForTests(context.Background(), models.GenerateRuleKeyWithGroup(1))
 			r.Stop(errRuleDeleted)
 			require.ErrorIs(t, r.ctx.Err(), errRuleDeleted)
 			require.False(t, r.Update(RuleVersionAndPauseStatus{fingerprint(rand.Uint64()), false}))
 		})
 		t.Run("eval should do nothing", func(t *testing.T) {
 			ruleSpec := gen.GenerateRef()
-			r := blankRuleForTests(context.Background(), ruleSpec.GetKey())
+			r := blankRuleForTests(context.Background(), ruleSpec.GetKeyWithGroup())
 			r.Stop(nil)
 			data := &Evaluation{
 				scheduledAt: time.Now(),
@@ -193,19 +193,19 @@ func TestAlertRule(t *testing.T) {
 			require.Nilf(t, dropped, "expected no dropped evaluations but got one")
 		})
 		t.Run("calling stop multiple times should not panic", func(t *testing.T) {
-			r := blankRuleForTests(context.Background(), models.GenerateRuleKey(1))
+			r := blankRuleForTests(context.Background(), models.GenerateRuleKeyWithGroup(1))
 			r.Stop(nil)
 			r.Stop(nil)
 		})
 		t.Run("stop should not panic if parent context stopped", func(t *testing.T) {
 			ctx, cancelFn := context.WithCancel(context.Background())
-			r := blankRuleForTests(ctx, models.GenerateRuleKey(1))
+			r := blankRuleForTests(ctx, models.GenerateRuleKeyWithGroup(1))
 			cancelFn()
 			r.Stop(nil)
 		})
 	})
 	t.Run("should be thread-safe", func(t *testing.T) {
-		r := blankRuleForTests(context.Background(), models.GenerateRuleKey(1))
+		r := blankRuleForTests(context.Background(), models.GenerateRuleKeyWithGroup(1))
 		wg := sync.WaitGroup{}
 		go func() {
 			for {
@@ -249,7 +249,7 @@ func TestAlertRule(t *testing.T) {
 	})
 
 	t.Run("Run should exit if idle when Stop is called", func(t *testing.T) {
-		rule := blankRuleForTests(context.Background(), models.GenerateRuleKey(1))
+		rule := blankRuleForTests(context.Background(), models.GenerateRuleKeyWithGroup(1))
 		runResult := make(chan error)
 		go func() {
 			runResult <- rule.Run()
@@ -266,7 +266,7 @@ func TestAlertRule(t *testing.T) {
 	})
 }
 
-func blankRuleForTests(ctx context.Context, key models.AlertRuleKey) *alertRule {
+func blankRuleForTests(ctx context.Context, key models.AlertRuleKeyWithGroup) *alertRule {
 	return newAlertRule(ctx, key, nil, false, 0, nil, nil, nil, nil, nil, nil, log.NewNopLogger(), nil, nil, nil)
 }
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -240,7 +240,7 @@ func (st *Manager) Get(orgID int64, alertRuleUID string, stateId data.Fingerprin
 // DeleteStateByRuleUID removes the rule instances from cache and instanceStore. A closed channel is returned to be able
 // to gracefully handle the clear state step in scheduler in case we do not need to use the historian to save state
 // history.
-func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.AlertRuleKey, reason string) []StateTransition {
+func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.AlertRuleKeyWithGroup, reason string) []StateTransition {
 	logger := st.log.FromContext(ctx)
 	logger.Debug("Resetting state of the rule")
 
@@ -290,7 +290,7 @@ func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.Al
 // ResetStateByRuleUID removes the rule instances from cache and instanceStore and saves state history. If the state
 // history has to be saved, rule must not be nil.
 func (st *Manager) ResetStateByRuleUID(ctx context.Context, rule *ngModels.AlertRule, reason string) []StateTransition {
-	ruleKey := rule.GetKey()
+	ruleKey := rule.GetKeyWithGroup()
 	transitions := st.DeleteStateByRuleUID(ctx, ruleKey, reason)
 
 	if rule == nil || st.historian == nil || len(transitions) == 0 {

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -2083,7 +2083,7 @@ func TestDeleteStateByRuleUID(t *testing.T) {
 			assert.Equal(t, tc.startingInstanceDBCount, len(alerts))
 
 			expectedReason := util.GenerateShortUID()
-			transitions := st.DeleteStateByRuleUID(ctx, rule.GetKey(), expectedReason)
+			transitions := st.DeleteStateByRuleUID(ctx, rule.GetKeyWithGroup(), expectedReason)
 
 			// Check that the deleted states are the same as the ones that were in cache
 			assert.Equal(t, tc.startingStateCacheCount, len(transitions))

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -13,7 +13,9 @@ type InstanceStore interface {
 	ListAlertInstances(ctx context.Context, cmd *models.ListAlertInstancesQuery) ([]*models.AlertInstance, error)
 	SaveAlertInstance(ctx context.Context, instance models.AlertInstance) error
 	DeleteAlertInstances(ctx context.Context, keys ...models.AlertInstanceKey) error
-	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error
+	// SaveAlertInstancesForRule overwrites the state for the given rule.
+	SaveAlertInstancesForRule(ctx context.Context, key models.AlertRuleKeyWithGroup, instances []models.AlertInstance) error
+	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKeyWithGroup) error
 	FullSync(ctx context.Context, instances []models.AlertInstance) error
 }
 

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -56,7 +56,11 @@ func (f *FakeInstanceStore) DeleteAlertInstances(ctx context.Context, q ...model
 	return nil
 }
 
-func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKey) error {
+func (f *FakeInstanceStore) SaveAlertInstancesForRule(ctx context.Context, key models.AlertRuleKeyWithGroup, instances []models.AlertInstance) error {
+	return nil
+}
+
+func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKeyWithGroup) error {
 	return nil
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds `SaveAlertInstancesForRule` instance store method. Currently not used.

* Related Grafana Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/7362
* Part of https://github.com/grafana/grafana-ruler/issues/3486

Main changes:
* A new `AlertRuleKeyWithGroup` key with the rule group information.
* New `SaveAlertInstancesForRule` method in the InstanceStore interface.
* Both `SaveAlertInstancesForRule` and `DeleteAlertInstancesByRule` accept the same `AlertRuleKeyWithGroup` alert rule key.

**Why do we need this feature?**

Currently we manage the rule state on the alert instance level. We save new alert instances and delete stale ones. `SaveAlertInstancesForRule` is meant to be a replacement for that. It allows `InstanceStore` to manage the state of an alert rule with two methods:
- `SaveAlertInstancesForRule` - saves (overwrites) the state of the rule.
- `DeleteAlertInstancesByRule` - deletes the state of the rule.

This will make it easier to do changes like [this one](https://github.com/grafana/grafana/pull/72227) in the future.
