### PR TITLE
Loki: pass backendSrv request options

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -326,7 +326,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchDetectedLabelValues(labelName, options);
 
-      expect(requestSpy).toHaveBeenCalledWith(`detected_field/${labelName}/values`, expectedOptions, true);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_field/${labelName}/values`, expectedOptions, true, undefined);
       expect(labelValues).toEqual(expectedResponse);
     });
 
@@ -340,7 +340,7 @@ describe('Language completion provider', () => {
 
       const nextLabelValues = await provider.fetchDetectedLabelValues(labelName, options);
       expect(requestSpy).toHaveBeenCalledTimes(1);
-      expect(requestSpy).toHaveBeenCalledWith(`detected_field/${labelName}/values`, expectedOptions, true);
+      expect(requestSpy).toHaveBeenCalledWith(`detected_field/${labelName}/values`, expectedOptions, true, undefined);
       expect(nextLabelValues).toEqual(expectedResponse);
     });
 
@@ -349,7 +349,12 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(provider, 'request');
       await provider.fetchDetectedLabelValues('`\\"testkey', options);
 
-      expect(requestSpy).toHaveBeenCalledWith('detected_field/%60%5C%22testkey/values', expectedOptions, true);
+      expect(requestSpy).toHaveBeenCalledWith(
+        'detected_field/%60%5C%22testkey/values',
+        expectedOptions,
+        true,
+        undefined
+      );
     });
 
     it('should cache by label name', async () => {
@@ -448,7 +453,7 @@ describe('Request URL', () => {
     const instance = new LanguageProvider(datasourceWithLabels);
     instance.fetchLabels();
     const expectedUrl = 'labels';
-    expect(datasourceSpy).toHaveBeenCalledWith(expectedUrl, rangeParams);
+    expect(datasourceSpy).toHaveBeenCalledWith(expectedUrl, rangeParams, undefined);
   });
 });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -48,10 +48,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
     url: string,
     params?: Record<string, string | number>,
     throwError?: boolean,
-    options?: Partial<BackendSrvRequest>
+    requestOptions?: Partial<BackendSrvRequest>
   ) => {
     try {
-      return await this.datasource.metadataRequest(url, params, options);
+      return await this.datasource.metadataRequest(url, params, requestOptions);
     } catch (error) {
       if (throwError) {
         throw error;


### PR DESCRIPTION
**What is this feature?**
Follow up on https://github.com/grafana/grafana/pull/95204, errors weren't properly being propagated, and the calling application should be able to optionally control the request options instead of requiring a core Grafana change.

**Why do we need this feature?**
To add support for detected_field/.../values in Explore Logs

**Who is this feature for?**
Explore Logs developers/users

**Special notes for your reviewer:**
After iterating a bit on https://github.com/grafana/explore-logs/pull/848, I realized my initial [attempt](https://github.com/grafana/grafana/pull/95204) didn't allow for graceful fallbacks if the user had an older Loki version. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
