### PR TITLE
Alerting: `Add example` dropdown in the Edit notification template view

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1792,7 +1792,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/alerting/unified/components/receivers/TemplatePreview.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]

--- a/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/PayloadEditor.tsx
@@ -111,7 +111,7 @@ export function PayloadEditor({
               </Dropdown>
               <Toggletip content={<AlertTemplateDataTable />} placement="top" fitContent>
                 <Button variant="secondary" fill="outline" size="sm" icon="question-circle">
-                  Help
+                  Reference
                 </Button>
               </Toggletip>
             </Stack>

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
@@ -51,7 +51,7 @@ export function TemplateDataDocs() {
   );
 }
 
-const getTemplateDataDocsStyles = (theme: GrafanaTheme2) => ({
+export const getTemplateDataDocsStyles = (theme: GrafanaTheme2) => ({
   header: css({
     color: theme.colors.text.primary,
 
@@ -131,7 +131,7 @@ function KeyValueTemplateDataTable() {
   );
 }
 
-const getTemplateDataTableStyles = (theme: GrafanaTheme2) => ({
+export const getTemplateDataTableStyles = (theme: GrafanaTheme2) => ({
   table: css({
     borderCollapse: 'collapse',
     width: '100%',

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataExamples.ts
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataExamples.ts
@@ -1,0 +1,82 @@
+export interface TemplateExampleItem {
+  description: string;
+  example: string;
+}
+
+export const GlobalTemplateDataExamples: TemplateExampleItem[] = [
+  {
+    description: 'Default template for titles',
+    example: `{{ define "copy_default.title" }}
+    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}
+{{ end }}`,
+  },
+  {
+    description: 'Default template for messages',
+    example: `{{ define "copy_default.message" }}{{ if gt (len .Alerts.Firing) 0 }}**Firing**
+{{ template "print_alert_list" .Alerts.Firing }}{{ if gt (len .Alerts.Resolved) 0 }}
+
+{{ end }}{{ end }}{{ if gt (len .Alerts.Resolved) 0 }}**Resolved**
+{{ template "print_alert_list" .Alerts.Resolved }}{{ end }}{{ end }}`,
+  },
+  {
+    description: 'Print alerts with summary and description',
+    example: `{{ define "Table" }}
+{{- "\nHost\t\tValue\n" -}}
+{{ range .Alerts -}}
+{{ range .Annotations.SortedPairs -}}
+{{ if (eq .Name  "ServerInfo") -}}
+{{ .Value -}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{ end }}`,
+  },
+  {
+    description: 'Print firing and resolved alerts',
+    example: `{{ define "my_conditional_notification" }}
+{{ if eq .CommonLabels.namespace "namespace-a" }}
+Alert: CPU limits have reached 80% in namespace-a.
+{{ else if eq .CommonLabels.namespace "namespace-b" }}
+Alert: CPU limits have reached 80% in namespace-b.
+{{ else if eq .CommonLabels.namespace "namespace-c" }}
+Alert: CPU limits have reached 80% in namespace-c.
+{{ else }}
+Alert: CPU limits have reached 80% for {{ .CommonLabels.namespace }} namespace.
+{{ end }}
+{{ end }}`,
+  },
+  {
+    description: 'Print individual labels and annotations',
+    example: `{{ define "slack.title" }}
+{{ len .Alerts.Firing }} firing alert(s), {{ len .Alerts.Resolved }} resolved alert(s)
+{{ end }}`,
+  },
+  {
+    description: 'Print common labels and common annotations',
+    example: `{{ define "slack.print_alert" -}}
+[{{.Status}}] {{ .Labels.alertname }}
+Labels:
+{{ range .Labels.SortedPairs -}}
+- {{ .Name }}: {{ .Value }}
+{{ end -}}
+{{ if .Annotations -}}
+Annotations:
+{{ range .Annotations.SortedPairs -}}
+- {{ .Name }}: {{ .Value }}
+{{ end -}}
+{{ end -}}
+{{ if .SilenceURL -}}
+Silence: {{ .SilenceURL }}
+{{ end -}}
+{{ if .DashboardURL -}}
+Go to dashboard: {{ .DashboardURL }}
+{{- end }}
+{{- end }}`,
+  },
+  {
+    description: 'Print runbook and Grafana URLs',
+    example: `{{ define "common.subject_title" }}
+{{ len .Alerts.Firing }} firing alert(s), {{ len .Alerts.Resolved }} resolved alert(s)
+{{ end }}`,
+  },
+];

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataExamples.ts
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataExamples.ts
@@ -129,12 +129,27 @@ Alert annotations: {{ len .Annotations.SortedPairs }}
 `,
   },
   {
-    description: 'Print runbook and Grafana URLs',
+    description: 'Print URLs for runbook and alert data in Grafana',
     example: `{{- /* Example displaying additional information, such as runbook link, DashboardURL and SilenceURL, for each alert in the notification.*/ -}}
 {{- /* Edit the template name and template content as needed. */ -}}
-{{ define "slack.title" }}
-{{ len .Alerts.Firing }} firing alert(s), {{ len .Alerts.Resolved }} resolved alert(s)
+{{ define "custom.alert_additional_details" -}}
+{{ len .Alerts.Resolved }} resolved alert(s)
+{{ range .Alerts.Resolved -}}
+  {{ template "alert.additional_details" . -}}
 {{ end }}
+{{ len .Alerts.Firing }} firing alert(s)
+{{ range .Alerts.Firing -}}
+  {{ template "alert.additional_details" . -}}
+{{ end -}}
+{{ end -}}
+
+{{ define "alert.additional_details" }}
+- Dashboard: {{ .DashboardURL }}
+- Panel: {{ .PanelURL }}
+- AlertGenerator: {{ .GeneratorURL }}
+- Silence: {{ .SilenceURL }}
+- RunbookURL: {{ .Annotations.runbook_url}}
+{{ end -}}
 `,
   },
 ];

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataExamples.ts
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataExamples.ts
@@ -10,8 +10,7 @@ export const GlobalTemplateDataExamples: TemplateExampleItem[] = [
 {{- /* Edit the template name and template content as needed. */ -}}
 {{ define "default.title.copy" }}
   [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}
-{{ end }}
-`,
+{{ end }}`,
   },
   {
     description: 'Default template for notification messages',
@@ -37,8 +36,7 @@ Labels:
 
 {{ define "__text_values_list.copy" }}{{ if len .Values }}{{ $first := true }}{{ range $refID, $value := .Values -}}
 {{ if $first }}{{ $first = false }}{{ else }}, {{ end }}{{ $refID }}={{ $value }}{{ end -}}
-{{ else }}[no value]{{ end }}{{ end }}
-`,
+{{ else }}[no value]{{ end }}{{ end }}`,
   },
   {
     description: 'Print alerts with summary and description',
@@ -55,8 +53,7 @@ Labels:
   Summary: {{.Annotations.summary}}
   Status: {{ .Status }}
   Description: {{.Annotations.description}}
-{{ end -}}
-`,
+{{ end -}}`,
   },
   {
     description: 'Print firing and resolved alerts',
@@ -77,8 +74,7 @@ Labels:
   Summary: {{.Annotations.summary}}
   Status: {{ .Status }}
   Description: {{.Annotations.description}}
-{{ end -}}
-`,
+{{ end -}}`,
   },
   {
     description: 'Print common labels and annotations',
@@ -88,7 +84,7 @@ Labels:
 {{ len .Alerts.Resolved }} resolved alert(s)
 {{ len .Alerts.Firing }} firing alert(s)
 
-Common labels: {{ len .CommonLabels.SortedPairs }} 
+Common labels: {{ len .CommonLabels.SortedPairs }}
 {{ range .CommonLabels.SortedPairs -}}
 - {{ .Name }} = {{ .Value }}
 {{ end }}
@@ -98,8 +94,7 @@ Common annotations: {{ len .CommonAnnotations.SortedPairs }}
 - {{ .Name }} = {{ .Value }}
 {{ end }}
 
-{{ end -}}
-`,
+{{ end -}}`,
   },
   {
     description: 'Print individual labels and annotations',
@@ -117,7 +112,7 @@ Common annotations: {{ len .CommonAnnotations.SortedPairs }}
 {{ end -}}
 
 {{ define "alert.labels_and_annotations" }}
-Alert labels: {{ len .Labels.SortedPairs }} 
+Alert labels: {{ len .Labels.SortedPairs }}
 {{ range .Labels.SortedPairs -}}
 - {{ .Name }} = {{ .Value }}
 {{ end -}}
@@ -125,8 +120,7 @@ Alert annotations: {{ len .Annotations.SortedPairs }}
 {{ range .Annotations.SortedPairs -}}
 - {{ .Name }} = {{ .Value }}
 {{ end -}}
-{{ end -}}
-`,
+{{ end -}}`,
   },
   {
     description: 'Print URLs for runbook and alert data in Grafana',
@@ -149,7 +143,6 @@ Alert annotations: {{ len .Annotations.SortedPairs }}
 - AlertGenerator: {{ .GeneratorURL }}
 - Silence: {{ .SilenceURL }}
 - RunbookURL: {{ .Annotations.runbook_url}}
-{{ end -}}
-`,
+{{ end -}}`,
   },
 ];

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -11,9 +11,11 @@ import { isFetchError, locationService } from '@grafana/runtime';
 import {
   Alert,
   Button,
+  Dropdown,
   FieldSet,
   Input,
   LinkButton,
+  Menu,
   useStyles2,
   Stack,
   useSplitter,
@@ -43,6 +45,7 @@ import {
 
 import { PayloadEditor } from './PayloadEditor';
 import { TemplateDataDocs } from './TemplateDataDocs';
+import { GlobalTemplateDataExamples } from './TemplateDataExamples';
 import { TemplateEditor } from './TemplateEditor';
 import { TemplatePreview } from './TemplatePreview';
 import { snippets } from './editor/templateDataSuggestions';
@@ -157,6 +160,11 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
     }
   };
 
+  const appendExample = (example: string) => {
+    const newValue = `${getValues('content')}\n\n${example}`;
+    setValue('content', newValue);
+  };
+
   const actionButtons = (
     <Stack>
       <Button onClick={() => formRef.current?.requestSubmit()} variant="primary" size="sm" disabled={isSubmitting}>
@@ -223,20 +231,48 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
                   <div {...columnSplitter.primaryProps}>
                     {/* primaryProps will set "minHeight: min-content;" so we have to make sure to apply minHeight to the child */}
                     <div className={cx(styles.flexColumn, styles.containerWithBorderAndRadius, styles.minEditorSize)}>
-                      <EditorColumnHeader
-                        label="Template"
-                        actions={
-                          <Button
-                            icon="question-circle"
-                            size="sm"
-                            fill="outline"
-                            variant="secondary"
-                            onClick={toggleCheatsheetOpened}
-                          >
-                            Help
-                          </Button>
-                        }
-                      />
+                      <div>
+                        <EditorColumnHeader
+                          label="Template"
+                          actions={
+                            <>
+                              <Dropdown
+                                overlay={
+                                  <Menu>
+                                    {GlobalTemplateDataExamples.map((item, index) => (
+                                      <Menu.Item
+                                        key={index}
+                                        label={item.description}
+                                        onClick={() => appendExample(item.example)}
+                                      />
+                                    ))}
+                                    <Menu.Divider />
+                                    <Menu.Item
+                                      label={'Examples documentation'}
+                                      url="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/"
+                                      target="_blank"
+                                      icon="external-link-alt"
+                                    />
+                                  </Menu>
+                                }
+                              >
+                                <Button variant="secondary" size="sm" icon="angle-down">
+                                  Add example
+                                </Button>
+                              </Dropdown>
+                              <Button
+                                icon="question-circle"
+                                size="sm"
+                                fill="outline"
+                                variant="secondary"
+                                onClick={toggleCheatsheetOpened}
+                              >
+                                Reference
+                              </Button>
+                            </>
+                          }
+                        />
+                      </div>
                       <Box flex={1}>
                         <AutoSizer>
                           {({ width, height }) => (

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -161,7 +161,8 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
   };
 
   const appendExample = (example: string) => {
-    const newValue = `${getValues('content')}\n\n${example}`;
+    const content = getValues('content'),
+      newValue = !content ? example : `${content}\n${example}`;
     setValue('content', newValue);
   };
 
@@ -249,7 +250,7 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
                                     <Menu.Divider />
                                     <Menu.Item
                                       label={'Examples documentation'}
-                                      url="https://grafana.com/docs/grafana/latest/alerting/manage-notifications/template-notifications/"
+                                      url="https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/examples/"
                                       target="_blank"
                                       icon="external-link-alt"
                                     />

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -237,30 +237,33 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
                           label="Template"
                           actions={
                             <>
-                              <Dropdown
-                                overlay={
-                                  <Menu>
-                                    {GlobalTemplateDataExamples.map((item, index) => (
+                              {/* examples dropdown – only available for Grafana Alertmanager */}
+                              {isGrafanaAlertManager && (
+                                <Dropdown
+                                  overlay={
+                                    <Menu>
+                                      {GlobalTemplateDataExamples.map((item, index) => (
+                                        <Menu.Item
+                                          key={index}
+                                          label={item.description}
+                                          onClick={() => appendExample(item.example)}
+                                        />
+                                      ))}
+                                      <Menu.Divider />
                                       <Menu.Item
-                                        key={index}
-                                        label={item.description}
-                                        onClick={() => appendExample(item.example)}
+                                        label={'Examples documentation'}
+                                        url="https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/examples/"
+                                        target="_blank"
+                                        icon="external-link-alt"
                                       />
-                                    ))}
-                                    <Menu.Divider />
-                                    <Menu.Item
-                                      label={'Examples documentation'}
-                                      url="https://grafana.com/docs/grafana/latest/alerting/configure-notifications/template-notifications/examples/"
-                                      target="_blank"
-                                      icon="external-link-alt"
-                                    />
-                                  </Menu>
-                                }
-                              >
-                                <Button variant="secondary" size="sm" icon="angle-down">
-                                  Add example
-                                </Button>
-                              </Dropdown>
+                                    </Menu>
+                                  }
+                                >
+                                  <Button variant="secondary" size="sm" icon="angle-down">
+                                    Add example
+                                  </Button>
+                                </Dropdown>
+                              )}
                               <Button
                                 icon="question-circle"
                                 size="sm"


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/93686 -> ` Alerting UI: Display common examples of notification templates`  

https://github.com/user-attachments/assets/2b1a7354-27bb-426e-9df6-ab376a390ef0




TODOs

- This PR should be merged after https://github.com/grafana/grafana/pull/94069,  which brings updates to the templating documentation.
- Some examples may not be applicable to data sources-managed alerts. Initially, the dropdown examples is only visible when using the Grafana AlertManager.
