### PR TITLE
ci: Update trivy action to run on action updates

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -4,11 +4,13 @@ on:
     # only run on PRs where go.mod/go.sum/etc have been updated
     paths:
       - go.*
+      - .github/workflows/trivy-scan.yml
   push:
     branches:
       - main
     paths:
       - go.*
+      - .github/workflows/trivy-scan.yml
 
 jobs:
   trivy-scan:
@@ -33,7 +35,9 @@ jobs:
         # for the PR check, ignore JS-related issues
         skip-files: 'yarn.lock,package.json'
     - name: Run Trivy vulnerability scanner (SARIF)
-      uses: aquasecurity/trivy-action@0.28.0
+      # Note: versions 0.27.0 and 0.28.0 are broken for SARIF output, but it's
+      # unclear why - worth testing again in the future
+      uses: aquasecurity/trivy-action@0.26.0
       with:
         scan-type: 'fs'
         scanners: 'vuln'


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/94787 probably broke the Trivy workflow, but I'm not sure, because scans are only run [in certain cases](https://github.com/grafana/grafana/pull/89433) - this expands those cases...