### PR TITLE
Add scopes to metrics explore

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -199,6 +199,7 @@ export interface FeatureToggles {
   failWrongDSUID?: boolean;
   zanzana?: boolean;
   reloadDashboardsOnParamsChange?: boolean;
+  enableScopesInMetricsExplore?: boolean;
   alertingApiServer?: boolean;
   cloudWatchRoundUpEndTime?: boolean;
   cloudwatchMetricInsightsCrossAccount?: boolean;

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -177,9 +177,14 @@ func (r *Resource) GetSuggestions(ctx context.Context, req *backend.CallResource
 	}
 
 	values := url.Values{}
-
 	for _, s := range selectorList {
 		vs := parser.VectorSelector{Name: s, LabelMatchers: matchers}
+		values.Add("match[]", vs.String())
+	}
+
+	// if no timeserie name is provided, but scopes are, the scope is still rendered and passed as match param.
+	if len(selectorList) == 0 && len(sugReq.Scopes) > 0 {
+		vs := parser.VectorSelector{LabelMatchers: matchers}
 		values.Add("match[]", vs.String())
 	}
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1374,6 +1374,17 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
+			Name:              "enableScopesInMetricsExplore",
+			Description:       "Enables the scopes usage in Metrics Explore",
+			FrontendOnly:      false,
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaDashboardsSquad,
+			RequiresRestart:   false,
+			AllowSelfServe:    false,
+			HideFromDocs:      true,
+			HideFromAdminPage: true,
+		},
+		{
 			Name:            "alertingApiServer",
 			Description:     "Register Alerting APIs with the K8s API server",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -180,6 +180,7 @@ ssoSettingsLDAP,preview,@grafana/identity-access-team,false,true,false
 failWrongDSUID,experimental,@grafana/plugins-platform-backend,false,false,false
 zanzana,experimental,@grafana/identity-access-team,false,false,false
 reloadDashboardsOnParamsChange,experimental,@grafana/dashboards-squad,false,false,false
+enableScopesInMetricsExplore,experimental,@grafana/dashboards-squad,false,false,false
 alertingApiServer,experimental,@grafana/alerting-squad,false,true,false
 cloudWatchRoundUpEndTime,GA,@grafana/aws-datasources,false,false,false
 cloudwatchMetricInsightsCrossAccount,GA,@grafana/aws-datasources,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -731,6 +731,10 @@ const (
 	// Enables reload of dashboards on scopes, time range and variables changes
 	FlagReloadDashboardsOnParamsChange = "reloadDashboardsOnParamsChange"
 
+	// FlagEnableScopesInMetricsExplore
+	// Enables the scopes usage in Metrics Explore
+	FlagEnableScopesInMetricsExplore = "enableScopesInMetricsExplore"
+
 	// FlagAlertingApiServer
 	// Register Alerting APIs with the K8s API server
 	FlagAlertingApiServer = "alertingApiServer"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1233,6 +1233,20 @@
     },
     {
       "metadata": {
+        "name": "enableScopesInMetricsExplore",
+        "resourceVersion": "1729765731452",
+        "creationTimestamp": "2024-10-24T10:28:51Z"
+      },
+      "spec": {
+        "description": "Enables the scopes usage in Metrics Explore",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "exploreContentOutline",
         "resourceVersion": "1717578796182",
         "creationTimestamp": "2023-10-13T16:57:13Z",

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -42,6 +42,7 @@ import { getSortByPreference } from '../services/store';
 import { ALL_VARIABLE_VALUE } from '../services/variables';
 import {
   MDP_METRIC_PREVIEW,
+  RefreshMetricsEvent,
   trailDS,
   VAR_FILTERS,
   VAR_GROUP_BY,
@@ -97,6 +98,14 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
     init().then(() => console.debug('Grafana ML initialized'));
 
     const variable = this.getVariable();
+
+    if (config.featureToggles.enableScopesInMetricsExplore) {
+      this._subs.add(
+        this.subscribeToEvent(RefreshMetricsEvent, () => {
+          this.updateBody(this.getVariable());
+        })
+      );
+    }
 
     variable.subscribeToState((newState, oldState) => {
       if (

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -3,6 +3,9 @@ import { useEffect } from 'react';
 
 import {
   AdHocVariableFilter,
+  DataQueryRequest,
+  DataSourceGetTagKeysOptions,
+  DataSourceGetTagValuesOptions,
   GetTagResponse,
   GrafanaTheme2,
   MetricFindValue,
@@ -35,6 +38,7 @@ import {
   VariableValueSelectors,
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
+import { getClosestScopesFacade, ScopesFacade } from 'app/features/scopes';
 
 import { DataTrailSettings } from './DataTrailSettings';
 import { DataTrailHistory } from './DataTrailsHistory';
@@ -91,6 +95,8 @@ export interface DataTrailState extends SceneObjectState {
 export class DataTrail extends SceneObjectBase<DataTrailState> {
   protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['metric', 'metricSearch'] });
 
+  private _scopesFacade: ScopesFacade;
+
   public constructor(state: Partial<DataTrailState>) {
     super({
       $timeRange: state.$timeRange ?? new SceneTimeRange({}),
@@ -113,8 +119,17 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       // preserve the otel join query
       otelJoinQuery: state.otelJoinQuery ?? '',
       showPreviews: true,
+      $behaviors: [
+        new ScopesFacade({
+          handler: (facade) => {
+            sceneGraph.getTimeRange(facade).onRefresh();
+          },
+        }),
+      ],
       ...state,
     });
+
+    this._scopesFacade = getClosestScopesFacade(this)!;
 
     this.addActivationHandler(this._onActivate.bind(this));
   }
@@ -199,6 +214,18 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       }
     },
   });
+
+  public enrichDataRequest(): Partial<DataQueryRequest> {
+    return {
+      scopes: this._scopesFacade?.value,
+    };
+  }
+
+  public enrichFiltersRequest(): Partial<DataSourceGetTagKeysOptions | DataSourceGetTagValuesOptions> {
+    return {
+      scopes: this._scopesFacade?.value,
+    };
+  }
 
   /**
    * Assuming that the change in filter was already reported with a cause other than `'adhoc_filter'`,
@@ -325,7 +352,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       const datasourceUid = sceneGraph.interpolate(trail, VAR_DATASOURCE_EXPR);
 
       const otelTargets = await totalOtelResources(datasourceUid, timeRange);
-      const deploymentEnvironments = await getDeploymentEnvironments(datasourceUid, timeRange);
+      const deploymentEnvironments = await getDeploymentEnvironments(
+        datasourceUid,
+        timeRange,
+        this._scopesFacade.value
+      );
       const hasOtelResources = otelTargets.jobs.length > 0 && otelTargets.instances.length > 0;
       if (
         otelResourcesVariable instanceof AdHocFiltersVariable &&
@@ -469,7 +500,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
         values: GetTagResponse | MetricFindValue[];
       }> => {
         // apply filters here
-        let values = await datasourceHelper.getTagKeys({ filters });
+        let values = await datasourceHelper.getTagKeys({ filters, scopes: this._scopesFacade.value });
         values = sortResources(values, filters.map((f) => f.key).concat(currentKey ?? ''));
         return { replace: true, values };
       },
@@ -483,7 +514,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
         // apply filters here
         // remove current selected filter if refiltering
         filters = filters.filter((f) => f.key !== filter.key);
-        const values = await datasourceHelper.getTagValues({ key: filter.key, filters });
+        const values = await datasourceHelper.getTagValues({
+          key: filter.key,
+          filters,
+          scopes: this._scopesFacade.value,
+        });
         return { replace: true, values };
       },
       hide: VariableHide.hideLabel,

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -10,6 +10,7 @@ import {
   VariableHide,
   urlUtil,
 } from '@grafana/data';
+import { PromQuery } from '@grafana/prometheus';
 import { locationService, useChromeHeaderHeight } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -24,6 +25,7 @@ import {
   SceneObjectState,
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
+  SceneQueryRunner,
   SceneRefreshPicker,
   SceneTimePicker,
   SceneTimeRange,
@@ -470,7 +472,13 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
         values: GetTagResponse | MetricFindValue[];
       }> => {
         // apply filters here
-        let values = await datasourceHelper.getTagKeys({ filters, scopes: getSelectedScopes() });
+        // we're passing the queries so we get the labels that adhere to the queries
+        // we're also passing the scopes so we get the labels that adhere to the scopes filters
+        let values = await datasourceHelper.getTagKeys({
+          filters,
+          scopes: getSelectedScopes(),
+          queries: this.getQueries(),
+        });
         values = sortResources(values, filters.map((f) => f.key).concat(currentKey ?? ''));
         return { replace: true, values };
       },
@@ -484,10 +492,13 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
         // apply filters here
         // remove current selected filter if refiltering
         filters = filters.filter((f) => f.key !== filter.key);
+        // we're passing the queries so we get the label values that adhere to the queries
+        // we're also passing the scopes so we get the label values that adhere to the scopes filters
         const values = await datasourceHelper.getTagValues({
           key: filter.key,
           filters,
           scopes: getSelectedScopes(),
+          queries: this.getQueries(),
         });
         return { replace: true, values };
       },
@@ -578,6 +589,22 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     }
   }
 
+  public getQueries(): PromQuery[] {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const sqrs = sceneGraph.findAllObjects(this, (b) => b instanceof SceneQueryRunner) as SceneQueryRunner[];
+
+    return sqrs.reduce<PromQuery[]>((acc, sqr) => {
+      acc.push(
+        ...sqr.state.queries.map((q) => ({
+          ...q,
+          expr: sceneGraph.interpolate(sqr, q.expr),
+        }))
+      );
+
+      return acc;
+    }, []);
+  }
+
   static Component = ({ model }: SceneComponentProps<DataTrail>) => {
     const { controls, topScene, history, settings, useOtelExperience, hasOtelResources } = model.useState();
 
@@ -611,7 +638,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     useEffect(() => {
       const filtersVariable = sceneGraph.lookupVariable(VAR_FILTERS, model);
       const datasourceHelper = model.datasourceHelper;
-      limitAdhocProviders(filtersVariable, datasourceHelper);
+      limitAdhocProviders(model, filtersVariable, datasourceHelper);
     }, [model]);
 
     return (

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -117,9 +117,11 @@ export function getDataTrailsApp() {
       $behaviors: [
         new ScopesFacade({
           handler: (facade) => {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            const trail = (facade.parent as DataTrailsApp).state.trail;
-            sceneGraph.getTimeRange(trail).onRefresh();
+            const trail = facade.parent && 'trail' in facade.parent.state ? facade.parent.state.trail : undefined;
+
+            if (trail instanceof DataTrail) {
+              sceneGraph.getTimeRange(trail).onRefresh();
+            }
           },
         }),
       ],

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -7,7 +7,7 @@ import {
   DataSourceGetTagValuesOptions,
   PageLayoutType,
 } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import {
   SceneComponentProps,
   sceneGraph,
@@ -39,12 +39,20 @@ export class DataTrailsApp extends SceneObjectBase<DataTrailsAppState> {
   }
 
   public enrichDataRequest(): Partial<DataQueryRequest> {
+    if (!config.featureToggles.promQLScope) {
+      return {};
+    }
+
     return {
       scopes: this._scopesFacade?.value,
     };
   }
 
   public enrichFiltersRequest(): Partial<DataSourceGetTagKeysOptions | DataSourceGetTagValuesOptions> {
+    if (!config.featureToggles.promQLScope) {
+      return {};
+    }
+
     return {
       scopes: this._scopesFacade?.value,
     };
@@ -111,20 +119,24 @@ let dataTrailsApp: DataTrailsApp;
 
 export function getDataTrailsApp() {
   if (!dataTrailsApp) {
+    const $behaviors = config.featureToggles.enableScopesInMetricsExplore
+      ? [
+          new ScopesFacade({
+            handler: (facade) => {
+              const trail = facade.parent && 'trail' in facade.parent.state ? facade.parent.state.trail : undefined;
+
+              if (trail instanceof DataTrail) {
+                sceneGraph.getTimeRange(trail).onRefresh();
+              }
+            },
+          }),
+        ]
+      : undefined;
+
     dataTrailsApp = new DataTrailsApp({
       trail: newMetricsTrail(),
       home: new DataTrailsHome({}),
-      $behaviors: [
-        new ScopesFacade({
-          handler: (facade) => {
-            const trail = facade.parent && 'trail' in facade.parent.state ? facade.parent.state.trail : undefined;
-
-            if (trail instanceof DataTrail) {
-              sceneGraph.getTimeRange(trail).onRefresh();
-            }
-          },
-        }),
-      ],
+      $behaviors,
     });
   }
 

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -135,6 +135,7 @@ export function getDataTrailsApp() {
 
               if (trail instanceof DataTrail) {
                 trail.publishEvent(new RefreshMetricsEvent());
+                trail.checkDataSourceForOTelResources();
               }
             },
           }),

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -19,7 +19,7 @@ import { AppChromeUpdate } from '../../core/components/AppChrome/AppChromeUpdate
 import { DataTrail } from './DataTrail';
 import { DataTrailsHome } from './DataTrailsHome';
 import { getTrailStore } from './TrailStore/TrailStore';
-import { HOME_ROUTE, TRAILS_ROUTE } from './shared';
+import { HOME_ROUTE, RefreshMetricsEvent, TRAILS_ROUTE } from './shared';
 import { getMetricName, getUrlForTrail, newMetricsTrail } from './utils';
 
 export interface DataTrailsAppState extends SceneObjectState {
@@ -134,7 +134,7 @@ export function getDataTrailsApp() {
               const trail = facade.parent && 'trail' in facade.parent.state ? facade.parent.state.trail : undefined;
 
               if (trail instanceof DataTrail) {
-                trail.checkDataSourceForOTelResources();
+                trail.publishEvent(new RefreshMetricsEvent());
               }
             },
           }),

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 
@@ -15,8 +16,11 @@ import {
   SceneObjectState,
   UrlSyncContextProvider,
 } from '@grafana/scenes';
+import { useStyles2 } from '@grafana/ui/';
 import { Page } from 'app/core/components/Page/Page';
-import { getClosestScopesFacade, ScopesFacade } from 'app/features/scopes';
+import { getClosestScopesFacade, ScopesFacade, ScopesSelector } from 'app/features/scopes';
+
+import { AppChromeUpdate } from '../../core/components/AppChrome/AppChromeUpdate';
 
 import { DataTrail } from './DataTrail';
 import { DataTrailsHome } from './DataTrailsHome';
@@ -90,6 +94,7 @@ export class DataTrailsApp extends SceneObjectBase<DataTrailsAppState> {
 }
 
 function DataTrailView({ trail }: { trail: DataTrail }) {
+  const styles = useStyles2(getStyles);
   const [isInitialized, setIsInitialized] = useState(false);
   const { metric } = trail.useState();
 
@@ -109,6 +114,15 @@ function DataTrailView({ trail }: { trail: DataTrail }) {
   return (
     <UrlSyncContextProvider scene={trail}>
       <Page navId="explore/metrics" pageNav={{ text: getMetricName(metric) }} layout={PageLayoutType.Custom}>
+        {config.featureToggles.singleTopNav && config.featureToggles.enableScopesInMetricsExplore && (
+          <AppChromeUpdate
+            actions={
+              <div className={styles.topNavContainer}>
+                <ScopesSelector />
+              </div>
+            }
+          />
+        )}
         <trail.Component model={trail} />
       </Page>
     </UrlSyncContextProvider>
@@ -142,3 +156,12 @@ export function getDataTrailsApp() {
 
   return dataTrailsApp;
 }
+
+const getStyles = () => ({
+  topNavContainer: css({
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyItems: 'flex-start',
+  }),
+});

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -9,13 +9,7 @@ import {
   PageLayoutType,
 } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
-import {
-  SceneComponentProps,
-  sceneGraph,
-  SceneObjectBase,
-  SceneObjectState,
-  UrlSyncContextProvider,
-} from '@grafana/scenes';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState, UrlSyncContextProvider } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui/';
 import { Page } from 'app/core/components/Page/Page';
 import { getClosestScopesFacade, ScopesFacade, ScopesSelector } from 'app/features/scopes';
@@ -140,7 +134,7 @@ export function getDataTrailsApp() {
               const trail = facade.parent && 'trail' in facade.parent.state ? facade.parent.state.trail : undefined;
 
               if (trail instanceof DataTrail) {
-                sceneGraph.getTimeRange(trail).onRefresh();
+                trail.checkDataSourceForOTelResources();
               }
             },
           }),

--- a/public/app/features/trails/DataTrailsApp.tsx
+++ b/public/app/features/trails/DataTrailsApp.tsx
@@ -1,10 +1,22 @@
 import { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 
-import { PageLayoutType } from '@grafana/data';
+import {
+  DataQueryRequest,
+  DataSourceGetTagKeysOptions,
+  DataSourceGetTagValuesOptions,
+  PageLayoutType,
+} from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { SceneComponentProps, SceneObjectBase, SceneObjectState, UrlSyncContextProvider } from '@grafana/scenes';
+import {
+  SceneComponentProps,
+  sceneGraph,
+  SceneObjectBase,
+  SceneObjectState,
+  UrlSyncContextProvider,
+} from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
+import { getClosestScopesFacade, ScopesFacade } from 'app/features/scopes';
 
 import { DataTrail } from './DataTrail';
 import { DataTrailsHome } from './DataTrailsHome';
@@ -18,8 +30,24 @@ export interface DataTrailsAppState extends SceneObjectState {
 }
 
 export class DataTrailsApp extends SceneObjectBase<DataTrailsAppState> {
+  private _scopesFacade: ScopesFacade | null;
+
   public constructor(state: DataTrailsAppState) {
     super(state);
+
+    this._scopesFacade = getClosestScopesFacade(this);
+  }
+
+  public enrichDataRequest(): Partial<DataQueryRequest> {
+    return {
+      scopes: this._scopesFacade?.value,
+    };
+  }
+
+  public enrichFiltersRequest(): Partial<DataSourceGetTagKeysOptions | DataSourceGetTagValuesOptions> {
+    return {
+      scopes: this._scopesFacade?.value,
+    };
   }
 
   goToUrlForTrail(trail: DataTrail) {
@@ -86,6 +114,15 @@ export function getDataTrailsApp() {
     dataTrailsApp = new DataTrailsApp({
       trail: newMetricsTrail(),
       home: new DataTrailsHome({}),
+      $behaviors: [
+        new ScopesFacade({
+          handler: (facade) => {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            const trail = (facade.parent as DataTrailsApp).state.trail;
+            sceneGraph.getTimeRange(trail).onRefresh();
+          },
+        }),
+      ],
     });
   }
 

--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -32,6 +32,7 @@ import {
   getVariablesWithMetricConstant,
   MakeOptional,
   MetricSelectedEvent,
+  RefreshMetricsEvent,
   trailDS,
   VAR_GROUP_BY,
   VAR_METRIC_EXPR,
@@ -68,6 +69,16 @@ export class MetricScene extends SceneObjectBase<MetricSceneState> {
   private _onActivate() {
     if (this.state.actionView === undefined) {
       this.setActionView('overview');
+    }
+
+    if (config.featureToggles.enableScopesInMetricsExplore) {
+      // Push the scopes change event to the tabs
+      // The event is not propagated because the tabs are not part of the scene graph
+      this._subs.add(
+        this.subscribeToEvent(RefreshMetricsEvent, (event) => {
+          this.state.body.state.selectedTab?.publishEvent(event);
+        })
+      );
     }
   }
 

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -3,7 +3,7 @@ import { debounce, isEqual } from 'lodash';
 import { SyntheticEvent, useReducer } from 'react';
 
 import { AdHocVariableFilter, GrafanaTheme2, RawTimeRange, SelectableValue } from '@grafana/data';
-import { isFetchError } from '@grafana/runtime';
+import { config, isFetchError } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   PanelBuilders,
@@ -37,6 +37,7 @@ import { reportExploreMetrics } from '../interactions';
 import {
   getVariablesWithMetricConstant,
   MetricSelectedEvent,
+  RefreshMetricsEvent,
   VAR_DATASOURCE,
   VAR_DATASOURCE_EXPR,
   VAR_FILTERS,
@@ -207,6 +208,14 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
         this.buildLayout();
       })
     );
+
+    if (config.featureToggles.enableScopesInMetricsExplore) {
+      this._subs.add(
+        trail.subscribeToEvent(RefreshMetricsEvent, () => {
+          this._debounceRefreshMetricNames();
+        })
+      );
+    }
 
     this._debounceRefreshMetricNames();
   }

--- a/public/app/features/trails/MetricSelect/api.ts
+++ b/public/app/features/trails/MetricSelect/api.ts
@@ -1,30 +1,24 @@
-import { RawTimeRange } from '@grafana/data';
-import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
-import { getBackendSrv } from '@grafana/runtime';
+import { AdHocVariableFilter, RawTimeRange, Scope } from '@grafana/data';
+import { PromResponse } from 'app/types/unified-alerting-dto';
 
-type MetricValuesResponse = {
-  data: string[];
-  status: 'success' | 'error';
-  error?: 'string';
-  warnings?: string[];
-};
+import { callSuggestionsApi } from '../utils';
 
-const LIMIT_REACHED = 'results truncated due to limit';
+export async function getMetricNames(
+  dataSourceUid: string,
+  timeRange: RawTimeRange,
+  scopes: Scope[],
+  filters: AdHocVariableFilter[],
+  limit?: number
+): Promise<PromResponse<string[]>> {
+  const response = await callSuggestionsApi(
+    dataSourceUid,
+    timeRange,
+    scopes,
+    filters,
+    '__name__',
+    limit,
+    'explore-metrics-names'
+  );
 
-export async function getMetricNames(dataSourceUid: string, timeRange: RawTimeRange, filters: string, limit?: number) {
-  const url = `/api/datasources/uid/${dataSourceUid}/resources/api/v1/label/__name__/values`;
-  const params: Record<string, string | number> = {
-    start: getPrometheusTime(timeRange.from, false),
-    end: getPrometheusTime(timeRange.to, true),
-    ...(filters && filters !== '{}' ? { 'match[]': filters } : {}),
-    ...(limit ? { limit } : {}),
-  };
-
-  const response = await getBackendSrv().get<MetricValuesResponse>(url, params, 'explore-metrics-names');
-
-  if (limit && response.warnings?.includes(LIMIT_REACHED)) {
-    return { ...response, limitReached: true };
-  }
-
-  return { ...response, limitReached: false };
+  return response.data;
 }

--- a/public/app/features/trails/MetricSelect/api.ts
+++ b/public/app/features/trails/MetricSelect/api.ts
@@ -1,10 +1,52 @@
 import { AdHocVariableFilter, RawTimeRange, Scope } from '@grafana/data';
+import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
+import { config, getBackendSrv } from '@grafana/runtime';
 
-import { callSuggestionsApi } from '../utils';
+import { callSuggestionsApi, SuggestionsResponse } from '../utils';
 
 const LIMIT_REACHED = 'results truncated due to limit';
 
 export async function getMetricNames(
+  dataSourceUid: string,
+  timeRange: RawTimeRange,
+  scopes: Scope[],
+  filters: AdHocVariableFilter[],
+  limit?: number
+) {
+  if (!config.featureToggles.enableScopesInMetricsExplore) {
+    const matchTerms = filters.map((filter) => `${filter.key}${filter.operator}"${filter.value}"`);
+    const match = `${matchTerms.join(',')}`;
+
+    return getMetricNamesWithoutScopes(dataSourceUid, timeRange, match, limit);
+  }
+
+  return getMetricNamesWithScopes(dataSourceUid, timeRange, scopes, filters, limit);
+}
+
+export async function getMetricNamesWithoutScopes(
+  dataSourceUid: string,
+  timeRange: RawTimeRange,
+  filters: string,
+  limit?: number
+) {
+  const url = `/api/datasources/uid/${dataSourceUid}/resources/api/v1/label/__name__/values`;
+  const params: Record<string, string | number> = {
+    start: getPrometheusTime(timeRange.from, false),
+    end: getPrometheusTime(timeRange.to, true),
+    ...(filters && filters !== '{}' ? { 'match[]': filters } : {}),
+    ...(limit ? { limit } : {}),
+  };
+
+  const response = await getBackendSrv().get<SuggestionsResponse>(url, params, 'explore-metrics-names');
+
+  if (limit && response.warnings?.includes(LIMIT_REACHED)) {
+    return { ...response, limitReached: true };
+  }
+
+  return { ...response, limitReached: false };
+}
+
+export async function getMetricNamesWithScopes(
   dataSourceUid: string,
   timeRange: RawTimeRange,
   scopes: Scope[],

--- a/public/app/features/trails/MetricSelect/api.ts
+++ b/public/app/features/trails/MetricSelect/api.ts
@@ -1,7 +1,8 @@
 import { AdHocVariableFilter, RawTimeRange, Scope } from '@grafana/data';
-import { PromResponse } from 'app/types/unified-alerting-dto';
 
 import { callSuggestionsApi } from '../utils';
+
+const LIMIT_REACHED = 'results truncated due to limit';
 
 export async function getMetricNames(
   dataSourceUid: string,
@@ -9,7 +10,7 @@ export async function getMetricNames(
   scopes: Scope[],
   filters: AdHocVariableFilter[],
   limit?: number
-): Promise<PromResponse<string[]>> {
+) {
   const response = await callSuggestionsApi(
     dataSourceUid,
     timeRange,
@@ -20,5 +21,8 @@ export async function getMetricNames(
     'explore-metrics-names'
   );
 
-  return response.data;
+  return {
+    ...response.data,
+    limitReached: limit && !!response.data.warnings?.includes(LIMIT_REACHED),
+  };
 }

--- a/public/app/features/trails/otel/api.test.ts
+++ b/public/app/features/trails/otel/api.test.ts
@@ -107,7 +107,7 @@ describe('OTEL API', () => {
 
   describe('getDeploymentEnvironments', () => {
     it('should fetch deployment environments', async () => {
-      const environments = await getDeploymentEnvironments(dataSourceUid, timeRange);
+      const environments = await getDeploymentEnvironments(dataSourceUid, timeRange, []);
 
       expect(environments).toEqual(['env1', 'env2']);
     });

--- a/public/app/features/trails/otel/api.test.ts
+++ b/public/app/features/trails/otel/api.test.ts
@@ -10,7 +10,9 @@ import {
 } from './api';
 
 jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
   config: {
+    ...jest.requireActual('@grafana/runtime').config,
     publicDashboardAccessToken: '123',
   },
   getBackendSrv: () => {

--- a/public/app/features/trails/otel/api.ts
+++ b/public/app/features/trails/otel/api.ts
@@ -1,6 +1,6 @@
 import { RawTimeRange, Scope } from '@grafana/data';
 import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 
 import { callSuggestionsApi } from '../utils';
 
@@ -154,6 +154,59 @@ export async function isOtelStandardization(
  * @returns string[], values for the deployment_environment label
  */
 export async function getDeploymentEnvironments(
+  dataSourceUid: string,
+  timeRange: RawTimeRange,
+  scopes: Scope[]
+): Promise<string[]> {
+  if (!config.featureToggles.enableScopesInMetricsExplore) {
+    return getDeploymentEnvironmentsWithoutScopes(dataSourceUid, timeRange);
+  }
+
+  return getDeploymentEnvironmentsWithScopes(dataSourceUid, timeRange, scopes);
+}
+
+/**
+ * Query the DS for deployment environment label values.
+ *
+ * @param dataSourceUid
+ * @param timeRange
+ * @returns string[], values for the deployment_environment label
+ */
+export async function getDeploymentEnvironmentsWithoutScopes(
+  dataSourceUid: string,
+  timeRange: RawTimeRange
+): Promise<string[]> {
+  const start = getPrometheusTime(timeRange.from, false);
+  const end = getPrometheusTime(timeRange.to, true);
+
+  const url = `/api/datasources/uid/${dataSourceUid}/resources/api/v1/label/deployment_environment/values`;
+  const params: Record<string, string | number> = {
+    start,
+    end,
+    'match[]': '{__name__="target_info"}',
+  };
+
+  const response = await getBackendSrv().get<LabelResponse>(
+    url,
+    params,
+    'explore-metrics-otel-resources-deployment-env'
+  );
+
+  // exclude __name__ or deployment_environment or previously chosen filters
+  const resources = response.data;
+
+  return resources;
+}
+
+/**
+ * Query the DS for deployment environment label values.
+ *
+ * @param dataSourceUid
+ * @param timeRange
+ * @param scopes
+ * @returns string[], values for the deployment_environment label
+ */
+export async function getDeploymentEnvironmentsWithScopes(
   dataSourceUid: string,
   timeRange: RawTimeRange,
   scopes: Scope[]

--- a/public/app/features/trails/otel/api.ts
+++ b/public/app/features/trails/otel/api.ts
@@ -1,6 +1,8 @@
-import { RawTimeRange } from '@grafana/data';
+import { RawTimeRange, Scope } from '@grafana/data';
 import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
 import { getBackendSrv } from '@grafana/runtime';
+
+import { callSuggestionsApi } from '../utils';
 
 import { OtelResponse, LabelResponse, OtelTargetType } from './types';
 import { sortResources } from './util';
@@ -148,29 +150,31 @@ export async function isOtelStandardization(
  *
  * @param dataSourceUid
  * @param timeRange
+ * @param scopes
  * @returns string[], values for the deployment_environment label
  */
-export async function getDeploymentEnvironments(dataSourceUid: string, timeRange: RawTimeRange): Promise<string[]> {
-  const start = getPrometheusTime(timeRange.from, false);
-  const end = getPrometheusTime(timeRange.to, true);
-
-  const url = `/api/datasources/uid/${dataSourceUid}/resources/api/v1/label/deployment_environment/values`;
-  const params: Record<string, string | number> = {
-    start,
-    end,
-    'match[]': '{__name__="target_info"}',
-  };
-
-  const response = await getBackendSrv().get<LabelResponse>(
-    url,
-    params,
+export async function getDeploymentEnvironments(
+  dataSourceUid: string,
+  timeRange: RawTimeRange,
+  scopes: Scope[]
+): Promise<string[]> {
+  const response = await callSuggestionsApi(
+    dataSourceUid,
+    timeRange,
+    scopes,
+    [
+      {
+        key: '__name__',
+        operator: '=',
+        value: 'target_info',
+      },
+    ],
+    'deployment_environment',
+    undefined,
     'explore-metrics-otel-resources-deployment-env'
   );
-
   // exclude __name__ or deployment_environment or previously chosen filters
-  const resources = response.data;
-
-  return resources;
+  return response.data.data;
 }
 
 /**

--- a/public/app/features/trails/otel/api.ts
+++ b/public/app/features/trails/otel/api.ts
@@ -47,9 +47,7 @@ export async function getOtelResources(
   const response = await getBackendSrv().get<LabelResponse>(url, params, 'explore-metrics-otel-resources');
 
   // exclude __name__ or deployment_environment or previously chosen filters
-  const resources = response.data?.filter((resource) => !allExcludedFilters.includes(resource)).map((el: string) => el);
-
-  return resources;
+  return response.data?.filter((resource) => !allExcludedFilters.includes(resource)).map((el: string) => el);
 }
 
 /**
@@ -58,7 +56,7 @@ export async function getOtelResources(
  *
  * @param dataSourceUid
  * @param timeRange
- * @param expr
+ * @param filters
  * @returns
  */
 export async function totalOtelResources(
@@ -101,12 +99,10 @@ export async function totalOtelResources(
     }
   });
 
-  const otelTargets: OtelTargetType = {
+  return {
     jobs,
     instances,
   };
-
-  return otelTargets;
 }
 
 /**
@@ -117,14 +113,9 @@ export async function totalOtelResources(
  *
  * @param dataSourceUid
  * @param timeRange
- * @param expr
  * @returns
  */
-export async function isOtelStandardization(
-  dataSourceUid: string,
-  timeRange: RawTimeRange,
-  expr?: string
-): Promise<boolean> {
+export async function isOtelStandardization(dataSourceUid: string, timeRange: RawTimeRange): Promise<boolean> {
   const url = `/api/datasources/uid/${dataSourceUid}/resources/api/v1/query`;
 
   const start = getPrometheusTime(timeRange.from, false);
@@ -140,9 +131,7 @@ export async function isOtelStandardization(
   const response = await getBackendSrv().get<OtelResponse>(url, paramsTargets, 'explore-metrics-otel-check-standard');
 
   // the response should be not greater than zero if it is standard
-  const checkStandard = !(response.data.result.length > 0);
-
-  return checkStandard;
+  return !(response.data.result.length > 0);
 }
 
 /**
@@ -193,9 +182,7 @@ export async function getDeploymentEnvironmentsWithoutScopes(
   );
 
   // exclude __name__ or deployment_environment or previously chosen filters
-  const resources = response.data;
-
-  return resources;
+  return response.data;
 }
 
 /**

--- a/public/app/features/trails/otel/util.ts
+++ b/public/app/features/trails/otel/util.ts
@@ -153,15 +153,14 @@ export function getOtelResourcesObject(scene: SceneObject, firstQueryVal?: strin
  * @param matchTerms __name__ and other Prom filters
  * @param jobsList list of jobs in target_info
  * @param instancesList list of instances in target_info
- * @param missingOtelTargets flag to indicate truncated job and instance filters
  * @returns
  */
 export function limitOtelMatchTerms(
   matchTerms: string[],
   jobsList: string[],
-  instancesList: string[],
-  missingOtelTargets: boolean
+  instancesList: string[]
 ): { missingOtelTargets: boolean; jobsRegex: string; instancesRegex: string } {
+  let missingOtelTargets = false;
   const charLimit = 2000;
 
   let initialCharAmount = matchTerms.join(',').length;

--- a/public/app/features/trails/otel/utils.test.ts
+++ b/public/app/features/trails/otel/utils.test.ts
@@ -152,9 +152,7 @@ describe('limitOtelMatchTerms', () => {
     const jobs = ['a', 'b', 'c'];
     const instances = ['d', 'e', 'f'];
 
-    const missingOtelTargets = false;
-
-    const result = limitOtelMatchTerms(promMatchTerms, jobs, instances, missingOtelTargets);
+    const result = limitOtelMatchTerms(promMatchTerms, jobs, instances);
 
     expect(result.missingOtelTargets).toEqual(true);
     expect(result.jobsRegex).toEqual('job=~"a"');
@@ -179,9 +177,7 @@ describe('limitOtelMatchTerms', () => {
     const jobs = ['a', 'b', 'c'];
     const instances = ['d', 'e', 'f'];
 
-    const missingOtelTargets = false;
-
-    const result = limitOtelMatchTerms(promMatchTerms, jobs, instances, missingOtelTargets);
+    const result = limitOtelMatchTerms(promMatchTerms, jobs, instances);
 
     expect(result.missingOtelTargets).toEqual(true);
     expect(result.jobsRegex).toEqual('job=~"a|b"');
@@ -195,9 +191,7 @@ describe('limitOtelMatchTerms', () => {
 
     const instances = ['instance1', 'instance2', 'instance3', 'instance4', 'instance5'];
 
-    const missingOtelTargets = false;
-
-    const result = limitOtelMatchTerms(promMatchTerms, jobs, instances, missingOtelTargets);
+    const result = limitOtelMatchTerms(promMatchTerms, jobs, instances);
 
     expect(result.missingOtelTargets).toEqual(false);
     expect(result.jobsRegex).toEqual('job=~"job1|job2|job3|job4|job5"');

--- a/public/app/features/trails/shared.ts
+++ b/public/app/features/trails/shared.ts
@@ -1,4 +1,4 @@
-import { BusEventWithPayload } from '@grafana/data';
+import { BusEventBase, BusEventWithPayload } from '@grafana/data';
 import { ConstantVariable, SceneObject } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
 
@@ -72,4 +72,8 @@ export function getVariablesWithOtelJoinQueryConstant(otelJoinQuery: string) {
 
 export class MetricSelectedEvent extends BusEventWithPayload<string | undefined> {
   public static type = 'metric-selected-event';
+}
+
+export class RefreshMetricsEvent extends BusEventBase {
+  public static type = 'refresh-metrics-event';
 }

--- a/public/app/features/trails/utils.test.ts
+++ b/public/app/features/trails/utils.test.ts
@@ -1,11 +1,13 @@
 import { AdHocFiltersVariable } from '@grafana/scenes';
 
+import { DataTrail } from './DataTrail';
 import { MetricDatasourceHelper } from './helpers/MetricDatasourceHelper';
 import { limitAdhocProviders } from './utils';
 
 describe('limitAdhocProviders', () => {
   let filtersVariable: AdHocFiltersVariable;
   let datasourceHelper: MetricDatasourceHelper;
+  let dataTrail: DataTrail;
 
   beforeEach(() => {
     // disable console.log called in Scenes for this test
@@ -22,6 +24,10 @@ describe('limitAdhocProviders', () => {
       getTagKeys: jest.fn().mockResolvedValue(Array(20000).fill({ text: 'key' })),
       getTagValues: jest.fn().mockResolvedValue(Array(20000).fill({ text: 'value' })),
     } as unknown as MetricDatasourceHelper;
+
+    dataTrail = {
+      getQueries: jest.fn().mockReturnValue([]),
+    } as unknown as DataTrail;
   });
 
   afterAll(() => {
@@ -29,7 +35,7 @@ describe('limitAdhocProviders', () => {
   });
 
   it('should limit the number of tag keys returned in the variable to 10000', async () => {
-    limitAdhocProviders(filtersVariable, datasourceHelper);
+    limitAdhocProviders(dataTrail, filtersVariable, datasourceHelper);
 
     if (filtersVariable instanceof AdHocFiltersVariable && filtersVariable.state.getTagKeysProvider) {
       console.log = jest.fn();
@@ -41,7 +47,7 @@ describe('limitAdhocProviders', () => {
   });
 
   it('should limit the number of tag values returned in the variable to 10000', async () => {
-    limitAdhocProviders(filtersVariable, datasourceHelper);
+    limitAdhocProviders(dataTrail, filtersVariable, datasourceHelper);
 
     if (filtersVariable instanceof AdHocFiltersVariable && filtersVariable.state.getTagValuesProvider) {
       const result = await filtersVariable.state.getTagValuesProvider(filtersVariable, {

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -185,9 +185,7 @@ export function limitAdhocProviders(
         opts.queries = [];
       }
 
-      const values = (
-        await datasourceHelper.getTagKeys(opts)
-      ).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
+      const values = (await datasourceHelper.getTagKeys(opts)).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };
     },
@@ -223,9 +221,7 @@ export function limitAdhocProviders(
         opts.queries = [];
       }
       
-      const values = (
-        await datasourceHelper.getTagValues(opts)
-      ).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
+      const values = (await datasourceHelper.getTagValues(opts)).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };
     },

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -221,6 +221,8 @@ export type SuggestionsResponse = {
   warnings?: string[];
 };
 
+// Suggestions API is an API that receives adhoc filters, scopes and queries and returns the labels or label values that match the provided parameters
+// Under the hood it does exactly what the label and label values API where doing but the processing is done in the BE rather than in the FE
 export async function callSuggestionsApi(
   dataSourceUid: string,
   timeRange: RawTimeRange,

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -177,7 +177,7 @@ export function limitAdhocProviders(
         filters,
         scopes: getClosestScopesFacade(variable)?.value,
         queries: dataTrail.getQueries(),
-      }
+      };
 
       // if there are too many queries it takes to much time to process the requests.
       // In this case we favour responsiveness over reducing the number of options.
@@ -207,20 +207,20 @@ export function limitAdhocProviders(
       // call getTagValues and truncate the response
       // we're passing the queries so we get the label values that adhere to the queries
       // we're also passing the scopes so we get the label values that adhere to the scopes filters
-      
+
       const opts = {
         key: filter.key,
         filters,
         scopes: getClosestScopesFacade(variable)?.value,
         queries: dataTrail.getQueries(),
-      }
+      };
 
       // if there are too many queries it takes to much time to process the requests.
       // In this case we favour responsiveness over reducing the number of options.
       if (opts.queries.length > 20) {
         opts.queries = [];
       }
-      
+
       const values = (await datasourceHelper.getTagValues(opts)).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -24,7 +24,6 @@ import {
   SceneVariableState,
 } from '@grafana/scenes';
 import { getClosestScopesFacade } from 'app/features/scopes';
-import { PromResponse } from 'app/types/unified-alerting-dto';
 
 import { getDatasourceSrv } from '../plugins/datasource_srv';
 
@@ -204,6 +203,13 @@ export function limitAdhocProviders(
   });
 }
 
+export type SuggestionsResponse = {
+  data: string[];
+  status: 'success' | 'error';
+  error?: 'string';
+  warnings?: string[];
+};
+
 export async function callSuggestionsApi(
   dataSourceUid: string,
   timeRange: RawTimeRange,
@@ -212,9 +218,9 @@ export async function callSuggestionsApi(
   labelName: string | undefined,
   limit: number | undefined,
   requestId: string
-): Promise<FetchResponse<PromResponse<string[]>>> {
+): Promise<FetchResponse<SuggestionsResponse>> {
   return await lastValueFrom(
-    getBackendSrv().fetch<PromResponse<string[]>>({
+    getBackendSrv().fetch<SuggestionsResponse>({
       url: `/api/datasources/uid/${dataSourceUid}/resources/suggestions`,
       data: {
         labelName,

--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -172,12 +172,21 @@ export function limitAdhocProviders(
       // call getTagKeys and truncate the response
       // we're passing the queries so we get the labels that adhere to the queries
       // we're also passing the scopes so we get the labels that adhere to the scopes filters
+
+      const opts = {
+        filters,
+        scopes: getClosestScopesFacade(variable)?.value,
+        queries: dataTrail.getQueries(),
+      }
+
+      // if there are too many queries it takes to much time to process the requests.
+      // In this case we favour responsiveness over reducing the number of options.
+      if (opts.queries.length > 20) {
+        opts.queries = [];
+      }
+
       const values = (
-        await datasourceHelper.getTagKeys({
-          filters,
-          scopes: getClosestScopesFacade(variable)?.value,
-          queries: dataTrail.getQueries(),
-        })
+        await datasourceHelper.getTagKeys(opts)
       ).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };
@@ -200,13 +209,22 @@ export function limitAdhocProviders(
       // call getTagValues and truncate the response
       // we're passing the queries so we get the label values that adhere to the queries
       // we're also passing the scopes so we get the label values that adhere to the scopes filters
+      
+      const opts = {
+        key: filter.key,
+        filters,
+        scopes: getClosestScopesFacade(variable)?.value,
+        queries: dataTrail.getQueries(),
+      }
+
+      // if there are too many queries it takes to much time to process the requests.
+      // In this case we favour responsiveness over reducing the number of options.
+      if (opts.queries.length > 20) {
+        opts.queries = [];
+      }
+      
       const values = (
-        await datasourceHelper.getTagValues({
-          key: filter.key,
-          filters,
-          scopes: getClosestScopesFacade(variable)?.value,
-          queries: dataTrail.getQueries(),
-        })
+        await datasourceHelper.getTagValues(opts)
       ).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };


### PR DESCRIPTION
**What is this feature?**

This PR brings support for scopes in the metrics explore area.

What it actually contains:
- make use of `ScopesFacade` behavior to:
   - show the scopes selector
   - subscribe to scopes changes so it refreshes the queries
- make use of suggestions API as opposed to the labels and label values one to get the labels and label values for the adhoc filters
   - this is particularly interesting because right now it makes use of what queries there are currently and it returns the suggestions only for those (as well as respecting the scopes and other adhoc filters)

**Why do we need this feature?**

Ease the usage of metrics explore.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

I left a couple of comments to explain better why something was added.

Please note that the OTel use case was not handled (left some TODOs) since I was not able to test this scenario.

There are a couple of feature toggles that need to exist so this works fine. I haven't tested this PR w/o the feature toggles.

```
[feature_toggles]
; enables scenes as scopes make use of those
scenes = true
; enable scopes
scopeFilters = true
; enables the K8s API server since scopes are built on top of it
grafanaAPIServer = true
grafanaAPIServerWithExperimentalAPIs = true
; enable passing scopes to Prometheus queries and other Prometheus APIs
promQLScope = true
; enable integration of scopes in metrics explore
enableScopesInMetricsExplore = true
```

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
