### PR TITLE
NPM releases: Stop publishing the e2e package 

### DIFF
--- a/pkg/build/npm/npm.go
+++ b/pkg/build/npm/npm.go
@@ -22,7 +22,6 @@ var packages = []string{
 	"@grafana/ui",
 	"@grafana/data",
 	"@grafana/runtime",
-	"@grafana/e2e",
 	"@grafana/e2e-selectors",
 	"@grafana/schema",
 	"@grafana/flamegraph",


### PR DESCRIPTION
**What is this feature?**

The `grafana/e2e` package was deprecated in G11 and its codebase was removed entirely in G11.1. Even though we have marked the entire package as deprecated in npm, it's gets _undeprecated_ every time a patch of <= G11.0 is released. This PR removes `e2e` from the list of packages. This means the `latest` tag will no longer be moved, and that means `grafana/e2e` can stay deprecated. 

This PR needs to be backporte to all supported versions of Grafana.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
