### PR TITLE
Frontend: Filter assets-manifest to only include entrypoints

### DIFF
--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -86,6 +86,21 @@ module.exports = (env = {}) =>
         integrity: true,
         integrityHashes: ['sha384', 'sha512'],
         publicPath: true,
+        // This transform filters down the assets to only include the ones that are part of the entrypoints
+        // this is all that the backend requires.
+        transform(assets, manifest) {
+          const entrypointAssets = Object.values(assets[manifest.options.entrypointsKey]).flatMap((entry) => [
+            ...(entry.assets.js || []),
+            ...(entry.assets.css || []),
+          ]);
+          const filteredAssets = Object.entries(assets).filter(([assetFileName]) =>
+            entrypointAssets.includes(assets[assetFileName].src)
+          );
+          const result = Object.fromEntries(filteredAssets);
+          result[manifest.options.entrypointsKey] = assets[manifest.options.entrypointsKey];
+
+          return result;
+        },
       }),
       new WebpackManifestPlugin({
         fileName: path.join(process.cwd(), 'manifest.json'),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Whilst working on #94655 I noticed that the assets-manifest.json file is enormous and the backend only needs the entrypoint files so opened this PR to trim it down to just the necessary info.

example [assets-manifest.json](https://grafana-assets.grafana.net/grafana/12.1.0-16060170605/public/build/assets-manifest.json) from main
example [assets-manifest.json](https://ephemeral1511182194679jackw.grafana-dev.net/public/build/assets-manifest.json) with this change

**Why do we need this feature?**

Not sure we do tbh as I assume that once the backend has loaded in prod it caches the asset info.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
