### PR TITLE
CloudWatch: Interpolate region in log context query

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -9,6 +9,7 @@ import {
   MutableDataFrame,
 } from '@grafana/data';
 
+import { regionVariable } from '../__mocks__/CloudWatchDataSource';
 import { setupMockedLogsQueryRunner } from '../__mocks__/LogsQueryRunner';
 import { LogsRequestMock } from '../__mocks__/Request';
 import { validLogsQuery } from '../__mocks__/queries';
@@ -23,7 +24,7 @@ describe('CloudWatchLogsQueryRunner', () => {
 
   describe('getLogRowContext', () => {
     it('replaces parameters correctly in the query', async () => {
-      const { runner, queryMock } = setupMockedLogsQueryRunner();
+      const { runner, queryMock } = setupMockedLogsQueryRunner({ variables: [regionVariable] });
       const row: LogRowModel = {
         entryFieldIndex: 0,
         rowIndex: 0,
@@ -50,14 +51,15 @@ describe('CloudWatchLogsQueryRunner', () => {
       };
       await runner.getLogRowContext(row, undefined, queryMock);
       expect(queryMock.mock.calls[0][0].targets[0].endTime).toBe(4);
-      expect(queryMock.mock.calls[0][0].targets[0].region).toBe('');
+      // sets the default region if region is empty
+      expect(queryMock.mock.calls[0][0].targets[0].region).toBe('us-west-1');
 
       await runner.getLogRowContext(row, { direction: LogRowContextQueryDirection.Forward }, queryMock, {
         ...validLogsQuery,
-        region: 'eu-east',
+        region: '$region',
       });
       expect(queryMock.mock.calls[1][0].targets[0].startTime).toBe(4);
-      expect(queryMock.mock.calls[1][0].targets[0].region).toBe('eu-east');
+      expect(queryMock.mock.calls[1][0].targets[0].region).toBe('templatedRegion');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -180,7 +180,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       refId: query?.refId || 'A', // dummy
       limit,
       startFromHead: direction !== LogRowContextQueryDirection.Backward,
-      region: query?.region || '',
+      region: this.templateSrv.replace(this.getActualRegion(query?.region)),
       logGroupName: parseLogGroupName(logField!.values[row.rowIndex]),
       logStreamName: logStreamField!.values[row.rowIndex],
     };
@@ -252,7 +252,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       this.logQueries[param.refId] = {
         id: param.queryId,
         region: param.region,
-        statsQuery: (param.statsGroups?.length ?? 0) > 0 ?? false,
+        statsQuery: (param.statsGroups?.length ?? 0) > 0,
       };
     });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Interpolates the region in getLogsQueryContext, so that the logs context feature can be used with queries that have a query region

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #88310 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
