### PR TITLE
Chore: Change filterTable nth-child to nth-of-type

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/filterTable.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/filterTable.ts
@@ -13,7 +13,7 @@ export function getFilterTableStyles(theme: GrafanaTheme2) {
       borderCollapse: 'separate',
 
       tbody: {
-        'tr:nth-child(odd)': {
+        'tr:nth-of-type(odd)': {
           background: theme.colors.emphasize(theme.colors.background.primary, 0.02),
         },
       },


### PR DESCRIPTION
Fixes the Emotion warning about the instability of `:nth-child` selectors, introduced by https://github.com/grafana/grafana/pull/90132


Before:
![8533_2024-10-24-11-44_firefox](https://github.com/user-attachments/assets/74ce1e03-97ec-463d-9002-0ffcf8591336)


After:
![8534_2024-10-24-11-44_firefox](https://github.com/user-attachments/assets/44ba404b-d365-4a84-82ea-b7ceae84d95f)
