### PR TITLE
Alerting: Fix saving advanced mode toggle state in the alert rule editor

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -313,12 +313,15 @@ func ValidateRuleGroup(
 			uids[rule.UID] = idx
 		}
 
-		var hasPause, isPaused bool
+		var hasPause, isPaused, hasMetadata bool
 		original := ruleGroupConfig.Rules[idx]
 		if alert := original.GrafanaManagedAlert; alert != nil {
 			if alert.IsPaused != nil {
 				isPaused = *alert.IsPaused
 				hasPause = true
+			}
+			if alert.Metadata != nil {
+				hasMetadata = true
 			}
 		}
 
@@ -327,6 +330,7 @@ func ValidateRuleGroup(
 		rule.RuleGroupIndex = idx + 1
 		ruleWithOptionals.AlertRule = *rule
 		ruleWithOptionals.HasPause = hasPause
+		ruleWithOptionals.HasMetadata = hasMetadata
 
 		result = append(result, &ruleWithOptionals)
 	}

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -299,7 +299,8 @@ type AlertRuleWithOptionals struct {
 	AlertRule
 	// This parameter is to know if an optional API field was sent and, therefore, patch it with the current field from
 	// DB in case it was not sent.
-	HasPause bool
+	HasPause    bool
+	HasMetadata bool
 }
 
 // AlertsRulesBy is a function that defines the ordering of alert rules.
@@ -809,7 +810,7 @@ func PatchPartialAlertRule(existingRule *AlertRule, ruleToPatch *AlertRuleWithOp
 	// Currently metadata contains only editor settings, so we can just copy it.
 	// If we add more fields to metadata, we might need to handle them separately,
 	// and/or merge or update their values.
-	if ruleToPatch.Metadata == (AlertRuleMetadata{}) {
+	if !ruleToPatch.HasMetadata {
 		ruleToPatch.Metadata = existingRule.Metadata
 	}
 }

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -257,6 +257,7 @@ func TestPatchPartialAlertRule(t *testing.T) {
 				name: "No metadata",
 				mutator: func(r *AlertRuleWithOptionals) {
 					r.Metadata = AlertRuleMetadata{}
+					r.HasMetadata = false
 				},
 			},
 		}

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -895,7 +895,28 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 
 		updatedRuleGroup := apiClient.GetRulesGroup(t, folderName, groupName).GettableRuleGroupConfig
 		require.Len(t, updatedRuleGroup.Rules, 1)
-		require.False(t, false, updatedRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
+		require.True(t, updatedRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
+	})
+
+	t.Run("disable simplified query editor in editor settings", func(t *testing.T) {
+		metadata := &apimodels.AlertRuleMetadata{
+			EditorSettings: apimodels.AlertRuleEditorSettings{
+				SimplifiedQueryAndExpressionsSection: true,
+			},
+		}
+		createdRuleGroup := createAlertInGrafana(metadata)
+
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+
+		// disabling the editor
+		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection = false
+
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		assert.Equal(t, http.StatusAccepted, status)
+
+		updatedRuleGroup := apiClient.GetRulesGroup(t, folderName, groupName).GettableRuleGroupConfig
+		require.Len(t, updatedRuleGroup.Rules, 1)
+		require.False(t, updatedRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
 	})
 
 	t.Run("post alert without metadata", func(t *testing.T) {
@@ -903,7 +924,7 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 
 		createdRuleGroup := apiClient.GetRulesGroup(t, folderName, groupName).GettableRuleGroupConfig
 		require.Len(t, createdRuleGroup.Rules, 1)
-		require.False(t, false, createdRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
+		require.False(t, createdRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

This fixes a bug that makes switching off the simplified rule editor impossible. The code considers metadata empty and replaces it with the existing rule metadata when it should not.

---

`metadata` right now contains only one boolean field:

```
metadata: { simplified_query_and_expressions_section: true }
```

If the API request tries to change the value from true to false, the code currently considers the structure empty and replaces it with the existing one, so it's impossible to set `simplified_query_and_expressions_section` to `false`.

**Why do we need this feature?**

It's impossible to enable `Advanced options` and save the rule. The toggle is switched back after a page refresh.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/13304

**Special notes for your reviewer:**

**How to test**

You should be able to create a new alerting rule, in both simple and advanced modes (feature toggle `alertingQueryAndExpressionsStepMode`). After creation it should be possible to change the editor mode when modifying the rule, and after saving the mode should be preserved.

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/b95063a8-8a49-4cf0-a973-df950c49ac1b">
 

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
