### PR TITLE
RefreshPicker: Fix styling

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { formatDuration } from 'date-fns';
 import { PureComponent } from 'react';
 
@@ -116,6 +117,10 @@ export class RefreshPicker extends PureComponent<Props> {
         </ToolbarButton>
         {!noIntervalPicker && (
           <ButtonSelect
+            className={css({
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0,
+            })}
             value={selectedValue}
             options={options}
             onChange={this.onChangeSelect}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- explicitly clears border radius for a smooth transition line
  - normally this is handled automatically by being part of `ButtonGroup`
  - but `ButtonSelect` has a wrapping div which prevents the immediate child selector from working
  - rather than try and handle this generically, simplest thing seems to be to explicitly override it in this component 

|  | before | after |
| --- | --- | --- |
| dashboards | ![image](https://github.com/user-attachments/assets/8dbfa8c7-4eb8-4151-80fb-042462f9941b) | ![image](https://github.com/user-attachments/assets/22605446-a11c-4771-a3c5-93469b42e159) |
| explore | ![image](https://github.com/user-attachments/assets/2855d0ea-9c4a-45dd-81d2-e13add2171b0) | ![image](https://github.com/user-attachments/assets/8178074c-0b27-4822-83f6-b51e1e312321) |

**Why do we need this feature?**

- it's been annoying me for ages 😠 

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
