### PR TITLE
Enforce empty RV and populated UID

### DIFF
--- a/pkg/apiserver/storage/testing/watcher_tests.go
+++ b/pkg/apiserver/storage/testing/watcher_tests.go
@@ -1541,6 +1541,7 @@ func makePod(namePrefix string) *example.Pod {
 	return &example.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("pod-%s", namePrefix),
+			UID:  "123",
 		},
 	}
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -281,7 +281,7 @@ func (s *server) newEvent(ctx context.Context, user claims.AuthInfo, key *Resour
 	}
 
 	if obj.GetUID() == "" {
-		s.log.Error("object is missing UID", "key", key)
+		return nil, NewBadRequestError("object must include UID")
 	}
 
 	if obj.GetResourceVersion() != "" {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -285,7 +285,7 @@ func (s *server) newEvent(ctx context.Context, user claims.AuthInfo, key *Resour
 	}
 
 	if obj.GetResourceVersion() != "" {
-		s.log.Error("object must not include a resource version", "key", key)
+		return nil, NewBadRequestError("object must not include resourceVersion")
 	}
 
 	event := &WriteEvent{


### PR DESCRIPTION
**What is this feature?**

Adds fail checks on the unified store server layer before writing payload.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
