### PR TITLE
Example for how to set folder version

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -884,7 +884,7 @@ func (fk8s *folderK8sHandler) newToFolderDto(c *contextmodel.ReqContext, item un
 		fDTO.AccessControl = acMetadata
 		fDTO.OrgID = f.OrgID
 		// #TODO version doesn't seem to be used--confirm or set it properly
-		fDTO.Version = 1
+		fDTO.Version = f.Version
 
 		return *fDTO, nil
 	}

--- a/pkg/apis/folder/v0alpha1/types.go
+++ b/pkg/apis/folder/v0alpha1/types.go
@@ -18,6 +18,8 @@ type Spec struct {
 
 	// Describe the feature toggle
 	Description string `json:"description,omitempty"`
+
+	Version int `json:"version"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -69,6 +69,7 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) *fo
 	spec := item.Object["spec"].(map[string]any)
 	uid := item.GetName()
 	title := spec["title"].(string)
+	version := spec["version"].(int64)
 
 	meta, err := utils.MetaAccessor(&item)
 	if err != nil {
@@ -113,6 +114,7 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) *fo
 		// it can't be saved in the resource metadata because then everything must cascade
 		// nolint:staticcheck
 		FullpathUIDs: meta.GetFullPathUIDs(),
+		Version:      int(version),
 	}
 	return f
 }
@@ -179,6 +181,7 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 		Spec: v0alpha1.Spec{
 			Title:       v.Title,
 			Description: v.Description,
+			Version:     v.Version,
 		},
 	}
 


### PR DESCRIPTION
Looks like this approach works for the most part. However, this error would need to be addressed:
```
		// ERROR[...] [SHOULD NOT HAPPEN] failed to update managedFields logger=grafana-apiserver err="failed to convert new object (default/[...]; folder.grafana.app/v0alpha1, Kind=Folder) to smd typed: .spec.version: field not declared in schema" versionKind="folder.grafana.app/v0alpha1, Kind=Folder" namespace=default name=[...]

```

Relates to https://github.com/grafana/grafana-org/issues/156