### PR TITLE
[Folder] Add general UID validation

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -36,6 +36,8 @@ var resourceInfo = v0alpha1.FolderResourceInfo
 var errNoUser = errors.New("valid user is required")
 var errNoResource = errors.New("resource name is required")
 
+const invalidName = "general"
+
 // This is used just so wire has something unique to return
 type FolderAPIBuilder struct {
 	gv            schema.GroupVersion
@@ -183,10 +185,6 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	})
 }
 
-func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
-	return nil
-}
-
 func authorizerFunc(ctx context.Context, attr authorizer.Attributes) (*authorizerParams, error) {
 	verb := attr.GetVerb()
 	name := attr.GetName()
@@ -219,4 +217,39 @@ func authorizerFunc(ctx context.Context, attr authorizer.Attributes) (*authorize
 		eval = accesscontrol.EvalPermission(dashboards.ActionFoldersRead, scope)
 	}
 	return &authorizerParams{evaluator: eval, user: user}, nil
+}
+
+func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// name cannot be called "general"
+	id := a.GetName()
+	if id == invalidName {
+		return dashboards.ErrFolderInvalidUID
+	}
+
+	//max depth folder is 4
+	var maxFolderDepth = 4
+	obj := a.GetObject()
+
+	for i := 0; i <= maxFolderDepth+1; i++ {
+		parent := getParent(obj)
+		if parent == "" {
+			break
+		}
+		if i == maxFolderDepth+1 {
+			return folder.ErrMaximumDepthReached
+		}
+
+		// TODO: investigate the best way to get a folder by name, considering validate is called before the storage layer
+		// parent, err := getFolderByNameSomehow()
+		// obj = parent
+	}
+	return nil
+}
+
+func getParent(o runtime.Object) string {
+	meta, err := utils.MetaAccessor(o)
+	if err != nil {
+		return ""
+	}
+	return meta.GetFolder()
 }

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -119,17 +119,24 @@ func TestFolderAPIBuilder_getAuthorizerFunc(t *testing.T) {
 }
 
 func TestFolderAPIBuilder_Validate(t *testing.T) {
+	type input struct {
+		obj  *unstructured.Unstructured
+		name string
+	}
 	tests := []struct {
 		name  string
-		input *unstructured.Unstructured
+		input input
 		err   error
 	}{
 		{
 			name: "should return error when nameis invalid",
-			input: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"meta": map[string]interface{}{"name": invalidName},
+			input: input{
+				obj: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"meta": map[string]interface{}{"name": folderValidationRules.invalidNames[0]},
+					},
 				},
+				name: folderValidationRules.invalidNames[0],
 			},
 			err: dashboards.ErrFolderInvalidUID,
 		},
@@ -145,11 +152,11 @@ func TestFolderAPIBuilder_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(
-				tt.input,
+				tt.input.obj,
 				nil,
 				v0alpha1.SchemeGroupVersion.WithKind("folder"),
 				"stacks-123",
-				invalidName,
+				tt.input.name,
 				v0alpha1.SchemeGroupVersion.WithResource("folders"),
 				"",
 				"create",


### PR DESCRIPTION
To be compliant withe the legacy implementation, we need to make sure that the legacy UID aka name in storage doesn't have the value "general".

**What is this feature?**

Part of https://github.com/grafana/search-and-storage-team/issues/110

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
