### PR TITLE
Fix: Check JSON data is not nil

### DIFF
--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -544,8 +544,10 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateD
 
 			if dataSource.JsonData != nil {
 				previousRules := dataSource.JsonData.Get("teamHttpHeaders").Interface()
-				if previousRules == nil && cmd.JsonData != nil {
-					cmd.JsonData.Del("teamHttpHeaders")
+				if previousRules == nil {
+					if cmd.JsonData != nil {
+						cmd.JsonData.Del("teamHttpHeaders")
+					}
 				} else {
 					if cmd.JsonData == nil {
 						// It's fine to instantiate a new JsonData here

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -544,9 +544,14 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateD
 
 			if dataSource.JsonData != nil {
 				previousRules := dataSource.JsonData.Get("teamHttpHeaders")
-				if previousRules == nil {
+				if previousRules == nil && cmd.JsonData != nil {
 					cmd.JsonData.Del("teamHttpHeaders")
 				} else {
+					if cmd.JsonData == nil {
+						// It's fine to instantiate a new JsonData here
+						// Because it's done in the SQLStore.UpdateDataSource anyway
+						cmd.JsonData = simplejson.New()
+					}
 					cmd.JsonData.Set("teamHttpHeaders", previousRules)
 				}
 			}

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -543,8 +543,8 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateD
 				"datasource_uid", dataSource.UID)
 
 			if dataSource.JsonData != nil {
-				previousRules := dataSource.JsonData.Get("teamHttpHeaders")
-				if previousRules.Interface() == nil && cmd.JsonData != nil {
+				previousRules := dataSource.JsonData.Get("teamHttpHeaders").Interface()
+				if previousRules == nil && cmd.JsonData != nil {
 					cmd.JsonData.Del("teamHttpHeaders")
 				} else {
 					if cmd.JsonData == nil {

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -544,7 +544,7 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateD
 
 			if dataSource.JsonData != nil {
 				previousRules := dataSource.JsonData.Get("teamHttpHeaders")
-				if previousRules == nil && cmd.JsonData != nil {
+				if previousRules.Interface() == nil && cmd.JsonData != nil {
 					cmd.JsonData.Del("teamHttpHeaders")
 				} else {
 					if cmd.JsonData == nil {


### PR DESCRIPTION
**What is this feature?**

If `cmd.JsonData` is `nil` we are currently panic-ing.

No backport needed, the change did not make it in 11.3

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
