### PR TITLE
Plugins: Disable plugin uninstall while plugin is installing

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.test.tsx
@@ -230,12 +230,40 @@ describe('InstallControlsButton', () => {
       expect(button).toBeDisabled();
     });
 
+    it('should be disabled when isInstalling=false but isUpdatingFromInstance=true', () => {
+      store.dispatch({ type: 'plugins/uninstall/fulfilled', payload: { id: '', changes: {} } });
+      render(
+        <TestProvider store={store}>
+          <InstallControlsButton
+            plugin={{ ...plugin, isUpdatingFromInstance: true }}
+            pluginStatus={PluginStatus.UNINSTALL}
+          />
+        </TestProvider>
+      );
+      const button = screen.getByText('Uninstall').closest('button');
+      expect(button).toBeDisabled();
+    });
+
+    it('should be disabled when isInstalling=false but isFullyInstalled=false', () => {
+      store.dispatch({ type: 'plugins/uninstall/fulfilled', payload: { id: '', changes: {} } });
+      render(
+        <TestProvider store={store}>
+          <InstallControlsButton
+            plugin={{ ...plugin, isFullyInstalled: false }}
+            pluginStatus={PluginStatus.UNINSTALL}
+          />
+        </TestProvider>
+      );
+      const button = screen.getByText('Uninstall').closest('button');
+      expect(button).toBeDisabled();
+    });
+
     it('should be enabled when isInstalling=false and isUninstallingFromInstance=false', () => {
       store.dispatch({ type: 'plugins/uninstall/fulfilled', payload: { id: '', changes: {} } });
       render(
         <TestProvider store={store}>
           <InstallControlsButton
-            plugin={{ ...plugin, isUninstallingFromInstance: false }}
+            plugin={{ ...plugin, isUninstallingFromInstance: false, isFullyInstalled: true }}
             pluginStatus={PluginStatus.UNINSTALL}
           />
         </TestProvider>

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -119,7 +119,7 @@ export function InstallControlsButton({
 
   let disableUninstall =
     config.pluginAdminExternalManageEnabled && configCore.featureToggles.managedPluginsInstall
-      ? plugin.isUninstallingFromInstance
+      ? plugin.isUninstallingFromInstance || !plugin.isFullyInstalled || plugin.isUpdatingFromInstance
       : isUninstalling;
   let uninstallTitle = '';
   if (plugin.isPreinstalled.found) {

--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsButton.tsx
@@ -117,10 +117,8 @@ export function InstallControlsButton({
     }
   };
 
-  let disableUninstall =
-    config.pluginAdminExternalManageEnabled && configCore.featureToggles.managedPluginsInstall
-      ? plugin.isUninstallingFromInstance || !plugin.isFullyInstalled || plugin.isUpdatingFromInstance
-      : isUninstalling;
+  let disableUninstall = shouldDisableUninstall(isUninstalling, plugin);
+
   let uninstallTitle = '';
   if (plugin.isPreinstalled.found) {
     disableUninstall = true;
@@ -178,4 +176,12 @@ export function InstallControlsButton({
       {isInstalling ? 'Installing' : 'Install'}
     </Button>
   );
+}
+
+function shouldDisableUninstall(isUninstalling: boolean, plugin: CatalogPlugin) {
+  if (config.pluginAdminExternalManageEnabled && config.featureToggles.managedPluginsInstall) {
+    return plugin.isUninstallingFromInstance || !plugin.isFullyInstalled || plugin.isUpdatingFromInstance;
+  }
+
+  return isUninstalling;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disable plugin uninstall while the plugin is not fully installed in cloud.

**Why do we need this feature?**

This is a bug fix to avoid that a user uninstall a plugin in cloud that was not fully installed.

**Who is this feature for?**

Plugin catalog users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/95050

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
