### PR TITLE
Alerting: Fix rule evaluation logging which sometimes fails to log about evaluation failures

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -381,9 +381,6 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 	} else {
 		results, err = ruleEval.Evaluate(ctx, e.scheduledAt)
 		dur = a.clock.Now().Sub(start)
-		if err != nil {
-			logger.Error("Failed to evaluate rule", "error", err, "duration", dur)
-		}
 	}
 
 	evalAttemptTotal.Inc()
@@ -428,7 +425,7 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			err = results.Error()
 		}
 
-		logger.Debug("Alert rule evaluated", "error", err, "duration", dur)
+		logger.Error("Failed to evaluate rule", "error", err, "duration", dur)
 		span.SetStatus(codes.Error, "rule evaluation failed")
 		span.RecordError(err)
 	} else {


### PR DESCRIPTION
**What is this feature?**

There are 2 types of evaluation failures, ones from the expression pipeline itself and one where the pipeline execution succeeds but the dataframe contains an error.

We log the former at Error level, and the latter at Debug level. This makes debugging evaluation failures extremely difficult, as sometimes the logs are lost unless debug logging is enabled. Some kinds of failures do log, and some don't. Different datasources handle errors in different ways, meaning for some datasources no error logs happen at all across the board.

The wording of the log line is generic and refers to evaluation failures, so it doesn't make sense to differentiate between the two.

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
