### PR TITLE
Alerting docs: fix `alertname` label name

### DIFF
--- a/docs/sources/alerting/fundamentals/alert-rules/annotation-label.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/annotation-label.md
@@ -97,7 +97,7 @@ Data source query labels labels are also used to generate multiple alert instanc
 
 Reserved labels are automatically added by Grafana:
 
-- `alert_name`: the name of the alert rule.
+- `alertname`: the name of the alert rule.
 - `grafana_folder`: the title of the folder containing the alert.
 
 Labels prefixed with `grafana_` are reserved by Grafana for special use. You can disable reserved labels via the [`unified_alerting.reserved_labels`](/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana#unified_alertingreserved_labels) option.

--- a/docs/sources/alerting/fundamentals/notifications/group-alert-notifications.md
+++ b/docs/sources/alerting/fundamentals/notifications/group-alert-notifications.md
@@ -105,15 +105,15 @@ Consider a notification policy that:
 - Groups notifications by the `team` label—one group for each distinct `team`.
 - Sets the Group wait timer to `30s`.
 
-| Time               | Incoming alert instance         | Notification policy group | Number of instances |                                                                         |
-| ------------------ | ------------------------------- | ------------------------- | ------------------- | ----------------------------------------------------------------------- |
-| 00:00              | `alert_name=f1` `team=frontend` | `frontend`                | 1                   | Starts the group wait timer of the `frontend` group.                    |
-| 00:10              | `alert_name=f2` `team=frontend` | `frontend`                | 2                   |                                                                         |
-| 00:20              | `alert_name=b1` `team=backend`  | `backend`                 | 1                   | Starts the group wait timer of the `backend` group.                     |
-| 00:30<sup>\*</sup> |                                 | `frontend`                | 2                   | Group wait elapsed. <br/> Send initial notification reporting 2 alerts. |
-| 00:35              | `alert_name=b2` `team=backend`  | `backend`                 | 2                   |                                                                         |
-| 00:40              | `alert_name=b3` `team=backend`  | `backend`                 | 3                   |                                                                         |
-| 00:50<sup>\*</sup> |                                 | `backend`                 | 3                   | Group wait elapsed. <br/> Send initial notification reporting 3 alerts. |
+| Time               | Incoming alert instance        | Notification policy group | Number of instances |                                                                         |
+| ------------------ | ------------------------------ | ------------------------- | ------------------- | ----------------------------------------------------------------------- |
+| 00:00              | `alertname=f1` `team=frontend` | `frontend`                | 1                   | Starts the group wait timer of the `frontend` group.                    |
+| 00:10              | `alertname=f2` `team=frontend` | `frontend`                | 2                   |                                                                         |
+| 00:20              | `alertname=b1` `team=backend`  | `backend`                 | 1                   | Starts the group wait timer of the `backend` group.                     |
+| 00:30<sup>\*</sup> |                                | `frontend`                | 2                   | Group wait elapsed. <br/> Send initial notification reporting 2 alerts. |
+| 00:35              | `alertname=b2` `team=backend`  | `backend`                 | 2                   |                                                                         |
+| 00:40              | `alertname=b3` `team=backend`  | `backend`                 | 3                   |                                                                         |
+| 00:50<sup>\*</sup> |                                | `backend`                 | 3                   | Group wait elapsed. <br/> Send initial notification reporting 3 alerts. |
 
 ### Group interval
 
@@ -134,15 +134,15 @@ Here are the related excerpts from the previous example:
 
 And below is the continuation of the example setting the Group interval timer to 5 minutes:
 
-| Time               | Incoming alert instance         | Notification policy group | Number of instances |                                                                                                |
-| ------------------ | ------------------------------- | ------------------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
-| 01:30              | `alert_name=f3` `team=frontend` | `frontend`                | 3                   |                                                                                                |
-| 02:30              | `alert_name=f4` `team=frontend` | `frontend`                | 4                   |                                                                                                |
-| 05:30<sup>\*</sup> |                                 | `frontend`                | 4                   | Group interval elapsed and resets timer. <br/> Send one notification reporting 4 alerts.       |
-| 05:50<sup>\*</sup> |                                 | `backend`                 | 3                   | Group interval elapsed and resets timer. <br/> No group changes, and do not send notification. |
-| 08:00              | `alert_name=f4` `team=backend`  | `backend`                 | 4                   |                                                                                                |
-| 10:30<sup>\*</sup> |                                 | `frontend`                | 4                   | Group interval elapsed and resets timer. <br/> No group changes, and do not send notification. |
-| 10:50<sup>\*</sup> |                                 | `backend`                 | 4                   | Group interval elapsed and resets timer. <br/> Send one notification reporting 4 alerts.       |
+| Time               | Incoming alert instance        | Notification policy group | Number of instances |                                                                                                |
+| ------------------ | ------------------------------ | ------------------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
+| 01:30              | `alertname=f3` `team=frontend` | `frontend`                | 3                   |                                                                                                |
+| 02:30              | `alertname=f4` `team=frontend` | `frontend`                | 4                   |                                                                                                |
+| 05:30<sup>\*</sup> |                                | `frontend`                | 4                   | Group interval elapsed and resets timer. <br/> Send one notification reporting 4 alerts.       |
+| 05:50<sup>\*</sup> |                                | `backend`                 | 3                   | Group interval elapsed and resets timer. <br/> No group changes, and do not send notification. |
+| 08:00              | `alertname=f4` `team=backend`  | `backend`                 | 4                   |                                                                                                |
+| 10:30<sup>\*</sup> |                                | `frontend`                | 4                   | Group interval elapsed and resets timer. <br/> No group changes, and do not send notification. |
+| 10:50<sup>\*</sup> |                                | `backend`                 | 4                   | Group interval elapsed and resets timer. <br/> Send one notification reporting 4 alerts.       |
 
 **How it works**
 


### PR DESCRIPTION
Correct label name, use `alertname` instead of `alert_name`.
