### PR TITLE
Transformations: Autofocus on search when drawer opens

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -84,6 +84,7 @@ export function TransformationPickerNg(props: TransformationPickerNgProps) {
           onKeyDown={onSearchKeyDown}
           suffix={suffix}
           ref={searchInputRef}
+          autoFocus={true}
         />
         <div className={styles.showImages}>
           <span className={styles.illustationSwitchLabel}>Show images</span>{' '}


### PR DESCRIPTION
**What is this feature?**

Autofocus the search field when the transformation drawer is open

**Why do we need this feature?**

So I can search for a transformation without suffering the indignity of moving my cursor to the upper right of the screen.

**Who is this feature for?**

People with extremely hard lives who like to make transformations quickly.

**Which issue(s) does this PR fix?**:

Issue not created.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
