### PR TITLE
CloudMigrations: create snapshot for Alert Rules

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -36,6 +36,7 @@ var currentMigrationTypes = []cloudmigration.MigrateDataType{
 	cloudmigration.NotificationTemplateType,
 	cloudmigration.ContactPointType,
 	cloudmigration.NotificationPolicyType,
+	cloudmigration.AlertRuleType,
 }
 
 func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.SignedInUser) (*cloudmigration.MigrateDataRequest, error) {
@@ -90,10 +91,17 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 		return nil, err
 	}
 
+	// Alerts: Alert Rules
+	alertRules, err := s.getAlertRules(ctx, signedInUser)
+	if err != nil {
+		s.log.Error("Failed to get alert rules", "err", err)
+		return nil, err
+	}
+
 	migrationDataSlice := make(
 		[]cloudmigration.MigrateDataRequestItem, 0,
 		len(dataSources)+len(dashs)+len(folders)+len(libraryElements)+
-			len(muteTimings)+len(notificationTemplates)+len(contactPoints),
+			len(muteTimings)+len(notificationTemplates)+len(contactPoints)+len(alertRules),
 	)
 
 	for _, ds := range dataSources {
@@ -174,6 +182,15 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 			RefID: notificationPolicies.Name, // no UID available
 			Name:  notificationPolicies.Name,
 			Data:  notificationPolicies.Routes,
+		})
+	}
+
+	for _, alertRule := range alertRules {
+		migrationDataSlice = append(migrationDataSlice, cloudmigration.MigrateDataRequestItem{
+			Type:  cloudmigration.AlertRuleType,
+			RefID: alertRule.UID,
+			Name:  alertRule.Title,
+			Data:  alertRule,
 		})
 	}
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -3,11 +3,14 @@ package cloudmigrationimpl
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	ngalertapi "github.com/grafana/grafana/pkg/services/ngalert/api"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -132,4 +135,61 @@ func (s *Service) getNotificationPolicies(ctx context.Context, signedInUser *use
 		Name:   "Notification Policy Tree",
 		Routes: policyTree,
 	}, nil
+}
+
+type alertRule struct {
+	Updated              time.Time                                  `json:"updated,omitempty"`
+	Annotations          map[string]string                          `json:"annotations,omitempty"`
+	Labels               map[string]string                          `json:"labels,omitempty"`
+	Record               *definitions.Record                        `json:"record"`
+	NotificationSettings *definitions.AlertRuleNotificationSettings `json:"notification_settings"`
+	FolderUID            string                                     `json:"folderUID"`
+	RuleGroup            string                                     `json:"ruleGroup"`
+	NoDataState          string                                     `json:"noDataState"`
+	Condition            string                                     `json:"condition"`
+	UID                  string                                     `json:"uid"`
+	Title                string                                     `json:"title"`
+	ExecErrState         string                                     `json:"execErrState"`
+	Data                 []definitions.AlertQuery                   `json:"data"`
+	ID                   int64                                      `json:"id"`
+	For                  model.Duration                             `json:"for"`
+	OrgID                int64                                      `json:"orgID"`
+	IsPaused             bool                                       `json:"isPaused"`
+}
+
+func (s *Service) getAlertRules(ctx context.Context, signedInUser *user.SignedInUser) ([]alertRule, error) {
+	if !s.features.IsEnabledGlobally(featuremgmt.FlagOnPremToCloudMigrationsAlerts) {
+		return nil, nil
+	}
+
+	alertRules, _, err := s.ngAlert.Api.AlertRules.GetAlertRules(ctx, signedInUser)
+	if err != nil {
+		return nil, fmt.Errorf("fetching alert rules: %w", err)
+	}
+
+	provisionedAlertRules := make([]alertRule, 0, len(alertRules))
+
+	for _, rule := range alertRules {
+		provisionedAlertRules = append(provisionedAlertRules, alertRule{
+			ID:                   rule.ID,
+			UID:                  rule.UID,
+			OrgID:                rule.OrgID,
+			FolderUID:            rule.NamespaceUID,
+			RuleGroup:            rule.RuleGroup,
+			Title:                rule.Title,
+			For:                  model.Duration(rule.For),
+			Condition:            rule.Condition,
+			Data:                 ngalertapi.ApiAlertQueriesFromAlertQueries(rule.Data),
+			Updated:              rule.Updated,
+			NoDataState:          rule.NoDataState.String(),
+			ExecErrState:         rule.ExecErrState.String(),
+			Annotations:          rule.Annotations,
+			Labels:               rule.Labels,
+			IsPaused:             rule.IsPaused,
+			NotificationSettings: ngalertapi.AlertRuleNotificationSettingsFromNotificationSettings(rule.NotificationSettings),
+			Record:               ngalertapi.ApiRecordFromModelRecord(rule.Record),
+		})
+	}
+
+	return provisionedAlertRules, nil
 }

--- a/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/NameCell.tsx
@@ -227,6 +227,8 @@ function ResourceIcon({ resource }: { resource: ResourceTableItem }) {
       return <Icon size="xl" name="bell" />;
     case 'NOTIFICATION_POLICY':
       return <Icon size="xl" name="bell" />;
+    case 'ALERT_RULE':
+      return <Icon size="xl" name="bell" />;
     default:
       return undefined;
   }

--- a/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/TypeCell.tsx
@@ -21,6 +21,8 @@ export function prettyTypeName(type: ResourceTableItem['type']) {
       return t('migrate-to-cloud.resource-type.contact_point', 'Contact Point');
     case 'NOTIFICATION_POLICY':
       return t('migrate-to-cloud.resource-type.notification_policy', 'Notification Policy');
+    case 'ALERT_RULE':
+      return t('migrate-to-cloud.resource-type.alert_rule', 'Alert Rule');
     default:
       return t('migrate-to-cloud.resource-type.unknown', 'Unknown');
   }

--- a/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
+++ b/public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx
@@ -60,6 +60,8 @@ function getTranslatedMessage(snapshot: GetSnapshotResponseDto) {
       types.push(t('migrate-to-cloud.migrated-counts.contact_points', 'contact points'));
     } else if (type === 'NOTIFICATION_POLICY') {
       types.push(t('migrate-to-cloud.migrated-counts.notification_policies', 'notification policies'));
+    } else if (type === 'ALERT_RULE') {
+      types.push(t('migrate-to-cloud.migrated-counts.alert_rules', 'alert rules'));
     }
 
     distinctItems += 1;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1552,6 +1552,7 @@
       "title": "Let us help you migrate to this stack"
     },
     "migrated-counts": {
+      "alert_rules": "alert rules",
       "contact_points": "contact points",
       "dashboards": "dashboards",
       "datasources": "data sources",
@@ -1652,6 +1653,7 @@
       "unknown-datasource-type": "Unknown data source"
     },
     "resource-type": {
+      "alert_rule": "Alert Rule",
       "contact_point": "Contact Point",
       "dashboard": "Dashboard",
       "datasource": "Data source",

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1552,6 +1552,7 @@
       "title": "Ŀęŧ ūş ĥęľp yőū mįģřäŧę ŧő ŧĥįş şŧäčĸ"
     },
     "migrated-counts": {
+      "alert_rules": "äľęřŧ řūľęş",
       "contact_points": "čőŉŧäčŧ pőįŉŧş",
       "dashboards": "đäşĥþőäřđş",
       "datasources": "đäŧä şőūřčęş",
@@ -1652,6 +1653,7 @@
       "unknown-datasource-type": "Ůŉĸŉőŵŉ đäŧä şőūřčę"
     },
     "resource-type": {
+      "alert_rule": "Åľęřŧ Ŗūľę",
       "contact_point": "Cőŉŧäčŧ Pőįŉŧ",
       "dashboard": "Đäşĥþőäřđ",
       "datasource": "Đäŧä şőūřčę",


### PR DESCRIPTION
**What is this feature?**

Adds [`Alert Rules`](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/) to the list of resources created in the migration snapshot, which is behind the `onPremToCloudMigrationsAlerts` feature toggle.

![alerts](https://github.com/user-attachments/assets/ef4c16d8-27e6-42c5-afb9-6f33de232ac8)

**Why do we need this feature?**

Extend the capability of the Cloud Migration Assistant to more resources.

**Who is this feature for?**

CloudMigration users

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/947

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
