### PR TITLE
EchoSrv: Add BrowserConsoleBackend to log analytics events

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -316,6 +316,9 @@ feedback_links_enabled = true
 # Static context that is being added to analytics events
 reporting_static_context =
 
+# Logs interaction events to the browser javascript console, intended for development only
+developer_console_reporter = false
+
 #################################### Security ############################
 [security]
 # disable creation of admin user on first start of grafana

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -317,7 +317,7 @@ feedback_links_enabled = true
 reporting_static_context =
 
 # Logs interaction events to the browser javascript console, intended for development only
-developer_console_reporter = false
+browser_console_reporter = false
 
 #################################### Security ############################
 [security]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -315,6 +315,9 @@
 # Static context that is being added to analytics events
 ;reporting_static_context = grafanaInstance=12, os=linux
 
+# Logs interaction events to the browser javascript console, intended for development only
+;developer_console_reporter = false
+
 #################################### Security ####################################
 [security]
 # disable creation of admin user on first start of grafana

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -316,7 +316,7 @@
 ;reporting_static_context = grafanaInstance=12, os=linux
 
 # Logs interaction events to the browser javascript console, intended for development only
-;developer_console_reporter = false
+;browser_console_reporter = false
 
 #################################### Security ####################################
 [security]

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -226,6 +226,7 @@ export interface GrafanaConfig {
   rudderstackSdkUrl: string | undefined;
   rudderstackConfigUrl: string | undefined;
   rudderstackIntegrationsUrl: string | undefined;
+  analyticsConsoleReporting: boolean;
   sqlConnectionLimits: SqlConnectionLimits;
   sharedWithMeFolderUID?: string;
   rootFolderUID?: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -183,6 +183,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   rudderstackSdkUrl: undefined;
   rudderstackConfigUrl: undefined;
   rudderstackIntegrationsUrl: undefined;
+  analyticsConsoleReporting = false;
   sqlConnectionLimits = {
     maxOpenConns: 100,
     maxIdleConns: 100,

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -187,6 +187,8 @@ type FrontendSettingsDTO struct {
 	RudderstackConfigUrl       string `json:"rudderstackConfigUrl"`
 	RudderstackIntegrationsUrl string `json:"rudderstackIntegrationsUrl"`
 
+	AnalyticsConsoleReporting bool `json:"analyticsConsoleReporting"`
+
 	FeedbackLinksEnabled                bool     `json:"feedbackLinksEnabled"`
 	ApplicationInsightsConnectionString string   `json:"applicationInsightsConnectionString"`
 	ApplicationInsightsEndpointUrl      string   `json:"applicationInsightsEndpointUrl"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -213,6 +213,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		RudderstackSdkUrl:                   hs.Cfg.RudderstackSDKURL,
 		RudderstackConfigUrl:                hs.Cfg.RudderstackConfigURL,
 		RudderstackIntegrationsUrl:          hs.Cfg.RudderstackIntegrationsURL,
+		AnalyticsConsoleReporting:           hs.Cfg.FrontendAnalyticsConsoleReporting,
 		FeedbackLinksEnabled:                hs.Cfg.FeedbackLinksEnabled,
 		ApplicationInsightsConnectionString: hs.Cfg.ApplicationInsightsConnectionString,
 		ApplicationInsightsEndpointUrl:      hs.Cfg.ApplicationInsightsEndpointUrl,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1159,7 +1159,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.RudderstackConfigURL = analytics.Key("rudderstack_config_url").String()
 	cfg.RudderstackIntegrationsURL = analytics.Key("rudderstack_integrations_url").String()
 	cfg.IntercomSecret = analytics.Key("intercom_secret").String()
-	cfg.FrontendAnalyticsConsoleReporting = analytics.Key("developer_console_reporter").MustBool(false)
+	cfg.FrontendAnalyticsConsoleReporting = analytics.Key("browser_console_reporter").MustBool(false)
 
 	cfg.ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
 	cfg.ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -382,6 +382,7 @@ type Cfg struct {
 	RudderstackConfigURL                string
 	RudderstackIntegrationsURL          string
 	IntercomSecret                      string
+	FrontendAnalyticsConsoleReporting   bool
 
 	// LDAP
 	LDAPAuthEnabled       bool
@@ -1158,6 +1159,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.RudderstackConfigURL = analytics.Key("rudderstack_config_url").String()
 	cfg.RudderstackIntegrationsURL = analytics.Key("rudderstack_integrations_url").String()
 	cfg.IntercomSecret = analytics.Key("intercom_secret").String()
+	cfg.FrontendAnalyticsConsoleReporting = analytics.Key("developer_console_reporter").MustBool(false)
 
 	cfg.ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
 	cfg.ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -67,6 +67,7 @@ import { Echo } from './core/services/echo/Echo';
 import { reportPerformance } from './core/services/echo/EchoSrv';
 import { PerformanceBackend } from './core/services/echo/backends/PerformanceBackend';
 import { ApplicationInsightsBackend } from './core/services/echo/backends/analytics/ApplicationInsightsBackend';
+import { BrowserConsoleBackend } from './core/services/echo/backends/analytics/BrowseConsoleBackend';
 import { GA4EchoBackend } from './core/services/echo/backends/analytics/GA4Backend';
 import { GAEchoBackend } from './core/services/echo/backends/analytics/GABackend';
 import { RudderstackBackend } from './core/services/echo/backends/analytics/RudderstackBackend';
@@ -381,6 +382,10 @@ function initEchoSrv() {
         endpointUrl: config.applicationInsightsEndpointUrl,
       })
     );
+  }
+
+  if (config.analyticsConsoleReporting) {
+    registerEchoBackend(new BrowserConsoleBackend());
   }
 }
 

--- a/public/app/core/config.ts
+++ b/public/app/core/config.ts
@@ -1,6 +1,5 @@
 import { PluginState } from '@grafana/data';
 import { config, GrafanaBootConfig } from '@grafana/runtime';
-// Legacy binding paths
 export { config, GrafanaBootConfig as Settings };
 
 let grafanaConfig: GrafanaBootConfig = config;

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+import {
+  EchoBackend,
+  EchoEventType,
+  isExperimentViewEvent,
+  isInteractionEvent,
+  isPageviewEvent,
+  PageviewEchoEvent,
+} from '@grafana/runtime';
+
+export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unknown> {
+  options = {};
+  supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction, EchoEventType.ExperimentView];
+
+  constructor() {
+    console.log('[EchoSrv]', 'Registering BrowserConsoleBackend');
+  }
+
+  addEvent = (e: PageviewEchoEvent) => {
+    if (isPageviewEvent(e)) {
+      console.log('[EchoSrv:pageview]', e.payload.page);
+    }
+
+    if (isInteractionEvent(e)) {
+      console.log('[EchoSrv:event]', e.payload.interactionName, e.payload.properties);
+    }
+
+    if (isExperimentViewEvent(e)) {
+      console.log('[EchoSrv:experiment]', e.payload);
+    }
+  };
+
+  flush = () => {};
+}

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -12,9 +12,7 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
   options = {};
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction, EchoEventType.ExperimentView];
 
-  constructor() {
-    console.log('[EchoSrv]', 'Registering BrowserConsoleBackend');
-  }
+  constructor() {}
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
@@ -22,7 +20,25 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
     }
 
     if (isInteractionEvent(e)) {
-      console.log('[EchoSrv:event]', e.payload.interactionName, e.payload.properties);
+      const eventName = e.payload.interactionName;
+      console.log('[EchoSrv:event]', eventName, e.payload.properties);
+
+      // Warn for non-scalar property values. We're not yet making this a hard a
+      const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
+        const valueType = typeof value;
+        const isValidType =
+          valueType === 'string' || valueType === 'number' || valueType === 'boolean' || valueType === 'undefined';
+        return !isValidType;
+      });
+
+      if (invalidTypeProperties.length > 0) {
+        console.warn(
+          'Event',
+          eventName,
+          'has invalid property types. Event properties should only be string, number or boolean. Invalid properties:',
+          Object.fromEntries(invalidTypeProperties)
+        );
+      }
     }
 
     if (isExperimentViewEvent(e)) {


### PR DESCRIPTION
**What is this feature?**

Adds a new EchoSrv to log events to the browser console. It is controlled via the `[analytics] browser_console_reporter` server config option and is disabled by default.

![image](https://github.com/user-attachments/assets/1e9d172a-5d44-4263-b6dc-eeb7db3b4041)

It also adds in a warning (in this echosrv backend) if events are fired with property values that are objects or arrays. Just opt-in warning logs for this is a first step in potentially restricting these from being sent at all.

**Why do we need this feature?**

To help developers test events without temporarily manually adding in console.logs which they have to remember to not commit...

**Who is this feature for?**

Grafana developers :) 