### PR TITLE
BarChart: Fix threshold lines rendering for horizontal orientation

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
@@ -58,13 +58,13 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
         color.setAlpha(0.7);
       }
 
-      const isVertical = u.scales.x ? u.scales.x.ori !== ScaleOrientation.Vertical : true;
+      const isHorizontal = u.scales.x!.ori === ScaleOrientation.Horizontal;
       const scaleVal = u.valToPos(step.value, yScaleKey, true);
 
-      let x0 = Math.round(isVertical ? u.bbox.left : scaleVal);
-      let y0 = Math.round(isVertical ? scaleVal : u.bbox.top);
-      let x1 = Math.round(isVertical ? u.bbox.left + u.bbox.width : scaleVal);
-      let y1 = Math.round(isVertical ? scaleVal : u.bbox.top + u.bbox.height);
+      let x0 = Math.round(isHorizontal ? u.bbox.left : scaleVal);
+      let y0 = Math.round(isHorizontal ? scaleVal : u.bbox.top);
+      let x1 = Math.round(isHorizontal ? u.bbox.left + u.bbox.width : scaleVal);
+      let y1 = Math.round(isHorizontal ? scaleVal : u.bbox.top + u.bbox.height);
 
       ctx.beginPath();
       ctx.moveTo(x0, y0);

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
@@ -2,7 +2,7 @@ import tinycolor from 'tinycolor2';
 import uPlot from 'uplot';
 
 import { GrafanaTheme2, Threshold, ThresholdsConfig, ThresholdsMode } from '@grafana/data';
-import { GraphThresholdsStyleConfig, GraphThresholdsStyleMode } from '@grafana/schema';
+import { GraphThresholdsStyleConfig, GraphThresholdsStyleMode, ScaleOrientation } from '@grafana/schema';
 
 import { getGradientRange, scaleGradient } from './gradientFills';
 
@@ -58,10 +58,13 @@ export function getThresholdsDrawHook(options: UPlotThresholdOptions) {
         color.setAlpha(0.7);
       }
 
-      let x0 = Math.round(u.bbox.left);
-      let y0 = Math.round(u.valToPos(step.value, yScaleKey, true));
-      let x1 = Math.round(u.bbox.left + u.bbox.width);
-      let y1 = Math.round(u.valToPos(step.value, yScaleKey, true));
+      const isVertical = u.scales.x ? u.scales.x.ori !== ScaleOrientation.Vertical : true;
+      const scaleVal = u.valToPos(step.value, yScaleKey, true);
+
+      let x0 = Math.round(isVertical ? u.bbox.left : scaleVal);
+      let y0 = Math.round(isVertical ? scaleVal : u.bbox.top);
+      let x1 = Math.round(isVertical ? u.bbox.left + u.bbox.width : scaleVal);
+      let y1 = Math.round(isVertical ? scaleVal : u.bbox.top + u.bbox.height);
 
       ctx.beginPath();
       ctx.moveTo(x0, y0);


### PR DESCRIPTION
**What is this feature?**

There are two main ways to show thresholds in Grafana - either with a line or a filled region in the background. The logic for areas that handled orientations is in `scaleGradient` but lines didn't have an equivalent. Now it does!

**Why do we need this feature?**

So thresholds will display on horizontal bar charts. 

**Which issue(s) does this PR fix?**:

Fixes #73534

**Special notes for your reviewer:**

Random Walk bar chart is all you need to see this. Set the threshold to a value in the data and set the orientation from horizontal to vertical

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
