### PR TITLE
Unified Storage/Folders: Disable k8s folder creation endpoint temporarily

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -60,7 +60,7 @@ func (hs *HTTPServer) registerFolderAPI(apiRoute routing.RouteRegister, authoriz
 				folderPermissionRoute.Post("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersPermissionsWrite, uidScope)), routing.Wrap(hs.UpdateFolderPermissions))
 			})
 		})
-		if hs.Features.IsEnabledGlobally(featuremgmt.FlagKubernetesFolders) {
+		if false {
 			// Use k8s client to implement legacy API
 			handler := newFolderK8sHandler(hs)
 			folderRoute.Post("/", handler.createFolder)

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -551,7 +551,7 @@ func doNestedCreateTest(t *testing.T, helper *apis.K8sTestHelper) {
 	// creating a folder with a known parent should succeed
 	require.Equal(t, parentUID, childCreate.Result.ParentUID)
 	require.Equal(t, parentUID, parent.UID)
-	require.Equal(t, "Test\\/parent", parent.Title)
+	require.Equal(t, "Test/parent", parent.Title)
 	require.Equal(t, parentCreate.Result.URL, parent.URL)
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Following [this incident](https://raintank-corp.slack.com/archives/C07UVFD6W2U), I propose we disable the folder creation endpoint but [enable k8s folders in mode 1](https://github.com/grafana/deployment_tools/pull/187801). This would allow us to continue data syncing folders (which has been running smoothly so far) while preventing the creation of folders using the /api/folders/ endpoint (which was the reason for the incident). 

<!--


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
-->
