### PR TITLE
Alerting: Fix some templates RBAC UI action control/checks

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -435,12 +435,16 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext) *navtree.Na
 			ac.EvalPermission(ac.ActionAlertingReceiversRead),
 			ac.EvalPermission(ac.ActionAlertingReceiversReadSecrets),
 			ac.EvalPermission(ac.ActionAlertingReceiversCreate),
+
+			ac.EvalPermission(ac.ActionAlertingNotificationsTemplatesRead),
+			ac.EvalPermission(ac.ActionAlertingNotificationsTemplatesWrite),
+			ac.EvalPermission(ac.ActionAlertingNotificationsTemplatesDelete),
 		)
 	}
 
 	if hasAccess(ac.EvalAny(contactPointsPerms...)) {
 		alertChildNavs = append(alertChildNavs, &navtree.NavLink{
-			Text: "Contact points", SubTitle: "Choose how to notify your  contact points when an alert instance fires", Id: "receivers", Url: s.cfg.AppSubURL + "/alerting/notifications",
+			Text: "Contact points", SubTitle: "Choose how to notify your contact points when an alert instance fires", Id: "receivers", Url: s.cfg.AppSubURL + "/alerting/notifications",
 			Icon: "comment-alt-share",
 		})
 	}

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -3,7 +3,7 @@ import { config } from 'app/core/config';
 import { GrafanaRouteComponent, RouteDescriptor } from 'app/core/navigation/types';
 import { AccessControlAction } from 'app/types';
 
-import { PERMISSIONS_CONTACT_POINTS } from './unified/components/contact-points/permissions';
+import { PERMISSIONS_CONTACT_POINTS, PERMISSIONS_TEMPLATES } from './unified/components/contact-points/permissions';
 import { evaluateAccess } from './unified/utils/access-control';
 
 export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
@@ -104,6 +104,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
         AccessControlAction.AlertingNotificationsRead,
         AccessControlAction.AlertingNotificationsExternalRead,
         ...PERMISSIONS_CONTACT_POINTS,
+        ...PERMISSIONS_TEMPLATES,
       ]),
       component: importAlertingComponent(
         () =>
@@ -150,8 +151,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
       roles: evaluateAccess([
         AccessControlAction.AlertingNotificationsRead,
         AccessControlAction.AlertingNotificationsExternalRead,
-        AccessControlAction.AlertingTemplatesRead,
-        AccessControlAction.AlertingTemplatesWrite,
+        ...PERMISSIONS_TEMPLATES,
       ]),
       component: importAlertingComponent(
         () => import(/* webpackChunkName: "Templates" */ 'app/features/alerting/unified/Templates')

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -150,6 +150,8 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
       roles: evaluateAccess([
         AccessControlAction.AlertingNotificationsRead,
         AccessControlAction.AlertingNotificationsExternalRead,
+        AccessControlAction.AlertingTemplatesRead,
+        AccessControlAction.AlertingTemplatesWrite,
       ]),
       component: importAlertingComponent(
         () => import(/* webpackChunkName: "Templates" */ 'app/features/alerting/unified/Templates')

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -3,7 +3,8 @@ import { config } from 'app/core/config';
 import { GrafanaRouteComponent, RouteDescriptor } from 'app/core/navigation/types';
 import { AccessControlAction } from 'app/types';
 
-import { PERMISSIONS_CONTACT_POINTS, PERMISSIONS_TEMPLATES } from './unified/components/contact-points/permissions';
+import { PERMISSIONS_CONTACT_POINTS } from './unified/components/contact-points/permissions';
+import { PERMISSIONS_TEMPLATES } from './unified/components/templates/permissions';
 import { evaluateAccess } from './unified/utils/access-control';
 
 export function getAlertingRoutes(cfg = config): RouteDescriptor[] {

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -188,7 +188,8 @@ export const ContactPointsPageContents = () => {
   const { contactPoints } = useContactPointsWithStatus({
     alertmanager: selectedAlertmanager!,
   });
-  const [_, showTemplatesTab] = useAlertmanagerAbility(AlertmanagerAction.ViewNotificationTemplate);
+  const [, showTemplatesTab] = useAlertmanagerAbility(AlertmanagerAction.ViewNotificationTemplate);
+  const [, showContactPointsTab] = useAlertmanagerAbility(AlertmanagerAction.ViewContactPoint);
 
   const showingContactPoints = activeTab === ActiveTab.ContactPoints;
   const showNotificationTemplates = activeTab === ActiveTab.NotificationTemplates;
@@ -198,12 +199,14 @@ export const ContactPointsPageContents = () => {
       <GrafanaAlertmanagerDeliveryWarning currentAlertmanager={selectedAlertmanager!} />
       <Stack direction="column">
         <TabsBar>
-          <Tab
-            label="Contact Points"
-            active={showingContactPoints}
-            counter={contactPoints.length}
-            onChangeTab={() => setActiveTab(ActiveTab.ContactPoints)}
-          />
+          {showContactPointsTab && (
+            <Tab
+              label="Contact Points"
+              active={showingContactPoints}
+              counter={contactPoints.length}
+              onChangeTab={() => setActiveTab(ActiveTab.ContactPoints)}
+            />
+          )}
           {showTemplatesTab && (
             <Tab
               label="Notification Templates"

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import {
   Alert,

--- a/public/app/features/alerting/unified/components/contact-points/permissions.ts
+++ b/public/app/features/alerting/unified/components/contact-points/permissions.ts
@@ -17,9 +17,20 @@ export const PERMISSIONS_CONTACT_POINTS_MODIFY = [
 
 /**
  * List of all permissions that allow contact points read/write functionality
- *
- * Any permission in this list will also be checked for whether the built-in Grafana Alertmanager is shown
+ */
+export const PERMISSIONS_CONTACT_POINTS = [...PERMISSIONS_CONTACT_POINTS_READ, ...PERMISSIONS_CONTACT_POINTS_MODIFY];
+
+/**
+ * List of all permissions that allow templates read/write functionality
+ */
+export const PERMISSIONS_TEMPLATES = [
+  AccessControlAction.AlertingTemplatesRead,
+  AccessControlAction.AlertingTemplatesWrite,
+  AccessControlAction.AlertingTemplatesDelete,
+];
+
+/**
+ * Any permission in this list will be used to check whether the built-in Grafana Alertmanager is shown
  * (as the implication is that if they have one of these permissions, then they should be able to see Grafana AM in the AM selector)
  */
-
-export const PERMISSIONS_CONTACT_POINTS = [...PERMISSIONS_CONTACT_POINTS_READ, ...PERMISSIONS_CONTACT_POINTS_MODIFY];
+export const PERMISSIONS_GRAFANA_ALERTMANAGER = [...PERMISSIONS_CONTACT_POINTS, ...PERMISSIONS_TEMPLATES];

--- a/public/app/features/alerting/unified/components/contact-points/permissions.ts
+++ b/public/app/features/alerting/unified/components/contact-points/permissions.ts
@@ -19,18 +19,3 @@ export const PERMISSIONS_CONTACT_POINTS_MODIFY = [
  * List of all permissions that allow contact points read/write functionality
  */
 export const PERMISSIONS_CONTACT_POINTS = [...PERMISSIONS_CONTACT_POINTS_READ, ...PERMISSIONS_CONTACT_POINTS_MODIFY];
-
-/**
- * List of all permissions that allow templates read/write functionality
- */
-export const PERMISSIONS_TEMPLATES = [
-  AccessControlAction.AlertingTemplatesRead,
-  AccessControlAction.AlertingTemplatesWrite,
-  AccessControlAction.AlertingTemplatesDelete,
-];
-
-/**
- * Any permission in this list will be used to check whether the built-in Grafana Alertmanager is shown
- * (as the implication is that if they have one of these permissions, then they should be able to see Grafana AM in the AM selector)
- */
-export const PERMISSIONS_GRAFANA_ALERTMANAGER = [...PERMISSIONS_CONTACT_POINTS, ...PERMISSIONS_TEMPLATES];

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
@@ -166,7 +166,7 @@ function TemplateRow({ notificationTemplate, idx, alertManagerName, onDeleteClic
               />
             </Authorize>
           )}
-          <Authorize actions={[AlertmanagerAction.CreateContactPoint]}>
+          <Authorize actions={[AlertmanagerAction.CreateNotificationTemplate]}>
             <ActionIcon
               to={makeAMLink(
                 `/alerting/notifications/templates/${encodeURIComponent(uid)}/duplicate`,

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
@@ -1,5 +1,8 @@
+import 'core-js/stable/structured-clone';
+import { MemoryHistoryBuildOptions } from 'history';
+import { ComponentProps, ReactNode } from 'react';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
-import { screen, waitFor } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 import { byLabelText, byRole, byTestId, byText } from 'testing-library-selector';
 
 import { config } from '@grafana/runtime';
@@ -8,6 +11,7 @@ import {
   setOnCallFeatures,
   setOnCallIntegrations,
 } from 'app/features/alerting/unified/mocks/server/handlers/plugins/configure-plugins';
+import { AlertmanagerProvider } from 'app/features/alerting/unified/state/AlertmanagerContext';
 import { SupportedPlugin } from 'app/features/alerting/unified/types/pluginBridges';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
@@ -15,9 +19,20 @@ import { AccessControlAction } from 'app/types';
 import { AlertmanagerConfigBuilder, setupMswServer } from '../../../mockApi';
 import { grantUserPermissions } from '../../../mocks';
 import { captureRequests } from '../../../mocks/server/events';
-import { renderWithProvider } from '../../contact-points/ContactPoints.test';
 
 import { GrafanaReceiverForm } from './GrafanaReceiverForm';
+
+const renderWithProvider = (
+  children: ReactNode,
+  historyOptions?: MemoryHistoryBuildOptions,
+  providerProps?: Partial<ComponentProps<typeof AlertmanagerProvider>>
+) =>
+  render(
+    <AlertmanagerProvider accessType="notification" {...providerProps}>
+      {children}
+    </AlertmanagerProvider>,
+    { historyOptions }
+  );
 
 setupMswServer();
 

--- a/public/app/features/alerting/unified/components/templates/permissions.ts
+++ b/public/app/features/alerting/unified/components/templates/permissions.ts
@@ -1,0 +1,11 @@
+import { AccessControlAction } from 'app/types';
+
+/**
+ * List of all permissions that allow templates read/write functionality
+ */
+
+export const PERMISSIONS_TEMPLATES = [
+  AccessControlAction.AlertingTemplatesRead,
+  AccessControlAction.AlertingTemplatesWrite,
+  AccessControlAction.AlertingTemplatesDelete,
+];

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -231,9 +231,21 @@ export function useAllAlertmanagerAbilities(): Abilities<AlertmanagerAction> {
       // TODO: Move this into the permissions config and generalise that code to allow for an array of permissions
       isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingReceiversCreate : null
     ),
-    [AlertmanagerAction.ViewContactPoint]: toAbility(AlwaysSupported, notificationsPermissions.read),
-    [AlertmanagerAction.UpdateContactPoint]: toAbility(hasConfigurationAPI, notificationsPermissions.update),
-    [AlertmanagerAction.DeleteContactPoint]: toAbility(hasConfigurationAPI, notificationsPermissions.delete),
+    [AlertmanagerAction.ViewContactPoint]: toAbility(
+      AlwaysSupported,
+      notificationsPermissions.read,
+      isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingReceiversRead : null
+    ),
+    [AlertmanagerAction.UpdateContactPoint]: toAbility(
+      hasConfigurationAPI,
+      notificationsPermissions.update,
+      isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingReceiversWrite : null
+    ),
+    [AlertmanagerAction.DeleteContactPoint]: toAbility(
+      hasConfigurationAPI,
+      notificationsPermissions.delete,
+      isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingReceiversWrite : null
+    ),
     // At the time of writing, only Grafana flavored alertmanager supports exporting,
     // and if a user can view the contact point, then they can also export it
     // So the only check we make is if the alertmanager is Grafana flavored

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -239,9 +239,21 @@ export function useAllAlertmanagerAbilities(): Abilities<AlertmanagerAction> {
     // So the only check we make is if the alertmanager is Grafana flavored
     [AlertmanagerAction.ExportContactPoint]: [isGrafanaFlavoredAlertmanager, isGrafanaFlavoredAlertmanager],
     // -- notification templates --
-    [AlertmanagerAction.CreateNotificationTemplate]: toAbility(hasConfigurationAPI, notificationsPermissions.create),
-    [AlertmanagerAction.ViewNotificationTemplate]: toAbility(AlwaysSupported, notificationsPermissions.read),
-    [AlertmanagerAction.UpdateNotificationTemplate]: toAbility(hasConfigurationAPI, notificationsPermissions.update),
+    [AlertmanagerAction.CreateNotificationTemplate]: toAbility(
+      hasConfigurationAPI,
+      notificationsPermissions.create,
+      isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingTemplatesWrite : null
+    ),
+    [AlertmanagerAction.ViewNotificationTemplate]: toAbility(
+      AlwaysSupported,
+      notificationsPermissions.read,
+      isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingTemplatesRead : null
+    ),
+    [AlertmanagerAction.UpdateNotificationTemplate]: toAbility(
+      hasConfigurationAPI,
+      notificationsPermissions.update,
+      isGrafanaFlavoredAlertmanager ? AccessControlAction.AlertingTemplatesWrite : null
+    ),
     [AlertmanagerAction.DeleteNotificationTemplate]: toAbility(hasConfigurationAPI, notificationsPermissions.delete),
     // -- notification policies --
     [AlertmanagerAction.CreateNotificationPolicy]: toAbility(hasConfigurationAPI, notificationsPermissions.create),

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -11,7 +11,7 @@ import { RulesSource } from 'app/types/unified-alerting';
 import { PromApplication, RulesSourceApplication } from 'app/types/unified-alerting-dto';
 
 import { alertmanagerApi } from '../api/alertmanagerApi';
-import { PERMISSIONS_CONTACT_POINTS } from '../components/contact-points/permissions';
+import { PERMISSIONS_GRAFANA_ALERTMANAGER } from '../components/contact-points/permissions';
 import { useAlertManagersByPermission } from '../hooks/useAlertManagerSources';
 import { isAlertManagerWithConfigAPI } from '../state/AlertmanagerContext';
 
@@ -150,7 +150,7 @@ export function getAlertManagerDataSourcesByPermission(permission: 'instance' | 
 
   const builtinAlertmanagerPermissions = [
     ...Object.values(permissions).flatMap((permissions) => permissions.grafana),
-    ...PERMISSIONS_CONTACT_POINTS,
+    ...PERMISSIONS_GRAFANA_ALERTMANAGER,
   ];
 
   const hasPermissionsForInternalAlertmanager = builtinAlertmanagerPermissions.some((permission) =>

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -12,11 +12,11 @@ import { PromApplication, RulesSourceApplication } from 'app/types/unified-alert
 
 import { alertmanagerApi } from '../api/alertmanagerApi';
 import { PERMISSIONS_CONTACT_POINTS } from '../components/contact-points/permissions';
+import { PERMISSIONS_TEMPLATES } from '../components/templates/permissions';
 import { useAlertManagersByPermission } from '../hooks/useAlertManagerSources';
 import { isAlertManagerWithConfigAPI } from '../state/AlertmanagerContext';
 
 import { instancesPermissions, notificationsPermissions, silencesPermissions } from './access-control';
-import { PERMISSIONS_TEMPLATES } from '../components/templates/permissions';
 import { getAllDataSources } from './config';
 
 export const GRAFANA_RULES_SOURCE_NAME = 'grafana';

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -11,11 +11,12 @@ import { RulesSource } from 'app/types/unified-alerting';
 import { PromApplication, RulesSourceApplication } from 'app/types/unified-alerting-dto';
 
 import { alertmanagerApi } from '../api/alertmanagerApi';
-import { PERMISSIONS_GRAFANA_ALERTMANAGER } from '../components/contact-points/permissions';
+import { PERMISSIONS_CONTACT_POINTS } from '../components/contact-points/permissions';
 import { useAlertManagersByPermission } from '../hooks/useAlertManagerSources';
 import { isAlertManagerWithConfigAPI } from '../state/AlertmanagerContext';
 
 import { instancesPermissions, notificationsPermissions, silencesPermissions } from './access-control';
+import { PERMISSIONS_TEMPLATES } from '../components/templates/permissions';
 import { getAllDataSources } from './config';
 
 export const GRAFANA_RULES_SOURCE_NAME = 'grafana';
@@ -150,7 +151,8 @@ export function getAlertManagerDataSourcesByPermission(permission: 'instance' | 
 
   const builtinAlertmanagerPermissions = [
     ...Object.values(permissions).flatMap((permissions) => permissions.grafana),
-    ...PERMISSIONS_GRAFANA_ALERTMANAGER,
+    ...PERMISSIONS_CONTACT_POINTS,
+    ...PERMISSIONS_TEMPLATES,
   ];
 
   const hasPermissionsForInternalAlertmanager = builtinAlertmanagerPermissions.some((permission) =>

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -137,6 +137,7 @@ export enum AccessControlAction {
   // Alerting templates actions
   AlertingTemplatesRead = 'alert.notifications.templates:read',
   AlertingTemplatesWrite = 'alert.notifications.templates:write',
+  AlertingTemplatesDelete = 'alert.notifications.templates:delete',
 
   ActionAPIKeysRead = 'apikeys:read',
   ActionAPIKeysCreate = 'apikeys:create',

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -134,6 +134,10 @@ export enum AccessControlAction {
   AlertingReceiversWrite = 'alert.notifications.receivers:write',
   AlertingReceiversRead = 'alert.notifications.receivers:read',
 
+  // Alerting templates actions
+  AlertingTemplatesRead = 'alert.notifications.templates:read',
+  AlertingTemplatesWrite = 'alert.notifications.templates:write',
+
   ActionAPIKeysRead = 'apikeys:read',
   ActionAPIKeysCreate = 'apikeys:create',
   ActionAPIKeysDelete = 'apikeys:delete',


### PR DESCRIPTION
**What is this feature?**
Fixes some checks for templates in alerting UI. When RBAC is enabled and a user had only the templates permissions, the tab wouldn't show up. Also fixes the checks for the actions in the templates table
