### PR TITLE
Frontend: Enable TS IsolatedModules

### DIFF
--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -26,7 +26,7 @@ import {
   SortOrder,
 } from './richHistoryTypes';
 
-export { RichHistorySearchFilters, RichHistorySettings, SortOrder };
+export { type RichHistorySearchFilters, type RichHistorySettings, SortOrder };
 
 /*
  * Add queries to rich history. Save only queries within the retention period, or that are starred.

--- a/public/app/features/dashboard-scene/settings/version-history/index.ts
+++ b/public/app/features/dashboard-scene/settings/version-history/index.ts
@@ -1,4 +1,4 @@
-export { HistorySrv, historySrv, RevisionsModel } from './HistorySrv';
+export { HistorySrv, historySrv, type RevisionsModel } from './HistorySrv';
 export { VersionHistoryTable } from './VersionHistoryTable';
 export { VersionHistoryHeader } from './VersionHistoryHeader';
 export { VersionsHistoryButtons } from './VersionHistoryButtons';

--- a/public/app/features/explore/TraceView/components/types/index.tsx
+++ b/public/app/features/explore/TraceView/components/types/index.tsx
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { TraceSpan, TraceResponse, Trace, TraceProcess, TraceLink, CriticalPathSection } from './trace';
-export { SpanBarOptions, SpanBarOptionsData } from '../settings/SpanBarSettings';
-export { default as TTraceTimeline } from './TTraceTimeline';
-export { default as TNil } from './TNil';
-export { SpanLinkFunc, SpanLinkDef } from './links';
+export type { TraceSpan, TraceResponse, Trace, TraceProcess, TraceLink, CriticalPathSection } from './trace';
+export type { SpanBarOptions, SpanBarOptionsData } from '../settings/SpanBarSettings';
+export type { default as TTraceTimeline } from './TTraceTimeline';
+export type { default as TNil } from './TNil';
+export type { SpanLinkFunc, SpanLinkDef } from './links';

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -10,7 +10,7 @@ import {
   VariableHide,
   TypedVariableModel,
 } from '@grafana/data';
-export { BaseVariableModel as VariableModel } from '@grafana/data';
+export type { BaseVariableModel as VariableModel } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
 import { NEW_VARIABLE_ID } from './constants';

--- a/public/app/plugins/datasource/azuremonitor/types/templateVariables.ts
+++ b/public/app/plugins/datasource/azuremonitor/types/templateVariables.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   GrafanaTemplateVariableQueryType,
   UnknownQuery,
   AppInsightsMetricNameQuery,

--- a/public/app/plugins/datasource/cloudwatch/expressions.ts
+++ b/public/app/plugins/datasource/cloudwatch/expressions.ts
@@ -5,14 +5,14 @@ import {
 } from './dataquery.gen';
 export {
   QueryEditorPropertyType,
-  QueryEditorProperty,
-  QueryEditorPropertyExpression,
-  QueryEditorGroupByExpression,
-  QueryEditorFunctionExpression,
-  QueryEditorFunctionParameterExpression,
-  QueryEditorArrayExpression,
+  type QueryEditorProperty,
+  type QueryEditorPropertyExpression,
+  type QueryEditorGroupByExpression,
+  type QueryEditorFunctionExpression,
+  type QueryEditorFunctionParameterExpression,
+  type QueryEditorArrayExpression,
   QueryEditorExpressionType,
-  QueryEditorExpression,
+  type QueryEditorExpression,
 } from './dataquery.gen';
 
 export interface QueryEditorOperator<T extends QueryEditorOperatorValueType> extends QueryEditorOperatorBase {

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -19,7 +19,7 @@ import {
 } from './dataquery.gen';
 
 export * from './dataquery.gen';
-export { ElasticsearchDataQuery as ElasticsearchQuery } from './dataquery.gen';
+export type { ElasticsearchDataQuery as ElasticsearchQuery } from './dataquery.gen';
 
 // We want to extend the settings of the Logs query with additional properties that
 // are not part of the schema. This is a workaround, because exporting LogsSettings

--- a/public/app/plugins/datasource/jaeger/_importedDependencies/types/index.tsx
+++ b/public/app/plugins/datasource/jaeger/_importedDependencies/types/index.tsx
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { TraceSpan, TraceResponse, Trace, TraceProcess, TraceLink, CriticalPathSection } from './trace';
+export type { TraceSpan, TraceResponse, Trace, TraceProcess, TraceLink, CriticalPathSection } from './trace';

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -33,7 +33,7 @@ export enum LokiVisualQueryOperationCategory {
   Formats = 'Formats',
   LineFilters = 'Line filters',
   LabelFilters = 'Label filters',
-  BinaryOps = BINARY_OPERATIONS_KEY,
+  BinaryOps = `${BINARY_OPERATIONS_KEY}`,
 }
 
 export enum LokiOperationId {

--- a/public/app/plugins/panel/candlestick/types.ts
+++ b/public/app/plugins/panel/candlestick/types.ts
@@ -28,12 +28,12 @@ export const defaultOptions: Partial<Options> = {
 };
 
 export {
-  Options,
-  CandlestickColors,
+  type Options,
+  type CandlestickColors,
   defaultCandlestickColors,
   CandleStyle,
   ColorStrategy,
   VizDisplayMode,
-  CandlestickFieldMap,
-  FieldConfig,
+  type CandlestickFieldMap,
+  type FieldConfig,
 };

--- a/public/app/plugins/panel/geomap/types.ts
+++ b/public/app/plugins/panel/geomap/types.ts
@@ -53,4 +53,10 @@ export interface MapLayerState<TConfig = unknown> extends LayerElement {
   mouseEvents: Subject<FeatureLike | undefined>;
 }
 
-export { Options, MapViewConfig, TooltipOptions, TooltipMode, defaultMapViewConfig } from './panelcfg.gen';
+export {
+  type Options,
+  type MapViewConfig,
+  type TooltipOptions,
+  TooltipMode,
+  defaultMapViewConfig,
+} from './panelcfg.gen';

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 
 import { DataFrame } from '@grafana/data';
 
-export { Options } from './panelcfg.gen';
+export type { Options } from './panelcfg.gen';
 
 type onClickFilterLabelType = (key: string, value: string, frame?: DataFrame) => void;
 type onClickFilterOutLabelType = (key: string, value: string, frame?: DataFrame) => void;

--- a/public/app/plugins/panel/nodeGraph/types.ts
+++ b/public/app/plugins/panel/nodeGraph/types.ts
@@ -2,7 +2,7 @@ import { SimulationNodeDatum, SimulationLinkDatum } from 'd3-force';
 
 import { DataFrame, Field, IconName } from '@grafana/data';
 
-export { Options as NodeGraphOptions, ArcOption } from './panelcfg.gen';
+export type { Options as NodeGraphOptions, ArcOption } from './panelcfg.gen';
 
 export type NodeDatum = SimulationNodeDatum & {
   id: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": true,
     "incremental": true,
+    "isolatedModules": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "paths": {
       "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR sets [`compilerOptions.isolatedModules`](https://www.typescriptlang.org/tsconfig/#isolatedModules) to true and fixes any reported errors.

**Why do we need this feature?**

Compilers (like `esbuild`, `babel`, and `swc`) work on individual files and don't understand the entire environment that the code executes in - they look at a single file and transpile it. This is (partly) what makes them faster than Typescript as they don't need to type check everything before compilation. Setting isolated modules true tells typescript that other things can/will compile the code and warn us (during type checking) if we write code that could cause runtime errors.

>Setting the isolatedModules flag tells TypeScript to warn you if you write certain code that can't be correctly interpreted by a single-file transpilation process. It does not change the behavior of your code, or otherwise change the behavior of TypeScript's checking and emitting process.

**Who is this feature for?**

Grafana contributors

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
