### PR TITLE
Shard query splitting: improve mergeResponse performance

### DIFF
--- a/public/app/plugins/datasource/loki/mergeResponses.test.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.test.ts
@@ -218,6 +218,7 @@ describe('combineResponses', () => {
     const responseA: DataQueryResponse = {
       data: [metricFrameA],
     };
+    metricFrameC.refId = 'B';
     const responseB: DataQueryResponse = {
       data: [metricFrameB, metricFrameC],
     };
@@ -654,7 +655,7 @@ describe('combineResponses', () => {
     });
   });
 
-  it('does not combine frames with different refId', () => {
+  it('does not combine frames with different name', () => {
     const { metricFrameA, metricFrameB } = getMockFrames();
     metricFrameA.name = 'A';
     metricFrameB.name = 'B';
@@ -911,6 +912,7 @@ describe('mergeFrames', () => {
     const responseA: DataQueryResponse = {
       data: [metricFrameB],
     };
+    metricFrameC.refId = 'B';
     const responseB: DataQueryResponse = {
       data: [metricFrameA, metricFrameC],
     };

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -280,6 +280,10 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
     return false;
   }
 
+  if (frame1.refId != null && frame2.refId != null && frame1.refId === frame2.refId) {
+    return true;
+  }
+
   const frameType1 = frame1.meta?.type;
   const frameType2 = frame2.meta?.type;
 


### PR DESCRIPTION
Core Grafana update of the improvements identified in https://github.com/grafana/explore-logs/pull/879