### PR TITLE
Chore: Move `structured-clone` polyfill to setupTests

### DIFF
--- a/public/app/features/alerting/unified/NotificationPolicies.test.tsx
+++ b/public/app/features/alerting/unified/NotificationPolicies.test.tsx
@@ -1,4 +1,3 @@
-import 'core-js/stable/structured-clone';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { render, screen, userEvent } from 'test/test-utils';
 import { byLabelText, byRole, byTestId, byText } from 'testing-library-selector';

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -12,7 +12,6 @@ import { grantUserPermissions } from 'app/features/alerting/unified/mocks';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { AccessControlAction } from 'app/types';
 
-import 'core-js/stable/structured-clone';
 import ContactPoints from './components/contact-points/ContactPoints';
 import EditContactPoint from './components/contact-points/EditContactPoint';
 import NewReceiverView from './components/receivers/NewReceiverView';

--- a/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
@@ -1,4 +1,3 @@
-import 'core-js/stable/structured-clone';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 import { render, screen } from 'test/test-utils';
 import { byLabelText, byPlaceholderText, byRole, byTestId } from 'testing-library-selector';

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.test.tsx
@@ -19,8 +19,6 @@ import { renderWithProvider } from '../../contact-points/ContactPoints.test';
 
 import { GrafanaReceiverForm } from './GrafanaReceiverForm';
 
-import 'core-js/stable/structured-clone';
-
 setupMswServer();
 
 const ui = {

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
@@ -3,8 +3,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { screen, render, within } from 'test/test-utils';
 import { byRole, byTestId } from 'testing-library-selector';
 
-import 'core-js/stable/structured-clone';
-
 import { DashboardSearchItemType } from '../../../../search/types';
 import { mockDashboardApi, setupMswServer } from '../../mockApi';
 import { mockDashboardDto, mockDashboardSearchItem } from '../../mocks';

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.test.tsx
@@ -3,8 +3,6 @@ import { Props } from 'react-virtualized-auto-sizer';
 import { render } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
-import 'core-js/stable/structured-clone';
-
 import { DashboardSearchItemType } from '../../../../search/types';
 import { mockDashboardApi, setupMswServer } from '../../mockApi';
 import { mockDashboardDto, mockDashboardSearchItem } from '../../mocks';

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -3,7 +3,6 @@ import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { AccessControlAction } from 'app/types/accessControl';
 
-import 'core-js/stable/structured-clone';
 import { MatcherOperator } from '../../../../../../plugins/datasource/alertmanager/types';
 import { Labels } from '../../../../../../types/unified-alerting-dto';
 import { mockApi, setupMswServer } from '../../../mockApi';

--- a/public/app/features/alerting/unified/utils/notification-policies.test.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.test.ts
@@ -10,8 +10,6 @@ import {
   unquoteRouteMatchers,
 } from './notification-policies';
 
-import 'core-js/stable/structured-clone';
-
 const CATCH_ALL_ROUTE: Route = {
   receiver: 'ALL',
   object_matchers: [],

--- a/public/app/features/alerting/unified/utils/receiver-form.test.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.test.ts
@@ -1,5 +1,3 @@
-import 'core-js/stable/structured-clone';
-
 import { NotifierDTO } from 'app/types';
 
 import { Receiver } from '../../../../plugins/datasource/alertmanager/types';

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -1,3 +1,5 @@
+// `structuredClone` is not yet in jsdom https://github.com/jsdom/jsdom/issues/3363
+import 'core-js/stable/structured-clone';
 import 'whatwg-fetch';
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';


### PR DESCRIPTION
**What is this feature?**

Moves the `structured-clone` fix for jest-dom into `setupTests` instead, so we don't have to worry about manually including it in individual tests

**Why do we need this feature?**

Cleaner tests/less concern with specific DOM features. Also, IDEs won't tend to import new files before an import that includes an entire package without any named/default imports, so you end up with `import 'corejs...'` in the middle of your imports
