### PR TITLE
DashboardScene: Re-add support for default datasource var

### DIFF
--- a/public/app/features/dashboard-scene/utils/variables.test.ts
+++ b/public/app/features/dashboard-scene/utils/variables.test.ts
@@ -251,6 +251,7 @@ describe('when creating variables objects', () => {
       isMulti: true,
       description: null,
       hide: 0,
+      defaultOptionEnabled: false,
     });
   });
 
@@ -673,6 +674,49 @@ describe('when creating variables objects', () => {
       type: 'datasource',
       value: '',
       isMulti: true,
+      defaultOptionEnabled: false,
+    });
+  });
+
+  it('should handle datasource variable with default selected', () => {
+    // @ts-expect-error
+    const variable: TypedVariableModel = {
+      id: 'query1',
+      current: {
+        text: 'default',
+        value: 'default',
+        selected: true,
+      },
+      name: 'query1',
+      type: 'datasource',
+      global: false,
+      regex: '/^gdev/',
+      options: [],
+      query: 'prometheus',
+      multi: true,
+      includeAll: true,
+      refresh: 1,
+      allValue: 'Custom all',
+    };
+
+    const migrated = createSceneVariableFromVariableModel(variable);
+    const { key, ...rest } = migrated.state;
+
+    expect(migrated).toBeInstanceOf(DataSourceVariable);
+    expect(rest).toEqual({
+      allValue: 'Custom all',
+      defaultToAll: true,
+      includeAll: true,
+      label: undefined,
+      name: 'query1',
+      options: [],
+      pluginId: 'prometheus',
+      regex: '/^gdev/',
+      text: 'default',
+      type: 'datasource',
+      value: 'default',
+      isMulti: true,
+      defaultOptionEnabled: true,
     });
   });
 });

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -18,6 +18,8 @@ import { SnapshotVariable } from '../serialization/custom-variables/SnapshotVari
 
 import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from './utils';
 
+const DEFAULT_DATASOURCE = 'default';
+
 export function createVariablesForDashboard(oldModel: DashboardModel) {
   const variableObjects = oldModel.templating.list
     .map((v) => {
@@ -189,6 +191,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       skipUrlSync: variable.skipUrlSync,
       isMulti: variable.multi,
       hide: variable.hide,
+      defaultOptionEnabled: variable.current?.value === DEFAULT_DATASOURCE && variable.current?.text === 'default',
     });
   } else if (variable.type === 'interval') {
     const intervals = getIntervalsFromQueryString(variable.query);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Re-adds default value support in the datasource variable in scenes powered dashboards.

**Why do we need this feature?**

To maintain compatibility between old and new arch

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
