### PR TITLE
chore: (@grafana/ui) - table documentation explain applyFieldOverrides

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.mdx
+++ b/packages/grafana-ui/src/components/Table/Table.mdx
@@ -34,35 +34,39 @@ Table component only works in conjunction with the applyFieldOverrides function 
 import { DataFrame, applyFieldOverrides, GrafanaTheme2 } from '@grafana/data';
 import { Table, useTheme2 } from '@grafana/ui';
 
-const theme = useTheme2();
-const displayData = applyFieldOverrides({
-  data: dataFrame,
-  fieldConfig: {
-    defaults: {
-      custom: {
-        align: 'auto',
-        cellOptions: {
-          type: 'gauge',
-          mode: 'gradient',
+const TableComponent = (dataFrame: DataFrame) => {
+  const theme = useTheme2();
+  const displayData = applyFieldOverrides({
+    data: dataFrame,
+    fieldConfig: {
+      defaults: {
+        custom: {
+          align: 'auto',
+          cellOptions: {
+            type: 'gauge',
+            mode: 'gradient',
+          },
+          inspect: false,
         },
-        inspect: false,
+        mappings: [],
+        unit: 'locale',
       },
-      mappings: [],
-      unit: 'locale',
+      overrides: [],
     },
-    overrides: [],
-  },
-  theme,
-  replaceVariables: (value) => value,
-});
+    theme,
+    replaceVariables: (value) => value,
+  });
 
-<Table
-  data={displayData}
-  width={1000}
-  height={400}
-  columnMinWidth={50}
-  footerOptions={{ show: true, reducer: ['sum'] }}
-/>;
+  return (
+    <Table
+      data={displayData}
+      width={1000}
+      height={400}
+      columnMinWidth={50}
+      footerOptions={{ show: true, reducer: ['sum'] }}
+    />
+  )
+}
 ```
 
 ## Cell rendering

--- a/packages/grafana-ui/src/components/Table/Table.mdx
+++ b/packages/grafana-ui/src/components/Table/Table.mdx
@@ -26,6 +26,45 @@ Each dataframe also supports using the following custom property under `datafram
 - @deprecated use `FieldType.nestedFrames` instead
   - **parentRowIndex**: number - The index of the parent row in the main dataframe (under the `data` prop of the Table component).
 
+## Table rendering
+
+Table component only works in conjunction with the applyFieldOverrides function from the @grafana/data package otherwise data will not render.
+
+```javascript
+import { DataFrame, applyFieldOverrides, GrafanaTheme2 } from '@grafana/data';
+import { Table, useTheme2 } from '@grafana/ui';
+
+const theme = useTheme2();
+const displayData = applyFieldOverrides({
+  data: dataFrame,
+  fieldConfig: {
+    defaults: {
+      custom: {
+        align: 'auto',
+        cellOptions: {
+          type: 'gauge',
+          mode: 'gradient',
+        },
+        inspect: false,
+      },
+      mappings: [],
+      unit: 'locale',
+    },
+    overrides: [],
+  },
+  theme,
+  replaceVariables: (value) => value,
+});
+
+<Table
+  data={displayData}
+  width={1000}
+  height={400}
+  columnMinWidth={50}
+  footerOptions={{ show: true, reducer: ['sum'] }}
+/>;
+```
+
 ## Cell rendering
 
 Cell rendering is controlled by table specific field config in the DataFrame passed as `data` prop. Each field can set its `field.config.custom` to be type `TableFieldOptions`. `TableFieldOptions` contain generic options to control some aspects of the cell and column rendering. They also contain `cellOptions` property which can be further used to control type of cell renderer that will be used. `cellOptions` subtypes:


### PR DESCRIPTION
**What is this feature?**

Add brief description and code snippet example to use `applyFieldOverrides` with the `<Table/>` component. Happy to update or change any of the wording or move it if there's a more appropriate place.

**Why do we need this feature?**

It took me longer than I care to admit that I needed to use `applyFieldOverrides` with the theme to render data in a table. I asked a few other Grafanistas and most were unaware. I hope this helps the next dev.

**Who is this feature for?**

User of the Table component

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

