### PR TITLE
[unified-storage/apistore] Fix GuranteedUpdate skipping updates when `tryUpdate` is passed

### DIFF
--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -465,7 +465,7 @@ func (s *Storage) GuaranteedUpdate(
 			return apierrors.NewNotFound(s.gr, req.Key.Name)
 		}
 
-		updatedObj, _, err = tryUpdate(existingObj, res)
+		updatedObj, _, err = tryUpdate(existingObj.DeepCopyObject(), res)
 		if err != nil {
 			if attempt >= MaxUpdateAttempts {
 				return err

--- a/pkg/storage/unified/apistore/store_test.go
+++ b/pkg/storage/unified/apistore/store_test.go
@@ -135,12 +135,12 @@ func TestDeleteWithSuggestion(t *testing.T) {
 	storagetesting.RunTestDeleteWithSuggestion(ctx, t, store)
 }
 
-//func TestDeleteWithSuggestionAndConflict(t *testing.T) {
-//	ctx, store, destroyFunc, err := testSetup(t)
-//	defer destroyFunc()
-//	assert.NoError(t, err)
-//	storagetesting.RunTestDeleteWithSuggestionAndConflict(ctx, t, store)
-//}
+func TestDeleteWithSuggestionAndConflict(t *testing.T) {
+	ctx, store, destroyFunc, err := testSetup(t)
+	defer destroyFunc()
+	assert.NoError(t, err)
+	storagetesting.RunTestDeleteWithSuggestionAndConflict(ctx, t, store)
+}
 
 // TODO: this test relies on update
 //func TestDeleteWithSuggestionOfDeletedObject(t *testing.T) {


### PR DESCRIPTION
`GuranteedUpdate` method of `apistore.Storage` had a bug, where it would errorneously conclude that the object is unchanged, in case a `tryUpdate` function is passed that modifies the existing object itself (as it is the case in many core types in K8s upstream).

The modified `existingObj` was compared with `updatedObj`, which would essentially be same and this lead to the update being skipped.

This patch fixes this by always passing a copy of the `existingObj`.

**Special notes for your reviewer:**

The `TestDeleteWithSuggestionAndConflict` function uses `GuranteedUpdate` with such a `tryUpdate` function. The test was failing before and commented. The test passes correctly after fixing this issue.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
