### PR TITLE
K8s: Pass gatherer to standalone apiserver

### DIFF
--- a/pkg/services/apiserver/standalone/options/metrics.go
+++ b/pkg/services/apiserver/standalone/options/metrics.go
@@ -13,6 +13,7 @@ type MetricsOptions struct {
 	logger            log.Logger
 	Enabled           bool
 	MetricsRegisterer prometheus.Registerer
+	MetricsGatherer   prometheus.Gatherer
 }
 
 func NewMetricsOptions(logger log.Logger) *MetricsOptions {
@@ -30,11 +31,15 @@ func (o *MetricsOptions) Validate() []error {
 }
 
 func (o *MetricsOptions) ApplyTo(c *genericapiserver.RecommendedConfig) error {
-	c.EnableMetrics = o.Enabled
+	// Disable the default /metrics endpoint
+	c.EnableMetrics = false
+
 	o.MetricsRegisterer = metrics.ProvideRegisterer()
 	metrics.SetBuildInformation(o.MetricsRegisterer, setting.BuildVersion, setting.BuildCommit, setting.BuildBranch, setting.BuildStamp)
 
 	if o.Enabled {
+		// only provide the gatherer if metrics are enabled
+		o.MetricsGatherer = metrics.ProvideGatherer()
 		o.logger.Debug("Metrics enabled")
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds the ability to pass a gatherer via metric options.

**Why do we need this feature?**

Metrics registered to the default prometheus registry are not available in standalone. Related PR https://github.com/grafana/grafana-enterprise/pull/7356

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
