### PR TITLE
Alerting docs: adds advanced config section

### DIFF
--- a/docs/sources/alerting/manage-notifications/_index.md
+++ b/docs/sources/alerting/manage-notifications/_index.md
@@ -10,12 +10,12 @@ labels:
     - cloud
     - enterprise
     - oss
-menuTitle: Detect and respond
-title: Detect and respond
+menuTitle: Monitor status
+title: Monitor status
 weight: 130
 ---
 
-# Detect and respond
+# Monitor status
 
 Use Grafana Alerting to track and generate alerts and send notifications, providing an efficient way for engineers to monitor, respond, and triage issues within their services.
 

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -35,7 +35,7 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/#supported-data-sources
   file-provisioning:
     - pattern: /docs/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-roles//alerting/set-up/provision-alerting-resources/file-provisioning/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/
   alerting-permissions:
     - pattern: /docs/
     - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-roles//alerting/set-up/configure-roles/

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -2,13 +2,13 @@
 aliases:
   - unified-alerting/set-up/ # /docs/grafana/<GRAFANA_VERSION>/alerting/unified-alerting/set-up/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/
-description: Set up or upgrade your implementation of Grafana Alerting
+description: Advanced configuration for Grafana Alerting
 labels:
   products:
     - oss
-menuTitle: Set up
-title: Set up Alerting
-weight: 110
+menuTitle: Advanced configuration
+title: Advanced configuration
+weight: 160
 refs:
   terraform-provisioning:
     - pattern: /docs/grafana/
@@ -35,56 +35,29 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/#supported-data-sources
   file-provisioning:
     - pattern: /docs/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-roles//alerting/set-up/provision-alerting-resources/file-provisioning/
+  alerting-permissions:
+    - pattern: /docs/
+    - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-roles//alerting/set-up/configure-roles/
+  alerting-rbac:
+    - pattern: /docs/
+    - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-rbac/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-rbac/
+  alert-state-history:
+    - pattern: /docs/
+    - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/
 ---
 
-# Set up Alerting
+# Advanced configuration
 
-Set up or upgrade your implementation of Grafana Alerting.
-
-**Note:**
-
-These are set-up instructions for Grafana Alerting Open Source.
-
-## Before you begin
-
-- Configure your [data sources](ref:data-source-management)
-- Check which data sources are compatible with and supported by [Grafana Alerting](ref:data-source-alerting)
-
-Watch this short video to get started, or follow the [written tutorial](http://grafana.com/tutorials/alerting-get-started/).
-
-{{< youtube id="6W8Nu4b_PXM" >}}
-
-## Set up Alerting
-
-To set up Alerting, you need to:
-
-1. Configure alert rules
-
-   - Create Grafana-managed or Mimir/Loki-managed alert rules and recording rules
-
-1. Configure contact points
-
-   - Check the default contact point and update the email address
-
-   - Optional: Add new contact points and integrations
-
-1. Configure notification policies
-
-   - Check the default notification policy
-
-   - Optional: Add additional nested policies
-
-   - Optional: Add labels and label matchers to control alert routing
-
-1. Optional: Integrate with [Grafana OnCall](/docs/oncall/latest/integrations/grafana-alerting)
-
-## Advanced set up options
-
-Grafana Alerting supports many additional configuration options, from configuring external Alertmanagers to routing Grafana-managed alerts outside of Grafana, to defining your alerting setup as code.
+Grafana Alerting offers a variety of advanced configuration options to further tailor your alerting setup. These optional features include configuring up permissions and role-based access control, adding external Alertmanagers, or defining your alerting setup as code. While not essential for basic alerting, these options can enhance security, scalability, and automation in complex environments.
 
 The following topics provide you with advanced configuration options for Grafana Alerting.
 
+- [Configure roles and permissions](ref:alerting-permissions)
+- [Configure RBAC](ref:alerting-rbac)
+- [Configure alert state history](ref:alert-state-history)
 - [Provision alert rules using file provisioning](ref:file-provisioning)
 - [Provision alert rules using Terraform](ref:terraform-provisioning)
 - [Add an external Alertmanager](ref:configure-alertmanager)

--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -7,7 +7,7 @@ labels:
   products:
     - oss
 menuTitle: Advanced configuration
-title: Advanced configuration
+title: Additional configuration
 weight: 160
 refs:
   terraform-provisioning:
@@ -49,7 +49,7 @@ refs:
     - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/
 ---
 
-# Advanced configuration
+# Additional configuration
 
 Grafana Alerting offers a variety of advanced configuration options to further tailor your alerting setup. These optional features include configuring up permissions and role-based access control, adding external Alertmanagers, or defining your alerting setup as code. While not essential for basic alerting, these options can enhance security, scalability, and automation in complex environments.
 
@@ -58,7 +58,7 @@ The following topics provide you with advanced configuration options for Grafana
 - [Configure roles and permissions](ref:alerting-permissions)
 - [Configure RBAC](ref:alerting-rbac)
 - [Configure alert state history](ref:alert-state-history)
-- [Provision alert rules using file provisioning](ref:file-provisioning)
-- [Provision alert rules using Terraform](ref:terraform-provisioning)
-- [Add an external Alertmanager](ref:configure-alertmanager)
+- [Use configuration files to provision](ref:file-provisioning)
+- [Use Terraform to provision](ref:terraform-provisioning)
+- [Configure Alertmanagers](ref:configure-alertmanager)
 - [Configure high availability](ref:configure-high-availability)


### PR DESCRIPTION
Removes set up topic and changes it to advanced config options. Moves down to the end of the menu as it's only for advanced users.