### PR TITLE
feat: ignore enterprise clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ __debug_bin*
 /devenv/docker/blocks/saml-enterprise
 # This is the new place of the block, but I leave the previous here for a while
 /devenv/docker/blocks/auth/saml-enterprise
+# Local clone of the repository.
+/grafana-enterprise
 
 /tmp
 tools/phantomjs/phantomjs


### PR DESCRIPTION
This just adds a gitignore for `grafana-enterprise` in the same subdir. See also the Enterprise PR (which will be linked by GH as an event in the comments).