### PR TITLE
FilterByNameTransformerEditor: improve selection and layout

### DIFF
--- a/packages/grafana-ui/src/components/FilterPill/FilterPill.tsx
+++ b/packages/grafana-ui/src/components/FilterPill/FilterPill.tsx
@@ -20,7 +20,7 @@ export const FilterPill = ({ label, selected, onClick, icon = 'check' }: FilterP
   const clearButton = useStyles2(clearButtonStyles);
   return (
     <button type="button" className={cx(clearButton, styles.wrapper, selected && styles.selected)} onClick={onClick}>
-      <span>{label}</span>
+      <span className={styles.label}>{label}</span>
       {selected && <Icon name={icon} className={styles.icon} />}
     </button>
   );
@@ -31,17 +31,19 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css({
       background: theme.colors.background.secondary,
       borderRadius: theme.shape.radius.pill,
-      padding: theme.spacing(0, 2),
+      padding: theme.spacing(1, 2),
       fontSize: theme.typography.bodySmall.fontSize,
       fontWeight: theme.typography.fontWeightMedium,
       lineHeight: theme.typography.bodySmall.lineHeight,
       color: theme.colors.text.secondary,
       display: 'flex',
-      alignItems: 'center',
-      height: '32px',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      minHeight: '32px',
       position: 'relative',
       border: `1px solid ${theme.colors.background.secondary}`,
-      whiteSpace: 'nowrap',
+      width: '100%',
+      textAlign: 'left',
 
       '&:hover': {
         background: theme.colors.action.hover,
@@ -56,8 +58,13 @@ const getStyles = (theme: GrafanaTheme2) => {
         background: theme.colors.action.focus,
       },
     }),
+    label: css({
+      wordBreak: 'break-word',
+      marginRight: theme.spacing(1),
+    }),
     icon: css({
       marginLeft: theme.spacing(0.5),
+      alignSelf: 'center',
     }),
   };
 };

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import * as React from 'react';
 
 import {
@@ -13,7 +14,8 @@ import {
 } from '@grafana/data';
 import { FilterFieldsByNameTransformerOptions } from '@grafana/data/src/transformations/transformers/filterByName';
 import { getTemplateSrv } from '@grafana/runtime/src/services';
-import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
+import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select, Button, Stack } from '@grafana/ui';
+import { Trans } from '@grafana/ui/src/utils/i18n';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
 
@@ -194,13 +196,22 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
     this.setState({ byVariable: val });
   };
 
+  onSelectAll = () => {
+    const allFieldNames = this.state.options.map((o) => o.name);
+    this.onChange(allFieldNames);
+  };
+
+  onDeselectAll = () => {
+    this.onChange([]);
+  };
+
   render() {
     const { options, selected, isRegexValid } = this.state;
     return (
-      <div>
-        <InlineFieldRow label="Use variable">
+      <Stack direction="column" gap={2}>
+        <InlineFieldRow>
           <InlineField label="From variable">
-            <InlineSwitch value={this.state.byVariable} onChange={this.onFromVariableChange}></InlineSwitch>
+            <InlineSwitch value={this.state.byVariable} onChange={this.onFromVariableChange} />
           </InlineField>
         </InlineFieldRow>
         {this.state.byVariable ? (
@@ -210,44 +221,64 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
                 value={this.state.variable}
                 onChange={this.onVariableChange}
                 options={this.state.variables || []}
-              ></Select>
+              />
             </InlineField>
           </InlineFieldRow>
         ) : (
-          <InlineFieldRow label="Identifier">
-            <InlineField
-              label="Identifier"
-              invalid={!isRegexValid}
-              error={!isRegexValid ? 'Invalid pattern' : undefined}
-            >
-              <Input
-                placeholder="Regular expression pattern"
-                value={this.state.regex || ''}
-                onChange={(e) => this.setState({ regex: e.currentTarget.value })}
-                onBlur={this.onInputBlur}
-                width={25}
-              />
-            </InlineField>
-            {options.map((o, i) => {
-              const label = `${o.name}${o.count > 1 ? ' (' + o.count + ')' : ''}`;
-              const isSelected = selected.indexOf(o.name) > -1;
-              return (
-                <FilterPill
-                  key={`${o.name}/${i}`}
-                  onClick={() => {
-                    this.onFieldToggle(o.name);
-                  }}
-                  label={label}
-                  selected={isSelected}
+          <Stack direction="column" gap={1}>
+            <InlineFieldRow>
+              <InlineField
+                label="Identifier"
+                invalid={!isRegexValid}
+                error={!isRegexValid ? 'Invalid pattern' : undefined}
+              >
+                <Input
+                  placeholder="Regular expression pattern"
+                  value={this.state.regex || ''}
+                  onChange={(e) => this.setState({ regex: e.currentTarget.value })}
+                  onBlur={this.onInputBlur}
+                  width={25}
                 />
-              );
-            })}
-          </InlineFieldRow>
+              </InlineField>
+            </InlineFieldRow>
+            <Stack direction="row" gap={1}>
+              <Button variant="secondary" size="sm" onClick={this.onSelectAll}>
+                <Trans i18nKey="grafana-ui.filter-by-name-transformer-editor.select-all">Select All</Trans>
+              </Button>
+              <Button variant="secondary" size="sm" onClick={this.onDeselectAll}>
+                <Trans i18nKey="grafana-ui.filter-by-name-transformer-editor.deselect-all">Deselect All</Trans>
+              </Button>
+            </Stack>
+            <div className={styles.pillContainer}>
+              {options.map((o, i) => {
+                const label = `${o.name}${o.count > 1 ? ' (' + o.count + ')' : ''}`;
+                const isSelected = selected.indexOf(o.name) > -1;
+                return (
+                  <FilterPill
+                    key={`${o.name}/${i}`}
+                    onClick={() => {
+                      this.onFieldToggle(o.name);
+                    }}
+                    label={label}
+                    selected={isSelected}
+                  />
+                );
+              })}
+            </div>
+          </Stack>
         )}
-      </div>
+      </Stack>
     );
   }
 }
+
+const styles = {
+  pillContainer: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+    gap: '8px',
+  }),
+};
 
 export const filterFieldsByNameTransformRegistryItem: TransformerRegistryItem<FilterFieldsByNameTransformerOptions> = {
   id: DataTransformerID.filterFieldsByName,


### PR DESCRIPTION
**What is this feature?**

This adds a feature to select/deselect all labels at once. Also, labels are now displayed in a regular pattern so they are easier to discern.

At the top we have the two new buttons.

Below are now up to three columns using `Stack` to display all labels, ensuring that text is properly wrapped.

<img width="828" alt="SCR-20241023-orhb" src="https://github.com/user-attachments/assets/b0795bd4-4115-4ade-b24b-b2f0e3872269">


**Why do we need this feature?**

This fixes https://github.com/grafana/grafana/issues/82471

**Who is this feature for?**

End-users of the filter feature.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/82471

**Special notes for your reviewer:**

I am a first-time contributor to Grafana. I am not sure if the below notes about docs apply.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
