### PR TITLE
Alerting: Fix remote Alertmanager readiness check path

### DIFF
--- a/pkg/services/ngalert/remote/client/alertmanager.go
+++ b/pkg/services/ngalert/remote/client/alertmanager.go
@@ -71,7 +71,7 @@ func (am *Alertmanager) IsReadyWithBackoff(ctx context.Context) (bool, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	readyURL := am.url.JoinPath(am.url.Path, alertmanagerAPIMountPath, alertmanagerReadyPath)
+	readyURL := am.url.JoinPath(alertmanagerAPIMountPath, alertmanagerReadyPath)
 
 	attempt := func() (int, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, readyURL.String(), nil)


### PR DESCRIPTION
In the function to perform the readiness check for the remote Alertmanager, we're duplicating any existing path in the URL provided in the `remote.alertmanager` section of Grafana's configuration.

Excerpt from docs for `*url.URL.JoinPath()`:
> ...returns a new [URL] with the provided path elements joined to **any existing path**

The solution is to omit `am.url.Path` from the call to `am.url.JoinPath()`.