### PR TITLE
PanelMenu: Allow showing panel menu when data source does not exist

### DIFF
--- a/public/app/features/trails/Integrations/dashboardIntegration.ts
+++ b/public/app/features/trails/Integrations/dashboardIntegration.ts
@@ -1,4 +1,4 @@
-import { PanelMenuItem } from '@grafana/data';
+import { DataSourceApi, PanelMenuItem } from '@grafana/data';
 import { PromQuery } from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { SceneTimeRangeState, VizPanel } from '@grafana/scenes';
@@ -34,7 +34,13 @@ export async function addDataTrailPanelAction(dashboard: DashboardScene, panel: 
     return;
   }
 
-  const dataSourceApi = await getDataSourceSrv().get(datasource);
+  let dataSourceApi: DataSourceApi | undefined;
+
+  try {
+    dataSourceApi = await getDataSourceSrv().get(datasource);
+  } catch (e) {
+    return;
+  }
 
   if (dataSourceApi.interpolateVariablesInQueries == null) {
     return;


### PR DESCRIPTION
When testing https://github.com/grafana/grafana/pull/94521 I've discovered a bug that doesn't allow showing the panel menu when data source doesn't exist (try attached dashboard). The problem was because of an uncought error caused by explore metrics menu item that resolves data source instance. 


<details>
<summary>dashboard.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 2642,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "prometheus",
        "uid": "fdloj1mdhsdfsdf4jcwe"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "11.3.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "fdloj1mdh4jcwe"
          },
          "disableTextWrap": false,
          "editorMode": "builder",
          "expr": "alertmanager_http_requests_in_flight",
          "fullMetaSearch": false,
          "includeNullMetadata": true,
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "A",
          "useBackend": false
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "preload": false,
  "schemaVersion": 40,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "Schema changes",
  "uid": "bdzdgq04gncowb",
  "version": 19,
  "weekStart": ""
}
```
</details?