### PR TITLE
GrafanaUI: Export Combobox from @grafana/ui

### DIFF
--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -230,11 +230,14 @@ export { InlineFieldRow } from './Forms/InlineFieldRow';
 export { FieldArray } from './Forms/FieldArray';
 
 // Select
+// Note - Select is nearly deprecated in favor of Combobox
 export { default as resetSelectStyles } from './Select/resetSelectStyles';
 export * from './Select/Select';
 export { SelectMenuOptions } from './Select/SelectMenu';
 export { getSelectStyles } from './Select/getSelectStyles';
 export * from './Select/types';
+
+export { Combobox, type ComboboxOption } from './Combobox/Combobox';
 
 export { HorizontalGroup, VerticalGroup, Container } from './Layout/Layout';
 export { Badge, type BadgeColor, type BadgeProps } from './Badge/Badge';

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -10,5 +10,4 @@
  */
 
 export * from './utils/skeleton';
-export * from './components/Combobox/Combobox';
 export * from './components/ScrollContainer/ScrollContainer';

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -15,8 +15,9 @@ import {
   TimeZonePicker,
   WeekStartPicker,
   FeatureBadge,
+  Combobox,
+  ComboboxOption,
 } from '@grafana/ui';
-import { Combobox, ComboboxOption } from '@grafana/ui/src/unstable';
 import { DashboardPicker } from 'app/core/components/Select/DashboardPicker';
 import { t, Trans } from 'app/core/internationalization';
 import { LANGUAGES, PSEUDO_LOCALE } from 'app/core/internationalization/constants';


### PR DESCRIPTION
🎉 Promotes Combobox to API-stable by exporting it from `@grafana/ui`.

![image](https://github.com/user-attachments/assets/33fc0b96-53a8-48b2-8a5f-0a4b1d6d4838)

Combobox is our new replacement for Select, which is much faster by default. We've been using it for a while in Grafana in user/org preferences, and now that we're adding it to Prometheus query editor, it's time to export it from the stable package 🌈 