### PR TITLE
Alerting: Fix getSimpleConditionFromExpressions

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -218,11 +218,17 @@ export function getSimpleConditionFromExpressions(expressions: Array<AlertQuery<
     (query) => query.model.type === ExpressionQueryType.threshold && query.refId === SIMPLE_CONDITION_THRESHOLD_ID
   );
   const conditionsFromThreshold = thresholdExpression?.model.conditions ?? [];
+  const whenField = reduceExpression?.model.reducer ?? ReducerID.last;
+  const params = conditionsFromThreshold[0]?.evaluator?.params
+    ? [...conditionsFromThreshold[0]?.evaluator?.params]
+    : [0];
+  const type = conditionsFromThreshold[0]?.evaluator?.type ?? EvalFunction.IsAbove;
+
   return {
-    whenField: reduceExpression?.model.reducer ?? ReducerID.last,
+    whenField: whenField,
     evaluator: {
-      params: [...conditionsFromThreshold[0]?.evaluator?.params] ?? [0],
-      type: conditionsFromThreshold[0]?.evaluator?.type ?? EvalFunction.IsAbove,
+      params: params,
+      type: type,
     },
   };
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug when creating a new alert rule from query params and threshold expression being not present.

**Why do we need this feature?**

Breaks UI.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
