### PR TITLE
Alerting: Optimize Prometheus rules query params

### DIFF
--- a/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
@@ -47,6 +47,8 @@ const RuleListV1 = () => {
   const [queryParams] = useQueryParams();
   const { filterState, hasActiveFilters } = useRulesFilter();
 
+  const hasActiveLabelsFilter = filterState.labels.length > 0;
+
   const queryParamView = queryParams.view as keyof typeof VIEWS;
   const view = VIEWS[queryParamView] ? queryParamView : 'groups';
 
@@ -77,7 +79,7 @@ const RuleListV1 = () => {
     return noRules && state.dispatched;
   });
 
-  const limitAlerts = hasActiveFilters ? undefined : LIMIT_ALERTS;
+  const limitAlerts = hasActiveLabelsFilter ? undefined : LIMIT_ALERTS;
   // Trigger data refresh only when the RULE_LIST_POLL_INTERVAL_MS elapsed since the previous load FINISHED
   const [_, fetchRules] = useAsyncFn(async () => {
     if (!loading) {


### PR DESCRIPTION
This PR adds a small optimization to the way we fetch rules from Prometheus.

Prior to this change, we were removing the `limit_alerts` parameter if any filter has been applied. 
This PR changes that behaviour, and we only remove the parameter if the `label` filter is applied.

The change should result in more frequent use of the `limit_alerts` paramter which results in smaller payload and faster server response

We need instances to do the filtering, but the only filter which actually needs them is the `label` one

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
