### PR TITLE
Alerting: Add simplified_notifications_section field to the alert rule metadata

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -337,6 +337,7 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		createdRules := gen.With(
 			gen.WithUniqueGroupIndex(), gen.WithUniqueID(),
 			gen.WithEditorSettingsSimplifiedQueryAndExpressionsSection(true),
+			gen.WithEditorSettingsSimplifiedNotificationsSection(true),
 		).GenerateManyRef(3)
 		require.Len(t, createdRules, 3)
 		ruleStore.PutRule(context.Background(), createdRules...)
@@ -356,6 +357,7 @@ func TestRouteGetRuleByUID(t *testing.T) {
 		require.Equal(t, expectedRule.RuleGroup, result.GrafanaManagedAlert.RuleGroup)
 		require.Equal(t, expectedRule.Title, result.GrafanaManagedAlert.Title)
 		require.True(t, result.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
+		require.True(t, result.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection)
 	})
 
 	t.Run("error when fetching rule with non-existent UID", func(t *testing.T) {

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -147,6 +147,7 @@ func validateAlertingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule 
 	if in.GrafanaManagedAlert.Metadata != nil {
 		newRule.Metadata.EditorSettings = ngmodels.EditorSettings{
 			SimplifiedQueryAndExpressionsSection: in.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection,
+			SimplifiedNotificationsSection:       in.GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection,
 		}
 	}
 

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -1046,6 +1046,36 @@ func TestValidateRuleNodeNotificationSettings(t *testing.T) {
 	}
 }
 
+func TestValidateRuleNodeEditorSettings(t *testing.T) {
+	cfg := config(t)
+	limits := makeLimits(cfg)
+
+	editorSettings := models.EditorSettings{
+		SimplifiedQueryAndExpressionsSection: true,
+		SimplifiedNotificationsSection:       true,
+	}
+
+	testCases := []struct {
+		name           string
+		editorSettings models.EditorSettings
+	}{
+		{
+			name:           "valid editor settings",
+			editorSettings: editorSettings,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			r := validRule()
+			r.GrafanaManagedAlert.Metadata = AlertRuleMetadataFromModelMetadata(models.AlertRuleMetadata{EditorSettings: tt.editorSettings})
+			newRule, err := validateRuleNode(&r, util.GenerateShortUID(), cfg.BaseInterval*time.Duration(rand.Int63n(10)+1), rand.Int63(), randFolder().UID, limits)
+			require.NoError(t, err)
+			require.Equal(t, tt.editorSettings, newRule.Metadata.EditorSettings)
+		})
+	}
+}
+
 func TestValidateRuleNodeReservedLabels(t *testing.T) {
 	cfg := config(t)
 	limits := makeLimits(cfg)

--- a/pkg/services/ngalert/api/compat.go
+++ b/pkg/services/ngalert/api/compat.go
@@ -425,6 +425,7 @@ func MuteTimingIntervalToMuteTimeIntervalHclExport(m definitions.MuteTimeInterva
 func AlertRuleEditorSettingsFromModelEditorSettings(es models.EditorSettings) *definitions.AlertRuleEditorSettings {
 	return &definitions.AlertRuleEditorSettings{
 		SimplifiedQueryAndExpressionsSection: es.SimplifiedQueryAndExpressionsSection,
+		SimplifiedNotificationsSection:       es.SimplifiedNotificationsSection,
 	}
 }
 

--- a/pkg/services/ngalert/api/compat_test.go
+++ b/pkg/services/ngalert/api/compat_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func TestToModel(t *testing.T) {
@@ -65,5 +66,21 @@ func TestToModel(t *testing.T) {
 		require.Empty(t, rule.Condition)
 		require.Empty(t, rule.ExecErrState)
 		require.Nil(t, rule.NotificationSettings)
+	})
+}
+
+func TestAlertRuleMetadataFromModelMetadata(t *testing.T) {
+	t.Run("should convert model metadata to api metadata", func(t *testing.T) {
+		modelMetadata := models.AlertRuleMetadata{
+			EditorSettings: models.EditorSettings{
+				SimplifiedQueryAndExpressionsSection: true,
+				SimplifiedNotificationsSection:       true,
+			},
+		}
+
+		apiMetadata := AlertRuleMetadataFromModelMetadata(modelMetadata)
+
+		require.True(t, apiMetadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
+		require.True(t, apiMetadata.EditorSettings.SimplifiedNotificationsSection)
 	})
 }

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -460,6 +460,7 @@ type AlertRuleMetadata struct {
 // swagger:model
 type AlertRuleEditorSettings struct {
 	SimplifiedQueryAndExpressionsSection bool `json:"simplified_query_and_expressions_section" yaml:"simplified_query_and_expressions_section"`
+	SimplifiedNotificationsSection       bool `json:"simplified_notifications_section" yaml:"simplified_notifications_section"`
 }
 
 // swagger:model

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -278,6 +278,7 @@ type AlertRuleMetadata struct {
 
 type EditorSettings struct {
 	SimplifiedQueryAndExpressionsSection bool `json:"simplified_query_and_expressions_section"`
+	SimplifiedNotificationsSection       bool `json:"simplified_notifications_section"`
 }
 
 // Namespaced describes a class of resources that are stored in a specific namespace.

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -197,9 +197,15 @@ func (a *AlertRuleMutators) WithUniqueID() AlertRuleMutator {
 	}
 }
 
-func (a *AlertRuleMutators) WithEditorSettingsSimplifiedQueryAndExpressionsSection(mode bool) AlertRuleMutator {
+func (a *AlertRuleMutators) WithEditorSettingsSimplifiedQueryAndExpressionsSection(enabled bool) AlertRuleMutator {
 	return func(rule *AlertRule) {
-		rule.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection = mode
+		rule.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection = enabled
+	}
+}
+
+func (a *AlertRuleMutators) WithEditorSettingsSimplifiedNotificationsSection(enabled bool) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		rule.Metadata.EditorSettings.SimplifiedNotificationsSection = enabled
 	}
 }
 

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -207,6 +207,7 @@ func TestRuleWithFolderFingerprint(t *testing.T) {
 			Metadata: models.AlertRuleMetadata{
 				EditorSettings: models.EditorSettings{
 					SimplifiedQueryAndExpressionsSection: false,
+					SimplifiedNotificationsSection:       false,
 				},
 			},
 		}

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -793,7 +793,8 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 								"exec_err_state": "Alerting",
 								"metadata": {
 									"editor_settings": {
-										"simplified_query_and_expressions_section": false
+										"simplified_query_and_expressions_section": false,
+										"simplified_notifications_section": false
 									}
 								}
 							}
@@ -1276,7 +1277,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "exec_err_state":"Alerting",
 						  "metadata": {
 						      "editor_settings": {
-							      "simplified_query_and_expressions_section": false
+							      "simplified_query_and_expressions_section": false,
+								  "simplified_notifications_section": false
 							  }
 						  }
 					   }
@@ -1317,7 +1319,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 						  "exec_err_state":"Alerting",
 						  "metadata": {
 						      "editor_settings": {
-							      "simplified_query_and_expressions_section": false
+							      "simplified_query_and_expressions_section": false,
+								  "simplified_notifications_section": false
 							  }
 						  }
 					   }
@@ -1630,7 +1633,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 		                  "exec_err_state":"Alerting",
 						  "metadata": {
 						      "editor_settings": {
-							      "simplified_query_and_expressions_section": false
+							      "simplified_query_and_expressions_section": false,
+								  "simplified_notifications_section": false
 							  }
 						  }
 		               }
@@ -1744,7 +1748,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "exec_err_state":"Alerting",
 					  "metadata": {
 				        "editor_settings": {
-					      "simplified_query_and_expressions_section": false
+					      "simplified_query_and_expressions_section": false,
+						  "simplified_notifications_section": false
 					    }
 					   }
 				      }
@@ -1837,7 +1842,8 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					  "exec_err_state":"Alerting",
 					  "metadata": {
 				        "editor_settings": {
-					      "simplified_query_and_expressions_section": false
+					      "simplified_query_and_expressions_section": false,
+						  "simplified_notifications_section": false
 					    }
 					   }
 				      }
@@ -2369,7 +2375,8 @@ func TestIntegrationQuota(t *testing.T) {
 						  "exec_err_state":"Alerting",
 						  "metadata": {
 						    "editor_settings": {
-							  "simplified_query_and_expressions_section": false
+							  "simplified_query_and_expressions_section": false,
+							  "simplified_notifications_section": false
 							 }
 						   }
 					      }

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -919,6 +919,46 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 		require.False(t, updatedRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedQueryAndExpressionsSection)
 	})
 
+	t.Run("set simplified notifications editor in editor settings", func(t *testing.T) {
+		metadata := &apimodels.AlertRuleMetadata{
+			EditorSettings: apimodels.AlertRuleEditorSettings{
+				SimplifiedQueryAndExpressionsSection: false,
+			},
+		}
+		createdRuleGroup := createAlertInGrafana(metadata)
+
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection = true
+
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		assert.Equal(t, http.StatusAccepted, status)
+
+		updatedRuleGroup := apiClient.GetRulesGroup(t, folderName, groupName).GettableRuleGroupConfig
+		require.Len(t, updatedRuleGroup.Rules, 1)
+		require.True(t, updatedRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection)
+	})
+
+	t.Run("disable simplified notifications editor in editor settings", func(t *testing.T) {
+		metadata := &apimodels.AlertRuleMetadata{
+			EditorSettings: apimodels.AlertRuleEditorSettings{
+				SimplifiedNotificationsSection: true,
+			},
+		}
+		createdRuleGroup := createAlertInGrafana(metadata)
+
+		rulesWithUID := convertGettableRuleGroupToPostable(createdRuleGroup)
+
+		// disabling the editor
+		rulesWithUID.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection = false
+
+		_, status, _ := apiClient.PostRulesGroupWithStatus(t, folderName, &rulesWithUID)
+		assert.Equal(t, http.StatusAccepted, status)
+
+		updatedRuleGroup := apiClient.GetRulesGroup(t, folderName, groupName).GettableRuleGroupConfig
+		require.Len(t, updatedRuleGroup.Rules, 1)
+		require.False(t, updatedRuleGroup.Rules[0].GrafanaManagedAlert.Metadata.EditorSettings.SimplifiedNotificationsSection)
+	})
+
 	t.Run("post alert without metadata", func(t *testing.T) {
 		createAlertInGrafana(nil)
 
@@ -1154,7 +1194,8 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"exec_err_state": "Alerting",
 				"metadata": {
 					"editor_settings": {
-						"simplified_query_and_expressions_section": false
+						"simplified_query_and_expressions_section": false,
+						"simplified_notifications_section": false
 					}
 				}
 			}
@@ -1192,7 +1233,8 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"exec_err_state": "Alerting",
 				"metadata": {
 					"editor_settings": {
-						"simplified_query_and_expressions_section": false
+						"simplified_query_and_expressions_section": false,
+						"simplified_notifications_section": false
 					}
 				}
 			}
@@ -1242,7 +1284,8 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 				"exec_err_state": "Alerting",
 				"metadata": {
 					"editor_settings": {
-						"simplified_query_and_expressions_section": false
+						"simplified_query_and_expressions_section": false,
+						"simplified_notifications_section": false
 					}
 				}
 			}

--- a/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-1-get.json
@@ -44,7 +44,8 @@
         "is_paused": false,
         "metadata": {
           "editor_settings": {
-            "simplified_query_and_expressions_section": false
+            "simplified_query_and_expressions_section": false,
+            "simplified_notifications_section": false
           }
         }
       }
@@ -91,7 +92,8 @@
         "is_paused": false,
         "metadata": {
           "editor_settings": {
-            "simplified_query_and_expressions_section": false
+            "simplified_query_and_expressions_section": false,
+            "simplified_notifications_section": false
           }
         }
       }

--- a/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-2-get.json
@@ -44,7 +44,8 @@
         "is_paused": false,
         "metadata": {
           "editor_settings": {
-            "simplified_query_and_expressions_section": false
+            "simplified_query_and_expressions_section": false,
+            "simplified_notifications_section": false
           }
         }
       }

--- a/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
+++ b/pkg/tests/api/alerting/test-data/rulegroup-3-get.json
@@ -44,7 +44,8 @@
         "is_paused": false,
         "metadata": {
           "editor_settings": {
-            "simplified_query_and_expressions_section": false
+            "simplified_query_and_expressions_section": false,
+            "simplified_notifications_section": false
           }
         }
       }
@@ -91,7 +92,8 @@
         "is_paused": false,
         "metadata": {
           "editor_settings": {
-            "simplified_query_and_expressions_section": false
+            "simplified_query_and_expressions_section": false,
+            "simplified_notifications_section": false
           }
         }
       }


### PR DESCRIPTION
**What is this feature?**

Adds `simplified_notifications_section` field to the alert rule metadata.

**Why do we need this feature?**

On the frontend side we can remember when the user has enabled simplified notifications settings UI.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/961

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
