### PR TITLE
[v11.2.x] Folders: Add admin permissions upon creation of a folder w. SA

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -194,7 +194,7 @@ func (hs *HTTPServer) setDefaultFolderPermissions(ctx context.Context, orgID int
 
 	var permissions []accesscontrol.SetResourcePermissionCommand
 
-	if identity.IsIdentityType(user.GetID(), identity.TypeUser) {
+	if identity.IsIdentityType(user.GetID(), identity.TypeUser, identity.TypeServiceAccount) {
 		userID, err := identity.UserIdentifier(user.GetID())
 		if err != nil {
 			return err

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -492,7 +492,7 @@ func (dr *DashboardServiceImpl) setDefaultPermissions(ctx context.Context, dto *
 		userID, err := identity.IntIdentifier(dto.User.GetID())
 		if err != nil {
 			dr.log.Error("Could not make user admin", "dashboard", dash.Title, "id", dto.User.GetID(), "error", err)
-		} else if identity.IsIdentityType(dto.User.GetID(), identity.TypeUser) {
+		} else if identity.IsIdentityType(dto.User.GetID(), identity.TypeUser, identity.TypeServiceAccount) {
 			permissions = append(permissions, accesscontrol.SetResourcePermissionCommand{
 				UserID: userID, Permission: dashboardaccess.PERMISSION_ADMIN.String(),
 			})


### PR DESCRIPTION
Backport 9ab064bfc5892419eeeffd1f4d73f6e2e5fe4783 from #95072

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This introduces so that service accounts creating a folder, would deliver full permissions for the service account itself to manage that folder.
Previously when we create a folder w. a service account, we did not grant full admin permissions of that folder to limit the surface of permissions that a SA would act upon.

**Why do we need this feature?**

Users whom rely heavily on SAs managing their infrastructure, they are unable to manage some aspects of the folders created by the SA itself. This enables SAs to act fully within the folder.

**Who is this feature for?**

Any user wanting to manage folders via SAs.
