### PR TITLE
PluginExtensions: Persisting log messages accross the browser session

### DIFF
--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -18,13 +18,17 @@ const channelName = 'ui-extension-logs';
 
 export class ExtensionsLog {
   private baseLabels: Labels | undefined;
-  private subject: ReplaySubject<ExtensionsLogItem> | undefined;
+  private subject: ReplaySubject<ExtensionsLogItem>;
   private channel: BroadcastChannel;
 
   constructor(baseLabels?: Labels, subject?: ReplaySubject<ExtensionsLogItem>, channel?: BroadcastChannel) {
     this.baseLabels = baseLabels;
     this.channel = channel ?? new BroadcastChannel(channelName);
-    this.subject = subject;
+    this.subject = subject ?? new ReplaySubject<ExtensionsLogItem>(1000, 1000 * 60 * 10);
+
+    if (!channel) {
+      this.channel.onmessage = (msg: MessageEvent<ExtensionsLogItem>) => this.subject.next(msg.data);
+    }
   }
 
   info(message: string, labels?: Labels): void {
@@ -67,17 +71,13 @@ export class ExtensionsLog {
       extensionPointId: isString(extensionPointId) ? extensionPointId : undefined,
     };
 
+    // We only receive messages from different contexts so adding the ones
+    // pushed by this log to the local subject.
+    this.subject.next(item);
     this.channel.postMessage(item);
   }
 
   asObservable(): Observable<ExtensionsLogItem> {
-    if (!this.subject) {
-      // Lazily create the subject on first subscription to prevent
-      // to create buffers when no subscribers exists
-      this.subject = new ReplaySubject<ExtensionsLogItem>(1000, 1000 * 60 * 10);
-      this.channel.onmessage = (msg: MessageEvent<ExtensionsLogItem>) => this.subject?.next(msg.data);
-    }
-
     return this.subject.asObservable();
   }
 

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -15,6 +15,8 @@ export type ExtensionsLogItem = {
 };
 
 const channelName = 'ui-extension-logs';
+const logsNumberLimit = 1000;
+const logsRetentionTime = 1000 * 60 * 10;
 
 export class ExtensionsLog {
   private baseLabels: Labels | undefined;
@@ -24,7 +26,7 @@ export class ExtensionsLog {
   constructor(baseLabels?: Labels, subject?: ReplaySubject<ExtensionsLogItem>, channel?: BroadcastChannel) {
     this.baseLabels = baseLabels;
     this.channel = channel ?? new BroadcastChannel(channelName);
-    this.subject = subject ?? new ReplaySubject<ExtensionsLogItem>(1000, 1000 * 60 * 10);
+    this.subject = subject ?? new ReplaySubject<ExtensionsLogItem>(logsNumberLimit, logsRetentionTime);
 
     if (!channel) {
       this.channel.onmessage = (msg: MessageEvent<ExtensionsLogItem>) => this.subject.next(msg.data);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
All log messages are available in the log panel until you do a refresh in the browser or one of the following occur:

- Log message is older than 10 minutes.
- 1000 newer log messages exists in the panel.

**Why do we need this feature?**



**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
