### PR TITLE
Replace myself with Irene who oversees Grafana documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,17 +38,11 @@
 /docs/.codespellignore                                                            @grafana/docs-tooling
 /docs/sources/                                                                    @irenerl24
 
-/docs/sources/administration/                                                     @irenerl24
 /docs/sources/alerting/                                                           @brendamuir
 /docs/sources/dashboards/                                                         @imatwawana
-/docs/sources/datasources/                                                        @irenerl24
 /docs/sources/explore/                                                            @grafana/explore-squad @lwandz13
-/docs/sources/fundamentals                                                        @irenerl24
-/docs/sources/getting-started/                                                    @irenerl24
-/docs/sources/introduction/                                                       @irenerl24
 /docs/sources/panels-visualizations/                                              @imatwawana
 /docs/sources/release-notes/                                                      @Eve832 @GrafanaWriter
-/docs/sources/setup-grafana/                                                      @irenerl24
 /docs/sources/upgrade-guide/                                                      @imatwawana
 /docs/sources/whatsnew/                                                           @imatwawana
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /docs/sources/dashboards/                                                         @imatwawana
 /docs/sources/explore/                                                            @grafana/explore-squad @lwandz13
 /docs/sources/panels-visualizations/                                              @imatwawana
-/docs/sources/release-notes/                                                      @Eve832 @GrafanaWriter
+/docs/sources/release-notes/                                                      @irenerl24 @GrafanaWriter
 /docs/sources/upgrade-guide/                                                      @imatwawana
 /docs/sources/whatsnew/                                                           @imatwawana
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,10 +38,10 @@
 /docs/.codespellignore                                                            @grafana/docs-tooling
 /docs/sources/                                                                    @irenerl24
 
-/docs/sources/administration/                                                     @jdbaldry
+/docs/sources/administration/                                                     @irenerl24
 /docs/sources/alerting/                                                           @brendamuir
 /docs/sources/dashboards/                                                         @imatwawana
-/docs/sources/datasources/                                                        @jdbaldry
+/docs/sources/datasources/                                                        @irenerl24
 /docs/sources/explore/                                                            @grafana/explore-squad @lwandz13
 /docs/sources/fundamentals                                                        @irenerl24
 /docs/sources/getting-started/                                                    @irenerl24


### PR DESCRIPTION
As discussed in Slack, my triaging of these sections of the documentation is hiding some of the workload from the Grafana docs team which could affect capacity planning.

The areas I owned don't tend to have too many PRs to review but it is also non-zero.

Irene does a great job of responding to PRs in a timely fashion.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

