### PR TITLE
Remove reference to Aggregate By being experimental

### DIFF
--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -118,7 +118,7 @@ For additional information, refer to [Traces to metrics: Ad-hoc RED metrics in G
 
 {{< youtube id="xOolCpm2F8c" >}}
 
-**Aggregate by** is an [experimental feature](/docs/release-life-cycle/) that is disabled by default.
+**Aggregate by** is disabled by default.
 [Enable the `metricsSummary` feature toggle](/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) in Grafana to use this feature.
 
 Your Grafana Tempo data source must also point to a Tempo database with the [Metrics Summary API](https://grafana.com/docs/tempo/latest/api_docs/metrics-summary/) enabled.


### PR DESCRIPTION
At this point, its moved from experimental to deprecated.

Follow on to:
https://github.com/grafana/grafana/pull/94761