### PR TITLE
go: run gomod updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,80 @@ updates:
       time: "02:00"
       timezone: UTC
     open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/apps/playlist"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/aggregator"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/apimachinery"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/apiserver"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/build"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/build/wire"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/promlib"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/semconv"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/storage/unified/apistore"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/storage/unified/resource"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/pkg/util/xorm"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: UTC
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
       interval: "daily"
       time: "02:00"
       timezone: UTC
+    open-pull-requests-limit: 10


### PR DESCRIPTION
By updating the go mods daily we should get less drift. less drift means less time spent resolving conflicts in PR's