### PR TITLE
Prometheus: Fix field name setting for heatmap-cells type

### DIFF
--- a/pkg/promlib/querydata/response.go
+++ b/pkg/promlib/querydata/response.go
@@ -113,14 +113,16 @@ func addMetadataToMultiFrame(q *models.Query, frame *data.Frame) {
 	}
 	frame.Fields[0].Config = &data.FieldConfig{Interval: float64(q.Step.Milliseconds())}
 
-	customName := getName(q, frame.Fields[1])
-	if customName != "" {
-		frame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: customName}
-	}
+	if frame.Meta.Type != "heatmap-cells" {
+		customName := getName(q, frame.Fields[1])
+		if customName != "" {
+			frame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: customName}
+		}
 
-	valueField := frame.Fields[1]
-	if n, ok := valueField.Labels["__name__"]; ok {
-		valueField.Name = n
+		valueField := frame.Fields[1]
+		if n, ok := valueField.Labels["__name__"]; ok {
+			valueField.Name = n
+		}
 	}
 }
 

--- a/pkg/promlib/querydata/response.go
+++ b/pkg/promlib/querydata/response.go
@@ -113,16 +113,20 @@ func addMetadataToMultiFrame(q *models.Query, frame *data.Frame) {
 	}
 	frame.Fields[0].Config = &data.FieldConfig{Interval: float64(q.Step.Milliseconds())}
 
-	if frame.Meta.Type != "heatmap-cells" {
-		customName := getName(q, frame.Fields[1])
-		if customName != "" {
-			frame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: customName}
-		}
+	customName := getName(q, frame.Fields[1])
+	if customName != "" {
+		frame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: customName}
+	}
 
-		valueField := frame.Fields[1]
-		if n, ok := valueField.Labels["__name__"]; ok {
-			valueField.Name = n
-		}
+	// For heatmap-cells type we don't want to set field name
+	// prometheus native histograms have their own field name structure
+	if frame.Meta.Type == "heatmap-cells" {
+		return
+	}
+
+	valueField := frame.Fields[1]
+	if n, ok := valueField.Labels["__name__"]; ok {
+		valueField.Name = n
 	}
 }
 

--- a/pkg/promlib/querydata/response_test.go
+++ b/pkg/promlib/querydata/response_test.go
@@ -56,3 +56,15 @@ func TestQueryData_parseResponse(t *testing.T) {
 		assert.Equal(t, result.Error.Error(), "unknown result type: ")
 	})
 }
+
+func TestAddMetadataToMultiFrame(t *testing.T) {
+	t.Run("when you have native histogram result", func(t *testing.T) {
+		qd := QueryData{exemplarSampler: exemplar.NewStandardDeviationSampler}
+		resBody := `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"rpc_durations_native_histogram_seconds","instance":"nativehisto:8080","job":"prometheus"},"histograms":[[1729529685,{"count":"7243102","sum":"72460202.93145595","buckets":[[0,"1.8340080864093422","2","10"],[0,"2","2.1810154653305154","68"]]}],[1729529700,{"count":"7243490","sum":"72464056.03309634","buckets":[[0,"1.8340080864093422","2","10"],[0,"2","2.1810154653305154","68"]]}],[1729529715,{"count":"7243880","sum":"72467935.35871512","buckets":[[0,"1.8340080864093422","2","10"],[0,"2","2.1810154653305154","68"]]}]]}]}}`
+		res := &http.Response{Body: io.NopCloser(bytes.NewBufferString(resBody))}
+		result := qd.parseResponse(context.Background(), &models.Query{}, res)
+		assert.Nil(t, result.Error)
+		assert.Len(t, result.Frames, 1)
+		assert.Equal(t, "yMin", result.Frames[0].Fields[1].Name)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

We don't want to change the field name when the response type is `heatmap-cells`. For this type we have `xMax`, `yMin`, `yMax`, `count`, `yLayout` fields. If that part in the code runs for `heatmap-cells` it changes the field name with the `__name__` label value. That is breaking our heatmap visualization. So we skip that part simply adding a condition for it. 

### How to reproduce the error?
- Create a native histogram producing Prometheus datasource i.e. https://github.com/laupse/prometheus-native-histograms
- Create a dashboard and add a panel with a native histogram metric
- Select Histogram visualization
- Select range query
- Run the query

**Why do we need this feature?**

To be able to visualize the native histograms

**Who is this feature for?**

Prometheus native histogram users
