### PR TITLE
Docs: Clarify plugin frontend sandbox

### DIFF
--- a/docs/sources/administration/plugin-management/index.md
+++ b/docs/sources/administration/plugin-management/index.md
@@ -238,6 +238,8 @@ When enabled, plugins run in a separate JavaScript context, which provides sever
 - Protects core Grafana features from being altered by plugins
 - Prevents plugins from modifying global browser objects and behaviors
 
+Plugins running inside the Frontend Sandbox should continue to work normally without any noticeable changes in their intended functionality.
+
 ### Enable Frontend Sandbox
 
 The Frontend Sandbox feature is currently behind the `pluginsFrontendSandbox` feature flag. To enable it, you'll need to:


### PR DESCRIPTION
Small left over from https://github.com/grafana/grafana/pull/95467/commits

I realized It was not clarified anywhere that the sandbox doesn't affect the normal behaviour of plugins