### PR TITLE
Chore: Avoid update-workspace when watching go files

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -16,7 +16,7 @@ watch_exts = [".go", ".ini", ".toml", ".template.html"]
 ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
-  ["GO_BUILD_DEV=1", "make", "build-go"],
+  ["GO_BUILD_DEV=1", "make", "build-go-fast"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,10 @@ update-workspace:
 
 .PHONY: build-go
 build-go: gen-go update-workspace ## Build all Go binaries.
+	@echo "build go files with updated workspace"
+	$(GO) run build.go $(GO_BUILD_FLAGS) build
+
+build-go-fast: gen-go ## Build all Go binaries.
 	@echo "build go files"
 	$(GO) run build.go $(GO_BUILD_FLAGS) build
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

`make run` is now significantly slower because after every change it resync all go.mod files. To avoid this, I have added a new Makefile target that avoids updating the go workspace and I added this new target in `.bra.toml` as the `cmd` (note I haven't changed the `init_cmd`). This way:

 - When running `make run` it will first update the workspace and then build go files.
 - After that, any change in the code will rebuild go files but not the workspace.

