### PR TITLE
CloudMigrations: create snapshot for Notification Templates

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -799,9 +799,6 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 	require.NoError(t, err)
 
 	var validConfig = `{
-		"template_files": {
-			"a": "template"
-		},
 		"alertmanager_config": {
 			"route": {
 				"receiver": "grafana-default-email"

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -33,6 +33,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.LibraryElementDataType,
 	cloudmigration.DashboardDataType,
 	cloudmigration.MuteTimingType,
+	cloudmigration.NotificationTemplateType,
 }
 
 func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser) (*cloudmigration.MigrateDataRequest, error) {
@@ -66,9 +67,17 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 		return nil, err
 	}
 
+	// Alerts: Notification Templates
+	notificationTemplates, err := s.getNotificationTemplates(ctx, signedInUser)
+	if err != nil {
+		s.log.Error("Failed to get alert notification templates", "err", err)
+		return nil, err
+	}
+
 	migrationDataSlice := make(
 		[]cloudmigration.MigrateDataRequestItem, 0,
-		len(dataSources)+len(dashs)+len(folders)+len(libraryElements)+len(muteTimings),
+		len(dataSources)+len(dashs)+len(folders)+len(libraryElements)+
+			len(muteTimings)+len(notificationTemplates),
 	)
 
 	for _, ds := range dataSources {
@@ -121,6 +130,15 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 			RefID: muteTiming.Name,
 			Name:  muteTiming.Name,
 			Data:  muteTiming,
+		})
+	}
+
+	for _, notificationTemplate := range notificationTemplates {
+		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+			Type:  cloudmigration.NotificationTemplateType,
+			RefID: notificationTemplate.Name,
+			Name:  notificationTemplate.Name,
+			Data:  notificationTemplate,
 		})
 	}
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -39,3 +39,30 @@ func (s *Service) getAlertMuteTimings(ctx context.Context, signedInUser *user.Si
 
 	return muteTimeIntervals, nil
 }
+
+type notificationTemplate struct {
+	Name     string `json:"name"`
+	Template string `json:"template"`
+}
+
+func (s *Service) getNotificationTemplates(ctx context.Context, signedInUser *user.SignedInUser) ([]notificationTemplate, error) {
+	if !s.features.IsEnabledGlobally(featuremgmt.FlagOnPremToCloudMigrationsAlerts) {
+		return nil, nil
+	}
+
+	templates, err := s.ngAlert.Api.Templates.GetTemplates(ctx, signedInUser.OrgID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching ngalert notification templates: %w", err)
+	}
+
+	notificationTemplates := make([]notificationTemplate, 0, len(templates))
+
+	for _, template := range templates {
+		notificationTemplates = append(notificationTemplates, notificationTemplate{
+			Name:     template.Name,
+			Template: template.Template,
+		})
+	}
+
+	return notificationTemplates, nil
+}

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -221,6 +221,8 @@ function ResourceIcon({ resource }: { resource: ResourceTableItem }) {
       return <Icon size="xl" name="library-panel" />;
     case 'MUTE_TIMING':
       return <Icon size="xl" name="bell-slash" />;
+    case 'NOTIFICATION_TEMPLATE':
+      return <Icon size="xl" name="gf-layout-simple" />;
     default:
       return undefined;
   }

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -15,6 +15,8 @@ export function prettyTypeName(type: ResourceTableItem['type']) {
       return t('migrate-to-cloud.resource-type.library_element', 'Library Element');
     case 'MUTE_TIMING':
       return t('migrate-to-cloud.resource-type.mute_timing', 'Mute Timing');
+    case 'NOTIFICATION_TEMPLATE':
+      return t('migrate-to-cloud.resource-type.notification_template', 'Notification Template');
     default:
       return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
   }

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -54,6 +54,8 @@ function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
       types.push(t('migrate-to-cloud.migrated-counts.library_elements', 'library elements'));
     } else if (type === 'MUTE_TIMING') {
       types.push(t('migrate-to-cloud.migrated-counts.mute_timings', 'mute timings'));
+    } else if (type === 'NOTIFICATION_TEMPLATE') {
+      types.push(t('migrate-to-cloud.migrated-counts.notification_templates', 'notification templates'));
     }
 
     distinctItems += 1;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1409,7 +1409,8 @@
       "datasources": "data sources",
       "folders": "folders",
       "library_elements": "library elements",
-      "mute_timings": "mute timings"
+      "mute_timings": "mute timings",
+      "notification_templates": "notification templates"
     },
     "migration-token": {
       "delete-button": "Delete token",
@@ -1494,6 +1495,7 @@
       "folder": "Folder",
       "library_element": "Library Element",
       "mute_timing": "Mute Timing",
+      "notification_template": "Notification Template",
       "unknown": "Unknown"
     },
     "summary": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1409,7 +1409,8 @@
       "datasources": "đäŧä şőūřčęş",
       "folders": "ƒőľđęřş",
       "library_elements": "ľįþřäřy ęľęmęŉŧş",
-      "mute_timings": "mūŧę ŧįmįŉģş"
+      "mute_timings": "mūŧę ŧįmįŉģş",
+      "notification_templates": "ŉőŧįƒįčäŧįőŉ ŧęmpľäŧęş"
     },
     "migration-token": {
       "delete-button": "Đęľęŧę ŧőĸęŉ",
@@ -1494,6 +1495,7 @@
       "folder": "Főľđęř",
       "library_element": "Ŀįþřäřy Ēľęmęŉŧ",
       "mute_timing": "Mūŧę Ŧįmįŉģ",
+      "notification_template": "Ńőŧįƒįčäŧįőŉ Ŧęmpľäŧę",
       "unknown": "Ůŉĸŉőŵŉ"
     },
     "summary": {


### PR DESCRIPTION
**What is this feature?**

Adds [`Notification Templates`](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/create-notification-templates/) to the list of resources created in the migration snapshot, which is behind the `onPremToCloudMigrationsAlerts` feature toggle.

![Screenshot 2024-10-14 at 12 13 09](https://github.com/user-attachments/assets/97e8a2b3-550c-4e70-b1af-c03bb69c5802)

**Why do we need this feature?**

Extend the capability of the Cloud Migration Assistant to more resources.

**Who is this feature for?**

CloudMigration users

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
