### PR TITLE
Auth: Fix missing authLabels from user list page

### DIFF
--- a/pkg/services/searchusers/searchusers.go
+++ b/pkg/services/searchusers/searchusers.go
@@ -112,7 +112,7 @@ func (s *OSSService) SearchUser(c *contextmodel.ReqContext) (*user.SearchUserQue
 
 	for _, user := range res.Users {
 		user.AvatarURL = dtos.GetGravatarUrl(s.cfg, user.Email)
-		user.AuthLabels = make([]string, len(user.AuthModule))
+		user.AuthLabels = make([]string, 0, len(user.AuthModule))
 		for _, authModule := range user.AuthModule {
 			user.AuthLabels = append(user.AuthLabels, login.GetAuthProviderLabel(authModule))
 		}


### PR DESCRIPTION
**What is this feature?**
Fix missing auth labels from the UserList (All Users tab)

@linoman reported the following issue:
<img width="690" alt="Screenshot 2024-10-11 at 14 19 56" src="https://github.com/user-attachments/assets/6ccc76af-db39-4307-9e93-ec7eabc7ae90">

**Why do we need this feature?**


**Who is this feature for?**


**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
