### PR TITLE
Alerting: Fix display of quotes in expression component

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -361,7 +361,8 @@ interface FrameProps extends Pick<ExpressionProps, 'isAlertCondition'> {
 
 const OpeningBracket = () => <span>{'{'}</span>;
 const ClosingBracket = () => <span>{'}'}</span>;
-const Quote = () => <span>{'&quot;'}</span>;
+// eslint-disable-next-line @grafana/no-untranslated-strings
+const Quote = () => <span>&quot;</span>;
 const Equals = () => <span>{'='}</span>;
 
 const FrameRow: FC<FrameProps> = ({ frame, index, isAlertCondition }) => {


### PR DESCRIPTION
**What is this feature?**

Fixes display of quotes from https://github.com/grafana/grafana/pull/94404 🤦 

I had moved the quotes to a component as well, and avoided complaints about un-translated strings, but went too far and broke the quotes