### PR TITLE
Query splitting: limit retries

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -128,7 +128,7 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
 
       const key = `${requestN}-${requestGroup}`;
       const retries = retriesMap.get(key) ?? 0;
-      if (retries > 3) {
+      if (retries > 0) {
         return false;
       }
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -40,7 +40,7 @@ import { LokiQuery } from './types';
  *       . nextRequest() will use the current cycle and group size to determine the next request or complete execution with done().
  *     - If the response is unsuccessful:
  *       . If the response is not a query error, and the group size bigger than 1, it will decrease the group size.
- *       . If the group size is already 1, it will retry the request up to 4 times.
+ *       . If the group size is already 1, it will retry the request up to 2 times.
  *       . If there are retry attempts, it will retry the current cycle, or else stop querying.
  * - Once all request groups have been executed, it will be done().
  */
@@ -122,7 +122,7 @@ function splitQueriesByStreamShard(
       const key = `${group}_${cycle}`;
       const retries = retriesMap.get(key) ?? 0;
 
-      if (retries > 3) {
+      if (retries > 1) {
         shouldStop = true;
         return false;
       }


### PR DESCRIPTION
Limiting the amount of retries from 4 to 2 for shard splitting and from 4 to 1 for time splitting.

Part of https://github.com/grafana/grafana/issues/95233