### PR TITLE
Alerting: Validate namespace when updating rules through the provisioning API

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -341,18 +341,17 @@ func TestProvisioningApi(t *testing.T) {
 			t.Run("PUT returns 400 if folder does not exist", func(t *testing.T) {
 				testEnv := createTestEnv(t, testConfig)
 				sut := createProvisioningSrvSutFromEnv(t, &testEnv)
-				orgID := int64(1)
+				orgID := int64(2)
 
-				// create a folder since we need an existing rule to update
+				rule := createTestAlertRule("rule", orgID)
 				_, err := sut.folderSvc.Create(context.Background(), &folder.CreateFolderCommand{
-					UID:          "folder-uid",
+					UID:          rule.FolderUID,
 					Title:        "Folder Title",
 					OrgID:        orgID,
 					SignedInUser: &user.SignedInUser{OrgID: orgID},
 				})
 				require.NoError(t, err)
 
-				rule := createTestAlertRule("rule", orgID)
 				insertRuleInOrg(t, sut, rule, orgID)
 				rule.FolderUID = "does-not-exist"
 

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -314,11 +314,54 @@ func TestProvisioningApi(t *testing.T) {
 				rule := createTestAlertRule("rule", 1)
 
 				response := sut.RoutePostAlertRule(&rc, rule)
-
 				require.Equal(t, 400, response.Status())
 				require.NotEmpty(t, response.Body())
 				require.Contains(t, string(response.Body()), "invalid alert rule")
 				require.Contains(t, string(response.Body()), "folder does not exist")
+			})
+
+			t.Run("PUT returns 400 when folderUID not set", func(t *testing.T) {
+				sut := createProvisioningSrvSut(t)
+				orgID := int64(1)
+
+				rule := createTestAlertRule("rule", orgID)
+				insertRuleInOrg(t, sut, rule, orgID)
+
+				rule.FolderUID = ""
+
+				rc := createTestRequestCtx()
+				res := sut.RoutePutAlertRule(&rc, rule, rule.UID)
+
+				require.Equal(t, 400, res.Status())
+				require.NotEmpty(t, res.Body())
+				require.Contains(t, string(res.Body()), "invalid alert rule")
+				require.Contains(t, string(res.Body()), "folderUID must be set")
+			})
+
+			t.Run("PUT returns 400 if folder does not exist", func(t *testing.T) {
+				testEnv := createTestEnv(t, testConfig)
+				sut := createProvisioningSrvSutFromEnv(t, &testEnv)
+				orgID := int64(1)
+
+				// create a folder since we need an existing rule to update
+				_, err := sut.folderSvc.Create(context.Background(), &folder.CreateFolderCommand{
+					UID:          "folder-uid",
+					Title:        "Folder Title",
+					OrgID:        orgID,
+					SignedInUser: &user.SignedInUser{OrgID: orgID},
+				})
+				require.NoError(t, err)
+
+				rule := createTestAlertRule("rule", orgID)
+				insertRuleInOrg(t, sut, rule, orgID)
+				rule.FolderUID = "does-not-exist"
+
+				rc := createTestRequestCtx()
+				res := sut.RoutePutAlertRule(&rc, rule, rule.UID)
+				require.Equal(t, 400, res.Status())
+				require.NotEmpty(t, res.Body())
+				require.Contains(t, string(res.Body()), "invalid alert rule")
+				require.Contains(t, string(res.Body()), "folder does not exist")
 			})
 		})
 

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -185,6 +185,9 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, user ident
 		return models.AlertRule{}, errors.Join(models.ErrAlertRuleFailedValidation, fmt.Errorf("cannot create rule with UID '%s': %w", rule.UID, err))
 	}
 	var interval = service.defaultIntervalSeconds
+	if err := service.ensureNamespace(ctx, user, rule.OrgID, rule.NamespaceUID); err != nil {
+		return models.AlertRule{}, err
+	}
 	// check if user can bypass fine-grained rule authorization checks. If it cannot, verfiy that the user can add rules to the group
 	canWriteAllRules, err := service.authz.CanWriteAllRules(ctx, user)
 	if err != nil {
@@ -214,9 +217,6 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, user ident
 	rule.IntervalSeconds = interval
 	err = rule.SetDashboardAndPanelFromAnnotations()
 	if err != nil {
-		return models.AlertRule{}, err
-	}
-	if err = service.ensureRuleNamespace(ctx, user, rule); err != nil {
 		return models.AlertRule{}, err
 	}
 	rule.Updated = time.Now()
@@ -544,6 +544,9 @@ func (service *AlertRuleService) persistDelta(ctx context.Context, user identity
 // UpdateAlertRule updates an alert rule.
 func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, user identity.Requester, rule models.AlertRule, provenance models.Provenance) (models.AlertRule, error) {
 	var storedRule *models.AlertRule
+	if err := service.ensureNamespace(ctx, user, rule.OrgID, rule.NamespaceUID); err != nil {
+		return models.AlertRule{}, err
+	}
 	// check if the user has full access to all rules and can bypass the regular authorization validations.
 	// If it cannot, calculate the changes to the group caused by this update and authorize them.
 	canWriteAllRules, err := service.authz.CanWriteAllRules(ctx, user)
@@ -583,9 +586,6 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, user ident
 	}
 	if storedProvenance != provenance && storedProvenance != models.ProvenanceNone {
 		return models.AlertRule{}, fmt.Errorf("cannot change provenance from '%s' to '%s'", storedProvenance, provenance)
-	}
-	if err := service.ensureRuleNamespace(ctx, user, rule); err != nil {
-		return models.AlertRule{}, err
 	}
 	if len(rule.NotificationSettings) > 0 {
 		validator, err := service.nsValidatorProvider.Validator(ctx, rule.OrgID)
@@ -839,10 +839,10 @@ func (service *AlertRuleService) checkGroupLimits(group models.AlertRuleGroup) e
 	return nil
 }
 
-// ensureRuleNamespace ensures that the rule has a valid namespace UID.
+// ensureNamespace ensures that the rule has a valid namespace UID.
 // If the rule does not have a namespace UID or the namespace (folder) does not exist it will return an error.
-func (service *AlertRuleService) ensureRuleNamespace(ctx context.Context, user identity.Requester, rule models.AlertRule) error {
-	if rule.NamespaceUID == "" {
+func (service *AlertRuleService) ensureNamespace(ctx context.Context, user identity.Requester, orgID int64, namespaceUID string) error {
+	if namespaceUID == "" {
 		return fmt.Errorf("%w: folderUID must be set", models.ErrAlertRuleFailedValidation)
 	}
 
@@ -854,8 +854,8 @@ func (service *AlertRuleService) ensureRuleNamespace(ctx context.Context, user i
 
 	// ensure the namespace exists
 	_, err := service.folderService.Get(ctx, &folder.GetFolderQuery{
-		OrgID:        rule.OrgID,
-		UID:          &rule.NamespaceUID,
+		OrgID:        orgID,
+		UID:          &namespaceUID,
 		SignedInUser: user,
 	})
 	if err != nil {

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -584,6 +584,9 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, user ident
 	if storedProvenance != provenance && storedProvenance != models.ProvenanceNone {
 		return models.AlertRule{}, fmt.Errorf("cannot change provenance from '%s' to '%s'", storedProvenance, provenance)
 	}
+	if err := service.ensureRuleNamespace(ctx, user, rule); err != nil {
+		return models.AlertRule{}, err
+	}
 	if len(rule.NotificationSettings) > 0 {
 		validator, err := service.nsValidatorProvider.Validator(ctx, rule.OrgID)
 		if err != nil {


### PR DESCRIPTION
**What is this feature?**

This adds the same folder validation to the `UpdateAlertRule` method of the provisioning rule service that was added to `CreateAlertRule`.

**Why do we need this feature?**

After creating a rule, it is currently possible to modify it and reference a nonexistent namespace (folder).

**Who is this feature for?**

Users of the alerting provisioning API.

**Which issue(s) does this PR fix?**:

Fixes #94639

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
