### PR TITLE
IAM: fix GetSearchPermissionCacheKey uniqueness

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -1,8 +1,12 @@
 package accesscontrol
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/gob"
 	"fmt"
+	"hash/fnv"
 	"strconv"
 	"strings"
 
@@ -123,6 +127,23 @@ func (s *SearchOptions) ComputeUserID() (int64, error) {
 	}
 
 	return strconv.ParseInt(id, 10, 64)
+}
+
+func (s *SearchOptions) HashString() (string, error) {
+	if s == nil {
+		return "", nil
+	}
+	var buf bytes.Buffer
+	encoder := gob.NewEncoder(&buf)
+	if err := encoder.Encode(s); err != nil {
+		return "", err
+	}
+	h := fnv.New64a()
+	_, err := h.Write(buf.Bytes())
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
 }
 
 type SyncUserRolesCommand struct {

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -1,12 +1,8 @@
 package accesscontrol
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/gob"
 	"fmt"
-	"hash/fnv"
 	"strconv"
 	"strings"
 
@@ -127,23 +123,6 @@ func (s *SearchOptions) ComputeUserID() (int64, error) {
 	}
 
 	return strconv.ParseInt(id, 10, 64)
-}
-
-func (s *SearchOptions) HashString() (string, error) {
-	if s == nil {
-		return "", nil
-	}
-	var buf bytes.Buffer
-	encoder := gob.NewEncoder(&buf)
-	if err := encoder.Encode(s); err != nil {
-		return "", err
-	}
-	h := fnv.New64a()
-	_, err := h.Write(buf.Bytes())
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
 }
 
 type SyncUserRolesCommand struct {

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -702,7 +702,10 @@ func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, search
 		permissions = s.actionResolver.ExpandActionSetsWithFilter(permissions, GetActionFilter(searchOptions))
 	}
 
-	key := accesscontrol.GetSearchPermissionCacheKey(&user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
+	key, err := accesscontrol.GetSearchPermissionCacheKey(s.log, &user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
+	if err != nil {
+		return nil, err
+	}
 	s.cache.Set(key, permissions, cacheTTL)
 
 	return permissions, nil
@@ -723,7 +726,10 @@ func (s *Service) searchUserPermissionsFromCache(ctx context.Context, orgID int6
 		OrgID:  orgID,
 	}
 
-	key := accesscontrol.GetSearchPermissionCacheKey(tempUser, searchOptions)
+	key, err := accesscontrol.GetSearchPermissionCacheKey(s.log, tempUser, searchOptions)
+	if err != nil {
+		return nil, false
+	}
 	permissions, ok := s.cache.Get((key))
 	if !ok {
 		metrics.MAccessSearchUserPermissionsCacheUsage.WithLabelValues(accesscontrol.CacheMiss).Inc()

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -704,9 +704,10 @@ func (s *Service) searchUserPermissions(ctx context.Context, orgID int64, search
 
 	key, err := accesscontrol.GetSearchPermissionCacheKey(s.log, &user.SignedInUser{UserID: userID, OrgID: orgID}, searchOptions)
 	if err != nil {
-		return nil, err
+		s.log.Warn("failed to create search permission cache key", "err", err)
+	} else {
+		s.cache.Set(key, permissions, cacheTTL)
 	}
-	s.cache.Set(key, permissions, cacheTTL)
 
 	return permissions, nil
 }
@@ -728,6 +729,7 @@ func (s *Service) searchUserPermissionsFromCache(ctx context.Context, orgID int6
 
 	key, err := accesscontrol.GetSearchPermissionCacheKey(s.log, tempUser, searchOptions)
 	if err != nil {
+		s.log.Warn("failed to create search permission cache key", "err", err)
 		return nil, false
 	}
 	permissions, ok := s.cache.Get((key))

--- a/pkg/services/accesscontrol/cacheutils.go
+++ b/pkg/services/accesscontrol/cacheutils.go
@@ -37,7 +37,6 @@ func GetUserPermissionCacheKey(user identity.Requester) string {
 func GetSearchPermissionCacheKey(log log.Logger, user identity.Requester, searchOptions SearchOptions) (string, error) {
 	searchHash, err := searchOptions.HashString()
 	if err != nil {
-		log.Debug("search options failed to compute hash", "err", err.Error())
 		return "", err
 	}
 	key := fmt.Sprintf("rbac-permissions-%s-%s", user.GetCacheKey(), searchHash)

--- a/pkg/services/accesscontrol/cacheutils_test.go
+++ b/pkg/services/accesscontrol/cacheutils_test.go
@@ -4,12 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/authlib/claims"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 )
+
+var testLogger = log.New("test")
 
 func TestPermissionCacheKey(t *testing.T) {
 	testcases := []struct {
@@ -75,23 +79,18 @@ func TestPermissionCacheKey(t *testing.T) {
 }
 
 func TestGetSearchPermissionCacheKey(t *testing.T) {
-	testcases := []struct {
-		name          string
+	keyInputs := []struct {
 		signedInUser  *user.SignedInUser
 		searchOptions SearchOptions
-		expected      string
 	}{
 		{
-			name: "should return correct key for user with no options",
 			signedInUser: &user.SignedInUser{
 				OrgID:  1,
 				UserID: 1,
 			},
 			searchOptions: SearchOptions{},
-			expected:      "rbac-permissions-1-user-1",
 		},
 		{
-			name: "should return correct key for user with action",
 			signedInUser: &user.SignedInUser{
 				OrgID:  1,
 				UserID: 1,
@@ -99,10 +98,8 @@ func TestGetSearchPermissionCacheKey(t *testing.T) {
 			searchOptions: SearchOptions{
 				Action: "datasources:read",
 			},
-			expected: "rbac-permissions-1-user-1-datasources:read",
 		},
 		{
-			name: "should return correct key for user with scope",
 			signedInUser: &user.SignedInUser{
 				OrgID:  1,
 				UserID: 1,
@@ -110,10 +107,8 @@ func TestGetSearchPermissionCacheKey(t *testing.T) {
 			searchOptions: SearchOptions{
 				Scope: "datasources:*",
 			},
-			expected: "rbac-permissions-1-user-1-datasources:*",
 		},
 		{
-			name: "should return correct key for user with action and scope",
 			signedInUser: &user.SignedInUser{
 				OrgID:  1,
 				UserID: 1,
@@ -122,10 +117,8 @@ func TestGetSearchPermissionCacheKey(t *testing.T) {
 				Action: "datasources:read",
 				Scope:  "datasources:*",
 			},
-			expected: "rbac-permissions-1-user-1-datasources:read-datasources:*",
 		},
 		{
-			name: "should return correct key for user with role prefixes",
 			signedInUser: &user.SignedInUser{
 				OrgID:  1,
 				UserID: 1,
@@ -133,13 +126,22 @@ func TestGetSearchPermissionCacheKey(t *testing.T) {
 			searchOptions: SearchOptions{
 				RolePrefixes: []string{"foo", "bar"},
 			},
-			expected: "rbac-permissions-1-user-1-foo-bar",
 		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, GetSearchPermissionCacheKey(tc.signedInUser, tc.searchOptions))
-		})
+	cacheKeys := make([]string, 0, len(keyInputs))
+
+	for _, i := range keyInputs {
+		key, err := GetSearchPermissionCacheKey(testLogger, i.signedInUser, i.searchOptions)
+		require.NoError(t, err)
+		cacheKeys = append(cacheKeys, key)
 	}
+
+	uniqueCheck := make(map[string]bool)
+	for _, str := range cacheKeys {
+		require.False(t, uniqueCheck[str], "Found duplicate string: %s", str)
+		uniqueCheck[str] = true
+	}
+
+	assert.Equal(t, len(cacheKeys), len(uniqueCheck), "The slice contains duplicate strings")
 }

--- a/pkg/services/accesscontrol/cacheutils_test.go
+++ b/pkg/services/accesscontrol/cacheutils_test.go
@@ -144,4 +144,22 @@ func TestGetSearchPermissionCacheKey(t *testing.T) {
 	}
 
 	assert.Equal(t, len(cacheKeys), len(uniqueCheck), "The slice contains duplicate strings")
+
+	t.Run("the cache key is consistent", func(t *testing.T) {
+		user := &user.SignedInUser{
+			OrgID:  1,
+			UserID: 1,
+		}
+		key1, err := GetSearchPermissionCacheKey(testLogger, user, SearchOptions{
+			ActionPrefix: "foobar",
+			RolePrefixes: []string{"foo", "bar"},
+		})
+		require.NoError(t, err)
+		key2, err := GetSearchPermissionCacheKey(testLogger, user, SearchOptions{
+			ActionPrefix: "foobar",
+			RolePrefixes: []string{"foo", "bar"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, key1, key2, "expected search cache keys to be consistent")
+	})
 }


### PR DESCRIPTION
This is a small fix that encodes and hashes the `ac.SearchOptions` for `GetSearchPermissionCacheKey()`. Previously there could be overlapping keys due to optional string concatenation. This should prevent any overlap between keys to prevent incorrect cache hits.