### PR TITLE
Fix relative time range parsing

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -41,15 +41,49 @@ describe('Range Utils', () => {
       expect(deserializedTimeRange.from.format()).toBe('1996-07-30T16:00:00Z');
     });
 
-    it('should leave the raw part intact if it has calulactions', () => {
+    it('should leave the raw part intact if it has calculations', () => {
+      const timeRange = {
+        from: 'now-6h',
+        to: 'now',
+      };
+
+      const deserialized = convertRawToRange(timeRange);
+      expect(deserialized.from).not.toBe(timeRange.from);
+      expect(deserialized.raw.from).not.toBe(deserialized.from);
+      expect(deserialized.raw.from).toBe(timeRange.from);
+      expect(deserialized.to).not.toBe(timeRange.to);
+      expect(deserialized.raw.to).not.toBe(deserialized.from);
+      expect(deserialized.raw.to).toBe(timeRange.to);
+    });
+
+    it('should leave the raw part intact if it has calculations for "from"', () => {
+      const timeRange = {
+        from: 'now',
+        to: DEFAULT_DATE_VALUE,
+      };
+
+      const deserialized = convertRawToRange(timeRange);
+      expect(deserialized.from).not.toBe(timeRange.from);
+      expect(deserialized.raw.from).not.toBe(deserialized.from);
+      expect(deserialized.raw.from).toBe(timeRange.from);
+      expect(deserialized.to).not.toBe(timeRange.to);
+      expect(deserialized.raw.to).toBe(deserialized.to);
+      expect(deserialized.raw.to).not.toBe(timeRange.to);
+    });
+
+    it('should leave the raw part intact if it has calculations for "to"', () => {
       const timeRange = {
         from: DEFAULT_DATE_VALUE,
         to: 'now',
       };
 
       const deserialized = convertRawToRange(timeRange);
-      expect(deserialized.raw).toStrictEqual(timeRange);
-      expect(deserialized.to.toString()).not.toBe(deserialized.raw.to);
+      expect(deserialized.from).not.toBe(timeRange.from);
+      expect(deserialized.raw.from).toBe(deserialized.from);
+      expect(deserialized.raw.from).not.toBe(timeRange.from);
+      expect(deserialized.to).not.toBe(timeRange.to);
+      expect(deserialized.raw.to).not.toBe(deserialized.to);
+      expect(deserialized.raw.to).toBe(timeRange.to);
     });
   });
 

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -207,11 +207,14 @@ export const convertRawToRange = (
   const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format });
   const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format });
 
-  if (dateMath.isMathString(raw.from) || dateMath.isMathString(raw.to)) {
-    return { from, to, raw };
-  }
-
-  return { from, to, raw: { from, to } };
+  return {
+    from,
+    to,
+    raw: {
+      from: dateMath.isMathString(raw.from) ? raw.from : from,
+      to: dateMath.isMathString(raw.to) ? raw.to : to,
+    },
+  };
 };
 
 export function isRelativeTime(v: DateTime | string) {


### PR DESCRIPTION
**What is this feature?**

This PR changes `convertRawToRange` so that it passes `raw` values in a time range also if only one option is relative. Previously if any of `from` or `to` or relative, then the entire raw value was left untouched.

**Why do we need this feature?**

The previous behavior was leading to some undesired side effects (i.e. incorrect URL setting in scenes, missing updates on time range picker etc.)

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
