### PR TITLE
Zanzana: add action sets to dashboard and folder schema

### DIFF
--- a/pkg/services/authz/zanzana/schema/core.fga
+++ b/pkg/services/authz/zanzana/schema/core.fga
@@ -26,6 +26,8 @@ type role
 type team
   relations
     define org: [org]
+
+    # Action sets
     define admin: [user]
     define member: [user] or admin
 

--- a/pkg/services/authz/zanzana/schema/dashboard.fga
+++ b/pkg/services/authz/zanzana/schema/dashboard.fga
@@ -29,16 +29,20 @@ type dashboard
   relations
     define org: [org]
 
-    define read: [user, team#member, role#assignee] or dashboard_read from org
-    define write: [user, team#member, role#assignee] or dashboard_write from org
-    define delete: [user, team#member, role#assignee] or dashboard_delete from org
+    # Action sets
+    define view: [user, team#member, role#assignee]
+    define edit: [user, team#member, role#assignee]
+    define admin: [user, team#member, role#assignee]
+
     define create: [user, team#member, role#assignee] or dashboard_create from org
-    define permissions_read: [user, team#member, role#assignee] or dashboard_permissions_read from org
-    define permissions_write: [user, team#member, role#assignee] or dashboard_permissions_write from org
+    define read: [user, team#member, role#assignee] or view or edit or admin or dashboard_read from org
+    define write: [user, team#member, role#assignee] or edit or admin or dashboard_write from org
+    define delete: [user, team#member, role#assignee] or edit or admin or dashboard_delete from org
+    define permissions_read: [user, team#member, role#assignee] or admin or dashboard_permissions_read from org
+    define permissions_write: [user, team#member, role#assignee] or admin or dashboard_permissions_write from org
 
     define public_write: [user, team#member, role#assignee] or dashboard_public_write from org or write
     define annotations_create: [user, team#member, role#assignee] or dashboard_annotations_create from org
     define annotations_read: [user, team#member, role#assignee] or dashboard_annotations_read from org
     define annotations_write: [user, team#member, role#assignee] or dashboard_annotations_write from org
     define annotations_delete: [user, team#member, role#assignee] or dashboard_annotations_delete from org
-

--- a/pkg/services/authz/zanzana/schema/folder.fga
+++ b/pkg/services/authz/zanzana/schema/folder.fga
@@ -37,35 +37,40 @@ type folder
     define parent: [folder]
     define org: [org]
 
-    define create: [user, team#member, role#assignee] or create from parent or folder_create from org
-    define read: [user, team#member, role#assignee] or read from parent or folder_read from org
-    define write: [user, team#member, role#assignee] or write from parent or folder_write from org
-    define delete: [user, team#member, role#assignee] or delete from parent or folder_delete from org
-    define permissions_read: [user, team#member, role#assignee] or permissions_read from parent or folder_permissions_read from org
-    define permissions_write: [user, team#member, role#assignee] or permissions_write from parent or folder_permissions_write from org
+    # Action sets
+    define view: [user, team#member, role#assignee]
+    define edit: [user, team#member, role#assignee]
+    define admin: [user, team#member, role#assignee]
 
-    define dashboard_create: [user, team#member, role#assignee] or dashboard_create from parent or dashboard_create from org
-    define dashboard_read: [user, team#member, role#assignee] or dashboard_read from parent or dashboard_read from org
-    define dashboard_write: [user, team#member, role#assignee] or dashboard_write from parent or dashboard_write from org
-    define dashboard_delete: [user, team#member, role#assignee] or dashboard_delete from parent or dashboard_delete from org
-    define dashboard_permissions_read: [user, team#member, role#assignee] or dashboard_permissions_read from parent or dashboard_permissions_read from org
-    define dashboard_permissions_write: [user, team#member, role#assignee] or dashboard_permissions_write from parent or dashboard_permissions_write from org
+    define create: [user, team#member, role#assignee] or edit or admin or create from parent or folder_create from org
+    define read: [user, team#member, role#assignee] or view or edit or admin or read from parent or folder_read from org
+    define write: [user, team#member, role#assignee] or edit or admin or write from parent or folder_write from org
+    define delete: [user, team#member, role#assignee] or edit or admin or delete from parent or folder_delete from org
+    define permissions_read: [user, team#member, role#assignee] or admin or permissions_read from parent or folder_permissions_read from org
+    define permissions_write: [user, team#member, role#assignee] or admin or permissions_write from parent or folder_permissions_write from org
+
+    define dashboard_create: [user, team#member, role#assignee] or edit or admin or dashboard_create from parent or dashboard_create from org
+    define dashboard_read: [user, team#member, role#assignee] or view or edit or admin or dashboard_read from parent or dashboard_read from org
+    define dashboard_write: [user, team#member, role#assignee] or edit or admin or dashboard_write from parent or dashboard_write from org
+    define dashboard_delete: [user, team#member, role#assignee] or edit or admin or dashboard_delete from parent or dashboard_delete from org
+    define dashboard_permissions_read: [user, team#member, role#assignee] or admin or dashboard_permissions_read from parent or dashboard_permissions_read from org
+    define dashboard_permissions_write: [user, team#member, role#assignee] or admin or dashboard_permissions_write from parent or dashboard_permissions_write from org
     define dashboard_public_write: [user, team#member, role#assignee] or dashboard_public_write from parent or dashboard_public_write from org or dashboard_write
     define dashboard_annotations_create: [user, team#member, role#assignee] or dashboard_annotations_create from parent or dashboard_annotations_create from org
     define dashboard_annotations_read: [user, team#member, role#assignee] or dashboard_annotations_read from parent or dashboard_annotations_read from org
     define dashboard_annotations_write: [user, team#member, role#assignee] or dashboard_annotations_write from parent or dashboard_annotations_write from org
     define dashboard_annotations_delete: [user, team#member, role#assignee] or dashboard_annotations_delete from parent or dashboard_annotations_delete from org
 
-    define library_panel_create: [user, team#member, role#assignee] or library_panel_create from parent or library_panel_create from org
-    define library_panel_read: [user, team#member, role#assignee] or library_panel_read from parent or library_panel_read from org or library_panel_write
-    define library_panel_write: [user, team#member, role#assignee] or library_panel_write from parent or library_panel_write from org or library_panel_create
-    define library_panel_delete: [user, team#member, role#assignee] or library_panel_delete from parent or library_panel_delete from org or library_panel_create
+    define library_panel_create: [user, team#member, role#assignee] or edit or admin or library_panel_create from parent or library_panel_create from org
+    define library_panel_read: [user, team#member, role#assignee] or view or edit or admin or library_panel_read from parent or library_panel_read from org or library_panel_write
+    define library_panel_write: [user, team#member, role#assignee] or edit or admin or library_panel_write from parent or library_panel_write from org or library_panel_create
+    define library_panel_delete: [user, team#member, role#assignee] or edit or admin or library_panel_delete from parent or library_panel_delete from org or library_panel_create
 
-    define alert_rule_create: [user, team#member, role#assignee] or alert_rule_create from parent or alert_rule_create from org
-    define alert_rule_read: [user, team#member, role#assignee] or alert_rule_read from parent or alert_rule_read from org or alert_rule_write
-    define alert_rule_write: [user, team#member, role#assignee] or alert_rule_write from parent or alert_rule_write from org or alert_rule_create
-    define alert_rule_delete: [user, team#member, role#assignee] or alert_rule_delete from parent or alert_rule_delete from org or alert_rule_write
-    define alert_silence_create: [user, team#member, role#assignee] or alert_silence_create from parent or alert_silence_create from org
-    define alert_silence_read: [user, team#member, role#assignee] or alert_silence_read from parent or alert_silence_read from org or alert_silence_write
-    define alert_silence_write: [user, team#member, role#assignee] or alert_silence_write from parent or alert_silence_write from org or alert_silence_create
+    define alert_rule_create: [user, team#member, role#assignee] or edit or admin or alert_rule_create from parent or alert_rule_create from org
+    define alert_rule_read: [user, team#member, role#assignee] or view or edit or admin or alert_rule_read from parent or alert_rule_read from org or alert_rule_write
+    define alert_rule_write: [user, team#member, role#assignee] or edit or admin or alert_rule_write from parent or alert_rule_write from org or alert_rule_create
+    define alert_rule_delete: [user, team#member, role#assignee] or edit or admin or alert_rule_delete from parent or alert_rule_delete from org or alert_rule_write
+    define alert_silence_create: [user, team#member, role#assignee] or edit or admin or alert_silence_create from parent or alert_silence_create from org
+    define alert_silence_read: [user, team#member, role#assignee] or view or edit or admin or alert_silence_read from parent or alert_silence_read from org or alert_silence_write
+    define alert_silence_write: [user, team#member, role#assignee] or edit or admin or alert_silence_write from parent or alert_silence_write from org or alert_silence_create
 


### PR DESCRIPTION
**What is this feature?**

Add action sets to the OpenFGA schema to make it possible to evaluate access with view/edit/admin permission style.

**Why do we need this feature?**

Action sets are released behind the feature flag, so we should respect it and move in this direction.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/806

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
