### PR TITLE
Fix(devenv): use #!/usr/bin/env for bash scripts

### DIFF
--- a/devenv/bulk-folders/bulk-folders.sh
+++ b/devenv/bulk-folders/bulk-folders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Deleting previous bulk folders"
 find ./bulk-folders -type d -name "Bulk Folder*" -exec rm -rf "{}" \;

--- a/devenv/create_docker_compose.sh
+++ b/devenv/create_docker_compose.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 blocks_dir=docker/blocks
 docker_dir=docker

--- a/devenv/setup.sh
+++ b/devenv/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bulkDashboard() {
 


### PR DESCRIPTION
**What is this feature?**

This solves problems on Linux distros like NixOS and BSDs like FreeBSD that don't provide `/bin/bash`, while also maintaining support for all other distros out there (AFAIK? even Alpine with its Busybox has /usr/bin/env).

**Why do we need this feature?**

We want to keep as many engineers as possible able to develop within our project.

**Who is this feature for?**

Users of the aforementioned Linux distros and BSDs.

**Which issue(s) does this PR fix?**:

I didn't create one.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
