### PR TITLE
Plugins:  Add `buildMode` to the plugin.json schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -234,6 +234,10 @@
       "type": "boolean",
       "description": "If the plugin has a backend component."
     },
+    "buildMode": {
+      "type": "string",
+      "description": "The build mode of the plugin. Can be `development` or `production`."
+    },
     "builtIn": {
       "type": "boolean",
       "description": "[internal only] Indicates whether the plugin is developed and shipped as part of Grafana. Also known as a 'core plugin'."

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -236,7 +236,7 @@
     },
     "buildMode": {
       "type": "string",
-      "description": "The build mode of the plugin. Can be `development` or `production`."
+      "description": "The build mode of the plugin. This field is set automatically at build time, so it should not be provided manually."
     },
     "builtIn": {
       "type": "boolean",


### PR DESCRIPTION
**What is this feature?**

This PR adds a new optional prop called `buildMode`. This indicates what mode the plugin was built for. 

**Why do we need this feature?**

This information can be useful at runtime so we can for example log to the console in case the plugin is in development mode.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
