### PR TITLE
ElasticSearch: Add playwright smoke test

### DIFF
--- a/e2e/plugin-e2e/elasticsearch/elasticsearch.spec.ts
+++ b/e2e/plugin-e2e/elasticsearch/elasticsearch.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test('Smoke test: decoupled frontend plugin loads', async ({ createDataSourceConfigPage, page }) => {
+  await createDataSourceConfigPage({ type: 'elasticsearch' });
+
+  await expect(await page.getByText('Type: Elasticsearch', { exact: true })).toBeVisible();
+  await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,15 @@ export default defineConfig<PluginOptions>({
       dependencies: ['createUserAndAuthenticate'],
     },
     {
+      name: 'elasticsearch',
+      testDir: path.join(testDirRoot, '/elasticsearch'),
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/admin.json',
+      },
+      dependencies: ['authenticate'],
+    },
+    {
       name: 'mysql',
       testDir: path.join(testDirRoot, '/mysql'),
       use: {


### PR DESCRIPTION
This PR adds a smoke test to assert that the frontend assets of the elasticsearch decoupled datasource have been built and load.

Note: I am actually not sure that elastic search has been decoupled but this shouldn't hurt anything :s

See https://github.com/grafana/grafana/pull/94977 for additional context