### PR TITLE
Alerting: Fix escaping of silence matchers in utf8 mode

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash';
 
+import { encodeMatcher } from 'app/features/alerting/unified/utils/matchers';
 import { dispatch } from 'app/store/store';
 import { ReceiversStateDTO } from 'app/types/alerting';
 
@@ -23,7 +24,7 @@ import {
   getDatasourceAPIUid,
   isVanillaPrometheusAlertManagerDataSource,
 } from '../utils/datasource';
-import { retryWhile, wrapWithQuotes } from '../utils/misc';
+import { retryWhile } from '../utils/misc';
 import { messageFromError, withSerializedError } from '../utils/redux';
 
 import { alertingApi } from './alertingApi';
@@ -72,9 +73,13 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
         // TODO Add support for active, silenced, inhibited, unprocessed filters
         const filterMatchers = filter?.matchers
           ?.filter((matcher) => matcher.name && matcher.value)
-          .map(
-            (matcher) => `${wrapWithQuotes(matcher.name)}${matcherToOperator(matcher)}${wrapWithQuotes(matcher.value)}`
-          );
+          .map((matcher) => {
+            return encodeMatcher({
+              name: matcher.name,
+              operator: matcherToOperator(matcher),
+              value: matcher.value,
+            });
+          });
 
         const { silenced, inhibited, unprocessed, active } = filter || {};
 

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../plugins/datasource/alertmanager/types';
 import { NotifierDTO } from '../../../../types';
 import { withPerformanceLogging } from '../Analytics';
-import { matcherToOperator } from '../utils/alertmanager';
+import { matcherToMatcherField } from '../utils/alertmanager';
 import {
   GRAFANA_RULES_SOURCE_NAME,
   getDatasourceAPIUid,
@@ -74,11 +74,7 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
         const filterMatchers = filter?.matchers
           ?.filter((matcher) => matcher.name && matcher.value)
           .map((matcher) => {
-            return encodeMatcher({
-              name: matcher.name,
-              operator: matcherToOperator(matcher),
-              value: matcher.value,
-            });
+            return encodeMatcher(matcherToMatcherField(matcher));
           });
 
         const { silenced, inhibited, unprocessed, active } = filter || {};

--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -1,7 +1,5 @@
 import {
   sortAlerts,
-  wrapWithQuotes,
-  escapeQuotes,
   createExploreLink,
   makeLabelBasedSilenceLink,
   makeDataSourceLink,
@@ -45,24 +43,6 @@ function permute(inputArray: any[]): any[] {
     );
   }, []);
 }
-
-describe('wrapWithQuotes', () => {
-  it('should work as expected', () => {
-    expect(wrapWithQuotes('"hello, world!"')).toBe('\\"hello, world!\\"');
-    expect(wrapWithQuotes('hello, world!')).toBe('"hello, world!"');
-    expect(wrapWithQuotes('hello, "world"!')).toBe('"hello, \\"world\\"!"');
-    expect(wrapWithQuotes('"hello""')).toBe('\\"hello\\"\\"');
-  });
-});
-
-describe('escapeQuotes', () => {
-  it('should escape all quotes', () => {
-    expect(escapeQuotes('"hello, world!"')).toBe('\\"hello, world!\\"');
-    expect(escapeQuotes('hello, world!')).toBe('hello, world!');
-    expect(escapeQuotes('hello, "world"!')).toBe('hello, \\"world\\"!');
-    expect(escapeQuotes('hello"')).toBe('hello\\"');
-  });
-});
 
 describe('Unified Altering misc', () => {
   describe('sortAlerts', () => {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -111,13 +111,6 @@ export function makeAMLink(path: string, alertManagerName?: string, options?: UR
   return `${path}?${search.toString()}`;
 }
 
-export const escapeQuotes = (input: string) => input.replace(/\"/g, '\\"');
-
-export function wrapWithQuotes(input: string) {
-  const alreadyWrapped = input.startsWith('"') && input.endsWith('"');
-  return alreadyWrapped ? escapeQuotes(input) : `"${escapeQuotes(input)}"`;
-}
-
 export function makeLabelBasedSilenceLink(alertManagerSourceName: string, labels: Labels) {
   const silenceUrlParams = new URLSearchParams();
   silenceUrlParams.append('alertmanager', alertManagerSourceName);


### PR DESCRIPTION
**What is this feature?**

This PR prevents the "silences preview" feature from not showing any results on older versions of Prometheus or Mimir with `utf8_strict_mode` disabled.

**Which issue(s) does this PR fix?**:

Fixes #94320
Fixes #94580