### PR TITLE
Backend: Inject server-timing header to match initial loads with client-side telemetry

### DIFF
--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -381,6 +381,15 @@ func TraceIDFromContext(ctx context.Context, requireSampled bool) string {
 	return spanCtx.TraceID().String()
 }
 
+func ServerTimingForSpan(span trace.Span) string {
+	spanCtx := span.SpanContext()
+	if !spanCtx.HasTraceID() || !spanCtx.IsValid() {
+		return ""
+	}
+
+	return fmt.Sprintf("00-%s-%s-01", spanCtx.TraceID().String(), spanCtx.SpanID().String())
+}
+
 // Error sets the status to error and record the error as an exception in the provided span.
 func Error(span trace.Span, err error) error {
 	attr := []attribute.KeyValue{}


### PR DESCRIPTION
**What is this feature?**

Faro Web SDK can read the server-timing information and correlate the initial request with the client-side telemetry gathered from navigation timings.

**Why do we need this feature?**

Correlate browser timings with a concrete backend trace.

**Who is this feature for?**

Important for our Grafana frontend teams to be able to track down performance bottlenecks and correlate seamlessly.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

More info:
* blog - https://grafana.com/blog/2024/08/26/gain-actionable-insights-with-real-user-monitoring-the-latest-features-in-grafana-cloud-frontend-observability/
* https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/apm-integration/