### PR TITLE
Alerting: Add pagination to /api/prometheus/grafana/api/v1/rules

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -354,11 +354,6 @@ func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager
 	var newToken string
 	foundToken := false
 	for _, rg := range groupedRules {
-		// folder, ok := opts.Namespaces[rg.GroupKey.NamespaceUID]
-		// if !ok {
-		// 	log.Warn("Query returned rules that belong to folder the user does not have access to. All rules that belong to that namespace will not be added to the response", "folder_uid", groupKey.NamespaceUID)
-		// 	continue
-		// }
 		ok, err := opts.AuthorizeRuleGroup(rg.Rules)
 		if err != nil {
 			ruleResponse.DiscoveryBase.Status = "error"
@@ -402,8 +397,6 @@ func PrepareRuleGroupStatuses(log log.Logger, manager state.AlertInstanceManager
 	ruleResponse.Data.NextToken = newToken
 	ruleResponse.Data.Totals = rulesTotals
 
-	// Sort Rule Groups before checking limits
-	// apimodels.RuleGroupsBy(apimodels.RuleGroupsByFileAndName).Sort(ruleResponse.Data.RuleGroups)
 	if limitGroups > -1 && int64(len(ruleResponse.Data.RuleGroups)) >= limitGroups {
 		ruleResponse.Data.RuleGroups = ruleResponse.Data.RuleGroups[0:limitGroups]
 	}

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -732,7 +732,10 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			result := &apimodels.RuleResponse{}
 			require.NoError(t, json.Unmarshal(resp.Body(), result))
 
+			returnedGroups := make([]apimodels.RuleGroup, 0, len(allRules))
+
 			require.Len(t, result.Data.RuleGroups, 2)
+			returnedGroups = append(returnedGroups, result.Data.RuleGroups...)
 			require.NotEmpty(t, result.Data.NextToken)
 			token := result.Data.NextToken
 
@@ -748,6 +751,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 				require.NoError(t, json.Unmarshal(resp.Body(), result))
 
 				require.Len(t, result.Data.RuleGroups, 2)
+				returnedGroups = append(returnedGroups, result.Data.RuleGroups...)
 				require.NotEmpty(t, result.Data.NextToken)
 				token = result.Data.NextToken
 			}
@@ -764,7 +768,15 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			require.NoError(t, json.Unmarshal(resp.Body(), result))
 
 			require.Len(t, result.Data.RuleGroups, 1)
+			returnedGroups = append(returnedGroups, result.Data.RuleGroups...)
 			require.Empty(t, result.Data.NextToken)
+
+			for i := 0; i < 9; i++ {
+				folder, err := api.store.GetNamespaceByUID(context.Background(), fmt.Sprintf("namespace_%d", i/9), orgID, user)
+				require.NoError(t, err)
+				require.Equal(t, folder.Fullpath, returnedGroups[i].File)
+				require.Equal(t, fmt.Sprintf("rule_group_%d", i), returnedGroups[i].Name)
+			}
 		})
 
 		t.Run("bad token should return no results", func(t *testing.T) {

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -72,6 +72,7 @@ type DiscoveryBase struct {
 type RuleDiscovery struct {
 	// required: true
 	RuleGroups []RuleGroup      `json:"groups"`
+	NextToken  string           `json:"groupNextToken,omitempty"`
 	Totals     map[string]int64 `json:"totals,omitempty"`
 }
 


### PR DESCRIPTION
**What is this feature?**
Adds two new query parameters `group_limit` and `group_next_token` to `/api/prometheus/grafana/api/v1/rules`. `group_limit` specifies the maximum number of rule groups to return, and subsequent responses will contain `groupNextToken` in the response. `groupNextToken` will be empty in the final response, and the page size will be `<= group_limit`

**Why do we need this feature?**
Allows the frontend to fetch rules in smaller page sizes, improving performance.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
