### PR TITLE
Extensions: Show error and warning logs in the console

### DIFF
--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -32,10 +32,12 @@ export class ExtensionsLog {
   }
 
   warning(message: string, labels?: Labels): void {
+    console.warn(message, labels);
     this.log(LogLevel.warning, message, labels);
   }
 
   error(message: string, labels?: Labels): void {
+    console.error(message, labels);
     this.log(LogLevel.error, message, labels);
   }
 


### PR DESCRIPTION
### What changed?
https://github.com/grafana/grafana/pull/94146 has added a way to visualize all extensions-specific logs in a single view the Grafana UI, but it looks like not having them in the console can lead to some confusions (e.g. [the following Slack thread](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1728908987713569)).

This PR is logging the error and warning messages to the console, too.

### Notes for the reviewer
This is just a "quick fix", but as a next step I think it would be nicer to log all log types to the console **in dev mode**, and / or to make them hideable. 