### PR TITLE
Docs: Remove org id from create team request docs

### DIFF
--- a/docs/sources/developers/http_api/team.md
+++ b/docs/sources/developers/http_api/team.md
@@ -147,7 +147,7 @@ Status Codes:
 
 ## Add Team
 
-The Team `name` needs to be unique. `name` is required and `email`,`orgId` is optional.
+The Team `name` needs to be unique. `name` is required and `email` is optional.
 
 `POST /api/teams`
 

--- a/docs/sources/developers/http_api/team.md
+++ b/docs/sources/developers/http_api/team.md
@@ -170,7 +170,6 @@ Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
 {
   "name": "MyTestTeam",
   "email": "email@test.com",
-  "orgId": 2
 }
 ```
 


### PR DESCRIPTION
**What is this feature?**
Pointed out in https://github.com/grafana/grafana/issues/93375. This makes it seems like you can control in what org a team is created from the request body. But this is in fact not true https://github.com/grafana/grafana/blob/f8ae71e4583499dd461ebaed31451966be04220b/pkg/services/team/model.go#L41. We always create the team that the request is authenticated for.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
