### PR TITLE
Chore: Increase fork ts webpack memory to 5GB

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -111,7 +111,7 @@ module.exports = (env = {}) => {
             async: true, // don't block webpack emit
             typescript: {
               mode: 'write-references',
-              memoryLimit: 4096,
+              memoryLimit: 5096,
               diagnosticOptions: {
                 semantic: true,
                 syntactic: true,


### PR DESCRIPTION
**What is this feature?**

Increases webpack fork ts plugin memory to 5GB

**Why do we need this feature?**

The current 4GB setting doesn't work correctly when some additional Grafana extensions are loaded in the development environmnet creating out of memory errors for the garbage collector

**Who is this feature for?**
