### PR TITLE
TableNG: use compiled fn for columns -> records conversion

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/css';
 import { Property } from 'csstype';
 import React, { useMemo, useState, useLayoutEffect, useCallback } from 'react';
 import DataGrid, { Column, RenderRowProps, Row, SortColumn, SortDirection } from 'react-data-grid';
-import { Cell } from 'react-table';
 
 import { DataFrame, Field, FieldType, GrafanaTheme2, ReducerID } from '@grafana/data';
 
@@ -21,11 +20,7 @@ import { TableCellNG } from './Cells/TableCellNG';
 const DEFAULT_CELL_PADDING = 6;
 const COLUMN_MIN_WIDTH = 150;
 
-interface TableRow {
-  id: number;
-  title: string;
-  cell: Cell;
-}
+type TableRow = Record<string, unknown>;
 
 interface TableColumn extends Column<TableRow> {
   key: string;
@@ -168,11 +163,11 @@ export function TableNG(props: TableNGProps) {
         rowHeight: rowHeightNumber,
         cellClass: (row) => {
           // eslint-ignore-next-line
-          const value = row[key];
-          const displayValue = shallowField.display!(value);
+          // const value = row[key];
+          // const displayValue = shallowField.display!(value);
 
           // if (shallowField.config.custom.type === TableCellDisplayMode.ColorBackground) {
-          let colors = getCellColors(theme, shallowField.config.custom, displayValue);
+          // let colors = getCellColors(theme, shallowField.config.custom, displayValue);
           // }
 
           // css()
@@ -230,26 +225,6 @@ export function TableNG(props: TableNGProps) {
 
     return columns;
   };
-
-  // const frameToRecords = (main: DataFrame) => {
-  //   const rows: Array<{ [key: string]: string }> = [];
-
-  //   main.fields.map((field, fieldIndex) => {
-  //     const key = field.name;
-
-  //     field.values.map((value, valueIndex) => {
-  //       const currentValue = { [key]: value };
-
-  //       if (rows.length > valueIndex) {
-  //         rows[valueIndex] = { ...rows[valueIndex], ...currentValue };
-  //       } else {
-  //         rows[valueIndex] = currentValue;
-  //       }
-  //     });
-  //   });
-
-  //   return rows;
-  // };
 
   const frameToRecords = useCallback((frame: DataFrame): Array<Record<string, string>> => {
     const fnBody = `
@@ -374,7 +349,7 @@ export function TableNG(props: TableNGProps) {
   );
 }
 
-function myRowRenderer(key: React.Key, props: RenderRowProps<Row>) {
+function myRowRenderer(key: React.Key, props: RenderRowProps<TableRow>): React.ReactNode {
   // Let's render row level things here!
   // i.e. we can look at row styles and such here
   return <Row {...props} />;

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -232,7 +232,7 @@ export function TableNG(props: TableNGProps) {
       const values = frame.fields.map(f => f.values);
 
       for (let i = 0; i < frame.length; i++) {
-        rows[i] = {${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
+        rows[i] = {index: i, ${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
       }
 
       return rows;

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -208,8 +208,9 @@ export function TableNG(props: TableNGProps) {
             justifyContent={justifyColumnContent}
           />
         ),
-        width: columnWidth,
-        minWidth: columnMinWidth,
+        // TODO these anys are making me sad
+        width: field.config.custom.width ?? columnWidth,
+        minWidth: field.config.custom.minWidth ?? columnMinWidth,
       });
 
       // Create row objects
@@ -319,6 +320,7 @@ export function TableNG(props: TableNGProps) {
   return (
     <>
       <DataGrid
+        key={`DataGrid${revId}`}
         rows={sortedRows}
         columns={columns}
         headerRowHeight={noHeader ? 0 : undefined}

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -1,7 +1,7 @@
 import 'react-data-grid/lib/styles.css';
 import { css } from '@emotion/css';
 import { Property } from 'csstype';
-import React, { useMemo, useState, useLayoutEffect } from 'react';
+import React, { useMemo, useState, useLayoutEffect, useCallback } from 'react';
 import DataGrid, { Column, RenderRowProps, Row, SortColumn, SortDirection } from 'react-data-grid';
 import { Cell } from 'react-table';
 
@@ -147,7 +147,6 @@ export function TableNG(props: TableNGProps) {
 
   const mapFrameToDataGrid = (main: DataFrame) => {
     const columns: TableColumn[] = [];
-    const rows: Array<{ [key: string]: string }> = [];
 
     // Footer calculations
     let footerItems: FooterItem[] = [];
@@ -156,7 +155,7 @@ export function TableNG(props: TableNGProps) {
 
     main.fields.map((field, fieldIndex) => {
       filterFields.push({ id: fieldIndex.toString(), field });
-      const key = `${field.name}-${revId}`;
+      const key = field.name;
       const { values: _, ...shallowField } = field;
 
       const justifyColumnContent = getTextAlign(field);
@@ -218,15 +217,6 @@ export function TableNG(props: TableNGProps) {
         // Only populate 2d array if needed for footer calculations
         allValues.push(field.values);
       }
-      field.values.map((value, valueIndex) => {
-        const currentValue = { [key]: value };
-
-        if (rows.length > valueIndex) {
-          rows[valueIndex] = { ...rows[valueIndex], ...currentValue };
-        } else {
-          rows[valueIndex] = currentValue;
-        }
-      });
     });
 
     if (footerOptions?.show && footerOptions.reducer.length > 0) {
@@ -237,12 +227,51 @@ export function TableNG(props: TableNGProps) {
       }
     }
 
-    return {
-      columns,
-      rows,
-    };
+    return columns;
   };
-  const { columns, rows } = mapFrameToDataGrid(props.data);
+
+  // const frameToRecords = (main: DataFrame) => {
+  //   const rows: Array<{ [key: string]: string }> = [];
+
+  //   main.fields.map((field, fieldIndex) => {
+  //     const key = field.name;
+
+  //     field.values.map((value, valueIndex) => {
+  //       const currentValue = { [key]: value };
+
+  //       if (rows.length > valueIndex) {
+  //         rows[valueIndex] = { ...rows[valueIndex], ...currentValue };
+  //       } else {
+  //         rows[valueIndex] = currentValue;
+  //       }
+  //     });
+  //   });
+
+  //   return rows;
+  // };
+
+  const frameToRecords = useCallback((frame: DataFrame): Array<Record<string, string>> => {
+    const fnBody = `
+      const rows = Array(frame.length);
+      const values = frame.fields.map(f => f.values);
+
+      for (let i = 0; i < frame.length; i++) {
+        rows[i] = {${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
+      }
+
+      return rows;
+    `;
+
+    const convert = new Function('frame', fnBody);
+
+    const records = convert(frame);
+
+    return records;
+  }, []);
+
+  const columns = mapFrameToDataGrid(props.data);
+
+  const rows = useMemo(() => frameToRecords(props.data), [frameToRecords, props.data]);
 
   const columnTypes = useMemo(() => {
     return columns.reduce(


### PR DESCRIPTION
note: i had to remove revId here from the key names. we need to find another strategy,

there was a double-conversion happening due to lack of memo and a re-render, so that needed to be fixed. but the main win was from using a single compiled conversion loop that leverages [monomorphism](https://www.builder.io/blog/monomorphic-javascript).

the wins are pretty drastic, tested with 42k records, 8x data refreshes.

memory usage:

before: grows continuously 95MB -> 395MB before being freed
after:  grows between 95-113MB heap during data refreshes and is GC'd efficiently

cpu time:

before: 4200ms
after: 470ms


before:

![Screenshot_20241105_142952](https://github.com/user-attachments/assets/c7d05bdb-6a29-40e2-a430-cbc56d8a35a6)

after:

![Screenshot_20241105_141926](https://github.com/user-attachments/assets/08b7ff12-8f96-43f7-abee-fda51f9ca381)

for reference, here is current Table panel with same stats: 260MB peak and 1970ms cpu:

![Screenshot_20241105_171103](https://github.com/user-attachments/assets/c6fa6742-9236-497d-8b09-e16219403039)

- [ ] key alternative
- [ ] footer calcs