### PR TITLE
Test Folder's GetAuthorizer

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -32,6 +32,7 @@ var _ builder.APIGroupBuilder = (*FolderAPIBuilder)(nil)
 var resourceInfo = v0alpha1.FolderResourceInfo
 
 var errNoUser = errors.New("valid user is required")
+var errNoResource = errors.New("resource name is required")
 
 // This is used just so wire has something unique to return
 type FolderAPIBuilder struct {
@@ -185,7 +186,7 @@ func authorizerFunc(ctx context.Context, attr authorizer.Attributes) (*authorize
 	verb := attr.GetVerb()
 	name := attr.GetName()
 	if (!attr.IsResourceRequest()) || (name == "" && verb != utils.VerbCreate) {
-		return nil, errors.New("resource name is required")
+		return nil, errNoResource
 	}
 
 	// require a user

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -168,7 +168,7 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 		in, err := authorizerFunc(ctx, attr)
 
 		if err != nil {
-			if err == errNoUser {
+			if errors.Is(err, errNoUser) {
 				return authorizer.DecisionDeny, "", nil
 			}
 			return authorizer.DecisionNoOpinion, "", nil

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -156,10 +156,10 @@ func (b *FolderAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAP
 
 func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-		ctx, user, eval, decision, requester := authorizerFunc(ctx, attr)
+		ctx, user, eval, decisionNoOpinion, requester := authorizerFunc(ctx, attr)
 
 		if user == nil {
-			return decision, requester, nil
+			return decisionNoOpinion, requester, nil
 		}
 
 		ok, err := b.accessControl.Evaluate(ctx, user, eval)

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -166,7 +166,6 @@ type authorizerParams struct {
 func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 		in, err := authorizerFunc(ctx, attr)
-
 		if err != nil {
 			if errors.Is(err, errNoUser) {
 				return authorizer.DecisionDeny, "", nil

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -4,25 +4,34 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
+	type expected struct {
+		user      identity.Requester
+		eval      authorizer.Attributes
+		decision  authorizer.Decision
+		requester string
+	}
+	var ctx = context.Background()
 	tests := []struct {
-		name         string
-		inputContext context.Context
-		inputAttr    authorizer.Attributes
-		want         authorizer.Authorizer
+		name  string
+		input context.Context
+		want  expected
 	}{
 		{
-			name: "When creating folder should not return access denied error",
+			name:  "When creating folder should not return access denied error",
+			input: identity.WithRequester(ctx, &user.SignedInUser{}),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			_, user, eval, decision, requester := authorizerFunc(tt.inputContext, tt.inputAttr)
+			_, user, eval, decision, requester := authorizerFunc(tt.input, authorizer.AttributesRecord{})
 			// require.NotNil(t, )
 		})
 	}

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -5,48 +5,51 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
-
-	var ctx = context.Background()
+	type input struct {
+		permissions map[int64]map[string][]string
+		verb        string
+	}
+	type expect struct {
+		user identity.Requester
+		eval string
+	}
 	var orgID int64 = 1
+	var userInfo = &user.SignedInUser{UserID: 1, Name: "123"}
 	tests := []struct {
-		name     string
-		input    context.Context
-		allow bool
+		name   string
+		input  input
+		expect expect
 	}{
 		{
 			name: "When creating folder should not return access denied error",
-			input: identity.WithRequester(ctx, &user.SignedInUser{UserID: 1, Permissions: map[int64]map[string][]string{
-				orgID: {dashboards.ActionFoldersCreate: {}, dashboards.ActionFoldersWrite: {dashboards.ScopeFoldersAll}},
-			}}),
-			allow: true,
+			input: input{
+				permissions: map[int64]map[string][]string{
+					orgID: {dashboards.ActionFoldersCreate: {}, dashboards.ActionFoldersWrite: {dashboards.ScopeFoldersAll}},
+				},
+				verb: string(utils.VerbCreate),
+			},
+			expect: expect{
+				user: userInfo,
+				eval: "folders:create",
+			},
 		},
-	}
-
-	b := &FolderAPIBuilder{
-		gv:            resourceInfo.GroupVersion(),
-		features:      nil,
-		namespacer:    func(_ int64) string { return "123" },
-		folderSvc:     foldertest.NewFakeService(),
-		accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures("nestedFolders"), zanzana.NewNoopClient()),
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, user, eval, _, _ := authorizerFunc(tt.input, authorizer.AttributesRecord{})
-			ok, err := b.accessControl.Evaluate(ctx, user, eval)
-			require.NoError(t, err)
-			require.Equal(t, tt.allow, ok)
+			userInfo.Permissions = tt.input.permissions
+			ctx := context.Background()
+			_, user, eval, _, _ := authorizerFunc(identity.WithRequester(ctx, userInfo), authorizer.AttributesRecord{User: userInfo, Verb: tt.input.verb, Resource: "folders", ResourceRequest: true, Name: "123"})
+			require.Equal(t, tt.expect.user, user)
+			require.Equal(t, tt.expect.eval, eval.String())
 		})
 	}
 }

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -5,34 +5,48 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
-	type expected struct {
-		user      identity.Requester
-		eval      authorizer.Attributes
-		decision  authorizer.Decision
-		requester string
-	}
+
 	var ctx = context.Background()
+	var orgID int64 = 1
 	tests := []struct {
-		name  string
-		input context.Context
-		want  expected
+		name     string
+		input    context.Context
+		allow bool
 	}{
 		{
-			name:  "When creating folder should not return access denied error",
-			input: identity.WithRequester(ctx, &user.SignedInUser{}),
+			name: "When creating folder should not return access denied error",
+			input: identity.WithRequester(ctx, &user.SignedInUser{UserID: 1, Permissions: map[int64]map[string][]string{
+				orgID: {dashboards.ActionFoldersCreate: {}, dashboards.ActionFoldersWrite: {dashboards.ScopeFoldersAll}},
+			}}),
+			allow: true,
 		},
+	}
+
+	b := &FolderAPIBuilder{
+		gv:            resourceInfo.GroupVersion(),
+		features:      nil,
+		namespacer:    func(_ int64) string { return "123" },
+		folderSvc:     foldertest.NewFakeService(),
+		accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures("nestedFolders"), zanzana.NewNoopClient()),
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			_, user, eval, decision, requester := authorizerFunc(tt.input, authorizer.AttributesRecord{})
-			// require.NotNil(t, )
+			ctx, user, eval, _, _ := authorizerFunc(tt.input, authorizer.AttributesRecord{})
+			ok, err := b.accessControl.Evaluate(ctx, user, eval)
+			require.NoError(t, err)
+			require.Equal(t, tt.allow, ok)
 		})
 	}
 }

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -90,10 +90,10 @@ func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			ctx, user, eval, _, _ := authorizerFunc(identity.WithRequester(ctx, tt.input.user), authorizer.AttributesRecord{User: tt.input.user, Verb: tt.input.verb, Resource: "folders", ResourceRequest: true, Name: "123"})
-			allow, err := b.accessControl.Evaluate(ctx, user, eval)
+			out := authorizerFunc(identity.WithRequester(ctx, tt.input.user), authorizer.AttributesRecord{User: tt.input.user, Verb: tt.input.verb, Resource: "folders", ResourceRequest: true, Name: "123"})
+			allow, err := b.accessControl.Evaluate(ctx, out.user, out.eval)
 			require.NoError(t, err)
-			require.Equal(t, tt.expect.eval, eval.String())
+			require.Equal(t, tt.expect.eval, out.eval.String())
 			require.Equal(t, tt.expect.allow, allow)
 		})
 	}

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -1,0 +1,37 @@
+package folders
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestFolderAPIBuilder_GetAuthorizer(t *testing.T) {
+	tests := []struct {
+		name  string
+		input authorizer.AuthorizerFunc
+		want  authorizer.Authorizer
+	}{
+		// name: ""
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &FolderAPIBuilder{
+				gv:            resourceInfo.GroupVersion(),
+				features:      nil,
+				namespacer:    func(_ int64) string { return "123" },
+				folderSvc:     foldertest.NewFakeService(),
+				accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures("nestedFolders"), zanzana.NewNoopClient()),
+			}
+			got := b.GetAuthorizer()
+
+			require.NotNil(t, got)
+		})
+	}
+}

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -14,10 +14,12 @@ import (
 func TestFolderAPIBuilder_GetAuthorizer(t *testing.T) {
 	tests := []struct {
 		name  string
-		input authorizer.AuthorizerFunc
+		input authorizer.Authorizer
 		want  authorizer.Authorizer
 	}{
-		// name: ""
+		{
+			name: "When creating folder should not return access denied error",
+		},
 	}
 
 	for _, tt := range tests {
@@ -30,7 +32,6 @@ func TestFolderAPIBuilder_GetAuthorizer(t *testing.T) {
 				accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures("nestedFolders"), zanzana.NewNoopClient()),
 			}
 			got := b.GetAuthorizer()
-
 			require.NotNil(t, got)
 		})
 	}

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -1,21 +1,18 @@
 package folders
 
 import (
+	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/services/folder/foldertest"
-	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
-func TestFolderAPIBuilder_GetAuthorizer(t *testing.T) {
+func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
 	tests := []struct {
-		name  string
-		input authorizer.Authorizer
-		want  authorizer.Authorizer
+		name         string
+		inputContext context.Context
+		inputAttr    authorizer.Attributes
+		want         authorizer.Authorizer
 	}{
 		{
 			name: "When creating folder should not return access denied error",
@@ -24,15 +21,9 @@ func TestFolderAPIBuilder_GetAuthorizer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &FolderAPIBuilder{
-				gv:            resourceInfo.GroupVersion(),
-				features:      nil,
-				namespacer:    func(_ int64) string { return "123" },
-				folderSvc:     foldertest.NewFakeService(),
-				accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures("nestedFolders"), zanzana.NewNoopClient()),
-			}
-			got := b.GetAuthorizer()
-			require.NotNil(t, got)
+
+			_, user, eval, decision, requester := authorizerFunc(tt.inputContext, tt.inputAttr)
+			// require.NotNil(t, )
 		})
 	}
 }

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -90,10 +90,10 @@ func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			out := authorizerFunc(identity.WithRequester(ctx, tt.input.user), authorizer.AttributesRecord{User: tt.input.user, Verb: tt.input.verb, Resource: "folders", ResourceRequest: true, Name: "123"})
-			allow, err := b.accessControl.Evaluate(ctx, out.user, out.eval)
+			out, err := authorizerFunc(identity.WithRequester(ctx, tt.input.user), authorizer.AttributesRecord{User: tt.input.user, Verb: tt.input.verb, Resource: "folders", ResourceRequest: true, Name: "123"})
+			allow, err := b.accessControl.Evaluate(ctx, out.user, out.evaluator)
 			require.NoError(t, err)
-			require.Equal(t, tt.expect.eval, out.eval.String())
+			require.Equal(t, tt.expect.eval, out.evaluator.String())
 			require.Equal(t, tt.expect.allow, allow)
 		})
 	}


### PR DESCRIPTION
**What is this feature?**

Add unit tests for `getAuthorizer` implementation for folders. Focusing on the `create` method for now.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/search-and-storage-team/issues/110

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
