### PR TITLE
ST querier: experiment with late binding headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ profile.cov
 /pkg/build/cmd/artifactspage.tmpl.html
 /pkg/server/wireexts_enterprise.go
 /pkg/cmd/grafana-cli/runner/wireexts_enterprise.go
+/pkg/build/cmd/exportversion.go
 !/pkg/extensions/main.go
 /public/app/extensions
 debug.test

--- a/pkg/registry/apis/query/client.go
+++ b/pkg/registry/apis/query/client.go
@@ -16,6 +16,6 @@ type CommonDataSourceClientSupplier struct {
 	Client data.QueryDataClient
 }
 
-func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, _ map[string]string) (data.QueryDataClient, error) {
+func (s *CommonDataSourceClientSupplier) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, headers map[string]string) (data.QueryDataClient, error) {
 	return s.Client, nil
 }

--- a/pkg/registry/apis/query/client/plugin.go
+++ b/pkg/registry/apis/query/client/plugin.go
@@ -23,6 +23,7 @@ import (
 type pluginClient struct {
 	pluginClient plugins.Client
 	pCtxProvider *plugincontext.Provider
+	headers      map[string]string
 }
 
 type pluginRegistry struct {
@@ -40,10 +41,11 @@ var _ data.QueryDataClient = (*pluginClient)(nil)
 var _ query.DataSourceApiServerRegistry = (*pluginRegistry)(nil)
 
 // NewQueryClientForPluginClient creates a client that delegates to the internal plugins.Client stack
-func NewQueryClientForPluginClient(p plugins.Client, ctx *plugincontext.Provider) data.QueryDataClient {
+func NewQueryClientForPluginClient(p plugins.Client, ctx *plugincontext.Provider, headers map[string]string) data.QueryDataClient {
 	return &pluginClient{
 		pluginClient: p,
 		pCtxProvider: ctx,
+		headers:      headers,
 	}
 }
 
@@ -74,6 +76,7 @@ func (d *pluginClient) QueryData(ctx context.Context, req data.QueryDataRequest)
 
 	qdr := &backend.QueryDataRequest{
 		Queries: queries,
+		Headers: d.headers,
 	}
 	qdr.PluginContext, err = d.pCtxProvider.PluginContextForDataSource(ctx, settings)
 	if err != nil {

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -208,7 +208,7 @@ func (b *QueryAPIBuilder) handleQuerySingleDatasource(ctx context.Context, req d
 		return &backend.QueryDataResponse{}, nil
 	}
 
-	// A hack, by late binding and not using the interface, it breaks unit-tests
+	// A hack, by late binding and not using what's supplied in the constructor, it breaks unit-tests
 	queryClient := CommonDataSourceClientSupplier{
 		client.NewQueryClientForPluginClient(b.pluginClient, b.pCtxProvider, req.Headers),
 	}

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -40,7 +40,7 @@ type QueryAPIBuilder struct {
 	tracer  tracing.Tracer
 	metrics *queryMetrics
 	parser  *queryParser
-	client  DataSourceClientSupplier
+	client  DataSourceClientSupplier // only used when not late binding headers
 
 	// the following two for making a late headers supplied client
 	pluginClient plugins.Client


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A completely hacky test to see if headers get propagated to loki when using ST querier.

**Why do we need this feature?**

Currently, alerting headers are not propagating correctly when running in ST context.

**Who is this feature for?**

Grafana App Plaform, Data sources

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
