### PR TITLE
Chore: Bump What's New url for v11.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "generate-apis": "rtk-query-codegen-openapi ./scripts/generate-rtk-apis.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v11-0/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v11-3/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump whats new package.json url straight into v11.3.x branch