### PR TITLE
Chore: Add vscode launcher to attach test process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,15 @@
       ]
     },
     {
+      "name": "Attach to Test Process",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "host": "127.0.0.1",
+      "port": 50480,
+      "apiVersion": 2,
+    },
+    {
       "name": "Run API Server (testdata)",
       "type": "go",
       "request": "launch",

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -163,6 +163,13 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 		dir, err := filepath.Abs(rootDir)
 		require.NoError(t, err)
 
+		// When running within an enterprise test, we need to move to the grafana directory
+		if strings.HasSuffix(dir, "grafana-enterprise") {
+			rootDir = filepath.Join(rootDir, "..", "grafana")
+			dir, err = filepath.Abs(rootDir)
+			require.NoError(t, err)
+		}
+
 		exists, err := fs.Exists(filepath.Join(dir, "public", "views"))
 		require.NoError(t, err)
 


### PR DESCRIPTION
**What is this feature?**

Adds a new launch config to attach a manually started dlv process

**Why do we need this feature?**

Help debug enterprise.  See https://github.com/grafana/grafana-enterprise?tab=readme-ov-file#debugging-grafana-enterprise-tests-on-macos-with-visual-studio-code

**Who is this feature for?**

Mostly enterprise devlopers who use vscode
