### PR TITLE
TableNG: Fix icon sorting direction

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -102,9 +102,9 @@ export function TableNG(props: TableNGProps) {
           <div>{column.name}</div>
           {direction &&
             (direction === 'ASC' ? (
-              <Icon size="lg" name="arrow-down" className={styles.sortIcon} />
-            ) : (
               <Icon name="arrow-up" size="lg" className={styles.sortIcon} />
+            ) : (
+              <Icon name="arrow-down" size="lg" className={styles.sortIcon} />
             ))}
         </button>
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes the sorting icon to show the correct ascending/descending direction.

Before:
<img width="166" alt="Screenshot 2024-10-31 at 14 31 28" src="https://github.com/user-attachments/assets/dabb5dfb-ee12-4fde-b6b4-49a081785643">

After:
<img width="165" alt="Screenshot 2024-10-31 at 14 30 24" src="https://github.com/user-attachments/assets/c4aefb0e-ba9d-4b2e-b090-b1349dcb4be5">


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #95635 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
