### PR TITLE
 Dashboard Scene: Add Missing Overrides Tab to Panel Edit

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
@@ -9,6 +9,7 @@ import {
   PanelPluginMeta,
   restoreCustomOverrideRules,
   PluginType,
+  SelectableValue,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
@@ -21,7 +22,7 @@ import {
   VizPanel,
   sceneGraph,
 } from '@grafana/scenes';
-import { Button, Card, FilterInput, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { Button, Card, FilterInput, RadioButtonGroup, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
 import { getPanelPluginNotFound } from 'app/features/panel/components/PanelPluginError';
@@ -104,6 +105,13 @@ export class PanelOptionsPane extends SceneObjectBase<PanelOptionsPaneState> {
     });
   };
 
+  getOptionRadioFilters(): Array<SelectableValue<OptionFilter>> {
+    return [
+      { label: OptionFilter.All, value: OptionFilter.All },
+      { label: OptionFilter.Overrides, value: OptionFilter.Overrides },
+    ];
+  }
+
   static Component = ({ model }: SceneComponentProps<PanelOptionsPane>) => {
     const { isVizPickerOpen, searchQuery, listMode, panelRef } = model.useState();
     const panel = panelRef.resolve();
@@ -111,6 +119,8 @@ export class PanelOptionsPane extends SceneObjectBase<PanelOptionsPaneState> {
     const { data } = sceneGraph.getData(panel).useState();
     const styles = useStyles2(getStyles);
     const isAngularPanel = isUsingAngularPanelPlugin(panel);
+    const isSearching = searchQuery.length > 0;
+    const showSearchRadioButtons = !isSearching && !panel.getPlugin()?.fieldConfigRegistry.isEmpty();
     return (
       <>
         {!isVizPickerOpen && (
@@ -123,6 +133,14 @@ export class PanelOptionsPane extends SceneObjectBase<PanelOptionsPaneState> {
                 placeholder="Search options"
                 onChange={model.onSetSearchQuery}
               />
+              {showSearchRadioButtons && (
+                <RadioButtonGroup
+                  options={model.getOptionRadioFilters()}
+                  value={listMode}
+                  fullWidth
+                  onChange={model.onSetListMode}
+                />
+              )}
             </div>
             {isAngularPanel && (
               <div className={styles.angularDeprecationContainer}>


### PR DESCRIPTION
Adds missing overrides tab to panel edit

https://github.com/user-attachments/assets/f121e67e-8889-4097-b033-7b58a0399d4a


Fixes #89540 

Please check that:
- [ ] It works as expected from a user's perspective.

