### PR TITLE
Dashboard: Append orgId to URL

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -4,6 +4,7 @@ import { AppEvents } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { SceneObjectUrlSyncHandler, SceneObjectUrlValues, VizPanel } from '@grafana/scenes';
 import appEvents from 'app/core/app_events';
+import { contextSrv } from 'app/core/core';
 import { KioskMode } from 'app/types';
 
 import { PanelInspectDrawer } from '../inspect/PanelInspectDrawer';
@@ -39,6 +40,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       editPanel: state.editPanel?.getUrlKey() || undefined,
       kiosk: state.kioskMode === KioskMode.Full ? '' : state.kioskMode === KioskMode.TV ? 'tv' : undefined,
       shareView: state.shareView,
+      orgId: contextSrv.user.orgId.toString(),
     };
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR brings back `orgId` to a dashboard URL.

In the old arch this was added upon initializing a dashboard [here](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/state/initDashboard.ts#L214-L217).

**Why do we need this feature?**

In a multi-org situation, upon opening a dashboard the `orgId` query parameter is not added to the URL. This leads to unintended behaviors when:
- bookmarking a link and opening it after switching the org
- sharing a dashboard URL with another user that's on another org

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
