### PR TITLE
Alerting: Add X-Remote-Alertmanager header to the remote AM client

### DIFF
--- a/pkg/services/ngalert/remote/client/mimir_auth_round_tripper.go
+++ b/pkg/services/ngalert/remote/client/mimir_auth_round_tripper.go
@@ -4,7 +4,10 @@ import (
 	"net/http"
 )
 
-const mimirTenantHeader = "X-Scope-OrgID"
+const (
+	MimirTenantHeader        = "X-Scope-OrgID"
+	RemoteAlertmanagerHeader = "X-Remote-Alertmanager"
+)
 
 type MimirAuthRoundTripper struct {
 	TenantID string
@@ -16,8 +19,9 @@ type MimirAuthRoundTripper struct {
 // It adds an `X-Scope-OrgID` header with the TenantID if only provided with a tenantID or sets HTTP Basic Authentication if both
 // a tenantID and a password are provided.
 func (r *MimirAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(RemoteAlertmanagerHeader, "true")
 	if r.TenantID != "" && r.Password == "" {
-		req.Header.Set(mimirTenantHeader, r.TenantID)
+		req.Header.Set(MimirTenantHeader, r.TenantID)
 	}
 
 	if r.TenantID != "" && r.Password != "" {


### PR DESCRIPTION
This PR adds an `X-Remote-Alertmanager: true` header to the remote Alertmanager HTTP client.
It also checks for the presence of this new header and the `X-Scope-OrgID` one in tests.