### PR TITLE
Validate if we are creating a folder more than 5 levels deep

### DIFF
--- a/pkg/registry/apis/folders/mocks.go
+++ b/pkg/registry/apis/folders/mocks.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
@@ -18,11 +17,7 @@ type storageMock struct {
 
 func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	args := m.Called(ctx, name, options)
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"meta": map[string]interface{}{"name": "valid-name", "grafana.app/folder": 4},
-		},
-	}, args.Error(1)
+	return args.Get(0).(runtime.Object), args.Error(1)
 }
 
 func (m storageMock) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {

--- a/pkg/registry/apis/folders/mocks.go
+++ b/pkg/registry/apis/folders/mocks.go
@@ -1,0 +1,74 @@
+package folders
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+type storageMock struct {
+	*mock.Mock
+	rest.Storage
+}
+
+func (m storageMock) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	args := m.Called(ctx, name, options)
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"meta": map[string]interface{}{"name": "valid-name", "grafana.app/folder": 4},
+		},
+	}, args.Error(1)
+}
+
+func (m storageMock) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	args := m.Called(ctx, obj, tableOptions)
+	return args.Get(0).(*metav1.Table), args.Error(1)
+}
+
+func (m storageMock) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	args := m.Called(ctx, obj, createValidation, options)
+	return args.Get(0).(runtime.Object), args.Error(1)
+}
+
+func (m storageMock) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	args := m.Called(ctx, name, deleteValidation, options)
+	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
+}
+
+func (m storageMock) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *internalversion.ListOptions) (runtime.Object, error) {
+	args := m.Called(ctx, deleteValidation, options, listOptions)
+	return args.Get(0).(runtime.Object), args.Error(1)
+}
+
+func (m storageMock) GetSingularName() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m storageMock) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	args := m.Called(ctx, options)
+	return args.Get(0).(runtime.Object), args.Error(1)
+}
+
+func (m storageMock) NamespaceScoped() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m storageMock) NewList() runtime.Object {
+	args := m.Called()
+	return args.Get(0).(runtime.Object)
+}
+
+func (m storageMock) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	args := m.Called(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	if name == "object-fail" {
+		return nil, false, args.Error(2)
+	}
+	return args.Get(0).(runtime.Object), args.Bool(1), args.Error(2)
+}

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,20 +37,13 @@ var resourceInfo = v0alpha1.FolderResourceInfo
 var errNoUser = errors.New("valid user is required")
 var errNoResource = errors.New("resource name is required")
 
-var folderValidationRules = struct {
-	maxDepth     int
-	invalidNames []string
-}{
-	maxDepth:     4,
-	invalidNames: []string{"general"},
-}
-
 // This is used just so wire has something unique to return
 type FolderAPIBuilder struct {
 	gv            schema.GroupVersion
 	features      featuremgmt.FeatureToggles
 	namespacer    request.NamespaceMapper
 	folderSvc     folder.Service
+	storage       grafanarest.Storage
 	accessControl accesscontrol.AccessControl
 }
 
@@ -138,6 +132,7 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 	}
 
 	apiGroupInfo.VersionedResourcesStorageMap[v0alpha1.VERSION] = storage
+	b.storage = storage[resourceInfo.StoragePath()].(grafanarest.DualWriter)
 	return nil
 }
 
@@ -225,8 +220,15 @@ func authorizerFunc(ctx context.Context, attr authorizer.Attributes) (*authorize
 	return &authorizerParams{evaluator: eval, user: user}, nil
 }
 
+var folderValidationRules = struct {
+	maxDepth     int
+	invalidNames []string
+}{
+	maxDepth:     5,
+	invalidNames: []string{"general"},
+}
+
 func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
-	// name cannot be called "general"
 	id := a.GetName()
 	for _, invalidName := range folderValidationRules.invalidNames {
 		if id == invalidName {
@@ -236,18 +238,21 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 
 	obj := a.GetObject()
 
-	for i := 0; i <= folderValidationRules.maxDepth+1; i++ {
+	for i := 1; i <= folderValidationRules.maxDepth; i++ {
 		parent := getParent(obj)
 		if parent == "" {
 			break
 		}
-		if i == folderValidationRules.maxDepth+1 {
+		if i == folderValidationRules.maxDepth {
 			return folder.ErrMaximumDepthReached
+			return nil
 		}
 
-		// TODO: investigate the best way to get a folder by name, considering validate is called before the storage layer
-		// parent, err := getFolderByNameSomehow()
-		// obj = parent
+		parentObj, err := b.storage.Get(ctx, parent, &metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		obj = parentObj
 	}
 	return nil
 }

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -132,7 +132,7 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 	}
 
 	apiGroupInfo.VersionedResourcesStorageMap[v0alpha1.VERSION] = storage
-	b.storage = storage[resourceInfo.StoragePath()].(grafanarest.DualWriter)
+	b.storage = storage[resourceInfo.StoragePath()].(grafanarest.Storage)
 	return nil
 }
 

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -245,7 +245,6 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		}
 		if i == folderValidationRules.maxDepth {
 			return folder.ErrMaximumDepthReached
-			return nil
 		}
 
 		parentObj, err := b.storage.Get(ctx, parent, &metav1.GetOptions{})

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -143,7 +143,7 @@ func TestFolderAPIBuilder_Validate(t *testing.T) {
 			err: dashboards.ErrFolderInvalidUID,
 		},
 		{
-			name: "should return error when creating a bested folder higher than max depth",
+			name: "should return error when creating a nested folder higher than max depth",
 			input: input{
 				obj: &unstructured.Unstructured{
 					Object: map[string]interface{}{

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -2,7 +2,6 @@ package folders
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -210,8 +209,6 @@ func TestFolderAPIBuilder_Validate(t *testing.T) {
 				true,
 				&user.SignedInUser{},
 			), nil)
-
-			fmt.Println("ERR", err)
 
 			if tt.err != nil {
 				require.ErrorIs(t, err, tt.err)


### PR DESCRIPTION
Validate if we are creating a folder more than 5 levels deep.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/search-and-storage-team/issues/110

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
