### PR TITLE
Alerting: Fix overflow for long receiver names

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
@@ -181,8 +181,8 @@ export const ContactPointHeader = ({ contactPoint, onDelete }: ContactPointHeade
   return (
     <div className={styles.headerWrapper}>
       <Stack direction="row" alignItems="center" gap={1}>
-        <Stack alignItems="center" gap={1}>
-          <Text element="h2" variant="body" weight="medium">
+        <Stack alignItems="center" gap={1} minWidth={0}>
+          <Text element="h2" variant="body" weight="medium" truncate>
             {name}
           </Text>
         </Stack>


### PR DESCRIPTION
**Before**
<img width="978" alt="image" src="https://github.com/user-attachments/assets/dc87f00c-6835-4c8d-bc88-dea257226f5a">

**After**
<img width="958" alt="image" src="https://github.com/user-attachments/assets/048abc65-f42b-4b50-9cd9-410cfc5dd185">
