### PR TITLE
alerting>tutorials:simple alert creation flow

### DIFF
--- a/docs/sources/tutorials/alerting-get-started-pt2/index.md
+++ b/docs/sources/tutorials/alerting-get-started-pt2/index.md
@@ -97,8 +97,9 @@ Make it short and descriptive as this will appear in your alert notification. Fo
 
 ### Define query and alert condition
 
-In this section, we define queries, expressions (used to manipulate the data), and the condition that must be met for the alert to be triggered.
+In this section, we use the **Advanced options** for Grafana-managed alert rule creation. The advanced options let us define queries, expressions (used to manipulate the data), and the condition that must be met for the alert to be triggered.
 
+1. Toggle **Advanced options** to view additional configuration options.
 1. Select **TestData** data source from the drop-down menu.
 1. From **Scenario** select **CSV Content**.
 1. Copy in the following CSV data:

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -24,7 +24,6 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/
     - pattern: /docs/grafana-cloud/create-grafana-managed-rule/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
-
 ---
 
 <!-- INTERACTIVE page intro.md START -->

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -18,12 +18,6 @@ killercoda:
   description: Get started with Grafana Alerting by creating your first alert in just a few minutes. Learn how to set up an alert, send alert notifications to a public webhook, and generate sample data to observe your alert in action.
   backend:
     imageid: ubuntu
-refs:
-  create-gm-alert-rule:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/
-    - pattern: /docs/grafana-cloud/create-grafana-managed-rule/
-      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
 ---
 
 <!-- INTERACTIVE page intro.md START -->
@@ -193,7 +187,7 @@ We have created a dummy Webhook endpoint and created a new Alerting contact poin
 
 ## Create an alert
 
-Next, we establish an [alert rule](ref:create-gm-alert-rule) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
+Next, we establish an [alert rule](https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
 
 1. In Grafana, **navigate to Alerting** > **Alert rules**. Click on **New alert rule**.
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -189,16 +189,18 @@ We have created a dummy Webhook endpoint and created a new Alerting contact poin
 
 Next, we'll establish an [alert rule](http://grafana.com/docs/grafana/next/alerting/fundamentals/alert-rule-evaluation/) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
 
+In this tutorial we'll use the default options for Grafana-managed alert rule creation.
+
 1. In Grafana, **navigate to Alerting** > **Alert rules**. Click on **New alert rule**.
 
 1. Enter alert rule name for your alert rule. Make it short and descriptive as this will appear in your alert notification. For instance, **database-metrics**
 
 ### Define query and alert condition
 
-In this section, we define queries, expressions (used to manipulate the data), and the condition that must be met for the alert to be triggered.
+In this section, we define the query, expression (used to manipulate the data -- `WHEN` in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
+
 
 1. Select the **Prometheus** data source from the drop-down menu.
-1. In the Query editor, switch to **Code** mode by clicking the button at the right.
 1. Enter the following query:
 
    ```promql
@@ -207,18 +209,15 @@ In this section, we define queries, expressions (used to manipulate the data), a
 
    In Prometheus, `vector(1)` is a special type of PromQL query that generates a constant vector. This is useful in testing and query manipulation, where you might need a constant value for calculations or comparisons. This query will allow you to create an alert rule that will be always firing.
 
-1. Remove the ‘B’ **Reduce expression** (click the bin icon). The Reduce expression comes by default, and in this case, it is not needed since the queried data is already reduced. Note that the Threshold expression is now your **Alert condition**.
+1. In the **Alert condition** section:
 
-1. In the ‘C’ **Threshold expression**:
+   - Keep `Last` as the value for the reducer function (`WHEN`), and `0` as the threshold value. This is the value above which the alert rule should trigger.
 
-   - Change the **Input** to **'A'** to select the data source.
-   - Enter `0` as the threshold value. This is the value above which the alert rule should trigger.
-
-1. Click **Preview** to run the queries.
+1. Click **Preview alert rule condition** to run the queries.
 
    It should return a single sample with the value 1 at the current timestamp. And, since `1` is above `0`, the alert condition has been met, and the alert rule state is `Firing`.
 
-   {{< figure src="/media/docs/alerting/alerting-always-firing-alert.png" max-width="1200px" caption="A preview of a firing alert" >}}
+   {{< figure src="/media/docs/alerting/firing-alert-preview.png" max-width="1200px" caption="A preview of a firing alert" >}}
 
 ### Set evaluation behavior
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -42,7 +42,7 @@ In this tutorial you will:
 
 {{< admonition type="tip" >}}
 
-Before you dive in, remember that you can [explore advanced topics like alert instances and notification routing](https://grafana.com/tutorials/alerting-get-started-pt2/) in the second part of this guide.
+Before you dive in, remember that you can [explore advanced topics like alert instances and notification routing](http://grafana.com/tutorials/alerting-get-started-pt2/) in the second part of this guide.
 
 {{< /admonition >}}
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -19,11 +19,12 @@ killercoda:
   backend:
     imageid: ubuntu
 refs:
-   create-gm-alert-rule:
-     - patern: /docs/grafana/create-grafana-managed-rule/
-       destination: /docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/
-     - patern: /docs/grafana-cloud/create-grafana-managed-rule/
-       destination: docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
+  create-gm-alert-rule:
+    - pattern: /docs/grafana/create-grafana-managed-rule/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/
+    - pattern: /docs/grafana-cloud/create-grafana-managed-rule/
+      destination: docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
+
 ---
 
 <!-- INTERACTIVE page intro.md START -->
@@ -204,7 +205,6 @@ In this tutorial we'll use the default options for Grafana-managed alert rule cr
 ### Define query and alert condition
 
 In this section, we define the query, expressions (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
-
 
 1. Select the **Prometheus** data source from the drop-down menu.
 1. Enter the following query:

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -30,7 +30,7 @@ refs:
 
 # Get Started with Grafana Alerting - Part 1
 
-In this guide, we'll walk you through the process of setting up your first alert in just a few minutes. You'll witness your alert in action with real-time data, as well as sending alert notifications.
+In this guide, we walk you through the process of setting up your first alert in just a few minutes. You'll witness your alert in action with real-time data, as well as sending alert notifications.
 
 In this tutorial you will:
 
@@ -160,7 +160,7 @@ To demonstrate the observation of data using the Grafana stack, download and run
 
 Besides being an open-source observability tool, Grafana has its own built-in alerting service. This means that you can receive notifications whenever there is an event of interest in your data, and even see these events graphed in your visualizations.
 
-In this step, we'll set up a new [contact point](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/). This contact point will use the _webhooks_ integration. In order to make this work, we also need an endpoint for our webhook integration to receive the alert. We will use [Webhook.site](https://webhook.site/) to quickly set up that test endpoint. This way we can make sure that our alert is actually sending a notification somewhere.
+In this step, we set up a new [contact point](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/). This contact point will use the _webhooks_ integration. In order to make this work, we also need an endpoint for our webhook integration to receive the alert. We will use [Webhook.site](https://webhook.site/) to quickly set up that test endpoint. This way we can make sure that our alert is actually sending a notification somewhere.
 
 1. In your browser, **sign in** to your Grafana Cloud account.
 
@@ -193,7 +193,7 @@ We have created a dummy Webhook endpoint and created a new Alerting contact poin
 
 ## Create an alert
 
-Next, we'll establish an [alert rule](ref:create-gm-alert-rule) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
+Next, we establish an [alert rule](ref:create-gm-alert-rule) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
 
 1. In Grafana, **navigate to Alerting** > **Alert rules**. Click on **New alert rule**.
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -195,7 +195,7 @@ We have created a dummy Webhook endpoint and created a new Alerting contact poin
 
 Next, we'll establish an [alert rule](ref:create-gm-alert-rule) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
 
-In this tutorial we'll use the default options for Grafana-managed alert rule creation.
+In this tutorial we use the default options for Grafana-managed alert rule creation.
 
 1. In Grafana, **navigate to Alerting** > **Alert rules**. Click on **New alert rule**.
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -197,7 +197,7 @@ In this tutorial we'll use the default options for Grafana-managed alert rule cr
 
 ### Define query and alert condition
 
-In this section, we define the query, expression (used to manipulate the data -- `WHEN` in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
+In this section, we define the query, expressions (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
 
 
 1. Select the **Prometheus** data source from the drop-down menu.

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -18,6 +18,12 @@ killercoda:
   description: Get started with Grafana Alerting by creating your first alert in just a few minutes. Learn how to set up an alert, send alert notifications to a public webhook, and generate sample data to observe your alert in action.
   backend:
     imageid: ubuntu
+refs:
+   create-gm-alert-rule:
+     - patern: /docs/grafana/create-grafana-managed-rule/
+       destination: /docs/grafana/latest/alerting/alerting-rules/create-grafana-managed-rule/
+     - patern: /docs/grafana-cloud/create-grafana-managed-rule/
+       destination: docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
 ---
 
 <!-- INTERACTIVE page intro.md START -->
@@ -187,7 +193,7 @@ We have created a dummy Webhook endpoint and created a new Alerting contact poin
 
 ## Create an alert
 
-Next, we'll establish an [alert rule](http://grafana.com/docs/grafana/next/alerting/fundamentals/alert-rule-evaluation/) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
+Next, we'll establish an [alert rule](ref:create-gm-alert-rule) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
 
 In this tutorial we'll use the default options for Grafana-managed alert rule creation.
 
@@ -213,7 +219,7 @@ In this section, we define the query, expressions (used to manipulate the data -
 
    - Keep `Last` as the value for the reducer function (`WHEN`), and `0` as the threshold value. This is the value above which the alert rule should trigger.
 
-1. Click **Preview alert rule condition** to run the queries.
+1. Click **Preview alert rule condition** to run the query.
 
    It should return a single sample with the value 1 at the current timestamp. And, since `1` is above `0`, the alert condition has been met, and the alert rule state is `Firing`.
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -42,7 +42,7 @@ In this tutorial you will:
 
 {{< admonition type="tip" >}}
 
-Before you dive in, remember that you can [explore advanced topics like alert instances and notification routing](http://grafana.com/tutorials/alerting-get-started-pt2/) in the second part of this guide.
+Before you dive in, remember that you can [explore advanced topics like alert instances and notification routing](https://grafana.com/tutorials/alerting-get-started-pt2/) in the second part of this guide.
 
 {{< /admonition >}}
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -201,7 +201,7 @@ Next, we'll establish an [alert rule](ref:create-gm-alert-rule) within Grafana A
 
 ### Define query and alert condition
 
-In this section, we use the default options for Grafana-managed alert rule creation. This option let us define the query, a expression (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
+In this section, we use the default options for Grafana-managed alert rule creation. The default options let us define the query, a expression (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
 
 1. Select the **Prometheus** data source from the drop-down menu.
 1. Enter the following query:

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -20,10 +20,10 @@ killercoda:
     imageid: ubuntu
 refs:
   create-gm-alert-rule:
-    - pattern: /docs/grafana/create-grafana-managed-rule/
+    - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/
     - pattern: /docs/grafana-cloud/create-grafana-managed-rule/
-      destination: docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/
 
 ---
 

--- a/docs/sources/tutorials/alerting-get-started/index.md
+++ b/docs/sources/tutorials/alerting-get-started/index.md
@@ -195,15 +195,13 @@ We have created a dummy Webhook endpoint and created a new Alerting contact poin
 
 Next, we'll establish an [alert rule](ref:create-gm-alert-rule) within Grafana Alerting to notify us whenever alert rules are triggered and resolved.
 
-In this tutorial we use the default options for Grafana-managed alert rule creation.
-
 1. In Grafana, **navigate to Alerting** > **Alert rules**. Click on **New alert rule**.
 
 1. Enter alert rule name for your alert rule. Make it short and descriptive as this will appear in your alert notification. For instance, **database-metrics**
 
 ### Define query and alert condition
 
-In this section, we define the query, expressions (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
+In this section, we use the default options for Grafana-managed alert rule creation. This option let us define the query, a expression (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
 
 1. Select the **Prometheus** data source from the drop-down menu.
 1. Enter the following query:

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -435,7 +435,7 @@ Now that Grafana knows how to notify us, it's time to set up an alert rule:
    sum(rate(tns_request_duration_seconds_count[5m])) by(route)
    ```
 
-1. Scroll down to bottom of section #2 and click the **Preview alert rule condition*** button. You should see some data returned.
+1. Scroll down to bottom of section #2 and click the **Preview alert rule condition** button. You should see some data returned.
 1. Keep `Last` as the value for the reducer function (`WHEN`), and `0.2` as the threshold value. This is the value above which the alert rule should trigger. [You can read more about queries and conditions here](/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
 1. In **Section 3**, in Folder, create a new folder, by clicking `New folder` and typing a name for the folder. This folder will contain our alert rules. For example: `fundamentals`. Then, click `create`.
 1. In the Evaluation group, repeat the above step to create a new one. We will name it `fundamentals` too.

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -423,10 +423,12 @@ We have now created a dummy webhook endpoint and created a new Alerting Contact 
 Now that Grafana knows how to notify us, it's time to set up an alert rule:
 
 1. In Grafana's sidebar, hover over the **Alerting** (bell) icon and then click **Alert rules**.
+
+   In this tutorial, we use the default options for Grafana-managed alert rule creation. The default options let us define the query, a expression (used to manipulate the data -- the `WHEN` field in the UI), and the condition that must be met for the alert to be triggered (in default mode is the threshold).
+
 1. Click **+ New alert rule**.
 1. For **Section 1**, name the rule `fundamentals-test`.
-1. For **Section 2**, Find the **query A** box. Choose your Prometheus data source. Note that the rule type should automatically switch to Grafana-managed alert rule.
-1. Switch to code mode by checking the Builder/Code toggle.
+1. For **Section 2**, Find the **query A** box, and choose your Prometheus data source.
 1. Enter the same Prometheus query that we used in our earlier panel:
 
    ```
@@ -434,7 +436,7 @@ Now that Grafana knows how to notify us, it's time to set up an alert rule:
    ```
 
 1. Scroll down to bottom of section #2 and click the **Preview** button. You should see some data returned.
-1. Keep expressions “B” and "C" as they are. These expressions (Reduce and Threshold, respectively) are included by default when creating a new rule. Expression "B", selects the last value of our query “A”, while the Threshold expression "C" will check if the last value from expression "B" is above a specific value. In addition, the Threshold expression is the alert rule condition by default. Enter `0.2` as threshold value. [You can read more about queries and conditions here](/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
+1. Keep `Last` as the value for the reducer function (`WHEN`), and `0.2` as the threshold value. This is the value above which the alert rule should trigger. [You can read more about queries and conditions here](/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
 1. In **Section 3**, in Folder, create a new folder, by clicking `New folder` and typing a name for the folder. This folder will contain our alert rules. For example: `fundamentals`. Then, click `create`.
 1. In the Evaluation group, repeat the above step to create a new one. We will name it `fundamentals` too.
 1. Choose an Evaluation interval (how often the alert rule will be evaluated). For example, every `10s` (10 seconds).

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -384,7 +384,7 @@ The most basic alert rule consists of two parts:
 
 1. An _Alert rule_ - An Alert rule defines one or more _conditions_ that Grafana regularly evaluates. When these evaluations meet the rule's criteria, the alert rule is triggered.
 
-To begin, let's set up a webhook contact point. Once we have a usable endpoint, we'll write an alert rule and trigger a notification.
+To begin, let's set up a webhook contact point. Once we have a usable endpoint, we write an alert rule and trigger a notification.
 
 <!-- INTERACTIVE page step8.md END -->
 
@@ -392,7 +392,7 @@ To begin, let's set up a webhook contact point. Once we have a usable endpoint, 
 
 ### Create a contact point for Grafana-managed alert rules
 
-In this step, we'll set up a new contact point. This contact point will use the _webhooks_ channel. In order to make this work, we also need an endpoint for our webhook channel to receive the alert notification. We will use [requestbin.com](https://requestbin.com) to quickly set up that test endpoint. This way we can make sure that our alert manager is actually sending a notification somewhere.
+In this step, we set up a new contact point. This contact point will use the _webhooks_ channel. In order to make this work, we also need an endpoint for our webhook channel to receive the alert notification. We will use [requestbin.com](https://requestbin.com) to quickly set up that test endpoint. This way we can make sure that our alert manager is actually sending a notification somewhere.
 
 1. Browse to [requestbin.com](https://requestbin.com).
 1. Under the **Create Request Bin** button, click the link to create a **public bin** instead.

--- a/docs/sources/tutorials/grafana-fundamentals/index.md
+++ b/docs/sources/tutorials/grafana-fundamentals/index.md
@@ -435,7 +435,7 @@ Now that Grafana knows how to notify us, it's time to set up an alert rule:
    sum(rate(tns_request_duration_seconds_count[5m])) by(route)
    ```
 
-1. Scroll down to bottom of section #2 and click the **Preview** button. You should see some data returned.
+1. Scroll down to bottom of section #2 and click the **Preview alert rule condition*** button. You should see some data returned.
 1. Keep `Last` as the value for the reducer function (`WHEN`), and `0.2` as the threshold value. This is the value above which the alert rule should trigger. [You can read more about queries and conditions here](/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
 1. In **Section 3**, in Folder, create a new folder, by clicking `New folder` and typing a name for the folder. This folder will contain our alert rules. For example: `fundamentals`. Then, click `create`.
 1. In the Evaluation group, repeat the above step to create a new one. We will name it `fundamentals` too.


### PR DESCRIPTION
## what's this PR about

- updates the instructions to match the new default (simple) alert creation flow
- the new alert creation is already been rolled out for Cloud, and it will be available for OSS behind the feature flag `alertingQueryAndExpressionsStepModeout` in v11.3.0 (this minor will be released on October 22nd)

## why do we need it?

- the new interface and steps are significantly different
- the new flow is much user friendly, which aligns with the adoption-oriented goal of these tutorials: 
  - https://grafana.com/tutorials/grafana-fundamentals/
  - https://grafana.com/tutorials/alerting-get-started-pt1/
  - https://grafana.com/tutorials/alerting-get-started-pt2/

NOTE: do not merge before the new alert creation flow is available for OSS
Killercoda parallel PR: https://github.com/grafana/killercoda/pull/144

BEFORE:

![image](https://github.com/user-attachments/assets/1020d277-857d-4a07-8a94-ca87e28c9385)


AFTER:

![image](https://github.com/user-attachments/assets/ae3e79c8-7ac8-4e0f-a8d6-57e5a88fbc15)
