### PR TITLE
[DOC] Add streamingEnabled to Tempo ds docs

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -419,6 +419,6 @@ datasources:
       spanBar:
         type: 'Tag'
         tag: 'http.path'
-+     streamingEnabled:
-+       search: true
+      streamingEnabled:
+        search: true
 ```

--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -419,4 +419,6 @@ datasources:
       spanBar:
         type: 'Tag'
         tag: 'http.path'
++     streamingEnabled:
++       search: true
 ```


### PR DESCRIPTION
Updating the Tempo docs to remove the traceQLStreaming feature toggle and found an issue in the Docker-compose YAML files. Reference: https://github.com/grafana/tempo/pull/4188

We had to add an additional line to the docker-compose datasource dshared YAML file: 
https://github.com/grafana/tempo/pull/4188#issuecomment-2414568589

This PR adds the two line fix to the example YAML file in the Tempo data source. It seems like we should add some text in the the Activate streaming section, but I'm not sure what to say about this or when someone needs to add these lines. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
