### PR TITLE
ci-wix: bump tag to force publish of new image

### DIFF
--- a/scripts/build/ci-wix/Magefile.go
+++ b/scripts/build/ci-wix/Magefile.go
@@ -7,7 +7,7 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-const imageName = "grafana/ci-wix:0.1.1"
+const imageName = "grafana/ci-wix:0.1.2"
 
 // Build builds the Docker image.
 func Build() error {


### PR DESCRIPTION
The tagged image `grafana/ci-wiz:0.1.1` is failing to be pulled. This change forces a new publish of the image to see if 1) that works and 2) we can pull the newly tagged image.