### PR TITLE
Prometheus: support dots in label names for PromQL queries

### DIFF
--- a/packages/grafana-prometheus/src/promql.ts
+++ b/packages/grafana-prometheus/src/promql.ts
@@ -600,7 +600,7 @@ export const promqlGrammar: Grammar = {
         pattern: /#.*/,
       },
       'label-key': {
-        pattern: /[a-z_]\w*(?=\s*(=|!=|=~|!~))/,
+        pattern: /[a-z_][\w.]*(?=\s*(=|!=|=~|!~))/,
         alias: 'attr-name',
         greedy: true,
       },


### PR DESCRIPTION
**What is this feature?**

This pull request addresses an issue that occurs when switching from a Prometheus data source to another data source. Specifically, the `exportToAbstractQueries` method currently ignores dots in label names, leading to the loss of part of the label expression. For example, in the query `{my.dotted.metric="value"}`, `my.dotted.metric` is incorrectly transformed into `metric`.

This PR makes a minor adjustment to the `label-key` pattern in the `promqlGrammar`, ensuring that label names with dots are fully preserved.

Additionally, the changes align with the Prometheus UTF-8 proposal outlined in the [Prometheus proposals document](https://github.com/prometheus/proposals/blob/main/proposals/2023-08-21-utf8.md).

**Why do we need this feature?**

This fix is needed to ensure that label names with dots in Prometheus queries are correctly parsed and preserved when switching between data sources. Without this fix, users may experience unexpected behavior, where label names lose essential parts of their expressions, affecting the accuracy of their queries.

**Who is this feature for?**

This feature is for users working with Prometheus queries that contain label names with dots, who frequently switch between different data sources in Grafana. It ensures that their queries are handled correctly across different data sources.

**Special notes for your reviewer:**

- [x] Please verify that label names with dots are now fully preserved when switching between data sources.
- [x] Ensure that the new pattern in the `promqlGrammar` works as expected across all scenarios.
- [x] Consider reviewing the linked Prometheus proposal to confirm full compliance. 