### PR TITLE
Migration: Remove table aliasing in delete statement to make it work for mariadb

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/orphaned.go
@@ -86,7 +86,7 @@ func (m *orphanedServiceAccountPermissions) exec(sess *xorm.Session, mg *migrato
 	}
 
 	// delete all orphaned permissions
-	rawDelete := "DELETE FROM permission AS p WHERE p.kind = 'serviceaccounts' AND p.identifier IN(?" + strings.Repeat(",?", len(orphaned)-1) + ")"
+	rawDelete := "DELETE FROM permission WHERE kind = 'serviceaccounts' AND identifier IN(?" + strings.Repeat(",?", len(orphaned)-1) + ")"
 	deleteArgs := make([]any, 0, len(orphaned)+1)
 	deleteArgs = append(deleteArgs, rawDelete)
 	for _, id := range orphaned {


### PR DESCRIPTION
**What is this feature?**
Table aliasing support in `DELETE` statements was added to [MariaDB v11.6 ](https://mariadb.com/kb/en/changes-improvements-in-mariadb-11-6/#syntax).

Even though mariaDB is not an [officially supported database for grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/#supported-databases) the fix is trivial.


**Which issue(s) does this PR fix?**:

Potentially related to https://github.com/grafana/grafana/issues/95219

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
