### PR TITLE
CloudMigrations: create snapshot for Contact Points

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -783,7 +783,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 	kvStore := kvstore.ProvideService(sqlStore)
 
 	bus := bus.ProvideBus(tracer)
-	fakeAccessControl := actest.FakeAccessControl{}
+	fakeAccessControl := actest.FakeAccessControl{ExpectedEvaluate: true}
 	fakeAccessControlService := actest.FakeService{}
 	alertMetrics := metrics.NewNGAlert(prometheus.NewRegistry())
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -34,6 +34,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.DashboardDataType,
 	cloudmigration.MuteTimingType,
 	cloudmigration.NotificationTemplateType,
+	cloudmigration.ContactPointType,
 }
 
 func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser) (*cloudmigration.MigrateDataRequest, error) {
@@ -74,10 +75,17 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 		return nil, err
 	}
 
+	// Alerts: Contact Points
+	contactPoints, err := s.getContactPoints(ctx, signedInUser)
+	if err != nil {
+		s.log.Error("Failed to get alert contact points", "err", err)
+		return nil, err
+	}
+
 	migrationDataSlice := make(
 		[]cloudmigration.MigrateDataRequestItem, 0,
 		len(dataSources)+len(dashs)+len(folders)+len(libraryElements)+
-			len(muteTimings)+len(notificationTemplates),
+			len(muteTimings)+len(notificationTemplates)+len(contactPoints),
 	)
 
 	for _, ds := range dataSources {
@@ -139,6 +147,15 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 			RefID: notificationTemplate.Name,
 			Name:  notificationTemplate.Name,
 			Data:  notificationTemplate,
+		})
+	}
+
+	for _, contactPoint := range contactPoints {
+		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+			Type:  cloudmigration.ContactPointType,
+			RefID: contactPoint.UID,
+			Name:  contactPoint.Name,
+			Data:  contactPoint,
 		})
 	}
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	ac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -72,6 +75,44 @@ func TestGetNotificationTemplates(t *testing.T) {
 	})
 }
 
+func TestGetContactPoints(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("when the feature flag `onPremToCloudMigrationsAlerts` is not enabled it returns nil", func(t *testing.T) {
+		s := setUpServiceTest(t, false).(*Service)
+		s.features = featuremgmt.WithFeatures(featuremgmt.FlagOnPremToCloudMigrations)
+
+		contactPoints, err := s.getContactPoints(ctx, nil)
+		require.NoError(t, err)
+		require.Nil(t, contactPoints)
+	})
+
+	t.Run("when the feature flag `onPremToCloudMigrationsAlerts` is enabled it returns the contact points", func(t *testing.T) {
+		s := setUpServiceTest(t, false).(*Service)
+		s.features = featuremgmt.WithFeatures(featuremgmt.FlagOnPremToCloudMigrations, featuremgmt.FlagOnPremToCloudMigrationsAlerts)
+
+		user := &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					accesscontrol.ActionAlertingNotificationsRead:    nil,
+					accesscontrol.ActionAlertingReceiversReadSecrets: {ac.ScopeReceiversAll},
+				},
+			},
+		}
+
+		defaultEmailContactPointCount := 1
+
+		createdContactPoints := createContactPoints(t, ctx, s, user)
+
+		contactPoints, err := s.getContactPoints(ctx, user)
+		require.NoError(t, err)
+		require.NotNil(t, contactPoints)
+		require.Len(t, contactPoints, len(createdContactPoints)+defaultEmailContactPointCount)
+	})
+}
+
 func createMuteTiming(t *testing.T, ctx context.Context, service *Service, orgID int64) definitions.MuteTimeInterval {
 	t.Helper()
 
@@ -99,6 +140,8 @@ func createMuteTiming(t *testing.T, ctx context.Context, service *Service, orgID
 }
 
 func createNotificationTemplate(t *testing.T, ctx context.Context, service *Service, orgID int64) definitions.NotificationTemplate {
+	t.Helper()
+
 	tmpl := definitions.NotificationTemplate{
 		Name:     "MyTestNotificationTemplate",
 		Template: "This is a test template\n{{ .ExternalURL }}",
@@ -108,4 +151,57 @@ func createNotificationTemplate(t *testing.T, ctx context.Context, service *Serv
 	require.NoError(t, err)
 
 	return createdTemplate
+}
+
+func createContactPoints(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser) []definitions.EmbeddedContactPoint {
+	t.Helper()
+
+	slackSettings, err := simplejson.NewJson([]byte(`{
+		"icon_emoji":"iconemoji",
+		"icon_url":"iconurl",
+		"recipient":"recipient",
+		"token":"slack-secret",
+		"username":"user"
+	}`))
+	require.NoError(t, err)
+
+	telegramSettings, err := simplejson.NewJson([]byte(`{
+		"bottoken":"telegram-secret",
+		"chatid":"chat-id",
+		"disable_notification":true,
+		"disable_web_page_preview":false,
+		"message_thread_id":"1234",
+		"parse_mode":"None",
+		"protect_content":true
+	}`))
+	require.NoError(t, err)
+
+	nameGroup := "group_1"
+
+	slackContactPoint := definitions.EmbeddedContactPoint{
+		Name:                  nameGroup,
+		Type:                  "slack",
+		Settings:              slackSettings,
+		DisableResolveMessage: false,
+		Provenance:            "",
+	}
+
+	createdSlack, err := service.ngAlert.Api.ContactPointService.CreateContactPoint(ctx, user.GetOrgID(), user, slackContactPoint, "")
+	require.NoError(t, err)
+
+	telegramContactPoint := definitions.EmbeddedContactPoint{
+		Name:                  nameGroup,
+		Type:                  "telegram",
+		Settings:              telegramSettings,
+		DisableResolveMessage: false,
+		Provenance:            "",
+	}
+
+	createdTelegram, err := service.ngAlert.Api.ContactPointService.CreateContactPoint(ctx, user.GetOrgID(), user, telegramContactPoint, "")
+	require.NoError(t, err)
+
+	return []definitions.EmbeddedContactPoint{
+		createdSlack,
+		createdTelegram,
+	}
 }

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -220,11 +220,11 @@ function ResourceIcon({ resource }: { resource: ResourceTableItem }) {
     case 'LIBRARY_ELEMENT':
       return <Icon size="xl" name="library-panel" />;
     case 'MUTE_TIMING':
-      return <Icon size="xl" name="bell-slash" />;
+      return <Icon size="xl" name="bell" />;
     case 'NOTIFICATION_TEMPLATE':
-      return <Icon size="xl" name="gf-layout-simple" />;
+      return <Icon size="xl" name="bell" />;
     case 'CONTACT_POINT':
-      return <Icon size="xl" name="user-arrows" />;
+      return <Icon size="xl" name="bell" />;
     default:
       return undefined;
   }

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -223,6 +223,8 @@ function ResourceIcon({ resource }: { resource: ResourceTableItem }) {
       return <Icon size="xl" name="bell-slash" />;
     case 'NOTIFICATION_TEMPLATE':
       return <Icon size="xl" name="gf-layout-simple" />;
+    case 'CONTACT_POINT':
+      return <Icon size="xl" name="user-arrows" />;
     default:
       return undefined;
   }

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -17,6 +17,8 @@ export function prettyTypeName(type: ResourceTableItem['type']) {
       return t('migrate-to-cloud.resource-type.mute_timing', 'Mute Timing');
     case 'NOTIFICATION_TEMPLATE':
       return t('migrate-to-cloud.resource-type.notification_template', 'Notification Template');
+    case 'CONTACT_POINT':
+      return t('migrate-to-cloud.resource-type.contact_point', 'Contact Point');
     default:
       return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
   }

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -56,6 +56,8 @@ function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
       types.push(t('migrate-to-cloud.migrated-counts.mute_timings', 'mute timings'));
     } else if (type === 'NOTIFICATION_TEMPLATE') {
       types.push(t('migrate-to-cloud.migrated-counts.notification_templates', 'notification templates'));
+    } else if (type === 'CONTACT_POINT') {
+      types.push(t('migrate-to-cloud.migrated-counts.contact_points', 'contact points'));
     }
 
     distinctItems += 1;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1405,6 +1405,7 @@
       "title": "Let us help you migrate to this stack"
     },
     "migrated-counts": {
+      "contact_points": "contact points",
       "dashboards": "dashboards",
       "datasources": "data sources",
       "folders": "folders",
@@ -1490,6 +1491,7 @@
       "unknown-datasource-type": "Unknown data source"
     },
     "resource-type": {
+      "contact_point": "Contact Point",
       "dashboard": "Dashboard",
       "datasource": "Data source",
       "folder": "Folder",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1405,6 +1405,7 @@
       "title": "Ŀęŧ ūş ĥęľp yőū mįģřäŧę ŧő ŧĥįş şŧäčĸ"
     },
     "migrated-counts": {
+      "contact_points": "čőŉŧäčŧ pőįŉŧş",
       "dashboards": "đäşĥþőäřđş",
       "datasources": "đäŧä şőūřčęş",
       "folders": "ƒőľđęřş",
@@ -1490,6 +1491,7 @@
       "unknown-datasource-type": "Ůŉĸŉőŵŉ đäŧä şőūřčę"
     },
     "resource-type": {
+      "contact_point": "Cőŉŧäčŧ Pőįŉŧ",
       "dashboard": "Đäşĥþőäřđ",
       "datasource": "Đäŧä şőūřčę",
       "folder": "Főľđęř",


### PR DESCRIPTION
**What is this feature?**

Adds [`Contact Points`](https://grafana.com/docs/grafana/latest/alerting/fundamentals/notifications/contact-points/) to the list of resources created in the migration snapshot, which is behind the `onPremToCloudMigrationsAlerts` feature toggle.

Since we've not decided yet on the icons to use, I've replaced them all with the "bell" for now.

**Why do we need this feature?**

Extend the capability of the Cloud Migration Assistant to more resources.

**Who is this feature for?**

CloudMigration users

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
