### PR TITLE
Grafana UI: Remove re-export of Ansicolor package

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -67,7 +67,6 @@
     "@types/jquery": "3.5.32",
     "@types/lodash": "4.17.12",
     "@types/react-table": "7.7.20",
-    "ansicolor": "1.1.100",
     "calculate-size": "1.1.1",
     "classnames": "2.5.1",
     "d3": "7.9.0",

--- a/packages/grafana-ui/src/utils/index.ts
+++ b/packages/grafana-ui/src/utils/index.ts
@@ -11,7 +11,6 @@ export * from './table';
 export * from './measureText';
 export * from './useForceUpdate';
 export { SearchFunctionType } from './searchFunctions';
-export { ansicolor } from 'ansicolor';
 
 export { DOMUtil };
 

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -1,3 +1,4 @@
+import ansicolor from 'ansicolor';
 import { groupBy, size } from 'lodash';
 import { from, isObservable, Observable } from 'rxjs';
 
@@ -41,7 +42,7 @@ import {
 import { SIPrefix } from '@grafana/data/src/valueFormats/symbolFormatters';
 import { config } from '@grafana/runtime';
 import { BarAlignment, GraphDrawStyle, StackingMode } from '@grafana/schema';
-import { ansicolor, colors } from '@grafana/ui';
+import { colors } from '@grafana/ui';
 import { getThemeColor } from 'app/core/utils/colors';
 
 import { LogsFrame, parseLogsFrame } from './logsFrame';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,7 +4271,6 @@ __metadata:
     "@types/slate-react": "npm:0.22.9"
     "@types/tinycolor2": "npm:1.4.6"
     "@types/uuid": "npm:9.0.8"
-    ansicolor: "npm:1.1.100"
     calculate-size: "npm:1.1.1"
     chance: "npm:1.1.12"
     classnames: "npm:2.5.1"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR removes the unused Ansicolor package from grafana/ui. It appears to be legacy from way back when it was vendor'd before @ifrost contributed back to the ansicolor package, removing the need to keep it in grafana/ui.

**Why do we need this feature?**

To not expose external apis that aren't used within the grafana/ui package to consumers. I cannot find any usage of this export within public plugins via the ops dashboard or github searches (where it only ever shows up in the `logsModel.ts`). Evidently it is a breaking change but I'm pretty sure anyone wanting to use `ansicolor` in a plugin would import it directly from the ansicolor package rather than import it from grafana/ui.

If we feel this is risky - I can provide a runtime fix for plugins.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

--------------------
# Release notice breaking change

The `ansicolor` export in `@grafana/ui` has been removed. To continue using this package within your plugin please import it directly: `import ansicolor from 'ansicolor';`
