### PR TITLE
Plugin extensions: Make description optional

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -50,7 +50,7 @@ type PluginExtensionConfigBase = {
   /**
    * A short description
    */
-  description: string;
+  description?: string;
 };
 
 export type PluginExtensionAddedComponentConfig<Props = {}> = PluginExtensionConfigBase & {

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -83,7 +83,7 @@ export const getPluginExtensions: GetExtensions = ({
         extensionPointId,
         path: addedLink.path ?? '',
         title: addedLink.title,
-        description: addedLink.description,
+        description: addedLink.description ?? '',
         onClick: typeof addedLink.onClick,
       });
       // Run the configure() function with the current context, and apply the ovverides
@@ -104,7 +104,7 @@ export const getPluginExtensions: GetExtensions = ({
         // Configurable properties
         icon: overrides?.icon || addedLink.icon,
         title: overrides?.title || addedLink.title,
-        description: overrides?.description || addedLink.description,
+        description: overrides?.description || addedLink.description || '',
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
       };
@@ -134,7 +134,7 @@ export const getPluginExtensions: GetExtensions = ({
 
     const componentLog = log.child({
       title: addedComponent.title,
-      description: addedComponent.description,
+      description: addedComponent.description ?? '',
       pluginId: addedComponent.pluginId,
     });
 
@@ -143,7 +143,7 @@ export const getPluginExtensions: GetExtensions = ({
       type: PluginExtensionTypes.component,
       pluginId: addedComponent.pluginId,
       title: addedComponent.title,
-      description: addedComponent.description,
+      description: addedComponent.description ?? '',
       component: wrapWithPluginContext(addedComponent.pluginId, addedComponent.component, componentLog),
     };
 

--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.test.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.test.ts
@@ -380,29 +380,6 @@ describe('AddedComponentsRegistry', () => {
     expect(Object.keys(currentState)).toHaveLength(1);
   });
 
-  it('should not register component when description is missing', async () => {
-    const registry = new AddedComponentsRegistry();
-    const extensionPointId = 'grafana/alerting/home';
-
-    registry.register({
-      pluginId,
-      configs: [
-        {
-          title: 'Component 1 title',
-          description: '',
-          targets: [extensionPointId],
-          component: () => React.createElement('div', null, 'Hello World1'),
-        },
-      ],
-    });
-
-    expect(log.error).toHaveBeenCalledWith(
-      "Could not register added component with title 'Component 1 title'. Reason: Description is missing."
-    );
-    const currentState = await registry.getState();
-    expect(Object.keys(currentState)).toHaveLength(0);
-  });
-
   it('should not register component when title is missing', async () => {
     const registry = new AddedComponentsRegistry();
     const extensionPointId = 'grafana/alerting/home';

--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
@@ -10,7 +10,7 @@ import { PluginExtensionConfigs, Registry, RegistryType } from './Registry';
 export type AddedComponentRegistryItem<Props = {}> = {
   pluginId: string;
   title: string;
-  description: string;
+  description?: string;
   component: React.ComponentType<Props>;
 };
 
@@ -42,13 +42,6 @@ export class AddedComponentsRegistry extends Registry<
 
       if (!config.title) {
         configLog.error(`Could not register added component. Reason: Title is missing.`);
-        continue;
-      }
-
-      if (!config.description) {
-        configLog.error(
-          `Could not register added component with title '${config.title}'. Reason: Description is missing.`
-        );
         continue;
       }
 

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -17,7 +17,7 @@ export type AddedLinkRegistryItem<Context extends object = object> = {
   pluginId: string;
   extensionPointId: string;
   title: string;
-  description: string;
+  description?: string;
   path?: string;
   onClick?: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
   configure?: PluginAddedLinksConfigureFunc<Context>;
@@ -45,7 +45,7 @@ export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], Plugin
       const { path, title, description, configure, onClick, targets } = config;
       const configLog = this.logger.child({
         path: path ?? '',
-        description,
+        description: description ?? '',
         title,
         pluginId,
         onClick: typeof onClick,
@@ -53,11 +53,6 @@ export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], Plugin
 
       if (!title) {
         configLog.error(`Could not register added link. Reason: Title is missing.`);
-        continue;
-      }
-
-      if (!description) {
-        configLog.error(`Could not register added link. Reason: Description is missing.`);
         continue;
       }
 

--- a/public/app/features/plugins/extensions/registry/ExportedComponentsRegistry.test.ts
+++ b/public/app/features/plugins/extensions/registry/ExportedComponentsRegistry.test.ts
@@ -352,29 +352,6 @@ describe('ExposedComponentsRegistry', () => {
     expect(Object.keys(currentState)).toHaveLength(1);
   });
 
-  it('should not register component when description is missing', async () => {
-    const registry = new ExposedComponentsRegistry();
-
-    registry.register({
-      pluginId: 'grafana-basic-app',
-      configs: [
-        {
-          id: 'grafana-basic-app/hello-world/v1',
-          title: 'not important',
-          description: '',
-          component: () => React.createElement('div', null, 'Hello World1'),
-        },
-      ],
-    });
-
-    expect(log.error).toHaveBeenCalledWith(
-      "Could not register exposed component with id 'grafana-basic-app/hello-world/v1'. Reason: Description is missing."
-    );
-
-    const currentState = await registry.getState();
-    expect(Object.keys(currentState)).toHaveLength(0);
-  });
-
   it('should not register component when title is missing', async () => {
     const registry = new ExposedComponentsRegistry();
 

--- a/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/ExposedComponentsRegistry.ts
@@ -10,7 +10,7 @@ import { Registry, RegistryType, PluginExtensionConfigs } from './Registry';
 export type ExposedComponentRegistryItem<Props = {}> = {
   pluginId: string;
   title: string;
-  description: string;
+  description?: string;
   component: React.ComponentType<Props>;
 };
 
@@ -39,7 +39,7 @@ export class ExposedComponentsRegistry extends Registry<
       const { id, description, title } = config;
       const pointIdLog = this.logger.child({
         extensionPointId: id,
-        description,
+        description: description ?? '',
         title,
         pluginId,
       });
@@ -66,11 +66,6 @@ export class ExposedComponentsRegistry extends Registry<
 
       if (!title) {
         pointIdLog.error(`Could not register exposed component with id '${id}'. Reason: Title is missing.`);
-        continue;
-      }
-
-      if (!description) {
-        pointIdLog.error(`Could not register exposed component with id '${id}'. Reason: Description is missing.`);
         continue;
       }
 

--- a/public/app/features/plugins/extensions/usePluginComponent.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.tsx
@@ -29,7 +29,7 @@ export function usePluginComponent<Props extends object = {}>(id: string): UsePl
     const registryItem = registryState[id];
     const componentLog = log.child({
       title: registryItem.title,
-      description: registryItem.description,
+      description: registryItem.description ?? '',
       pluginId: registryItem.pluginId,
     });
 

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -85,7 +85,7 @@ export function usePluginLinks({
       const linkLog = pointLog.child({
         path: addedLink.path ?? '',
         title: addedLink.title,
-        description: addedLink.description,
+        description: addedLink.description ?? '',
         onClick: typeof addedLink.onClick,
       });
       // Run the configure() function with the current context, and apply the ovverides
@@ -106,7 +106,7 @@ export function usePluginLinks({
         // Configurable properties
         icon: overrides?.icon || addedLink.icon,
         title: overrides?.title || addedLink.title,
-        description: overrides?.description || addedLink.description,
+        description: overrides?.description || addedLink.description || '',
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
       };

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -554,24 +554,6 @@ describe('Plugin Extensions / Utils', () => {
       expect(log.warning).toHaveBeenCalledTimes(1);
       expect(jest.mocked(log.warning).mock.calls[0][0]).toMatch('"targets" don\'t match');
     });
-
-    it('should return TRUE and log a warning if the "description" does not match', () => {
-      const log = createLogMock();
-      config.apps[pluginId].extensions.addedLinks.push(extensionConfig);
-
-      const returnValue = isAddedLinkMetaInfoMissing(
-        pluginId,
-        {
-          ...extensionConfig,
-          description: 'Link description UPDATED',
-        },
-        log
-      );
-
-      expect(returnValue).toBe(true);
-      expect(log.warning).toHaveBeenCalledTimes(1);
-      expect(jest.mocked(log.warning).mock.calls[0][0]).toMatch('"description" doesn\'t match');
-    });
   });
 
   describe('isAddedComponentMetaInfoMissing()', () => {
@@ -667,24 +649,6 @@ describe('Plugin Extensions / Utils', () => {
       expect(log.warning).toHaveBeenCalledTimes(1);
       expect(jest.mocked(log.warning).mock.calls[0][0]).toMatch('"targets" don\'t match');
     });
-
-    it('should return TRUE and log a warning if the "description" does not match', () => {
-      const log = createLogMock();
-      config.apps[pluginId].extensions.addedComponents.push(extensionConfig);
-
-      const returnValue = isAddedComponentMetaInfoMissing(
-        pluginId,
-        {
-          ...extensionConfig,
-          description: 'UPDATED',
-        },
-        log
-      );
-
-      expect(returnValue).toBe(true);
-      expect(log.warning).toHaveBeenCalledTimes(1);
-      expect(jest.mocked(log.warning).mock.calls[0][0]).toMatch('"description" doesn\'t match');
-    });
   });
 
   describe('isExposedComponentMetaInfoMissing()', () => {
@@ -779,24 +743,6 @@ describe('Plugin Extensions / Utils', () => {
       expect(returnValue).toBe(true);
       expect(log.warning).toHaveBeenCalledTimes(1);
       expect(jest.mocked(log.warning).mock.calls[0][0]).toMatch('"title" doesn\'t match');
-    });
-
-    it('should return TRUE and log a warning if the "description" does not match', () => {
-      const log = createLogMock();
-      config.apps[pluginId].extensions.exposedComponents.push(exposedComponentConfig);
-
-      const returnValue = isExposedComponentMetaInfoMissing(
-        pluginId,
-        {
-          ...exposedComponentConfig,
-          description: 'UPDATED',
-        },
-        log
-      );
-
-      expect(returnValue).toBe(true);
-      expect(log.warning).toHaveBeenCalledTimes(1);
-      expect(jest.mocked(log.warning).mock.calls[0][0]).toMatch('"description" doesn\'t match');
     });
   });
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -490,14 +490,6 @@ export const isAddedLinkMetaInfoMissing = (
     return true;
   }
 
-  if (pluginJsonMetaInfo.description !== metaInfo.description) {
-    log.warning(
-      `${logPrefix} the "description" doesn't match with one in the plugin.json under "extensions.addedLinks[]".`
-    );
-
-    return true;
-  }
-
   return false;
 };
 
@@ -530,14 +522,6 @@ export const isAddedComponentMetaInfoMissing = (
     return true;
   }
 
-  if (pluginJsonMetaInfo.description !== metaInfo.description) {
-    log.warning(
-      `${logPrefix} the "description" doesn't match with one in the plugin.json under "extensions.addedComponents[]".`
-    );
-
-    return true;
-  }
-
   return false;
 };
 
@@ -564,14 +548,6 @@ export const isExposedComponentMetaInfoMissing = (
   if (pluginJsonMetaInfo.title !== metaInfo.title) {
     log.warning(
       `${logPrefix} the "title" doesn't match with one in the plugin.json under "extensions.exposedComponents[]".`
-    );
-
-    return true;
-  }
-
-  if (pluginJsonMetaInfo.description !== metaInfo.description) {
-    log.warning(
-      `${logPrefix} the "description" doesn't match with one in the plugin.json under "extensions.exposedComponents[]".`
     );
 
     return true;


### PR DESCRIPTION
**What is this feature?**

This PR makes the `description` property in the plugin extensions config object optional. This means it no longer needs to be provided upon registration of links, components and exposed components. I'm also removing the check that made sure the description specified in the meta data matched the description provided at runtime registration. 

**Why do we need this feature?**

The `description` field is already optional in the [plugin.json schema](https://github.com/grafana/grafana/blob/extensions/make-description-optional/docs/sources/developers/plugins/plugin.schema.json/#L603-L608).  

**Who is this feature for?**

Plugin developers

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
