### PR TITLE
Combobox: Combine loading and search/caret icons

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -156,6 +156,7 @@ export const Combobox = <T extends string | number>({
       onChange(selectedItem);
     },
     defaultHighlightedIndex: selectedItemIndex ?? 0,
+
     scrollIntoView: () => {},
     onInputValueChange: ({ inputValue }) => {
       const customValueOption =
@@ -223,7 +224,18 @@ export const Combobox = <T extends string | number>({
     setInputValue(selectedItem?.label ?? value?.toString() ?? '');
   }, [selectedItem, setInputValue, value]);
 
+  const handleSuffixClick = useCallback(() => {
+    isOpen ? closeMenu() : openMenu();
+  }, [isOpen, openMenu, closeMenu]);
+
   const InputComponent = width === 'auto' ? AutoSizeInput : Input;
+
+  const suffixIcon = asyncLoading
+    ? 'spinner'
+    : // If it's loading, show loading icon. Otherwise, icon indicating menu state
+      isOpen
+      ? 'search'
+      : 'angle-down';
 
   return (
     <div>
@@ -248,19 +260,14 @@ export const Combobox = <T extends string | number>({
                 }}
               />
             )}
-            <Icon
-              name={isOpen ? 'search' : 'angle-down'}
-              onClick={() => {
-                if (isOpen) {
-                  closeMenu();
-                } else {
-                  openMenu();
-                }
-              }}
-            />
+
+            {/* When you click the input, it should just focus the text box. However, clicks on input suffix arent
+                translated to the input, so it blocks the input from being focused. So we need an additional event
+                handler here to open/close the menu. It should not have button role because we intentionally don't
+                want it in the a11y tree. */}
+            <Icon name={suffixIcon} onClick={handleSuffixClick} />
           </>
         }
-        loading={asyncLoading}
         {...restProps}
         {...getInputProps({
           ref: inputRef,


### PR DESCRIPTION
Even in the current Select, specifying loading={true} on the Input with the suffix icon makes it take up additional width. We workaround that by just showing the loading icon in the suffix instead of the search/caret icons.

Split out of Split out of https://github.com/grafana/grafana/pull/93262