### PR TITLE
ci(trivy): Use non-default DB registry to avoid rate limits

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -17,39 +17,46 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - name: Install Trivy
+      uses: aquasecurity/setup-trivy@v0.2.1
+      with:
+        version: v0.56.2
+        cache: true
+    - name: Download Trivy DB
+      run: |
+        trivy fs --no-progress --download-db-only --db-repository public.ecr.aws/aquasecurity/trivy-db
     - name: Run Trivy vulnerability scanner (table output)
-      uses: aquasecurity/trivy-action@0.28.0
-      with:
-        # scan the filesystem, rather than building a Docker image prior - the
-        # downside is we won't catch dependencies that are only installed in the
-        # image, but the upside is we'll only catch vulnerabilities that are
-        # explicitly in the our dependencies
-        scan-type: 'fs'
-        scanners: 'vuln'
-        format: 'table'
-        exit-code: 1
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'
-        trivyignores: .trivyignore
-        # for the PR check, ignore JS-related issues
-        skip-files: 'yarn.lock,package.json'
+      # Use the trivy binary rather than the aquasecurity/trivy-action action
+      # to avoid a few bugs
+      # scan the filesystem, rather than building a Docker image prior - the
+      # downside is we won't catch dependencies that are only installed in the
+      # image, but the upside is we'll only catch vulnerabilities that are
+      # explicitly in the our dependencies
+      run: |
+        trivy fs \
+          --scanners vuln \
+          --format table \
+          --exit-code 1 \
+          --ignore-unfixed \
+          --pkg-types os,library \
+          --severity CRITICAL,HIGH \
+          --ignorefile .trivyignore \
+          --skip-files yarn.lock,package.json \
+          --skip-db-update \
+          .
     - name: Run Trivy vulnerability scanner (SARIF)
-      # Note: versions 0.27.0 and 0.28.0 are broken for SARIF output, but it's
-      # unclear why - worth testing again in the future
-      uses: aquasecurity/trivy-action@0.26.0
-      with:
-        scan-type: 'fs'
-        scanners: 'vuln'
-        # Note: The SARIF format ignores severity and uploads all vulns for
-        # later triage. The table-format step above is used to fail the build
-        # if there are any critical or high vulnerabilities.
-        # See https://github.com/aquasecurity/trivy-action/issues/95
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        trivyignores: .trivyignore
+      # Use the trivy binary rather than the aquasecurity/trivy-action action
+      # to avoid a few bugs
+      run: |
+        trivy fs \
+          --scanners vuln \
+          --format sarif \
+          --output trivy-results.sarif \
+          --ignore-unfixed \
+          --pkg-types os,library \
+          --ignorefile .trivyignore \
+          --skip-db-update \
+          .
       if: always() && github.repository == 'grafana/grafana'
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
**What is this feature?**

We keep running into https://github.com/aquasecurity/trivy-action/issues/389. This is an attempt to work around those limits. (Note that it's just an attempt, and may not be able to be merged)

**Who is this feature for?**

Contributors