### PR TITLE
Zanzana: fix generic schema

### DIFF
--- a/pkg/services/accesscontrol/dualwrite/reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/reconciler.go
@@ -72,8 +72,14 @@ func NewZanzanaReconciler(client zanzana.Client, store db.DB, lock *serverlock.S
 				client,
 			),
 			newResourceReconciler(
-				"managed permissison",
-				managedPermissionsCollector2(store),
+				"managed folder permissions",
+				managedPermissionsCollector2(store, zanzana.KindFolders),
+				zanzanaCollector(client, zanzana.Folder2Relations),
+				client,
+			),
+			newResourceReconciler(
+				"managed dashboard permissions",
+				managedPermissionsCollector2(store, zanzana.KindDashboards),
 				zanzanaCollector(client, zanzana.ResourceRelations),
 				client,
 			),

--- a/pkg/services/accesscontrol/dualwrite/resource_reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/resource_reconciler.go
@@ -38,6 +38,8 @@ func (r resourceReconciler) reconcile(ctx context.Context) error {
 	)
 
 	for object, tuples := range res {
+		// FIXME(kalleep): Merge some tuples due to list of groups...
+
 		// 2. Fetch all tuples for given object.
 		// Due to limitations in open fga api we need to collect tuples per object
 		zanzanaTuples, err := r.zanzana(ctx, r.client, object)
@@ -70,11 +72,10 @@ func (r resourceReconciler) reconcile(ctx context.Context) error {
 		return nil
 	}
 
-	// FIXME: batch them together
-	if len(writes) > 0 {
-		err := batch(writes, 100, func(items []*openfgav1.TupleKey) error {
+	if len(deletes) > 0 {
+		err := batch(deletes, 100, func(items []*openfgav1.TupleKeyWithoutCondition) error {
 			return r.client.Write(ctx, &openfgav1.WriteRequest{
-				Writes: &openfgav1.WriteRequestWrites{TupleKeys: items},
+				Deletes: &openfgav1.WriteRequestDeletes{TupleKeys: items},
 			})
 		})
 
@@ -83,10 +84,10 @@ func (r resourceReconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
-	if len(deletes) > 0 {
-		err := batch(deletes, 100, func(items []*openfgav1.TupleKeyWithoutCondition) error {
+	if len(writes) > 0 {
+		err := batch(writes, 100, func(items []*openfgav1.TupleKey) error {
 			return r.client.Write(ctx, &openfgav1.WriteRequest{
-				Deletes: &openfgav1.WriteRequestDeletes{TupleKeys: items},
+				Writes: &openfgav1.WriteRequestWrites{TupleKeys: items},
 			})
 		})
 

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -13,6 +13,10 @@ const (
 	namespaceType      = "namespace"
 )
 
+func FolderResourceRelation(relation string) string {
+	return fmt.Sprintf("%s_%s", resourceType, relation)
+}
+
 func NewTypedIdent(typ string, name string) string {
 	return fmt.Sprintf("%s:%s", typ, name)
 }
@@ -52,7 +56,7 @@ func NewResourceTuple(subject, relation, group, resource, name string) *openfgav
 func NewFolderResourceTuple(subject, relation, group, resource, folder string) *openfgav1.TupleKey {
 	return &openfgav1.TupleKey{
 		User:     subject,
-		Relation: "resource_" + relation,
+		Relation: FolderResourceRelation(relation),
 		Object:   NewFolderIdent(folder),
 		Condition: &openfgav1.RelationshipCondition{
 			Name: "folder_group_filter",

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -42,9 +42,7 @@ func NewResourceTuple(subject, relation, group, resource, name string) *openfgav
 			Name: "group_filter",
 			Context: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"group_resources": structpb.NewListValue(&structpb.ListValue{
-						Values: []*structpb.Value{structpb.NewStringValue(FormatGroupResource(group, resource))},
-					}),
+					"resource_group": structpb.NewStringValue(FormatGroupResource(group, resource)),
 				},
 			},
 		},
@@ -57,7 +55,7 @@ func NewFolderResourceTuple(subject, relation, group, resource, folder string) *
 		Relation: "resource_" + relation,
 		Object:   NewFolderIdent(folder),
 		Condition: &openfgav1.RelationshipCondition{
-			Name: "group_filter",
+			Name: "folder_group_filter",
 			Context: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"group_resources": structpb.NewListValue(&structpb.ListValue{

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	resourceType       = "resource"
+	resourceTypeFolder = "folder2"
 	namespaceType      = "namespace"
-	folderResourceType = "folder_resource"
 )
 
 func NewTypedIdent(typ string, name string) string {
@@ -21,8 +21,8 @@ func NewResourceIdent(group, resource, name string) string {
 	return fmt.Sprintf("%s:%s/%s", resourceType, FormatGroupResource(group, resource), name)
 }
 
-func NewFolderResourceIdent(group, resource, folder string) string {
-	return fmt.Sprintf("%s:%s/%s", folderResourceType, FormatGroupResource(group, resource), folder)
+func NewFolderIdent(name string) string {
+	return fmt.Sprintf("folder2:%s", name)
 }
 
 func NewNamespaceResourceIdent(group, resource string) string {
@@ -42,7 +42,9 @@ func NewResourceTuple(subject, relation, group, resource, name string) *openfgav
 			Name: "group_filter",
 			Context: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"resource_group": structpb.NewStringValue(FormatGroupResource(group, resource)),
+					"group_resources": structpb.NewListValue(&structpb.ListValue{
+						Values: []*structpb.Value{structpb.NewStringValue(FormatGroupResource(group, resource))},
+					}),
 				},
 			},
 		},
@@ -52,13 +54,15 @@ func NewResourceTuple(subject, relation, group, resource, name string) *openfgav
 func NewFolderResourceTuple(subject, relation, group, resource, folder string) *openfgav1.TupleKey {
 	return &openfgav1.TupleKey{
 		User:     subject,
-		Relation: relation,
-		Object:   NewFolderResourceIdent(group, resource, folder),
+		Relation: "resource_" + relation,
+		Object:   NewFolderIdent(folder),
 		Condition: &openfgav1.RelationshipCondition{
 			Name: "group_filter",
 			Context: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"resource_group": structpb.NewStringValue(FormatGroupResource(group, resource)),
+					"group_resources": structpb.NewListValue(&structpb.ListValue{
+						Values: []*structpb.Value{structpb.NewStringValue(FormatGroupResource(group, resource))},
+					}),
 				},
 			},
 		},
@@ -70,6 +74,14 @@ func NewNamespaceResourceTuple(subject, relation, group, resource string) *openf
 		User:     subject,
 		Relation: relation,
 		Object:   NewNamespaceResourceIdent(group, resource),
+	}
+}
+
+func NewFolderParentTuple(folder, parent string) *openfgav1.TupleKey {
+	return &openfgav1.TupleKey{
+		Object:   NewFolderIdent(folder),
+		Relation: "parent",
+		User:     NewFolderIdent(parent),
 	}
 }
 

--- a/pkg/services/authz/zanzana/schema/resource.fga
+++ b/pkg/services/authz/zanzana/schema/resource.fga
@@ -29,16 +29,16 @@ type folder2
     define permissions_read: [user, team#member, role#assignee] or admin or permissions_read from parent
     define permissions_write: [user, team#member, role#assignee] or admin or permissions_write from parent
 
-    define resource_view: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_edit
-    define resource_edit: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_admin
-    define resource_admin: [user with group_filter, team#member with group_filter, role#assignee with group_filter]
+    define resource_view: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit
+    define resource_edit: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin
+    define resource_admin: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter]
 
-    define resource_read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_view or resource_read from parent
-    define resource_create: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_edit or resource_create from parent
-    define resource_write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_edit or resource_write from parent
-    define resource_delete: [user, team#member, role#assignee] or resource_edit or resource_delete from parent
-    define resource_permissions_read: [user, team#member, role#assignee] or resource_admin or resource_permissions_read from parent
-    define resource_permissions_write: [user, team#member, role#assignee] or resource_admin or resource_permissions_write from parent
+    define resource_read: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_view or resource_read from parent
+    define resource_create: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_create from parent
+    define resource_write: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_write from parent
+    define resource_delete: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_delete from parent
+    define resource_permissions_read: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin or resource_permissions_read from parent
+    define resource_permissions_write: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin or resource_permissions_write from parent
 
 type resource
   relations
@@ -53,7 +53,12 @@ type resource
     define permissions_read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
     define permissions_write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
 
-condition group_filter(requested_group: string, group_resources: list<string>) {
+
+condition group_filter(requested_group: string, resource_group: string) {
+  resource_group == requested_group
+}
+
+condition folder_group_filter(requested_group: string, group_resources: list<string>) {
   requested_group in group_resources
 }
 

--- a/pkg/services/authz/zanzana/schema/resource.fga
+++ b/pkg/services/authz/zanzana/schema/resource.fga
@@ -18,9 +18,9 @@ type folder2
     define parent: [folder2]
 
     # Action sets
-    define view: [user, team#member, role#assignee] or edit
-    define edit: [user, team#member, role#assignee] or admin
-    define admin: [user, team#member, role#assignee]
+    define view: [user, team#member, role#assignee] or edit or view from parent
+    define edit: [user, team#member, role#assignee] or admin or edit from parent
+    define admin: [user, team#member, role#assignee] or admin from parent
 
     define read: [user, team#member, role#assignee] or view or read from parent
     define create: [user, team#member, role#assignee] or edit or create from parent
@@ -29,9 +29,9 @@ type folder2
     define permissions_read: [user, team#member, role#assignee] or admin or permissions_read from parent
     define permissions_write: [user, team#member, role#assignee] or admin or permissions_write from parent
 
-    define resource_view: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit
-    define resource_edit: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin
-    define resource_admin: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter]
+    define resource_view: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_view from parent
+    define resource_edit: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin or resource_edit from parent
+    define resource_admin: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin from parent
 
     define resource_read: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_view or resource_read from parent
     define resource_create: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_create from parent

--- a/pkg/services/authz/zanzana/schema/resource.fga
+++ b/pkg/services/authz/zanzana/schema/resource.fga
@@ -29,18 +29,16 @@ type folder2
     define permissions_read: [user, team#member, role#assignee] or admin or permissions_read from parent
     define permissions_write: [user, team#member, role#assignee] or admin or permissions_write from parent
 
-type folder_resource
-  relations
-    define view: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or edit
-    define edit: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
-    define admin: [user with group_filter, team#member with group_filter, role#assignee with group_filter]
+    define resource_view: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_edit
+    define resource_edit: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_admin
+    define resource_admin: [user with group_filter, team#member with group_filter, role#assignee with group_filter]
 
-    define read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or view
-    define create: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or edit
-    define write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or edit
-    define delete: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or edit
-    define permissions_read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
-    define permissions_write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
+    define resource_read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_view or resource_read from parent
+    define resource_create: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_edit or resource_create from parent
+    define resource_write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or resource_edit or resource_write from parent
+    define resource_delete: [user, team#member, role#assignee] or resource_edit or resource_delete from parent
+    define resource_permissions_read: [user, team#member, role#assignee] or resource_admin or resource_permissions_read from parent
+    define resource_permissions_write: [user, team#member, role#assignee] or resource_admin or resource_permissions_write from parent
 
 type resource
   relations
@@ -55,7 +53,7 @@ type resource
     define permissions_read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
     define permissions_write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
 
-condition group_filter(requested_group: string, resource_group: string) {
-  resource_group == requested_group
+condition group_filter(requested_group: string, group_resources: list<string>) {
+  requested_group in group_resources
 }
 

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	resourceType       = "resource"
-	namespaceType      = "namespace"
-	folderResourceType = "folder_resource"
+	resourceType     = "resource"
+	namespaceType    = "namespace"
+	folderTypePrefix = "folder2:"
 )
 
 var _ authzv1.AuthzServiceServer = (*Server)(nil)

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -113,7 +113,7 @@ func (s *Server) checkGeneric(ctx context.Context, r *authzv1.CheckRequest) (*au
 		AuthorizationModelId: s.modelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
-			Relation: "resource_" + relation,
+			Relation: common.FolderResourceRelation(relation),
 			Object:   common.NewFolderIdent(r.GetFolder()),
 		},
 		Context: &structpb.Struct{

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -113,8 +113,8 @@ func (s *Server) checkGeneric(ctx context.Context, r *authzv1.CheckRequest) (*au
 		AuthorizationModelId: s.modelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
-			Relation: relation,
-			Object:   common.NewFolderResourceIdent(r.GetGroup(), r.GetResource(), r.GetFolder()),
+			Relation: "resource_" + relation,
+			Object:   common.NewFolderIdent(r.GetFolder()),
 		},
 		Context: &structpb.Struct{
 			Fields: map[string]*structpb.Value{

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -93,4 +93,18 @@ func testCheck(t *testing.T, server *Server) {
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
+
+	t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboar in folder 6 through folder 5", func(t *testing.T) {
+		res, err := server.Check(context.Background(), newRead("user:8", dashboardGroup, dashboardResource, "6", "10"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+
+		res, err = server.Check(context.Background(), newRead("user:8", dashboardGroup, dashboardResource, "5", "11"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+
+		res, err = server.Check(context.Background(), newRead("user:8", folderGroup, folderResource, "4", "12"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 }

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -86,7 +86,7 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 		StoreId:              s.storeID,
 		AuthorizationModelId: s.modelID,
 		Type:                 "folder2",
-		Relation:             "resource_" + relation,
+		Relation:             common.FolderResourceRelation(relation),
 		User:                 r.GetSubject(),
 		Context: &structpb.Struct{
 			Fields: map[string]*structpb.Value{

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -85,8 +85,8 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 	folders, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
 		StoreId:              s.storeID,
 		AuthorizationModelId: s.modelID,
-		Type:                 "folder_resource",
-		Relation:             relation,
+		Type:                 "folder2",
+		Relation:             "resource_" + relation,
 		User:                 r.GetSubject(),
 		Context: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
@@ -138,9 +138,8 @@ func directObjects(group, resource string, objects []string) []string {
 }
 
 func folderObject(group, resource string, objects []string) []string {
-	prefix := fmt.Sprintf("%s:%s/%s/", folderResourceType, group, resource)
 	for i := range objects {
-		objects[i] = strings.TrimPrefix(objects[i], prefix)
+		objects[i] = strings.TrimPrefix(objects[i], folderTypePrefix)
 	}
 	return objects
 }

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -75,6 +75,9 @@ func setup(t *testing.T, testDB db.DB, cfg *setting.Cfg) *Server {
 				common.NewFolderResourceTuple("user:5", "view", dashboardGroup, dashboardResource, "1"),
 				common.NewFolderTuple("user:6", "read", "1"),
 				common.NewNamespaceResourceTuple("user:7", "read", folderGroup, folderResource),
+				common.NewFolderParentTuple("5", "4"),
+				common.NewFolderParentTuple("6", "5"),
+				common.NewFolderResourceTuple("user:8", "read", dashboardGroup, dashboardResource, "5"),
 			},
 		},
 	})

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -35,9 +35,18 @@ const (
 	RelationDelete           string = "delete"
 	RelationPermissionsRead  string = "permissions_read"
 	RelationPermissionsWrite string = "permissions_write"
+
+	FolderResourceRelationAdmin            string = "resource_admin"
+	FolderResourceRelationRead             string = "resource_read"
+	FolderResourceRelationWrite            string = "resource_write"
+	FolderResourceRelationCreate           string = "resource_create"
+	FolderResourceRelationDelete           string = "resource_delete"
+	FolderResourceRelationPermissionsRead  string = "resource_permissions_read"
+	FolderResourceRelationPermissionsWrite string = "resource_permissions_write"
 )
 
 var ResourceRelations = []string{RelationRead, RelationWrite, RelationCreate, RelationDelete, RelationPermissionsRead, RelationPermissionsWrite}
+var Folder2Relations = append(ResourceRelations, FolderResourceRelationRead, FolderResourceRelationWrite, FolderResourceRelationCreate, FolderResourceRelationDelete, FolderResourceRelationPermissionsRead, FolderResourceRelationPermissionsWrite)
 
 const (
 	KindOrg        string = "org"
@@ -128,6 +137,16 @@ func TranslateToResourceTuple(subject string, action, kind, name string) (*openf
 	}
 
 	return common.NewTypedTuple(translation.typ, subject, m.relation, name), true
+}
+
+func IsFolderResourceTuple(t *openfgav1.TupleKey) bool {
+	return strings.HasPrefix(t.Object, TypeFolder2) && strings.HasPrefix(t.Relation, "resource_")
+}
+
+func MergeFolderResourceTuples(a, b *openfgav1.TupleKey) {
+	va := a.Condition.Context.Fields["group_resources"]
+	vb := b.Condition.Context.Fields["group_resources"]
+	va.GetListValue().Values = append(va.GetListValue().Values, vb.GetListValue().Values...)
 }
 
 func TranslateToOrgTuple(user string, action string, orgID int64) (*openfgav1.TupleKey, bool) {


### PR DESCRIPTION
**What is this feature?**
With the previous schema resource specific permissions on a folder was not inherited because it was a disconnected type.

To fix this I removed `folder_resource` type and added them as relations instead. Previous group filter would not work because for this because you could only ever add one of these relations from one user to one folders. To fix this we store an list of GroupResource on these relations.

This makes writes a bit trickier because we now have to alter already stored tuples instead of just adding new ones whenever a new GroupResource should be part of the relation.

I also made it so that the managedPermissionsCollector now works on one kid so we don't fetch permissions that are not yet ready to be reconciled.

**Which issue(s) does this PR fix?**:

Part of: https://github.com/grafana/identity-access-team/issues/974

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
