### PR TITLE
query: add missing x-rule headers

### DIFF
--- a/pkg/registry/apis/datasource/sub_query_test.go
+++ b/pkg/registry/apis/datasource/sub_query_test.go
@@ -35,9 +35,12 @@ func TestSubQueryConnect(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/some-path", nil)
 	req.Header.Set(models.FromAlertHeaderName, "true")
 	req.Header.Set(models.CacheSkipHeaderName, "true")
+	req.Header.Set("X-Rule-Name", "name-1")
 	req.Header.Set("X-Rule-Uid", "abc")
 	req.Header.Set("X-Rule-Folder", "folder-1")
 	req.Header.Set("X-Rule-Source", "grafana-ruler")
+	req.Header.Set("X-Rule-Type", "type-1")
+	req.Header.Set("X-Rule-Version", "version-1")
 	req.Header.Set("X-Grafana-Org-Id", "1")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("some-unexpected-header", "some-value")
@@ -47,9 +50,12 @@ func TestSubQueryConnect(t *testing.T) {
 	require.Equal(t, map[string]string{
 		models.FromAlertHeaderName: "true",
 		models.CacheSkipHeaderName: "true",
+		"X-Rule-Name":              "name-1",
 		"X-Rule-Uid":               "abc",
 		"X-Rule-Folder":            "folder-1",
 		"X-Rule-Source":            "grafana-ruler",
+		"X-Rule-Type":              "type-1",
+		"X-Rule-Version":           "version-1",
 		"X-Grafana-Org-Id":         "1",
 	}, *sqr.builder.client.(mockClient).lastCalledWithHeaders)
 }

--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -10,17 +10,20 @@ import (
 // Set of headers that we want to forward to the datasource api servers. Those are used i.e. for
 // cache control or identifying the source of the request.
 //
-// The headers related to grafana alerting can be found here:
-// https://github.com/grafana/grafana-ruler/blob/96e6d4b25c0d973a7615b92b35739511a6fbd72f/pkg/ruler/rulesmanager/ds_query_rule_evaluator.go#L313-L328
+// The headers related to grafana alerting (x-rule-*), should match the list at
+// https://github.com/grafana/grafana/blob/f8ae71e4583499dd461ebaed31451966be04220b/pkg/services/pluginsintegration/clientmiddleware/usealertingheaders_middleware.go#L23
 //
 // The usage of strings.ToLower is because the server would convert `FromAlert` to `Fromalert`. So the make matching
 // easier, we just match all headers in lower case.
 var expectedHeaders = map[string]string{
 	strings.ToLower(models.FromAlertHeaderName): models.FromAlertHeaderName,
 	strings.ToLower(models.CacheSkipHeaderName): models.CacheSkipHeaderName,
+	strings.ToLower("X-Rule-Name"):              "X-Rule-Name",
 	strings.ToLower("X-Rule-Uid"):               "X-Rule-Uid",
 	strings.ToLower("X-Rule-Folder"):            "X-Rule-Folder",
 	strings.ToLower("X-Rule-Source"):            "X-Rule-Source",
+	strings.ToLower("X-Rule-Type"):              "X-Rule-Type",
+	strings.ToLower("X-Rule-Version"):           "X-Rule-Version",
 	strings.ToLower("X-Grafana-Org-Id"):         "X-Grafana-Org-Id",
 }
 

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -56,9 +56,12 @@ func TestQueryRestConnectHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/some-path", bytes.NewReader(body.Raw))
 	req.Header.Set(models.FromAlertHeaderName, "true")
 	req.Header.Set(models.CacheSkipHeaderName, "true")
+	req.Header.Set("X-Rule-Name", "name-1")
 	req.Header.Set("X-Rule-Uid", "abc")
 	req.Header.Set("X-Rule-Folder", "folder-1")
 	req.Header.Set("X-Rule-Source", "grafana-ruler")
+	req.Header.Set("X-Rule-Type", "type-1")
+	req.Header.Set("X-Rule-Version", "version-1")
 	req.Header.Set("X-Grafana-Org-Id", "1")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("some-unexpected-header", "some-value")
@@ -67,9 +70,12 @@ func TestQueryRestConnectHandler(t *testing.T) {
 	require.Equal(t, map[string]string{
 		models.FromAlertHeaderName: "true",
 		models.CacheSkipHeaderName: "true",
+		"X-Rule-Name":              "name-1",
 		"X-Rule-Uid":               "abc",
 		"X-Rule-Folder":            "folder-1",
 		"X-Rule-Source":            "grafana-ruler",
+		"X-Rule-Type":              "type-1",
+		"X-Rule-Version":           "version-1",
 		"X-Grafana-Org-Id":         "1",
 	}, *b.client.(mockClient).lastCalledWithHeaders)
 }


### PR DESCRIPTION
some of the existing `x-rule-*` alerting-headers were not included in the list of headers to forward, this PR fixes that.