### PR TITLE
Alerting: Add interactions for Fullstory

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -190,6 +190,18 @@ export const trackAlertRuleFormError = (
   reportInteraction('grafana_alerting_rule_form_error', props);
 };
 
+export const trackNewGrafanaAlertRuleFormSavedSuccess = () => {
+  reportInteraction('grafana_alerting_grafana_rule_creation_new_success');
+};
+
+export const trackNewGrafanaAlertRuleFormCancelled = () => {
+  reportInteraction('grafana_alerting_grafana_rule_creation_new_aborted');
+};
+
+export const trackNewGrafanaAlertRuleFormError = () => {
+  reportInteraction('grafana_alerting_grafana_rule_creation_new_error');
+};
+
 export const trackInsightsFeedback = async (props: { useful: boolean; panel: string }) => {
   const defaults = {
     grafana_version: config.buildInfo.version,


### PR DESCRIPTION

**What is this feature?**

This PR adds tracking for 3 interactions:

- when user saves a new grafana-managed alert rule successfully
- when users tries to save a new grafana-maaged alert rule and gets an error in the form
- when user is creating a new grafana-managed alert rule and clicks cancel button.

**Why do we need this feature?**

We want to track this kind of interactions in Fullstory.

**Who is this feature for?**

devs

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
