### PR TITLE
Extensions: Add base log labels to console warn and error logs

### DIFF
--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -32,12 +32,12 @@ export class ExtensionsLog {
   }
 
   warning(message: string, labels?: Labels): void {
-    console.warn(message, labels);
+    console.warn(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
   }
 
   error(message: string, labels?: Labels): void {
-    console.error(message, labels);
+    console.error(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
   }
 


### PR DESCRIPTION
**What is this feature?**

This change adds the base logger labels to the messages that we log to the console.

**Why do we need this feature?**

Since we started to use a centralised logger for extensions specific log messages, we have valuable labels for each use-case, however currently they are only available in dev mode, when the logger UI is visible - and they are not logged to the console. This PR changes that.

**Who is this feature for?**

Plugin developers mainly.
