### PR TITLE
IAM: turn off migration causing instances to crashloop

### DIFF
--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -160,7 +160,8 @@ func addUserMigrations(mg *Migrator) {
 	mg.AddMigration(usermig.AllowSameLoginCrossOrgs, &usermig.ServiceAccountsSameLoginCrossOrgs{})
 	// Before it was fixed, the previous migration introduced the org_id again in logins that already had it.
 	// This migration removes the duplicate org_id from the login.
-	mg.AddMigration(usermig.DedupOrgInLogin, &usermig.ServiceAccountsDeduplicateOrgInLogin{})
+	// TODO(aarongodin): this migration was causing instances to fail to start. It must be corrected before being added
+	// mg.AddMigration(usermig.DedupOrgInLogin, &usermig.ServiceAccountsDeduplicateOrgInLogin{})
 
 	// Users login and email should be in lower case
 	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail, &usermig.UsersLowerCaseLoginAndEmail{})


### PR DESCRIPTION
The migration introduced in this PR is causing crashlooping of instances: https://github.com/grafana/grafana/pull/94378

This disables the migration until we correct the issue.