### PR TITLE
CI: Consolidate package and docker steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -544,13 +544,6 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.23.1-alpine
-  name: compile-build-cmd
-- commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -612,9 +605,10 @@ steps:
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
     -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.1 --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.3
-    --tag-format='{{ .version_base }}-{{ .buildid }}-{{ .arch }}' --ubuntu-tag-format='{{
-    .version_base }}-{{ .buildid }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
+    --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
+    .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
     > packages.txt
+  - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
   depends_on:
   - yarn-install
   environment:
@@ -1948,13 +1942,6 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
-  depends_on: []
-  environment:
-    CGO_ENABLED: 0
-  image: golang:1.23.1-alpine
-  name: compile-build-cmd
-- commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -2015,9 +2002,10 @@ steps:
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
     -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.1 --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.3
-    --tag-format='{{ .version_base }}-{{ .buildid }}-{{ .arch }}' --ubuntu-tag-format='{{
-    .version_base }}-{{ .buildid }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
+    --tag-format='{{ .version_base }}-{{ .buildID }}-{{ .arch }}' --ubuntu-tag-format='{{
+    .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
     > packages.txt
+  - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
   depends_on:
   - update-package-json-version
   environment:
@@ -5747,6 +5735,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 9369485da5deec0e8bdd7a34b86062e067a6ed83f0d0cab972a887a416dadf4a
+hmac: f013c4f29990680d071f01eefed5a27df1064123d48c1fe4bee0194b53f85b9d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -606,9 +606,15 @@ steps:
     token:
       from_secret: drone_token
 - commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
-    -a targz:grafana:linux/arm/v7 --go-version=1.23.1 --yarn-cache=$$YARN_CACHE_FOLDER
-    --build-id=$$DRONE_BUILD_NUMBER --grafana-dir=$$PWD > packages.txt
+    -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
+    -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
+    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.1 --yarn-cache=$$YARN_CACHE_FOLDER
+    --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.3
+    --tag-format='{{ .version_base }}-{{ .buildid }}-{{ .arch }}' --ubuntu-tag-format='{{
+    .version_base }}-{{ .buildid }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
+    > packages.txt
   depends_on:
   - yarn-install
   environment:
@@ -617,6 +623,27 @@ steps:
   image: grafana/grafana-build:main
   name: rgm-package
   pull: always
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+- commands:
+  - ./bin/grabpl artifacts docker publish --dockerhub-repo grafana/grafana
+  depends_on:
+  - rgm-package
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+    GITHUB_APP_ID:
+      from_secret: delivery-bot-app-id
+    GITHUB_APP_INSTALLATION_ID:
+      from_secret: delivery-bot-app-installation-id
+    GITHUB_APP_PRIVATE_KEY:
+      from_secret: delivery-bot-app-private-key
+  failure: ignore
+  image: google/cloud-sdk:431.0.0
+  name: publish-images-grafana
   volumes:
   - name: docker
     path: /var/run/docker.sock
@@ -855,47 +882,6 @@ steps:
   failure: always
   image: grafana/docker-puppeteer:1.1.0
   name: test-a11y-frontend
-- commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - /src/grafana-build artifacts -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
-    -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
-    -a docker:grafana:linux/arm/v7:ubuntu --yarn-cache=$$YARN_CACHE_FOLDER --build-id=$$DRONE_BUILD_NUMBER
-    --go-version=1.23.1 --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.3 --tag-format='{{
-    .version_base }}-{{ .buildID }}-{{ .arch }}' --grafana-dir=$$PWD --ubuntu-tag-format='{{
-    .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' > docker.txt
-  - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
-  depends_on:
-  - yarn-install
-  environment:
-    _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
-      from_secret: dagger_token
-  image: grafana/grafana-build:main
-  name: rgm-build-docker
-  pull: always
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-- commands:
-  - ./bin/grabpl artifacts docker publish --dockerhub-repo grafana/grafana
-  depends_on:
-  - rgm-build-docker
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GITHUB_APP_ID:
-      from_secret: delivery-bot-app-id
-    GITHUB_APP_INSTALLATION_ID:
-      from_secret: delivery-bot-app-installation-id
-    GITHUB_APP_PRIVATE_KEY:
-      from_secret: delivery-bot-app-private-key
-  failure: ignore
-  image: google/cloud-sdk:431.0.0
-  name: publish-images-grafana
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
 trigger:
   event:
   - pull_request
@@ -2023,9 +2009,15 @@ steps:
   image: node:20.9.0-alpine
   name: build-frontend-packages
 - commands:
+  - docker run --privileged --rm tonistiigi/binfmt --install all
   - /src/grafana-build artifacts -a targz:grafana:linux/amd64 -a targz:grafana:linux/arm64
-    -a targz:grafana:linux/arm/v7 --go-version=1.23.1 --yarn-cache=$$YARN_CACHE_FOLDER
-    --build-id=$$DRONE_BUILD_NUMBER --grafana-dir=$$PWD > packages.txt
+    -a targz:grafana:linux/arm/v7 -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
+    -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
+    -a docker:grafana:linux/arm/v7:ubuntu --go-version=1.23.1 --yarn-cache=$$YARN_CACHE_FOLDER
+    --build-id=$$DRONE_BUILD_NUMBER --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.3
+    --tag-format='{{ .version_base }}-{{ .buildid }}-{{ .arch }}' --ubuntu-tag-format='{{
+    .version_base }}-{{ .buildid }}-ubuntu-{{ .arch }}' --verify='false' --grafana-dir=$$PWD
+    > packages.txt
   depends_on:
   - update-package-json-version
   environment:
@@ -2037,6 +2029,31 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+- commands:
+  - ./bin/grabpl artifacts docker publish --dockerhub-repo grafana/grafana
+  depends_on:
+  - rgm-package
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+    GCP_KEY:
+      from_secret: gcp_grafanauploads
+    GITHUB_APP_ID:
+      from_secret: delivery-bot-app-id
+    GITHUB_APP_INSTALLATION_ID:
+      from_secret: delivery-bot-app-installation-id
+    GITHUB_APP_PRIVATE_KEY:
+      from_secret: delivery-bot-app-private-key
+  image: google/cloud-sdk:431.0.0
+  name: publish-images-grafana
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - yarn e2e:plugin:build
   depends_on:
@@ -2309,54 +2326,9 @@ steps:
     repo:
     - grafana/grafana
 - commands:
-  - docker run --privileged --rm tonistiigi/binfmt --install all
-  - /src/grafana-build artifacts -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
-    -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu -a docker:grafana:linux/arm/v7
-    -a docker:grafana:linux/arm/v7:ubuntu --yarn-cache=$$YARN_CACHE_FOLDER --build-id=$$DRONE_BUILD_NUMBER
-    --go-version=1.23.1 --ubuntu-base=ubuntu:22.04 --alpine-base=alpine:3.20.3 --tag-format='{{
-    .version_base }}-{{ .buildID }}-{{ .arch }}' --grafana-dir=$$PWD --ubuntu-tag-format='{{
-    .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}' > docker.txt
-  - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
-  depends_on:
-  - update-package-json-version
-  environment:
-    _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
-      from_secret: dagger_token
-  image: grafana/grafana-build:main
-  name: rgm-build-docker
-  pull: always
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-- commands:
-  - ./bin/grabpl artifacts docker publish --dockerhub-repo grafana/grafana
-  depends_on:
-  - rgm-build-docker
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: docker_password
-    DOCKER_USER:
-      from_secret: docker_username
-    GCP_KEY:
-      from_secret: gcp_grafanauploads
-    GITHUB_APP_ID:
-      from_secret: delivery-bot-app-id
-    GITHUB_APP_INSTALLATION_ID:
-      from_secret: delivery-bot-app-installation-id
-    GITHUB_APP_PRIVATE_KEY:
-      from_secret: delivery-bot-app-private-key
-  image: google/cloud-sdk:431.0.0
-  name: publish-images-grafana
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  when:
-    repo:
-    - grafana/grafana
-- commands:
   - ./bin/grabpl artifacts docker publish --dockerhub-repo grafana/grafana-oss
   depends_on:
-  - rgm-build-docker
+  - rgm-package
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -2401,10 +2373,7 @@ steps:
 - commands:
   - ./bin/build upload-packages --edition oss
   depends_on:
-  - end-to-end-tests-dashboards-suite
-  - end-to-end-tests-panels-suite
-  - end-to-end-tests-smoke-tests-suite
-  - end-to-end-tests-various-suite
+  - rgm-package
   environment:
     GCP_KEY:
       from_secret: gcp_grafanauploads_base64
@@ -2418,7 +2387,7 @@ steps:
 - commands:
   - ./bin/build upload-cdn --edition oss
   depends_on:
-  - grafana-server
+  - rgm-package
   environment:
     GCP_KEY:
       from_secret: gcp_grafanauploads
@@ -5778,6 +5747,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: f49fe1151910b4a42835e0779c676649e2e7ec76ca50fdf522ffea72e60638cc
+hmac: 9369485da5deec0e8bdd7a34b86062e067a6ed83f0d0cab972a887a416dadf4a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -544,6 +544,13 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.23.1-alpine
+  name: compile-build-cmd
+- commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -562,13 +569,6 @@ steps:
   depends_on: []
   image: golang:1.23.1-alpine
   name: verify-gen-jsonnet
-- commands:
-  - apk add --update make
-  - make gen-go
-  depends_on:
-  - verify-gen-cue
-  image: golang:1.23.1-alpine
-  name: wire-install
 - commands:
   - yarn install --immutable || yarn install --immutable
   depends_on: []
@@ -1942,6 +1942,13 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.23.1-alpine
+  name: compile-build-cmd
+- commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -1960,13 +1967,6 @@ steps:
   depends_on: []
   image: golang:1.23.1-alpine
   name: verify-gen-jsonnet
-- commands:
-  - apk add --update make
-  - make gen-go
-  depends_on:
-  - verify-gen-cue
-  image: golang:1.23.1-alpine
-  name: wire-install
 - commands:
   - yarn install --immutable || yarn install --immutable
   depends_on: []
@@ -5735,6 +5735,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: f013c4f29990680d071f01eefed5a27df1064123d48c1fe4bee0194b53f85b9d
+hmac: 250d3c2ae9ddf7cbfd2a9fed01fe81312a882ba09b8f8725f4704629da00a774
 
 ...

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -6,7 +6,6 @@ load(
     "build_storybook_step",
     "build_test_plugins_step",
     "cloud_plugins_e2e_tests_step",
-    "compile_build_cmd",
     "download_grabpl_step",
     "e2e_tests_artifacts",
     "e2e_tests_step",
@@ -58,7 +57,6 @@ def build_e2e(trigger, ver_mode):
     init_steps = [
         identify_runner_step(),
         download_grabpl_step(),
-        compile_build_cmd(),
         verify_gen_cue_step(),
         verify_gen_jsonnet_step(),
         wire_install_step(),
@@ -81,9 +79,9 @@ def build_e2e(trigger, ver_mode):
             "docker:grafana:linux/arm/v7:ubuntu",
         ],
         file = "packages.txt",
-        tag_format = "{{ .version_base }}-{{ .buildid }}-{{ .arch }}",
         ubuntu = images["ubuntu"],
-        ubuntu_tag_format = "{{ .version_base }}-{{ .buildid }}-ubuntu-{{ .arch }}",
+        tag_format = "{{ .version_base }}-{{ .buildID }}-{{ .arch }}",
+        ubuntu_tag_format = "{{ .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}",
     )
 
     publish_docker = publish_images_step(

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -6,6 +6,7 @@ load(
     "build_storybook_step",
     "build_test_plugins_step",
     "cloud_plugins_e2e_tests_step",
+    "compile_build_cmd",
     "download_grabpl_step",
     "e2e_tests_artifacts",
     "e2e_tests_step",
@@ -26,7 +27,6 @@ load(
     "upload_packages_step",
     "verify_gen_cue_step",
     "verify_gen_jsonnet_step",
-    "wire_install_step",
     "yarn_install_step",
 )
 load(
@@ -57,9 +57,9 @@ def build_e2e(trigger, ver_mode):
     init_steps = [
         identify_runner_step(),
         download_grabpl_step(),
+        compile_build_cmd(),
         verify_gen_cue_step(),
         verify_gen_jsonnet_step(),
-        wire_install_step(),
         yarn_install_step(),
     ]
 

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -42,6 +42,8 @@ load(
     "pipeline",
 )
 
+# This function isn't actually unused but I don't know why the linter thinks it is...
+# @unused
 def build_e2e(trigger, ver_mode):
     """Perform e2e building, testing, and publishing.
 
@@ -79,8 +81,8 @@ def build_e2e(trigger, ver_mode):
             "docker:grafana:linux/arm/v7:ubuntu",
         ],
         file = "packages.txt",
-        ubuntu = images["ubuntu"],
         tag_format = "{{ .version_base }}-{{ .buildID }}-{{ .arch }}",
+        ubuntu = images["ubuntu"],
         ubuntu_tag_format = "{{ .version_base }}-{{ .buildID }}-ubuntu-{{ .arch }}",
     )
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -412,6 +412,7 @@ def upload_cdn_step(ver_mode, trigger = None, depends_on = ["grafana-server"]):
       ver_mode: only uses the step trigger when ver_mode == 'release-branch' or 'main'
       trigger: a Drone trigger for the step.
         Defaults to None.
+      depends_on: drone steps that this step depends on
 
     Returns:
       Drone step.
@@ -937,6 +938,7 @@ def publish_images_step(ver_mode, docker_repo, trigger = None, depends_on = ["rg
         It is combined with the 'grafana/' library prefix.
       trigger: a Drone trigger for the pipeline.
         Defaults to None.
+      depends_on: drone steps that this step depends on
 
     Returns:
       Drone step.
@@ -1160,6 +1162,7 @@ def upload_packages_step(ver_mode, trigger = None, depends_on = [
         edition packages when executed.
       trigger: a Drone trigger for the step.
         Defaults to None.
+      depends_on: drone steps that this step depends on
 
     Returns:
       Drone step.

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -405,7 +405,7 @@ def playwright_e2e_report_post_link():
         ],
     }
 
-def upload_cdn_step(ver_mode, trigger = None):
+def upload_cdn_step(ver_mode, trigger = None, depends_on = ["grafana-server"]):
     """Uploads CDN assets using the Grafana build tool.
 
     Args:
@@ -420,9 +420,7 @@ def upload_cdn_step(ver_mode, trigger = None):
     step = {
         "name": "upload-cdn-assets",
         "image": images["publish"],
-        "depends_on": [
-            "grafana-server",
-        ],
+        "depends_on": depends_on,
         "environment": {
             "GCP_KEY": from_secret(gcp_grafanauploads),
             "PRERELEASE_BUCKET": from_secret(prerelease_bucket),
@@ -929,7 +927,7 @@ def fetch_images_step():
         "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }
 
-def publish_images_step(ver_mode, docker_repo, trigger = None):
+def publish_images_step(ver_mode, docker_repo, trigger = None, depends_on = ["rgm-build-docker"]):
     """Generates a step for publishing public Docker images with grabpl.
 
     Args:
@@ -959,7 +957,7 @@ def publish_images_step(ver_mode, docker_repo, trigger = None):
         docker_repo,
     )
 
-    deps = ["rgm-build-docker"]
+    deps = depends_on
     if ver_mode == "release":
         deps = ["fetch-images"]
         cmd += " --version-tag ${DRONE_TAG}"
@@ -1149,7 +1147,12 @@ def release_canary_npm_packages_step(trigger = None):
 
     return step
 
-def upload_packages_step(ver_mode, trigger = None):
+def upload_packages_step(ver_mode, trigger = None, depends_on = [
+    "end-to-end-tests-dashboards-suite",
+    "end-to-end-tests-panels-suite",
+    "end-to-end-tests-smoke-tests-suite",
+    "end-to-end-tests-various-suite",
+]):
     """Upload packages to object storage.
 
     Args:
@@ -1164,7 +1167,7 @@ def upload_packages_step(ver_mode, trigger = None):
     step = {
         "name": "upload-packages",
         "image": images["publish"],
-        "depends_on": end_to_end_tests_deps(),
+        "depends_on": depends_on,
         "environment": {
             "GCP_KEY": from_secret(gcp_grafanauploads_base64),
             "PRERELEASE_BUCKET": from_secret("prerelease_bucket"),

--- a/scripts/drone/steps/rgm.star
+++ b/scripts/drone/steps/rgm.star
@@ -58,6 +58,7 @@ def rgm_artifacts_step(
             "--ubuntu-tag-format='{}' ".format(ubuntu_tag_format) +
             "--verify='{}' ".format(verify) +
             "--grafana-dir=$$PWD > {}".format(file),
+            "find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i",
         ],
         "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],
     }

--- a/scripts/drone/steps/rgm.star
+++ b/scripts/drone/steps/rgm.star
@@ -4,6 +4,10 @@ These aren't used in releases.
 """
 
 load(
+    "scripts/drone/utils/images.star",
+    "images",
+)
+load(
     "scripts/drone/variables.star",
     "golang_version",
 )
@@ -22,7 +26,16 @@ def artifacts_cmd(artifacts = []):
     return cmd
 
 # rgm_artifacts_step will create artifacts using the '/src/build artifacts' command.
-def rgm_artifacts_step(name = "rgm-package", artifacts = ["targz:grafana:linux/amd64", "targz:grafana:linux/arm64"], file = "packages.txt", depends_on = ["yarn-install"]):
+def rgm_artifacts_step(
+        name = "rgm-package",
+        artifacts = ["targz:grafana:linux/amd64", "targz:grafana:linux/arm64"],
+        file = "packages.txt",
+        depends_on = ["yarn-install"],
+        tag_format = "{{ .version }}-{{ .arch }}",
+        ubuntu_tag_format = "{{ .version }}-ubuntu-{{ .arch }}",
+        verify = "false",
+        ubuntu = images["ubuntu"],
+        alpine = images["alpine"]):
     cmd = artifacts_cmd(artifacts = artifacts)
 
     return {
@@ -34,10 +47,16 @@ def rgm_artifacts_step(name = "rgm-package", artifacts = ["targz:grafana:linux/a
             "_EXPERIMENTAL_DAGGER_CLOUD_TOKEN": from_secret(rgm_dagger_token),
         },
         "commands": [
+            "docker run --privileged --rm tonistiigi/binfmt --install all",
             cmd +
             "--go-version={} ".format(golang_version) +
             "--yarn-cache=$$YARN_CACHE_FOLDER " +
             "--build-id=$$DRONE_BUILD_NUMBER " +
+            "--ubuntu-base={} ".format(ubuntu) +
+            "--alpine-base={} ".format(alpine) +
+            "--tag-format='{}' ".format(tag_format) +
+            "--ubuntu-tag-format='{}' ".format(ubuntu_tag_format) +
+            "--verify='{}' ".format(verify) +
             "--grafana-dir=$$PWD > {}".format(file),
         ],
         "volumes": [{"name": "docker", "path": "/var/run/docker.sock"}],


### PR DESCRIPTION
This PR combines the steps which create `packages` and `docker images`.

The same command, `grafana-build`, now supports defining both of these at the same time which allows the process to reuse files and folders that are common in each artifact.

This should make things a little bit faster.