### PR TITLE
Azure: Handle namespace request rejection

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -265,6 +265,10 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
           }
         }
         return result;
+      })
+      .catch((reason) => {
+        console.error(`Failed to get metric namespaces: ${reason}`);
+        return [];
       });
   }
 


### PR DESCRIPTION
It's possible for the metric namespaces request to fail and this can lead to the resource picker failing to display resources as no namespaces will be returned.

This change gracefully handles any promise rejections by logging them to the console and continuing with the execution. As we now have fallback namespaces this is acceptable behaviour.

Follow up on #94722