### PR TITLE
setting variable: label can't have dot

### DIFF
--- a/packages/grafana-prometheus/src/metric_find_query.ts
+++ b/packages/grafana-prometheus/src/metric_find_query.ts
@@ -28,7 +28,7 @@ export class PrometheusMetricFindQuery {
     this.range = timeRange;
     const labelNamesRegex = PrometheusLabelNamesRegex;
     const labelNamesRegexWithMatch = PrometheusLabelNamesRegexWithMatch;
-    const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_]*)\)\s*$/;
+    const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_][a-zA-Z0-9_.]*)\)\s*$/;
     const metricNamesRegex = PrometheusMetricNamesRegex;
     const queryResultRegex = PrometheusQueryResultRegex;
     const labelNamesQuery = this.query.match(labelNamesRegex);

--- a/packages/grafana-prometheus/src/migrations/variableMigration.ts
+++ b/packages/grafana-prometheus/src/migrations/variableMigration.ts
@@ -5,7 +5,7 @@ import { PromVariableQuery, PromVariableQueryType as QueryType } from '../types'
 
 export const PrometheusLabelNamesRegex = /^label_names\(\)\s*$/;
 // Note that this regex is different from the one in metric_find_query.ts because this is used pre-interpolation
-export const PrometheusLabelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_$][a-zA-Z0-9_]*)\)\s*$/;
+export const PrometheusLabelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_$][a-zA-Z0-9_.]*)\)\s*$/;
 export const PrometheusMetricNamesRegex = /^metrics\((.+)\)\s*$/;
 export const PrometheusQueryResultRegex = /^query_result\((.+)\)\s*$/;
 export const PrometheusLabelNamesRegexWithMatch = /^label_names\((.+)\)\s*$/;


### PR DESCRIPTION
when i wanna use label value. i find the label can't contain dot. but our k8s cluster has a lot of this kind of label.
and i add dot in the regex pattern.
![image](https://github.com/user-attachments/assets/2bc34801-6c3b-43ee-8b85-cbd2fae8e137)

i want choose `Label` that contains dot