### PR TITLE
Alerting UI: rename `Template title/name` input

### DIFF
--- a/public/app/features/alerting/unified/Templates.test.tsx
+++ b/public/app/features/alerting/unified/Templates.test.tsx
@@ -43,7 +43,7 @@ jest.mock('@grafana/ui', () => ({
 const ui = {
   templateForm: byRole('form', { name: 'Template form' }),
   form: {
-    title: byLabelText(/Template name/),
+    title: byLabelText(/Template title\/name/),
     saveButton: byRole('button', { name: 'Save' }),
   },
 };
@@ -93,7 +93,7 @@ describe('Templates routes', () => {
     const form = await ui.templateForm.find();
 
     expect(form).toBeInTheDocument();
-    expect(within(form).getByRole('textbox', { name: /Template name/ })).toHaveValue('');
+    expect(within(form).getByRole('textbox', { name: /Template title\/name/ })).toHaveValue('');
   });
 
   it('should pass name validation when editing existing template', async () => {
@@ -134,7 +134,7 @@ describe('Templates K8s API', () => {
     const form = await ui.templateForm.find();
 
     expect(form).toBeInTheDocument();
-    expect(within(form).getByRole('textbox', { name: /Template name/ })).toHaveValue('custom-email');
+    expect(within(form).getByRole('textbox', { name: /Template title\/name/ })).toHaveValue('custom-email');
     expect(within(form).getAllByTestId('code-editor')[0]).toHaveValue(
       '{{ define "custom-email" }}  Custom email template {{ end }}'
     );
@@ -146,7 +146,7 @@ describe('Templates K8s API', () => {
     const form = await ui.templateForm.find();
 
     expect(form).toBeInTheDocument();
-    expect(within(form).getByRole('textbox', { name: /Template name/ })).toHaveValue('custom-email (copy)');
+    expect(within(form).getByRole('textbox', { name: /Template title\/name/ })).toHaveValue('custom-email (copy)');
     expect(within(form).getAllByTestId('code-editor')[0]).toHaveTextContent(
       '{{ define "custom-email_NEW" }} Custom email template {{ end }}'
     );

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -202,10 +202,11 @@ export const TemplateForm = ({ originalTemplate, prefill, alertmanager }: Props)
             </Box>
           )}
 
-          {/* name field for the template */}
+          {/* title/name field for the template */}
           <FieldSet disabled={isProvisioned} className={styles.fieldset}>
             <InlineField
-              label="Template name"
+              label="Template title/name"
+              tooltip="The template name is set using {{ define }}. The Alerting Provisioning HTTP API refers to this field as the template name."
               error={errors?.title?.message}
               invalid={!!errors.title?.message}
               required


### PR DESCRIPTION
Continuation of [Alerting docs: differentiate template name and title](https://github.com/grafana/grafana/pull/95506). 

Currently, template name in Alerting refers to two different things:

1 - The name of the template created in the UI.

2 - The name of the template defined in {{ define "template-name" }}.

This PR changes the input field to help distinguish between the Alertmanager notification templates (`{{ define "template-name}}`) and the Grafana notification template.

![Screenshot 2024-10-28 at 18 05 18](https://github.com/user-attachments/assets/1a6f52b3-e221-4670-9857-93b8ac4aa3b9)


I am not fully confident in the `template title/name` proposal. 

If it’s not suitable, this PR could at least help spark a conversation about this issue, and discuss other ideas.
