### PR TITLE
CloudMigrations: increase size of resource_uid column

### DIFF
--- a/pkg/services/sqlstore/migrations/cloud_migrations.go
+++ b/pkg/services/sqlstore/migrations/cloud_migrations.go
@@ -176,4 +176,9 @@ func addCloudMigrationsMigrations(mg *Migrator) {
 		Type:     DB_Text,
 		Nullable: true,
 	}))
+
+	mg.AddMigration("increase resource_uid column length to 255", NewRawSQLMigration("").
+		Mysql("ALTER TABLE cloud_migration_resource MODIFY resource_uid NVARCHAR(255);").
+		Postgres("ALTER TABLE cloud_migration_resource ALTER COLUMN resource_uid TYPE NVARCHAR(255);"))
+
 }

--- a/pkg/services/sqlstore/migrations/cloud_migrations.go
+++ b/pkg/services/sqlstore/migrations/cloud_migrations.go
@@ -181,5 +181,5 @@ func addCloudMigrationsMigrations(mg *Migrator) {
 	// -- not needed in sqlite as type is TEXT with length defined by SQLITE_MAX_LENGTH preprocessor macro
 	mg.AddMigration("increase resource_uid column length", NewRawSQLMigration("").
 		Mysql("ALTER TABLE cloud_migration_resource MODIFY resource_uid NVARCHAR(255);").
-		Postgres("ALTER TABLE cloud_migration_resource ALTER COLUMN resource_uid TYPE NVARCHAR(255);"))
+		Postgres("ALTER TABLE cloud_migration_resource ALTER COLUMN resource_uid TYPE VARCHAR(255);"))
 }

--- a/pkg/services/sqlstore/migrations/cloud_migrations.go
+++ b/pkg/services/sqlstore/migrations/cloud_migrations.go
@@ -180,5 +180,4 @@ func addCloudMigrationsMigrations(mg *Migrator) {
 	mg.AddMigration("increase resource_uid column length", NewRawSQLMigration("").
 		Mysql("ALTER TABLE cloud_migration_resource MODIFY resource_uid NVARCHAR(255);").
 		Postgres("ALTER TABLE cloud_migration_resource ALTER COLUMN resource_uid TYPE NVARCHAR(255);"))
-
 }

--- a/pkg/services/sqlstore/migrations/cloud_migrations.go
+++ b/pkg/services/sqlstore/migrations/cloud_migrations.go
@@ -177,7 +177,7 @@ func addCloudMigrationsMigrations(mg *Migrator) {
 		Nullable: true,
 	}))
 
-	mg.AddMigration("increase resource_uid column length to 255", NewRawSQLMigration("").
+	mg.AddMigration("increase resource_uid column length", NewRawSQLMigration("").
 		Mysql("ALTER TABLE cloud_migration_resource MODIFY resource_uid NVARCHAR(255);").
 		Postgres("ALTER TABLE cloud_migration_resource ALTER COLUMN resource_uid TYPE NVARCHAR(255);"))
 

--- a/pkg/services/sqlstore/migrations/cloud_migrations.go
+++ b/pkg/services/sqlstore/migrations/cloud_migrations.go
@@ -177,6 +177,8 @@ func addCloudMigrationsMigrations(mg *Migrator) {
 		Nullable: true,
 	}))
 
+	// -- increase the length of resource_uid column
+	// -- not needed in sqlite as type is TEXT with length defined by SQLITE_MAX_LENGTH preprocessor macro
 	mg.AddMigration("increase resource_uid column length", NewRawSQLMigration("").
 		Mysql("ALTER TABLE cloud_migration_resource MODIFY resource_uid NVARCHAR(255);").
 		Postgres("ALTER TABLE cloud_migration_resource ALTER COLUMN resource_uid TYPE NVARCHAR(255);"))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Increase the size of the `resource_uid` column in the `cloud_migration_resource`. Didn't easily find consistency so chose a default number.

**Why do we need this feature?**

The initial value was arbitrary and while running test migration, noticed there are resources with uids of longer length.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:



Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1077

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
