### PR TITLE
Fix: Display organization name on SignupInvited page (#94932)

### DIFF
--- a/public/app/features/invites/SignupInvited.tsx
+++ b/public/app/features/invites/SignupInvited.tsx
@@ -9,7 +9,6 @@ import { Button, Field, Input, useStyles2 } from '@grafana/ui';
 import { Form } from 'app/core/components/Form/Form';
 import { Page } from 'app/core/components/Page/Page';
 import { getConfig } from 'app/core/config';
-import { contextSrv } from 'app/core/core';
 
 import { w3cStandardEmailValidator } from '../admin/utils';
 
@@ -37,19 +36,28 @@ export const SignupInvitedPage = () => {
   const [initFormModel, setInitFormModel] = useState<FormModel>();
   const [greeting, setGreeting] = useState<string>();
   const [invitedBy, setInvitedBy] = useState<string>();
+  const [orgName, setOrgName] = useState<string>(''); // State for organization name
   const styles = useStyles2(getStyles);
 
+  // Fetch invite data including organization name
   useAsync(async () => {
-    const invite = await getBackendSrv().get(`/api/user/invite/${code}`);
+    try {
+      const invite = await getBackendSrv().get(`/api/user/invite/${code}`);
 
-    setInitFormModel({
-      email: invite.email,
-      name: invite.name,
-      username: invite.email,
-    });
+      setInitFormModel({
+        email: invite.email,
+        name: invite.name,
+        username: invite.email,
+      });
 
-    setGreeting(invite.name || invite.email || invite.username);
-    setInvitedBy(invite.invitedBy);
+      setGreeting(invite.name || invite.email || invite.username);
+      setInvitedBy(invite.invitedBy);
+
+      // Fetch organization name from invite or fallback to 'your organization'
+      setOrgName(invite.orgName || 'your organization');
+    } catch (error) {
+      console.error('Failed to load invite data:', error);
+    }
   }, [code]);
 
   const onSubmit = async (formData: FormModel) => {
@@ -68,7 +76,7 @@ export const SignupInvitedPage = () => {
 
         <div className={cx('modal-tagline', styles.tagline)}>
           <em>{invitedBy || 'Someone'}</em> has invited you to join Grafana and the organization{' '}
-          <span className="highlight-word">{contextSrv.user.orgName}</span>
+          <span className="highlight-word">{orgName}</span> {/* Display fetched organization name */}
           <br />
           Please complete the following and choose a password to accept your invitation and continue:
         </div>


### PR DESCRIPTION

### What Happened?

When a user is invited to an organization and clicks the invite link (in the format `https://<grafana_domain>/invite/<invite_code>`), the text on the signup page was incomplete. It read:

Alice has invited you to join Grafana and the organization


The organization name was missing, and it should have been included at the end, e.g.,

Alice has invited you to join Grafana and the organization BigCorp


This was due to the fact that the user account doesn't yet exist at this stage (it only exists as a temporary account), so `contextSrv.user.orgName` was not available.

### What Did You Expect to Happen?

The page should correctly display the organization name that the user was invited to.

### What Was Done to Fix It?

This pull request fixes issue #94932 by @iemafzalhassan:

- Fetching the organization name directly from the invite data rather than relying on the temporary user account.
- Updating the `SignupInvited.tsx` component to correctly display the organization name.
- Adding a fallback to display "your organization" if the organization name isn't available in the invite data.

### How to Reproduce?

1. Under "Organization users", click "Invite" and generate an invite.
2. Either copy the invite link from the email or get it from the list of pending invites.
3. Open the invite link on a different browser or in incognito mode.
4. Observe that the organization name is now correctly included in the invite message.

### Did This Work Before?

It seems that this issue has been present in all major Grafana versions, so it's not a regression. Testing has been done across multiple versions from v3.x to v11.x, and the bug persists.

### How Was This Tested?

- Manually tested the invite flow to ensure that the organization name is displayed correctly on the signup page.
- Tested in multiple browsers and across different Grafana versions to ensure compatibility.

### Issue Reference

Closes #94932.

