### PR TITLE
Dashboards: Fixes performance issue expanding a row 

### DIFF
--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -122,7 +122,6 @@ export class DashboardSceneChangeTracker {
   }
 
   private detectSaveModelChanges() {
-    console.log('detectSaveModelChanges');
     const changedDashboard = transformSceneToSaveModel(this._dashboard);
     const initialDashboard = this._dashboard.getInitialSaveModel();
 

--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -32,7 +32,7 @@ export class DashboardSceneChangeTracker {
   private _changesWorker?: Worker;
   private _dashboard: DashboardScene;
 
-  constructor(dashboard: DashboardScene, debounce?: number) {
+  constructor(dashboard: DashboardScene) {
     this._dashboard = dashboard;
   }
 


### PR DESCRIPTION
When expanding a row with many panels on a dashboard with many collapsed rows it resulted in A LOT of calls to detectdetectSaveModelChanges (which has a very expensive step inside sceneToSaveModel which does a sorting of all properties in the resulting save model) 

![image](https://github.com/user-attachments/assets/9e3e0590-772e-41f7-96de-055b04f41356)

This freezes the browser for several seconds. We must have missed to debounce this function (we do it in panel editor) but not here. 

To simplify the unit tests I skip the debounce in unit tests. 

Related: https://github.com/grafana/support-escalations/issues/13059