### PR TITLE
K8s/Folders: Fix mode 2 folder creation

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -808,12 +807,12 @@ func (fk8s *folderK8sHandler) newToFolderDto(c *contextmodel.ReqContext, item un
 	}
 
 	// #TODO Is there a preexisting function we can use instead, something along the lines of UserIdentifier?
-	toUID := func(rawIdentifier string) (string, error) {
+	toUID := func(rawIdentifier string) string {
 		parts := strings.Split(rawIdentifier, ":")
 		if len(parts) < 2 {
-			return "", fmt.Errorf("invalid user identifier")
+			return ""
 		}
-		return parts[1], nil
+		return parts[1]
 	}
 
 	toDTO := func(fold *folder.Folder, checkCanView bool) (dtos.Folder, error) {
@@ -832,18 +831,10 @@ func (fk8s *folderK8sHandler) newToFolderDto(c *contextmodel.ReqContext, item un
 		// #TODO refactor the various conversions of the folder so that we either set created by in folder.Folder or
 		// we convert from unstructured to folder DTO without an intermediate conversion to folder.Folder
 		if len(fDTO.CreatedBy) > 0 {
-			userUID, err := toUID(fDTO.CreatedBy)
-			if err != nil {
-				return dtos.Folder{}, err
-			}
-			creator = fk8s.getUserLogin(ctx, userUID, orgID)
+			creator = fk8s.getUserLogin(ctx, toUID(fDTO.CreatedBy), orgID)
 		}
 		if len(fDTO.UpdatedBy) > 0 {
-			userUID, err := toUID(fDTO.UpdatedBy)
-			if err != nil {
-				return dtos.Folder{}, err
-			}
-			updater = fk8s.getUserLogin(ctx, userUID, orgID)
+			updater = fk8s.getUserLogin(ctx, toUID(fDTO.UpdatedBy), orgID)
 		}
 
 		acMetadata, _ := fk8s.getFolderACMetadata(c, fold)

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -177,11 +177,11 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 	// #TODO: turns out these get overwritten by Unified Storage (see pkg/storage/unified/apistore/prepare.go)
 	// We're going to have to align with that. For now we do need the user ID because the folder type stores it
 	// as the only user identifier
-	if v.CreatedBy > 0 {
-		meta.SetCreatedBy(fmt.Sprintf("user:%d", v.CreatedBy))
+	if v.CreatedByUID != "" {
+		meta.SetCreatedBy(v.UpdatedByUID)
 	}
-	if v.UpdatedBy > 0 {
-		meta.SetUpdatedBy(fmt.Sprintf("user:%d", v.UpdatedBy))
+	if v.UpdatedByUID != "" {
+		meta.SetUpdatedBy(v.UpdatedByUID)
 	}
 	if v.ParentUID != "" {
 		meta.SetFolder(v.ParentUID)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -674,6 +674,12 @@ func (s *Service) Create(ctx context.Context, cmd *folder.CreateFolderCommand) (
 	}
 
 	if s.features.IsEnabled(ctx, featuremgmt.FlagKubernetesFolders) {
+		// #TODO is some kind of intermediate conversion required as is the case with user id where
+		// it gets parsed using UserIdentifier(). Also is there some kind of validation taking place as
+		// part of the parsing?
+		f.CreatedByUID = user.GetUID()
+		f.UpdatedByUID = user.GetUID()
+
 		if f.ParentUID == "" {
 			return f, nil
 		}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -48,6 +48,8 @@ type Folder struct {
 	URL          string
 	UpdatedBy    int64
 	CreatedBy    int64
+	UpdatedByUID string
+	CreatedByUID string
 	HasACL       bool
 	Fullpath     string `xorm:"fullpath"`
 	FullpathUIDs string `xorm:"fullpath_uids"`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Mode 1 was using user ID as identifier while mode 2 was using user UID. This PR unifies our approach. Mode 2 creation was failing because of this.

**Who is this feature for?**

Search and storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/120

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
