### PR TITLE
Fix: Initialize tracer in file provisioning

### DIFF
--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -82,6 +82,7 @@ func ProvideService(
 		orgService:                   orgService,
 		folderService:                folderService,
 		resourcePermissions:          resourcePermissions,
+		tracer:                       tracer,
 	}
 
 	if err := s.setDashboardProvisioner(); err != nil {


### PR DESCRIPTION
PR https://github.com/grafana/grafana/pull/94572 introduced the tracer in provisioning service but factory method was not updated. This PR fixes it.