### PR TITLE
Alerting: Add RuleGroup field to ListAlertInstancesQuery struct

### DIFF
--- a/pkg/services/ngalert/models/instance.go
+++ b/pkg/services/ngalert/models/instance.go
@@ -55,6 +55,7 @@ func (i InstanceStateType) IsValid() bool {
 type ListAlertInstancesQuery struct {
 	RuleUID   string
 	RuleOrgID int64 `json:"-"`
+	RuleGroup string
 }
 
 // ValidateAlertInstance validates that the alert instance contains an alert rule id,

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -33,6 +33,9 @@ func (st DBstore) ListAlertInstances(ctx context.Context, cmd *models.ListAlertI
 		if cmd.RuleUID != "" {
 			addToQuery(` AND rule_uid = ?`, cmd.RuleUID)
 		}
+		if cmd.RuleGroup != "" {
+			return errors.New("filtering by RuleGroup is not supported")
+		}
 
 		if st.FeatureToggles.IsEnabled(ctx, featuremgmt.FlagAlertingNoNormalState) {
 			s.WriteString(fmt.Sprintf(" AND NOT (current_state = '%s' AND current_reason = '')", models.InstanceStateNormal))


### PR DESCRIPTION
**What is this feature?**

Add `RuleGroup` field to `ListAlertInstancesQuery` struct, to be able to filter alert instances from the InstanceStore for a specific rule group. Not supported yet.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
