### PR TITLE
Dashboard datasource: Include source panel annotations

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -78,7 +78,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       return sourceDataProvider!.getResultsStream!().pipe(
         map((result) => {
           return {
-            data: result.data.series,
+            data: [...result.data.series, ...(result.data.annotations ?? [])],
             state: result.data.state,
             errors: result.data.errors,
             error: result.data.error,


### PR DESCRIPTION
Fixes a regression in scenes where a panel using the dashboard data source wouldn't include the annotations of the source panel.
There is a related issue where the "Annotations" mode of the data source doesn't work correctly.