### PR TITLE
Chore: Turn off apiserver tracing when embedded in Grafana

### DIFF
--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -4,12 +4,15 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/log/slogadapter"
 	"github.com/spf13/pflag"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/slogadapter"
 )
 
 type ExtraOptions struct {
@@ -40,7 +43,11 @@ func (o *ExtraOptions) Validate() []error {
 func (o *ExtraOptions) ApplyTo(c *genericapiserver.RecommendedConfig) error {
 	handler := slogadapter.New(log.New("grafana-apiserver"))
 	logger := slog.New(handler)
-
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
+		string(genericfeatures.APIServerTracing): false,
+	}); err != nil {
+		return err
+	}
 	klog.SetSlogLogger(logger)
 	if _, err := logs.GlogSetter(strconv.Itoa(o.Verbosity)); err != nil {
 		logger.Error("failed to set log level", "error", err)


### PR DESCRIPTION
**What is this feature?**
This PR disabled API in Kubernetes API server.

**Why do we need this feature?**
Currently, Kubernetes apiserver embedded into Grafana overrides the trace context at some point in the request pipeline. 
This results in a broken chain of spans registered for a request

<details>
<summary>Screenshots</summary>

Before:
![image](https://github.com/user-attachments/assets/7fb3230e-730a-434b-9acd-c886a5b7faf7)
![image](https://github.com/user-attachments/assets/b87a32a3-6d32-4a8f-90c5-834a1b164585)

After:
![image](https://github.com/user-attachments/assets/7830ec60-ebec-48d3-8a01-da2438aa454a)

</details>