### PR TITLE
Canvas: Fix references for ResourcePicker

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/Popover.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Popover.tsx
@@ -24,6 +24,7 @@ interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> {
   referenceElement: HTMLElement;
   wrapperClassName?: string;
   renderArrow?: boolean;
+  hidePopper?: () => void;
 }
 
 export function Popover({
@@ -34,6 +35,7 @@ export function Popover({
   wrapperClassName,
   referenceElement,
   renderArrow,
+  hidePopper,
   ...rest
 }: Props) {
   const theme = useTheme2();
@@ -95,7 +97,7 @@ export function Popover({
           {renderArrow && <FloatingArrow fill={theme.colors.border.weak} ref={arrowRef} context={context} />}
           {typeof content === 'string' && content}
           {React.isValidElement(content) && React.cloneElement(content)}
-          {typeof content === 'function' && content({})}
+          {typeof content === 'function' && content({ hidePopper })}
         </div>
       </div>
     </Portal>

--- a/packages/grafana-ui/src/components/Tooltip/types.ts
+++ b/packages/grafana-ui/src/components/Tooltip/types.ts
@@ -11,6 +11,7 @@ export interface PopoverContentProps {
   hidePopper?: () => void;
 }
 
+// hidePopper is only available to popover content when it is passed as a function
 export type PopoverContent = string | React.ReactElement | ((props: PopoverContentProps) => JSX.Element);
 
 export type TooltipPlacement = Placement | 'auto' | 'auto-start' | 'auto-end';

--- a/packages/grafana-ui/src/components/Tooltip/types.ts
+++ b/packages/grafana-ui/src/components/Tooltip/types.ts
@@ -7,6 +7,8 @@ export interface PopoverContentProps {
    * It will be removed in a future release.
    */
   updatePopperPosition?: () => void;
+
+  hidePopper?: () => void;
 }
 
 export type PopoverContent = string | React.ReactElement | ((props: PopoverContentProps) => JSX.Element);

--- a/public/app/features/dimensions/editors/ResourcePicker.tsx
+++ b/public/app/features/dimensions/editors/ResourcePicker.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { createRef } from 'react';
+import { useRef } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -42,16 +42,19 @@ export const ResourcePicker = (props: Props) => {
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
 
-  const pickerTriggerRef = createRef<HTMLDivElement>();
-  const popoverElement = (
-    <ResourcePickerPopover
-      onChange={onChange}
-      value={value}
-      mediaType={mediaType}
-      folderName={folderName}
-      maxFiles={maxFiles}
-    />
-  );
+  const pickerTriggerRef = useRef<HTMLDivElement>(null);
+  const popoverElement = (props: { hidePopper?: () => void }) => {
+    return (
+      <ResourcePickerPopover
+        onChange={onChange}
+        value={value}
+        mediaType={mediaType}
+        folderName={folderName}
+        maxFiles={maxFiles}
+        hidePopper={props.hidePopper}
+      />
+    );
+  };
 
   let sanitizedSrc = src;
   if (!sanitizedSrc && value) {
@@ -101,6 +104,7 @@ export const ResourcePicker = (props: Props) => {
                 onKeyDown={(event) => {
                   closePopover(event, hidePopper);
                 }}
+                hidePopper={hidePopper}
               />
             )}
 

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
-import { createRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
@@ -21,20 +21,22 @@ interface Props {
   mediaType: MediaType;
   folderName: ResourceFolderName;
   maxFiles?: number;
+  hidePopper?: () => void;
 }
 
 interface ErrorResponse {
   message: string;
 }
 export const ResourcePickerPopover = (props: Props) => {
-  const { value, onChange, mediaType, folderName, maxFiles } = props;
+  const { value, onChange, mediaType, folderName, maxFiles, hidePopper } = props;
   const styles = useStyles2(getStyles);
 
   const onClose = () => {
     onChange(value);
+    hidePopper?.();
   };
 
-  const ref = createRef<HTMLElement>();
+  const ref = useRef<HTMLElement>(null);
   const { dialogProps } = useDialog({}, ref);
   const { overlayProps } = useOverlay({ onClose, isDismissable: true, isOpen: true }, ref);
 
@@ -124,7 +126,10 @@ export const ResourcePickerPopover = (props: Props) => {
                         getBackendSrv()
                           .get(`api/storage/read/${data.path}`)
                           .then(() => setNewValue(`${config.appUrl}api/storage/read/${data.path}`))
-                          .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`));
+                          .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
+                          .then(() => {
+                            hidePopper?.();
+                          });
                       })
                       .catch((err) => console.error(err));
                   } else {

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -127,13 +127,12 @@ export const ResourcePickerPopover = (props: Props) => {
                           .get(`api/storage/read/${data.path}`)
                           .then(() => setNewValue(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
-                          .then(() => {
-                            hidePopper?.();
-                          });
+                          .then(() => hidePopper?.());
                       })
                       .catch((err) => console.error(err));
                   } else {
                     onChange(newValue);
+                    hidePopper?.();
                   }
                 }}
               >


### PR DESCRIPTION
**What is this feature?**

The ResourcePicker is a component used by Canvas and GeoMap to handle a complicated popup for selecting different options. Notably, this popup has a "Cancel" button, where the pop up can be closed without a selection.

When auto refresh is turned on,  components on the screen are rerendered. The component for this popup was using `createRef` which is great for class components, but functional components will have the ref lost when re-rendered. This means that this pop up would automatically disappear with the refresh cycle when it is turned on.

When changing this to use `useRef`, we ran into the problem where hitting the save and cancel buttons would no longer close the popup. I believe this was working before because it would null out the reference and then close due to the thing that caused the bug. To enable this to save, I expose the hide function and, if the content is a functional component, pass it to that function so it can be used by the component.

This was always an issue but hidden because auto refresh was turned off in edit mode. With Scenes, that is no longer the case so the bug is pronounced.

Side note: I believe the pattern was taken from the [ColorPicker](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx#L34) - however the ColorPicker is ultimately a class component where createRef will work fine, which is why that is not an issue.

**Which issue(s) does this PR fix?**:

Fixes [support-escalations/13000
](https://github.com/grafana/support-escalations/issues/13000)

**Special notes for your reviewer:**

To replicate: Go to a canvas panel. Turn auto-refresh on to 5s. Open the background image popup. See it disappear on page refresh.

This panel on play is a good place to see it https://play.grafana.org/d/c9ea65f5-ed5a-45cf-8fb7-f82af7c3afdf/canvas-visualization3a-buttons?from=now-6h&to=now&var-ServerID=Server%203&refresh=5s&editPanel=2

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
