### PR TITLE
ServerLock: Fix pg concurrency/locking issue

### DIFF
--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -352,15 +352,25 @@ func (sl *ServerLockService) executeFunc(ctx context.Context, actionName string,
 }
 
 func (sl *ServerLockService) createLock(ctx context.Context,
-	lockRow *serverLock, dbSession *sqlstore.DBSession) (*serverLock, error) {
+	lockRow *serverLock, dbSession *sqlstore.DBSession,
+) (*serverLock, error) {
 	affected := int64(1)
 	rawSQL := `INSERT INTO server_lock (operation_uid, last_execution, version) VALUES (?, ?, ?)`
 	if sl.SQLStore.GetDBType() == migrator.Postgres {
-		rawSQL += ` RETURNING id`
+		rawSQL += ` ON CONFLICT DO NOTHING RETURNING id`
 		var id int64
 		_, err := dbSession.SQL(rawSQL, lockRow.OperationUID, lockRow.LastExecution, 0).Get(&id)
 		if err != nil {
 			return nil, err
+		}
+		if id == 0 {
+			// Considering the default isolation level (READ COMMITTED), an entry could be added to the table
+			// between the SELECT and the INSERT. And inserting a row with the same operation_uid would violate the unique
+			// constraint. In this case, the ON CONFLICT DO NOTHING clause will prevent generating an error.
+			// And the returning id will be 0 which means that there wasn't any row inserted (another server has the lock),
+			// therefore we return the ServerLockExistsError.
+			// https://www.postgresql.org/docs/current/transaction-iso.html#XACT-READ-COMMITTED
+			return nil, &ServerLockExistsError{actionName: lockRow.OperationUID}
 		}
 		lockRow.Id = id
 	} else {


### PR DESCRIPTION
**What is this feature?**
Fixes the concurrency issue with postgresql in serverlock.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #95355 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
