### PR TITLE
RestoreDashboards: Correct tracking data

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -115,6 +115,6 @@ function trackAction(action: keyof typeof actionMap, selectedItems: Omit<Dashboa
       dashboard: selectedDashboards.length,
     },
     source: 'tree_actions',
-    restore_enabled: config.featureToggles.dashboardRestore,
+    restore_enabled: config.featureToggles.dashboardRestore ?? false,
   });
 }

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -115,6 +115,6 @@ function trackAction(action: keyof typeof actionMap, selectedItems: Omit<Dashboa
       dashboard: selectedDashboards.length,
     },
     source: 'tree_actions',
-    restore_enabled: config.featureToggles.dashboardRestore ?? false,
+    restore_enabled: Boolean(config.featureToggles.dashboardRestore),
   });
 }

--- a/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx
@@ -27,7 +27,7 @@ export const DeleteModal = ({ onConfirm, onDismiss, selectedItems, ...props }: P
         folder: Object.keys(selectedItems.folder).length,
       },
       source: 'browse_dashboards',
-      restore_enabled: config.featureToggles.dashboardRestore ?? false,
+      restore_enabled: Boolean(config.featureToggles.dashboardRestore),
     });
     setIsDeleting(true);
     try {

--- a/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/DeleteModal.tsx
@@ -27,7 +27,7 @@ export const DeleteModal = ({ onConfirm, onDismiss, selectedItems, ...props }: P
         folder: Object.keys(selectedItems.folder).length,
       },
       source: 'browse_dashboards',
-      restore_enabled: config.featureToggles.dashboardRestore,
+      restore_enabled: config.featureToggles.dashboardRestore ?? false,
     });
     setIsDeleting(true);
     try {

--- a/public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx
@@ -33,7 +33,7 @@ export function DeleteDashboardButton({ dashboard }: ButtonProps) {
         dashboard: 1,
       },
       source: 'dashboard_scene_settings',
-      restore_enabled: config.featureToggles.dashboardRestore,
+      restore_enabled: config.featureToggles.dashboardRestore ?? false,
     });
     toggleModal();
     if (dashboard.state.uid) {

--- a/public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx
@@ -33,7 +33,7 @@ export function DeleteDashboardButton({ dashboard }: ButtonProps) {
         dashboard: 1,
       },
       source: 'dashboard_scene_settings',
-      restore_enabled: config.featureToggles.dashboardRestore ?? false,
+      restore_enabled: Boolean(config.featureToggles.dashboardRestore),
     });
     toggleModal();
     if (dashboard.state.uid) {

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -34,7 +34,7 @@ const DeleteDashboardModalUnconnected = ({ hideModal, cleanUpDashboardAndVariabl
         dashboard: 1,
       },
       source: 'dashboard_settings',
-      restore_enabled: config.featureToggles.dashboardRestore ?? false,
+      restore_enabled: Boolean(config.featureToggles.dashboardRestore),
     });
     await deleteItems({
       selectedItems: {

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -34,7 +34,7 @@ const DeleteDashboardModalUnconnected = ({ hideModal, cleanUpDashboardAndVariabl
         dashboard: 1,
       },
       source: 'dashboard_settings',
-      restore_enabled: config.featureToggles.dashboardRestore,
+      restore_enabled: config.featureToggles.dashboardRestore ?? false,
     });
     await deleteItems({
       selectedItems: {


### PR DESCRIPTION
**What is this feature?**
Payload data for tracking `grafana_manage_dashboards_delete_clicked` didn't show the expected values for restore_enabled. We expect a boolean here and got null if the feature toggle wasn't enabled.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
