### PR TITLE
RBAC: Add legacy authorization checks to teams

### DIFF
--- a/pkg/apis/iam/v0alpha1/types_team.go
+++ b/pkg/apis/iam/v0alpha1/types_team.go
@@ -1,6 +1,8 @@
 package v0alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,6 +17,13 @@ type Team struct {
 type TeamSpec struct {
 	Title string `json:"title,omitempty"`
 	Email string `json:"email,omitempty"`
+
+	// This is currently used for authorization checks but we don't want to expose it
+	InternalID int64 `json:"-"`
+}
+
+func (t Team) AuthID() string {
+	return fmt.Sprintf("%d", t.Spec.InternalID)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -54,6 +54,19 @@ func newLegacyAuthorizer(ac accesscontrol.AccessControl, store legacy.LegacyIden
 				return []string{fmt.Sprintf("serviceaccounts:id:%d", res.ID)}, nil
 			}),
 		},
+		accesscontrol.ResourceAuthorizerOptions{
+			Resource: iamv0.TeamResourceInfo.GetName(),
+			Attr:     "id",
+			Resolver: accesscontrol.ResourceResolverFunc(func(ctx context.Context, ns claims.NamespaceInfo, name string) ([]string, error) {
+				res, err := store.GetTeamInternalID(ctx, ns, legacy.GetTeamInternalIDQuery{
+					UID: name,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return []string{fmt.Sprintf("teams:id:%d", res.ID)}, nil
+			}),
+		},
 	)
 
 	return gfauthorizer.NewResourceAuthorizer(client), client

--- a/pkg/registry/apis/iam/legacy/sql.go
+++ b/pkg/registry/apis/iam/legacy/sql.go
@@ -22,6 +22,7 @@ type LegacyIdentityStore interface {
 	ListServiceAccounts(ctx context.Context, ns claims.NamespaceInfo, query ListServiceAccountsQuery) (*ListServiceAccountResult, error)
 	ListServiceAccountTokens(ctx context.Context, ns claims.NamespaceInfo, query ListServiceAccountTokenQuery) (*ListServiceAccountTokenResult, error)
 
+	GetTeamInternalID(ctx context.Context, ns claims.NamespaceInfo, query GetTeamInternalIDQuery) (*GetTeamInternalIDResult, error)
 	ListTeams(ctx context.Context, ns claims.NamespaceInfo, query ListTeamQuery) (*ListTeamResult, error)
 	ListTeamBindings(ctx context.Context, ns claims.NamespaceInfo, query ListTeamBindingsQuery) (*ListTeamBindingsResult, error)
 	ListTeamMembers(ctx context.Context, ns claims.NamespaceInfo, query ListTeamMembersQuery) (*ListTeamMembersResult, error)

--- a/pkg/registry/apis/iam/legacy/team.go
+++ b/pkg/registry/apis/iam/legacy/team.go
@@ -3,6 +3,7 @@ package legacy
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,79 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
+
+type GetTeamInternalIDQuery struct {
+	OrgID int64
+	UID   string
+}
+
+type GetTeamInternalIDResult struct {
+	ID int64
+}
+
+var sqlQueryTeamInternalIDTemplate = mustTemplate("team_internal_id.sql")
+
+func newGetTeamInternalID(sql *legacysql.LegacyDatabaseHelper, q *GetTeamInternalIDQuery) getTeamInternalIDQuery {
+	return getTeamInternalIDQuery{
+		SQLTemplate: sqltemplate.New(sql.DialectForDriver()),
+		TeamTable:   sql.Table("team"),
+		Query:       q,
+	}
+}
+
+type getTeamInternalIDQuery struct {
+	sqltemplate.SQLTemplate
+	TeamTable string
+	Query     *GetTeamInternalIDQuery
+}
+
+func (r getTeamInternalIDQuery) Validate() error { return nil }
+
+func (s *legacySQLStore) GetTeamInternalID(
+	ctx context.Context,
+	ns claims.NamespaceInfo,
+	query GetTeamInternalIDQuery,
+) (*GetTeamInternalIDResult, error) {
+	query.OrgID = ns.OrgID
+	if query.OrgID == 0 {
+		return nil, fmt.Errorf("expected non zero org id")
+	}
+
+	sql, err := s.sql(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	req := newGetTeamInternalID(sql, &query)
+	q, err := sqltemplate.Execute(sqlQueryTeamInternalIDTemplate, req)
+	if err != nil {
+		return nil, fmt.Errorf("execute template %q: %w", sqlQueryTeamInternalIDTemplate.Name(), err)
+	}
+
+	rows, err := sql.DB.GetSqlxSession().Query(ctx, q, req.GetArgs()...)
+	defer func() {
+		if rows != nil {
+			_ = rows.Close()
+		}
+	}()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !rows.Next() {
+		return nil, errors.New("team not found")
+	}
+
+	var id int64
+	if err := rows.Scan(&id); err != nil {
+		return nil, err
+	}
+
+	return &GetTeamInternalIDResult{
+		id,
+	}, nil
+}
 
 type ListTeamQuery struct {
 	OrgID int64

--- a/pkg/registry/apis/iam/legacy/team_internal_id.sql
+++ b/pkg/registry/apis/iam/legacy/team_internal_id.sql
@@ -1,0 +1,5 @@
+SELECT t.id
+FROM {{ .Ident .TeamTable }} as t
+WHERE t.org_id = {{ .Arg .Query.OrgID }}
+AND t.uid = {{ .Arg .Query.UID }}
+LIMIT 1;

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -97,7 +97,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	storage := map[string]rest.Storage{}
 
 	teamResource := iamv0.TeamResourceInfo
-	storage[teamResource.StoragePath()] = team.NewLegacyStore(b.store)
+	storage[teamResource.StoragePath()] = team.NewLegacyStore(b.store, b.accessClient)
 	storage[teamResource.StoragePath("members")] = team.NewLegacyTeamMemberREST(b.store)
 
 	teamBindingResource := iamv0.TeamBindingResourceInfo


### PR DESCRIPTION
**What is this feature?**
Add authorization checks for teams through k8s api for single tenant instance.

**Which issue(s) does this PR fix?**:
Part of https://github.com/grafana/identity-access-team/issues/889

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
