### PR TITLE
[v11.3.x] Dashboard datasource: Return annotations as series when query topic is "annotations"

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -7,6 +7,9 @@ import {
   DataSourceInstanceSettings,
   TestDataSourceResponse,
   ScopedVar,
+  DataTopic,
+  PanelData,
+  DataFrame,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
@@ -74,7 +77,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       return sourceDataProvider!.getResultsStream!().pipe(
         map((result) => {
           return {
-            data: result.data.series,
+            data: this.getDataFramesForQueryTopic(result.data, query),
             state: result.data.state,
             errors: result.data.errors,
             error: result.data.error,
@@ -84,6 +87,21 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         finalize(cleanUp)
       );
     });
+  }
+
+  private getDataFramesForQueryTopic(data: PanelData, query: DashboardQuery): DataFrame[] {
+    const annotations = data.annotations ?? [];
+    if (query.topic === DataTopic.Annotations) {
+      return annotations.map((frame) => ({
+        ...frame,
+        meta: {
+          ...frame.meta,
+          dataTopic: DataTopic.Series,
+        },
+      }));
+    } else {
+      return [...data.series, ...annotations];
+    }
   }
 
   private findSourcePanel(scene: SceneObject, panelId: number) {


### PR DESCRIPTION
Backport 26b0e8f105c7ebe1e7f982c83af1f7d26370150c from #95965

---

Follow up to https://github.com/grafana/grafana/pull/95958
Fixes a regression introduced with scenes where changing the "data" mode to "annotations" didn't have any effect.

Fixes https://github.com/grafana/grafana/issues/95616
