### PR TITLE
Chore: Fix population of details when converting from errutil errors to K8s error

### DIFF
--- a/pkg/apimachinery/errutil/errors.go
+++ b/pkg/apimachinery/errutil/errors.go
@@ -391,11 +391,12 @@ func (e Error) Status() metav1.Status {
 		for k, v := range public.Extra {
 			v, err := json.Marshal(v)
 			if err != nil {
-				s.Details.Causes = append(s.Details.Causes, metav1.StatusCause{
-					Field:   k,
-					Message: string(v),
-				})
+				continue
 			}
+			s.Details.Causes = append(s.Details.Causes, metav1.StatusCause{
+				Field:   k,
+				Message: string(v),
+			})
 		}
 	}
 	return s


### PR DESCRIPTION
**What is this feature?**
PR fixes the typo in the method that converts errutil.Error to k8s error
