### PR TITLE
MSSQL: Add playwright smoke test

### DIFF
--- a/e2e/plugin-e2e/mssql/mssql.spec.ts
+++ b/e2e/plugin-e2e/mssql/mssql.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('Smoke test: decoupled frontend plugin loads', async ({ createDataSourceConfigPage, page }) => {
+  await createDataSourceConfigPage({ type: 'mssql' });
+
+  await expect(await page.getByText('Type: Microsoft SQL Server', { exact: true })).toBeVisible();
+  await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,6 +71,15 @@ export default defineConfig<PluginOptions>({
       dependencies: ['authenticate'],
     },
     {
+      name: 'mssql',
+      testDir: path.join(testDirRoot, '/mssql'),
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['authenticate'],
+    },
+    {
       name: 'extensions-test-app',
       testDir: 'e2e/test-plugins/grafana-extensionstest-app',
       use: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a smoke test to assert that the frontend assets of the mssql decoupled datasource have been built and load. 

**Without Built Assets**
<img width="1792" alt="Screenshot 2024-10-18 at 16 29 35" src="https://github.com/user-attachments/assets/c3bb55f4-b295-4c88-a676-0f2c7c8f368e">

**With Built Assets**

<img width="1792" alt="Screenshot 2024-10-18 at 16 29 07" src="https://github.com/user-attachments/assets/00a26418-55c6-477b-8de1-26b57bdd979c">

**Why do we need this feature?**

Following on from #88341 which prevented building the decoupled mssql ds and #94866 which fixed it. This PR helps to prevent this occurring again in the future.

**Who is this feature for?**

Grafana and MSSQL developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #94798

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
