### PR TITLE
Prometheus: Add error source to differentiate errors for api server work

### DIFF
--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -235,8 +235,9 @@ func (s *QueryData) rangeQuery(ctx context.Context, c *client.Client, q *models.
 	res, err := c.QueryRange(ctx, q)
 	if err != nil {
 		return backend.DataResponse{
-			Error:  err,
-			Status: backend.StatusBadGateway,
+			Error:       err,
+			Status:      backend.StatusBadGateway,
+			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
 
@@ -254,15 +255,17 @@ func (s *QueryData) instantQuery(ctx context.Context, c *client.Client, q *model
 	res, err := c.QueryInstant(ctx, q)
 	if err != nil {
 		return backend.DataResponse{
-			Error:  err,
-			Status: backend.StatusBadGateway,
+			Error:       err,
+			Status:      backend.StatusBadGateway,
+			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
 
 	// This is only for health check fall back scenario
 	if res.StatusCode != 200 && q.RefId == "__healthcheck__" {
 		return backend.DataResponse{
-			Error: errors.New(res.Status),
+			Error:       errors.New(res.Status),
+			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
 
@@ -280,7 +283,8 @@ func (s *QueryData) exemplarQuery(ctx context.Context, c *client.Client, q *mode
 	res, err := c.QueryExemplars(ctx, q)
 	if err != nil {
 		return backend.DataResponse{
-			Error: err,
+			Error:       err,
+			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
 


### PR DESCRIPTION
**What is this?**

The API server collects errors from the Prometheus plugin. When monitoring dashboards we are seeing our SLO budget get burned up by incorrect queries, or errors downstream, from Prometheus and not our data source plugin.

This PR adds an error source to the response when the error comes from Prometheus.

[See here for more information.](https://docs.google.com/document/d/1FWbHFg6aEYgCo9uSvDaTCPcb9xUub-3rzXpBGjudWxU/edit?tab=t.0)

**Special notes for your reviewer:**

To test this, go to Explore. Type "space" so the query is " ". Run the query and check the logs. See that `status_source=downstream` has been added to the log.

![Screenshot 2024-11-06 at 4 45 12 PM](https://github.com/user-attachments/assets/a0c2cebf-12b9-4ab7-a87d-e45d7a2e2f9b)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
