### PR TITLE
ScrollContainer: use in Explore pages

### DIFF
--- a/e2e/old-arch/various-suite/trace-view-scrolling.spec.ts
+++ b/e2e/old-arch/various-suite/trace-view-scrolling.spec.ts
@@ -32,7 +32,7 @@ describe('Trace view', () => {
     e2e.components.TraceViewer.spanBar()
       .its('length')
       .then((oldLength) => {
-        e2e.pages.Explore.General.scrollView().children('.scrollbar-view').scrollTo('center');
+        e2e.pages.Explore.General.scrollView().children().first().scrollTo('center');
 
         // After scrolling we should load more spans
         e2e.components.TraceViewer.spanBar().should(($span) => {

--- a/e2e/various-suite/trace-view-scrolling.spec.ts
+++ b/e2e/various-suite/trace-view-scrolling.spec.ts
@@ -32,7 +32,7 @@ describe('Trace view', () => {
     e2e.components.TraceViewer.spanBar()
       .its('length')
       .then((oldLength) => {
-        e2e.pages.Explore.General.scrollView().children('.scrollbar-view').scrollTo('center');
+        e2e.pages.Explore.General.scrollView().children().first().scrollTo('center');
 
         // After scrolling we should load more spans
         e2e.components.TraceViewer.spanBar().should(($span) => {

--- a/public/app/features/explore/ContentOutline/ContentOutline.tsx
+++ b/public/app/features/explore/ContentOutline/ContentOutline.tsx
@@ -4,7 +4,8 @@ import { useToggle, useScroll } from 'react-use';
 
 import { GrafanaTheme2, store } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { useStyles2, PanelContainer, CustomScrollbar } from '@grafana/ui';
+import { useStyles2, PanelContainer } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 
 import { ContentOutlineItemContextProps, useContentOutlineContext } from './ContentOutlineContext';
 import { ContentOutlineItemButton } from './ContentOutlineItemButton';
@@ -154,7 +155,7 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
 
   return (
     <PanelContainer className={styles.wrapper} id={panelId}>
-      <CustomScrollbar>
+      <ScrollContainer>
         <div className={styles.content}>
           <ContentOutlineItemButton
             icon={'arrow-from-right'}
@@ -235,7 +236,7 @@ export function ContentOutline({ scroller, panelId }: { scroller: HTMLElement | 
             );
           })}
         </div>
-      </CustomScrollbar>
+      </ScrollContainer>
     </PanelContainer>
   );
 }

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -20,15 +20,9 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import {
-  AdHocFilterItem,
-  CustomScrollbar,
-  ErrorBoundaryAlert,
-  PanelContainer,
-  Themeable2,
-  withTheme2,
-} from '@grafana/ui';
+import { AdHocFilterItem, ErrorBoundaryAlert, PanelContainer, Themeable2, withTheme2 } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/src/components/Table/types';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 import { supportedFeatures } from 'app/core/history/richHistoryStorageProvider';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { StoreState } from 'app/types';
@@ -578,10 +572,9 @@ export class Explore extends PureComponent<Props, ExploreState> {
             {contentOutlineVisible && (
               <ContentOutline scroller={this.scrollElement} panelId={`content-outline-container-${exploreId}`} />
             )}
-            <CustomScrollbar
-              testId={selectors.pages.Explore.General.scrollView}
-              scrollRefCallback={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
-              hideHorizontalTrack
+            <ScrollContainer
+              data-testid={selectors.pages.Explore.General.scrollView}
+              ref={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
             >
               <div className={styles.exploreContainer}>
                 {datasourceInstance ? (
@@ -649,7 +642,7 @@ export class Explore extends PureComponent<Props, ExploreState> {
                   this.renderEmptyState(styles.exploreContainer)
                 )}
               </div>
-            </CustomScrollbar>
+            </ScrollContainer>
           </div>
         </div>
       </ContentOutlineContextProvider>

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import { EventBusSrv, getTimeZone } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { CustomScrollbar } from '@grafana/ui';
 import { stopQueryState } from 'app/core/utils/explore';
 import { StoreState, useSelector } from 'app/types';
 
@@ -45,23 +44,21 @@ function ExplorePaneContainerUnconnected({ exploreId }: Props) {
   }, []);
 
   return (
-    <CustomScrollbar hideVerticalTrack>
-      <div className={containerStyles} ref={ref} data-testid={selectors.pages.Explore.General.container}>
-        <Explore
+    <div className={containerStyles} ref={ref} data-testid={selectors.pages.Explore.General.container}>
+      <Explore
+        exploreId={exploreId}
+        eventBus={eventBus.current}
+        showQueryInspector={showQueryInspector}
+        setShowQueryInspector={setShowQueryInspector}
+      />
+      {showQueryInspector && (
+        <ExploreQueryInspector
           exploreId={exploreId}
-          eventBus={eventBus.current}
-          showQueryInspector={showQueryInspector}
-          setShowQueryInspector={setShowQueryInspector}
+          onClose={() => setShowQueryInspector(false)}
+          timeZone={getTimeZone()}
         />
-        {showQueryInspector && (
-          <ExploreQueryInspector
-            exploreId={exploreId}
-            onClose={() => setShowQueryInspector(false)}
-            timeZone={getTimeZone()}
-          />
-        )}
-      </div>
-    </CustomScrollbar>
+      )}
+    </div>
   );
 }
 

--- a/public/app/features/explore/Logs/LogsNavigationPages.tsx
+++ b/public/app/features/explore/Logs/LogsNavigationPages.tsx
@@ -2,7 +2,8 @@ import { css, cx } from '@emotion/css';
 
 import { dateTimeFormat, systemDateFormats, GrafanaTheme2 } from '@grafana/data';
 import { TimeZone } from '@grafana/schema';
-import { CustomScrollbar, Spinner, useTheme2, clearButtonStyles } from '@grafana/ui';
+import { Spinner, useTheme2, clearButtonStyles } from '@grafana/ui';
+import { ScrollContainer } from '@grafana/ui/src/unstable';
 
 import { LogsPage } from './LogsNavigation';
 
@@ -36,7 +37,7 @@ export function LogsNavigationPages({ pages, currentPageIndex, oldestLogsFirst, 
   const styles = getStyles(theme, loading);
 
   return (
-    <CustomScrollbar autoHide>
+    <ScrollContainer>
       <div className={styles.pagesWrapper} data-testid="logsNavigationPages">
         <div className={styles.pagesContainer}>
           {pages.map((page: LogsPage, index: number) => (
@@ -58,7 +59,7 @@ export function LogsNavigationPages({ pages, currentPageIndex, oldestLogsFirst, 
           ))}
         </div>
       </div>
-    </CustomScrollbar>
+    </ScrollContainer>
   );
 }
 
@@ -69,7 +70,6 @@ const getStyles = (theme: GrafanaTheme2, loading: boolean) => {
       paddingLeft: theme.spacing(0.5),
       display: 'flex',
       flexDirection: 'column',
-      overflowY: 'scroll',
       '&::after': {
         content: "''",
         display: 'block',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- follow on from https://github.com/grafana/grafana/pull/94689
- applies `ScrollContainer` in Explore pages

windows screenshots incoming:
|  | before | after |
| --- | --- | --- |
| `ContentOutline` |  ![image](https://github.com/user-attachments/assets/4961869e-0edb-44d7-970d-6429e4bd978c) | ![image](https://github.com/user-attachments/assets/0ae7b8d5-b309-41eb-adc4-d4c646d83803) |
| `Explore` |  ![image](https://github.com/user-attachments/assets/0050c2b1-1d88-4015-803b-3b5b1e8c276c) | ![image](https://github.com/user-attachments/assets/b8b40437-4507-4ac0-a30d-8c1a8e035eb2) |
| `LogsNavigationPages` | ![image](https://github.com/user-attachments/assets/82e85fb9-3c64-4e1f-9c33-32d380a61c0b) | ![image](https://github.com/user-attachments/assets/be0b0fd9-88de-4caf-beaa-1147885b97f6) |

**Why do we need this feature?**

- `ScrollContainer` uses native scrollbars
  - more consistent with user's platform
  - better a11y

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
