### PR TITLE
Release: Install git in npm release step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2379,7 +2379,7 @@ steps:
     repo:
     - grafana/grafana
 - commands:
-  - apk add --update bash
+  - apk add --update bash git
   - ./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org'
   depends_on:
   - end-to-end-tests-dashboards-suite
@@ -5937,6 +5937,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: a8084d907b286e710ed331c4c09a23f16c1afed5c428a9a1b99da3ad05ab3a3f
+hmac: 54085f152d1aeb8bd67a69de6a253a75f7c1d2c2a842f9a467ce4a75e218aa84
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1129,7 +1129,7 @@ def release_canary_npm_packages_step(trigger = None):
             "NPM_TOKEN": from_secret(npm_token),
         },
         "commands": [
-            "apk add --update bash",
+            "apk add --update bash git",
             "./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org'",
         ],
     }


### PR DESCRIPTION

**What is this feature?**

I recently made some [changes](https://github.com/grafana/grafana/pull/93813) in the npm release canary step that moves the new `modified` tag in case there are changes in the e2e-selectors package. However, this step [failed](https://drone.grafana.net/grafana/grafana/204172/7/31) because git is not installed. This PR fixes that. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
