### PR TITLE
K8s/Folders: Warn against using full path in metadata 

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -106,9 +106,16 @@ type GrafanaMetaAccessor interface {
 	// NOTE the type must match the existing value, or an error will be thrown
 	SetStatus(any) error
 
+	// Deprecated: this is a temporary hack for folders, it will be removed without notice soon
 	GetFullPath() string
+
+	// Deprecated: this is a temporary hack for folders, it will be removed without notice soon
 	SetFullPath(path string)
+
+	// Deprecated: this is a temporary hack for folders, it will be removed without notice soon
 	GetFullPathUIDs() string
+
+	// Deprecated: this is a temporary hack for folders, it will be removed without notice soon
 	SetFullPathUIDs(path string)
 
 	// Find a title in the object

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -86,11 +86,19 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) *fo
 		// #TODO add created by field if necessary
 		// CreatedBy: meta.GetCreatedBy(),
 		// UpdatedBy: meta.GetCreatedBy(),
-		URL:          getURL(meta, title),
-		Created:      createdTime,
-		Updated:      createdTime,
-		OrgID:        orgID,
-		Fullpath:     meta.GetFullPath(),
+		URL:     getURL(meta, title),
+		Created: createdTime,
+		Updated: createdTime,
+		OrgID:   orgID,
+
+		// This will need to be restructured so the full path is looked up when saving
+		// it can't be saved in the resource metadata because then everything must cascade
+		// nolint:staticcheck
+		Fullpath: meta.GetFullPath(),
+
+		// This will need to be restructured so the full path is looked up when saving
+		// it can't be saved in the resource metadata because then everything must cascade
+		// nolint:staticcheck
 		FullpathUIDs: meta.GetFullPathUIDs(),
 	}
 	return f
@@ -187,9 +195,11 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 		meta.SetFolder(v.ParentUID)
 	}
 	if v.Fullpath != "" {
+		// nolint:staticcheck
 		meta.SetFullPath(v.Fullpath)
 	}
 	if v.FullpathUIDs != "" {
+		// nolint:staticcheck
 		meta.SetFullPathUIDs(v.FullpathUIDs)
 	}
 	f.UID = gapiutil.CalculateClusterWideUID(f)


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/94450 the full path to a folder was added as generic metadata -- this is fine as a quick hack, but lives in the one place we advertise as common behavior/properties for everything.

In addition to that, the full path must not be saved in a resource -- the tree depends on the state of the whole system, so we can not save it as text in the json blob.

This PR makes the properties as deprecated and adds a waring -- we should soon remove them and find another approach.
