### PR TITLE
TimeRangeProvider: Fix synced status being kept when only one picker is mounted

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangeContext.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangeContext.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
 
 import { makeTimeRange } from '@grafana/data';
@@ -75,6 +75,43 @@ describe('TimeRangeProvider', () => {
 
     expect(context2).toMatchObject({
       syncPossible: true,
+      synced: false,
+      syncedValue: undefined,
+    });
+  });
+
+  it('sets status to not synced if only 1 component remains', async () => {
+    let context2: TimeRangeContextHookValue | undefined = undefined;
+    function onContextChange2(val?: TimeRangeContextHookValue) {
+      context2 = val;
+    }
+
+    const renderContext = render(
+      <TimeRangeProvider>
+        <TestComponent onContextChange={onContextChange} />
+        <TestComponent onContextChange={onContextChange2} />
+      </TimeRangeProvider>
+    );
+
+    const timeRange = makeTimeRange('2021-01-01', '2021-01-02');
+    act(() => {
+      context?.sync(timeRange);
+    });
+
+    expect(context2).toMatchObject({
+      syncPossible: true,
+      synced: true,
+      syncedValue: timeRange,
+    });
+
+    renderContext.rerender(
+      <TimeRangeProvider>
+        <TestComponent onContextChange={onContextChange2} />
+      </TimeRangeProvider>
+    );
+
+    expect(context2).toMatchObject({
+      syncPossible: false,
       synced: false,
       syncedValue: undefined,
     });

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangeContext.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangeContext.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { useEffect } from 'react';
 
 import { makeTimeRange } from '@grafana/data';

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangeContext.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangeContext.tsx
@@ -42,7 +42,15 @@ export function TimeRangeProvider({ children }: { children: ReactNode }) {
       sync: (value: TimeRange) => setSyncedValue(value),
       unSync: () => setSyncedValue(undefined),
       addPicker: () => setPickersCount((val) => val + 1),
-      removePicker: () => setPickersCount((val) => val - 1),
+      removePicker: () => {
+        setPickersCount((val) => {
+          const newVal = val - 1;
+          if (newVal < 2) {
+            setSyncedValue(undefined);
+          }
+          return newVal;
+        });
+      },
       syncPossible: pickersCount > 1,
       synced: Boolean(syncedValue),
       syncedValue,


### PR DESCRIPTION
Fixes this error where picker would still looked synced (the orange underline) even though there is no other picker visible:

https://github.com/user-attachments/assets/f587382f-2c3a-4e26-80dc-9b61dea05010

