### PR TITLE
Frontend/Themes: Fix handleMotion function

### DIFF
--- a/packages/grafana-data/src/themes/createTransitions.ts
+++ b/packages/grafana-data/src/themes/createTransitions.ts
@@ -56,7 +56,7 @@ export function create(props: string | string[] = ['all'], options: CreateTransi
 type ReducedMotionProps = 'no-preference' | 'reduce';
 
 export function handleMotion(...props: ReducedMotionProps[]) {
-  return props.map((prop) => `@media (prefers-reduced-motion: ${prop})`).join(',');
+  return `@media ${props.map((prop) => `(prefers-reduced-motion: ${prop})`).join(',')}`;
 }
 
 export function getAutoHeightDuration(height: number) {


### PR DESCRIPTION
Previously, calls like

```typescript
{
      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
        transition: 'background-color 0.1s ease-in-out',
      }
}
```
would result in the following:

```typescript
{
      '@media (prefers-reduced-motion: no-preference), @media (prefers-reduced-motion: reduce)': {
        transition: 'background-color 0.1s ease-in-out',
      }
}
```

This PR fixes the `handleMotion` function so instead it produces the following:

```typescript
{
      '@media (prefers-reduced-motion: no-preference), (prefers-reduced-motion: reduce)': {
        transition: 'background-color 0.1s ease-in-out',
      }
}
```