### PR TITLE
add featureflag to guard large object support

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -208,6 +208,7 @@ Experimental features might be changed or removed without prior notice.
 | `alertingQueryAndExpressionsStepMode`         | Enables step mode for alerting queries and expressions                                                                                                                                                                                                                            |
 | `rolePickerDrawer`                            | Enables the new role picker drawer design                                                                                                                                                                                                                                         |
 | `pluginsSriChecks`                            | Enables SRI checks for plugin assets                                                                                                                                                                                                                                              |
+| `unifiedStorageBigObjectSupport`              | Enables to save big objects in blob storage                                                                                                                                                                                                                                       |
 
 ## Development feature toggles
 

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -208,7 +208,7 @@ Experimental features might be changed or removed without prior notice.
 | `alertingQueryAndExpressionsStepMode`         | Enables step mode for alerting queries and expressions                                                                                                                                                                                                                            |
 | `rolePickerDrawer`                            | Enables the new role picker drawer design                                                                                                                                                                                                                                         |
 | `pluginsSriChecks`                            | Enables SRI checks for plugin assets                                                                                                                                                                                                                                              |
-| `unifiedStorageBigObjectSupport`              | Enables to save big objects in blob storage                                                                                                                                                                                                                                       |
+| `unifiedStorageBigObjectsSupport`             | Enables to save big objects in blob storage                                                                                                                                                                                                                                       |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -220,4 +220,5 @@ export interface FeatureToggles {
   rolePickerDrawer?: boolean;
   unifiedStorageSearch?: boolean;
   pluginsSriChecks?: boolean;
+  unifiedStorageBigObjectSupport?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -220,5 +220,5 @@ export interface FeatureToggles {
   rolePickerDrawer?: boolean;
   unifiedStorageSearch?: boolean;
   pluginsSriChecks?: boolean;
-  unifiedStorageBigObjectSupport?: boolean;
+  unifiedStorageBigObjectsSupport?: boolean;
 }

--- a/pkg/registry/apis/dashboard/legacy_storage.go
+++ b/pkg/registry/apis/dashboard/legacy_storage.go
@@ -10,6 +10,7 @@ import (
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
@@ -19,7 +20,8 @@ type dashboardStorage struct {
 	access         legacy.DashboardAccess
 	tableConverter rest.TableConvertor
 
-	server resource.ResourceServer
+	server   resource.ResourceServer
+	features featuremgmt.FeatureToggles
 }
 
 func (s *dashboardStorage) newStore(scheme *runtime.Scheme, defaultOptsGetter generic.RESTOptionsGetter, reg prometheus.Registerer) (grafanarest.LegacyStorage, error) {
@@ -46,6 +48,7 @@ func (s *dashboardStorage) newStore(scheme *runtime.Scheme, defaultOptsGetter ge
 	client := resource.NewLocalResourceClient(server)
 	optsGetter := apistore.NewRESTOptionsGetterForClient(client,
 		defaultOpts.StorageConfig.Config,
+		s.features,
 	)
 
 	return grafanaregistry.NewRegistryStore(scheme, resourceInfo, optsGetter)

--- a/pkg/registry/apis/dashboard/legacy_storage.go
+++ b/pkg/registry/apis/dashboard/legacy_storage.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -46,9 +48,15 @@ func (s *dashboardStorage) newStore(scheme *runtime.Scheme, defaultOptsGetter ge
 		return nil, err
 	}
 	client := resource.NewLocalResourceClient(server)
+	// This is needed as the apistore doesn't allow any core grafana dependencies. We extract the needed features
+	// to a map, to check them in the apistore itself.
+	features := make(map[string]any)
+	if s.features.IsEnabled(context.Background(), featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
+		features[featuremgmt.FlagUnifiedStorageBigObjectsSupport] = struct{}{}
+	}
 	optsGetter := apistore.NewRESTOptionsGetterForClient(client,
 		defaultOpts.StorageConfig.Config,
-		s.features,
+		features,
 	)
 
 	return grafanaregistry.NewRegistryStore(scheme, resourceInfo, optsGetter)

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -129,7 +129,6 @@ func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	scheme := opts.Scheme
 
-
 	optsGetter := opts.OptsGetter
 	dualWriteBuilder := opts.DualWriteBuilder
 	dash := b.legacy.resource

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -75,6 +75,7 @@ func RegisterAPIService(cfg *setting.Cfg, features featuremgmt.FeatureToggles,
 			resource:       dashboard.DashboardResourceInfo,
 			access:         legacy.NewDashboardAccess(dbp, namespacer, dashStore, provisioning, softDelete),
 			tableConverter: dashboard.DashboardResourceInfo.TableConverter(),
+			features:       features,
 		},
 		reg: reg,
 	}

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -128,6 +128,7 @@ func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	scheme := opts.Scheme
 
+
 	optsGetter := opts.OptsGetter
 	dualWriteBuilder := opts.DualWriteBuilder
 	dash := b.legacy.resource

--- a/pkg/services/apiserver/aggregator/aggregator_test.go
+++ b/pkg/services/apiserver/aggregator/aggregator_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/stretchr/testify/require"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
@@ -42,8 +41,7 @@ func TestAggregatorPostStartHooks(t *testing.T) {
 	cfg.GenericConfig.SharedInformerFactory = informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 10*time.Minute)
 
 	// override the RESTOptionsGetter to use the in memory storage options
-	features := featuremgmt.WithFeatures()
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(*storagebackend.NewDefaultConfig("memory", nil), features)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(*storagebackend.NewDefaultConfig("memory", nil), make(map[string]any))
 	require.NoError(t, err)
 	cfg.GenericConfig.RESTOptionsGetter = restOptionsGetter
 

--- a/pkg/services/apiserver/aggregator/aggregator_test.go
+++ b/pkg/services/apiserver/aggregator/aggregator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/stretchr/testify/require"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
@@ -41,7 +42,8 @@ func TestAggregatorPostStartHooks(t *testing.T) {
 	cfg.GenericConfig.SharedInformerFactory = informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 10*time.Minute)
 
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(*storagebackend.NewDefaultConfig("memory", nil))
+	features := featuremgmt.WithFeatures()
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(*storagebackend.NewDefaultConfig("memory", nil), features)
 	require.NoError(t, err)
 	cfg.GenericConfig.RESTOptionsGetter = restOptionsGetter
 

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -165,6 +166,7 @@ func InstallAPIs(
 	namespaceMapper request.NamespaceMapper,
 	kvStore grafanarest.NamespacedKVStore,
 	serverLock ServerLockService,
+	features featuremgmt.FeatureToggles,
 ) error {
 	// dual writing is only enabled when the storage type is not legacy.
 	// this is needed to support setting a default RESTOptionsGetter for new APIs that don't

--- a/pkg/services/apiserver/options/grafana-aggregator.go
+++ b/pkg/services/apiserver/options/grafana-aggregator.go
@@ -74,7 +74,7 @@ func (o *GrafanaAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver
 		return err
 	}
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/grafana-aggregator.go
+++ b/pkg/services/apiserver/options/grafana-aggregator.go
@@ -3,7 +3,6 @@ package options
 import (
 	"maps"
 
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -74,10 +73,8 @@ func (o *GrafanaAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver
 	if err := etcdOptions.ApplyTo(&genericConfig.Config); err != nil {
 		return err
 	}
-	// provide an empty feature registry, for now.
-	features := featuremgmt.WithFeatures()
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, features)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, make(map[string]any))
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/grafana-aggregator.go
+++ b/pkg/services/apiserver/options/grafana-aggregator.go
@@ -3,6 +3,7 @@ package options
 import (
 	"maps"
 
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -73,8 +74,10 @@ func (o *GrafanaAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver
 	if err := etcdOptions.ApplyTo(&genericConfig.Config); err != nil {
 		return err
 	}
+	// provide an empty feature registry, for now.
+	features := featuremgmt.WithFeatures()
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, nil)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, features)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -81,7 +81,7 @@ func (o *KubeAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver.Co
 		return err
 	}
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,10 +80,8 @@ func (o *KubeAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver.Co
 	if err := etcdOptions.ApplyTo(&genericConfig.Config); err != nil {
 		return err
 	}
-	// provide an empty feature registry, for now.
-	features := featuremgmt.WithFeatures()
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, features)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, make(map[string]any))
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -1,6 +1,7 @@
 package options
 
 import (
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -80,8 +81,10 @@ func (o *KubeAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver.Co
 	if err := etcdOptions.ApplyTo(&genericConfig.Config); err != nil {
 		return err
 	}
+	// TODO(JP): Do we need feature flags here?
+	features := featuremgmt.WithFeatures()
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, nil)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, features)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/kube-aggregator.go
+++ b/pkg/services/apiserver/options/kube-aggregator.go
@@ -81,7 +81,7 @@ func (o *KubeAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver.Co
 	if err := etcdOptions.ApplyTo(&genericConfig.Config); err != nil {
 		return err
 	}
-	// TODO(JP): Do we need feature flags here?
+	// provide an empty feature registry, for now.
 	features := featuremgmt.WithFeatures()
 	// override the RESTOptionsGetter to use the in memory storage options
 	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, features)

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -160,7 +160,6 @@ func ProvideService(
 		serverLockService: serverLockService,
 		unified:           unified,
 	}
-
 	// This will be used when running as a dskit service
 	s.BasicService = services.NewBasicService(s.start, s.running, nil).WithName(modules.GrafanaAPIServer)
 
@@ -292,7 +291,7 @@ func (s *service) start(ctx context.Context) error {
 	} else {
 		// Use unified storage client
 		serverConfig.Config.RESTOptionsGetter = apistore.NewRESTOptionsGetterForClient(
-			s.unified, o.RecommendedOptions.Etcd.StorageConfig)
+			s.unified, o.RecommendedOptions.Etcd.StorageConfig, s.features)
 	}
 
 	// Add OpenAPI specs for each group+version
@@ -319,7 +318,7 @@ func (s *service) start(ctx context.Context) error {
 	// Install the API group+version
 	err = builder.InstallAPIs(Scheme, Codecs, server, serverConfig.RESTOptionsGetter, builders, o.StorageOptions,
 		// Required for the dual writer initialization
-		s.metrics, request.GetNamespaceMapper(s.cfg), kvstore.WithNamespace(s.kvStore, 0, "storage.dualwriting"), s.serverLockService,
+		s.metrics, request.GetNamespaceMapper(s.cfg), kvstore.WithNamespace(s.kvStore, 0, "storage.dualwriting"), s.serverLockService, s.features,
 	)
 	if err != nil {
 		return err

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -289,9 +289,14 @@ func (s *service) start(ctx context.Context) error {
 			return err
 		}
 	} else {
+		// This is needed as the apistore doesn't allow any core grafana dependencies.
+		features := make(map[string]any)
+		if s.features.IsEnabled(context.Background(), featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
+			features[featuremgmt.FlagUnifiedStorageBigObjectsSupport] = struct{}{}
+		}
 		// Use unified storage client
 		serverConfig.Config.RESTOptionsGetter = apistore.NewRESTOptionsGetterForClient(
-			s.unified, o.RecommendedOptions.Etcd.StorageConfig, s.features)
+			s.unified, o.RecommendedOptions.Etcd.StorageConfig, features)
 	}
 
 	// Add OpenAPI specs for each group+version

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1518,6 +1518,12 @@ var (
 			Stage:       FeatureStageExperimental,
 			Owner:       grafanaPluginsPlatformSquad,
 		},
+		{
+			Name:        "unifiedStorageBigObjectSupport",
+			Description: "Enables to save big objects in blob storage",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSearchAndStorageSquad,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1519,7 +1519,7 @@ var (
 			Owner:       grafanaPluginsPlatformSquad,
 		},
 		{
-			Name:        "unifiedStorageBigObjectSupport",
+			Name:        "unifiedStorageBigObjectsSupport",
 			Description: "Enables to save big objects in blob storage",
 			Stage:       FeatureStageExperimental,
 			Owner:       grafanaSearchAndStorageSquad,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -201,4 +201,4 @@ useSessionStorageForRedirection,preview,@grafana/identity-access-team,false,fals
 rolePickerDrawer,experimental,@grafana/identity-access-team,false,false,false
 unifiedStorageSearch,experimental,@grafana/search-and-storage,false,false,false
 pluginsSriChecks,experimental,@grafana/plugins-platform-backend,false,false,false
-unifiedStorageBigObjectSupport,experimental,@grafana/search-and-storage,false,false,false
+unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -201,3 +201,4 @@ useSessionStorageForRedirection,preview,@grafana/identity-access-team,false,fals
 rolePickerDrawer,experimental,@grafana/identity-access-team,false,false,false
 unifiedStorageSearch,experimental,@grafana/search-and-storage,false,false,false
 pluginsSriChecks,experimental,@grafana/plugins-platform-backend,false,false,false
+unifiedStorageBigObjectSupport,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -815,7 +815,7 @@ const (
 	// Enables SRI checks for plugin assets
 	FlagPluginsSriChecks = "pluginsSriChecks"
 
-	// FlagUnifiedStorageBigObjectSupport
+	// FlagUnifiedStorageBigObjectsSupport
 	// Enables to save big objects in blob storage
-	FlagUnifiedStorageBigObjectSupport = "unifiedStorageBigObjectSupport"
+	FlagUnifiedStorageBigObjectsSupport = "unifiedStorageBigObjectsSupport"
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -814,4 +814,8 @@ const (
 	// FlagPluginsSriChecks
 	// Enables SRI checks for plugin assets
 	FlagPluginsSriChecks = "pluginsSriChecks"
+
+	// FlagUnifiedStorageBigObjectSupport
+	// Enables to save big objects in blob storage
+	FlagUnifiedStorageBigObjectSupport = "unifiedStorageBigObjectSupport"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3068,6 +3068,18 @@
     },
     {
       "metadata": {
+        "name": "unifiedStorageBigObjectSupport",
+        "resourceVersion": "1728561321640",
+        "creationTimestamp": "2024-10-10T11:55:21Z"
+      },
+      "spec": {
+        "description": "Enables to save big objects in blob storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
         "name": "unifiedStorageSearch",
         "resourceVersion": "1726771421439",
         "creationTimestamp": "2024-09-19T18:43:41Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3070,7 +3070,20 @@
       "metadata": {
         "name": "unifiedStorageBigObjectSupport",
         "resourceVersion": "1728561321640",
-        "creationTimestamp": "2024-10-10T11:55:21Z"
+        "creationTimestamp": "2024-10-10T11:55:21Z",
+        "deletionTimestamp": "2024-10-15T12:09:18Z"
+      },
+      "spec": {
+        "description": "Enables to save big objects in blob storage",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage"
+      }
+    },
+    {
+      "metadata": {
+        "name": "unifiedStorageBigObjectsSupport",
+        "resourceVersion": "1728994158474",
+        "creationTimestamp": "2024-10-15T12:09:18Z"
       },
       "spec": {
         "description": "Enables to save big objects in blob storage",

--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -128,7 +128,7 @@ func (r *RESTOptionsGetter) GetRESTOptions(resource schema.GroupResource, _ runt
 			trigger storage.IndexerFuncs,
 			indexers *cache.Indexers,
 		) (storage.Interface, factory.DestroyFunc, error) {
-			if r.features.IsEnabled(context.Background(), featuremgmt.FlagUnifiedStorageBigObjectSupport) {
+			if r.features.IsEnabled(context.Background(), featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
 				return NewStorage(config, r.client, keyFunc, nil, newFunc, newListFunc, getAttrsFunc,
 					trigger, indexers, LargeObjectSupportEnabled)
 			}

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -32,7 +32,11 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-const MaxUpdateAttempts = 30
+const (
+	MaxUpdateAttempts          = 30
+	LargeObjectSupportEnabled  = true
+	LargeObjectSupportDisabled = false
+)
 
 var _ storage.Interface = (*Storage)(nil)
 
@@ -51,6 +55,10 @@ type Storage struct {
 	getKey func(string) (*resource.ResourceKey, error)
 
 	versioner storage.Versioner
+
+	// Defines if we want to outsource large objects to another storage type.
+	// By default, this feature is disabled.
+	largeObjectSupport bool
 }
 
 // ErrFileNotExists means the file doesn't actually exist.
@@ -70,6 +78,7 @@ func NewStorage(
 	getAttrsFunc storage.AttrFunc,
 	trigger storage.IndexerFuncs,
 	indexers *cache.Indexers,
+	largeObjectSupport bool,
 ) (storage.Interface, factory.DestroyFunc, error) {
 	s := &Storage{
 		store:        store,
@@ -85,6 +94,8 @@ func NewStorage(
 		getKey: keyParser,
 
 		versioner: &storage.APIObjectVersioner{},
+		// Explicitly disable large object support.
+		largeObjectSupport: largeObjectSupport,
 	}
 
 	// The key parsing callback allows us to support the hardcoded paths from upstream tests

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -94,7 +94,7 @@ func NewStorage(
 		getKey: keyParser,
 
 		versioner: &storage.APIObjectVersioner{},
-		// Explicitly disable large object support.
+
 		largeObjectSupport: largeObjectSupport,
 	}
 

--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -176,6 +176,7 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 		storage.DefaultNamespaceScopedAttr,
 		make(map[string]storage.IndexerFunc, 0),
 		nil,
+		LargeObjectSupportDisabled,
 	)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
Adds a new feature toggle that is called `unifiedStorageBigObjectsSupport` to enable large object support.