### PR TITLE
Transformation: Fix label width

### DIFF
--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx
@@ -105,7 +105,7 @@ export const WindowOptionsEditor = (props: {
           onChange={onTypeChange}
         />
       </InlineField>
-      <InlineField label="Window size mode">
+      <InlineField label="Window size mode" labelWidth={LABEL_WIDTH}>
         <RadioButtonGroup
           value={window?.windowSizeMode ?? WindowSizeMode.Percentage}
           options={windowSizeModeOptions}

--- a/public/app/features/transformers/editors/CalculateFieldTransformerEditor/constants.ts
+++ b/public/app/features/transformers/editors/CalculateFieldTransformerEditor/constants.ts
@@ -1,1 +1,1 @@
-export const LABEL_WIDTH = 16;
+export const LABEL_WIDTH = 17;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Just fix UI label width issue

Before:
<img width="530" alt="Screenshot 2024-10-22 at 15 14 42" src="https://github.com/user-attachments/assets/a8736527-9642-4716-b41f-37589ef81b24">

After:
<img width="529" alt="Screenshot 2024-10-22 at 15 19 23" src="https://github.com/user-attachments/assets/98841317-a795-44e8-bf4c-343f9de3bf97">


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
