### PR TITLE
Shard query splitting: improve error handling

### DIFF
--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -316,6 +316,7 @@ export function requestSupportsSplitting(allQueries: LokiQuery[]) {
 export function requestSupportsSharding(allQueries: LokiQuery[]) {
   const queries = allQueries
     .filter((query) => !query.hide)
+    .filter((query) => query.queryType !== LokiQueryType.Instant)
     .filter((query) => !query.refId.includes('do-not-shard'))
     .filter((query) => query.expr)
     .filter((query) => query.direction === LokiQueryDirection.Scan || !isLogsQuery(query.expr));

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -133,10 +133,16 @@ export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | n
 }
 
 export function isRetriableError(errorResponse: DataQueryResponse) {
-  const message = errorResponse.errors ? (errorResponse.errors[0].message ?? '').toLowerCase() : '';
+  const message = errorResponse.errors
+    ? (errorResponse.errors[0].message ?? '').toLowerCase()
+    : errorResponse.error?.message ?? '';
   if (message.includes('timeout')) {
     return true;
-  } else if (message.includes('parse error') || message.includes('max entries')) {
+  } else if (
+    message.includes('parse error') ||
+    message.includes('max entries') ||
+    message.includes('maximum of series')
+  ) {
     // If the error is a parse error, we want to signal to stop querying.
     throw new Error(message);
   }

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -138,11 +138,7 @@ export function isRetriableError(errorResponse: DataQueryResponse) {
     : (errorResponse.error?.message ?? '');
   if (message.includes('timeout')) {
     return true;
-  } else if (
-    message.includes('parse error') ||
-    message.includes('max entries') ||
-    message.includes('maximum of series')
-  ) {
+  } else if (message.includes('parse error')) {
     // If the error is a parse error, we want to signal to stop querying.
     throw new Error(message);
   }

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -135,7 +135,7 @@ export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | n
 export function isRetriableError(errorResponse: DataQueryResponse) {
   const message = errorResponse.errors
     ? (errorResponse.errors[0].message ?? '').toLowerCase()
-    : errorResponse.error?.message ?? '';
+    : (errorResponse.error?.message ?? '');
   if (message.includes('timeout')) {
     return true;
   } else if (

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -15,8 +15,9 @@ jest.mock('uuid', () => ({
 const originalLog = console.log;
 const originalWarn = console.warn;
 beforeEach(() => {
-  //jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 afterAll(() => {
   console.log = originalLog;
@@ -179,6 +180,16 @@ describe('runShardSplitQuery()', () => {
       // 1 shard + empty shard + 1 retry = 3
       expect(response).toHaveLength(3);
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  test('Failed requests have loading state Error', async () => {
+    jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue(['1']);
+    jest
+      .spyOn(datasource, 'runQuery')
+      .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'max entries' }, data: [] }));
+    await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
+      expect(response[0].state).toBe(LoadingState.Error);
     });
   });
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -187,7 +187,7 @@ describe('runShardSplitQuery()', () => {
     jest.mocked(datasource.languageProvider.fetchLabelValues).mockResolvedValue(['1']);
     jest
       .spyOn(datasource, 'runQuery')
-      .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'max entries' }, data: [] }));
+      .mockReturnValue(of({ state: LoadingState.Error, error: { refId: 'A', message: 'parse error' }, data: [] }));
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
       expect(response[0].state).toBe(LoadingState.Error);
     });

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -75,16 +75,16 @@ function splitQueriesByStreamShard(
       subquerySubscription = null;
     }
 
-    if (shouldStop) {
-      subscriber.complete();
-      return;
-    }
-
     const done = () => {
-      mergedResponse.state = LoadingState.Done;
+      mergedResponse.state = shouldStop ? LoadingState.Error : LoadingState.Done;
       subscriber.next(mergedResponse);
       subscriber.complete();
     };
+
+    if (shouldStop) {
+      done();
+      return;
+    }
 
     const nextRequest = () => {
       const nextGroup =


### PR DESCRIPTION
This PR improves error handling in the shard splitting implementation. This is done by:

- Removing the Streaming state when sharding should stop.
- Assigning the Error state on the merged response.

Additionally, instant queries are excluded from sharding.
