### PR TITLE
Transformations: Binary operation allow alias

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -200,9 +200,12 @@ export const calculateFieldTransformer: DataTransformerInfo<CalculateFieldTransf
                     for (let i = 0; i < arr.length; i++) {
                       arr[i] = operator.operation(left[i], right[i]);
                     }
+                    const name = options.alias?.length
+                      ? options.alias
+                      : `${field.name} ${options.binary?.operator ?? ''} ${options.binary?.right.matcher?.options ?? options.binary?.right.fixed}`;
                     const newField = {
                       ...field,
-                      name: `${field.name} ${options.binary?.operator ?? ''} ${options.binary?.right.matcher?.options ?? options.binary?.right.fixed}`,
+                      name,
                       values: arr,
                     };
                     newFields.push(newField);

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx
@@ -14,7 +14,6 @@ import {
   TransformerRegistryItem,
   TransformerUIProps,
   TransformerCategory,
-  FieldMatcherID,
 } from '@grafana/data';
 import {
   CalculateFieldMode,
@@ -172,10 +171,6 @@ export const CalculateFieldTransformerEditor = (props: CalculateFieldTransformer
   };
 
   const mode = options.mode ?? CalculateFieldMode.BinaryOperation;
-  // For binary operation with type matching, disable alias input
-  const disableAlias =
-    mode === CalculateFieldMode.BinaryOperation && options.binary?.left.matcher?.id === FieldMatcherID.byType;
-
   return (
     <>
       <InlineField labelWidth={LABEL_WIDTH} label="Mode">
@@ -217,7 +212,7 @@ export const CalculateFieldTransformerEditor = (props: CalculateFieldTransformer
       {mode === CalculateFieldMode.Index && (
         <IndexOptionsEditor options={options} onChange={props.onChange}></IndexOptionsEditor>
       )}
-      <InlineField labelWidth={LABEL_WIDTH} label="Alias" disabled={disableAlias}>
+      <InlineField labelWidth={LABEL_WIDTH} label="Alias">
         <Input
           className="width-18"
           value={options.alias ?? ''}


### PR DESCRIPTION
For `binary operation` mode of `add field from calculation` transformation, allow alias to be used to override display names.

For these queries:
![image](https://github.com/user-attachments/assets/5fc05c9a-f733-48d4-8c64-654d7ea9f038)
![image](https://github.com/user-attachments/assets/7562f3eb-52c7-45ec-8ee4-cf77b0655144)
![image](https://github.com/user-attachments/assets/d2721588-eced-4171-9033-c8fc47793c74)

Before:
![image](https://github.com/user-attachments/assets/817e8554-4710-466a-aad1-9b67dba1e2a2)

After:
![image](https://github.com/user-attachments/assets/325ae191-763f-4cf2-93bf-479cd21cd131)

- [ ] Documentation
