### PR TITLE
DashboardScenes: Fix queryOptions interval not resetting on empty minInterval

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -504,6 +504,27 @@ describe('PanelDataQueriesTab', () => {
           });
           expect(dataObj.state.minInterval).toBe('1s');
         });
+
+        it('should update min interval to undefined if empty input', async () => {
+          const { queriesTab } = await setupScene('panel-1');
+          const dataObj = queriesTab.queryRunner;
+
+          expect(dataObj.state.maxDataPoints).toBeUndefined();
+
+          queriesTab.onQueryOptionsChange({
+            dataSource: { name: 'grafana-testdata', type: 'grafana-testdata-datasource', default: true },
+            queries: [],
+            minInterval: '1s',
+          });
+          expect(dataObj.state.minInterval).toBe('1s');
+
+          queriesTab.onQueryOptionsChange({
+            dataSource: { name: 'grafana-testdata', type: 'grafana-testdata-datasource', default: true },
+            queries: [],
+            minInterval: null,
+          });
+          expect(dataObj.state.minInterval).toBe(undefined);
+        });
       });
 
       describe('query caching', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -201,8 +201,8 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       dataObjStateUpdate.maxDataPoints = options.maxDataPoints ?? undefined;
     }
 
-    if (options.minInterval !== dataObj.state.minInterval && options.minInterval !== null) {
-      dataObjStateUpdate.minInterval = options.minInterval;
+    if (options.minInterval !== dataObj.state.minInterval) {
+      dataObjStateUpdate.minInterval = options.minInterval ?? undefined;
     }
 
     if (options.timeRange) {

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -129,7 +129,7 @@ export const QueryGroupOptionsEditor = React.memo(({ options, dataSource, data, 
 
   const onMinIntervalBlur = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      const minInterval = emptyToUndefined(event.target.value);
+      const minInterval = emptyToNull(event.target.value);
       if (minInterval !== options.minInterval) {
         onChange({
           ...options,
@@ -377,10 +377,6 @@ QueryGroupOptionsEditor.displayName = 'QueryGroupOptionsEditor';
 
 function timeRangeValidation(value: string | null) {
   return !value || rangeUtil.isValidTimeSpan(value);
-}
-
-function emptyToUndefined(value: string) {
-  return value === '' ? undefined : value;
 }
 
 function emptyToNull(value: string) {

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -129,7 +129,7 @@ export const QueryGroupOptionsEditor = React.memo(({ options, dataSource, data, 
 
   const onMinIntervalBlur = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      const minInterval = emptyToNull(event.target.value);
+      let minInterval = emptyToUndefined(event.target.value);
       if (minInterval !== options.minInterval) {
         onChange({
           ...options,
@@ -377,6 +377,10 @@ QueryGroupOptionsEditor.displayName = 'QueryGroupOptionsEditor';
 
 function timeRangeValidation(value: string | null) {
   return !value || rangeUtil.isValidTimeSpan(value);
+}
+
+function emptyToUndefined(value: string) {
+  return value === '' ? undefined : value;
 }
 
 function emptyToNull(value: string) {

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -129,7 +129,7 @@ export const QueryGroupOptionsEditor = React.memo(({ options, dataSource, data, 
 
   const onMinIntervalBlur = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      let minInterval = emptyToUndefined(event.target.value);
+      const minInterval = emptyToUndefined(event.target.value);
       if (minInterval !== options.minInterval) {
         onChange({
           ...options,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug where removing minInterval in query options would not reset the interval properly. If the minInterval would be removed, the interval would not be recalculated. Changing the timerange would also not properly calculate the interval.

**Why do we need this feature?**

Fixes the bug

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
