### PR TITLE
Unified Storage: Add index for poller query

### DIFF
--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -105,5 +105,9 @@ func initResourceTables(mg *migrator.Migrator) string {
 		Name: "previous_resource_version", Type: migrator.DB_BigInt, Nullable: true,
 	}))
 
+	mg.AddMigration("Add index to resource_history for polling", migrator.NewAddIndexMigration(resource_history_table, &migrator.Index{
+		Cols: []string{"group", "resource", "resource_version"}, Type: migrator.IndexType,
+	}))
+
 	return marker
 }


### PR DESCRIPTION
The query for the watch poller was causing constant high db cpu usage because it was doing table scans on the `resource_history` table.

![Screenshot 2024-10-23 at 1 04 54 PM](https://github.com/user-attachments/assets/216f0c5b-44ba-41a8-ad3f-7b4469e72bfc)

The query is:
```mysql
SELECT
  `resource_version`,
  `namespace`,
  `group`,
  `resource`,
  `name`,
  `value`,
  `action`,
  `previous_resource_version`
FROM
  `resource_history`
WHERE
  ? = ?
  AND `group` = ?
  AND `resource` = ?
  AND `resource_version` > ?
ORDER BY
  `resource_version` ASC
```

This adds a composite index to fix that. I already added it directly to the dev US database to test, and it dropped cpu usage down to 4%.

<img width="842" alt="Screenshot 2024-10-23 at 1 42 37 PM" src="https://github.com/user-attachments/assets/9cdcef96-8619-4ab7-8560-08b531e96454">

