### PR TITLE
NodeGraph: Use target if in link

### DIFF
--- a/public/app/features/explore/utils/links.ts
+++ b/public/app/features/explore/utils/links.ts
@@ -211,7 +211,7 @@ export const getFieldLinksForExplore = (options: {
           if (!linkModel.title) {
             linkModel.title = getTitleFromHref(linkModel.href);
           }
-          linkModel.target = '_blank';
+          linkModel.target = linkModel.target ?? '_blank';
           return { ...linkModel, variables: variables };
         } else {
           const splitFnWithTracking = (options?: SplitOpenOptions<DataQuery>) => {

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -297,7 +297,7 @@ export class LinkSrv implements LinkService {
     const info: LinkModel<T> = {
       href: locationUtil.assureBaseUrl(href.replace(/\n/g, '')),
       title: link.title ?? '',
-      target: link.targetBlank ? '_blank' : undefined,
+      target: link.targetBlank !== undefined ? (link.targetBlank ? '_blank' : '_self') : undefined,
       origin,
     };
 

--- a/public/app/plugins/panel/nodeGraph/useContextMenu.tsx
+++ b/public/app/plugins/panel/nodeGraph/useContextMenu.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { MouseEvent, useCallback, useState } from 'react';
 import * as React from 'react';
 
-import { DataFrame, Field, GrafanaTheme2, LinkModel } from '@grafana/data';
+import { DataFrame, Field, GrafanaTheme2, LinkModel, LinkTarget } from '@grafana/data';
 import { ContextMenu, MenuGroup, MenuItem, useStyles2 } from '@grafana/ui';
 
 import { Config } from './layout';
@@ -129,7 +129,7 @@ function mapMenuItem<T extends NodeDatum | EdgeDatumLayout>(item: T) {
               }
             : undefined
         }
-        target={'_self'}
+        target={link.target || '_self'}
       />
     );
   };
@@ -140,6 +140,7 @@ type LinkData<T extends NodeDatum | EdgeDatumLayout> = {
   ariaLabel?: string;
   url?: string;
   onClick?: (item: T) => void;
+  target?: LinkTarget;
 };
 
 function getItems(links: LinkModel[]) {
@@ -169,6 +170,7 @@ function getItems(links: LinkModel[]) {
         ariaLabel: link.newTitle || link.l.title,
         url: link.l.href,
         onClick: link.l.onClick,
+        target: link.l.target,
       })),
     };
   });


### PR DESCRIPTION
**What is this feature?**

Links have targets to define if they go to a new tab or not. The node graph wasn't using it, causing a bug.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/13153

**Special notes for your reviewer:**

Node graph panel, use node graph scenario in test datasource. Use field override to create data link, specify it should open in a new tab.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
