### PR TITLE
Sidecar: Make header consistently 100% width so the X button is visible

### DIFF
--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -108,7 +108,7 @@ export function ExperimentalSplitPaneRouterWrapper(props: RouterWrapperProps) {
               <LocationServiceProvider service={memoryLocationService}>
                 <CompatRouter>
                   <GlobalStyles />
-                  <div className={styles.secondAppWrapper}>
+                  <div className={styles.secondAppChrome}>
                     <div className={styles.secondAppToolbar}>
                       <IconButton
                         size={'lg'}
@@ -118,7 +118,9 @@ export function ExperimentalSplitPaneRouterWrapper(props: RouterWrapperProps) {
                         onClick={() => closeApp(activePluginId)}
                       />
                     </div>
-                    <AppRootPage pluginId={activePluginId} />
+                    <div className={styles.secondAppWrapper}>
+                      <AppRootPage pluginId={activePluginId} />
+                    </div>
                   </div>
                 </CompatRouter>
               </LocationServiceProvider>
@@ -132,10 +134,11 @@ export function ExperimentalSplitPaneRouterWrapper(props: RouterWrapperProps) {
 
 const getStyles = (theme: GrafanaTheme2, headerHeight: number | undefined) => {
   return {
-    secondAppWrapper: css({
-      label: 'secondAppWrapper',
+    secondAppChrome: css({
+      label: 'secondAppChrome',
       display: 'flex',
       height: '100%',
+      width: '100%',
       paddingTop: headerHeight || 0,
       flexGrow: 1,
       flexDirection: 'column',
@@ -145,6 +148,12 @@ const getStyles = (theme: GrafanaTheme2, headerHeight: number | undefined) => {
       label: 'secondAppToolbar',
       display: 'flex',
       justifyContent: 'flex-end',
+    }),
+
+    secondAppWrapper: css({
+      label: 'secondAppWrapper',
+      overflow: 'auto',
+      flex: '1',
     }),
 
     // This is basically the same as grafana-app class. This means the 2 additional wrapper divs that are in between


### PR DESCRIPTION
Makes the header 100% width, this makes header all visible even if contents overflow.

<img width="680" alt="Screenshot 2024-11-06 at 18 52 44" src="https://github.com/user-attachments/assets/cc38814a-5bd9-407c-a15b-e518f640abbd">
