### PR TITLE
api: use alerting headers

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
@@ -1,0 +1,60 @@
+package clientmiddleware
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/services/contexthandler"
+)
+
+func NewUseAlertHeadersMiddleware() backend.HandlerMiddleware {
+	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
+		return &UseAlertHeadersMiddleware{
+			BaseHandler: backend.NewBaseHandler(next),
+		}
+	})
+}
+
+type UseAlertHeadersMiddleware struct {
+	backend.BaseHandler
+}
+
+var alertHeaders = []string{
+	"Fromalert",
+	"X-Rule-Name",
+	"X-Rule-Folder",
+	"X-Rule-Source",
+	"X-Rule-Type",
+	"X-Rule-Version",
+}
+
+func applyAlertHeaders(ctx context.Context, req *backend.QueryDataRequest) {
+	reqCtx := contexthandler.FromContext(ctx)
+	if reqCtx == nil || reqCtx.Req == nil {
+		return
+	}
+	incomingHeaders := reqCtx.Req.Header
+
+	for _, key := range alertHeaders {
+		incomingValue := incomingHeaders.Get(key)
+		if incomingValue != "" {
+			req.SetHTTPHeader(key, incomingValue)
+		}
+	}
+
+	// datasources check for the "alerting" case by checking
+	// req.Headers["FromAlert"]
+	// (yes, incorrectly capitalized).
+	// so we specially add that one
+	// to req.Headers (not to headers-to-forward,
+	// that we solved above)
+	isFromAlert := incomingHeaders.Get("Fromalert")
+	if isFromAlert != "" {
+		req.Headers["FromAlert"] = isFromAlert
+	}
+}
+
+func (m *UseAlertHeadersMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	applyAlertHeaders(ctx, req)
+	return m.BaseHandler.QueryData(ctx, req)
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
@@ -39,7 +39,9 @@ func applyAlertHeaders(ctx context.Context, req *backend.QueryDataRequest) {
 	for _, key := range alertHeaders {
 		incomingValue := incomingHeaders.Get(key)
 		if incomingValue != "" {
-			// FromAlert must be set directly, with the wrong capitalization.
+			// FromAlert must be set directly, because we need
+			// to keep the incorrect capitalization for backwards-compatibility
+			// reasons. otherwise Go would normalize it to "Fromalert"
 			if key == ngalertmodels.FromAlertHeaderName {
 				req.Headers[key] = incomingValue
 			} else {

--- a/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
@@ -26,7 +26,7 @@ var alertHeaders = []string{
 	"X-Rule-Source",
 	"X-Rule-Type",
 	"X-Rule-Version",
-	// note, this list does not Contain `Fromalert`, we handle that separately
+	ngalertmodels.FromAlertHeaderName,
 }
 
 func applyAlertHeaders(ctx context.Context, req *backend.QueryDataRequest) {
@@ -39,20 +39,13 @@ func applyAlertHeaders(ctx context.Context, req *backend.QueryDataRequest) {
 	for _, key := range alertHeaders {
 		incomingValue := incomingHeaders.Get(key)
 		if incomingValue != "" {
-			req.SetHTTPHeader(key, incomingValue)
+			// FromAlert must be set directly, with the wrong capitalization.
+			if key == ngalertmodels.FromAlertHeaderName {
+				req.Headers[key] = incomingValue
+			} else {
+				req.SetHTTPHeader(key, incomingValue)
+			}
 		}
-	}
-
-	// datasources check for the "alerting" case by checking
-	// req.Headers["FromAlert"]
-	// (yes, incorrectly capitalized).
-	// so we specially add that one
-	// to req.Headers (not to headers-to-forward,
-	// that we solved above)
-	alertHeader := ngalertmodels.FromAlertHeaderName
-	isFromAlert := incomingHeaders.Get(alertHeader)
-	if isFromAlert != "" {
-		req.Headers[alertHeader] = isFromAlert
 	}
 }
 

--- a/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
+	ngalertmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func NewUseAlertHeadersMiddleware() backend.HandlerMiddleware {
@@ -20,12 +21,12 @@ type UseAlertHeadersMiddleware struct {
 }
 
 var alertHeaders = []string{
-	"Fromalert",
 	"X-Rule-Name",
 	"X-Rule-Folder",
 	"X-Rule-Source",
 	"X-Rule-Type",
 	"X-Rule-Version",
+	// note, this list does not Contain `Fromalert`, we handle that separately
 }
 
 func applyAlertHeaders(ctx context.Context, req *backend.QueryDataRequest) {
@@ -48,9 +49,10 @@ func applyAlertHeaders(ctx context.Context, req *backend.QueryDataRequest) {
 	// so we specially add that one
 	// to req.Headers (not to headers-to-forward,
 	// that we solved above)
-	isFromAlert := incomingHeaders.Get("Fromalert")
+	alertHeader := ngalertmodels.FromAlertHeaderName
+	isFromAlert := incomingHeaders.Get(alertHeader)
 	if isFromAlert != "" {
-		req.Headers["FromAlert"] = isFromAlert
+		req.Headers[alertHeader] = isFromAlert
 	}
 }
 

--- a/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware_test.go
@@ -1,0 +1,76 @@
+package clientmiddleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserAlertingHeadersMiddleware(t *testing.T) {
+	testQueryDataReq := func(t *testing.T, req *http.Request) *backend.QueryDataRequest {
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			handlertest.WithMiddlewares(NewUseAlertHeadersMiddleware()),
+		)
+
+		pluginCtx := backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+		}
+
+		_, err := cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+			PluginContext: pluginCtx,
+			Headers:       map[string]string{},
+		})
+		require.NoError(t, err)
+		return cdt.QueryDataReq
+	}
+
+	t.Run("Handle non-alerting case without problems", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
+		require.NoError(t, err)
+		outReq := testQueryDataReq(t, req)
+
+		// special marker
+		require.Equal(t, "", outReq.Headers["FromAlert"])
+
+		// the normal http header
+		require.Equal(t, "", outReq.GetHTTPHeader("Fromalert"))
+
+		// the rest of hte x-rule headers
+		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Name"))
+		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Folder"))
+		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Source"))
+		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Type"))
+		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Version"))
+	})
+
+	t.Run("Use Alerting headers when they exist", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
+		require.NoError(t, err)
+		req.Header.Set("Fromalert", "true")
+		req.Header.Set("X-Rule-Name", "n1")
+		req.Header.Set("X-Rule-Folder", "f1")
+		req.Header.Set("X-Rule-Source", "s1")
+		req.Header.Set("X-Rule-Type", "t1")
+		req.Header.Set("X-Rule-Version", "v1")
+
+		outReq := testQueryDataReq(t, req)
+
+		// the special marker
+		require.Equal(t, "true", outReq.Headers["FromAlert"])
+
+		// the normal http header
+		require.Equal(t, "true", outReq.GetHTTPHeader("Fromalert"))
+
+		// the rest of hte x-rule headers
+		require.Equal(t, "n1", outReq.GetHTTPHeader("X-Rule-Name"))
+		require.Equal(t, "f1", outReq.GetHTTPHeader("X-Rule-Folder"))
+		require.Equal(t, "s1", outReq.GetHTTPHeader("X-Rule-Source"))
+		require.Equal(t, "t1", outReq.GetHTTPHeader("X-Rule-Type"))
+		require.Equal(t, "v1", outReq.GetHTTPHeader("X-Rule-Version"))
+	})
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware_test.go
@@ -37,10 +37,7 @@ func TestUserAlertingHeadersMiddleware(t *testing.T) {
 		// special marker
 		require.Equal(t, "", outReq.Headers["FromAlert"])
 
-		// the normal http header
-		require.Equal(t, "", outReq.GetHTTPHeader("Fromalert"))
-
-		// the rest of hte x-rule headers
+		// the normal http headers
 		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Name"))
 		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Folder"))
 		require.Equal(t, "", outReq.GetHTTPHeader("X-Rule-Source"))
@@ -60,13 +57,10 @@ func TestUserAlertingHeadersMiddleware(t *testing.T) {
 
 		outReq := testQueryDataReq(t, req)
 
-		// the special marker
+		// special marker
 		require.Equal(t, "true", outReq.Headers["FromAlert"])
 
-		// the normal http header
-		require.Equal(t, "true", outReq.GetHTTPHeader("Fromalert"))
-
-		// the rest of hte x-rule headers
+		// normal http headers
 		require.Equal(t, "n1", outReq.GetHTTPHeader("X-Rule-Name"))
 		require.Equal(t, "f1", outReq.GetHTTPHeader("X-Rule-Folder"))
 		require.Equal(t, "s1", outReq.GetHTTPHeader("X-Rule-Source"))

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -199,6 +199,8 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		middlewares = append(middlewares, clientmiddleware.NewHostedGrafanaACHeaderMiddleware(cfg))
 	}
 
+	middlewares = append(middlewares, clientmiddleware.NewUseAlertHeadersMiddleware())
+
 	middlewares = append(middlewares, clientmiddleware.NewHTTPClientMiddleware())
 
 	// ErrorSourceMiddleware should be at the very bottom, or any middlewares below it won't see the

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -189,6 +189,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
 		clientmiddleware.NewCachingMiddlewareWithFeatureManager(cachingService, features),
 		clientmiddleware.NewForwardIDMiddleware(),
+		clientmiddleware.NewUseAlertHeadersMiddleware(),
 	)
 
 	if cfg.SendUserHeader {
@@ -198,8 +199,6 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 	if cfg.IPRangeACEnabled {
 		middlewares = append(middlewares, clientmiddleware.NewHostedGrafanaACHeaderMiddleware(cfg))
 	}
-
-	middlewares = append(middlewares, clientmiddleware.NewUseAlertHeadersMiddleware())
 
 	middlewares = append(middlewares, clientmiddleware.NewHTTPClientMiddleware())
 

--- a/pkg/tests/api/loki/loki_test.go
+++ b/pkg/tests/api/loki/loki_test.go
@@ -75,57 +75,6 @@ func TestIntegrationLoki(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	t.Run("When calling /api/ds/query forward alerting-related headers", func(t *testing.T) {
-		query := simplejson.NewFromAny(map[string]interface{}{
-			"datasource": map[string]interface{}{
-				"uid": uid,
-			},
-			"expr": "{job=\"grafana\"}",
-		})
-		buf1 := &bytes.Buffer{}
-		err = json.NewEncoder(buf1).Encode(dtos.MetricRequest{
-			From:    "now-1h",
-			To:      "now",
-			Queries: []*simplejson.Json{query},
-		})
-		require.NoError(t, err)
-		u := fmt.Sprintf("http://admin:admin@%s/api/ds/query", grafanaListeningAddr)
-		// nolint:gosec
-		req, err := http.NewRequest("POST", u, buf1)
-		if err != nil {
-			require.NoError(t, err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("X-Unspported-Header", "uh")
-		req.Header.Set("Fromalert", "true")
-		req.Header.Set("X-Rule-Name", "n1")
-		req.Header.Set("X-Rule-Folder", "f1")
-		req.Header.Set("X-Rule-Source", "s1")
-		req.Header.Set("X-Rule-Type", "t1")
-		req.Header.Set("X-Rule-Version", "v1")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-
-		require.NoError(t, err)
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		t.Cleanup(func() {
-			err := resp.Body.Close()
-			require.NoError(t, err)
-		})
-		_, err = io.ReadAll(resp.Body)
-		require.NoError(t, err)
-
-		require.NotNil(t, outgoingRequest)
-		require.Equal(t, "", outgoingRequest.Header.Get("X-Unspported-Header"))
-		require.Equal(t, "true", outgoingRequest.Header.Get("Fromalert"))
-		require.Equal(t, "n1", outgoingRequest.Header.Get("X-Rule-Name"))
-		require.Equal(t, "f1", outgoingRequest.Header.Get("X-Rule-Folder"))
-		require.Equal(t, "s1", outgoingRequest.Header.Get("X-Rule-Source"))
-		require.Equal(t, "t1", outgoingRequest.Header.Get("X-Rule-Type"))
-		require.Equal(t, "v1", outgoingRequest.Header.Get("X-Rule-Version"))
-	})
-
 	t.Run("When calling /api/ds/query should set expected headers on outgoing HTTP request", func(t *testing.T) {
 		query := simplejson.NewFromAny(map[string]interface{}{
 			"datasource": map[string]interface{}{
@@ -142,7 +91,17 @@ func TestIntegrationLoki(t *testing.T) {
 		require.NoError(t, err)
 		u := fmt.Sprintf("http://admin:admin@%s/api/ds/query", grafanaListeningAddr)
 		// nolint:gosec
-		resp, err := http.Post(u, "application/json", buf1)
+		req, err := http.NewRequest("POST", u, buf1)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Unspported-Header", "uh")
+		req.Header.Set("Fromalert", "true")
+		req.Header.Set("X-Rule-Name", "n1")
+		req.Header.Set("X-Rule-Folder", "f1")
+		req.Header.Set("X-Rule-Source", "s1")
+		req.Header.Set("X-Rule-Type", "t1")
+		req.Header.Set("X-Rule-Version", "v1")
+		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
@@ -158,6 +117,13 @@ func TestIntegrationLoki(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "basicAuthUser", username)
 		require.Equal(t, "basicAuthPassword", pwd)
+		require.Equal(t, "", outgoingRequest.Header.Get("X-Unspported-Header"))
+		require.Equal(t, "true", outgoingRequest.Header.Get("Fromalert"))
+		require.Equal(t, "n1", outgoingRequest.Header.Get("X-Rule-Name"))
+		require.Equal(t, "f1", outgoingRequest.Header.Get("X-Rule-Folder"))
+		require.Equal(t, "s1", outgoingRequest.Header.Get("X-Rule-Source"))
+		require.Equal(t, "t1", outgoingRequest.Header.Get("X-Rule-Type"))
+		require.Equal(t, "v1", outgoingRequest.Header.Get("X-Rule-Version"))
 	})
 
 	t.Run("should forward `X-Dashboard-Title` header but no `X-Panel-Title`", func(t *testing.T) {

--- a/pkg/tests/api/loki/loki_test.go
+++ b/pkg/tests/api/loki/loki_test.go
@@ -75,6 +75,57 @@ func TestIntegrationLoki(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	t.Run("When calling /api/ds/query forward alerting-related headers", func(t *testing.T) {
+		query := simplejson.NewFromAny(map[string]interface{}{
+			"datasource": map[string]interface{}{
+				"uid": uid,
+			},
+			"expr": "{job=\"grafana\"}",
+		})
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dtos.MetricRequest{
+			From:    "now-1h",
+			To:      "now",
+			Queries: []*simplejson.Json{query},
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/ds/query", grafanaListeningAddr)
+		// nolint:gosec
+		req, err := http.NewRequest("POST", u, buf1)
+		if err != nil {
+			require.NoError(t, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Unspported-Header", "uh")
+		req.Header.Set("Fromalert", "true")
+		req.Header.Set("X-Rule-Name", "n1")
+		req.Header.Set("X-Rule-Folder", "f1")
+		req.Header.Set("X-Rule-Source", "s1")
+		req.Header.Set("X-Rule-Type", "t1")
+		req.Header.Set("X-Rule-Version", "v1")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		_, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.NotNil(t, outgoingRequest)
+		require.Equal(t, "", outgoingRequest.Header.Get("X-Unspported-Header"))
+		require.Equal(t, "true", outgoingRequest.Header.Get("Fromalert"))
+		require.Equal(t, "n1", outgoingRequest.Header.Get("X-Rule-Name"))
+		require.Equal(t, "f1", outgoingRequest.Header.Get("X-Rule-Folder"))
+		require.Equal(t, "s1", outgoingRequest.Header.Get("X-Rule-Source"))
+		require.Equal(t, "t1", outgoingRequest.Header.Get("X-Rule-Type"))
+		require.Equal(t, "v1", outgoingRequest.Header.Get("X-Rule-Version"))
+	})
+
 	t.Run("When calling /api/ds/query should set expected headers on outgoing HTTP request", func(t *testing.T) {
 		query := simplejson.NewFromAny(map[string]interface{}{
 			"datasource": map[string]interface{}{


### PR DESCRIPTION
when sending a request to `/api/ds/query`, if we receive alerting-related headers, we pass them forward, so the datasource can send them to the database.