### PR TITLE
GCM: Time field naming

### DIFF
--- a/pkg/tsdb/cloud-monitoring/time_series_filter.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_filter.go
@@ -37,6 +37,9 @@ func parseTimeSeriesResponse(queryRes *backend.DataResponse,
 				"groupBys":         groupBys,
 			},
 		}
+		// Ensure the time field is named correctly
+		timeField := frame.Fields[0]
+		timeField.Name = data.TimeSeriesTimeFieldName
 
 		var err error
 		frames, err = appendFrames(frames, series, 0, defaultMetricName, seriesLabels, frame, query)

--- a/pkg/tsdb/cloud-monitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_filter_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	sdkdata "github.com/grafana/grafana-plugin-sdk-go/data"
+	gdata "github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/tsdb/cloud-monitoring/kinds/dataquery"
 
 	"github.com/stretchr/testify/assert"
@@ -429,7 +429,7 @@ func TestTimeSeriesFilter(t *testing.T) {
 		frames := res.Frames
 		custom, ok := frames[0].Meta.Custom.(map[string]any)
 		require.True(t, ok)
-		labels, ok := custom["labels"].(sdkdata.Labels)
+		labels, ok := custom["labels"].(gdata.Labels)
 		require.True(t, ok)
 		assert.Equal(t, "114250375703598695", labels["resource.label.instance_id"])
 	})
@@ -459,12 +459,12 @@ func TestTimeSeriesFilter(t *testing.T) {
 			require.NoError(t, (&cloudMonitoringTimeSeriesList{parameters: &dataquery.TimeSeriesList{GroupBys: []string{"test_group_by"}}}).parseResponse(res, data, "test_query", service.logger))
 
 			require.NotNil(t, res.Frames[0].Meta)
-			assert.Equal(t, sdkdata.FrameMeta{
+			assert.Equal(t, gdata.FrameMeta{
 				ExecutedQueryString: "test_query",
 				Custom: map[string]any{
 					"groupBys":        []string{"test_group_by"},
 					"alignmentPeriod": "",
-					"labels": sdkdata.Labels{
+					"labels": gdata.Labels{
 						"resource.label.project_id": "grafana-prod",
 						"resource.type":             "https_lb_rule",
 					},
@@ -482,12 +482,12 @@ func TestTimeSeriesFilter(t *testing.T) {
 			require.NoError(t, (&cloudMonitoringTimeSeriesList{parameters: &dataquery.TimeSeriesList{GroupBys: []string{"test_group_by"}}}).parseResponse(res, data, "test_query", service.logger))
 
 			require.NotNil(t, res.Frames[0].Meta)
-			assert.Equal(t, sdkdata.FrameMeta{
+			assert.Equal(t, gdata.FrameMeta{
 				ExecutedQueryString: "test_query",
 				Custom: map[string]any{
 					"groupBys":        []string{"test_group_by"},
 					"alignmentPeriod": "",
-					"labels": sdkdata.Labels{
+					"labels": gdata.Labels{
 						"resource.label.project_id": "grafana-demo",
 						"resource.type":             "global",
 					},
@@ -505,12 +505,12 @@ func TestTimeSeriesFilter(t *testing.T) {
 			require.NoError(t, (&cloudMonitoringTimeSeriesList{parameters: &dataquery.TimeSeriesList{GroupBys: []string{"test_group_by"}}}).parseResponse(res, data, "test_query", service.logger))
 
 			require.NotNil(t, res.Frames[0].Meta)
-			assert.Equal(t, sdkdata.FrameMeta{
+			assert.Equal(t, gdata.FrameMeta{
 				ExecutedQueryString: "test_query",
 				Custom: map[string]any{
 					"groupBys":        []string{"test_group_by"},
 					"alignmentPeriod": "",
-					"labels": sdkdata.Labels{
+					"labels": gdata.Labels{
 						"resource.label.project_id": "grafana-prod",
 						"resource.type":             "https_lb_rule",
 					},
@@ -543,6 +543,22 @@ func TestTimeSeriesFilter(t *testing.T) {
 
 			assert.Contains(t, value, `zone=monitoring.regex.full_match("us-central1-a~")`)
 		})
+	})
+
+	t.Run("time field is appropriately named", func(t *testing.T) {
+		res := &backend.DataResponse{}
+		data, err := loadTestFile("./test-data/4-series-response-distribution-explicit.json")
+		require.NoError(t, err)
+		query := &cloudMonitoringTimeSeriesList{
+			parameters: &dataquery.TimeSeriesList{
+				ProjectName: "test-proj",
+			},
+			aliasBy: "",
+		}
+		err = query.parseResponse(res, data, "", service.logger)
+		require.NoError(t, err)
+		frames := res.Frames
+		assert.Equal(t, gdata.TimeSeriesTimeFieldName, frames[0].Fields[0].Name)
 	})
 }
 

--- a/pkg/tsdb/cloud-monitoring/time_series_query.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_query.go
@@ -75,6 +75,9 @@ func (timeSeriesQuery *cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *b
 				return err
 			}
 		}
+		// Ensure the time field is named correctly
+		timeField := frame.Fields[0]
+		timeField.Name = data.TimeSeriesTimeFieldName
 	}
 	if len(response.TimeSeriesData) > 0 {
 		dl := timeSeriesQuery.buildDeepLink()

--- a/pkg/tsdb/cloud-monitoring/time_series_query_test.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_query_test.go
@@ -148,4 +148,27 @@ func TestTimeSeriesQuery(t *testing.T) {
 		query := &cloudMonitoringTimeSeriesQuery{parameters: &dataquery.TimeSeriesQuery{GraphPeriod: strPtr("disabled")}}
 		assert.Equal(t, query.appendGraphPeriod(&backend.QueryDataRequest{Queries: []backend.DataQuery{{}}}), "")
 	})
+
+	t.Run("time field is appropriately named", func(t *testing.T) {
+		res := &backend.DataResponse{}
+		data, err := loadTestFile("./test-data/7-series-response-mql.json")
+		require.NoError(t, err)
+		fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
+		query := &cloudMonitoringTimeSeriesQuery{
+			parameters: &dataquery.TimeSeriesQuery{
+				ProjectName: "test-proj",
+				Query:       "test-query",
+			},
+			aliasBy: "",
+			timeRange: backend.TimeRange{
+				From: fromStart,
+				To:   fromStart.Add(34 * time.Minute),
+			},
+		}
+		err = query.parseResponse(res, data, "", service.logger)
+		require.NoError(t, err)
+		frames := res.Frames
+		assert.Equal(t, gdata.TimeSeriesTimeFieldName, frames[0].Fields[0].Name)
+	})
+
 }

--- a/pkg/tsdb/cloud-monitoring/time_series_query_test.go
+++ b/pkg/tsdb/cloud-monitoring/time_series_query_test.go
@@ -170,5 +170,4 @@ func TestTimeSeriesQuery(t *testing.T) {
 		frames := res.Frames
 		assert.Equal(t, gdata.TimeSeriesTimeFieldName, frames[0].Fields[0].Name)
 	})
-
 }


### PR DESCRIPTION
Time fields returned in data frames by the GCM data source were not appropriately named. This could lead to issues with transformations or visualizations that expect the time field to have a name defined.

A name is added to the time fields here for consistency, however further work should be undertaken to understand if this issue exists for other data sources. Work may also need to be done to ensure transformations and panels handle this case appropriately in future.

See grafana/support-escalations#12885 for details.
