### PR TITLE
Plugin Extension: use correct `PluginExtensionAddedLinkConfig` component in deprecation note

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -223,7 +223,7 @@ type Dashboard = {
 
 // deprecated types
 
-/** @deprecated - use PluginAddedComponentConfig instead */
+/** @deprecated - use PluginExtensionAddedLinkConfig instead */
 export type PluginExtensionLinkConfig<Context extends object = object> = {
   type: PluginExtensionTypes.link;
   title: string;


### PR DESCRIPTION
**What is this feature?**

Changes deprecation note to use the correct component, which is `PluginExtensionAddedLinkConfig`