### PR TITLE
Alerting: Fix templates editing validation

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useNotificationTemplates.ts
+++ b/public/app/features/alerting/unified/components/contact-points/useNotificationTemplates.ts
@@ -285,7 +285,15 @@ export function useDeleteNotificationTemplate({ alertmanager }: BaseAlertmanager
   return k8sApiSupported ? deleteUsingK8sApi : deleteUsingConfigFileApi;
 }
 
-export function useValidateNotificationTemplate({ alertmanager }: BaseAlertmanagerArgs) {
+interface ValidateNotificationTemplateParams {
+  alertmanager: string;
+  originalTemplate?: NotificationTemplate;
+}
+
+export function useValidateNotificationTemplate({
+  alertmanager,
+  originalTemplate,
+}: ValidateNotificationTemplateParams) {
   const { useLazyGetAlertmanagerConfigurationQuery } = alertmanagerApi;
   const [fetchAmConfig] = useLazyGetAlertmanagerConfigurationQuery();
 
@@ -295,6 +303,11 @@ export function useValidateNotificationTemplate({ alertmanager }: BaseAlertmanag
     if (k8sApiSupported) {
       // K8s API handles validation for us, so we can just return true
       // and rely on API errors
+      return true;
+    }
+
+    if (originalTemplate?.title === name) {
+      // If original template is defined we update existing template so name will not be unique but it's ok
       return true;
     }
 

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -92,7 +92,7 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
 
   const createNewTemplate = useCreateNotificationTemplate({ alertmanager });
   const updateTemplate = useUpdateNotificationTemplate({ alertmanager });
-  const { titleIsUnique } = useValidateNotificationTemplate({ alertmanager });
+  const { titleIsUnique } = useValidateNotificationTemplate({ alertmanager, originalTemplate });
 
   useCleanup((state) => (state.unifiedAlerting.saveAMConfig = initialAsyncRequestState));
   const formRef = useRef<HTMLFormElement>(null);


### PR DESCRIPTION
**What is this feature?**
This PR fixes incorrectly applied validation rule when the user edits a notification template


Fixes https://github.com/grafana/support-escalations/issues/13011


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
