### PR TITLE
Selectors: Remove outdated comment

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -487,7 +487,6 @@ export const versionedComponents = {
         '11.0.0': (title: string) => `data-testid Panel editor option pane field input ${title}`,
       },
     },
-    // not sure about the naming *DataPane*
     DataPane: {
       content: {
         '11.1.0': 'data-testid Panel editor data pane content',


### PR DESCRIPTION
**What is this feature?**

This is a bit of a dummie change. I just want to test the automatic flow to see that when selectors are updated, plugin-e2e gets a dependency bump of the e2e-selectors package. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
