### PR TITLE
Box: Expose `position` property

### DIFF
--- a/packages/grafana-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/grafana-ui/src/components/Layout/Box/Box.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import { Property } from 'csstype';
 import { ElementType, forwardRef, PropsWithChildren } from 'react';
 import * as React from 'react';
 
@@ -66,6 +67,7 @@ interface BoxProps extends FlexProps, SizeProps, Omit<React.HTMLAttributes<HTMLE
   boxShadow?: ResponsiveProp<BoxShadow>;
   /** Sets the HTML element that will be rendered as a Box. Defaults to 'div' */
   element?: ElementType;
+  position?: ResponsiveProp<Property.Position>;
 }
 
 export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, ref) => {
@@ -106,6 +108,7 @@ export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, 
     height,
     minHeight,
     maxHeight,
+    position,
     ...rest
   } = props;
   const styles = useStyles2(
@@ -137,7 +140,8 @@ export const Box = forwardRef<HTMLElement, PropsWithChildren<BoxProps>>((props, 
     justifyContent,
     alignItems,
     boxShadow,
-    gap
+    gap,
+    position
   );
   const sizeStyles = useStyles2(getSizeStyles, width, minWidth, maxWidth, height, minHeight, maxHeight);
   const Element = element ?? 'div';
@@ -204,7 +208,8 @@ const getStyles = (
   justifyContent: BoxProps['justifyContent'],
   alignItems: BoxProps['alignItems'],
   boxShadow: BoxProps['boxShadow'],
-  gap: BoxProps['gap']
+  gap: BoxProps['gap'],
+  position: BoxProps['position']
 ) => {
   return {
     root: css([
@@ -298,6 +303,9 @@ const getStyles = (
       })),
       getResponsiveStyle(theme, gap, (val) => ({
         gap: theme.spacing(val),
+      })),
+      getResponsiveStyle(theme, position, (val) => ({
+        position: val,
       })),
     ]),
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- exposes `position` prop on `Box`

**Why do we need this feature?**

- so consumers can set a `position`

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
