### PR TITLE
Postgresql: Support tables from non-default schema

### DIFF
--- a/public/app/plugins/datasource/grafana-postgresql-datasource/sqlCompletionProvider.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/sqlCompletionProvider.ts
@@ -2,8 +2,10 @@ import {
   ColumnDefinition,
   getStandardSQLCompletionProvider,
   LanguageCompletionProvider,
+  LinkedToken,
   TableDefinition,
   TableIdentifier,
+  TokenType,
 } from '@grafana/experimental';
 import { DB, SQLQuery } from '@grafana/sql';
 
@@ -19,6 +21,23 @@ export const getSqlCompletionProvider: (args: CompletionProviderGetterArgs) => L
     tables: {
       resolve: async () => {
         return await getTables.current();
+      },
+      // Default parser doesn't handle schema.table syntax
+      parseName: (token: LinkedToken | undefined | null) => {
+        if (!token) {
+          return { table: '' };
+        }
+
+        let processedToken = token;
+        let tablePath = processedToken.value;
+
+        // Parse schema.table syntax
+        while (processedToken.next && processedToken.next.type !== TokenType.Whitespace) {
+          tablePath += processedToken.next.value;
+          processedToken = processedToken.next;
+        }
+
+        return { table: tablePath };
       },
     },
     columns: {


### PR DESCRIPTION
**What is this feature?**

- Add support for schema-qualified table names in the query builder.
- Partially resolve an issue where the column type of a table from the wrong schema with the same table name was incorrectly used. Now limited to tables of schemas within the search_path.

**Why do we need this feature?**

When a User uses the PostgreSQL datasource, the query builder only shows the tables of the schemas in the `search_path` and all other schemas are ignored. It is a big improvement if all tables, also from non-default schemas, are shown.

**Who is this feature for?**

Users which use a PostgreSQL datasource with non-default schemas.

**Which issue(s) does this PR fix?**:

Fixes #80771

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
