### PR TITLE
fix: pass context into secrets logs

### DIFF
--- a/pkg/services/encryption/service/service.go
+++ b/pkg/services/encryption/service/service.go
@@ -105,7 +105,7 @@ func (s *Service) Decrypt(ctx context.Context, payload []byte, secret string) ([
 	var err error
 	defer func() {
 		if err != nil {
-			s.log.Error("Decryption failed", "error", err)
+			s.log.FromContext(ctx).Error("Decryption failed", "error", err)
 		}
 	}()
 

--- a/pkg/services/secrets/manager/manager.go
+++ b/pkg/services/secrets/manager/manager.go
@@ -331,7 +331,7 @@ func (s *SecretsService) Decrypt(ctx context.Context, payload []byte) ([]byte, e
 		}).Inc()
 
 		if err != nil {
-			s.log.Error("Failed to decrypt secret", "error", err)
+			s.log.FromContext(ctx).Error("Failed to decrypt secret", "error", err)
 		}
 	}()
 
@@ -371,7 +371,7 @@ func (s *SecretsService) Decrypt(ctx context.Context, payload []byte) ([]byte, e
 
 		dataKey, err = s.dataKeyById(ctx, string(keyId))
 		if err != nil {
-			s.log.Error("Failed to lookup data key by id", "id", string(keyId), "error", err)
+			s.log.FromContext(ctx).Error("Failed to lookup data key by id", "id", string(keyId), "error", err)
 			return nil, err
 		}
 	}

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -436,19 +436,19 @@ func (s *Service) decryptSecrets(ctx context.Context, settings map[string]any) (
 			if IsSecretField(k) && v != "" {
 				strValue, ok := v.(string)
 				if !ok {
-					s.logger.Error("Failed to parse secret value, it is not a string", "key", k)
+					s.logger.FromContext(ctx).Error("Failed to parse secret value, it is not a string", "key", k)
 					return nil, fmt.Errorf("secret value is not a string")
 				}
 
 				decoded, err := base64.RawStdEncoding.DecodeString(strValue)
 				if err != nil {
-					s.logger.Error("Failed to decode secret string", "err", err, "value")
+					s.logger.FromContext(ctx).Error("Failed to decode secret string", "err", err, "value")
 					return nil, err
 				}
 
 				decrypted, err := s.secrets.Decrypt(ctx, decoded)
 				if err != nil {
-					s.logger.Error("Failed to decrypt secret", "err", err)
+					s.logger.FromContext(ctx).Error("Failed to decrypt secret", "err", err)
 					return nil, err
 				}
 


### PR DESCRIPTION
**What is this feature?**
This adds the context into more secrets logs.

**Why do we need this feature?**
We are trying to debug why we're failing on decrypting some secrets, and the logs are not as helpful as they could be.

**Who is this feature for?**
Anyone running into errors on secrets, but first and foremost ourselves.

**Which issue(s) does this PR fix?**:
N/A; issue noticed on Slack.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
