### PR TITLE
Folders: Don't show error pop-up if the user can't fetch the root folder

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -81,8 +81,10 @@ const BrowseDashboardsPage = memo(() => {
 
   const hasSelection = useHasSelection();
 
-  const { data: rootFolder } = useGetFolderQuery('general');
-  let folder = folderDTO ? folderDTO : rootFolder;
+  // Fetch the root (aka general) folder if we're not in a specific folder
+  const { data: rootFolderDTO } = useGetFolderQuery(folderDTO ? skipToken : 'general');
+  const folder = folderDTO ?? rootFolderDTO;
+
   const { canEditFolders, canEditDashboards, canCreateDashboards, canCreateFolders } = getFolderPermissions(folder);
   const hasAdminRights = contextSrv.hasRole('Admin') || contextSrv.isGrafanaAdmin;
 

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -66,12 +66,15 @@ interface HardDeleteDashboardArgs {
 
 function createBackendSrvBaseQuery({ baseURL }: { baseURL: string }): BaseQueryFn<RequestOptions> {
   async function backendSrvBaseQuery(requestOptions: RequestOptions) {
+    // Suppress error pop-up for root (aka 'general') folder
+    const isGeneralFolder = requestOptions.url === `/folders/general`;
+    requestOptions = isGeneralFolder ? { ...requestOptions, showErrorAlert: false } : requestOptions;
+
     try {
       const { data: responseData, ...meta } = await lastValueFrom(
         getBackendSrv().fetch({
           ...requestOptions,
           url: baseURL + requestOptions.url,
-          showErrorAlert: requestOptions.showErrorAlert,
         })
       );
       return { data: responseData, meta };


### PR DESCRIPTION
**What is this feature?**

Hide the error pop-up when a user doesn't have permissions to fetch the root (aka "general") folder.

**Why do we need this feature?**

This is a UI only change that hides an unhelpful error pop-up. No other behaviour changes (as in, user still sees the same UI components apart from the error pop-up, and they don't have any additional access).

We attempt to fetch the root folder to check user's permissions on it and display components that user has access to (eg, "create new dashboard/folder" button under the root folder). If user doesn't have access to fetch the root folder, we assume that they don't have any other permissions on it either.

**Who is this feature for?**

Anyone that use's the `None` role (`Viewer` role by default has access to fetch the root folder).

**Notes for the reviewers**

We could also do this on the backend, by always returning data about the `general` folder no matter what permissions the user has. However, it would require writing a new middleware specifically for the folder fetching endpoint, so the required changes would be much larger.