### PR TITLE
Elasticsearch: Stop escaping backslash in regex adhoc filter

### DIFF
--- a/devenv/docker/blocks/elastic/data/data.js
+++ b/devenv/docker/blocks/elastic/data/data.js
@@ -150,7 +150,8 @@ function getRandomLogItem(counter, timestamp) {
     value: counter,
     metric: chooseRandomElement(['cpu', 'memory', 'latency']),
     description: "this is description",
-    slash: "Access to the path '\\\\tkasnpo\\KASNPO\\Files\\contacts.xml' is denied."
+    slash: "Access to the path '\\\\tkasnpo\\KASNPO\\Files\\contacts.xml' is denied.",
+    url: "/foo/blah"
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -721,6 +721,12 @@ describe('ElasticDatasource', () => {
           const query = ds.addAdHocFilters('', filters);
           expect(query).toBe('field\\:name:"field \\"value\\""');
         });
+
+        it('should not escape backslash in regex', () => {
+          const filters = [{ key: 'field:name', operator: '=~', value: 'field value\\/', condition: '' }];
+          const query = ds.addAdHocFilters('', filters);
+          expect(query).toBe('field\\:name:/field value\\//');
+        });
       });
     });
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -695,10 +695,10 @@ describe('ElasticDatasource', () => {
                 expect(query).toBe('foo:"bar" AND -key:"value"');
                 break;
               case '=~':
-                expect(query).toBe('foo:"bar" AND key:/value/');
+                expect(query).toBe('foo:"bar" AND key:"value"');
                 break;
               case '!~':
-                expect(query).toBe('foo:"bar" AND -key:/value/');
+                expect(query).toBe('foo:"bar" AND -key:"value"');
                 break;
               case '>':
                 expect(query).toBe('foo:"bar" AND key:>value');
@@ -734,13 +734,13 @@ describe('ElasticDatasource', () => {
       it('should correctly add ad hoc filters when query is not empty', () => {
         const query = ds.addAdHocFilters('foo:"bar" AND test:"test1"', filters);
         expect(query).toBe(
-          'foo:"bar" AND test:"test1" AND bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1'
+          'foo:"bar" AND test:"test1" AND bar:"baz" AND -job:"grafana" AND service:"service" AND count:>1'
         );
       });
 
       it('should correctly add ad hoc filters when query is  empty', () => {
         const query = ds.addAdHocFilters('', filters);
-        expect(query).toBe('bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1');
+        expect(query).toBe('bar:"baz" AND -job:"grafana" AND service:"service" AND count:>1');
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -695,10 +695,10 @@ describe('ElasticDatasource', () => {
                 expect(query).toBe('foo:"bar" AND -key:"value"');
                 break;
               case '=~':
-                expect(query).toBe('foo:"bar" AND key:"value"');
+                expect(query).toBe('foo:"bar" AND key:/value/');
                 break;
               case '!~':
-                expect(query).toBe('foo:"bar" AND -key:"value"');
+                expect(query).toBe('foo:"bar" AND -key:/value/');
                 break;
               case '>':
                 expect(query).toBe('foo:"bar" AND key:>value');
@@ -734,13 +734,13 @@ describe('ElasticDatasource', () => {
       it('should correctly add ad hoc filters when query is not empty', () => {
         const query = ds.addAdHocFilters('foo:"bar" AND test:"test1"', filters);
         expect(query).toBe(
-          'foo:"bar" AND test:"test1" AND bar:"baz" AND -job:"grafana" AND service:"service" AND count:>1'
+          'foo:"bar" AND test:"test1" AND bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1'
         );
       });
 
       it('should correctly add ad hoc filters when query is  empty', () => {
         const query = ds.addAdHocFilters('', filters);
-        expect(query).toBe('bar:"baz" AND -job:"grafana" AND service:"service" AND count:>1');
+        expect(query).toBe('bar:"baz" AND -job:"grafana" AND service:/service/ AND count:>1');
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -61,8 +61,8 @@ describe('addFilterToQuery', () => {
   it('should support filters with colons', () => {
     expect(addFilterToQuery('', 'label:name', 'value')).toBe('label\\:name:"value"');
   });
-  it('should support filters with quotes', () => {
-    expect(addFilterToQuery('', 'label:name', 'the "value"')).toBe('label\\:name:"the \\"value\\""');
+  it('should support filters with forward slash', () => {
+    expect(addFilterToQuery('', 'label', '/value/foo')).toBe('label:"\\/value\\/foo"');
   });
 });
 
@@ -133,6 +133,15 @@ describe('addStringFilterToQuery', () => {
     );
     expect(addStringFilterToQuery('label:"value"', '"filter with \\"', false)).toBe(
       'label:"value" NOT "\\"filter with \\\\\\""'
+    );
+  });
+
+  it('should escape filter values with forwardslashes', () => {
+    expect(addStringFilterToQuery('label:"value"', '"/filter/slash"')).toBe(
+      'label:"value" AND "\\"\\/filter\\/slash\\""'
+    );
+    expect(addStringFilterToQuery('label:"value"', '"/filter/slash"', false)).toBe(
+      'label:"value" NOT "\\"\\/filter\\/slash\\""'
     );
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -61,7 +61,7 @@ describe('addFilterToQuery', () => {
   it('should support filters with colons', () => {
     expect(addFilterToQuery('', 'label:name', 'value')).toBe('label\\:name:"value"');
   });
-  it('should support filters with forward slash', () => {
+  it('should support filters with quotes', () => {
     expect(addFilterToQuery('', 'label:name', 'the "value"')).toBe('label\\:name:"the \\"value\\""');
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -62,7 +62,7 @@ describe('addFilterToQuery', () => {
     expect(addFilterToQuery('', 'label:name', 'value')).toBe('label\\:name:"value"');
   });
   it('should support filters with forward slash', () => {
-    expect(addFilterToQuery('', 'label', '/value/foo')).toBe('label:"/value/foo"');
+    expect(addFilterToQuery('', 'label:name', 'the "value"')).toBe('label\\:name:"the \\"value\\""');
   });
 });
 

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.test.ts
@@ -62,7 +62,7 @@ describe('addFilterToQuery', () => {
     expect(addFilterToQuery('', 'label:name', 'value')).toBe('label\\:name:"value"');
   });
   it('should support filters with forward slash', () => {
-    expect(addFilterToQuery('', 'label', '/value/foo')).toBe('label:"\\/value\\/foo"');
+    expect(addFilterToQuery('', 'label', '/value/foo')).toBe('label:"/value/foo"');
   });
 });
 
@@ -133,15 +133,6 @@ describe('addStringFilterToQuery', () => {
     );
     expect(addStringFilterToQuery('label:"value"', '"filter with \\"', false)).toBe(
       'label:"value" NOT "\\"filter with \\\\\\""'
-    );
-  });
-
-  it('should escape filter values with forwardslashes', () => {
-    expect(addStringFilterToQuery('label:"value"', '"/filter/slash"')).toBe(
-      'label:"value" AND "\\"\\/filter\\/slash\\""'
-    );
-    expect(addStringFilterToQuery('label:"value"', '"/filter/slash"', false)).toBe(
-      'label:"value" NOT "\\"\\/filter\\/slash\\""'
     );
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -107,10 +107,10 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
   let addHocFilter = '';
   switch (filter.operator) {
     case '=~':
-      addHocFilter = `${key}:/${value}/`;
+      addHocFilter = `${key}:"${value}"`;
       break;
     case '!~':
-      addHocFilter = `-${key}:/${value}/`;
+      addHocFilter = `-${key}:"${value}"`;
       break;
     case '>':
       addHocFilter = `${key}:>${value}`;

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -188,6 +188,7 @@ export function escapeFilter(value: string) {
  */
 export function escapeFilterValue(value: string) {
   value = value.replace(/\\/g, '\\\\');
+  value = value.replace(/\//g, '\\/');
   return lucene.phrase.escape(value);
 }
 

--- a/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
+++ b/public/app/plugins/datasource/elasticsearch/modifyQuery.ts
@@ -104,13 +104,14 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
    */
   const key = escapeFilter(filter.key);
   const value = escapeFilterValue(filter.value);
+  const regexValue = escapeFilterValue(filter.value, false);
   let addHocFilter = '';
   switch (filter.operator) {
     case '=~':
-      addHocFilter = `${key}:"${value}"`;
+      addHocFilter = `${key}:/${regexValue}/`;
       break;
     case '!~':
-      addHocFilter = `-${key}:"${value}"`;
+      addHocFilter = `-${key}:/${regexValue}/`;
       break;
     case '>':
       addHocFilter = `${key}:>${value}`;
@@ -186,9 +187,10 @@ export function escapeFilter(value: string) {
  * Values can possibly reserved special characters such as quotes.
  * Use this function to escape filter values.
  */
-export function escapeFilterValue(value: string) {
-  value = value.replace(/\\/g, '\\\\');
-  value = value.replace(/\//g, '\\/');
+export function escapeFilterValue(value: string, escapeBackslash = true) {
+  if (escapeBackslash) {
+    value = value.replace(/\\/g, '\\\\');
+  }
   return lucene.phrase.escape(value);
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Stops escaping backslashes in regexes

**Why do we need this feature?**

Otherwise, users can't escape characters in regexes.

**Who is this feature for?**

Users that want to use elasticseach with regexes with escaped characters.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of #91582

**Special notes for your reviewer:**
It turns out that elasticsearch doesn't distinguish regex queries with backslashes, but that the query type we're using for filters assumes that the query passed in is a regex [query_string docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html) [link to code](https://github.com/grafana/grafana/blob/27c44f4709ad203010f004134f58149b45c38cfb/pkg/tsdb/elasticsearch/data_query.go#L290)
We may want to create a follow up ticket to figure out how to make `=` and `!=` filters not presumed to be regexes

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
