### PR TITLE
RemoteCache: Refactor remote cache settings

### DIFF
--- a/pkg/infra/remotecache/memcached_storage.go
+++ b/pkg/infra/remotecache/memcached_storage.go
@@ -18,7 +18,7 @@ type memcachedStorage struct {
 	c *memcache.Client
 }
 
-func newMemcachedStorage(opts *setting.RemoteCacheOptions) *memcachedStorage {
+func newMemcachedStorage(opts *setting.RemoteCacheSettings) *memcachedStorage {
 	return &memcachedStorage{
 		c: memcache.New(opts.ConnStr),
 	}

--- a/pkg/infra/remotecache/memcached_storage_integration_test.go
+++ b/pkg/infra/remotecache/memcached_storage_integration_test.go
@@ -17,7 +17,7 @@ func TestIntegrationMemcachedCacheStorage(t *testing.T) {
 		t.Skip("No Memcached hosts provided")
 	}
 
-	opts := &setting.RemoteCacheOptions{Name: memcachedCacheType, ConnStr: u}
+	opts := &setting.RemoteCacheSettings{Name: memcachedCacheType, ConnStr: u}
 	client := createTestClient(t, opts, nil)
 	runTestsForClient(t, client)
 }

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -78,7 +78,7 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 	return options, nil
 }
 
-func newRedisStorage(opts *setting.RemoteCacheOptions) (*redisStorage, error) {
+func newRedisStorage(opts *setting.RemoteCacheSettings) (*redisStorage, error) {
 	opt, err := parseRedisConnStr(opts.ConnStr)
 	if err != nil {
 		return nil, err

--- a/pkg/infra/remotecache/redis_storage_integration_test.go
+++ b/pkg/infra/remotecache/redis_storage_integration_test.go
@@ -34,7 +34,7 @@ func TestIntegrationRedisCacheStorage(t *testing.T) {
 		b.WriteString(fmt.Sprintf(",db=%d", db))
 	}
 
-	opts := &setting.RemoteCacheOptions{Name: redisCacheType, ConnStr: b.String()}
+	opts := &setting.RemoteCacheSettings{Name: redisCacheType, ConnStr: b.String()}
 	client := createTestClient(t, opts, nil)
 	runTestsForClient(t, client)
 }

--- a/pkg/infra/remotecache/remotecache.go
+++ b/pkg/infra/remotecache/remotecache.go
@@ -109,7 +109,7 @@ func (ds *RemoteCache) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func createClient(opts *setting.RemoteCacheOptions, sqlstore db.DB, secretsService secrets.Service) (cache CacheStorage, err error) {
+func createClient(opts *setting.RemoteCacheSettings, sqlstore db.DB, secretsService secrets.Service) (cache CacheStorage, err error) {
 	switch opts.Name {
 	case redisCacheType:
 		cache, err = newRedisStorage(opts)

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func createTestClient(t *testing.T, opts *setting.RemoteCacheOptions, sqlstore db.DB) CacheStorage {
+func createTestClient(t *testing.T, opts *setting.RemoteCacheSettings, sqlstore db.DB) CacheStorage {
 	t.Helper()
 
 	cfg := &setting.Cfg{
@@ -45,7 +45,7 @@ func TestCachedBasedOnConfig(t *testing.T) {
 }
 
 func TestInvalidCacheTypeReturnsError(t *testing.T) {
-	_, err := createClient(&setting.RemoteCacheOptions{Name: "invalid"}, nil, nil)
+	_, err := createClient(&setting.RemoteCacheSettings{Name: "invalid"}, nil, nil)
 	assert.Equal(t, err, ErrInvalidCacheType)
 }
 
@@ -94,7 +94,7 @@ func TestCollectUsageStats(t *testing.T) {
 		"stats.remote_cache.encrypt_enabled.count": 1,
 	}
 	cfg := setting.NewCfg()
-	cfg.RemoteCacheOptions = &setting.RemoteCacheOptions{Name: redisCacheType, Encryption: true}
+	cfg.RemoteCacheOptions = &setting.RemoteCacheSettings{Name: redisCacheType, Encryption: true}
 
 	remoteCache := &RemoteCache{
 		Cfg: cfg,

--- a/pkg/infra/remotecache/testing.go
+++ b/pkg/infra/remotecache/testing.go
@@ -15,7 +15,7 @@ import (
 func NewFakeStore(t *testing.T) *RemoteCache {
 	t.Helper()
 
-	opts := &setting.RemoteCacheOptions{
+	opts := &setting.RemoteCacheSettings{
 		Name:    "database",
 		ConnStr: "",
 	}

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -145,7 +145,7 @@ func TestCollectingUsageStats(t *testing.T) {
 		AuthProxy:            setting.AuthProxySettings{Enabled: true},
 		Packaging:            "deb",
 		ReportingDistributor: "hosted-grafana",
-		RemoteCacheOptions: &setting.RemoteCacheOptions{
+		RemoteCacheOptions: &setting.RemoteCacheSettings{
 			Name: "database",
 		},
 	}, sqlStore, statsService,

--- a/pkg/services/login/authinfoimpl/service.go
+++ b/pkg/services/login/authinfoimpl/service.go
@@ -47,7 +47,7 @@ func (s *Service) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery
 
 	authInfo, err := s.getAuthInfoFromCache(ctx, query)
 	if err != nil && !errors.Is(err, remotecache.ErrCacheItemNotFound) {
-		s.logger.Error("failed to retrieve auth info from cache", "error", err)
+		s.logger.Warn("failed to retrieve auth info from cache", "error", err)
 	} else if authInfo != nil {
 		return authInfo, nil
 	}

--- a/pkg/services/login/authinfoimpl/service.go
+++ b/pkg/services/login/authinfoimpl/service.go
@@ -59,7 +59,7 @@ func (s *Service) GetAuthInfo(ctx context.Context, query *login.GetAuthInfoQuery
 
 	err = s.setAuthInfoInCache(ctx, query, authInfo)
 	if err != nil {
-		s.logger.Error("failed to set auth info in cache", "error", err)
+		s.logger.Warn("failed to set auth info in cache", "error", err)
 	} else {
 		s.logger.Debug("auth info set in cache", "cacheKey", generateCacheKey(query))
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -291,7 +291,7 @@ type Cfg struct {
 	DataProxyUserAgent             string
 
 	// DistributedCache
-	RemoteCacheOptions *RemoteCacheOptions
+	RemoteCacheOptions *RemoteCacheSettings
 
 	ViewersCanEdit  bool
 	EditorsCanAdmin bool
@@ -1296,19 +1296,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	enterprise := iniFile.Section("enterprise")
 	cfg.EnterpriseLicensePath = valueAsString(enterprise, "license_path", filepath.Join(cfg.DataPath, "license.jwt"))
 
-	cacheServer := iniFile.Section("remote_cache")
-	dbName := valueAsString(cacheServer, "type", "database")
-	connStr := valueAsString(cacheServer, "connstr", "")
-	prefix := valueAsString(cacheServer, "prefix", "")
-	encryption := cacheServer.Key("encryption").MustBool(false)
-
-	cfg.RemoteCacheOptions = &RemoteCacheOptions{
-		Name:       dbName,
-		ConnStr:    connStr,
-		Prefix:     prefix,
-		Encryption: encryption,
-	}
-
 	geomapSection := iniFile.Section("geomap")
 	basemapJSON := valueAsString(geomapSection, "default_baselayer_config", "")
 	if basemapJSON != "" {
@@ -1322,6 +1309,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	}
 	cfg.GeomapEnableCustomBaseLayers = geomapSection.Key("enable_custom_baselayers").MustBool(true)
 
+	cfg.readRemoteCacheSettings()
 	cfg.readDateFormats()
 	cfg.readGrafanaJavascriptAgentConfig()
 
@@ -1352,13 +1340,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 
 func valueAsString(section *ini.Section, keyName string, defaultValue string) string {
 	return section.Key(keyName).MustString(defaultValue)
-}
-
-type RemoteCacheOptions struct {
-	Name       string
-	ConnStr    string
-	Prefix     string
-	Encryption bool
 }
 
 func (cfg *Cfg) readSAMLConfig() {

--- a/pkg/setting/setting_remote_cache.go
+++ b/pkg/setting/setting_remote_cache.go
@@ -1,0 +1,23 @@
+package setting
+
+type RemoteCacheSettings struct {
+	Name       string
+	ConnStr    string
+	Prefix     string
+	Encryption bool
+}
+
+func (cfg *Cfg) readRemoteCacheSettings() {
+	cacheServer := cfg.Raw.Section("remote_cache")
+	dbName := valueAsString(cacheServer, "type", "database")
+	connStr := valueAsString(cacheServer, "connstr", "")
+	prefix := valueAsString(cacheServer, "prefix", "")
+	encryption := cacheServer.Key("encryption").MustBool(false)
+
+	cfg.RemoteCacheOptions = &RemoteCacheSettings{
+		Name:       dbName,
+		ConnStr:    connStr,
+		Prefix:     prefix,
+		Encryption: encryption,
+	}
+}


### PR DESCRIPTION
Split from https://github.com/grafana/grafana/pull/92353 to ease review

This pull request includes several changes to refactor the `RemoteCacheOptions` type to `RemoteCacheSettings` across various files. The primary goal is to improve code clarity and maintainability by renaming the type and updating its usage throughout the codebase.

Key changes include:

### Type Refactoring:
* Renamed `RemoteCacheOptions` to `RemoteCacheSettings` in the `setting` package and updated all instances where it is used. [[1]](diffhunk://#diff-a48756a0913034d1d0ba7eaa9e0b444b145ffd3ac9e64e199be8f18ff7d3bc48L21-R21) [[2]](diffhunk://#diff-1817a57f3d1fe8c4a2c9adcf1f1e19084dbfbfd30f6f52c351ca78b586fe4b3fR1-R23)

### Function and Method Updates:
* Updated function signatures and implementations to use `RemoteCacheSettings` instead of `RemoteCacheOptions` in `memcached_storage.go`, `redis_storage.go`, and `remotecache.go`. [[1]](diffhunk://#diff-9a3072bb69bad885069a366ea24b6f09343165a5ab667b7bc3457fec8fcb4f7bL20-R20) [[2]](diffhunk://#diff-9dcc536e0c45561b1dc9535376c451363a4b72d2d93aa6dae23806eb48138080L81-R81) [[3]](diffhunk://#diff-463ee7d3bf63f22e7a70950a3b13509ee116910af6fb3678667bf514eaf1f45fL112-R112)

### Test Updates:
* Modified test functions to reflect the new type name in `memcached_storage_integration_test.go`, `redis_storage_integration_test.go`, and `remotecache_test.go`. [[1]](diffhunk://#diff-9a3072bb69bad885069a366ea24b6f09343165a5ab667b7bc3457fec8fcb4f7bL20-R20) [[2]](diffhunk://#diff-667c888dc0457bb7078b721c9798117ccc9deadd9b8e462ebc0209bd14774444L37-R37) [[3]](diffhunk://#diff-1134a7d120d66abe9819ac2e0a034a37f74e1a6d7dfcb52a938682661776680fL24-R24) [[4]](diffhunk://#diff-1134a7d120d66abe9819ac2e0a034a37f74e1a6d7dfcb52a938682661776680fL48-R48) [[5]](diffhunk://#diff-1134a7d120d66abe9819ac2e0a034a37f74e1a6d7dfcb52a938682661776680fL97-R97)

### Configuration Parsing:
* Adjusted the configuration parsing logic in `setting.go` to use `RemoteCacheSettings` and moved related parsing code to a new file `setting_remote_cache.go`. [[1]](diffhunk://#diff-dc899ea32f268c53e94f76ae5ff45a239dde212d815e715fc3804ea4dfe87a75L294-R294) [[2]](diffhunk://#diff-dc899ea32f268c53e94f76ae5ff45a239dde212d815e715fc3804ea4dfe87a75L1299-L1311) [[3]](diffhunk://#diff-dc899ea32f268c53e94f76ae5ff45a239dde212d815e715fc3804ea4dfe87a75R1312) [[4]](diffhunk://#diff-dc899ea32f268c53e94f76ae5ff45a239dde212d815e715fc3804ea4dfe87a75L1357-L1363)

### Test Configuration:
* Updated test configurations to use `RemoteCacheSettings` in `service_test.go` and `testing.go`. [[1]](diffhunk://#diff-1964191f454deb9a09fb5c6811e41cc60fc72907da6c865f2dc884b0f8ffed53L148-R148) [[2]](diffhunk://#diff-f340583fbd559915c46b0022f37d6429738e90c498917df7ccbcf2933116551eL18-R18)