### PR TITLE
Histogram: Fix field displayName cache

### DIFF
--- a/public/app/plugins/panel/histogram/HistogramPanel.tsx
+++ b/public/app/plugins/panel/histogram/HistogramPanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { PanelProps, buildHistogram, getHistogramFields } from '@grafana/data';
+import { PanelProps, buildHistogram, cacheFieldDisplayNames, getHistogramFields } from '@grafana/data';
 import { histogramFieldsToFrame } from '@grafana/data/src/transformations/transformers/histogram';
 import { TooltipDisplayMode, TooltipPlugin2, useTheme2 } from '@grafana/ui';
 import { TooltipHoverMode } from '@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2';
@@ -31,6 +31,8 @@ export const HistogramPanel = ({ data, options, width, height }: Props) => {
         };
       });
     });
+
+    cacheFieldDisplayNames(data.series);
 
     if (data.series.length === 1) {
       const info = getHistogramFields(data.series[0]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Discovered that the `displayName` override was not working in the Histogram if the legend was set to not display. Tracked it down to the fact that the legend calls `getFieldDisplayName` which both returns the `displayName` but also caches the value in `field.state.displayName`. After talking to @leeoniya we concluded that the best fix was to call `cacheFieldDisplayNames` in the data prep path to make sure the `displayName` is cached.

**Why do we need this feature?**

Make sure `displayName` overrides in Histogram without having legend enabled.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
