### PR TITLE
Docs: Remove bad `info.` from generic-oauth JMESPaths

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -256,7 +256,7 @@ Payload:
 Config:
 
 ```bash
-role_attribute_path = contains(info.groups[*], 'admin') && 'Admin' || contains(info.groups[*], 'editor') && 'Editor' || 'Viewer'
+role_attribute_path = contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'editor') && 'Editor' || 'Viewer'
 ```
 
 ##### Map server administrator role
@@ -282,7 +282,7 @@ Payload:
 Config:
 
 ```ini
-role_attribute_path = contains(info.roles[*], 'admin') && 'GrafanaAdmin' || contains(info.roles[*], 'editor') && 'Editor' || 'Viewer'
+role_attribute_path = contains(roles[*], 'admin') && 'GrafanaAdmin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'
 allow_assign_grafana_admin = true
 ```
 
@@ -324,7 +324,7 @@ Payload:
 Config:
 
 ```ini
-role_attribute_path = contains(info.roles[*], 'admin') && 'GrafanaAdmin' || 'None'
+role_attribute_path = contains(roles[*], 'admin') && 'GrafanaAdmin' || 'None'
 allow_assign_grafana_admin = true
 org_attribute_path = info.roles
 org_mapping = org_foo:org_foo:Viewer org_bar:org_bar:Editor *:org_baz:Editor

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -299,11 +299,7 @@ Payload:
 
 ```json
 {
-    "roles": [
-        "org_foo",
-        "org_bar",
-        "another_org"
-    ],
+  "roles": ["org_foo", "org_bar", "another_org"]
 }
 ```
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -241,14 +241,10 @@ Payload:
 ```json
 {
     ...
-    "info": {
-        ...
-        "groups": [
-            "engineer",
-            "admin",
-        ],
-        ...
-    },
+    "groups": [
+        "engineer",
+        "admin",
+    ],
     ...
 }
 ```
@@ -268,13 +264,9 @@ Payload:
 ```json
 {
     ...
-    "info": {
-        ...
-        "roles": [
-            "admin",
-        ],
-        ...
-    },
+    "roles": [
+        "admin",
+    ],
     ...
 }
 ```
@@ -307,17 +299,11 @@ Payload:
 
 ```json
 {
-    ...
-    "info": {
-        ...
-        "roles": [
-            "org_foo",
-            "org_bar",
-            "another_org"
-        ],
-        ...
-    },
-    ...
+    "roles": [
+        "org_foo",
+        "org_bar",
+        "another_org"
+    ],
 }
 ```
 
@@ -326,7 +312,7 @@ Config:
 ```ini
 role_attribute_path = contains(roles[*], 'admin') && 'GrafanaAdmin' || 'None'
 allow_assign_grafana_admin = true
-org_attribute_path = info.roles
+org_attribute_path = roles
 org_mapping = org_foo:org_foo:Viewer org_bar:org_bar:Editor *:org_baz:Editor
 ```
 
@@ -347,7 +333,7 @@ To learn more about Team Sync, refer to [Configure team sync]({{< relref "../../
 Configuration:
 
 ```bash
-groups_attribute_path = info.groups
+groups_attribute_path = groups
 ```
 
 Payload:
@@ -355,14 +341,10 @@ Payload:
 ```json
 {
     ...
-    "info": {
-        ...
-        "groups": [
-            "engineers",
-            "analysts",
-        ],
-        ...
-    },
+    "groups": [
+        "engineers",
+        "analysts",
+    ],
     ...
 }
 ```


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The generic oauth docs mention an `info.` section in the JMES Paths for role mappings that shouldn't be there. This change removes it

**Why do we need this feature?**

The needed entries are top-level in the oauth userinfo body, not under an info key.

**Who is this feature for?**

Anyone configuring role mappings through oauth.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

I'm pretty sure this change applies to the groups key, but I don't know for certain whether it's also correct for roles, as my oauth userinfo doesn't contain that field.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
