### PR TITLE
Users: Fix potential panics on UID translation

### DIFF
--- a/pkg/services/team/team.go
+++ b/pkg/services/team/team.go
@@ -32,6 +32,10 @@ func UIDToIDHandler(teamService Service) func(ctx context.Context, orgID int64, 
 			return resourceID, nil
 		}
 		team, err := teamService.GetTeamByID(ctx, &GetTeamByIDQuery{UID: resourceID, OrgID: orgID})
+		if err != nil {
+			return "", err
+		}
+
 		return strconv.FormatInt(team.ID, 10), err
 	}
 }

--- a/pkg/services/user/user.go
+++ b/pkg/services/user/user.go
@@ -40,6 +40,10 @@ func UIDToIDHandler(userService Service) func(ctx context.Context, userID string
 		user, err := userService.GetByUID(ctx, &GetUserByUIDQuery{
 			UID: userID,
 		})
+		if err != nil {
+			return "", err
+		}
+
 		return strconv.FormatInt(user.ID, 10), err
 	}
 }


### PR DESCRIPTION
This pull request includes error handling improvements in two service handler functions to ensure proper error propagation when retrieving team and user information by UID.

Error handling improvements:

* [`pkg/services/team/team.go`](diffhunk://#diff-ab58182e1226a18add5ce198ebba36c0401a3c5d358f9ec78076818aa3dcd79eR35-R38): Added error handling in `UIDToIDHandler` to return an error if the `GetTeamByID` query fails.
* [`pkg/services/user/user.go`](diffhunk://#diff-180104cf6c2dbcf5f0dd9f68737b44519f8b40298fa8317db7547a65322bc6ffR43-R46): Added error handling in `UIDToIDHandler` to return an error if the `GetByUID` query fails.