### PR TITLE
Fix: Actually call the DedupOrgInLogin migration

### DIFF
--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -158,6 +158,9 @@ func addUserMigrations(mg *Migrator) {
 	// Service accounts login were not unique per org. this migration is part of making it unique per org
 	// to be able to create service accounts that are unique per org
 	mg.AddMigration(usermig.AllowSameLoginCrossOrgs, &usermig.ServiceAccountsSameLoginCrossOrgs{})
+	// Before it was fixed, the previous migration introduced the org_id again in logins that already had it.
+	// This migration removes the duplicate org_id from the login.
+	mg.AddMigration(usermig.DedupOrgInLogin, &usermig.ServiceAccountsDeduplicateOrgInLogin{})
 
 	// Users login and email should be in lower case
 	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail, &usermig.UsersLowerCaseLoginAndEmail{})

--- a/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
+++ b/pkg/services/sqlstore/migrations/usermig/service_account_multiple_org_login_migrator.go
@@ -16,9 +16,6 @@ const (
 // to be able to create service accounts that are unique per org
 func AddServiceAccountsAllowSameLoginCrossOrgs(mg *migrator.Migrator) {
 	mg.AddMigration(AllowSameLoginCrossOrgs, &ServiceAccountsSameLoginCrossOrgs{})
-	// Before it was fixed, the previous migration introduced the org_id again in logins that already had it.
-	// This migration removes the duplicate org_id from the login.
-	mg.AddMigration(DedupOrgInLogin, &ServiceAccountsDeduplicateOrgInLogin{})
 }
 
 var _ migrator.CodeMigration = new(ServiceAccountsSameLoginCrossOrgs)


### PR DESCRIPTION
**What is this feature?**

With https://github.com/grafana/grafana/pull/94378 I introduced a migration that's not actually run because I wrongfully assumed that `AddServiceAccountsAllowSameLoginCrossOrgs` was called in user migrations. This PR intends to fix this.

Follow up to https://github.com/grafana/grafana/pull/94347.
Some service accounts logins were migrated even though their logins were correctly formed (`sa-<orgID>`) thus introducing a duplicated `orgID`  (`sa-<orgID>-<orgID>`).
This PR introduces a new migration that de-duplicates the `orgID`.

This is particularly necessary in the case of external service accounts as their logins is what we use to protect them against deletion and modifications.