### PR TITLE
Transformations: Allow negatives in limit

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -1069,6 +1069,14 @@ Here is the result after adding a Limit transformation with a value of '3':
 | 2020-07-07 11:34:20 | Humidity    | 22    |
 | 2020-07-07 10:32:20 | Humidity    | 29    |
 
+Using a negative number, you can keep values from the end of the set. Here is the result after adding a Limit transformation with a value of '-3':
+
+| Time                | Metric      | Value |
+| ------------------- | ----------- | ----- |
+| 2020-07-07 10:31:22 | Temperature | 22    |
+| 2020-07-07 09:30:57 | Humidity    | 33    |
+| 2020-07-07 09:30:05 | Temperature | 19    |
+
 This transformation helps you tailor the visual presentation of your data to focus on the most relevant information.
 
 ### Merge series/tables

--- a/packages/grafana-data/src/transformations/transformers/limit.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/limit.test.ts
@@ -12,7 +12,7 @@ describe('Limit transformer', () => {
     mockTransformationsRegistry([limitTransformer]);
   });
 
-  it('should limit the number of items', async () => {
+  it('should limit the number of items by removing from the end if the number is positive', async () => {
     const testSeries = toDataFrame({
       name: 'A',
       fields: [
@@ -48,6 +48,50 @@ describe('Limit transformer', () => {
           name: 'values',
           type: FieldType.number,
           values: [1, 2, 2],
+          config: {},
+        },
+      ];
+
+      expect(result[0].fields).toEqual(expected);
+    });
+  });
+
+  it('should limit the number of items by removing from the front if the limit is negative', async () => {
+    const testSeries = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [3000, 4000, 5000, 6000, 7000, 8000] },
+        { name: 'message', type: FieldType.string, values: ['one', 'two', 'two', 'three', 'three', 'three'] },
+        { name: 'values', type: FieldType.number, values: [1, 2, 2, 3, 3, 3] },
+      ],
+    });
+
+    const cfg: DataTransformerConfig<LimitTransformerOptions> = {
+      id: DataTransformerID.limit,
+      options: {
+        limitField: -3,
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [testSeries])).toEmitValuesWith((received) => {
+      const result = received[0];
+      const expected: Field[] = [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [6000, 7000, 8000],
+          config: {},
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['three', 'three', 'three'],
+          config: {},
+        },
+        {
+          name: 'values',
+          type: FieldType.number,
+          values: [3, 3, 3],
           config: {},
         },
       ];

--- a/packages/grafana-data/src/transformations/transformers/limit.ts
+++ b/packages/grafana-data/src/transformations/transformers/limit.ts
@@ -34,10 +34,7 @@ export const limitTransformer: DataTransformerInfo<LimitTransformerOptions> = {
             limit = options.limitField;
           }
         }
-        // Prevent negative limit
-        if (limit < 0) {
-          limit = 0;
-        }
+
         return data.map((frame) => {
           if (frame.length > limit) {
             return {
@@ -45,10 +42,11 @@ export const limitTransformer: DataTransformerInfo<LimitTransformerOptions> = {
               fields: frame.fields.map((f) => {
                 return {
                   ...f,
-                  values: f.values.slice(0, limit),
+                  values:
+                    limit >= 0 ? f.values.slice(0, limit) : f.values.slice(f.values.length + limit, f.values.length),
                 };
               }),
-              length: limit,
+              length: Math.abs(limit),
             };
           }
 

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -1080,6 +1080,15 @@ Here is the result after adding a Limit transformation with a value of '3':
 | 2020-07-07 11:34:20 | Humidity    | 22    |
 | 2020-07-07 10:32:20 | Humidity    | 29    |
 
+Using a negative number, you can keep values from the end of the set. Here is the result after adding a Limit transformation with a value of '-3':
+
+| Time                | Metric      | Value |
+| ------------------- | ----------- | ----- |
+| 2020-07-07 10:31:22 | Temperature | 22    |
+| 2020-07-07 09:30:57 | Humidity    | 33    |
+| 2020-07-07 09:30:05 | Temperature | 19    |
+
+
 This transformation helps you tailor the visual presentation of your data to focus on the most relevant information.
   `;
     },


### PR DESCRIPTION
**What is this feature?**

Allows using a negative number in limit to keep items from the end of a list, instead of the start.

**Why do we need this feature?**

When limiting data, some would like to keep from the end of their data, instead of the start. The expectation is this could be done with a negative number.

**Which issue(s) does this PR fix?**:

Fixes an escalation

**Special notes for your reviewer:**

Used the following dataset under test datasource / CSV content 

```
time,amt
1729006088000,25
1729006098000,22
1729006108000,29
1729006208000,22
1729006308000,33
1729006408000,19
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
