### PR TITLE
expr: add explicit strict-mode const

### DIFF
--- a/pkg/expr/query.go
+++ b/pkg/expr/query.go
@@ -96,6 +96,9 @@ type ReduceSettings struct {
 type ReduceMode string
 
 const (
+	// Default mode
+	ReduceModeStrict = ""
+
 	// Drop non-numbers
 	ReduceModeDrop ReduceMode = "dropNN"
 

--- a/pkg/expr/reader.go
+++ b/pkg/expr/reader.go
@@ -74,7 +74,7 @@ func (h *ExpressionQueryReader) ReadQuery(
 		}
 		if err == nil && q.Settings != nil {
 			switch q.Settings.Mode {
-			case "":
+			case ReduceModeStrict:
 				mapper = nil
 			case ReduceModeDrop:
 				mapper = mathexp.DropNonNumber{}


### PR DESCRIPTION
added a const to represent the "strict mode", instead of using `""` directly.

this is purely a "stylistic" change, so if you dislike it, or see a problem with it, just say so, thanks!