### PR TITLE
search: dashboard list link

### DIFF
--- a/pkg/services/unifiedSearch/service.go
+++ b/pkg/services/unifiedSearch/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -211,10 +212,18 @@ func (s *StandardSearchService) doSearchQuery(ctx context.Context, qry Query, _ 
 			return response
 		}
 		kind := strings.ToLower(doc.Kind)
-		frame.AppendRow(kind, doc.UID, doc.Spec.Title, "", nil, doc.FolderID)
+		link := dashboardPageItemLink(doc, s.cfg.AppSubURL)
+		frame.AppendRow(kind, doc.UID, doc.Spec.Title, link, nil, doc.FolderID)
 	}
 	response.Frames = append(response.Frames, frame)
 	return response
+}
+
+func dashboardPageItemLink(doc *DashboardListDoc, subURL string) string {
+	if doc.FolderID == "" {
+		return fmt.Sprintf("%s/d/%s/%s", subURL, doc.Name, doc.Namespace)
+	}
+	return fmt.Sprintf("%s/dashboards/f/%s/%s", subURL, doc.Name, doc.Namespace)
 }
 
 type customMeta struct {


### PR DESCRIPTION
set the `url` field to the appropriate dashboard page link.  this is the link that is triggered when clicking on the name.

api doesn't seem to be implemented yet
![image](https://github.com/user-attachments/assets/4818d511-0ee9-4a45-897a-ec3e8d81270e)

same from swagger
![image](https://github.com/user-attachments/assets/1c4a438c-9d54-49d3-88d5-0a86fb49d11c)
