### PR TITLE
Folders: Correctly show new folder button under root folder

### DIFF
--- a/public/app/features/browse-dashboards/permissions.ts
+++ b/public/app/features/browse-dashboards/permissions.ts
@@ -8,7 +8,7 @@ function checkFolderPermission(action: AccessControlAction, folderDTO?: FolderDT
 
 function checkCanCreateFolders(folderDTO?: FolderDTO) {
   // Can only create a folder if we have permissions and either we're at root or nestedFolders is enabled
-  if (folderDTO && !config.featureToggles.nestedFolders) {
+  if (folderDTO && folderDTO.uid !== 'general' && !config.featureToggles.nestedFolders) {
     return false;
   }
 


### PR DESCRIPTION
**What is this feature?**

Fix a bug where `New Folder` button was not displayed under `/dashboards` page if `nestedFolders` feature toggle is disabled.

The bug was introduced in [this PR](https://github.com/grafana/grafana/pull/91215/files#diff-86ed66e30ed1e77f097b6dbe391b7139607841a60035f5ed89f38e89cb2833d9R10) where I incorrectly assumed that we don't pass a folder in for permission checks on root folder.

**Why do we need this feature?**

So that users with nested folders disabled could use the UI to create folders.

**Who is this feature for?**

Any users with `nestedFolders` disabled.