### PR TITLE
ScrollContainer: Use `ScrollContainer` in some dashboard components

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -8,7 +8,7 @@ import { LegendPlacement } from '@grafana/schema';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { getFocusStyles } from '../../themes/mixins';
-import { CustomScrollbar } from '../CustomScrollbar/CustomScrollbar';
+import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
 
 /**
  * @beta
@@ -98,7 +98,7 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
     <div style={containerStyle}>
       <div className={styles.viz}>{size && children(size.width, size.height)}</div>
       <div style={legendStyle} ref={legendRef}>
-        <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
+        <ScrollContainer>{legend}</ScrollContainer>
       </div>
     </div>
   );

--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.tsx
@@ -23,6 +23,7 @@ import {
   sceneGraph,
 } from '@grafana/scenes';
 import { Button, Card, FilterInput, RadioButtonGroup, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { Trans } from 'app/core/internationalization';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
 import { getPanelPluginNotFound } from 'app/features/panel/components/PanelPluginError';
@@ -175,9 +176,9 @@ export class PanelOptionsPane extends SceneObjectBase<PanelOptionsPaneState> {
                 </AngularDeprecationPluginNotice>
               </div>
             )}
-            <div className={styles.listOfOptions}>
+            <ScrollContainer>
               <PanelOptions panel={panel} searchQuery={searchQuery} listMode={listMode} data={data} />
-            </div>
+            </ScrollContainer>
           </>
         )}
         {isVizPickerOpen && (
@@ -200,12 +201,6 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'column',
       padding: theme.spacing(2, 1),
       gap: theme.spacing(2),
-    }),
-    listOfOptions: css({
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: '1',
-      overflow: 'auto',
     }),
     searchOptions: css({
       minHeight: theme.spacing(4),

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -7,7 +7,8 @@ import { GrafanaTheme2, PanelData, SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
-import { Button, CustomScrollbar, Field, FilterInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, Field, FilterInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { LS_VISUALIZATION_SELECT_TAB_KEY } from 'app/core/constants';
 import { VisualizationSelectPaneTab } from 'app/features/dashboard/components/PanelEditor/types';
 import { VisualizationSuggestions } from 'app/features/panel/components/VizTypePicker/VisualizationSuggestions';
@@ -100,7 +101,7 @@ export function PanelVizTypePicker({ panel, data, onChange, onClose }: Props) {
       <Field className={styles.customFieldMargin}>
         <RadioButtonGroup options={radioOptions} value={listMode} onChange={handleListModeChange} fullWidth />
       </Field>
-      <CustomScrollbar>
+      <ScrollContainer>
         {listMode === VisualizationSelectPaneTab.Visualizations && (
           <VizTypePicker
             pluginId={panel.state.pluginId}
@@ -118,7 +119,7 @@ export function PanelVizTypePicker({ panel, data, onChange, onClose }: Props) {
             data={data}
           />
         )}
-      </CustomScrollbar>
+      </ScrollContainer>
     </div>
   );
 }

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -130,11 +130,9 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
           </div>
         )}
       </div>
-      <div className={styles.scrollWrapper}>
-        <ScrollContainer minHeight="100%">
-          <div className={styles.mainBox}>{mainBoxElements}</div>
-        </ScrollContainer>
-      </div>
+      <ScrollContainer minHeight="100%">
+        <div className={styles.mainBox}>{mainBoxElements}</div>
+      </ScrollContainer>
     </div>
   );
 };
@@ -207,10 +205,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   searchHits: css({
     padding: theme.spacing(1, 1, 0, 1),
-  }),
-  scrollWrapper: css({
-    flexGrow: 1,
-    minHeight: 0,
   }),
   searchNotice: css({
     fontSize: theme.typography.size.sm,

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -130,7 +130,7 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
           </div>
         )}
       </div>
-      <ScrollContainer minHeight="100%">
+      <ScrollContainer>
         <div className={styles.mainBox}>{mainBoxElements}</div>
       </ScrollContainer>
     </div>

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { CustomScrollbar, FilterInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { FilterInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { AngularDeprecationPluginNotice } from 'app/features/plugins/angularDeprecation/AngularDeprecationPluginNotice';
 
 import { isPanelModelLibraryPanel } from '../../../library-panels/guard';
@@ -130,9 +131,9 @@ export const OptionsPaneOptions = (props: OptionPaneRenderProps) => {
         )}
       </div>
       <div className={styles.scrollWrapper}>
-        <CustomScrollbar autoHeightMin="100%">
+        <ScrollContainer minHeight="100%">
           <div className={styles.mainBox}>{mainBoxElements}</div>
-        </CustomScrollbar>
+        </ScrollContainer>
       </div>
     </div>
   );

--- a/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx
@@ -4,8 +4,9 @@ import { useLocalStorage } from 'react-use';
 
 import { GrafanaTheme2, PanelData, SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Button, CustomScrollbar, FilterInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, FilterInput, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 import { Field } from '@grafana/ui/src/components/Forms/Field';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { LS_VISUALIZATION_SELECT_TAB_KEY } from 'app/core/constants';
 import { PanelLibraryOptionsGroup } from 'app/features/library-panels/components/PanelLibraryOptionsGroup/PanelLibraryOptionsGroup';
 import { VisualizationSuggestions } from 'app/features/panel/components/VizTypePicker/VisualizationSuggestions';
@@ -93,7 +94,7 @@ export const VisualizationSelectPane = ({ panel, data }: Props) => {
         </Field>
       </div>
       <div className={styles.scrollWrapper}>
-        <CustomScrollbar autoHeightMin="100%">
+        <ScrollContainer>
           <div className={styles.scrollContent}>
             {listMode === VisualizationSelectPaneTab.Visualizations && (
               <VizTypePicker pluginId={plugin.meta.id} onChange={onVizChange} searchQuery={searchQuery} />
@@ -105,7 +106,7 @@ export const VisualizationSelectPane = ({ panel, data }: Props) => {
               <PanelLibraryOptionsGroup searchQuery={searchQuery} panel={panel} key="Panel Library" />
             )}
           </div>
-        </CustomScrollbar>
+        </ScrollContainer>
       </div>
     </div>
   );

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx
@@ -1,5 +1,5 @@
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, createRef, RefObject } from 'react';
 import * as React from 'react';
 import { Unsubscribable } from 'rxjs';
 
@@ -13,16 +13,8 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
-import {
-  Button,
-  ConfirmModal,
-  Container,
-  CustomScrollbar,
-  Themeable,
-  withTheme,
-  IconButton,
-  ButtonGroup,
-} from '@grafana/ui';
+import { Button, ConfirmModal, Container, Themeable, withTheme, IconButton, ButtonGroup } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import config from 'app/core/config';
 import { EmptyTransformationsMessage } from 'app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage';
 
@@ -60,6 +52,7 @@ interface State {
 
 class UnThemedTransformationsEditor extends React.PureComponent<TransformationsEditorProps, State> {
   subscription?: Unsubscribable;
+  ref: RefObject<HTMLDivElement>;
 
   constructor(props: TransformationsEditorProps) {
     super(props);
@@ -78,6 +71,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
       selectedFilter: VIEW_ALL_VALUE,
       showIllustrations: true,
     };
+    this.ref = createRef<HTMLDivElement>();
   }
 
   onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -151,6 +145,10 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
 
         this.setState({ scrollTop: currentShowPicker ? kindOfZero : Number.MAX_SAFE_INTEGER });
       }
+    }
+
+    if (prevState.scrollTop !== this.state.scrollTop) {
+      this.ref.current?.scrollTo({ top: this.state.scrollTop });
     }
   }
 
@@ -459,7 +457,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
     }
 
     return (
-      <CustomScrollbar scrollTop={this.state.scrollTop} autoHeightMin="100%">
+      <ScrollContainer ref={this.ref} minHeight="100%">
         <Container padding="lg">
           <div data-testid={selectors.components.TransformTab.content}>
             {!hasTransforms && config.featureToggles.transformationsRedesign && this.renderEmptyMessage()}
@@ -467,7 +465,7 @@ class UnThemedTransformationsEditor extends React.PureComponent<TransformationsE
             {this.renderTransformsPicker()}
           </div>
         </Container>
-      </CustomScrollbar>
+      </ScrollContainer>
     );
   }
 }

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -5,15 +5,8 @@ import { useMemo, useState } from 'react';
 import { DataSourceInstanceSettings, DataSourceRef, GrafanaTheme2 } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import {
-  Modal,
-  FileDropzone,
-  FileDropzoneDefaultChildren,
-  CustomScrollbar,
-  useStyles2,
-  Input,
-  Icon,
-} from '@grafana/ui';
+import { Modal, FileDropzone, FileDropzoneDefaultChildren, useStyles2, Input, Icon } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { t, Trans } from 'app/core/internationalization';
 import * as DFImport from 'app/features/dataframe-import';
 import { GrafanaQuery } from 'app/plugins/datasource/grafana/types';
@@ -166,7 +159,7 @@ export function DataSourceModal({
             reportSearchUsageOnce();
           }}
         />
-        <CustomScrollbar>
+        <ScrollContainer>
           <DataSourceList
             onChange={onChangeDataSource}
             current={current}
@@ -189,13 +182,15 @@ export function DataSourceModal({
             mixed={mixed}
           />
           <BuiltInList className={styles.appendBuiltInDataSourcesList} />
-        </CustomScrollbar>
+        </ScrollContainer>
       </div>
       <div className={styles.rightColumn}>
         <div className={styles.builtInDataSources}>
-          <CustomScrollbar className={styles.builtInDataSourcesList}>
-            <BuiltInList />
-          </CustomScrollbar>
+          <div className={styles.builtInDataSourcesList}>
+            <ScrollContainer>
+              <BuiltInList />
+            </ScrollContainer>
+          </div>
           {uploadFile && config.featureToggles.editPanelCSVDragAndDrop && (
             <FileDropzone
               readAs="readAsArrayBuffer"

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -12,7 +12,8 @@ import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { DataQuery, DataSourceRef } from '@grafana/schema';
-import { Button, CustomScrollbar, Icon, Input, ModalsController, Portal, useStyles2 } from '@grafana/ui';
+import { Button, Icon, Input, ModalsController, Portal, useStyles2 } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import config from 'app/core/config';
 import { Trans } from 'app/core/internationalization';
 import { useKeyNavigationListener } from 'app/features/search/hooks/useSearchKeyboardSelection';
@@ -347,7 +348,7 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
 
   return (
     <div style={props.style} ref={ref} className={styles.container}>
-      <CustomScrollbar>
+      <ScrollContainer showScrollIndicators>
         <DataSourceList
           {...props}
           enableKeyboardNavigation
@@ -361,7 +362,7 @@ const PickerContent = React.forwardRef<HTMLDivElement, PickerContentProps>((prop
             })
           }
         ></DataSourceList>
-      </CustomScrollbar>
+      </ScrollContainer>
       <FocusScope>
         <Footer
           {...props}

--- a/public/app/features/scopes/internal/ScopesDashboardsScene.tsx
+++ b/public/app/features/scopes/internal/ScopesDashboardsScene.tsx
@@ -4,7 +4,8 @@ import { finalize, from, Subscription } from 'rxjs';
 
 import { GrafanaTheme2, ScopeDashboardBinding } from '@grafana/data';
 import { SceneComponentProps, SceneObjectBase, SceneObjectRef, SceneObjectState } from '@grafana/scenes';
-import { Button, CustomScrollbar, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { Button, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { t, Trans } from 'app/core/internationalization';
 
 import { ScopesDashboardsTree } from './ScopesDashboardsTree';
@@ -248,13 +249,13 @@ export function ScopesDashboardsSceneRenderer({ model }: SceneComponentProps<Sco
           data-testid="scopes-dashboards-loading"
         />
       ) : filteredFolders[''] ? (
-        <CustomScrollbar>
+        <ScrollContainer>
           <ScopesDashboardsTree
             folders={filteredFolders}
             folderPath={['']}
             onFolderUpdate={(path, isExpanded) => model.updateFolder(path, isExpanded)}
           />
-        </CustomScrollbar>
+        </ScrollContainer>
       ) : (
         <p className={styles.noResultsContainer} data-testid="scopes-dashboards-notFoundForFilter">
           <Trans i18nKey="scopes.dashboards.noResultsForFilter">No results found for your query</Trans>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- follow on from https://github.com/grafana/grafana/pull/94689
- replaces `CustomScrollbar` with `ScrollContainer` in some dashboard related components

<windows screenshots incoming...>

|  | before | after |
| --- | --- | --- |
| `VizLayout` | ![image](https://github.com/user-attachments/assets/511f1b24-65c1-4dc5-845c-ddb054816518) | ![image](https://github.com/user-attachments/assets/5326f020-0b20-4e3b-8e81-116d00f1e015) |
| `PanelOptionsPane` | ![image](https://github.com/user-attachments/assets/ff728d8f-e687-4c6a-9a5c-cc37e832b2d0) | ![image](https://github.com/user-attachments/assets/b8edd290-0864-424e-84e2-3f5305b983d4) |
| `PanelVizTypePicker` | ![image](https://github.com/user-attachments/assets/365cee7b-31e3-4e20-92b8-89cea13e0d95) | ![image](https://github.com/user-attachments/assets/6a764879-f7e2-4405-8b1f-468c542fa847) |
| `OptionsPaneOptions` | ![image](https://github.com/user-attachments/assets/aeaf6ff3-a223-48f4-b264-28e1c5532b09) | ![image](https://github.com/user-attachments/assets/c04d5c9a-b7f7-4f81-bfdd-95bd9cd2dcf4) |
| `VisualizationSelectPane` | ![image](https://github.com/user-attachments/assets/62f4362b-6514-4ccf-848a-ef2dcd46fc15) | ![image](https://github.com/user-attachments/assets/72f5a0b8-7423-4730-9c31-9ca2384577dc) |
| `TransformationsEditor` | ![image](https://github.com/user-attachments/assets/5b54901c-2ad9-4347-a47e-d6c906734b27) | ![image](https://github.com/user-attachments/assets/fa921288-fad9-4e29-bff8-4dd5beb3fcea) |
| `DataSourceModal` | ![image](https://github.com/user-attachments/assets/8fbfac55-2e85-469a-a4c7-48608c1faeaf) | ![image](https://github.com/user-attachments/assets/72c54b54-e59f-4fb0-b017-015ce44cb851) |
| `DataSourcePicker` | ![image](https://github.com/user-attachments/assets/4a4affa7-b698-4f2b-be3d-062863f0e812) | ![image](https://github.com/user-attachments/assets/dc4eb6f7-1b8c-4b05-82aa-80e32e6b7d0c) |

**Why do we need this feature?**

- `ScrollContainer` uses native scrollbars 🥳 
  - better a11y
  - consistent look with native platform scrollbars 

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
