### PR TITLE
SingleTopNav: Ignore `searchBarHidden`/`kiosk=tv` flags

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -37,6 +37,7 @@ export class AppChromeService {
   searchBarStorageKey = 'SearchBar_Hidden';
   private currentRoute?: RouteDescriptor;
   private routeChangeHandled = true;
+  private isSingleTopNav = config.featureToggles.singleTopNav;
 
   private megaMenuDocked = Boolean(
     window.innerWidth >= config.theme2.breakpoints.values.xl &&
@@ -49,7 +50,8 @@ export class AppChromeService {
   readonly state = new BehaviorSubject<AppChromeState>({
     chromeless: true, // start out hidden to not flash it on pages without chrome
     sectionNav: { node: { text: t('nav.home.title', 'Home') }, main: { text: '' } },
-    searchBarHidden: store.getBool(this.searchBarStorageKey, false),
+    // TODO remove this state once singleTopNav is live
+    searchBarHidden: this.isSingleTopNav ? false : store.getBool(this.searchBarStorageKey, false),
     megaMenuOpen: this.megaMenuDocked && store.getBool(DOCKED_MENU_OPEN_LOCAL_STORAGE_KEY, true),
     megaMenuDocked: this.megaMenuDocked,
     kioskMode: null,
@@ -213,7 +215,9 @@ export class AppChromeService {
 
     switch (kiosk) {
       case 'tv':
-        newKioskMode = KioskMode.TV;
+        if (!this.isSingleTopNav) {
+          newKioskMode = KioskMode.TV;
+        }
         break;
       case '1':
       case true:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- ignores `?kiosk=tv` query param when `singleTopNav` is enabled
  - this can happen from e.g. saved playlist urls
- forces `searchBarHidden` state to `false` when `singleTopNav` is enabled
  - this can be true in local storage if you previously had the search bar collapsed  

| | before | after |
| --- | --- | --- |
| `searchBarHidden` | ![image](https://github.com/user-attachments/assets/ff45e64f-ef69-4ee0-99f9-46ddd89c3410) | ![image](https://github.com/user-attachments/assets/cf32b7fe-fa17-4181-9414-eb0bd1358486) |
| `?kiosk=tv` | ![image](https://github.com/user-attachments/assets/cc9da367-8a92-4b24-8114-e4453667ddc3) | ![image](https://github.com/user-attachments/assets/cd077781-40fa-4b09-a1e7-5c354e28eb3d) |
 
**Why do we need this feature?**

- prevent broken states in the UI

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/95342

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
