### PR TITLE
Prometheus: Fix passing query timeout to upstream queries

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -97,7 +97,6 @@ export class PrometheusDatasource
   basicAuth: any;
   withCredentials: boolean;
   interval: string;
-  queryTimeout: string | undefined;
   httpMethod: string;
   languageProvider: PrometheusLanguageProvider;
   exemplarTraceIdDestinations: ExemplarTraceIdDestination[] | undefined;
@@ -127,7 +126,6 @@ export class PrometheusDatasource
     this.basicAuth = instanceSettings.basicAuth;
     this.withCredentials = Boolean(instanceSettings.withCredentials);
     this.interval = instanceSettings.jsonData.timeInterval || '15s';
-    this.queryTimeout = instanceSettings.jsonData.queryTimeout;
     this.httpMethod = instanceSettings.jsonData.httpMethod || 'GET';
     this.exemplarTraceIdDestinations = instanceSettings.jsonData.exemplarTraceIdDestinations;
     this.hasIncrementalQuery = instanceSettings.jsonData.incrementalQuerying ?? false;

--- a/pkg/promlib/client/client_test.go
+++ b/pkg/promlib/client/client_test.go
@@ -30,7 +30,7 @@ func TestClient(t *testing.T) {
 	t.Run("QueryResource", func(t *testing.T) {
 		doer := &MockDoer{}
 		// The method here does not really matter for resource calls
-		client := NewClient(doer, http.MethodGet, "http://localhost:9090")
+		client := NewClient(doer, http.MethodGet, "http://localhost:9090", "60s")
 
 		t.Run("sends correct POST request", func(t *testing.T) {
 			req := &backend.CallResourceRequest{
@@ -86,7 +86,7 @@ func TestClient(t *testing.T) {
 		doer := &MockDoer{}
 
 		t.Run("sends correct POST query", func(t *testing.T) {
-			client := NewClient(doer, http.MethodPost, "http://localhost:9090")
+			client := NewClient(doer, http.MethodPost, "http://localhost:9090", "60s")
 			req := &models.Query{
 				Expr:       "rate(ALERTS{job=\"test\" [$__rate_interval]})",
 				Start:      time.Unix(0, 0),
@@ -108,12 +108,12 @@ func TestClient(t *testing.T) {
 			require.Equal(t, "application/x-www-form-urlencoded", doer.Req.Header.Get("Content-Type"))
 			body, err := io.ReadAll(doer.Req.Body)
 			require.NoError(t, err)
-			require.Equal(t, []byte("end=1234&query=rate%28ALERTS%7Bjob%3D%22test%22+%5B%24__rate_interval%5D%7D%29&start=0&step=1"), body)
+			require.Equal(t, []byte("end=1234&query=rate%28ALERTS%7Bjob%3D%22test%22+%5B%24__rate_interval%5D%7D%29&start=0&step=1&timeout=60s"), body)
 			require.Equal(t, "http://localhost:9090/api/v1/query_range", doer.Req.URL.String())
 		})
 
 		t.Run("sends correct GET query", func(t *testing.T) {
-			client := NewClient(doer, http.MethodGet, "http://localhost:9090")
+			client := NewClient(doer, http.MethodGet, "http://localhost:9090", "60s")
 			req := &models.Query{
 				Expr:       "rate(ALERTS{job=\"test\" [$__rate_interval]})",
 				Start:      time.Unix(0, 0),
@@ -135,7 +135,7 @@ func TestClient(t *testing.T) {
 			body, err := io.ReadAll(doer.Req.Body)
 			require.NoError(t, err)
 			require.Equal(t, []byte{}, body)
-			require.Equal(t, "http://localhost:9090/api/v1/query_range?end=1234&query=rate%28ALERTS%7Bjob%3D%22test%22+%5B%24__rate_interval%5D%7D%29&start=0&step=1", doer.Req.URL.String())
+			require.Equal(t, "http://localhost:9090/api/v1/query_range?end=1234&query=rate%28ALERTS%7Bjob%3D%22test%22+%5B%24__rate_interval%5D%7D%29&start=0&step=1&timeout=60s", doer.Req.URL.String())
 		})
 	})
 }

--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -44,8 +44,7 @@ type QueryData struct {
 	ID                 int64
 	URL                string
 	TimeInterval       string
-	// QueryTimeout       time.Duration
-	exemplarSampler func() exemplar.Sampler
+	exemplarSampler    func() exemplar.Sampler
 }
 
 func New(

--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -67,6 +67,9 @@ func New(
 	}
 
 	queryTimeout, err := maputil.GetStringOptional(jsonData, "queryTimeout")
+	if err != nil {
+		return nil, err
+	}
 
 	promClient := client.NewClient(httpClient, httpMethod, settings.URL, queryTimeout)
 

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -40,9 +40,11 @@ func New(
 		httpMethod = http.MethodPost
 	}
 
+	queryTimeout, err := maputil.GetStringOptional(jsonData, "queryTimeout")
+
 	return &Resource{
 		log:        plog,
-		promClient: client.NewClient(httpClient, httpMethod, settings.URL),
+		promClient: client.NewClient(httpClient, httpMethod, settings.URL, queryTimeout),
 	}, nil
 }
 

--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -40,11 +40,10 @@ func New(
 		httpMethod = http.MethodPost
 	}
 
-	queryTimeout, err := maputil.GetStringOptional(jsonData, "queryTimeout")
-
 	return &Resource{
-		log:        plog,
-		promClient: client.NewClient(httpClient, httpMethod, settings.URL, queryTimeout),
+		log: plog,
+		// we don't use queryTimeout for resource calls
+		promClient: client.NewClient(httpClient, httpMethod, settings.URL, ""),
 	}, nil
 }
 


### PR DESCRIPTION
**What is this feature?**

In Prometheus data source we have an additional "query timeout" value in the settings. This was being used to limit how long a query will be evaluated. See the docs: https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
![image](https://github.com/user-attachments/assets/8a69e09c-846f-48a6-839d-3415ac0bc39b)

During the backend transformation of the data source this was missed to be included to the code. We already have "timeout" configuration. But this is being used to control how long after a query going to grafana backend will be canceled. 
![image](https://github.com/user-attachments/assets/55a92426-3206-4e65-bf91-b14dfa46cf79)

So in this PR we put back that upstream query timeout value in place. 

**Why do we need this feature?**

For more explicit query timeout setting.

**Who is this feature for?**

Prometheus users
