### PR TITLE
Chore: Add generic currency formatter without a prefix

### DIFF
--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -1625,7 +1625,7 @@
               "value": "currencyBGN"
             },
             {
-              "text": "Generic (No prefix)",
+              "text": "Generic",
               "value": "currency"
             }
           ],

--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -458,7 +458,7 @@
               "value": "currencyBGN"
             },
             {
-              "text": "Generic (No prefix)",
+              "text": "Generic",
               "value": "currency"
             }
           ],

--- a/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
+++ b/devenv/dev-dashboards-without-uid/panel_tests_polystat.json
@@ -456,6 +456,10 @@
             {
               "text": "Bulgarian Lev (BGN)",
               "value": "currencyBGN"
+            },
+            {
+              "text": "Generic (No prefix)",
+              "value": "currency"
             }
           ],
           "text": "currency"
@@ -1619,6 +1623,10 @@
             {
               "text": "Bulgarian Lev (BGN)",
               "value": "currencyBGN"
+            },
+            {
+              "text": "Generic (No prefix)",
+              "value": "currency"
             }
           ],
           "text": "currency"

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -1625,7 +1625,7 @@
               "value": "currencyBGN"
             },
             {
-              "text": "Generic (No prefix)",
+              "text": "Generic",
               "value": "currency"
             }
           ],

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -458,7 +458,7 @@
               "value": "currencyBGN"
             },
             {
-              "text": "Generic (No prefix)",
+              "text": "Generic",
               "value": "currency"
             }
           ],

--- a/devenv/dev-dashboards/panel-polystat/polystat_test.json
+++ b/devenv/dev-dashboards/panel-polystat/polystat_test.json
@@ -456,6 +456,10 @@
             {
               "text": "Bulgarian Lev (BGN)",
               "value": "currencyBGN"
+            },
+            {
+              "text": "Generic (No prefix)",
+              "value": "currency"
             }
           ],
           "text": "currency"
@@ -1619,6 +1623,10 @@
             {
               "text": "Bulgarian Lev (BGN)",
               "value": "currencyBGN"
+            },
+            {
+              "text": "Generic (No prefix)",
+              "value": "currency"
             }
           ],
           "text": "currency"

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -149,6 +149,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Guaraní (₲)', id: 'currencyPYG', fn: currency('₲') },
       { name: 'Uruguay Peso (UYU)', id: 'currencyUYU', fn: currency('UYU') },
       { name: 'Israeli New Shekels (₪)', id: 'currencyILS', fn: currency('₪') },
+      { name: 'Generic (No prefix)', id: 'currency', fn: currency('') },
     ],
   },
   {

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -149,7 +149,7 @@ export const getCategories = (): ValueFormatCategory[] => [
       { name: 'Guaraní (₲)', id: 'currencyPYG', fn: currency('₲') },
       { name: 'Uruguay Peso (UYU)', id: 'currencyUYU', fn: currency('UYU') },
       { name: 'Israeli New Shekels (₪)', id: 'currencyILS', fn: currency('₪') },
-      { name: 'Generic (No prefix)', id: 'currency', fn: currency('') },
+      { name: 'Generic', id: 'currency', fn: currency('') },
     ],
   },
   {


### PR DESCRIPTION
**What is this feature?**

Adding the option to not have a currency prefixed while still getting the number formatted. 

**Why do we need this feature?**

Currently, there are 30 currencies supported by Grafana. However, there are [180 currencies](https://en.wikipedia.org/wiki/List_of_circulating_currencies) in use in the world. This generic currency means you can get the benefit of the currency format without having to create a pull request for a specific currency. 

**Who is this feature for?**

- All users who use one of the 150 unsupported currencies
- Users who want to specify the prefix manually, e.g. using "Display name" to create `USD 2.4M`
- All non-technical users who can't create a PR to support their currency.

**Which issue(s) does this PR fix?**:

None

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
