### PR TITLE
Unified Storage: Use ssl_mode instead of sslmode

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
@@ -72,7 +72,7 @@ func getEnginePostgres(getter confGetter) (*xorm.Engine, error) {
 		// Unified Storage used `pass`
 		"password": cmp.Or(getter.String("pass"), getter.String("password")),
 		"dbname":   getter.String("name"),
-		"sslmode":  cmp.Or(getter.String("sslmode"), "disable"),
+		"sslmode":  cmp.Or(getter.String("ssl_mode"), "disable"),
 	}
 
 	// TODO: probably interesting:


### PR DESCRIPTION
**What is this feature?**

Fix the following error:

> initialize Resource Server: initialize resource DB: run migrations: pq: no pg_hba.conf entry for host "10.X.X.X", user "grafana", database "grafana", no encryption

This is caused by unistore consuming the wrong flag (sslmode instead of ssl_mode)
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
