### PR TITLE
fix: add missing `data` field on `AnnotationEvent` model.

### DIFF
--- a/packages/grafana-data/src/types/annotations.ts
+++ b/packages/grafana-data/src/types/annotations.ts
@@ -33,6 +33,8 @@ export interface AnnotationEvent {
   login?: string;
   email?: string;
   avatarUrl?: string;
+  created?: number;
+  updated?: number;
   time?: number;
   timeEnd?: number;
   isRegion?: boolean;

--- a/packages/grafana-data/src/types/annotations.ts
+++ b/packages/grafana-data/src/types/annotations.ts
@@ -43,6 +43,7 @@ export interface AnnotationEvent {
   color?: string;
   alertId?: number;
   newState?: string;
+  data?: any;
 
   // Currently used to merge annotations from alerts and dashboard
   source?: any; // source.type === 'dashboard' -- should be AnnotationQuery


### PR DESCRIPTION
[AnnotationEvent](https://github.com/grafana/grafana/blob/3e1f5559a6b55ddd2db66ed796126eaf64eb295d/packages/grafana-data/src/types/annotations.ts#L25) is used as the param type [when saving the annotation](https://github.com/grafana/grafana/blob/3c6e0e8ef85048af952367751e478c08342e17b4/public/app/features/annotations/api.ts#L6), but missing the `data` field, which is [accepted](https://github.com/grafana/grafana/blob/3e1f5559a6b55ddd2db66ed796126eaf64eb295d/pkg/api/dtos/annotations.go#L14) in the [backend API](https://github.com/grafana/grafana/blob/728150bdbd51a7ad1031bb0f2990c2a645c515ec/pkg/api/annotations.go#L113).

Update: also add `created` and `updated` fields: https://github.com/grafana/grafana/blob/388023a1727609c8779d35dcd819bb59693c7252/pkg/services/annotations/models.go#L107-L127