### PR TITLE
Logging: Add error logging to syslog

### DIFF
--- a/pkg/infra/log/syslog.go
+++ b/pkg/infra/log/syslog.go
@@ -4,6 +4,7 @@
 package log
 
 import (
+	"fmt"
 	"log/syslog"
 	"os"
 
@@ -55,10 +56,18 @@ func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
 	handler.Tag = sec.Key("tag").MustString("")
 
 	if err := handler.Init(); err != nil {
+		fmt.Printf("Failed to init syslog handler. Error: %v\n", err)
 		root.Error("Failed to init syslog log handler", "error", err)
 		os.Exit(1)
 	}
 	handler.logger = gokitsyslog.NewSyslogLogger(handler.syslog, format, gokitsyslog.PrioritySelectorOption(selector))
+
+	if err := handler.Log("msg", "syslog logger initialized"); err != nil {
+		fmt.Printf("Failed to log to syslog handler. Error: %v\n", err)
+		root.Error("Failed to log to syslog log handler", "error", err)
+		os.Exit(1)
+	}
+
 	return handler
 }
 


### PR DESCRIPTION
**What is this feature?**

This PR adds some additional logging & an initialization check to the syslog logger. Specifically it will:
- Print a failure message if it cannot initialize. Currently, the error is [discarded](https://github.com/grafana/grafana/blob/main/pkg/infra/log/log.go#L50) in the default root logger.
- Adds a check to the initialization that it can send a message. If it cannot, it fails & prints the issue.

**Why do we need this feature?**

It is currently pretty difficult to debug syslog issues, as things are failing silently.