### PR TITLE
Prometheus: Remove unused query timeout configuration

### DIFF
--- a/e2e/various-suite/prometheus-config.spec.ts
+++ b/e2e/various-suite/prometheus-config.spec.ts
@@ -36,8 +36,6 @@ describe('Prometheus config', () => {
     cy.get(`#${selectors.components.DataSource.Prometheus.configPage.manageAlerts}`).scrollIntoView().should('exist');
     // scrape interval
     e2e.components.DataSource.Prometheus.configPage.scrapeInterval().scrollIntoView().should('exist');
-    // query timeout
-    e2e.components.DataSource.Prometheus.configPage.queryTimeout().scrollIntoView().should('exist');
     // default editor
     e2e.components.DataSource.Prometheus.configPage.defaultEditor().scrollIntoView().should('exist');
     // disable metric lookup

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -65,7 +65,6 @@ export const Components = {
         connectionSettings: 'Data source connection URL', // aria-label in grafana experimental
         manageAlerts: 'prometheus-alerts-manager', // id for switch component
         scrapeInterval: 'data-testid scrape interval',
-        queryTimeout: 'data-testid query timeout',
         defaultEditor: 'data-testid default editor',
         disableMetricLookup: 'disable-metric-lookup', // id for switch component
         prometheusType: 'data-testid prometheus type',

--- a/packages/grafana-prometheus/src/configuration/PromSettings.tsx
+++ b/packages/grafana-prometheus/src/configuration/PromSettings.tsx
@@ -74,13 +74,11 @@ export const PromSettings = (props: Props) => {
 
   type ValidDuration = {
     timeInterval: string;
-    queryTimeout: string;
     incrementalQueryOverlapWindow: string;
   };
 
   const [validDuration, updateValidDuration] = useState<ValidDuration>({
     timeInterval: '',
-    queryTimeout: '',
     incrementalQueryOverlapWindow: '',
   });
 
@@ -129,36 +127,6 @@ export const PromSettings = (props: Props) => {
                     data-testid={selectors.components.DataSource.Prometheus.configPage.scrapeInterval}
                   />
                   {validateInput(validDuration.timeInterval, DURATION_REGEX, durationError)}
-                </>
-              </InlineField>
-            </div>
-          </div>
-          {/* Query Timeout */}
-          <div className="gf-form-inline">
-            <div className="gf-form">
-              <InlineField
-                label="Query timeout"
-                labelWidth={PROM_CONFIG_LABEL_WIDTH}
-                tooltip={<>Set the Prometheus query timeout. {docsTip()}</>}
-                interactive={true}
-                disabled={options.readOnly}
-              >
-                <>
-                  <Input
-                    className="width-20"
-                    value={options.jsonData.queryTimeout}
-                    onChange={onChangeHandler('queryTimeout', options, onOptionsChange)}
-                    spellCheck={false}
-                    placeholder="60s"
-                    onBlur={(e) =>
-                      updateValidDuration({
-                        ...validDuration,
-                        queryTimeout: e.currentTarget.value,
-                      })
-                    }
-                    data-testid={selectors.components.DataSource.Prometheus.configPage.queryTimeout}
-                  />
-                  {validateInput(validDuration.queryTimeout, DURATION_REGEX, durationError)}
                 </>
               </InlineField>
             </div>

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -97,7 +97,6 @@ export class PrometheusDatasource
   basicAuth: any;
   withCredentials: boolean;
   interval: string;
-  queryTimeout: string | undefined;
   httpMethod: string;
   languageProvider: PrometheusLanguageProvider;
   exemplarTraceIdDestinations: ExemplarTraceIdDestination[] | undefined;
@@ -127,7 +126,6 @@ export class PrometheusDatasource
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = Boolean(instanceSettings.withCredentials);
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
-    this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
     this.exemplarTraceIdDestinations = instanceSettings.jsonData.exemplarTraceIdDestinations;
     this.hasIncrementalQuery = instanceSettings.jsonData.incrementalQuerying ?? false;

--- a/packages/grafana-prometheus/src/test/__mocks__/datasource.ts
+++ b/packages/grafana-prometheus/src/test/__mocks__/datasource.ts
@@ -43,7 +43,6 @@ export function createDefaultConfigOptions(): DataSourceSettings<PromOptions> {
   return getMockDataSource<PromOptions>({
     jsonData: {
       timeInterval: '1m',
-      queryTimeout: '1m',
       httpMethod: 'GET',
     },
   });

--- a/packages/grafana-prometheus/src/types.ts
+++ b/packages/grafana-prometheus/src/types.ts
@@ -38,7 +38,6 @@ export enum PromApplication {
 
 export interface PromOptions extends DataSourceJsonData {
   timeInterval?: string;
-  queryTimeout?: string;
   httpMethod?: string;
   customQueryParameters?: string;
   disableMetricsLookup?: boolean;

--- a/public/app/plugins/datasource/tempo/_importedDependencies/datasources/prometheus/types.ts
+++ b/public/app/plugins/datasource/tempo/_importedDependencies/datasources/prometheus/types.ts
@@ -56,7 +56,6 @@ export enum PromApplication {
 
 export interface PromOptions extends DataSourceJsonData {
   timeInterval?: string;
-  queryTimeout?: string;
   httpMethod?: string;
   customQueryParameters?: string;
   disableMetricsLookup?: boolean;


### PR DESCRIPTION
**What is this feature?**

Query timeout is an old setting we used when the Prometheus datasource sends queries to the upstream datasource from frontend directly. Since we have backend mode by default, timeouts are being handled out of the box with the Timeout setting under the Advanced HTTP Settings. So we don't need the "Query Timeout" setting anymore.

