### PR TITLE
Prometheus: enable custom values in MetricCombobox

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -95,6 +95,7 @@ export function MetricCombobox({
           options={loadOptions}
           value={query.metric}
           onChange={onComboboxChange}
+          createCustomValue
         />
 
         {metricsExplorerEnabled ? (


### PR DESCRIPTION
Restores the custom value creation to selecting metrics in Prometheus with Combobox

![image](https://github.com/user-attachments/assets/8e00e6d4-c6fb-4b12-adea-defcb0edffe9)
