### PR TITLE
Alerting: Keep state manager cache during cache warm-up

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -193,12 +193,6 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader, instanceRea
 				annotations = make(map[string]string)
 			}
 
-			rulesStates, ok := orgStates[entry.RuleUID]
-			if !ok {
-				rulesStates = &ruleStates{states: make(map[data.Fingerprint]*State)}
-				orgStates[entry.RuleUID] = rulesStates
-			}
-
 			lbs := map[string]string(entry.Labels)
 			cacheID := entry.Labels.Fingerprint()
 			var resultFp data.Fingerprint
@@ -209,7 +203,7 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader, instanceRea
 				}
 				resultFp = data.Fingerprint(fp)
 			}
-			rulesStates.states[cacheID] = &State{
+			state := State{
 				AlertRuleUID:         entry.RuleUID,
 				OrgID:                entry.RuleOrgID,
 				CacheID:              cacheID,
@@ -225,11 +219,11 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader, instanceRea
 				ResolvedAt:           entry.ResolvedAt,
 				LastSentAt:           entry.LastSentAt,
 			}
+			st.cache.getOrAdd(state, st.log)
 			statesCount++
 		}
 	}
 
-	st.cache.setAllStates(states)
 	st.log.Info("State cache has been initialized", "states", statesCount, "duration", time.Since(startTime))
 }
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -137,7 +137,6 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader, instanceRea
 	}
 
 	statesCount := 0
-	states := make(map[int64]map[string]*ruleStates, len(orgIds))
 	for _, orgId := range orgIds {
 		// Get Rules
 		ruleCmd := ngModels.ListAlertRulesQuery{
@@ -167,9 +166,6 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader, instanceRea
 				)
 			}
 		}
-
-		orgStates := make(map[string]*ruleStates, len(ruleByUID))
-		states[orgId] = orgStates
 
 		// Get Instances
 		cmd := ngModels.ListAlertInstancesQuery{


### PR DESCRIPTION
**What is this feature?**
Instead of overwriting the state manager cache during warm-up (called [here](https://github.com/grafana/grafana/blob/2ba1740698c005b2bbd11c475db717ee64451135/pkg/services/ngalert/ngalert.go#L555)), we update the data in the cache if it is not there yet. If the cache already contains a state entry with the same key, we do not overwrite it.

**Why do we need this feature?**

This refactoring allows us to call `Warm` not only during start-up in the future.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-ruler/issues/3549

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
