### PR TITLE
Explore Metrics: Add button to add to exploration

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4285,6 +4285,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
+    "public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
+    ],
     "public/app/features/trails/MetricSelect/MetricSelectScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -4285,10 +4285,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
-    "public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
-    ],
     "public/app/features/trails/MetricSelect/MetricSelectScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],

--- a/public/app/features/trails/AutomaticMetricQueries/AutoVizPanelQuerySelector.tsx
+++ b/public/app/features/trails/AutomaticMetricQueries/AutoVizPanelQuerySelector.tsx
@@ -1,0 +1,42 @@
+import { SceneObjectState, SceneObjectBase, SceneComponentProps } from '@grafana/scenes';
+import { RadioButtonGroup } from '@grafana/ui';
+
+import { getMetricSceneFor } from '../utils';
+
+import { AutoQueryDef } from './types';
+
+interface QuerySelectorState extends SceneObjectState {
+  queryDef: AutoQueryDef;
+  onChangeQuery: (variant: string) => void;
+  options?: Array<{
+    label: string;
+    value: string;
+  }>;
+}
+
+export class AutoVizPanelQuerySelector extends SceneObjectBase<QuerySelectorState> {
+  constructor(state: QuerySelectorState) {
+    super(state);
+    this.addActivationHandler(this._onActivate.bind(this));
+  }
+
+  private _onActivate() {
+    const { autoQuery } = getMetricSceneFor(this).state;
+
+    if (autoQuery.variants.length === 0) {
+      return;
+    }
+
+    this.setState({ options: autoQuery.variants.map((q) => ({ label: q.variant, value: q.variant })) });
+  }
+
+  public static Component = ({ model }: SceneComponentProps<AutoVizPanelQuerySelector>) => {
+    const { options, onChangeQuery, queryDef } = model.useState();
+
+    if (!options) {
+      return null;
+    }
+
+    return <RadioButtonGroup size="sm" options={options} value={queryDef.variant} onChange={onChangeQuery} />;
+  };
+}

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -494,7 +494,10 @@ function buildNormalLayout(
       .setTitle(getLabelValue(frame))
       .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
       .setColor({ mode: 'fixed', fixedColor: getColorByIndex(frameIndex) })
-      .setHeaderActions(new AddToFiltersGraphAction({ frame }))
+      .setHeaderActions([
+        new AddToFiltersGraphAction({ frame }),
+        new AddToExplorationButton({ labelName: getLabelValue(frame) }),
+      ])
       .setUnit(unit)
       .build();
 

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -34,6 +34,7 @@ import { AutoQueryDef } from '../AutomaticMetricQueries/types';
 import { BreakdownLabelSelector } from '../BreakdownLabelSelector';
 import { DataTrail } from '../DataTrail';
 import { MetricScene } from '../MetricScene';
+import { AddToExplorationButton } from '../MetricSelect/AddToExplorationsButton';
 import { StatusWrapper } from '../StatusWrapper';
 import { reportExploreMetrics } from '../interactions';
 import { updateOtelJoinWithGroupLeft } from '../otel/util';
@@ -439,7 +440,10 @@ export function buildAllLayout(
           ],
         })
       )
-      .setHeaderActions(new SelectLabelAction({ labelName: String(option.value) }))
+      .setHeaderActions([
+        new SelectLabelAction({ labelName: String(option.value) }),
+        new AddToExplorationButton({ labelName: String(option.value) }),
+      ])
       .setUnit(unit)
       .setBehaviors([fixLegendForUnspecifiedLabelValueBehavior])
       .build();

--- a/public/app/features/trails/MetricSelect/AddToExplorationsButton.test.tsx
+++ b/public/app/features/trails/MetricSelect/AddToExplorationsButton.test.tsx
@@ -40,7 +40,7 @@ describe('AddToExplorationButton', () => {
     }));
     const scene = new AddToExplorationButton({});
     render(<scene.Component model={scene} />);
-    expect(screen.queryByLabelText(addToExplorationsButtonLabel)).not.toBeInTheDocument();
+    expect(() => screen.getByLabelText(addToExplorationsButtonLabel)).toThrow();
   });
 
   it('should render when the Explorations app provides a plugin extension link', async () => {

--- a/public/app/features/trails/MetricSelect/AddToExplorationsButton.test.tsx
+++ b/public/app/features/trails/MetricSelect/AddToExplorationsButton.test.tsx
@@ -59,6 +59,7 @@ describe('AddToExplorationButton', () => {
     }));
     const scene = new AddToExplorationButton({});
     render(<scene.Component model={scene} />);
-    expect(screen.queryByLabelText(addToExplorationsButtonLabel)).toBeInTheDocument();
+    const button = screen.getByLabelText(addToExplorationsButtonLabel);
+    expect(button).toBeInTheDocument();
   });
 });

--- a/public/app/features/trails/MetricSelect/AddToExplorationsButton.test.tsx
+++ b/public/app/features/trails/MetricSelect/AddToExplorationsButton.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+
+import { PluginExtensionTypes } from '@grafana/data';
+import { setPluginLinksHook } from '@grafana/runtime';
+
+import { mockPluginLinkExtension } from '../../alerting/unified/mocks';
+
+import { AddToExplorationButton, addToExplorationsButtonLabel, explorationsPluginId } from './AddToExplorationsButton';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  setPluginExtensionGetter: jest.fn(),
+  getPluginLinkExtensions: jest.fn().mockReturnValue({ extensions: [] }),
+  useChromeHeaderHeight: jest.fn().mockReturnValue(80),
+  getBackendSrv: () => {
+    return {
+      get: jest.fn(),
+    };
+  },
+  getDataSourceSrv: () => {
+    return {
+      get: jest.fn().mockResolvedValue({}),
+      getInstanceSettings: jest.fn().mockResolvedValue({ uid: 'ds1' }),
+    };
+  },
+  getAppEvents: () => ({
+    publish: jest.fn(),
+  }),
+}));
+
+describe('AddToExplorationButton', () => {
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shouldn't render when a plugin extension link isn't provided by the Explorations app ", async () => {
+    setPluginLinksHook(() => ({
+      links: [],
+      isLoading: false,
+    }));
+    const scene = new AddToExplorationButton({});
+    render(<scene.Component model={scene} />);
+    expect(screen.queryByLabelText(addToExplorationsButtonLabel)).not.toBeInTheDocument();
+  });
+
+  it('should render when the Explorations app provides a plugin extension link', async () => {
+    setPluginLinksHook(() => ({
+      links: [
+        mockPluginLinkExtension({
+          description: addToExplorationsButtonLabel, // this overrides the aria-label
+          onClick: () => {},
+          path: '/a/grafana-explorations-app',
+          pluginId: explorationsPluginId,
+          title: 'Explorations',
+          type: PluginExtensionTypes.link,
+        }),
+      ],
+      isLoading: false,
+    }));
+    const scene = new AddToExplorationButton({});
+    render(<scene.Component model={scene} />);
+    expect(screen.queryByLabelText(addToExplorationsButtonLabel)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx
+++ b/public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx
@@ -1,0 +1,131 @@
+import { DataFrame, TimeRange } from '@grafana/data';
+import { usePluginLinks } from '@grafana/runtime';
+import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState, SceneQueryRunner } from '@grafana/scenes';
+import { DataQuery, DataSourceRef } from '@grafana/schema';
+import { IconButton } from '@grafana/ui';
+
+import MimirLogo from '../../../plugins/datasource/prometheus/img/mimir_logo.svg';
+import { VAR_DATASOURCE_EXPR } from '../shared';
+
+export interface AddToExplorationButtonState extends SceneObjectState {
+  frame?: DataFrame;
+  dsUid?: string;
+  labelName?: string;
+  fieldName?: string;
+  context?: ExtensionContext;
+
+  disabledLinks: string[];
+  queries: DataQuery[];
+}
+
+type ExtensionContext = {
+  timeRange: TimeRange;
+  queries: DataQuery[];
+  datasource: DataSourceRef;
+  origin: string;
+  url: string;
+  type: string;
+  title: string;
+  id: string;
+  logoPath: string;
+  note?: string;
+  drillDownLabel?: string;
+};
+
+export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButtonState> {
+  constructor(state: Omit<AddToExplorationButtonState, 'disabledLinks' | 'queries'>) {
+    super({ ...state, disabledLinks: [], queries: [] });
+    this.addActivationHandler(this.onActivate);
+  }
+
+  private onActivate = () => {
+    const datasourceUid = sceneGraph.interpolate(this, VAR_DATASOURCE_EXPR);
+
+    this._subs.add(
+      this.subscribeToState(() => {
+        this.getQueries();
+        this.getContext();
+      })
+    );
+    this.setState({ dsUid: datasourceUid });
+  };
+
+  private getQueries = () => {
+    const data = sceneGraph.getData(this);
+    const queryRunner = sceneGraph.findObject(
+      data,
+      (o) => o instanceof SceneQueryRunner
+    ) as unknown as SceneQueryRunner;
+    if (queryRunner) {
+      const filter = this.state.frame ? getFilter(this.state.frame) : null;
+      const queries = queryRunner.state.queries.map((q) => ({
+        ...q,
+        expr: sceneGraph.interpolate(queryRunner, q.expr),
+        legendFormat: filter?.name ? `{{ ${filter.name} }}` : sceneGraph.interpolate(queryRunner, q.legendFormat),
+      }));
+      if (JSON.stringify(queries) !== JSON.stringify(this.state.queries)) {
+        this.setState({ queries });
+      }
+    }
+  };
+
+  private getContext = () => {
+    const { queries, dsUid, labelName, fieldName } = this.state;
+    const timeRange = sceneGraph.getTimeRange(this);
+
+    if (!timeRange || !queries || !dsUid) {
+      return;
+    }
+    const ctx = {
+      origin: 'Explore Metrics',
+      type: 'timeseries',
+      queries,
+      timeRange: { ...timeRange.state.value },
+      datasource: { uid: dsUid },
+      url: window.location.href,
+      id: `${JSON.stringify(queries)}${labelName}${fieldName}`,
+      title: `${labelName}${fieldName ? ` > ${fieldName}` : ''}`,
+      logoPath: MimirLogo,
+      drillDownLabel: fieldName,
+    };
+    if (JSON.stringify(ctx) !== JSON.stringify(this.state.context)) {
+      this.setState({ context: ctx });
+    }
+  };
+
+  public static Component = ({ model }: SceneComponentProps<AddToExplorationButton>) => {
+    const { context, disabledLinks } = model.useState();
+    const { links } = usePluginLinks({ extensionPointId: 'grafana-explore-metrics/exploration/v1', context });
+
+    return (
+      <>
+        {links
+          .filter((link) => link.pluginId === 'grafana-explorations-app' && link.onClick)
+          .map((link) => (
+            <IconButton
+              tooltip={link.description}
+              disabled={link.category === 'disabled' || disabledLinks.includes(link.id)}
+              aria-label="extension-link-to-open-exploration"
+              key={link.id}
+              name={link.icon ?? 'panel-add'}
+              onClick={(e) => {
+                if (link.onClick) {
+                  link.onClick(e);
+                }
+                model.setState({ disabledLinks: [...disabledLinks, link.id] });
+              }}
+            />
+          ))}
+      </>
+    );
+  };
+}
+
+const getFilter = (frame: DataFrame) => {
+  const filterNameAndValueObj = frame.fields[1]?.labels ?? {};
+  if (Object.keys(filterNameAndValueObj).length !== 1) {
+    return;
+  }
+  const name = Object.keys(filterNameAndValueObj)[0];
+  return { name, value: filterNameAndValueObj[name] };
+};

--- a/public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx
+++ b/public/app/features/trails/MetricSelect/AddToExplorationsButton.tsx
@@ -99,7 +99,7 @@ export class AddToExplorationButton extends SceneObjectBase<AddToExplorationButt
 
   public static Component = ({ model }: SceneComponentProps<AddToExplorationButton>) => {
     const { context, disabledLinks } = model.useState();
-    const { links } = usePluginLinks({ extensionPointId, context });
+    const { links } = usePluginLinks({ extensionPointId, context, limitPerPlugin: 1 });
     const link = links.find((link) => link.pluginId === explorationsPluginId);
 
     if (!link) {

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -45,6 +45,7 @@ import {
 } from '../shared';
 import { getFilters, getTrailFor, isSceneTimeRangeState } from '../utils';
 
+import { AddToExplorationButton } from './AddToExplorationsButton';
 import { SelectMetricAction } from './SelectMetricAction';
 import { getMetricNames } from './api';
 import { getPreviewPanelFor } from './previewPanel';
@@ -624,7 +625,10 @@ function getCardPanelFor(metric: string, description?: string) {
   return PanelBuilders.text()
     .setTitle(metric)
     .setDescription(description)
-    .setHeaderActions(new SelectMetricAction({ metric, title: 'Select' }))
+    .setHeaderActions([
+      new SelectMetricAction({ metric, title: 'Select' }),
+      new AddToExplorationButton({ labelName: metric }),
+    ])
     .setOption('content', '')
     .build();
 }

--- a/public/app/features/trails/MetricSelect/previewPanel.ts
+++ b/public/app/features/trails/MetricSelect/previewPanel.ts
@@ -5,6 +5,7 @@ import { getAutoQueriesForMetric } from '../AutomaticMetricQueries/AutoQueryEngi
 import { getVariablesWithMetricConstant, MDP_METRIC_PREVIEW, trailDS } from '../shared';
 import { getColorByIndex } from '../utils';
 
+import { AddToExplorationButton } from './AddToExplorationsButton';
 import { SelectMetricAction } from './SelectMetricAction';
 import { hideEmptyPreviews } from './hideEmptyPreviews';
 
@@ -15,7 +16,10 @@ export function getPreviewPanelFor(metric: string, index: number, currentFilterC
     .vizBuilder()
     .setColor({ mode: 'fixed', fixedColor: getColorByIndex(index) })
     .setDescription(description)
-    .setHeaderActions(new SelectMetricAction({ metric, title: 'Select' }))
+    .setHeaderActions([
+      new SelectMetricAction({ metric, title: 'Select' }),
+      new AddToExplorationButton({ labelName: metric }),
+    ])
     .build();
 
   const queries = autoQuery.preview.queries.map((query) =>


### PR DESCRIPTION
## What is this feature?

Adds a PoC implementation of the `Add to Exploration` button to Explore Metrics.

## Demo

https://github.com/user-attachments/assets/c92f2b71-73ec-4c10-9685-9b1b180d8fc3

## How does it work?

When the [Investigations App](https://github.com/grafana/investigations-app) is installed, it  uses a [UI extension](https://grafana.com/developers/plugin-tools/how-to-guides/ui-extensions) to connect with the new `AddToExplorationsButton`. This button appears in various panels throughout Explore Metrics, allowing users to add metrics panels to their exploration (alongside logs panels, etc.).

## Notes for reviewers

Running this locally requires setup in both `grafana/grafana` and `grafana/investigations-app`.

### `grafana/investigations-app`

1. Clone [grafana/investigations-app](https://github.com/grafana/investigations-app) and switch to its `svennergr/add-explore-metrics-link` branch.
2. Install frontend dependencies (`npm install`)
3. Build the backend with `mage -v`
4. Build the frontend with the `build` script (`npm run build`)

### `grafana/grafana`

1. Check out the `svennergr/explorations-explore-metrics` branch.
2. Create a symlink for `grafana-explorations-app` in the Grafana plugins directory:
```
cd grafana/data/plugins/
ln -s /ABSOLUTE/PATH/TO/investigations-app/dist grafana-explorations-app
```
3. Configure Grafana to allow unsigned plugins by enabling `development` mode for apps in `conf/custom.ini`:
```
app_mode = development
```
4. Start/restart grafana

After following these steps, you should see the `AddToExplorationsButton` in panels throughout Explore Metrics:

![demo explorations button](https://github.com/user-attachments/assets/3e75fcee-abe5-46c6-915c-b58708e204bf)
