### PR TITLE
Tempo: Escape span names in TraceQL editor

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -34,7 +34,7 @@ const isRegExpOperator = (operator: string) => operator === '=~' || operator ===
 const escapeValues = (values: string[]) => getEscapedSpanNames(values);
 
 export const valueHelper = (f: TraceqlFilter) => {
-  const value = isRegExpOperator(f.operator!) ? escapeValues(f.value as string[]) : f.value;
+  const value = Array.isArray(f.value) && isRegExpOperator(f.operator!) ? escapeValues(f.value) : f.value;
 
   if (Array.isArray(value) && value.length > 1) {
     return `"${value.join('|')}"`;

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -5,6 +5,7 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { VariableFormatID } from '@grafana/schema';
 
 import { TraceqlFilter, TraceqlSearchScope } from '../dataquery.gen';
+import { getEscapedSpanNames } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
 import { Scope } from '../types';
 
@@ -28,14 +29,20 @@ export const interpolateFilters = (filters: TraceqlFilter[], scopedVars?: Scoped
   return interpolatedFilters;
 };
 
+const isRegExpOperator = (operator: string) => operator === '=~' || operator === '!~';
+
+const escapeValues = (values: string[]) => getEscapedSpanNames(values);
+
 export const valueHelper = (f: TraceqlFilter) => {
-  if (Array.isArray(f.value) && f.value.length > 1) {
-    return `"${f.value.join('|')}"`;
+  const value = isRegExpOperator(f.operator!) ? escapeValues(f.value as string[]) : f.value;
+
+  if (Array.isArray(value) && value.length > 1) {
+    return `"${value.join('|')}"`;
   }
   if (f.valueType === 'string') {
-    return `"${f.value}"`;
+    return `"${value}"`;
   }
-  return f.value;
+  return value;
 };
 
 export const scopeHelper = (f: TraceqlFilter, lp: TempoLanguageProvider) => {

--- a/public/app/plugins/datasource/tempo/language_provider.test.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.test.ts
@@ -173,6 +173,20 @@ describe('Language_provider', () => {
         lp.generateQueryFromFilters([{ id: 'foo', tag: 'footag', value: '1234', operator: '>', valueType: 'integer' }])
       ).toBe('{.footag>1234}');
     });
+    it.each([['=~'], ['!~']])('a field with a regexp operator (%s)', (operator) => {
+      expect(
+        lp.generateQueryFromFilters([
+          {
+            id: 'span-name',
+            tag: 'name',
+            operator,
+            scope: TraceqlSearchScope.Span,
+            value: ['api/v2/variants/by-upc/(?P<upc>[\\s\\S]*)/$'],
+            valueType: 'string',
+          },
+        ])
+      ).toBe(`{name${operator}"api/v2/variants/by-upc/\\\\(\\\\?P<upc>\\\\[\\\\\\\\s\\\\\\\\S\\\\]\\\\*\\\\)/\\\\$"}`);
+    });
     it('two fields with everything filled in', () => {
       expect(
         lp.generateQueryFromFilters([


### PR DESCRIPTION
**What is this feature?**

Fix for the TraceQL Search in Explore when dealing with values that are regexes (values used with the `=~` or `!~` operators).

**Why do we need this feature?**

Regexes must be properly escaped (e.g. backslashes must be doubly escaped for them to be interpreted as a literal backslash character).

**Who is this feature for?**

Anyone who uses TraceQL Search in Explore

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/12888, similar to https://github.com/grafana/grafana/pull/83024

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
