### PR TITLE
Prometheus: Add Metrics Explorer button next to MetricCombobox

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -2,7 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import '@testing-library/jest-dom';
+
 import { DataSourceInstanceSettings, MetricFindValue } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { PrometheusDatasource } from '../../datasource';
 import { PromOptions } from '../../types';
@@ -123,5 +125,31 @@ describe('MetricCombobox', () => {
     await userEvent.click(item);
 
     expect(mockOnChange).toHaveBeenCalledWith({ metric: 'random_metric', labels: [], operations: [] });
+  });
+
+  it("doesn't show the metrics explorer button by default", () => {
+    render(<MetricCombobox {...defaultProps} />);
+    expect(screen.queryByRole('button', { name: /open metrics explorer/i })).not.toBeInTheDocument();
+  });
+
+  describe('when metrics explorer toggle is enabled', () => {
+    beforeAll(() => {
+      jest.replaceProperty(config, 'featureToggles', {
+        prometheusMetricEncyclopedia: true,
+      });
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('opens the metrics explorer when the button is clicked', async () => {
+      render(<MetricCombobox {...defaultProps} onGetMetrics={() => Promise.resolve([])} />);
+
+      const button = screen.getByRole('button', { name: /open metrics explorer/i });
+      await userEvent.click(button);
+
+      expect(screen.getByText('Metrics explorer')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
@@ -52,7 +52,7 @@ export type MetricsModalProps = {
   query: PromVisualQuery;
   onClose: () => void;
   onChange: (query: PromVisualQuery) => void;
-  initialMetrics: string[];
+  initialMetrics: string[] | (() => Promise<string[]>);
 };
 
 export const MetricsModal = (props: MetricsModalProps) => {
@@ -70,7 +70,11 @@ export const MetricsModal = (props: MetricsModalProps) => {
     // *** Loading Gif
     dispatch(setIsLoading(true));
 
-    const data: MetricsModalMetadata = await setMetrics(datasource, query, initialMetrics);
+    // Because Combobox in MetricsCombobox doesn't use the same lifecycle as Select to open the Metrics Explorer
+    // it might not have loaded any metrics yet, so it instead passes in an async function to get the metrics
+    const metrics = typeof initialMetrics === 'function' ? await initialMetrics() : initialMetrics;
+
+    const data: MetricsModalMetadata = await setMetrics(datasource, query, metrics);
     dispatch(
       buildMetrics({
         isLoading: false,


### PR DESCRIPTION
This PR restores a way to open the Metrics Explorer when the `prometheusUsesCombobox` toggle is enabled.

Because Combobox purposefully lacks the customisation options that was previously used to put a button to open Metrics Explorer _inside_ the dropdown, we've instead used an accessory button outside of the combobox to open it.

Because now the menu might never have been interacted with (and thus no metrics ever loaded), the Metrics Explorer needs a way to load metrics itself. I've changed the signature to allow `initialMetrics` to be an async function instead.

![image](https://github.com/user-attachments/assets/6ec58e0f-ce45-402f-85c6-e622bf4f81dd)


(originally opened in https://github.com/grafana/grafana/pull/95609 but I accidentally closed it with all the wrong rebasing i was doing...)