### PR TITLE
Update index.md to update Grafana Assume Role Notes

### DIFF
--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -160,7 +160,7 @@ securityContext:
 ## Use Grafana Assume Role
 
 {{% admonition type="note" %}}
-Grafana Assume Role is currently in [private preview]({{< relref "https://grafana.com/docs/release-life-cycle" >}}) for Grafana Cloud. To get early access this feature, reach out to Customer Support and ask for the `awsDatasourcesTempCredentials` feature toggle to be enabled on your account. It is currently only available for CloudWatch.
+Grafana Assume Role is currently in [private preview]({{< relref "https://grafana.com/docs/release-life-cycle" >}}) for Grafana Cloud. To get early access this feature, reach out to Customer Support and ask for the `awsDatasourcesTempCredentials` feature toggle to be enabled and set the cloudwatchRemoteDatasource and athenaRemoteDatasource feature toggles to false on your account. It is currently only available for CloudWatch.
 {{% /admonition %}}
 
 The Grafana Assume Role authentication provider lets you authenticate with AWS without having to create and maintain long term AWS users or rotate their access and secret keys. Instead, you can create an IAM role that has permissions to access CloudWatch and a trust relationship with Grafana's AWS account. Grafana's AWS account then makes an STS request to AWS to create temporary credentials to access your AWS data. It makes this STS request by passing along an `externalID` that's unique per Cloud account, to ensure that Grafana Cloud users can only access their own AWS data. For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).

--- a/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
+++ b/docs/sources/datasources/aws-cloudwatch/aws-authentication/index.md
@@ -160,7 +160,11 @@ securityContext:
 ## Use Grafana Assume Role
 
 {{% admonition type="note" %}}
-Grafana Assume Role is currently in [private preview]({{< relref "https://grafana.com/docs/release-life-cycle" >}}) for Grafana Cloud. To get early access this feature, reach out to Customer Support and ask for the `awsDatasourcesTempCredentials` feature toggle to be enabled and set the cloudwatchRemoteDatasource and athenaRemoteDatasource feature toggles to false on your account. It is currently only available for CloudWatch.
+Grafana Assume Role is currently in [private preview]({{< relref "https://grafana.com/docs/release-life-cycle" >}}) for Grafana Cloud.
+
+It's currently only available for Amazon CloudWatch.
+
+To get early access this feature, reach out to Customer Support and ask for the `awsDatasourcesTempCredentials` feature toggle to be enabled and the `cloudwatchRemoteDatasource` and `athenaRemoteDatasource` feature toggles to be disabled on your account.
 {{% /admonition %}}
 
 The Grafana Assume Role authentication provider lets you authenticate with AWS without having to create and maintain long term AWS users or rotate their access and secret keys. Instead, you can create an IAM role that has permissions to access CloudWatch and a trust relationship with Grafana's AWS account. Grafana's AWS account then makes an STS request to AWS to create temporary credentials to access your AWS data. It makes this STS request by passing along an `externalID` that's unique per Cloud account, to ensure that Grafana Cloud users can only access their own AWS data. For more information, refer to the [AWS documentation on external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).


### PR DESCRIPTION
Fixes: https://github.com/grafana/support-escalations/issues/13019

moving forward if you’re turning on the awsDatasourcesTempCredentials feature toggle for Grafana Assume Role for a customer you also need to set the cloudwatchRemoteDatasource  and athenaRemoteDatasource feature toggles to false. (For context, we’re currently rolling the CloudWatch API Server out, but Grafana Assume Role doesn’t currently work on the api servers)

