### PR TITLE
Alerting: Fix per-receiver RBAC for receivers with long names

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
@@ -2,6 +2,8 @@ package ossaccesscontrol
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 
 	"github.com/grafana/authlib/claims"
 
@@ -76,12 +78,13 @@ type ReceiverPermissionsService struct {
 // SetDefaultPermissions sets the default permissions for a newly created receiver.
 func (r ReceiverPermissionsService) SetDefaultPermissions(ctx context.Context, orgID int64, user identity.Requester, uid string) {
 	r.log.Debug("Setting default permissions for receiver", "receiver_uid", uid)
+	resourceId := uidToResourceID(uid)
 	permissions := defaultPermissions()
 	clearCache := false
 	if user != nil && user.IsIdentityType(claims.TypeUser) {
 		userID, err := user.GetInternalID()
 		if err != nil {
-			r.log.Error("Could not make user admin", "receiver_uid", uid, "id", user.GetID(), "error", err)
+			r.log.Error("Could not make user admin", "receiver_uid", uid, "resource_id", resourceId, "id", user.GetID(), "error", err)
 		} else {
 			permissions = append(permissions, accesscontrol.SetResourcePermissionCommand{
 				UserID: userID, Permission: string(alertingac.ReceiverPermissionAdmin),
@@ -90,8 +93,8 @@ func (r ReceiverPermissionsService) SetDefaultPermissions(ctx context.Context, o
 		}
 	}
 
-	if _, err := r.SetPermissions(ctx, orgID, uid, permissions...); err != nil {
-		r.log.Error("Could not set default permissions", "receiver_uid", uid, "error", err)
+	if _, err := r.SetPermissions(ctx, orgID, resourceId, permissions...); err != nil {
+		r.log.Error("Could not set default permissions", "receiver_uid", uid, "resource_id", resourceId, "id", "error", err)
 	}
 
 	if clearCache {
@@ -120,13 +123,15 @@ func copyPermissionUser(orgID int64) identity.Requester {
 // name.
 func (r ReceiverPermissionsService) CopyPermissions(ctx context.Context, orgID int64, user identity.Requester, oldUID, newUID string) (int, error) {
 	r.log.Debug("Copying permissions from receiver", "old_uid", oldUID, "new_uid", newUID)
-	currentPermissions, err := r.GetPermissions(ctx, copyPermissionUser(orgID), oldUID)
+	oldResourceId := uidToResourceID(oldUID)
+	newResourceId := uidToResourceID(newUID)
+	currentPermissions, err := r.GetPermissions(ctx, copyPermissionUser(orgID), oldResourceId)
 	if err != nil {
 		return 0, err
 	}
 
 	setPermissionCommands := r.toSetResourcePermissionCommands(currentPermissions)
-	if _, err := r.SetPermissions(ctx, orgID, newUID, setPermissionCommands...); err != nil {
+	if _, err := r.SetPermissions(ctx, orgID, newResourceId, setPermissionCommands...); err != nil {
 		return 0, err
 	}
 
@@ -144,6 +149,17 @@ func (r ReceiverPermissionsService) CopyPermissions(ctx context.Context, orgID i
 	}
 
 	return countCustomPermissions(setPermissionCommands), nil
+}
+
+func (r ReceiverPermissionsService) DeleteResourcePermissions(ctx context.Context, orgID int64, uid string) error {
+	return r.Service.DeleteResourcePermissions(ctx, orgID, uidToResourceID(uid))
+}
+
+// uidToResourceID converts a receiver uid to a resource id. This is necessary as resource ids are limited to 40 characters.
+func uidToResourceID(uid string) string {
+	h := sha1.New()
+	h.Write([]byte(uid))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // toSetResourcePermissionCommands converts a list of resource permissions to a list of set resource permission commands.

--- a/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
@@ -76,7 +76,7 @@ type ReceiverPermissionsService struct {
 // SetDefaultPermissions sets the default permissions for a newly created receiver.
 func (r ReceiverPermissionsService) SetDefaultPermissions(ctx context.Context, orgID int64, user identity.Requester, uid string) {
 	r.log.Debug("Setting default permissions for receiver", "receiver_uid", uid)
-	resourceId := alertingac.ReceiverUidToResourceId(uid)
+	resourceId := alertingac.ScopeReceiversProvider.GetResourceIDFromUID(uid)
 	permissions := defaultPermissions()
 	clearCache := false
 	if user != nil && user.IsIdentityType(claims.TypeUser) {
@@ -121,8 +121,8 @@ func copyPermissionUser(orgID int64) identity.Requester {
 // name.
 func (r ReceiverPermissionsService) CopyPermissions(ctx context.Context, orgID int64, user identity.Requester, oldUID, newUID string) (int, error) {
 	r.log.Debug("Copying permissions from receiver", "old_uid", oldUID, "new_uid", newUID)
-	oldResourceId := alertingac.ReceiverUidToResourceId(oldUID)
-	newResourceId := alertingac.ReceiverUidToResourceId(newUID)
+	oldResourceId := alertingac.ScopeReceiversProvider.GetResourceIDFromUID(oldUID)
+	newResourceId := alertingac.ScopeReceiversProvider.GetResourceIDFromUID(newUID)
 	currentPermissions, err := r.GetPermissions(ctx, copyPermissionUser(orgID), oldResourceId)
 	if err != nil {
 		return 0, err
@@ -150,7 +150,7 @@ func (r ReceiverPermissionsService) CopyPermissions(ctx context.Context, orgID i
 }
 
 func (r ReceiverPermissionsService) DeleteResourcePermissions(ctx context.Context, orgID int64, uid string) error {
-	return r.Service.DeleteResourcePermissions(ctx, orgID, alertingac.ReceiverUidToResourceId(uid))
+	return r.Service.DeleteResourcePermissions(ctx, orgID, alertingac.ScopeReceiversProvider.GetResourceIDFromUID(uid))
 }
 
 // toSetResourcePermissionCommands converts a list of resource permissions to a list of set resource permission commands.

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -1,8 +1,6 @@
 package resourcepermissions
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -14,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	alertingac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/setting"
@@ -441,13 +440,7 @@ func MiddlewareReceiverUIDResolver(paramName string) web.Handler {
 	return func(c *contextmodel.ReqContext) {
 		gotParams := web.Params(c.Req)
 		uid := gotParams[paramName]
-		gotParams[paramName] = uidToResourceID(uid)
+		gotParams[paramName] = alertingac.ReceiverUidToResourceId(uid)
 		web.SetURLParams(c.Req, gotParams)
 	}
-}
-
-func uidToResourceID(uid string) string {
-	h := sha1.New()
-	h.Write([]byte(uid))
-	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -440,7 +440,7 @@ func MiddlewareReceiverUIDResolver(paramName string) web.Handler {
 	return func(c *contextmodel.ReqContext) {
 		gotParams := web.Params(c.Req)
 		uid := gotParams[paramName]
-		gotParams[paramName] = alertingac.ReceiverUidToResourceId(uid)
+		gotParams[paramName] = alertingac.ScopeReceiversProvider.GetResourceIDFromUID(uid)
 		web.SetURLParams(c.Req, gotParams)
 	}
 }

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -439,8 +439,9 @@ func permissionSetResponse(cmd setPermissionCommand) response.Response {
 func MiddlewareReceiverUIDResolver(paramName string) web.Handler {
 	return func(c *contextmodel.ReqContext) {
 		gotParams := web.Params(c.Req)
-		uid := gotParams[paramName]
-		gotParams[paramName] = alertingac.ScopeReceiversProvider.GetResourceIDFromUID(uid)
-		web.SetURLParams(c.Req, gotParams)
+		if uid, ok := gotParams[paramName]; ok {
+			gotParams[paramName] = alertingac.ScopeReceiversProvider.GetResourceIDFromUID(uid)
+			web.SetURLParams(c.Req, gotParams)
+		}
 	}
 }

--- a/pkg/services/ngalert/accesscontrol/receivers.go
+++ b/pkg/services/ngalert/accesscontrol/receivers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const (
@@ -291,6 +292,9 @@ func extendAccessControl[T models.Identified](base *actionAccess[T], operator fu
 
 // ReceiverUidToResourceId converts a receiver uid to a resource id. This is necessary as resource ids are limited to 40 characters.
 func ReceiverUidToResourceId(uid string) string {
+	if len(uid) <= util.MaxUIDLength {
+		return uid
+	}
 	h := sha1.New()
 	h.Write([]byte(uid))
 	return hex.EncodeToString(h.Sum(nil))

--- a/pkg/services/ngalert/accesscontrol/receivers.go
+++ b/pkg/services/ngalert/accesscontrol/receivers.go
@@ -2,6 +2,7 @@ package accesscontrol
 
 import (
 	"context"
+	// #nosec G505 Used only for shortening the uid, not for security purposes.
 	"crypto/sha1"
 	"encoding/hex"
 
@@ -34,6 +35,7 @@ func (p ReceiverScopeProvider) GetResourceIDFromUID(uid string) string {
 	if len(uid) <= util.MaxUIDLength {
 		return uid
 	}
+	// #nosec G505 Used only for shortening the uid, not for security purposes.
 	h := sha1.New()
 	h.Write([]byte(uid))
 	return hex.EncodeToString(h.Sum(nil))

--- a/pkg/services/ngalert/accesscontrol/receivers.go
+++ b/pkg/services/ngalert/accesscontrol/receivers.go
@@ -182,7 +182,7 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 			action:        "read",
 			authorizeSome: readRedactedReceiversPreConditionsEval,
 			authorizeOne: func(receiver models.Identified) ac.Evaluator {
-				return readRedactedReceiverEval(receiver.GetUID())
+				return readRedactedReceiverEval(ReceiverUidToResourceId(receiver.GetUID()))
 			},
 			authorizeAll: readRedactedAllReceiversEval,
 		},
@@ -194,7 +194,7 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 			action:        "read",
 			authorizeSome: readDecryptedReceiversPreConditionsEval,
 			authorizeOne: func(receiver models.Identified) ac.Evaluator {
-				return readDecryptedReceiverEval(receiver.GetUID())
+				return readDecryptedReceiverEval(ReceiverUidToResourceId(receiver.GetUID()))
 			},
 			authorizeAll: readDecryptedAllReceiversEval,
 		},
@@ -218,7 +218,7 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 			action:        "update",
 			authorizeSome: updateReceiversPreConditionsEval,
 			authorizeOne: func(receiver models.Identified) ac.Evaluator {
-				return updateReceiverEval(receiver.GetUID())
+				return updateReceiverEval(ReceiverUidToResourceId(receiver.GetUID()))
 			},
 			authorizeAll: updateAllReceiversEval,
 		},
@@ -230,7 +230,7 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 			action:        "delete",
 			authorizeSome: deleteReceiversPreConditionsEval,
 			authorizeOne: func(receiver models.Identified) ac.Evaluator {
-				return deleteReceiverEval(receiver.GetUID())
+				return deleteReceiverEval(ReceiverUidToResourceId(receiver.GetUID()))
 			},
 			authorizeAll: deleteAllReceiversEval,
 		},
@@ -242,7 +242,7 @@ func NewReceiverAccess[T models.Identified](a ac.AccessControl, includeProvision
 			action:        "admin", // Essentially read+write receiver resource permissions.
 			authorizeSome: permissionsReceiversPreConditionsEval,
 			authorizeOne: func(receiver models.Identified) ac.Evaluator {
-				return permissionsReceiverEval(receiver.GetUID())
+				return permissionsReceiverEval(ReceiverUidToResourceId(receiver.GetUID()))
 			},
 			authorizeAll: permissionsAllReceiversEval,
 		},

--- a/pkg/services/ngalert/accesscontrol/receivers.go
+++ b/pkg/services/ngalert/accesscontrol/receivers.go
@@ -2,6 +2,8 @@ package accesscontrol
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -285,6 +287,13 @@ func extendAccessControl[T models.Identified](base *actionAccess[T], operator fu
 	base.authorizeOne = func(resource models.Identified) ac.Evaluator {
 		return operator(extension.authorizeOne(resource), baseOne(resource))
 	}
+}
+
+// ReceiverUidToResourceId converts a receiver uid to a resource id. This is necessary as resource ids are limited to 40 characters.
+func ReceiverUidToResourceId(uid string) string {
+	h := sha1.New()
+	h.Write([]byte(uid))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // HasList checks if user has access to list redacted receivers. Returns false if user does not have access.

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -851,7 +851,7 @@ func TestReceiverServiceAC_Read(t *testing.T) {
 	emailIntegration := models.IntegrationGen(models.IntegrationMuts.WithName("test receiver"), models.IntegrationMuts.WithValidConfig("email"))
 	recv1 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver1"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	recv2 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver2"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
-	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver3"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
+	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver with a really long name that surpasses 40 characters"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	allReceivers := func() []models.Receiver {
 		return []models.Receiver{recv1, recv2, recv3}
 	}
@@ -990,7 +990,7 @@ func TestReceiverServiceAC_Create(t *testing.T) {
 	emailIntegration := models.IntegrationGen(models.IntegrationMuts.WithName("test receiver"), models.IntegrationMuts.WithValidConfig("email"))
 	recv1 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver1"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	recv2 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver2"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
-	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver3"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
+	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver with a really long name that surpasses 40 characters"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	allReceivers := func() []models.Receiver {
 		return []models.Receiver{recv1, recv2, recv3}
 	}
@@ -1078,7 +1078,7 @@ func TestReceiverServiceAC_Update(t *testing.T) {
 	emailIntegration := models.IntegrationGen(models.IntegrationMuts.WithName("test receiver"), models.IntegrationMuts.WithValidConfig("email"))
 	recv1 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver1"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	recv2 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver2"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
-	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver3"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
+	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver with a really long name that surpasses 40 characters"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	allReceivers := func() []models.Receiver {
 		return []models.Receiver{recv1, recv2, recv3}
 	}
@@ -1230,7 +1230,7 @@ func TestReceiverServiceAC_Delete(t *testing.T) {
 	emailIntegration := models.IntegrationGen(models.IntegrationMuts.WithName("test receiver"), models.IntegrationMuts.WithValidConfig("email"))
 	recv1 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver1"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	recv2 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver2"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
-	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver3"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
+	recv3 := models.ReceiverGen(models.ReceiverMuts.WithName("receiver with a really long name that surpasses 40 characters"), models.ReceiverMuts.WithIntegrations(slackIntegration(), emailIntegration()))()
 	allReceivers := func() []models.Receiver {
 		return []models.Receiver{recv1, recv2, recv3}
 	}

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -481,6 +481,14 @@ func TestIntegrationAccessControl(t *testing.T) {
 		)...),
 	})
 
+	// Test receivers with uids longer than 40 characters. User name is used in receiver name.
+	adminLikeUserLongName := helper.CreateUser("adminLikeUserCreatingAReallyLongReceiverName", apis.Org1, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{
+		createWildcardPermission(append(
+			[]string{accesscontrol.ActionAlertingReceiversCreate},
+			ossaccesscontrol.ReceiversAdminActions...,
+		)...),
+	})
+
 	// endregion
 
 	testCases := []testCase{
@@ -548,6 +556,15 @@ func TestIntegrationAccessControl(t *testing.T) {
 		},
 		{
 			user:           adminLikeUser,
+			canRead:        true,
+			canCreate:      true,
+			canUpdate:      true,
+			canDelete:      true,
+			canAdmin:       true,
+			canReadSecrets: true,
+		},
+		{
+			user:           adminLikeUserLongName,
 			canRead:        true,
 			canCreate:      true,
 			canUpdate:      true,


### PR DESCRIPTION
As part of per-receiver RBAC (FF `alertingApiServer`), receiver permissions are scoped at the UID level. However, receiver's don't yet have "real" UIDs, instead UIDs are generated from the base64 hex encoding of the receiver name. This is to maintain backwards compatibility with the stable provision API.

The issue arises when receiver names are long enough that their base64 encoding surpasses the maximum column length for identifiers in the `permission` table (40 characters).

The solution in this PR is to resolve UIDs longer than 40 characters to their SHA1 hash hex encoding (always 40 characters long). This SHA1 is used as the resource identifier for these long-named receivers.

There were a couple alternatives we considered:

1. Modify the UID to be the SHA1 hash directly, instead of just as the resource ID for permissions. We decided against this as the reversibility of base64 allows us much simpler logic when handling renames of receivers.
2. Always use the SHA1 hash as the resource ID, not just when the UID is longer than 40 characters. Making the resource ID conditional means we don't have to create a migration to migrate all existing receiver uid-like identifiers to their SHA1 hash.

This is slightly hacky, but a proper solution that introduces an actual UID on the receiver type will have to wait until a major version update / a new provisioning API version.

Notes:
- The identifiers stored under the `uid` attribute can now be either the base64 encoding of the receiver name OR the SHA1 hash of said encoding, this is a bit awkward but no information should be lose as we should always be able to identify which type it is from the value.
- This feature is not GA and is still behind an experimental FF.