### PR TITLE
datasources: querier: handle reducer-settings-mode correctly

### DIFF
--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -74,6 +74,8 @@ func (h *ExpressionQueryReader) ReadQuery(
 		}
 		if err == nil && q.Settings != nil {
 			switch q.Settings.Mode {
+			case "":
+				mapper = nil
 			case ReduceModeDrop:
 				mapper = mathexp.DropNonNumber{}
 			case ReduceModeReplace:

--- a/pkg/expr/reader_test.go
+++ b/pkg/expr/reader_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestReaderReduceMode(t *testing.T) {
-
 	testData := []struct {
 		name          string
 		bytes         []byte

--- a/pkg/expr/reader_test.go
+++ b/pkg/expr/reader_test.go
@@ -1,0 +1,144 @@
+package expr
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
+	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReaderReduceMode(t *testing.T) {
+
+	testData := []struct {
+		name          string
+		bytes         []byte
+		expectedError string
+	}{
+		{
+			name: "no_settings",
+			bytes: []byte(`
+				{
+					"refId": "B",
+					"datasource": {
+						"type": "__expr__",
+						"uid": "__expr__"
+					},
+					"reducer": "last",
+					"expression": "A",
+					"window": "",
+					"type": "reduce"
+				}
+			`),
+			expectedError: "",
+		},
+		{
+			name: "mode_dropnn",
+			bytes: []byte(`
+				{
+					"refId": "B",
+					"datasource": {
+						"type": "__expr__",
+						"uid": "__expr__"
+					},
+					"reducer": "last",
+					"expression": "A",
+					"window": "",
+					"settings": {
+						"mode": "dropNN"
+					},
+					"type": "reduce"
+				}
+			`),
+			expectedError: "",
+		},
+		{
+			name: "mode_replacenn",
+			bytes: []byte(`
+				{
+					"refId": "B",
+					"datasource": {
+						"type": "__expr__",
+						"uid": "__expr__"
+					},
+					"reducer": "last",
+					"expression": "A",
+					"window": "",
+					"settings": {
+						"mode": "replaceNN",
+						"replaceWithValue": 42
+					},
+					"type": "reduce"
+				}
+			`),
+			expectedError: "",
+		},
+		{
+			name: "mode_strict",
+			bytes: []byte(`
+				{
+					"refId": "B",
+					"datasource": {
+						"type": "__expr__",
+						"uid": "__expr__"
+					},
+					"reducer": "last",
+					"expression": "A",
+					"window": "",
+					"settings": {
+						"mode": ""
+					},
+					"type": "reduce"
+				}
+			`),
+			expectedError: "",
+		},
+		{
+			name: "mode_invalid",
+			bytes: []byte(`
+				{
+					"refId": "B",
+					"datasource": {
+						"type": "__expr__",
+						"uid": "__expr__"
+					},
+					"reducer": "last",
+					"expression": "A",
+					"window": "",
+					"settings": {
+						"mode": "invalid-mode"
+					},
+					"type": "reduce"
+				}
+			`),
+			expectedError: "unsupported reduce mode",
+		},
+	}
+
+	for _, test := range testData {
+		t.Run("TestReduceReader:"+test.name, func(t *testing.T) {
+			var q data.DataQuery
+
+			err := json.Unmarshal(test.bytes, &q)
+			require.NoError(t, err)
+
+			raw, err := json.Marshal(q)
+			require.NoError(t, err)
+
+			iter, err := jsoniter.ParseBytes(jsoniter.ConfigDefault, raw)
+			require.NoError(t, err)
+
+			reader := NewExpressionQueryReader(featuremgmt.WithFeatures())
+
+			_, err = reader.ReadQuery(q, iter)
+
+			if test.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
when a Reduce Expression is configured, it has a `mode` setting.
<img width="702" alt="reduce" src="https://github.com/user-attachments/assets/1ab083a5-440e-4db6-81ff-70d084057bca">

 it has the following options:
- Strict
- Drop non-numeric
- Replace non-numeric

the option `Strict`, can be represented in two ways:
- A. if you switch it to something else, then back to the default-value, then `  "settings": {"mode": ""},` is added to the query-json
- B. if you just leave the setting on it's default-value, then no `"settings": {...}` section is added to the query-json

the ds-querier handled case `B` correctly, but did not handle case `A` correctly. this PR fixes this.

sample query-json to test the querier with:
```json
{
  "queries": [
    {
      "refId": "A",
      "datasource": {
        "type": "prometheus",
        "uid": "x-prom"
      },
      "expr": "1 + 2",
      "range": true,
      "instant": false,
      "intervalMs": 300000
    },
    {
      "refId": "B",
      "datasource": {
        "type": "__expr__",
        "uid": "__expr__"
      },
      "type": "reduce",
      "reducer": "last",
      "expression": "A",
      "settings": {
        "mode": ""
      },
      "window": ""
    }
  ],
  "from": "now-1h",
  "to": "now"
}
```
please make sure to replace the prometheus-datasource-uid (`x-prom` in the sample) with the correct uid.
