### PR TITLE
Suggestion handler should always inject scope in _some_ way. 

### DIFF
--- a/pkg/promlib/resource/resource.go
+++ b/pkg/promlib/resource/resource.go
@@ -177,9 +177,14 @@ func (r *Resource) GetSuggestions(ctx context.Context, req *backend.CallResource
 	}
 
 	values := url.Values{}
-
 	for _, s := range selectorList {
 		vs := parser.VectorSelector{Name: s, LabelMatchers: matchers}
+		values.Add("match[]", vs.String())
+	}
+
+	// if no timeserie name is provided, but scopes are, the scope is still rendered and passed as match param.
+	if len(selectorList) == 0 && len(sugReq.Scopes) > 0 {
+		vs := parser.VectorSelector{LabelMatchers: matchers}
 		values.Add("match[]", vs.String())
 	}
 


### PR DESCRIPTION
In metric exlore, queries are sent to the suggestion handler for two reasons. 
1. find all timeseries for the label filters you have applied
2. find all relevant label filter/values for the filters you have applied. 

Case two works as expected since the scope is injected into all queries that are available. 
Problem is that case 1 one is executed first and has no queries to inject the scope into. This PR defaults to always passing the scope if no queries are passed. 

Once this is merged into https://github.com/grafana/grafana/pull/94802 run `/deploy-to-hg` to test the new changes :)