### PR TITLE
Combobox: Call loadOptions with current input value when reopening menu

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -195,7 +195,7 @@ export const Combobox = <T extends string | number>({
       setItems(customValueOption ? [customValueOption, ...filteredItems] : filteredItems);
     },
 
-    onIsOpenChange: ({ isOpen }) => {
+    onIsOpenChange: ({ isOpen, inputValue }) => {
       // Default to displaying all values when opening
       if (isOpen && !isAsync) {
         setItems(options);
@@ -204,7 +204,7 @@ export const Combobox = <T extends string | number>({
 
       if (isOpen && isAsync) {
         setAsyncLoading(true);
-        loadOptions('').then((options) => {
+        loadOptions(inputValue ?? '').then((options) => {
           setItems(options);
           setAsyncLoading(false);
         });


### PR DESCRIPTION
Fixes Async combobox so it calls loadOptions with the current input value when opening the menu, rather than just an empty string.

Part of https://github.com/grafana/grafana/issues/87959