### PR TITLE
Alerting: Wrap all `AlertingPageWrapper`s in `StrictMode`

### DIFF
--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
@@ -17,9 +17,11 @@ interface AlertingPageWrapperProps extends PageProps {
 }
 
 export const AlertingPageWrapper = ({ children, isLoading, ...rest }: AlertingPageWrapperProps) => (
-  <Page {...rest}>
-    <Page.Contents isLoading={isLoading}>{children}</Page.Contents>
-  </Page>
+  <StrictMode>
+    <Page {...rest}>
+      <Page.Contents isLoading={isLoading}>{children}</Page.Contents>
+    </Page>
+  </StrictMode>
 );
 
 /**

--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, StrictMode } from 'react';
 import { useLocation } from 'react-use';
 
 import { Page } from 'app/core/components/Page/Page';
@@ -32,11 +32,13 @@ export const AlertmanagerPageWrapper = ({ children, accessType, ...props }: Aler
   const disableAlertmanager = useIsDisabledAlertmanagerSelection();
 
   return (
-    <AlertmanagerProvider accessType={accessType}>
-      <AlertingPageWrapper {...props} actions={<AlertManagerPicker disabled={disableAlertmanager} />}>
-        <AlertManagerPagePermissionsCheck>{children}</AlertManagerPagePermissionsCheck>
-      </AlertingPageWrapper>
-    </AlertmanagerProvider>
+    <StrictMode>
+      <AlertmanagerProvider accessType={accessType}>
+        <AlertingPageWrapper {...props} actions={<AlertManagerPicker disabled={disableAlertmanager} />}>
+          <AlertManagerPagePermissionsCheck>{children}</AlertManagerPagePermissionsCheck>
+        </AlertingPageWrapper>
+      </AlertmanagerProvider>
+    </StrictMode>
   );
 };
 


### PR DESCRIPTION
**What is this feature?**

There have been some issues within alerting that _might_ have been made more visible by using [StrictMode](https://react.dev/reference/react/StrictMode). Rather than opt the entire Grafana UI into this, we can wrap any (or, most) alerting UI in StrictMode when running locally, so we're more likely to spot issues moving forward

**Why do we need this feature?**

🧹, 🐛 and best practices (we previously had StrictMode but it was removed in https://github.com/grafana/grafana/pull/64428 due to it being stricter in React 18). This is a step towards reintroducing it

**Who is this feature for?**
(mainly Alerting) UI devs