### PR TITLE
E2E Selectors: Force plugin-e2e to use workspace version of e2e-selectors

### DIFF
--- a/e2e/plugin-e2e/plugin-e2e-api-tests/README.md
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/README.md
@@ -1,8 +1,3 @@
 # @grafana/plugin-e2e API tests
 
-The purpose of the E2E tests in this directory is not to test the plugins per se - it's to verify that the fixtures, models and expect matchers provided by the [`@grafana/plugin-e2e`](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e) package are compatible with the latest version of Grafana. If you find that any of these tests are failing, it's probably due to one of the following reasons:
-
-- you have changed a value of a selector defined in @grafana/e2e-selector
-- you have made structural changes to the UI
-
-For information on how to address this, follow the instructions in the [contributing guidelines](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CONTRIBUTING.md#how-to-fix-broken-test-scenarios-after-changes-in-grafana) for the @grafana/plugin-e2e package in the plugin-tools repository.
+The purpose of the E2E tests in this directory is not to test the plugins per se - it's to verify that the fixtures, models and expect matchers provided by the [`@grafana/plugin-e2e`](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e) package are compatible with the latest version of Grafana. If you find that any of these tests are failing, it's likely because you have made changes in the Grafana UI that breaks the end-to-end testing APIs in plugin-e2e. For information on how to address this, follow the instructions in the [contributing guidelines](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CONTRIBUTING.md#how-to-fix-broken-test-scenarios-after-changes-in-grafana) for the @grafana/plugin-e2e package in the plugin-tools repository.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@emotion/eslint-plugin": "11.12.0",
     "@grafana/eslint-config": "7.0.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
-    "@grafana/plugin-e2e": "^1.8.3",
+    "@grafana/plugin-e2e": "^1.11.0",
     "@grafana/tsconfig": "^2.0.0",
     "@manypkg/get-packages": "^2.2.0",
     "@playwright/test": "1.48.2",

--- a/package.json
+++ b/package.json
@@ -415,6 +415,7 @@
   "resolutions": {
     "underscore": "1.13.7",
     "@types/slate": "0.47.11",
+    "@grafana/e2e-selectors": "workspace:*",
     "ngtemplate-loader/loader-utils": "^2.0.0",
     "semver@~7.0.0": "7.5.4",
     "semver@7.3.4": "7.5.4",

--- a/package.json
+++ b/package.json
@@ -415,7 +415,6 @@
   "resolutions": {
     "underscore": "1.13.7",
     "@types/slate": "0.47.11",
-    "@grafana/e2e-selectors": "workspace:*",
     "ngtemplate-loader/loader-utils": "^2.0.0",
     "semver@~7.0.0": "7.5.4",
     "semver@7.3.4": "7.5.4",
@@ -428,6 +427,7 @@
     "redux": "^5.0.0",
     "@storybook/blocks@npm:8.1.6": "patch:@storybook/blocks@npm%3A8.1.6#~/.yarn/patches/@storybook-blocks-npm-8.1.6-892f57a6d7.patch",
     "react-grid-layout": "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch",
+    "@grafana/plugin-e2e/@grafana/e2e-selectors": "workspace:*",
     "@grafana/scenes/@grafana/e2e-selectors": "workspace:*",
     "@grafana/scenes-react/@grafana/e2e-selectors": "workspace:*"
   },

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1060,6 +1060,7 @@ export const versionedComponents = {
   },
   CodeEditor: {
     container: {
+      '11.4.0': 'data-testid abc',
       '10.2.3': 'data-testid Code editor container',
       [MIN_GRAFANA_VERSION]: 'Code editor container',
     },

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1060,7 +1060,6 @@ export const versionedComponents = {
   },
   CodeEditor: {
     container: {
-      '11.4.0': 'data-testid abc',
       '10.2.3': 'data-testid Code editor container',
       [MIN_GRAFANA_VERSION]: 'Code editor container',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3890,16 +3890,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:^1.8.3":
-  version: 1.9.0
-  resolution: "@grafana/plugin-e2e@npm:1.9.0"
+"@grafana/plugin-e2e@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@grafana/plugin-e2e@npm:1.11.0"
   dependencies:
+    "@grafana/e2e-selectors": "npm:^11.4.0-204289"
     semver: "npm:^7.5.4"
     uuid: "npm:^10.0.0"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@playwright/test": ^1.41.2
-  checksum: 10/afc74b27473412a96b6bcdb77144c8bd25d3a299f55daff91a91aca951caca5cb0d009ec71e74c7efc906140d870076f4d763f7775fe2f5d2971657958daff96
+  checksum: 10/87726ecfd9c9895e075f8c9d3bd20b49ba458e43bbf8f41e46e635b2157597f36fd6ccb3f35dcea9df04c2dd65d63e9893318cbcf1903340e6668b3b122a9c83
   languageName: node
   linkType: hard
 
@@ -19025,7 +19026,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:0.2.6"
     "@grafana/monaco-logql": "npm:^0.0.7"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:^1.8.3"
+    "@grafana/plugin-e2e": "npm:^1.11.0"
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

Now that the selectors in `grafana/e2e-selectors` are [versioned](https://github.com/grafana/grafana/pull/93468), `grafana/plugin-e2e` no longer needs to maintain duplicates of the selectors as it can depend directly on the `grafana/e2e-selectors` package. This PR adds a resolution that forces plugin-e2e to use the workspace version of the selectors. This will prevent plugin-e2e tests from failing in the case the value of a versioned selector was changed (and the selector is used in plugin-e2e). cc @ashharrison90 @joshhunt 

**Why do we need this feature?**

To prevent maintainers of Grafana from having to update the same selector i two different repos. 

**Who is this feature for?**

Grafana maintainers

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
