### PR TITLE
Alerting: Default pending period (for) to 0s when the rule is created using file provisioning

### DIFF
--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -97,11 +97,17 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: no UID set", alertRule.Title)
 	}
 	alertRule.OrgID = orgID
-	duration, err := model.ParseDuration(rule.For.Value())
-	if err != nil {
-		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: %w", alertRule.Title, err)
+
+	duration := model.Duration(0)
+	if rule.For.Value() != "" {
+		var err error
+		duration, err = model.ParseDuration(rule.For.Value())
+		if err != nil {
+			return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse 'for' field: %w", alertRule.Title, err)
+		}
 	}
 	alertRule.For = time.Duration(duration)
+
 	dasboardUID := rule.DasboardUID.Value()
 	dashboardUID := rule.DashboardUID.Value()
 	alertRule.DashboardUID = withFallback(dashboardUID, dasboardUID) // Use correct spelling over supported typo.

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -102,11 +102,12 @@ func TestRules(t *testing.T) {
 		_, err := rule.mapToModel(1)
 		require.Error(t, err)
 	})
-	t.Run("a rule with out a for duration should error", func(t *testing.T) {
+	t.Run("a rule without a for duration should default to 0s", func(t *testing.T) {
 		rule := validRuleV1(t)
 		rule.For = values.StringValue{}
-		_, err := rule.mapToModel(1)
-		require.Error(t, err)
+		ruleMapped, err := rule.mapToModel(1)
+		require.NoError(t, err)
+		require.Equal(t, time.Duration(0), ruleMapped.For)
 	})
 	t.Run("a rule with an invalid for duration should error", func(t *testing.T) {
 		rule := validRuleV1(t)


### PR DESCRIPTION
**What is this feature?**

Makes the `for` field (pending period) optional for alert rules when created using file provisioning. 

Currently, if you export an alert rule with no pending period (`0s`), the resulting file does not contain the `for` field. If you try to import it back via file provisioning, it fails with `failed to parse: empty duration string`. This PR makes the `for` default to `0s` when it's not specified.


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
