### PR TITLE
CloudMigrations: create snapshot for Mute Timings

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -1,0 +1,41 @@
+package cloudmigrationimpl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/alertmanager/config"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+type muteTimeInterval struct {
+	// There is a lot of custom (de)serialization logic from Alertmanager,
+	// and this is the same type used by the underlying API, hence we can use the type as-is.
+	config.MuteTimeInterval `json:",inline"`
+}
+
+func (s *Service) getAlertMuteTimings(ctx context.Context, signedInUser *user.SignedInUser) ([]muteTimeInterval, error) {
+	if !s.features.IsEnabledGlobally(featuremgmt.FlagOnPremToCloudMigrationsAlerts) {
+		return nil, nil
+	}
+
+	muteTimings, err := s.ngAlert.Api.MuteTimings.GetMuteTimings(ctx, signedInUser.OrgID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching ngalert mute timings: %w", err)
+	}
+
+	muteTimeIntervals := make([]muteTimeInterval, 0, len(muteTimings))
+
+	for _, muteTiming := range muteTimings {
+		muteTimeIntervals = append(muteTimeIntervals, muteTimeInterval{
+			MuteTimeInterval: config.MuteTimeInterval{
+				Name:          muteTiming.Name,
+				TimeIntervals: muteTiming.TimeIntervals,
+			},
+		})
+	}
+
+	return muteTimeIntervals, nil
+}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -1,0 +1,69 @@
+package cloudmigrationimpl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+func TestGetAlertMuteTimings(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("when the feature flag `onPremToCloudMigrationsAlerts` is not enabled it returns nil", func(t *testing.T) {
+		s := setUpServiceTest(t, false).(*Service)
+		s.features = featuremgmt.WithFeatures(featuremgmt.FlagOnPremToCloudMigrations)
+
+		muteTimeIntervals, err := s.getAlertMuteTimings(ctx, nil)
+		require.NoError(t, err)
+		require.Nil(t, muteTimeIntervals)
+	})
+
+	t.Run("when the feature flag `onPremToCloudMigrationsAlerts` is enabled it returns the mute timings", func(t *testing.T) {
+		s := setUpServiceTest(t, false).(*Service)
+		s.features = featuremgmt.WithFeatures(featuremgmt.FlagOnPremToCloudMigrations, featuremgmt.FlagOnPremToCloudMigrationsAlerts)
+
+		var orgID int64 = 1
+		user := &user.SignedInUser{OrgID: orgID}
+
+		createdMuteTiming := createMuteTiming(t, ctx, s, orgID)
+
+		muteTimeIntervals, err := s.getAlertMuteTimings(ctx, user)
+		require.NoError(t, err)
+		require.NotNil(t, muteTimeIntervals)
+		require.Len(t, muteTimeIntervals, 1)
+		require.Equal(t, createdMuteTiming.Name, muteTimeIntervals[0].Name)
+	})
+}
+
+func createMuteTiming(t *testing.T, ctx context.Context, service *Service, orgID int64) definitions.MuteTimeInterval {
+	t.Helper()
+
+	muteTiming := `{
+		"name": "My Unique MuteTiming 1",
+		"time_intervals": [
+			{
+				"times": [{"start_time": "12:12","end_time": "23:23"}],
+				"weekdays": ["monday","wednesday","friday","sunday"],
+				"days_of_month": ["10:20","25:-1"],
+				"months": ["1:6","10:12"],
+				"years": ["2022:2054"],
+				"location": "Africa/Douala"
+			}
+		]
+	}`
+
+	var mt definitions.MuteTimeInterval
+	require.NoError(t, json.Unmarshal([]byte(muteTiming), &mt))
+
+	createdTiming, err := service.ngAlert.Api.MuteTimings.CreateMuteTiming(ctx, mt, orgID)
+	require.NoError(t, err)
+
+	return createdTiming
+}

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -219,6 +219,8 @@ function ResourceIcon({ resource }: { resource: ResourceTableItem }) {
       return <Icon size="xl" name="database" />;
     case 'LIBRARY_ELEMENT':
       return <Icon size="xl" name="library-panel" />;
+    case 'MUTE_TIMING':
+      return <Icon size="xl" name="bell-slash" />;
     default:
       return undefined;
   }

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -13,6 +13,8 @@ export function prettyTypeName(type: ResourceTableItem['type']) {
       return t('migrate-to-cloud.resource-type.folder', 'Folder');
     case 'LIBRARY_ELEMENT':
       return t('migrate-to-cloud.resource-type.library_element', 'Library Element');
+    case 'MUTE_TIMING':
+      return t('migrate-to-cloud.resource-type.mute_timing', 'Mute Timing');
     default:
       return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
   }

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -52,6 +52,8 @@ function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
       types.push(t('migrate-to-cloud.migrated-counts.folders', 'folders'));
     } else if (type === 'LIBRARY_ELEMENT') {
       types.push(t('migrate-to-cloud.migrated-counts.library_elements', 'library elements'));
+    } else if (type === 'MUTE_TIMING') {
+      types.push(t('migrate-to-cloud.migrated-counts.mute_timings', 'mute timings'));
     }
 
     distinctItems += 1;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1408,7 +1408,8 @@
       "dashboards": "dashboards",
       "datasources": "data sources",
       "folders": "folders",
-      "library_elements": "library elements"
+      "library_elements": "library elements",
+      "mute_timings": "mute timings"
     },
     "migration-token": {
       "delete-button": "Delete token",
@@ -1492,6 +1493,7 @@
       "datasource": "Data source",
       "folder": "Folder",
       "library_element": "Library Element",
+      "mute_timing": "Mute Timing",
       "unknown": "Unknown"
     },
     "summary": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1408,7 +1408,8 @@
       "dashboards": "đäşĥþőäřđş",
       "datasources": "đäŧä şőūřčęş",
       "folders": "ƒőľđęřş",
-      "library_elements": "ľįþřäřy ęľęmęŉŧş"
+      "library_elements": "ľįþřäřy ęľęmęŉŧş",
+      "mute_timings": "mūŧę ŧįmįŉģş"
     },
     "migration-token": {
       "delete-button": "Đęľęŧę ŧőĸęŉ",
@@ -1492,6 +1493,7 @@
       "datasource": "Đäŧä şőūřčę",
       "folder": "Főľđęř",
       "library_element": "Ŀįþřäřy Ēľęmęŉŧ",
+      "mute_timing": "Mūŧę Ŧįmįŉģ",
       "unknown": "Ůŉĸŉőŵŉ"
     },
     "summary": {


### PR DESCRIPTION
**What is this feature?**

Adds [`Mute Timings`](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/mute-timings/) to the list of resources created in the migration snapshot, which is behind the `onPremToCloudMigrationsAlerts` feature toggle.

**Why do we need this feature?**

Extend the capability of the Cloud Migration Assistant to more resources.

**Who is this feature for?**

CloudMigration users

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.