### PR TITLE
UniStore: expand nested folders testing

### DIFF
--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -41,8 +41,6 @@ var gvr = schema.GroupVersionResource{
 }
 
 func TestIntegrationFoldersApp(t *testing.T) {
-	t.Skip("skipping integration test")
-
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -490,6 +488,9 @@ func doNestedCreateTest(t *testing.T, helper *apis.K8sTestHelper) {
 		Body:   []byte(parentPayload),
 	}, &folder.Folder{})
 	require.NotNil(t, parentCreate.Result)
+	// creating a folder without providing a parent should default to the empty parent folder
+	require.Empty(t, parentCreate.Result.ParentUID)
+
 	parentUID := parentCreate.Result.UID
 	require.NotEmpty(t, parentUID)
 
@@ -511,6 +512,8 @@ func doNestedCreateTest(t *testing.T, helper *apis.K8sTestHelper) {
 	require.Equal(t, 1, len(childCreate.Result.Parents))
 
 	parent := childCreate.Result.Parents[0]
+	// creating a folder with a known parent should succeed
+	require.Equal(t, parentUID, childCreate.Result.ParentUID)
 	require.Equal(t, parentUID, parent.UID)
 	require.Equal(t, "Test\\/parent", parent.Title)
 	require.Equal(t, parentCreate.Result.URL, parent.URL)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Expand Nested Folders testing by ensure that we are testing the following conditions:
- creating a folder without providing a parent should default to the empty parent folder
- creating a folder with a known parent should succeed

**Why do we need this feature?**

We want the UniStore implementation of Folders to cover the same tests covered by legacy implementation

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/search-and-storage-team/issues/110

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
