### PR TITLE
Logs Panel: Added support to pass custom options to the log rows menu

### DIFF
--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -17,6 +17,8 @@ export interface Options {
   displayedFields?: Array<string>;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
+  logRowMenuIconsAfter?: unknown;
+  logRowMenuIconsBefore?: unknown;
   /**
    * TODO: figure out how to define callbacks
    */

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -2,7 +2,7 @@ import { cx } from '@emotion/css';
 import { debounce } from 'lodash';
 import memoizeOne from 'memoize-one';
 import * as React from 'react';
-import { MouseEvent, PureComponent } from 'react';
+import { MouseEvent, PureComponent, ReactNode } from 'react';
 
 import {
   CoreApp,
@@ -65,6 +65,8 @@ interface Props extends Themeable2 {
   pinned?: boolean;
   containerRendered?: boolean;
   handleTextSelection?: (e: MouseEvent<HTMLTableRowElement>, row: LogRowModel) => boolean;
+  logRowMenuIconsBefore?: ReactNode;
+  logRowMenuIconsAfter?: ReactNode;
 }
 
 interface State {
@@ -210,6 +212,8 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       styles,
       getRowContextQuery,
       pinned,
+      logRowMenuIconsBefore,
+      logRowMenuIconsAfter,
     } = this.props;
 
     const { showDetails, showingContext, permalinked } = this.state;
@@ -314,6 +318,8 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               mouseIsOver={this.state.mouseIsOver}
               onBlur={this.onMouseLeave}
               expanded={this.state.showDetails}
+              logRowMenuIconsBefore={logRowMenuIconsBefore}
+              logRowMenuIconsAfter={logRowMenuIconsAfter}
             />
           )}
         </tr>

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -65,8 +65,8 @@ interface Props extends Themeable2 {
   pinned?: boolean;
   containerRendered?: boolean;
   handleTextSelection?: (e: MouseEvent<HTMLTableRowElement>, row: LogRowModel) => boolean;
-  logRowMenuIconsBefore?: ReactNode;
-  logRowMenuIconsAfter?: ReactNode;
+  logRowMenuIconsBefore?: ReactNode[];
+  logRowMenuIconsAfter?: ReactNode[];
 }
 
 interface State {

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -1,4 +1,4 @@
-import { memo, FocusEvent, SyntheticEvent, useCallback } from 'react';
+import { memo, FocusEvent, SyntheticEvent, useCallback, ReactNode } from 'react';
 
 import { LogRowContextOptions, LogRowModel, getDefaultTimeRange, locationUtil, urlUtil } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
@@ -26,6 +26,8 @@ interface Props {
   mouseIsOver: boolean;
   onBlur: () => void;
   onPinToContentOutlineClick?: (row: LogRowModel, onOpenContext: (row: LogRowModel) => void) => void;
+  addonBefore?: ReactNode;
+  addonAfter?: ReactNode;
 }
 
 export const LogRowMenuCell = memo(
@@ -43,6 +45,8 @@ export const LogRowMenuCell = memo(
     mouseIsOver,
     onBlur,
     getRowContextQuery,
+    addonBefore,
+    addonAfter,
   }: Props) => {
     const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
     const onLogRowClick = useCallback((e: SyntheticEvent) => {
@@ -94,6 +98,7 @@ export const LogRowMenuCell = memo(
       // We keep this click listener here to prevent the row from being selected when clicking on the menu.
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <span className={`log-row-menu ${styles.rowMenu}`} onClick={onLogRowClick} onBlur={handleBlur}>
+        {addonBefore}
         {pinned && !mouseIsOver && (
           <IconButton
             className={styles.unPinButton}
@@ -165,6 +170,7 @@ export const LogRowMenuCell = memo(
                 tabIndex={0}
               />
             )}
+            {addonAfter}
           </>
         )}
       </span>

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -1,4 +1,14 @@
-import { memo, FocusEvent, SyntheticEvent, useCallback, ReactNode } from 'react';
+import {
+  memo,
+  FocusEvent,
+  SyntheticEvent,
+  useCallback,
+  ReactNode,
+  useMemo,
+  cloneElement,
+  isValidElement,
+  MouseEvent,
+} from 'react';
 
 import { LogRowContextOptions, LogRowModel, getDefaultTimeRange, locationUtil, urlUtil } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
@@ -26,8 +36,8 @@ interface Props {
   mouseIsOver: boolean;
   onBlur: () => void;
   onPinToContentOutlineClick?: (row: LogRowModel, onOpenContext: (row: LogRowModel) => void) => void;
-  addonBefore?: ReactNode;
-  addonAfter?: ReactNode;
+  addonBefore?: ReactNode[];
+  addonAfter?: ReactNode[];
 }
 
 export const LogRowMenuCell = memo(
@@ -48,12 +58,15 @@ export const LogRowMenuCell = memo(
     addonBefore,
     addonAfter,
   }: Props) => {
-    const shouldShowContextToggle = showContextToggle ? showContextToggle(row) : false;
+    const shouldShowContextToggle = useMemo(
+      () => (showContextToggle ? showContextToggle(row) : false),
+      [row, showContextToggle]
+    );
     const onLogRowClick = useCallback((e: SyntheticEvent) => {
       e.stopPropagation();
     }, []);
     const onShowContextClick = useCallback(
-      async (event: SyntheticEvent<HTMLButtonElement, MouseEvent>) => {
+      async (event: MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
         // if ctrl or meta key is pressed, open query in new Explore tab
         if (
@@ -94,6 +107,21 @@ export const LogRowMenuCell = memo(
       [onBlur]
     );
     const getLogText = useCallback(() => logText, [logText]);
+
+    const beforeContent = useMemo(() => {
+      if (!addonBefore) {
+        return null;
+      }
+      return addClickListenersToNode(addonBefore, row);
+    }, [addonBefore, row]);
+
+    const afterContent = useMemo(() => {
+      if (!addonAfter) {
+        return null;
+      }
+      return addClickListenersToNode(addonAfter, row);
+    }, [addonAfter, row]);
+
     return (
       // We keep this click listener here to prevent the row from being selected when clicking on the menu.
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
@@ -112,7 +140,7 @@ export const LogRowMenuCell = memo(
         )}
         {mouseIsOver && (
           <>
-            {addonBefore}
+            {beforeContent}
             {shouldShowContextToggle && (
               <IconButton
                 size="md"
@@ -170,12 +198,34 @@ export const LogRowMenuCell = memo(
                 tabIndex={0}
               />
             )}
-            {addonAfter}
+            {afterContent}
           </>
         )}
       </span>
     );
   }
 );
+
+type AddonOnClickListener = (event: MouseEvent, row: LogRowModel) => void | undefined;
+function addClickListenersToNode(nodes: ReactNode[], row: LogRowModel) {
+  return nodes.map((node, index) => {
+    if (isValidElement(node)) {
+      const onClick: AddonOnClickListener = node.props.onClick;
+      if (!onClick) {
+        return node;
+      }
+      return cloneElement(node, {
+        // @ts-expect-error
+        onClick: (event: MouseEvent<HTMLElement>) => {
+          onClick(event, row);
+        },
+        key: index,
+      });
+    }
+
+    // Return primitive nodes (like strings, numbers) as they are
+    return node;
+  });
+}
 
 LogRowMenuCell.displayName = 'LogRowMenuCell';

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -222,8 +222,6 @@ function addClickListenersToNode(nodes: ReactNode[], row: LogRowModel) {
         key: index,
       });
     }
-
-    // Return primitive nodes (like strings, numbers) as they are
     return node;
   });
 }

--- a/public/app/features/logs/components/LogRowMenuCell.tsx
+++ b/public/app/features/logs/components/LogRowMenuCell.tsx
@@ -98,7 +98,6 @@ export const LogRowMenuCell = memo(
       // We keep this click listener here to prevent the row from being selected when clicking on the menu.
       // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
       <span className={`log-row-menu ${styles.rowMenu}`} onClick={onLogRowClick} onBlur={handleBlur}>
-        {addonBefore}
         {pinned && !mouseIsOver && (
           <IconButton
             className={styles.unPinButton}
@@ -113,6 +112,7 @@ export const LogRowMenuCell = memo(
         )}
         {mouseIsOver && (
           <>
+            {addonBefore}
             {shouldShowContextToggle && (
               <IconButton
                 size="md"

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 
 import { CoreApp, createTheme, LogLevel, LogRowModel } from '@grafana/data';
+import { IconButton } from '@grafana/ui';
 
 import { LogRowMessage } from './LogRowMessage';
 import { createLogRow } from './__mocks__/logRow';
@@ -195,6 +196,28 @@ line3`;
       expect(screen.getByText(/line2/)).toBeInTheDocument();
       expect(screen.getByText(/line3/)).toBeInTheDocument();
       expect(screen.queryByText(singleLineEntry)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('With custom buttons', () => {
+    it('supports custom buttons before and after the default options', async () => {
+      const onBefore = jest.fn();
+      const logRowMenuIconsBefore = (
+        <IconButton name="eye-slash" onClick={onBefore} tooltip="Addon before" aria-label="Addon before" />
+      );
+      const onAfter = jest.fn();
+      const logRowMenuIconsAfter = (
+        <IconButton name="rss" onClick={onAfter} tooltip="Addon after" aria-label="Addon after" />
+      );
+
+      setup({ logRowMenuIconsBefore, logRowMenuIconsAfter });
+
+      await userEvent.hover(screen.getByText('test123'));
+      await userEvent.click(screen.getByLabelText('Addon before'));
+      await userEvent.click(screen.getByLabelText('Addon after'));
+
+      expect(onBefore).toHaveBeenCalled();
+      expect(onAfter).toHaveBeenCalled();
     });
   });
 });

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -202,22 +202,22 @@ line3`;
   describe('With custom buttons', () => {
     it('supports custom buttons before and after the default options', async () => {
       const onBefore = jest.fn();
-      const logRowMenuIconsBefore = (
-        <IconButton name="eye-slash" onClick={onBefore} tooltip="Addon before" aria-label="Addon before" />
-      );
+      const logRowMenuIconsBefore = [
+        <IconButton name="eye-slash" onClick={onBefore} tooltip="Addon before" aria-label="Addon before" key={1} />,
+      ];
       const onAfter = jest.fn();
-      const logRowMenuIconsAfter = (
-        <IconButton name="rss" onClick={onAfter} tooltip="Addon after" aria-label="Addon after" />
-      );
+      const logRowMenuIconsAfter = [
+        <IconButton name="rss" onClick={onAfter} tooltip="Addon after" aria-label="Addon after" key={1} />,
+      ];
 
-      setup({ logRowMenuIconsBefore, logRowMenuIconsAfter });
+      const { row } = setup({ logRowMenuIconsBefore, logRowMenuIconsAfter });
 
       await userEvent.hover(screen.getByText('test123'));
       await userEvent.click(screen.getByLabelText('Addon before'));
       await userEvent.click(screen.getByLabelText('Addon after'));
 
-      expect(onBefore).toHaveBeenCalled();
-      expect(onAfter).toHaveBeenCalled();
+      expect(onBefore).toHaveBeenCalledWith(expect.anything(), row);
+      expect(onAfter).toHaveBeenCalledWith(expect.anything(), row);
     });
   });
 });

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -32,8 +32,8 @@ interface Props {
   mouseIsOver: boolean;
   onBlur: () => void;
   expanded?: boolean;
-  logRowMenuIconsBefore?: ReactNode;
-  logRowMenuIconsAfter?: ReactNode;
+  logRowMenuIconsBefore?: ReactNode[];
+  logRowMenuIconsAfter?: ReactNode[];
 }
 
 interface LogMessageProps {

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, ReactNode, useMemo } from 'react';
 import Highlighter from 'react-highlight-words';
 
 import { CoreApp, findHighlightChunksInText, LogRowContextOptions, LogRowModel } from '@grafana/data';
@@ -32,6 +32,8 @@ interface Props {
   mouseIsOver: boolean;
   onBlur: () => void;
   expanded?: boolean;
+  logRowMenuIconsBefore?: ReactNode;
+  logRowMenuIconsAfter?: ReactNode;
 }
 
 interface LogMessageProps {
@@ -96,6 +98,8 @@ export const LogRowMessage = memo((props: Props) => {
     onBlur,
     getRowContextQuery,
     expanded,
+    logRowMenuIconsBefore,
+    logRowMenuIconsAfter,
   } = props;
   const { hasAnsi, raw } = row;
   const restructuredEntry = useMemo(
@@ -132,6 +136,8 @@ export const LogRowMessage = memo((props: Props) => {
             styles={styles}
             mouseIsOver={mouseIsOver}
             onBlur={onBlur}
+            addonBefore={logRowMenuIconsBefore}
+            addonAfter={logRowMenuIconsAfter}
           />
         )}
       </td>

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -1,6 +1,6 @@
 import { cx } from '@emotion/css';
 import memoizeOne from 'memoize-one';
-import { PureComponent, MouseEvent, createRef } from 'react';
+import { PureComponent, MouseEvent, createRef, ReactNode } from 'react';
 
 import {
   TimeZone,
@@ -72,6 +72,8 @@ export interface Props extends Themeable2 {
   overflowingContent?: boolean;
   onClickFilterString?: (value: string, refId?: string) => void;
   onClickFilterOutString?: (value: string, refId?: string) => void;
+  logRowMenuIconsBefore?: ReactNode;
+  logRowMenuIconsAfter?: ReactNode;
 }
 
 interface State {

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -72,8 +72,8 @@ export interface Props extends Themeable2 {
   overflowingContent?: boolean;
   onClickFilterString?: (value: string, refId?: string) => void;
   onClickFilterOutString?: (value: string, refId?: string) => void;
-  logRowMenuIconsBefore?: ReactNode;
-  logRowMenuIconsAfter?: ReactNode;
+  logRowMenuIconsBefore?: ReactNode[];
+  logRowMenuIconsAfter?: ReactNode[];
 }
 
 interface State {

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -262,6 +262,31 @@ describe('LogsPanel', () => {
         expect(showContextDs.getLogRowContext).toBeCalled();
       });
     });
+
+    it('supports adding custom options to the log row menu', async () => {
+      const logRowMenuIconsBefore = (
+        <grafanaUI.IconButton name="eye-slash" tooltip="Addon before" aria-label="Addon before" />
+      );
+      const logRowMenuIconsAfter = <grafanaUI.IconButton name="rss" tooltip="Addon after" aria-label="Addon after" />;
+
+      setup(
+        {
+          data: {
+            series,
+          },
+        },
+        {
+          logRowMenuIconsBefore,
+          logRowMenuIconsAfter,
+        }
+      );
+
+      await waitFor(async () => {
+        await userEvent.hover(screen.getByText(/logline text/i));
+        expect(screen.getByLabelText('Addon before')).toBeInTheDocument();
+        expect(screen.getByLabelText('Addon after')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('Performance regressions', () => {
@@ -571,7 +596,7 @@ describe('LogsPanel', () => {
   });
 });
 
-const setup = (propsOverrides?: {}) => {
+const setup = (propsOverrides?: {}, optionOverrides?: {}) => {
   const props: LogsPanelProps = {
     data: {
       error: undefined,
@@ -604,6 +629,7 @@ const setup = (propsOverrides?: {}) => {
       dedupStrategy: LogsDedupStrategy.none,
       enableLogDetails: true,
       showLogContextToggle: false,
+      ...optionOverrides,
     },
     title: 'Logs panel',
     id: 1,

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -264,10 +264,12 @@ describe('LogsPanel', () => {
     });
 
     it('supports adding custom options to the log row menu', async () => {
-      const logRowMenuIconsBefore = (
-        <grafanaUI.IconButton name="eye-slash" tooltip="Addon before" aria-label="Addon before" />
-      );
-      const logRowMenuIconsAfter = <grafanaUI.IconButton name="rss" tooltip="Addon after" aria-label="Addon after" />;
+      const logRowMenuIconsBefore = [
+        <grafanaUI.IconButton name="eye-slash" tooltip="Addon before" aria-label="Addon before" key={1} />,
+      ];
+      const logRowMenuIconsAfter = [
+        <grafanaUI.IconButton name="rss" tooltip="Addon after" aria-label="Addon after" key={1} />,
+      ];
 
       setup(
         {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -68,10 +68,10 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Called from the "eye" icon in Log Details to request hiding the displayed field. If ommited, a default implementation is used.
    * onClickHideField?: (key: string) => void;
-   * 
+   *
    * Passed to the LogRowMenuCell component to be rendered before the default actions in the menu.
    * logRowMenuIconsBefore?: ReactNode[];
-   * 
+   *
    * Passed to the LogRowMenuCell component to be rendered after the default actions in the menu.
    * logRowMenuIconsAfter?: ReactNode[];
    */

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -68,6 +68,12 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Called from the "eye" icon in Log Details to request hiding the displayed field. If ommited, a default implementation is used.
    * onClickHideField?: (key: string) => void;
+   * 
+   * Passed to the LogRowMenuCell component to be rendered before the default actions in the menu.
+   * logRowMenuIconsBefore?: ReactNode[];
+   * 
+   * Passed to the LogRowMenuCell component to be rendered after the default actions in the menu.
+   * logRowMenuIconsAfter?: ReactNode[];
    */
 }
 interface LogsPermalinkUrlState {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -96,6 +96,8 @@ export const LogsPanel = ({
     onClickFilterOutString,
     onClickFilterString,
     isFilterLabelActive,
+    logRowMenuIconsBefore,
+    logRowMenuIconsAfter,
     ...options
   },
   id,
@@ -389,6 +391,8 @@ export const LogsPanel = ({
             displayedFields={displayedFields}
             onClickShowField={displayedFields !== undefined ? onClickShowField : undefined}
             onClickHideField={displayedFields !== undefined ? onClickHideField : undefined}
+            logRowMenuIconsBefore={logRowMenuIconsBefore}
+            logRowMenuIconsAfter={logRowMenuIconsAfter}
           />
           {showCommonLabels && isAscending && renderCommonLabels()}
         </div>

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -38,6 +38,7 @@ import {
   isOnClickFilterString,
   isOnClickHideField,
   isOnClickShowField,
+  isReactNode,
   Options,
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
@@ -391,8 +392,8 @@ export const LogsPanel = ({
             displayedFields={displayedFields}
             onClickShowField={displayedFields !== undefined ? onClickShowField : undefined}
             onClickHideField={displayedFields !== undefined ? onClickHideField : undefined}
-            logRowMenuIconsBefore={logRowMenuIconsBefore}
-            logRowMenuIconsAfter={logRowMenuIconsAfter}
+            logRowMenuIconsBefore={isReactNode(logRowMenuIconsBefore) ? logRowMenuIconsBefore : undefined}
+            logRowMenuIconsAfter={isReactNode(logRowMenuIconsAfter) ? logRowMenuIconsAfter : undefined}
           />
           {showCommonLabels && isAscending && renderCommonLabels()}
         </div>

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -38,7 +38,7 @@ import {
   isOnClickFilterString,
   isOnClickHideField,
   isOnClickShowField,
-  isReactNode,
+  isReactNodeArray,
   Options,
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
@@ -392,8 +392,8 @@ export const LogsPanel = ({
             displayedFields={displayedFields}
             onClickShowField={displayedFields !== undefined ? onClickShowField : undefined}
             onClickHideField={displayedFields !== undefined ? onClickHideField : undefined}
-            logRowMenuIconsBefore={isReactNode(logRowMenuIconsBefore) ? logRowMenuIconsBefore : undefined}
-            logRowMenuIconsAfter={isReactNode(logRowMenuIconsAfter) ? logRowMenuIconsAfter : undefined}
+            logRowMenuIconsBefore={isReactNodeArray(logRowMenuIconsBefore) ? logRowMenuIconsBefore : undefined}
+            logRowMenuIconsAfter={isReactNodeArray(logRowMenuIconsAfter) ? logRowMenuIconsAfter : undefined}
           />
           {showCommonLabels && isAscending && renderCommonLabels()}
         </div>

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -43,6 +43,8 @@ composableKinds: PanelCfg: {
 					onClickFilterOutString?: _
 					onClickShowField?:       _
 					onClickHideField?:       _
+					logRowMenuIconsBefore?:  _
+					logRowMenuIconsAfter?:   _
 					displayedFields?: [...string]
 				} @cuetsy(kind="interface")
 			}

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -15,6 +15,8 @@ export interface Options {
   displayedFields?: Array<string>;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
+  logRowMenuIconsAfter?: unknown;
+  logRowMenuIconsBefore?: unknown;
   /**
    * TODO: figure out how to define callbacks
    */

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -40,6 +40,6 @@ export function isOnClickHideField(callback: unknown): callback is isOnClickHide
   return typeof callback === 'function';
 }
 
-export function isReactNodeArray(node: any): node is ReactNode[] {
+export function isReactNodeArray(node: unknown): node is ReactNode[] {
   return Array.isArray(node) && node.every(React.isValidElement);
 }

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -40,6 +40,6 @@ export function isOnClickHideField(callback: unknown): callback is isOnClickHide
   return typeof callback === 'function';
 }
 
-export function isReactNode(node: any): node is ReactNode {
-  return React.isValidElement(node) || (Array.isArray(node) && node.every(isReactNode));
+export function isReactNodeArray(node: any): node is ReactNode[] {
+  return Array.isArray(node) && node.every(React.isValidElement);
 }

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -1,3 +1,5 @@
+import React, { ReactNode } from 'react';
+
 import { DataFrame } from '@grafana/data';
 
 export { Options } from './panelcfg.gen';
@@ -36,4 +38,8 @@ export function isOnClickShowField(callback: unknown): callback is isOnClickShow
 
 export function isOnClickHideField(callback: unknown): callback is isOnClickHideFieldType {
   return typeof callback === 'function';
+}
+
+export function isReactNode(node: any): node is ReactNode {
+  return React.isValidElement(node) || (Array.isArray(node) && node.every(isReactNode));
 }


### PR DESCRIPTION
This PR updates the Logs visualization to expose APIs to support custom options in the log rows menu, using the optional props: `logRowMenuIconsBefore` and `logRowMenuIconsAfter` to add content before and after the menu buttons.

Both props are expected to be `React.ReactNode[]`, which can have attached onClick listeners. If they do, they should have the following type: `(event: MouseEvent<HTMLElement>, row: LogRowModel) => void`.

For example:

![example](https://github.com/user-attachments/assets/ee98cdd2-17c7-41ac-bb19-cdc3fff9ec27)

Demo:

https://github.com/user-attachments/assets/7585aaa8-614a-4ca5-9a77-729a4025fa10

Part of https://github.com/grafana/explore-logs/issues/772