### PR TITLE
Transformations: Window calculation should use 0 if value in window does not exist

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
@@ -753,7 +753,7 @@ describe('calculateField transformer w/ timeseries', () => {
       //console.log(data.fields);
 
       expect(data.fields.length).toEqual(2);
-      expect(data.fields[1].values).toEqual([1, 0.5, 1.5, 3.5, 4.5]);
+      expect(data.fields[1].values).toEqual([1, 1, 3, 3.5, 4.5]);
     });
   });
 
@@ -911,9 +911,9 @@ describe('calculateField transformer w/ timeseries', () => {
 
       expect(data.fields.length).toEqual(2);
       expect(data.fields[1].values[0]).toEqual(1);
-      expect(data.fields[1].values[1]).toEqual(0.5);
-      expect(data.fields[1].values[2]).toEqual(1);
-      expect(data.fields[1].values[3]).toEqual(3);
+      expect(data.fields[1].values[1]).toEqual(1);
+      expect(data.fields[1].values[2]).toEqual(1.5);
+      expect(data.fields[1].values[3]).toEqual(4.5);
     });
   });
 

--- a/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
@@ -753,11 +753,7 @@ describe('calculateField transformer w/ timeseries', () => {
       //console.log(data.fields);
 
       expect(data.fields.length).toEqual(2);
-      expect(data.fields[1].values[0]).toEqual(1);
-      expect(data.fields[1].values[1]).toEqual(0.5);
-      expect(data.fields[1].values[2]).toEqual(1.5);
-      expect(data.fields[1].values[3]).toEqual(3.5);
-      expect(data.fields[1].values[4]).toEqual(4.5);
+      expect(data.fields[1].values).toEqual([1, 0.5, 1.5, 3.5, 4.5]);
     });
   });
 

--- a/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
@@ -728,6 +728,39 @@ describe('calculateField transformer w/ timeseries', () => {
     });
   });
 
+  it('calculates fixed, trailing moving average with missing values', async () => {
+    const cfg = {
+      id: DataTransformerID.calculateField,
+      options: {
+        mode: CalculateFieldMode.WindowFunctions,
+        window: {
+          windowAlignment: WindowAlignment.Trailing,
+          field: 'x',
+          windowSize: 2,
+          windowSizeMode: WindowSizeMode.Fixed,
+          reducer: ReducerID.mean,
+        },
+      },
+    };
+
+    const series = toDataFrame({
+      fields: [{ name: 'x', type: FieldType.number, values: [1, undefined, 3, 4, 5] }],
+    });
+
+    await expect(transformDataFrame([cfg], [series])).toEmitValuesWith((received) => {
+      const data = received[0][0];
+
+      //console.log(data.fields);
+
+      expect(data.fields.length).toEqual(2);
+      expect(data.fields[1].values[0]).toEqual(1);
+      expect(data.fields[1].values[1]).toEqual(1);
+      expect(data.fields[1].values[2]).toEqual(3);
+      expect(data.fields[1].values[3]).toEqual(7);
+      expect(data.fields[1].values[4]).toEqual(9);
+    });
+  });
+
   it('throws error when calculating moving average if window size < 1', async () => {
     const cfg = {
       id: DataTransformerID.calculateField,

--- a/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.test.ts
@@ -754,10 +754,10 @@ describe('calculateField transformer w/ timeseries', () => {
 
       expect(data.fields.length).toEqual(2);
       expect(data.fields[1].values[0]).toEqual(1);
-      expect(data.fields[1].values[1]).toEqual(1);
-      expect(data.fields[1].values[2]).toEqual(3);
-      expect(data.fields[1].values[3]).toEqual(7);
-      expect(data.fields[1].values[4]).toEqual(9);
+      expect(data.fields[1].values[1]).toEqual(0.5);
+      expect(data.fields[1].values[2]).toEqual(1.5);
+      expect(data.fields[1].values[3]).toEqual(3.5);
+      expect(data.fields[1].values[4]).toEqual(4.5);
     });
   });
 
@@ -915,9 +915,9 @@ describe('calculateField transformer w/ timeseries', () => {
 
       expect(data.fields.length).toEqual(2);
       expect(data.fields[1].values[0]).toEqual(1);
-      expect(data.fields[1].values[1]).toEqual(1);
-      expect(data.fields[1].values[2]).toEqual(1.5);
-      expect(data.fields[1].values[3]).toEqual(4.5);
+      expect(data.fields[1].values[1]).toEqual(0.5);
+      expect(data.fields[1].values[2]).toEqual(1);
+      expect(data.fields[1].values[3]).toEqual(3);
     });
   });
 

--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -351,7 +351,7 @@ function getTrailingWindowValues(frame: DataFrame, reducer: ReducerID, selectedF
   let count = 0;
   for (let i = 0; i < frame.length; i++) {
     if (reducer === ReducerID.mean) {
-      const currentValue = selectedField.values[i];
+      const currentValue = selectedField.values[i] ?? 0;
       if (currentValue !== null && currentValue !== undefined) {
         count++;
         sum += currentValue;

--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -357,7 +357,7 @@ function getTrailingWindowValues(frame: DataFrame, reducer: ReducerID, selectedF
         sum += currentValue;
 
         if (i > window - 1) {
-          sum -= selectedField.values[i - window];
+          sum -= selectedField.values[i - window] != null ? selectedField.values[i - window] : 0;
           count--;
         }
       }

--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -357,7 +357,7 @@ function getTrailingWindowValues(frame: DataFrame, reducer: ReducerID, selectedF
         sum += currentValue;
 
         if (i > window - 1) {
-          sum -= selectedField.values[i - window] != null ? selectedField.values[i - window] : 0;
+          sum -= selectedField.values[i - window] ?? 0;
           count--;
         }
       }

--- a/packages/grafana-data/src/transformations/transformers/calculateField.ts
+++ b/packages/grafana-data/src/transformations/transformers/calculateField.ts
@@ -351,14 +351,17 @@ function getTrailingWindowValues(frame: DataFrame, reducer: ReducerID, selectedF
   let count = 0;
   for (let i = 0; i < frame.length; i++) {
     if (reducer === ReducerID.mean) {
-      const currentValue = selectedField.values[i] ?? 0;
+      const currentValue = selectedField.values[i];
       if (currentValue !== null && currentValue !== undefined) {
         count++;
         sum += currentValue;
 
         if (i > window - 1) {
-          sum -= selectedField.values[i - window] ?? 0;
-          count--;
+          const value = selectedField.values[i - window];
+          if (value != null) {
+            sum -= value;
+            count--;
+          }
         }
       }
       vals.push(count === 0 ? 0 : sum / count);


### PR DESCRIPTION
**What is this feature?**

This updates the window calculation such that if a value does not exist, it counts as 0.

This is somewhat hard to replicate because in some scenarios if the value doesnt exist, it will be null, and in other scenarios it will be undefined. Javascript can `-= null` and have null count as 0, but with `-= undefined`, it will return NaN. With this logic, if it is either null or undefined it will count as 0.

**Why do we need this feature?**

So joined queries where data does not exist in all time fields will calculate properly without returning NaN.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/13051

**Special notes for your reviewer:**
I initially tried reproing this with a CSV dataset, either 3 queries or 1 query with some empty values and neither of them worked. 3 queries does not work and 1 query with some empty values returns null instead of undefined.

I ended up importing data into a postgres database I have running locally and having 3 queries coming from one table with different WHERE clauses. Then you can see it. I dont want to export out the whole panel because the data set was derived from customer data. Let me know if you would like me to set up something for reproing this.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
