### PR TITLE
K8s/Folders: Fix folder status error message

### DIFF
--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -689,13 +689,11 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			permissions:  folderCreatePermission,
 		},
 		{
-			description:  "folder creation fails without permissions to create a folder",
-			input:        folderWithoutParentInput,
-			expectedCode: http.StatusForbidden,
-			// #TODO: instead of "access denied to folder", currently we are returning something like `folders.folder.grafana.app is
-			// forbidden: User "" cannot create resource "folders" in API group "folder.grafana.app" in the namespace "default": folder``
-			// expectedMessage: dashboards.ErrFolderAccessDenied.Error(),
-			permissions: []resourcepermissions.SetResourcePermissionCommand{},
+			description:     "folder creation fails without permissions to create a folder",
+			input:           folderWithoutParentInput,
+			expectedCode:    http.StatusForbidden,
+			expectedMessage: dashboards.ErrFolderAccessDenied.Error(),
+			permissions:     []resourcepermissions.SetResourcePermissionCommand{},
 		},
 		{
 			// #TODO This test case doesn't set up the conditions it describes. We should have created a folder with the same UID before

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -657,8 +657,8 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 	folderWithoutParentInput := "{ \"uid\": \"uid\", \"title\": \"Folder\"}"
 	folderWithoutUID := "{ \"title\": \"Folder without UID\"}"
 	folderWithTitleEmpty := "{ \"title\": \"\"}"
-	folderWithInvalidUid := "{ \"uid\": \"------------\"}"
-	folderWithUIDTooLong := "{ \"uid\": \"asdfghjklqwertyuiopzxcvbnmasdfghjklqwertyuiopzxcvbnmasdfghjklqwertyuiopzxcvbnm\"}"
+	folderWithInvalidUid := "{ \"uid\": \"::::::::::::\", \"title\": \"Another folder\"}"
+	folderWithUIDTooLong := "{ \"uid\": \"asdfghjklqwertyuiopzxcvbnmasdfghjklqwertyuiopzxcvbnmasdfghjklqwertyuiopzxcvbnm\", \"title\": \"Third folder\"}"
 	folderWithSameName := "{\"title\": \"same name\"}"
 
 	type testCase struct {
@@ -698,10 +698,12 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			permissions: []resourcepermissions.SetResourcePermissionCommand{},
 		},
 		{
-			description:            "folder creation fails given folder service error %s",
-			input:                  folderWithoutUID,
-			expectedCode:           http.StatusConflict,
-			expectedMessage:        dashboards.ErrFolderSameNameExists.Error(),
+			// #TODO This test case doesn't set up the conditions it describes. We should have created a folder with the same UID before
+			// creating a second one and failing to do so successfully.
+			description:  "folder creation fails given folder service error %s",
+			input:        folderWithoutUID,
+			expectedCode: http.StatusConflict,
+			// expectedMessage:        dashboards.ErrFolderWithSameUIDExists.Error(),
 			expectedFolderSvcError: dashboards.ErrFolderWithSameUIDExists,
 			createSecondRecord:     true,
 			permissions:            folderCreatePermission,
@@ -718,7 +720,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithInvalidUid,
 			expectedCode:           http.StatusBadRequest,
-			expectedMessage:        dashboards.ErrFolderTitleEmpty.Error(),
+			expectedMessage:        dashboards.ErrDashboardInvalidUid.Error(),
 			expectedFolderSvcError: dashboards.ErrDashboardInvalidUid,
 			permissions:            folderCreatePermission,
 		},
@@ -726,7 +728,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithUIDTooLong,
 			expectedCode:           http.StatusBadRequest,
-			expectedMessage:        dashboards.ErrFolderTitleEmpty.Error(),
+			expectedMessage:        dashboards.ErrDashboardUidTooLong.Error(),
 			expectedFolderSvcError: dashboards.ErrDashboardUidTooLong,
 			permissions:            folderCreatePermission,
 		},

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -664,6 +664,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 	type testCase struct {
 		description            string
 		expectedCode           int
+		expectedMessage        string
 		expectedFolderSvcError error
 		permissions            []resourcepermissions.SetResourcePermissionCommand
 		input                  string
@@ -691,12 +692,16 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:  "folder creation fails without permissions to create a folder",
 			input:        folderWithoutParentInput,
 			expectedCode: http.StatusForbidden,
-			permissions:  []resourcepermissions.SetResourcePermissionCommand{},
+			// #TODO: instead of "access denied to folder", currently we are returning something like `folders.folder.grafana.app is
+			// forbidden: User "" cannot create resource "folders" in API group "folder.grafana.app" in the namespace "default": folder``
+			// expectedMessage: dashboards.ErrFolderAccessDenied.Error(),
+			permissions: []resourcepermissions.SetResourcePermissionCommand{},
 		},
 		{
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutUID,
 			expectedCode:           http.StatusConflict,
+			expectedMessage:        dashboards.ErrFolderSameNameExists.Error(),
 			expectedFolderSvcError: dashboards.ErrFolderWithSameUIDExists,
 			createSecondRecord:     true,
 			permissions:            folderCreatePermission,
@@ -705,6 +710,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithTitleEmpty,
 			expectedCode:           http.StatusBadRequest,
+			expectedMessage:        dashboards.ErrFolderTitleEmpty.Error(),
 			expectedFolderSvcError: dashboards.ErrFolderTitleEmpty,
 			permissions:            folderCreatePermission,
 		},
@@ -712,6 +718,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithInvalidUid,
 			expectedCode:           http.StatusBadRequest,
+			expectedMessage:        dashboards.ErrFolderTitleEmpty.Error(),
 			expectedFolderSvcError: dashboards.ErrDashboardInvalidUid,
 			permissions:            folderCreatePermission,
 		},
@@ -719,6 +726,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithUIDTooLong,
 			expectedCode:           http.StatusBadRequest,
+			expectedMessage:        dashboards.ErrFolderTitleEmpty.Error(),
 			expectedFolderSvcError: dashboards.ErrDashboardUidTooLong,
 			permissions:            folderCreatePermission,
 		},
@@ -726,6 +734,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithSameName,
 			expectedCode:           http.StatusConflict,
+			expectedMessage:        dashboards.ErrFolderSameNameExists.Error(),
 			expectedFolderSvcError: dashboards.ErrFolderSameNameExists,
 			createSecondRecord:     true,
 			permissions:            folderCreatePermission,
@@ -734,6 +743,7 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithoutParentInput,
 			expectedCode:           http.StatusPreconditionFailed,
+			expectedMessage:        dashboards.ErrFolderVersionMismatch.Error(),
 			expectedFolderSvcError: dashboards.ErrFolderVersionMismatch,
 			createSecondRecord:     true,
 			permissions:            folderCreatePermission,
@@ -792,7 +802,12 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			require.NotNil(t, resp)
 			require.Equal(t, tc.expectedCode, resp.StatusCode)
 
-			folder := dtos.Folder{}
+			type folderWithMessage struct {
+				dtos.Folder
+				Message string `json:"message"`
+			}
+
+			folder := folderWithMessage{}
 			err = json.NewDecoder(resp.Body).Decode(&folder)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
@@ -800,6 +815,10 @@ func TestFoldersCreateAPIEndpointK8S(t *testing.T) {
 			if tc.expectedCode == http.StatusOK {
 				require.Equal(t, "uid", folder.UID)
 				require.Equal(t, "Folder", folder.Title)
+			}
+
+			if tc.expectedMessage != "" {
+				require.Equal(t, tc.expectedMessage, folder.Message)
 			}
 		})
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The message field in the folder create response is being improperly set. See context: https://raintank-corp.slack.com/archives/C05FYAPEPKP/p1729669987312569. This PR fixes it.

**Who is this feature for?**

Search and Storage team

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/125

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
