### PR TITLE
Update Discord contact point documentation for use_discord_username type

### DIFF
--- a/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
+++ b/docs/sources/alerting/set-up/provision-alerting-resources/file-provisioning/index.md
@@ -270,8 +270,8 @@ settings:
   url: https://discord/webhook
   # <string>
   avatar_url: https://my_avatar
-  # <string>
-  use_discord_username: Grafana
+  # <bool>
+  use_discord_username: false
   # <string>
   message: |
     {{ template "default.message" . }}


### PR DESCRIPTION
**What is this feature?**

This pull request updates the documentation for the Discord contact point in the alerting setup. It corrects the data type of the `use_discord_username` setting from `<string>` to `<bool>`.

**Why do we need this feature?**

The current documentation specifies `use_discord_username` as a `<string>`, but it should be a `<bool>`. This update helps prevent configuration errors for users setting up Discord contact points in alerting.

**Who is this feature for?**

This update is for Grafana users who are configuring alerting contact points with Discord. It ensures accurate documentation, which is crucial for correctly setting up alerting integrations.

**Which issue(s) does this PR fix?**

Fixes #94893


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.