### PR TITLE
Azure: Fix duplicated traces in multi-resource trace query

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -497,7 +497,7 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryUR
 	}
 
 	if query.AppInsightsQuery {
-		body["applications"] = query.Resources
+		body["applications"] = []string{query.Resources[0]}
 	}
 
 	jsonValue, err := json.Marshal(body)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -649,7 +649,7 @@ func TestLogAnalyticsCreateRequest(t *testing.T) {
 			TimeColumn:       "timestamp",
 		})
 		require.NoError(t, err)
-		expectedBody := fmt.Sprintf(`{"applications":["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1","/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r2"],"query":"","query_datetimescope_column":"timestamp","query_datetimescope_from":"%s","query_datetimescope_to":"%s","timespan":"%s/%s"}`, from.Format(time.RFC3339), to.Format(time.RFC3339), from.Format(time.RFC3339), to.Format(time.RFC3339))
+		expectedBody := fmt.Sprintf(`{"applications":["/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/components/r1"],"query":"","query_datetimescope_column":"timestamp","query_datetimescope_from":"%s","query_datetimescope_to":"%s","timespan":"%s/%s"}`, from.Format(time.RFC3339), to.Format(time.RFC3339), from.Format(time.RFC3339), to.Format(time.RFC3339))
 		body, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		if !cmp.Equal(string(body), expectedBody) {


### PR DESCRIPTION
The current behaviour uses all selected resources in the request body for the `applications` property.

This creates duplicate traces as we also specify all resources [here](https://github.com/grafana/grafana/blob/986bd2f9f8006858fc05c30ec482273ff3af3550/pkg/tsdb/azuremonitor/loganalytics/traces.go#L46) directly in the query.

This change updates our logic to define the resources directly in the query rather than using the request body.

This can be tested by executing a query against multiple Application Insights resources (specifically for the `dependencies` event type to avoid returning too much data) and seeing that traces are duplicated if the first resource selected is _not_ the resource that contains the traces.

Doing the same against this branch will not lead to duplicated resources.

Fixes grafana/support-escalations#13002