### PR TITLE
explore: only pass queries to suggestion if the list is short

### DIFF
--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -172,12 +172,21 @@ export function limitAdhocProviders(
       // call getTagKeys and truncate the response
       // we're passing the queries so we get the labels that adhere to the queries
       // we're also passing the scopes so we get the labels that adhere to the scopes filters
+
+      const opts = {
+        filters,
+        scopes: getClosestScopesFacade(variable)?.value,
+        queries: dataTrail.getQueries(),
+      }
+
+      // if there are too many queries it takes to much time to process the requests.
+      // In this case we favour responsiveness over reducing the number of options.
+      if (opts.queries.length > 20) {
+        opts.queries = [];
+      }
+
       const values = (
-        await datasourceHelper.getTagKeys({
-          filters,
-          scopes: getClosestScopesFacade(variable)?.value,
-          queries: dataTrail.getQueries(),
-        })
+        await datasourceHelper.getTagKeys(opts)
       ).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };
@@ -200,13 +209,22 @@ export function limitAdhocProviders(
       // call getTagValues and truncate the response
       // we're passing the queries so we get the label values that adhere to the queries
       // we're also passing the scopes so we get the label values that adhere to the scopes filters
+      
+      const opts = {
+        key: filter.key,
+        filters,
+        scopes: getClosestScopesFacade(variable)?.value,
+        queries: dataTrail.getQueries(),
+      }
+
+      // if there are too many queries it takes to much time to process the requests.
+      // In this case we favour responsiveness over reducing the number of options.
+      if (opts.queries.length > 20) {
+        opts.queries = [];
+      }
+      
       const values = (
-        await datasourceHelper.getTagValues({
-          key: filter.key,
-          filters,
-          scopes: getClosestScopesFacade(variable)?.value,
-          queries: dataTrail.getQueries(),
-        })
+        await datasourceHelper.getTagValues(opts)
       ).slice(0, MAX_ADHOC_VARIABLE_OPTIONS);
       // use replace: true to override the default lookup in adhoc filter variable
       return { replace: true, values };


### PR DESCRIPTION
This speeds up the suggestion call in metric explore. 

Explore metrics will show all metrics by design which means suggestions queries can be very expensive if all queries shown are taking into account. With this change we optimize for faster response at the cost of returning more labels and values. 