### PR TITLE
ci-wix: add gha ci to build+publish image

### DIFF
--- a/.github/workflows/image-ci-wix.yml
+++ b/.github/workflows/image-ci-wix.yml
@@ -1,0 +1,30 @@
+name: Image - ci-wix
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/build/ci-wix/**"
+      - ".github/workflows/image-ci-wix.yml"
+  pull_request:
+    paths:
+      - "scripts/build/ci-wix/**"
+      - ".github/workflows/image-ci-wix.yml"
+
+jobs:
+  build:
+    name: Build image
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Set up go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: 1.21
+      - name: Build image
+        uses: magefile/mage-action@6a5dcb5fe61f43d7c08a98bc3cf9bc63c308c08e # v3.0.0
+        with:
+          version: latest
+          args: build

--- a/.github/workflows/image-ci-wix.yml
+++ b/.github/workflows/image-ci-wix.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           version: latest
           args: build
+          workdir: scripts/build/ci-wix

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/windows:1809
 WORKDIR C:\\App
 
 RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-RUN powershell Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
 RUN scoop install wixtoolset@3.11.2
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
   \"https://grafana-downloads.storage.googleapis.com/ci-dependencies/nssm-2.24.zip\", \

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR C:\\App
 RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
 RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh -outfile 'install.ps1'
 RUN powershell .\install.ps1 -RunAsAdmin
-RUN scoop install wixtoolset@3.11.2
+RUN powershell dotnet tool install --global wix
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
   \"https://grafana-downloads.storage.googleapis.com/ci-dependencies/nssm-2.24.zip\", \
   \"nssm-2.24.zip\")

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -4,7 +4,8 @@ FROM mcr.microsoft.com/windows/servercore:10.0.17763.6414
 WORKDIR C:\\App
 
 RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh | powershell Invoke-Expression -RunAsAdmin
+RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh -outfile 'install.ps1'
+RUN powershell .\install.ps1 -RunAsAdmin
 RUN scoop install wixtoolset@3.11.2
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
   \"https://grafana-downloads.storage.googleapis.com/ci-dependencies/nssm-2.24.zip\", \

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/windows:1809
 WORKDIR C:\\App
 
 RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh | powershell Invoke-Expression
 RUN scoop install wixtoolset@3.11.2
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
   \"https://grafana-downloads.storage.googleapis.com/ci-dependencies/nssm-2.24.zip\", \

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/windows/servercore:10.0.17763.6414
 WORKDIR C:\\App
 
 RUN powershell Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh | powershell Invoke-Expression
+RUN powershell Invoke-RestMethod -Uri https://get.scoop.sh | powershell Invoke-Expression -RunAsAdmin
 RUN scoop install wixtoolset@3.11.2
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
   \"https://grafana-downloads.storage.googleapis.com/ci-dependencies/nssm-2.24.zip\", \

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -1,5 +1,5 @@
 # This has to correspond to the version the Drone runners have
-FROM mcr.microsoft.com/windows:1809
+FROM mcr.microsoft.com/windows/servercore:10.0.17763.6414
 
 WORKDIR C:\\App
 

--- a/scripts/build/ci-wix/Dockerfile
+++ b/scripts/build/ci-wix/Dockerfile
@@ -9,9 +9,9 @@ RUN scoop install wixtoolset@3.11.2
 RUN powershell (New-Object Net.WebClient).DownloadFile(\
   \"https://grafana-downloads.storage.googleapis.com/ci-dependencies/nssm-2.24.zip\", \
   \"nssm-2.24.zip\")
-RUN scoop install git@2.28.0.windows.1
-RUN scoop bucket add extras
-RUN scoop install gcloud@305.0.0
+RUN powershell scoop install git@2.28.0.windows.1
+RUN powershell scoop bucket add extras
+RUN powershell scoop install gcloud@305.0.0
 # Installing dos2unix fails if not under PowerShell
 RUN powershell scoop install dos2unix
 


### PR DESCRIPTION
We'd like to republish the `grafana/ci-wix` image as we believe it has some issues with its base image. Currently, the image is not able to be pulled.

This change adds CI to build and publish the image.
