### PR TITLE
SA: Fix name validation so we can prevent creating service account with protected prefix

### DIFF
--- a/pkg/services/serviceaccounts/proxy/service.go
+++ b/pkg/services/serviceaccounts/proxy/service.go
@@ -183,5 +183,5 @@ func (s *ServiceAccountsProxy) SearchOrgServiceAccounts(ctx context.Context, que
 }
 
 func isNameValid(name string) bool {
-	return !strings.HasPrefix(name, serviceaccounts.ExtSvcPrefix)
+	return !strings.HasPrefix(name, strings.TrimSuffix(serviceaccounts.ExtSvcPrefix, "-"))
 }

--- a/pkg/services/serviceaccounts/proxy/service_test.go
+++ b/pkg/services/serviceaccounts/proxy/service_test.go
@@ -43,9 +43,16 @@ func TestProvideServiceAccount_crudServiceAccount(t *testing.T) {
 				expectedError: nil,
 			},
 			{
-				description: "should not allow to create a service account with extsvc prefix",
+				description: "should not allow to create a service account with extsvc- prefix",
 				form: sa.CreateServiceAccountForm{
 					Name: "extsvc-my-service-account",
+				},
+				expectedError: extsvcaccounts.ErrInvalidName,
+			},
+			{
+				description: "should not allow to create a service account with extsvc prefix",
+				form: sa.CreateServiceAccountForm{
+					Name: "extsvc my-service-account",
 				},
 				expectedError: extsvcaccounts.ErrInvalidName,
 			},


### PR DESCRIPTION
**What is this feature?**
With `externalServiceAccounts` feature toggle enabled it is still possible to create a service account with `extsvc` prefix making it impossible to delete it, because it is now counted as an externally registered service account.

Fix is simple just check for `extsvc` prefix instead of `extsvc-`


**Which issue(s) does this PR fix?**:


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
