### PR TITLE
Proxy: Write error message to HTTP response

### DIFF
--- a/pkg/util/proxyutil/reverse_proxy.go
+++ b/pkg/util/proxyutil/reverse_proxy.go
@@ -3,6 +3,7 @@ package proxyutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -128,6 +129,9 @@ func errorHandler(logger glog.Logger) func(http.ResponseWriter, *http.Request, e
 		if errors.Is(err, context.Canceled) {
 			ctxLogger.Debug("Proxy request cancelled by client")
 			w.WriteHeader(StatusClientClosedRequest)
+
+			//nolint:errcheck
+			fmt.Fprint(w, "Proxy request cancelled by client")
 			return
 		}
 
@@ -135,11 +139,17 @@ func errorHandler(logger glog.Logger) func(http.ResponseWriter, *http.Request, e
 		if timeoutErr, ok := err.(timeoutError); ok && timeoutErr.Timeout() {
 			ctxLogger.Error("Proxy request timed out", "err", err)
 			w.WriteHeader(http.StatusGatewayTimeout)
+
+			//nolint:errcheck
+			fmt.Fprintf(w, "Proxy request timed out: %s", err)
 			return
 		}
 
 		ctxLogger.Error("Proxy request failed", "err", err)
 		w.WriteHeader(http.StatusBadGateway)
+
+		//nolint:errcheck
+		fmt.Fprintf(w, "Proxy request failed: %s", err)
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

It the http proxy fails it will also responsd with a (hopefully) helpful error message.

**Why do we need this feature?**

It saves time to debug errors occuring during proxy requests.

**Who is this feature for?**

For everyone setting up data sources.

**Special notes for your reviewer:**

I don't know how to display the error message in the Web UI. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
