### PR TITLE
Plugins: Simplify TestExtractFiles test

### DIFF
--- a/pkg/plugins/storage/fs.go
+++ b/pkg/plugins/storage/fs.go
@@ -168,7 +168,7 @@ func isSymlinkRelativeTo(basePath string, symlinkDestPath string, symlinkOrigPat
 		return false
 	}
 	fileDir := filepath.Dir(symlinkOrigPath)
-	cleanPath := filepath.Clean(filepath.Join(fileDir, "/", symlinkDestPath))
+	cleanPath := filepath.Clean(filepath.Join(fileDir, symlinkDestPath))
 	p, err := filepath.Rel(basePath, cleanPath)
 	if err != nil {
 		return false


### PR DESCRIPTION
- Make use of `filepath.Join` where necessary
- No longer create and cleanup plugin dir from within a function (could be causing an issue with [flaky tests](https://drone.grafana.net/grafana/grafana-enterprise/77854/5/7))