### PR TITLE
Alerting: Use normal setting in case of missing secure setting

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -62,6 +62,7 @@ export function ChannelOptions<R extends ChannelValues>({
         )?.[option.propertyName];
 
         const defaultValue = defaultValues?.settings?.[option.propertyName];
+        const hasSecureProperty = defaultValues.secureSettings?.[option.propertyName];
 
         return (
           <OptionField
@@ -72,7 +73,7 @@ export function ChannelOptions<R extends ChannelValues>({
             key={key}
             error={error}
             pathPrefix={pathPrefix}
-            pathSuffix={option.secure ? 'secureSettings.' : 'settings.'}
+            pathSuffix={option.secure && hasSecureProperty ? 'secureSettings.' : 'settings.'}
             option={option}
             customValidator={customValidators[option.propertyName]}
           />


### PR DESCRIPTION
This PR makes the contact point form use normal settings in case a secure setting is missing.