### PR TITLE
Chore: Prevent xorm from interfering with indexes

### DIFF
--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -286,8 +286,6 @@ func (engine *Engine) loadTableInfo(table *core.Table) error {
 		for _, name := range index.Cols {
 			if col := table.GetColumn(name); col != nil {
 				col.Indexes[index.Name] = index.Type
-			} else {
-				return fmt.Errorf("unknown col %s in index %v of table %v, columns %v", name, index.Name, table.Name, table.ColumnsSeq())
 			}
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

Prevent xorm from interfering with custom indexes. Currently it fails if it finds Index Expressions, after these changes it will just ignore them.