### PR TITLE
IAM - Fix panic from accessing nil serviceAccount

### DIFF
--- a/pkg/services/serviceaccounts/serviceaccounts.go
+++ b/pkg/services/serviceaccounts/serviceaccounts.go
@@ -69,6 +69,9 @@ func UIDToIDHandler(saService ServiceAccountRetriever) func(ctx context.Context,
 			OrgID: orgID,
 			UID:   resourceID,
 		})
+		if err != nil {
+			return "", err
+		}
 		return strconv.FormatInt(serviceAccount.Id, 10), err
 	}
 }


### PR DESCRIPTION
The change for resolving service accounts by UID or ID was missing an error check. This can cause a panic if there was an error retrieving the SA.

Relevant: https://github.com/grafana/grafana/pull/95423