### PR TITLE
Tempo: Return a not found error if the trace is empty from v2

### DIFF
--- a/pkg/tsdb/tempo/trace.go
+++ b/pkg/tsdb/tempo/trace.go
@@ -114,6 +114,14 @@ func (s *Service) getTrace(ctx context.Context, pCtx backend.PluginContext, quer
 			return &backend.DataResponse{}, fmt.Errorf("failed to transform trace %v to data frame: %w", model.Query, err)
 		}
 
+		if frame == nil {
+			result.Status = http.StatusNotFound
+			result.Error = fmt.Errorf("failed to get trace with id: %s Status: %s", *model.Query, result.Status)
+			span.RecordError(result.Error)
+			span.SetStatus(codes.Error, result.Error.Error())
+			return result, nil
+		}
+
 		frame.Meta.Custom = map[string]interface{}{
 			"partial": tr.GetStatus() == tempopb.TraceByIDResponse_PARTIAL,
 			"message": tr.GetMessage(),


### PR DESCRIPTION
**What is this feature?**

Fixes a crash when the trace isn't found for a `/api/v2/traces/` request.

![image](https://github.com/user-attachments/assets/f596893a-10ff-4fd1-8dc9-208c9e89569e)

**Who is this feature for?**

Users of the Tempo datasource. 
