### PR TITLE
GrafanaUI: Add new unstable `ScrollContainer` component

### DIFF
--- a/packages/grafana-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/grafana-ui/src/components/Layout/Box/Box.tsx
@@ -17,7 +17,7 @@ export type BorderColor = keyof GrafanaTheme2['colors']['border'] | 'error' | 's
 export type BorderRadius = keyof ThemeShape['radius'];
 export type BoxShadow = keyof ThemeShadows;
 
-interface BoxProps extends FlexProps, SizeProps, Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
+export interface BoxProps extends FlexProps, SizeProps, Omit<React.HTMLAttributes<HTMLElement>, 'className' | 'style'> {
   // Margin props
   /** Sets the property `margin` */
   margin?: ResponsiveProp<ThemeSpacingTokens>;

--- a/packages/grafana-ui/src/components/ScrollContainer/ScrollContainer.tsx
+++ b/packages/grafana-ui/src/components/ScrollContainer/ScrollContainer.tsx
@@ -1,0 +1,65 @@
+import { css } from '@emotion/css';
+import { Property } from 'csstype';
+import { forwardRef, PropsWithChildren, UIEventHandler } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../themes';
+import { Box, BoxProps } from '../Layout/Box/Box';
+
+import { ScrollIndicators } from './ScrollIndicators';
+
+interface Props extends Omit<BoxProps, 'display' | 'direction' | 'flex' | 'position'> {
+  showScrollIndicators?: boolean;
+  onScroll?: UIEventHandler<HTMLDivElement>;
+  overflowX?: Property.OverflowX;
+  overflowY?: Property.OverflowY;
+  scrollbarWidth?: Property.ScrollbarWidth;
+}
+
+export const ScrollContainer = forwardRef<HTMLDivElement, PropsWithChildren<Props>>(
+  (
+    {
+      children,
+      showScrollIndicators = false,
+      onScroll,
+      overflowX = 'auto',
+      overflowY = 'auto',
+      scrollbarWidth = 'thin',
+      ...rest
+    },
+    ref
+  ) => {
+    const styles = useStyles2(getStyles, scrollbarWidth, overflowY, overflowX);
+    const defaults: Partial<BoxProps> = {
+      maxHeight: '100%',
+      minHeight: 0,
+    };
+    const boxProps = { ...defaults, ...rest };
+
+    return (
+      <Box {...boxProps} display="flex" direction="column" flex={1} position="relative">
+        <div onScroll={onScroll} className={styles.scroller} ref={ref}>
+          {showScrollIndicators ? <ScrollIndicators>{children}</ScrollIndicators> : children}
+        </div>
+      </Box>
+    );
+  }
+);
+ScrollContainer.displayName = 'ScrollContainer';
+
+const getStyles = (
+  theme: GrafanaTheme2,
+  scrollbarWidth: Props['scrollbarWidth'],
+  overflowY: Props['overflowY'],
+  overflowX: Props['overflowX']
+) => ({
+  scroller: css({
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+    overflowX,
+    overflowY,
+    scrollbarWidth,
+  }),
+});

--- a/packages/grafana-ui/src/components/ScrollContainer/ScrollIndicators.tsx
+++ b/packages/grafana-ui/src/components/ScrollContainer/ScrollIndicators.tsx
@@ -1,0 +1,101 @@
+import { css, cx } from '@emotion/css';
+import { useEffect, useRef, useState } from 'react';
+import * as React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../themes';
+
+export const ScrollIndicators = ({ children }: React.PropsWithChildren<{}>) => {
+  const [showScrollTopIndicator, setShowTopScrollIndicator] = useState(false);
+  const [showScrollBottomIndicator, setShowBottomScrollIndicator] = useState(false);
+  const scrollTopMarker = useRef<HTMLDivElement>(null);
+  const scrollBottomMarker = useRef<HTMLDivElement>(null);
+  const styles = useStyles2(getStyles);
+
+  // Here we observe the top and bottom markers to determine if we should show the scroll indicators
+  useEffect(() => {
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.target === scrollTopMarker.current) {
+          setShowTopScrollIndicator(!entry.isIntersecting);
+        } else if (entry.target === scrollBottomMarker.current) {
+          setShowBottomScrollIndicator(!entry.isIntersecting);
+        }
+      });
+    });
+    [scrollTopMarker, scrollBottomMarker].forEach((ref) => {
+      if (ref.current) {
+        intersectionObserver.observe(ref.current);
+      }
+    });
+    return () => intersectionObserver.disconnect();
+  }, []);
+
+  return (
+    <>
+      <div
+        className={cx(styles.scrollIndicator, styles.scrollTopIndicator, {
+          [styles.scrollIndicatorVisible]: showScrollTopIndicator,
+        })}
+      />
+      <div className={styles.scrollContent}>
+        <div ref={scrollTopMarker} className={cx(styles.scrollMarker, styles.scrollTopMarker)} />
+        {children}
+        <div ref={scrollBottomMarker} className={cx(styles.scrollMarker, styles.scrollBottomMarker)} />
+      </div>
+      <div
+        className={cx(styles.scrollIndicator, styles.scrollBottomIndicator, {
+          [styles.scrollIndicatorVisible]: showScrollBottomIndicator,
+        })}
+      />
+    </>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    scrollContent: css({
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+      position: 'relative',
+    }),
+    scrollIndicator: css({
+      height: theme.spacing(6),
+      left: 0,
+      opacity: 0,
+      pointerEvents: 'none',
+      position: 'absolute',
+      right: 0,
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create('opacity'),
+      },
+      zIndex: 1,
+    }),
+    scrollTopIndicator: css({
+      background: `linear-gradient(0deg, transparent, ${theme.colors.background.canvas})`,
+      top: 0,
+    }),
+    scrollBottomIndicator: css({
+      background: `linear-gradient(180deg, transparent, ${theme.colors.background.canvas})`,
+      bottom: 0,
+    }),
+    scrollIndicatorVisible: css({
+      opacity: 1,
+    }),
+    scrollMarker: css({
+      height: '1px',
+      left: 0,
+      pointerEvents: 'none',
+      position: 'absolute',
+      right: 0,
+    }),
+    scrollTopMarker: css({
+      top: 0,
+    }),
+    scrollBottomMarker: css({
+      bottom: 0,
+    }),
+  };
+};

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -11,3 +11,4 @@
 
 export * from './utils/skeleton';
 export * from './components/Combobox/Combobox';
+export * from './components/ScrollContainer/ScrollContainer';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- follow up to [previous PoC](https://github.com/grafana/grafana/pull/94689)
- adds a new `ScrollContainer` component as an unstable export

**Why do we need this feature?**

- component with native scrollbars to handle scrolling
- needed to eventually deprecate `CustomScrollbar`

**Who is this feature for?**

- grafana devs/plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
