### PR TITLE
Alerting: Fix the unnecessary `FolderCreationModal` that is displayed twice

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderAndGroup.tsx
@@ -198,10 +198,6 @@ export function FolderAndGroup({
         )}
       </Stack>
 
-      {isCreatingFolder && (
-        <FolderCreationModal onCreate={handleFolderCreation} onClose={() => setIsCreatingFolder(false)} />
-      )}
-
       <Stack alignItems="center">
         <div style={{ width: 420 }}>
           <Field


### PR DESCRIPTION
**What is this feature?**

Remove  the unnecessary `FolderCreationModal` that is displayed twice.

This modification does not affect any function.

Modification details:

```ts
       <Stack>
         ...
        {isCreatingFolder && (
          <FolderCreationModal onCreate={handleFolderCreation} onClose={() => setIsCreatingFolder(false)} />
        )}
      </Stack>

      // removed
      {isCreatingFolder && (
        <FolderCreationModal onCreate={handleFolderCreation} onClose={() => setIsCreatingFolder(false)} />
      )}
```

**Why do we need this feature?**

To avoid performance degradation due to the rendering of unnecessary content.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #94476

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
