### PR TITLE
K8s/Folders: Require create permissions when creating folder

### DIFF
--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -36,7 +35,6 @@ type legacyStorage struct {
 	service        folder.Service
 	namespacer     request.NamespaceMapper
 	tableConverter rest.TableConvertor
-	accessControl  accesscontrol.AccessControl
 }
 
 func (s *legacyStorage) New() runtime.Object {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -101,7 +101,6 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		service:        b.folderSvc,
 		namespacer:     b.namespacer,
 		tableConverter: resourceInfo.TableConverter(),
-		accessControl:  b.accessControl,
 	}
 
 	storage := map[string]rest.Storage{}

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -168,8 +168,8 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 				return authorizer.DecisionDeny, "valid user is required", err
 			}
 
-			var eval accesscontrol.Evaluator
 			scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(name)
+			eval := accesscontrol.EvalPermission(dashboards.ActionFoldersRead, scope)
 
 			// "get" is used for sub-resources with GET http (parents, access, count)
 			switch verb {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/kube-openapi/pkg/spec3"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -157,7 +158,7 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 		func(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 			verb := attr.GetVerb()
 			name := attr.GetName()
-			if (!attr.IsResourceRequest()) || (name == "" && verb != "create") {
+			if (!attr.IsResourceRequest()) || (name == "" && verb != utils.VerbCreate) {
 				return authorizer.DecisionNoOpinion, "", nil
 			}
 
@@ -172,9 +173,9 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 
 			// "get" is used for sub-resources with GET http (parents, access, count)
 			switch verb {
-			case "patch":
+			case utils.VerbPatch:
 				fallthrough
-			case "create":
+			case utils.VerbCreate:
 				action = dashboards.ActionFoldersCreate
 				evaluator := accesscontrol.EvalPermission(action)
 				ok, err := b.accessControl.Evaluate(ctx, user, evaluator)
@@ -182,11 +183,11 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 					return authorizer.DecisionAllow, "", nil
 				}
 				return authorizer.DecisionDeny, "folder", err
-			case "update":
+			case utils.VerbUpdate:
 				action = dashboards.ActionFoldersWrite
-			case "deletecollection":
+			case utils.VerbDeleteCollection:
 				fallthrough
-			case "delete":
+			case utils.VerbDelete:
 				action = dashboards.ActionFoldersDelete
 			}
 

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -100,6 +100,7 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		service:        b.folderSvc,
 		namespacer:     b.namespacer,
 		tableConverter: resourceInfo.TableConverter(),
+		accessControl:  b.accessControl,
 	}
 
 	storage := map[string]rest.Storage{}

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -219,9 +219,11 @@ func (c *K8sResourceClient) sanitizeObject(v *unstructured.Unstructured, replace
 }
 
 type OrgUsers struct {
-	Admin  User
-	Editor User
-	Viewer User
+	Admin        User
+	Editor       User
+	Viewer       User
+	Creator      User
+	Unauthorized User
 
 	// The team with admin+editor in it (but not viewer)
 	Staff team.Team
@@ -424,6 +426,15 @@ func (c *K8sTestHelper) createTestUsers(orgName string) OrgUsers {
 		Admin:  c.CreateUser("admin", orgName, org.RoleAdmin, nil),
 		Editor: c.CreateUser("editor", orgName, org.RoleEditor, nil),
 		Viewer: c.CreateUser("viewer", orgName, org.RoleViewer, nil),
+		Creator: c.CreateUser("creator", orgName, org.RoleViewer, []resourcepermissions.SetResourcePermissionCommand{
+			{
+				Actions:           []string{"folders:create"},
+				Resource:          "folders",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+		}),
+		Unauthorized: c.CreateUser("unauthorized", orgName, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{}),
 	}
 	users.Staff = c.CreateTeam("staff", "staff@"+orgName, users.Admin.Identity.GetOrgID())
 

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -219,11 +219,9 @@ func (c *K8sResourceClient) sanitizeObject(v *unstructured.Unstructured, replace
 }
 
 type OrgUsers struct {
-	Admin        User
-	Editor       User
-	Viewer       User
-	Creator      User
-	Unauthorized User
+	Admin  User
+	Editor User
+	Viewer User
 
 	// The team with admin+editor in it (but not viewer)
 	Staff team.Team
@@ -426,15 +424,6 @@ func (c *K8sTestHelper) createTestUsers(orgName string) OrgUsers {
 		Admin:  c.CreateUser("admin", orgName, org.RoleAdmin, nil),
 		Editor: c.CreateUser("editor", orgName, org.RoleEditor, nil),
 		Viewer: c.CreateUser("viewer", orgName, org.RoleViewer, nil),
-		Creator: c.CreateUser("creator", orgName, org.RoleViewer, []resourcepermissions.SetResourcePermissionCommand{
-			{
-				Actions:           []string{"folders:create"},
-				Resource:          "folders",
-				ResourceAttribute: "uid",
-				ResourceID:        "*",
-			},
-		}),
-		Unauthorized: c.CreateUser("unauthorized", orgName, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{}),
 	}
 	users.Staff = c.CreateTeam("staff", "staff@"+orgName, users.Admin.Identity.GetOrgID())
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fix folder creations permissions when `kubernetesFolders` is enabled. The GetAuthorizer implementation wasn't considering the specific `folders:create` action before. 

[Slack context](https://raintank-corp.slack.com/archives/C05JDQ100NS/p1728459360087279)

**Who is this feature for?**

Search and Storage team

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/109

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
