### PR TITLE
Frontend Monitoring: adding ignoreUrls param to EchoSrvTransport

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/EchoSrvTransport.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/EchoSrvTransport.ts
@@ -3,6 +3,14 @@ import { getEchoSrv, EchoEventType, config } from '@grafana/runtime';
 export class EchoSrvTransport extends BaseTransport {
   readonly name: string = 'EchoSrvTransport';
   readonly version: string = config.buildInfo.version;
+  private ignoreUrls: RegExp[] = [];
+
+  constructor(private options?: { ignoreUrls: RegExp[] }) {
+    super();
+
+    this.ignoreUrls = options?.ignoreUrls ?? [];
+  }
+
   send(items: TransportItem[]) {
     getEchoSrv().addEvent({
       type: EchoEventType.GrafanaJavascriptAgent,
@@ -15,6 +23,6 @@ export class EchoSrvTransport extends BaseTransport {
   }
 
   getIgnoreUrls() {
-    return [];
+    return this.ignoreUrls;
   }
 }

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/EchoSrvTransport.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/EchoSrvTransport.ts
@@ -1,11 +1,16 @@
 import { BaseTransport, TransportItem } from '@grafana/faro-core';
 import { getEchoSrv, EchoEventType, config } from '@grafana/runtime';
+
+interface EchoSrcTransportOptions {
+  ignoreUrls: RegExp[];
+}
+
 export class EchoSrvTransport extends BaseTransport {
   readonly name: string = 'EchoSrvTransport';
   readonly version: string = config.buildInfo.version;
   private ignoreUrls: RegExp[] = [];
 
-  constructor(private options?: { ignoreUrls: RegExp[] }) {
+  constructor(options?: EchoSrcTransportOptions) {
     super();
 
     this.ignoreUrls = options?.ignoreUrls ?? [];

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -91,6 +91,7 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
     expect(initializeFaroMock).toHaveBeenCalledTimes(1);
     expect(initializeFaroMock.mock.calls[0][0].transports?.length).toEqual(2);
     expect(initializeFaroMock.mock.calls[0][0].transports?.[0]).toBeInstanceOf(EchoSrvTransport);
+    expect(initializeFaroMock.mock.calls[0][0].transports?.[0].getIgnoreUrls()).toEqual([new RegExp('/*/log-grafana-javascript-agent/'), /.*.google-analytics.com*.*/, /.*.googletagmanager.com*.*/, /frontend-metrics/, /\/collect(?:\/[\w]*)?$/]);
     expect(initializeFaroMock.mock.calls[0][0].transports?.[1]).toBeInstanceOf(FetchTransport);
   });
 

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -91,7 +91,13 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
     expect(initializeFaroMock).toHaveBeenCalledTimes(1);
     expect(initializeFaroMock.mock.calls[0][0].transports?.length).toEqual(2);
     expect(initializeFaroMock.mock.calls[0][0].transports?.[0]).toBeInstanceOf(EchoSrvTransport);
-    expect(initializeFaroMock.mock.calls[0][0].transports?.[0].getIgnoreUrls()).toEqual([new RegExp('/*/log-grafana-javascript-agent/'), /.*.google-analytics.com*.*/, /.*.googletagmanager.com*.*/, /frontend-metrics/, /\/collect(?:\/[\w]*)?$/]);
+    expect(initializeFaroMock.mock.calls[0][0].transports?.[0].getIgnoreUrls()).toEqual([
+      new RegExp('/*/log-grafana-javascript-agent/'),
+      /.*.google-analytics.com*.*/,
+      /.*.googletagmanager.com*.*/,
+      /frontend-metrics/,
+      /\/collect(?:\/[\w]*)?$/,
+    ]);
     expect(initializeFaroMock.mock.calls[0][0].transports?.[1]).toBeInstanceOf(FetchTransport);
   });
 

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -37,7 +37,12 @@ export interface GrafanaJavascriptAgentBackendOptions extends BrowserConfig {
   ignoreUrls: RegExp[];
 }
 
-const TRACKING_URLS = [/.*.google-analytics.com*.*/, /.*.googletagmanager.com*.*/, /frontend-metrics/, /\/collect(?:\/[\w]*)?$/];
+const TRACKING_URLS = [
+  /.*.google-analytics.com*.*/,
+  /.*.googletagmanager.com*.*/,
+  /frontend-metrics/,
+  /\/collect(?:\/[\w]*)?$/,
+];
 
 export class GrafanaJavascriptAgentBackend
   implements EchoBackend<GrafanaJavascriptAgentEchoEvent, GrafanaJavascriptAgentBackendOptions>

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -95,6 +95,7 @@ export class GrafanaJavascriptAgentBackend
         'ResizeObserver loop limit exceeded',
         'ResizeObserver loop completed',
         'Non-Error exception captured with keys',
+        'Failed sending payload to the receiver',
       ],
       ignoreUrls,
       sessionTracking: {


### PR DESCRIPTION
**What is this feature?**

the custom `EchoSrcTransport` does not have a set of ignored URLs which can cause an infinite loop of requests as the tracing instrumentation creates a new tracing when a plugin's Faro instance calls a different collector endpoint than the one specified in Grafana frontend's Faro instance 

**Why do we need this feature?**

prevent the issue highlighted in [this slack thread](https://raintank-corp.slack.com/archives/C03QDE75DRV/p1730469389629589)

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
