### PR TITLE
Alerting: Migration to remove scope from permission alert.notifications.receivers:create

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -138,6 +138,8 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	accesscontrol.AddActionSetPermissionsMigrator(mg)
 
 	externalsession.AddMigration(mg)
+
+	accesscontrol.AddReceiverCreateScopeMigration(mg)
 }
 
 func addStarMigrations(mg *Migrator) {


### PR DESCRIPTION
**What is this feature?**
Initially, the permission was introduced with a scope. However, later we removed the scope in the code. This PR is to update all records in the database for permission to match the code. 

**Why do we need this feature?**
Fix discrepancy between code and database.

**Who is this feature for?**
Mostly cloud users because the permission was introduced after 11.2 and changed before 11.3.

Related to https://github.com/grafana/grafana/pull/91738 and https://github.com/grafana/grafana/pull/93552

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
