### PR TITLE
fix: make org_id not nullable and set default value

### DIFF
--- a/pkg/services/sqlstore/migrations/plugin_setting.go
+++ b/pkg/services/sqlstore/migrations/plugin_setting.go
@@ -37,4 +37,44 @@ func addAppSettingsMigration(mg *Migrator) {
 		{Name: "secure_json_data", Type: DB_Text, Nullable: true},
 		{Name: "plugin_version", Type: DB_NVarchar, Nullable: true, Length: 50},
 	}))
+
+	// set org_id default value to 1 and not null
+	mg.AddMigration("update NULL org_id to 1", NewRawSQLMigration("UPDATE plugin_setting SET org_id=1 where org_id IS NULL;"))
+
+	mg.AddMigration("make org_id NOT NULL and DEFAULT VALUE 1", NewRawSQLMigration("").
+		Mysql("ALTER TABLE plugin_setting MODIFY COLUMN org_id BIGINT NOT NULL DEFAULT 1;").
+		Postgres(`
+			ALTER TABLE plugin_setting
+				ALTER COLUMN org_id SET NOT NULL,
+				ALTER COLUMN org_id SET DEFAULT 1;
+		`).
+		SQLite(`
+			CREATE TABLE "plugin_setting_new" (
+			"id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+			"org_id" INTEGER NOT NULL DEFAULT 1,
+			"plugin_id" TEXT NOT NULL,
+			"enabled" INTEGER NOT NULL,
+			"pinned" INTEGER NOT NULL,
+			"json_data" TEXT NULL,
+			"secure_json_data" TEXT NULL,
+			"created" DATETIME NOT NULL,
+			"updated" DATETIME NOT NULL,
+			"plugin_version" TEXT NULL);
+			INSERT INTO "plugin_setting_new" SELECT
+				"id",
+				COALESCE("org_id", 1),
+				"plugin_id",
+				"enabled",
+				"pinned",
+				"json_data",
+				"secure_json_data",
+				"created",
+				"updated",
+				"plugin_version"
+			FROM "plugin_setting";
+			DROP TABLE "plugin_setting";
+			ALTER TABLE "plugin_setting_new" RENAME TO "plugin_setting";
+			CREATE UNIQUE INDEX "UQE_plugin_setting_org_id_plugin_id" ON "plugin_setting" ("org_id","plugin_id");
+		`),
+	)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Make `org_id` in `plugin_setting` table `NOT NULL` and `DEFAULT VALUE 1`

**Why do we need this feature?**

We should fix the `UQE_plugin_setting_org_id_plugin_id` index to ensure that it does not allow for duplicates

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-community-team/issues/229

**Testing**:

Schema and data before migration:
**Mysql**
```
mysql> describe plugin_setting;
+------------------+--------------+------+-----+---------+----------------+
| Field            | Type         | Null | Key | Default | Extra          |
+------------------+--------------+------+-----+---------+----------------+
| id               | bigint       | NO   | PRI | NULL    | auto_increment |
| org_id           | bigint       | YES  | MUL | NULL    |                |
| plugin_id        | varchar(190) | NO   |     | NULL    |    

mysql> select * from plugin_setting;
+----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------+
| id | org_id | plugin_id                 | enabled | pinned | json_data | secure_json_data | created             | updated             | plugin_version |
+----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------+
|  1 |   NULL | instabug-instabug-app     |       0 |      0 | null      | {}               | 2024-10-28 09:59:42 | 2024-10-28 09:59:42 |                |
|  2 |   NULL | grafana-iot-twinmaker-app |       0 |      0 | null      | {}               | 2024-10-28 09:59:55 | 2024-10-28 09:59:55 |                |
+----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------+         

INDEXES:
| plugin_setting |          0 | UQE_plugin_setting_org_id_plugin_id |            1 | org_id      | A         |           1 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
| plugin_setting |          0 | UQE_plugin_setting_org_id_plugin_id |            2 | plugin_id   | A         |           2 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |   
```

**Postgres**
```
grafana_db=# \d plugin_setting;
                                           Table "public.plugin_setting"
      Column      |            Type             | Collation | Nullable |                  Default                   
------------------+-----------------------------+-----------+----------+--------------------------------------------
 id               | integer                     |           | not null | nextval('plugin_setting_id_seq'::regclass)
 org_id           | bigint                      |           |          | 
 plugin_id        | character varying(190)      |           | not null | 

grafana_db=# select * from "plugin_setting";
 id | org_id |         plugin_id         | enabled | pinned | json_data | secure_json_data |       created       |       updated       | plugin_version 
----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------
  1 |        | grafana-exploretraces-app | t       | t      | null      | {}               | 2024-10-28 09:14:23 | 2024-10-28 09:14:51 | 0.1.2
  2 |        | redis-app                 | t       | t      | null      | {}               | 2024-10-28 09:15:55 | 2024-10-28 09:15:55 | 2.2.1

Indexes:
    "plugin_setting_pkey" PRIMARY KEY, btree (id)
    "UQE_plugin_setting_org_id_plugin_id" UNIQUE, btree (org_id, plugin_id)

```

**SQLite**

```
CREATE TABLE `plugin_setting` (
`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
, `org_id` INTEGER NULL
, `plugin_id` TEXT NOT NULL
, `enabled` INTEGER NOT NULL
, `pinned` INTEGER NOT NULL
, `json_data` TEXT NULL
, `secure_json_data` TEXT NULL
, `created` DATETIME NOT NULL
, `updated` DATETIME NOT NULL
, `plugin_version` TEXT NULL)

CREATE UNIQUE INDEX `UQE_plugin_setting_org_id_plugin_id` ON `plugin_setting` (`org_id`,`plugin_id`)

id | org_id | plugin_id | enabled | pinned | json_data | secure_json_data | created | updated | plugin_version
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | NULL | grafana-lokiexplore-app | 1 | 1 | null | {} |   |   | 1.0.1
2 | NULL | grafana-exploretraces-app | 1 | 1 | null | {} |   |   | 0.1.2

```

After migration


**Mysql**
```
mysql> describe plugin_setting;
+------------------+--------------+------+-----+---------+----------------+
| Field            | Type         | Null | Key | Default | Extra          |
+------------------+--------------+------+-----+---------+----------------+
| id               | bigint       | NO   | PRI | NULL    | auto_increment |
| org_id           | bigint       | NO   | MUL | 1       |                |


mysql> select * from plugin_setting;
+----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------+
| id | org_id | plugin_id                 | enabled | pinned | json_data | secure_json_data | created             | updated             | plugin_version |
+----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------+
|  1 |      1 | instabug-instabug-app     |       0 |      0 | null      | {}               | 2024-10-28 09:59:42 | 2024-10-28 09:59:42 |                
|  2 |      1 | grafana-iot-twinmaker-app |       0 |      0 | null      | {}               | 2024-10-28 09:59:55 | 2024-10-28 09:59:55 |                
 
INDEXES:
| plugin_setting |          0 | UQE_plugin_setting_org_id_plugin_id |            1 | org_id      | A         |           1 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
| plugin_setting |          0 | UQE_plugin_setting_org_id_plugin_id |            2 | plugin_id   | A         |           2 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
```

**Postgres**
```
grafana_db=# \d plugin_setting;
                                           Table "public.plugin_setting"
      Column      |            Type             | Collation | Nullable |                  Default                   
------------------+-----------------------------+-----------+----------+--------------------------------------------
 id               | integer                     |           | not null | nextval('plugin_setting_id_seq'::regclass)
 org_id           | bigint                      |           | not null | 1
 plugin_id        | character varying(190)      |           | not null | 


grafana_db=# select * from "plugin_setting";
 id | org_id |         plugin_id         | enabled | pinned | json_data | secure_json_data |       created       |       updated       | plugin_version 
----+--------+---------------------------+---------+--------+-----------+------------------+---------------------+---------------------+----------------
  1 |      1 | grafana-exploretraces-app | t       | t      | null      | {}               | 2024-10-28 09:14:23 | 2024-10-28 09:14:51 | 0.1.2
  2 |      1 | redis-app                 | t       | t      | null      | {}               | 2024-10-28 09:15:55 | 2024-10-28 09:15:55 | 2.2.1
(2 rows)

Indexes:
    "plugin_setting_pkey" PRIMARY KEY, btree (id)
    "UQE_plugin_setting_org_id_plugin_id" UNIQUE, btree (org_id, plugin_id)

```

**SQLite**

```
CREATE TABLE "plugin_setting" (
	"id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
	"org_id" INTEGER NOT NULL DEFAULT 1, -- default and not null added here
	"plugin_id" TEXT NOT NULL,
	"enabled" INTEGER NOT NULL,
	"pinned" INTEGER NOT NULL,
	"json_data" TEXT NULL,
	"secure_json_data" TEXT NULL,
	"created" DATETIME NOT NULL,
	"updated" DATETIME NOT NULL,
	"plugin_version" TEXT NULL)

CREATE UNIQUE INDEX `UQE_plugin_setting_org_id_plugin_id` ON `plugin_setting` (`org_id`,`plugin_id`)

id | org_id | plugin_id | enabled | pinned | json_data | secure_json_data | created | updated | plugin_version
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 1 | grafana-lokiexplore-app | 1 | 1 | null | {} |   |   | 1.0.1
2 | 1 | grafana-exploretraces-app | 1 | 1 | null | {} |   |   | 0.1.2

```

- [x] Already installed applications running as expected.
- [x] Migration should run on all 3 DBs correctly.
- [x] Check schema - `org_id NOT NULL DEFAULT 1;` 3 DBs
- [x] Entries without `org_id` should have gotten `1` as value
- [x] Add / Remove `plugin_setting`
- [x] Install application after migration
- [x] Provision app plugins

`provision.yaml`
```
apiVersion: 1

apps:
  - type: grafana-exploretraces-app
    org_id: 1
    jsonData:
      apiKey: 'API KEY'
  - type: redis-app
    org_id: 1
  - type: grafana-selfservetutorials-app
    org_id: 1
  - type: instabug-instabug-app
    org_id: 1
  - type: grafana-iot-twinmaker-app
    org_id: 1
  - type: azure-monitor-app
    org_id: 0
```

Mysql 
```
mysql> select * from plugin_setting;
+----+--------+--------------------------------+---------+--------+----------------------+------------------+---------------------+---------------------+----------------+
| id | org_id | plugin_id                      | enabled | pinned | json_data            | secure_json_data | created             | updated             | plugin_version |
+----+--------+--------------------------------+---------+--------+----------------------+------------------+---------------------+---------------------+----------------+
|  1 |      1 | instabug-instabug-app          |       0 |      0 | null                 | {}               | 2024-10-28 09:59:42 | 2024-10-28 09:59:42 |                |
|  2 |      1 | grafana-iot-twinmaker-app      |       0 |      0 | null                 | {}               | 2024-10-28 09:59:55 | 2024-10-28 09:59:55 |                |
|  3 |      1 | grafana-exploretraces-app      |       1 |      1 | {"apiKey":"API KEY"} | {}               | 2024-10-30 09:42:42 | 2024-10-30 09:42:42 | 0.1.2          |
|  4 |      1 | redis-app                      |       1 |      1 | null                 | {}               | 2024-10-30 09:42:42 | 2024-10-30 09:42:42 | 2.2.1          |
|  5 |      1 | grafana-selfservetutorials-app |       1 |      1 | null                 | {}               | 2024-10-30 09:42:43 | 2024-10-30 09:42:43 | 1.1.7          |

```


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
