### PR TITLE
Prometheus: Ensure auth config can be switched away from Azure option

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -8,9 +8,15 @@ import { Alert, SecureSocksProxySettings, useTheme2 } from '@grafana/ui';
 // NEED TO EXPORT THIS FROM GRAFANA/UI FOR EXTERNAL DS
 import { AzureAuthSettings } from '@grafana/ui/src/components/DataSourceSettings/types';
 
+import type { AzureCredentials } from './AzureCredentials';
+
+interface PromOptionsWithCloudAuth extends PromOptions {
+  azureCredentials?: AzureCredentials;
+}
+
 type Props = {
-  options: DataSourceSettings<PromOptions, {}>;
-  onOptionsChange: (options: DataSourceSettings<PromOptions, {}>) => void;
+  options: DataSourceSettings<PromOptionsWithCloudAuth, {}>;
+  onOptionsChange: (options: DataSourceSettings<PromOptionsWithCloudAuth, {}>) => void;
   azureAuthSettings: AzureAuthSettings;
   sigV4AuthToggleEnabled: boolean | undefined;
   renderSigV4Editor: React.ReactNode;
@@ -73,7 +79,7 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
   const azureAuthOption: CustomMethod = {
     id: azureAuthId,
     label: 'Azure auth',
-    description: 'This is Azure auth description',
+    description: 'Authenticate with Azure',
     component: (
       <>
         {azureAuthSettings.azureSettingsUI && (
@@ -161,6 +167,7 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
             withCredentials: method === AuthMethod.CrossSiteCredentials,
             jsonData: {
               ...options.jsonData,
+              azureCredentials: method === azureAuthId ? options.jsonData.azureCredentials : undefined,
               sigV4Auth: method === sigV4Id,
               oauthPassThru: method === AuthMethod.OAuthForward,
             },


### PR DESCRIPTION
## What is this change?

Removes `azureCredentials` from `jsonData` when switching the Prometheus data source's auth config from [**Azure auth**](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/#azure-authentication-settings) to a different auth option. This prevents [`azureAuthSettings.getAzureAuthEnabled`](https://github.com/grafana/grafana/blob/00bb3215cb633df0e4fe1cb49b5743a1da2de728/public/app/plugins/datasource/prometheus/configuration/ConfigEditorPackage.tsx#L23) from erroneously returning `true`, which prevents other auth options from being selected & persisted.

## Why do we need this change?

To fix #94813.

### Demo

#### Before

After **Azure auth** is selected, we can't switch to **No auth** and save the change:

https://github.com/user-attachments/assets/905128f8-4a98-49f4-9edc-a545bf56880d

#### After

After **Azure auth** is selected, we can switch to **No auth** and save the change:

https://github.com/user-attachments/assets/8c0a5614-440c-411f-b802-e181882a9287

## Who is this feature for?

Prometheus data source users, especially those who might depend on Azure auth.

## Which issue(s) does this PR fix?:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #94813.

## Housekeeping

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
