### PR TITLE
Unistore: List from RV using window function

### DIFF
--- a/pkg/storage/unified/sql/data/resource_history_list.sql
+++ b/pkg/storage/unified/sql/data/resource_history_list.sql
@@ -3,51 +3,42 @@ SELECT
     kv.{{ .Ident "namespace" }},
     kv.{{ .Ident "name" }},
     kv.{{ .Ident "value" }}
-    FROM {{ .Ident "resource_history" }} as kv 
-    INNER JOIN  (
-        SELECT {{ .Ident "namespace" }}, {{ .Ident "group" }}, {{ .Ident "resource" }}, {{ .Ident "name" }},  max({{ .Ident "resource_version" }}) AS {{ .Ident "resource_version" }}
-        FROM {{ .Ident "resource_history" }} AS mkv
-        WHERE 1 = 1
-            AND {{ .Ident "resource_version" }} <=  {{ .Arg .Request.ResourceVersion }}
-            {{ if and .Request.Options .Request.Options.Key }}
-                {{ if .Request.Options.Key.Namespace }}
-                AND {{ .Ident "namespace" }} = {{ .Arg .Request.Options.Key.Namespace }}
-                {{ end }}
-                {{ if .Request.Options.Key.Group }}
-                AND {{ .Ident "group" }}     = {{ .Arg .Request.Options.Key.Group }}
-                {{ end }}
-                {{ if .Request.Options.Key.Resource }}
-                AND {{ .Ident "resource" }}  = {{ .Arg .Request.Options.Key.Resource }}
-                {{ end }}
-                {{ if .Request.Options.Key.Name }}
-                AND {{ .Ident "name" }}      = {{ .Arg .Request.Options.Key.Name }}
-                {{ end }}
+FROM (
+    SELECT
+        {{ .Ident "resource_version" }},
+        {{ .Ident "namespace" }},
+        {{ .Ident "group" }},
+        {{ .Ident "resource" }},
+        {{ .Ident "name" }},
+        {{ .Ident "value" }},
+        {{ .Ident "action" }},
+        MAX({{ .Ident "resource_version" }}) OVER (
+            PARTITION BY {{ .Ident "namespace" }}, {{ .Ident "group" }}, {{ .Ident "resource" }}, {{ .Ident "name" }}
+            ORDER BY {{ .Ident "resource_version" }}
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS max_resource_version
+    FROM {{ .Ident "resource_history" }}
+    WHERE 1 = 1
+        AND {{ .Ident "resource_version" }} <= {{ .Arg .Request.ResourceVersion }}
+        {{ if and .Request.Options .Request.Options.Key }}
+            {{ if .Request.Options.Key.Namespace }}
+            AND {{ .Ident "namespace" }} = {{ .Arg .Request.Options.Key.Namespace }}
             {{ end }}
-        GROUP BY mkv.{{ .Ident "namespace" }}, mkv.{{ .Ident "group" }}, mkv.{{ .Ident "resource" }}, mkv.{{ .Ident "name" }} 
-    ) AS maxkv
-    ON
-        maxkv.{{ .Ident "resource_version" }}  = kv.{{ .Ident "resource_version" }}
-        AND maxkv.{{ .Ident "namespace" }}     = kv.{{ .Ident "namespace" }}
-        AND maxkv.{{ .Ident "group" }}         = kv.{{ .Ident "group" }}
-        AND maxkv.{{ .Ident "resource" }}      = kv.{{ .Ident "resource" }}
-        AND maxkv.{{ .Ident "name" }}          = kv.{{ .Ident "name" }}
-    WHERE kv.{{ .Ident "action" }}  != 3 
-    {{ if and .Request.Options .Request.Options.Key }}
-        {{ if .Request.Options.Key.Namespace }}
-        AND kv.{{ .Ident "namespace" }} = {{ .Arg .Request.Options.Key.Namespace }}
+            {{ if .Request.Options.Key.Group }}
+            AND {{ .Ident "group" }} = {{ .Arg .Request.Options.Key.Group }}
+            {{ end }}
+            {{ if .Request.Options.Key.Resource }}
+            AND {{ .Ident "resource" }} = {{ .Arg .Request.Options.Key.Resource }}
+            {{ end }}
+            {{ if .Request.Options.Key.Name }}
+            AND {{ .Ident "name" }} = {{ .Arg .Request.Options.Key.Name }}
+            {{ end }}
         {{ end }}
-        {{ if .Request.Options.Key.Group }}
-        AND kv.{{ .Ident "group" }}     = {{ .Arg .Request.Options.Key.Group }}
-        {{ end }}
-        {{ if .Request.Options.Key.Resource }}
-        AND kv.{{ .Ident "resource" }}  = {{ .Arg .Request.Options.Key.Resource }}
-        {{ end }}
-        {{ if .Request.Options.Key.Name }}
-        AND kv.{{ .Ident "name" }}      = {{ .Arg .Request.Options.Key.Name }}
-        {{ end }}
-    {{ end }}
-    ORDER BY kv.{{ .Ident "namespace" }} ASC, kv.{{ .Ident "name" }} ASC
-    {{ if (gt .Request.Limit 0) }}
-    LIMIT {{ .Arg .Request.Limit }} OFFSET {{ .Arg .Request.Offset }}
-    {{ end }}
+) AS kv
+WHERE kv.{{ .Ident "resource_version" }} = kv.max_resource_version
+    AND kv.{{ .Ident "action" }} != 3
+ORDER BY kv.{{ .Ident "namespace" }} ASC, kv.{{ .Ident "name" }} ASC
+{{ if (gt .Request.Limit 0) }}
+LIMIT {{ .Arg .Request.Limit }} OFFSET {{ .Arg .Request.Offset }}
+{{ end }}
 ;

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -63,9 +63,9 @@ func newServer(t *testing.T, cfg *setting.Cfg) (sql.Backend, resource.ResourceSe
 }
 
 func TestIntegrationBackendHappyPath(t *testing.T) {
-	if infraDB.IsTestDbSQLite() {
-		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
-	}
+	// if infraDB.IsTestDbSQLite() {
+	// 	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// }
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -199,9 +199,9 @@ func TestIntegrationBackendWatchWriteEventsFromLastest(t *testing.T) {
 }
 
 func TestIntegrationBackendList(t *testing.T) {
-	if infraDB.IsTestDbSQLite() {
-		t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
-	}
+	// if infraDB.IsTestDbSQLite() {
+	// 	t.Skip("TODO: test blocking, skipping to unblock Enterprise until we fix this")
+	// }
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/storage/unified/sql/testdata/postgres--resource_history_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_history_list-single path.sql
@@ -3,23 +3,27 @@ SELECT
     kv."namespace",
     kv."name",
     kv."value"
-    FROM "resource_history" as kv 
-    INNER JOIN  (
-        SELECT "namespace", "group", "resource", "name",  max("resource_version") AS "resource_version"
-        FROM "resource_history" AS mkv
-        WHERE 1 = 1
-            AND "resource_version" <=  0
-                AND "namespace" = 'ns'
-        GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name" 
-    ) AS maxkv
-    ON
-        maxkv."resource_version"  = kv."resource_version"
-        AND maxkv."namespace"     = kv."namespace"
-        AND maxkv."group"         = kv."group"
-        AND maxkv."resource"      = kv."resource"
-        AND maxkv."name"          = kv."name"
-    WHERE kv."action"  != 3 
-        AND kv."namespace" = 'ns'
-    ORDER BY kv."namespace" ASC, kv."name" ASC
-    LIMIT 10 OFFSET 0
+FROM (
+    SELECT
+        "resource_version",
+        "namespace",
+        "group",
+        "resource",
+        "name",
+        "value",
+        "action",
+        MAX("resource_version") OVER (
+            PARTITION BY "namespace", "group", "resource", "name"
+            ORDER BY "resource_version"
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS max_resource_version
+    FROM "resource_history"
+    WHERE 1 = 1
+        AND "resource_version" <= 0
+            AND "namespace" = 'ns'
+) AS kv
+WHERE kv."resource_version" = kv.max_resource_version
+    AND kv."action" != 3
+ORDER BY kv."namespace" ASC, kv."name" ASC
+LIMIT 10 OFFSET 0
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_history_list-single path.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_history_list-single path.sql
@@ -3,23 +3,27 @@ SELECT
     kv."namespace",
     kv."name",
     kv."value"
-    FROM "resource_history" as kv 
-    INNER JOIN  (
-        SELECT "namespace", "group", "resource", "name",  max("resource_version") AS "resource_version"
-        FROM "resource_history" AS mkv
-        WHERE 1 = 1
-            AND "resource_version" <=  0
-                AND "namespace" = 'ns'
-        GROUP BY mkv."namespace", mkv."group", mkv."resource", mkv."name" 
-    ) AS maxkv
-    ON
-        maxkv."resource_version"  = kv."resource_version"
-        AND maxkv."namespace"     = kv."namespace"
-        AND maxkv."group"         = kv."group"
-        AND maxkv."resource"      = kv."resource"
-        AND maxkv."name"          = kv."name"
-    WHERE kv."action"  != 3 
-        AND kv."namespace" = 'ns'
-    ORDER BY kv."namespace" ASC, kv."name" ASC
-    LIMIT 10 OFFSET 0
+FROM (
+    SELECT
+        "resource_version",
+        "namespace",
+        "group",
+        "resource",
+        "name",
+        "value",
+        "action",
+        MAX("resource_version") OVER (
+            PARTITION BY "namespace", "group", "resource", "name"
+            ORDER BY "resource_version"
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS max_resource_version
+    FROM "resource_history"
+    WHERE 1 = 1
+        AND "resource_version" <= 0
+            AND "namespace" = 'ns'
+) AS kv
+WHERE kv."resource_version" = kv.max_resource_version
+    AND kv."action" != 3
+ORDER BY kv."namespace" ASC, kv."name" ASC
+LIMIT 10 OFFSET 0
 ;


### PR DESCRIPTION
This attempts to rewrite the query from history to use [SQL window functions](https://mode.com/sql-tutorial/sql-window-functions).

## Initial results.

I've tested the row query using mysql8 with 30k resources in the history table, 8 version for each resource (total of ~240k rows).

- The current inner join version takes ~0.6s to run
- The window function version takes  ~10s which is so much more. Looking at the query analyser, most of the time sorting (already sorted column 🤷) and computing the max within each partition
- Also tested a version using RANK() instead of max taking ~7s (aka 10x slower than current).

# details
```
mysql> explain analyze
    -> SELECT     kv.`resource_version`,     kv.`namespace`,     kv.`name`,     kv.`folder`,     kv.`value`
    -> FROM `resource_history` as kv
    -> INNER JOIN  (
    ->     SELECT `namespace`, `group`, `resource`, `name`,  max(`resource_version`) AS `resource_version`
    ->     FROM `resource_history` AS mkv
    ->     WHERE 1 = 1
    ->     AND `resource_version` <=  3730888589594730
    ->     AND `namespace` = 'default'
    ->     AND `group` = "peakq.grafana.app"
    ->     GROUP BY mkv.`namespace`, mkv.`group`, mkv.`resource`, mkv.`name`
    -> ) AS maxkv
    -> ON         maxkv.`resource_version`  = kv.`resource_version`
    -> AND maxkv.`namespace`     = kv.`namespace`         AND maxkv.`group`         = kv.`group`
    -> AND maxkv.`resource`      = kv.`resource`         AND maxkv.`name`          = kv.`name`
    -> WHERE kv.`action`  != 3          AND kv.`namespace` = 'default'     ORDER BY kv.`namespace` ASC, kv.`name` ASC     LIMIT 10 OFFSET 0;
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| -> Limit: 10 row(s)  (actual time=566.956..566.962 rows=10 loops=1)
    -> Sort row IDs: kv.namespace, kv.`name`, limit input to 10 row(s) per chunk  (actual time=566.955..566.961 rows=10 loops=1)
        -> Table scan on <temporary>  (cost=16727.18..16882.43 rows=12222) (actual time=537.703..543.729 rows=30410 loops=1)
            -> Temporary table  (cost=16727.17..16727.17 rows=12222) (actual time=537.687..537.687 rows=30410 loops=1)
                -> Nested loop inner join  (cost=15504.97 rows=12222) (actual time=275.555..499.533 rows=30410 loops=1)
                    -> Filter: ((maxkv.namespace = 'default') and (maxkv.resource_version is not null))  (cost=23781.25..1530.25 rows=13580) (actual time=275.031..281.477 rows=30410 loops=1)
                        -> Table scan on maxkv  (cost=23782.90..23955.13 rows=13580) (actual time=275.030..278.054 rows=30410 loops=1)
                            -> Materialize  (cost=23782.88..23782.88 rows=13580) (actual time=275.028..275.028 rows=30410 loops=1)
                                -> Filter: ((mkv.resource_version <= 3730888589594730) and (mkv.namespace = 'default') and (mkv.`group` = 'peakq.grafana.app'))  (cost=22424.88 rows=13580) (actual time=0.813..265.308 rows=30410 loops=1)
                                    -> Covering index skip scan for grouping on mkv using UQE_resource_history_namespace_group_name_version over (NULL < resource_version <= 3730888589594730)  (cost=22424.88 rows=13580) (actual time=0.806..259.556 rows=30410 loops=1)
                    -> Filter: (kv.`action` <> 3)  (cost=0.93 rows=1) (actual time=0.007..0.007 rows=1 loops=30410)
                        -> Single-row index lookup on kv using UQE_resource_history_namespace_group_name_version (namespace='default', group=maxkv.`group`, resource=maxkv.`resource`, name=maxkv.`name`, resource_version=maxkv.resource_version), with index condition: (kv.namespace = maxkv.namespace)  (cost=0.93 rows=1) (actual time=0.007..0.007 rows=1 loops=30410)
 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.60 sec)

mysql>
mysql>  EXPLAIN analyze SELECT
    ->     kv.`resource_version`,
    ->     kv.`namespace`,
    ->     kv.`name`,
    ->     kv.`value`
    -> FROM (
    ->     SELECT
    ->         `resource_version`,
    ->         `namespace`,
    ->         `group`,
    ->         `resource`,
    ->         `name`,
    ->         `value`,
    ->         `action`,
    ->         MAX("resource_version") over (
    ->             PARTITION BY `namespace`,`group`,`resource`,`name`
    ->             ORDER BY `resource_version` DESC
    ->             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
    ->         ) AS max_resource_version
    ->     FROM `resource_history`
    ->     WHERE 1 = 1
    ->         AND `resource_version` <= 3730888589594730
    ->         AND `namespace` = "default"
    ->         AND `group` = "peakq.grafana.app"
    ->
    -> ) AS kv
    -> WHERE kv.resource_version = kv.max_resource_version AND kv.`action` != 3
    -> ORDER BY kv.`namespace` ASC, kv.`name` ASC
    -> LIMIT 10 OFFSET 0
    -> ;
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| -> Limit: 10 row(s)  (cost=2.60..2.60 rows=0) (actual time=9834.541..9834.541 rows=0 loops=1)
    -> Sort row IDs: kv.namespace, kv.`name`, limit input to 10 row(s) per chunk  (cost=2.60..2.60 rows=0) (actual time=9834.540..9834.540 rows=0 loops=1)
        -> Filter: ((cast(kv.resource_version as double) = cast(kv.max_resource_version as double)) and (kv.`action` <> 3))  (cost=2.50..2.50 rows=0) (actual time=9834.482..9834.482 rows=0 loops=1)
            -> Table scan on kv  (cost=2.50..2.50 rows=0) (actual time=9652.337..9802.672 rows=243280 loops=1)
                -> Materialize  (cost=0.00..0.00 rows=0) (actual time=9652.285..9652.285 rows=243280 loops=1)
                    -> Window aggregate with buffering: max('resource_version') OVER (PARTITION BY resource_history.namespace,resource_history.`group`,resource_history.`resource`,resource_history.`name` ORDER BY resource_history.resource_version desc ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)   (actual time=5209.180..9370.783 rows=243280 loops=1)
                        -> Sort row IDs: resource_history.namespace, resource_history.`group`, resource_history.`resource`, resource_history.`name`, resource_history.resource_version DESC  (cost=25459.43 rows=112216) (actual time=5208.141..8428.611 rows=243280 loops=1)
                            -> Index lookup on resource_history using UQE_resource_history_namespace_group_name_version (namespace='default', group='peakq.grafana.app'), with index condition: (resource_history.resource_version <= 3730888589594730)  (cost=25459.43 rows=112216) (actual time=0.682..2080.909 rows=243280 loops=1)
 |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set, 65535 warnings (9.85 sec)

mysql> explain analyze SELECT     kv.`resource_version`,     kv.`namespace`,     kv.`name`,     kv.`value` FROM (     SELECT         `resource_version`,         `namespace`,         `group`,         `resource`,
     `name`,         `value`,         `action`,         RANK() OVER (             PARTITION BY `namespace`,`group`,`resource`,`name`             ORDER BY `resource_version` DESC         ) AS version_rank     FROM `resource_history`     WHERE 1 = 1         AND `resource_version` <= 3730888589594730         AND `namespace` = "default"  ) AS kv WHERE kv.version_rank = 1     AND kv.`action` != 3 ORDER BY kv.`namespace` ASC, kv.`name` ASC LIMIT 10 OFFSET 0;
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| EXPLAIN                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| -> Limit: 10 row(s)  (cost=2.60..2.60 rows=0) (actual time=7292.258..7292.296 rows=10 loops=1)
    -> Sort row IDs: kv.namespace, kv.`name`, limit input to 10 row(s) per chunk  (cost=2.60..2.60 rows=0) (actual time=7292.257..7292.294 rows=10 loops=1)
        -> Filter: ((kv.version_rank = 1) and (kv.`action` <> 3))  (cost=2.50..2.50 rows=0) (actual time=7114.487..7260.203 rows=30410 loops=1)
            -> Table scan on kv  (cost=2.50..2.50 rows=0) (actual time=7114.423..7252.882 rows=243280 loops=1)
                -> Materialize  (cost=0.00..0.00 rows=0) (actual time=7114.374..7114.374 rows=243280 loops=1)
                    -> Window aggregate: rank() OVER (PARTITION BY resource_history.namespace,resource_history.`group`,resource_history.`resource`,resource_history.`name` ORDER BY resource_history.resource_version desc )   (actual time=4662.279..6900.103 rows=243280 loops=1)
                        -> Sort row IDs: resource_history.namespace, resource_history.`group`, resource_history.`resource`, resource_history.`name`, resource_history.resource_version DESC  (cost=25513.93 rows=112216) (actual time=4662.158..6761.293 rows=243280 loops=1)
                            -> Index lookup on resource_history using UQE_resource_history_namespace_group_name_version (namespace='default'), with index condition: (resource_history.resource_version <= 3730888589594730)  (cost=25513.93 rows=112216) (actual time=0.366..1871.988 rows=243280 loops=1)
 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (7.31 sec)
```
