### PR TITLE
Theme: Add `debug` theme behind `extraThemes` toggle

### DIFF
--- a/packages/grafana-data/src/themes/createShape.ts
+++ b/packages/grafana-data/src/themes/createShape.ts
@@ -22,7 +22,7 @@ export function createShape(options: ThemeShapeInput): ThemeShape {
   const baseBorderRadius = options.borderRadius ?? 2;
 
   const radius = {
-    default: '2px',
+    default: `${baseBorderRadius}px`,
     pill: '9999px',
     circle: '100%',
   };

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,5 +1,6 @@
 import { Registry, RegistryItem } from '../utils/Registry';
 
+import { createColors } from './createColors';
 import { createTheme } from './createTheme';
 import { GrafanaTheme2 } from './types';
 
@@ -35,8 +36,7 @@ const themeRegistry = new Registry<ThemeRegistryItem>(() => {
     { id: 'system', name: 'System preference', build: getSystemPreferenceTheme },
     { id: 'dark', name: 'Dark', build: () => createTheme({ colors: { mode: 'dark' } }) },
     { id: 'light', name: 'Light', build: () => createTheme({ colors: { mode: 'light' } }) },
-    { id: 'blue-night', name: 'Blue night', build: createBlueNight, isExtra: true },
-    { id: 'midnight', name: 'Midnight', build: createMidnight, isExtra: true },
+    { id: 'debug', name: 'Debug', build: createDebug, isExtra: true },
   ];
 });
 
@@ -47,47 +47,59 @@ function getSystemPreferenceTheme() {
 }
 
 /**
- * Just a temporary placeholder for a possible new theme
+ * a very ugly theme that is useful for debugging and checking if the theme is applied correctly
+ * borders are red,
+ * backgrounds are blue,
+ * text is yellow,
+ * and grafana loves you <3
+ * (also corners are rounded, action states (hover, focus, selected) are purple)
  */
-function createMidnight(): GrafanaTheme2 {
-  const whiteBase = '204, 204, 220';
+function createDebug(): GrafanaTheme2 {
+  const baseDarkColors = createColors({
+    mode: 'dark',
+  });
 
   return createTheme({
-    name: 'Midnight',
+    name: 'Debug',
     colors: {
       mode: 'dark',
       background: {
-        canvas: '#000000',
-        primary: '#000000',
-        secondary: '#181818',
+        canvas: '#000033',
+        primary: '#000044',
+        secondary: '#000055',
+      },
+      text: {
+        primary: '#bbbb00',
+        secondary: '#888800',
+        disabled: '#444400',
+        link: '#dddd00',
+        maxContrast: '#ffff00',
       },
       border: {
-        weak: `rgba(${whiteBase}, 0.17)`,
-        medium: `rgba(${whiteBase}, 0.25)`,
-        strong: `rgba(${whiteBase}, 0.35)`,
+        weak: '#ff000044',
+        medium: '#ff000088',
+        strong: '#ff0000ff',
+      },
+      primary: {
+        ...baseDarkColors.primary,
+        border: '#ff000088',
+        text: '#cccc00',
+        contrastText: '#ffff00',
+      },
+      secondary: {
+        ...baseDarkColors.secondary,
+        border: '#ff000088',
+        text: '#cccc00',
+        contrastText: '#ffff00',
+      },
+      action: {
+        hover: '#9900dd',
+        focus: '#6600aa',
+        selected: '#440088',
       },
     },
-  });
-}
-
-/**
- * Just a temporary placeholder for a possible new theme
- */
-function createBlueNight(): GrafanaTheme2 {
-  return createTheme({
-    name: 'Blue night',
-    colors: {
-      mode: 'dark',
-      background: {
-        canvas: '#15161d',
-        primary: '#15161d',
-        secondary: '#1d1f2e',
-      },
-      border: {
-        weak: `#2e304f`,
-        medium: `#2e304f`,
-        strong: `#2e304f`,
-      },
+    shape: {
+      borderRadius: 8,
     },
   });
 }

--- a/pkg/services/preference/themes.go
+++ b/pkg/services/preference/themes.go
@@ -10,8 +10,7 @@ var themes = []ThemeDTO{
 	{ID: "light", Type: "light"},
 	{ID: "dark", Type: "dark"},
 	{ID: "system", Type: "dark"},
-	{ID: "midnight", Type: "dark", IsExtra: true},
-	{ID: "blue-night", Type: "dark", IsExtra: true},
+	{ID: "debug", Type: "dark", IsExtra: true},
 }
 
 func GetThemeByID(id string) *ThemeDTO {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds a really ugly `debug` theme behind the `extraThemes` toggle
- removes the placeholder `midnight`/`blue-night` themes
- makes the base `borderRadius` configurable by the theme (default is still 2px)

in all it's glory:
![image](https://github.com/user-attachments/assets/254217b8-851a-49fa-bb15-a06529bcf918)

we can probably make further adjustments to this theme to make it easier to spot things, but this feels like a good start 🤷 

**Why do we need this feature?**

- makes it much easier to spot areas that aren't utilising the theme properly
- things i've spotted in 5 mins with this theme:
  - we're using the wrong hover state in the browse dashboards page rows
  - we're using the wrong active state in the megamenu
  - we're using the wrong hover state in `ToolbarButton`
  - we're not increasing the border contrast when hovering a `RadioButtonGroup`
  - we're not using the borderRadius theme variable in our select menus
  - the new explore -> metrics cards aren't using the borderRadius theme variable properly
- these are all very minor nits in the current theme, but they add up to a more inconsistent and overall worse experience

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
