### PR TITLE
Update images-in-notifications for Alerting

### DIFF
--- a/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
@@ -118,6 +118,7 @@ Grafana supports a wide range of contact points with varied support for images i
 ## Limitations
 
 - This feature is not supported in Mimir or Loki, or when Grafana is configured to send alerts to other Alertmanagers such as the Prometheus Alertmanager.
+- This feature is not supported when using custom modified Templates in the notifications.
 - A number of contact points support at most one image per notification. In this case, just the first image is either uploaded to the receiving service or referenced from cloud storage per notification.
 - When multiple alerts are sent in a single notification a screenshot might be included for each alert. The order the images are shown is random.
 - If uploading screenshots to a cloud storage service such as Amazon S3, Azure Blob Storage or Google Cloud Storage; and accessing screenshots in the bucket requires authentication, logging into a VPN or corporate network; image previews might not work in all instant messaging and communication platforms as some services rewrite URLs to use their CDN.

--- a/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
@@ -118,7 +118,7 @@ Grafana supports a wide range of contact points with varied support for images i
 ## Limitations
 
 - This feature is not supported in Mimir or Loki, or when Grafana is configured to send alerts to other Alertmanagers such as the Prometheus Alertmanager.
-- This feature is not supported when using custom modified templates in notifications.
+- This feature is not supported when using custom templates in email notifications.
 - A number of contact points support at most one image per notification. In this case, just the first image is either uploaded to the receiving service or referenced from cloud storage per notification.
 - When multiple alerts are sent in a single notification a screenshot might be included for each alert. The order the images are shown is random.
 - If uploading screenshots to a cloud storage service such as Amazon S3, Azure Blob Storage or Google Cloud Storage; and accessing screenshots in the bucket requires authentication, logging into a VPN or corporate network; image previews might not work in all instant messaging and communication platforms as some services rewrite URLs to use their CDN.

--- a/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/images-in-notifications.md
@@ -118,7 +118,7 @@ Grafana supports a wide range of contact points with varied support for images i
 ## Limitations
 
 - This feature is not supported in Mimir or Loki, or when Grafana is configured to send alerts to other Alertmanagers such as the Prometheus Alertmanager.
-- This feature is not supported when using custom modified Templates in the notifications.
+- This feature is not supported when using custom modified templates in notifications.
 - A number of contact points support at most one image per notification. In this case, just the first image is either uploaded to the receiving service or referenced from cloud storage per notification.
 - When multiple alerts are sent in a single notification a screenshot might be included for each alert. The order the images are shown is random.
 - If uploading screenshots to a cloud storage service such as Amazon S3, Azure Blob Storage or Google Cloud Storage; and accessing screenshots in the bucket requires authentication, logging into a VPN or corporate network; image previews might not work in all instant messaging and communication platforms as some services rewrite URLs to use their CDN.


### PR DESCRIPTION
Clarification that the images attached to notifications in Grafana, are not supported when using a custom template.
See: https://github.com/grafana/grafana/issues/89874#issuecomment-2426882647 

Please check that:
- [x ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
