### PR TITLE
Docs: Fix shared file references

### DIFF
--- a/docs/sources/alerting/alerting-rules/templates/language.md
+++ b/docs/sources/alerting/alerting-rules/templates/language.md
@@ -78,4 +78,4 @@ Dot (`.`) might refer to something else when used in a [range](#range), a [with]
 
 [//]: <> (The above section is not included in the shared file because `refs` links are not supported in shared files.)
 
-{{< docs/shared lookup="alerts/template-language.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="alerts/template-language.md" source="grafana" version="<GRAFANA_VERSION>" >}}

--- a/docs/sources/alerting/configure-notifications/template-notifications/language.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/language.md
@@ -82,4 +82,4 @@ Dot (`.`) might refer to something else when used in a [range](#range), a [with]
 
 [//]: <> (The above section is not included in the shared file because `refs` links are not supported in shared files.)
 
-{{< docs/shared lookup="alerts/template-language.md" source="grafana" version="<GRAFANA VERSION>" >}}
+{{< docs/shared lookup="alerts/template-language.md" source="grafana" version="<GRAFANA_VERSION>" >}}


### PR DESCRIPTION
The version syntax is missing an underscore which might be causing the doc-validator check to fail on other PRs