### PR TITLE
scopes: test case for supporting queries using __name__

### DIFF
--- a/pkg/promlib/models/scope_test.go
+++ b/pkg/promlib/models/scope_test.go
@@ -97,6 +97,15 @@ func TestApplyQueryFiltersAndGroupBy_Filters(t *testing.T) {
 			expected:  `http_requests_total{job="prometheus",status=~"404|400"}`,
 			expectErr: false,
 		},
+		{
+			name:  "using __name__ as part of the query",
+			query: `{__name__="http_requests_total"}`,
+			scopeFilters: []ScopeFilter{
+				{Key: "namespace", Value: "istio", Operator: FilterOperatorEquals},
+			},
+			expected:  `{__name__="http_requests_total",namespace="istio"}`,
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This was already supported so Im adding it primarly to consider it part of the "spec" :)

Im using queries like this to match timeseries that has a prefix. Like `loki_ring*` and `mimir_ring*`