### PR TITLE
Plugin extensions: Temp remove isReactComponent check

### DIFF
--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
@@ -40,13 +40,6 @@ export class AddedComponentsRegistry extends Registry<
         pluginId,
       });
 
-      if (!isReactComponent(config.component)) {
-        configLog.error(
-          `Could not register added component. Reason: The provided component is not a valid React component.`
-        );
-        continue;
-      }
-
       if (!config.title) {
         configLog.error(`Could not register added component. Reason: Title is missing.`);
         continue;

--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
@@ -3,7 +3,7 @@ import { ReplaySubject } from 'rxjs';
 import { PluginExtensionAddedComponentConfig } from '@grafana/data';
 
 import { isAddedComponentMetaInfoMissing, isGrafanaDevMode, wrapWithPluginContext } from '../utils';
-import { extensionPointEndsWithVersion, isGrafanaCoreExtensionPoint, isReactComponent } from '../validators';
+import { extensionPointEndsWithVersion, isGrafanaCoreExtensionPoint } from '../validators';
 
 import { PluginExtensionConfigs, Registry, RegistryType } from './Registry';
 


### PR DESCRIPTION

**What is this feature?**

It turns out the `isReactComponent` check we perform upon registration of an added component doesn't work for lazy loaded components. This PR temporarily removes this check until we have figured out a way to get it to work.  

Have created this [issue](https://github.com/grafana/grafana/issues/95345) to follow up on this. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

https://github.com/grafana/grafana/issues/95345

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
