### PR TITLE
CloudMigrations: only append notification policy if feature flag is on and it exists

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -167,13 +167,15 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 		})
 	}
 
-	// Notification Policy can only be managed by updating its entire tree, so we send the whole thing as one item.
-	migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
-		Type:  cloudmigration.NotificationPolicyType,
-		RefID: notificationPolicies.Name, // no UID available
-		Name:  notificationPolicies.Name,
-		Data:  notificationPolicies.Routes,
-	})
+	if s.features.IsEnabledGlobally(featuremgmt.FlagOnPremToCloudMigrationsAlerts) && len(notificationPolicies.Name) > 0 {
+		// Notification Policy can only be managed by updating its entire tree, so we send the whole thing as one item.
+		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+			Type:  cloudmigration.NotificationPolicyType,
+			RefID: notificationPolicies.Name, // no UID available
+			Name:  notificationPolicies.Name,
+			Data:  notificationPolicies.Routes,
+		})
+	}
 
 	// Obtain the names of parent elements for Dashboard and Folders data types
 	parentNamesByType, err := s.getParentNames(ctx, signedInUser, dashs, folders, libraryElements)


### PR DESCRIPTION
**What is this feature?**

In https://github.com/grafana/grafana/pull/94852, we were always adding a notification policy even though it might not be present. Instead we should be gating it behind the FT + only adding it if it is not empty.

**Why do we need this feature?**

Bug fix for the Alerts migration support.

**Who is this feature for?**

CloudMigration users

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
