### PR TITLE
Alerting: Fix editing expressions refId

### DIFF
--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -327,10 +327,6 @@ const Header: FC<HeaderProps> = ({
               autoFocus
               defaultValue={refId}
               minWidth={5}
-              onChange={(event) => {
-                onUpdateRefId(event.currentTarget.value);
-                setEditMode(false);
-              }}
               onFocus={(event) => event.target.select()}
               onBlur={(event) => {
                 onUpdateRefId(event.currentTarget.value);


### PR DESCRIPTION
**What is this feature?**
This PR fixes a bug which surfaced after changes in the `AutoSizeInput` https://github.com/grafana/grafana/pull/94459

It appears we never really used the `onChange` callback for the refId input,as the `AutoSizeInput` component did't pass that property down. Instead we relied solely on the `onBlur` event and this is now correctly reflected in the code

**Why do we need this feature?**
To fix a bug where users can change only one letter in the input

**Who is this feature for?**
All users



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
