### PR TITLE
K8s: modify metrics to make cloud aggregation o11y simpler

### DIFF
--- a/pkg/services/apiserver/aggregator/registeredMetrics.go
+++ b/pkg/services/apiserver/aggregator/registeredMetrics.go
@@ -1,0 +1,136 @@
+package aggregator
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+)
+
+/*
+ * By default, all the following metrics are defined as falling under
+ * ALPHA stability level https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md#stability-classes)
+ *
+ * Promoting the stability level of the metric is a responsibility of the component owner, since it
+ * involves explicitly acknowledging support for the metric across multiple releases, in accordance with
+ * the metric stability policy.
+ */
+var (
+	registeredGaugeDesc = metrics.NewDesc(
+		"st_aggregator_registered_apiservice",
+		"Gauge of Grafana APIServices which are marked as registered broken down by APIService name.",
+		[]string{"name"},
+		nil,
+		metrics.ALPHA,
+		"",
+	)
+)
+
+type RegisteredMetrics struct {
+	registeredCounter *metrics.CounterVec
+
+	*registeredCollector
+}
+
+// These metrics are registered in the main kube-aggregator package as well, prefixing with single-tenant (ST) to avoid
+// "duplicate metrics collector registration attempted" in https://github.com/prometheus/client_golang
+// a more descriptive prefix is already added for apiserver metrics during scraping in cloud and didn't want
+// to double a word by using a word such as "grafana" here
+func newRegisteredMetrics() *RegisteredMetrics {
+	return &RegisteredMetrics{
+		registeredCounter: metrics.NewCounterVec(
+			&metrics.CounterOpts{
+				Name:           "st_aggregator_registered_apiservice_total",
+				Help:           "Counter of Grafana APIServices which are marked as registered broken down by APIService name and reason.",
+				StabilityLevel: metrics.ALPHA,
+			},
+			[]string{"name", "reason"},
+		),
+		registeredCollector: newRegisteredCollector(),
+	}
+}
+
+// Register registers apiservice availability metrics.
+func (m *RegisteredMetrics) Register(
+	registrationFunc func(metrics.Registerable) error,
+	customRegistrationFunc func(metrics.StableCollector) error,
+) error {
+	err := registrationFunc(m.registeredCounter)
+	if err != nil {
+		return err
+	}
+
+	err = customRegistrationFunc(m.registeredCollector)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RegisteredCounter returns a counter to track apiservices marked as registered.
+func (m *RegisteredMetrics) RegisteredCounter(apiServiceName string) metrics.CounterMetric {
+	return m.registeredCounter.WithLabelValues(apiServiceName)
+}
+
+type registeredCollector struct {
+	metrics.BaseStableCollector
+
+	mtx        sync.RWMutex
+	registered map[string]bool
+}
+
+// SetRegisteredGauge set the metrics so that it reflect the current state based on availability of the given service
+func (m *RegisteredMetrics) SetRegisteredGauge(newAPIService *apiregistrationv1.APIService) {
+	m.setAPIServiceRegistered(newAPIService.Name)
+}
+
+func (m *RegisteredMetrics) SetRegisteredCounter(newAPIService *apiregistrationv1.APIService) {
+	m.RegisteredCounter(newAPIService.Name).Inc()
+}
+
+// Check if apiServiceStatusCollector implements necessary interface.
+var _ metrics.StableCollector = &registeredCollector{}
+
+func newRegisteredCollector() *registeredCollector {
+	return &registeredCollector{
+		registered: make(map[string]bool),
+	}
+}
+
+// DescribeWithStability implements the metrics.StableCollector interface.
+func (c *registeredCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- registeredGaugeDesc
+}
+
+// CollectWithStability implements the metrics.StableCollector interface.
+func (c *registeredCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	for apiServiceName := range c.registered {
+		gaugeValue := 1.0
+
+		ch <- metrics.NewLazyConstMetric(
+			registeredGaugeDesc,
+			metrics.GaugeValue,
+			gaugeValue,
+			apiServiceName,
+		)
+	}
+}
+
+func (c *registeredCollector) setAPIServiceRegistered(apiServiceKey string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	c.registered[apiServiceKey] = true
+}
+
+// ForgetAPIService removes the registered gauge of the given apiservice.
+func (c *registeredCollector) ForgetAPIService(apiServiceKey string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	delete(c.registered, apiServiceKey)
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

While working on SLO for cloud aggregation o11y today, I ran into multiple difficulties trying to use. The SLO [automation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/slo#nested-schema-for-queryfreeform) we use would only allow for `freeform` SLOs with the metric we have in `main`. With that too, given it puts a rate on it, I am not sure how to make the `unavailable` part (negative test) in the current metric actually count as a failure.

This is an attempt to go back to the `ratio` type SLO definition. It does that by introducing two changes:

1. It flips the unavailable metric to be an available metric.
2. It introduces a registered metric so we have something for the denominator.

**Why do we need this feature?**

Cloud Aggregation needs to be shipped soon and we have made it contingent of having good o11y for it.

**Who is this feature for?**

App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
