### PR TITLE
Feature support logs context with sqldatasource，e.g. MySQL

### DIFF
--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -141,7 +141,7 @@ export interface DashboardProps {
   toString: () => string;
 }
 
-export interface DashboardVariableModel extends SystemVariable<DashboardProps> { }
+export interface DashboardVariableModel extends SystemVariable<DashboardProps> {}
 
 export interface OrgProps {
   name: string;
@@ -149,7 +149,7 @@ export interface OrgProps {
   toString: () => string;
 }
 
-export interface OrgVariableModel extends SystemVariable<OrgProps> { }
+export interface OrgVariableModel extends SystemVariable<OrgProps> {}
 
 export interface UserProps {
   login: string;
@@ -158,7 +158,7 @@ export interface UserProps {
   toString: () => string;
 }
 
-export interface UserVariableModel extends SystemVariable<UserProps> { }
+export interface UserVariableModel extends SystemVariable<UserProps> {}
 
 export interface SystemVariable<TProps extends { toString: () => string }> extends BaseVariableModel {
   type: 'system';

--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -141,7 +141,7 @@ export interface DashboardProps {
   toString: () => string;
 }
 
-export interface DashboardVariableModel extends SystemVariable<DashboardProps> {}
+export interface DashboardVariableModel extends SystemVariable<DashboardProps> { }
 
 export interface OrgProps {
   name: string;
@@ -149,7 +149,7 @@ export interface OrgProps {
   toString: () => string;
 }
 
-export interface OrgVariableModel extends SystemVariable<OrgProps> {}
+export interface OrgVariableModel extends SystemVariable<OrgProps> { }
 
 export interface UserProps {
   login: string;
@@ -158,7 +158,7 @@ export interface UserProps {
   toString: () => string;
 }
 
-export interface UserVariableModel extends SystemVariable<UserProps> {}
+export interface UserVariableModel extends SystemVariable<UserProps> { }
 
 export interface SystemVariable<TProps extends { toString: () => string }> extends BaseVariableModel {
   type: 'system';

--- a/packages/grafana-sql/src/components/query-editor-raw/SimpleLogContextUi.tsx
+++ b/packages/grafana-sql/src/components/query-editor-raw/SimpleLogContextUi.tsx
@@ -51,6 +51,8 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
     (q: SQLQuery) => {
       if (isQueryValid(q) && runContextQuery) {
         cachedSql.splice(0, cachedSql.length);
+        // add twice to cache, becasuse send two http request for log context
+        cachedSql.push(q);
         cachedSql.push(q);
         setDisplayLabel(q.rawSql || "");
         runContextQuery();
@@ -59,10 +61,8 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
     [runContextQuery]
   );
 
-  // 定义 onChange 函数
   const onChange = (query: SQLQuery, process: boolean) => {
     setQueryToValidate(query);
-    //onChange(query);
 
     if (haveColumns(query.sql?.columns) && query.sql?.columns.some((c) => c.name) && !queryRowFilter.group) {
       setQueryRowFilter({ ...queryRowFilter, group: true });
@@ -73,9 +73,15 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
     }
   };
 
-  // 定义 onValidate 函数
+  const getQueryExpress = () => {
+    if (displayLabel !== "") {
+      orignQuery.rawSql = displayLabel;
+    }
+    return orignQuery;
+  }
+
+  // do nothing of validate
   const onValidate = (isValid: boolean) => {
-    console.log("do nothing of validate");
   };
 
   return (
@@ -88,7 +94,7 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
       >
         <RawEditor
           db={sqlDataSource.db}
-          query={orignQuery}
+          query={getQueryExpress()}
           queryToValidate={queryToValidate}
           onChange={onChange}
           onRunQuery={() => runContextQuery?.()}

--- a/packages/grafana-sql/src/components/query-editor-raw/SimpleLogContextUi.tsx
+++ b/packages/grafana-sql/src/components/query-editor-raw/SimpleLogContextUi.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useState } from 'react';
+import { useToggle } from 'react-use';
 import { css } from '@emotion/css';
 
 import { applyQueryDefaults, SqlDatasource }from '@grafana/sql';
 import { GrafanaTheme2, LogRowModel, TimeRange } from '@grafana/data';
-import {  useStyles2 } from '@grafana/ui';
+import {  useStyles2, Collapse } from '@grafana/ui';
 
 import { SQLQuery, QueryRowFilter } from '../../types';
 import { haveColumns } from '../../utils/sql.utils';
@@ -32,6 +33,7 @@ function getStyles(theme: GrafanaTheme2) {
 export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
   const { sqlDataSource, orignQuery, range, cachedSql, runContextQuery } = props;
   const styles = useStyles2(getStyles);
+  const [isOpen, toggleOpen] = useToggle(false);
   const queryWithDefaults = applyQueryDefaults(orignQuery);
   const [queryRowFilter, setQueryRowFilter] = useState<QueryRowFilter>({
     filter: !!queryWithDefaults.sql?.whereString,
@@ -40,7 +42,7 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
     preview: true,
   });
   const [queryToValidate, setQueryToValidate] = useState(queryWithDefaults);
-
+  const [displayLabel, setDisplayLabel] = useState("");
   const isQueryValid = (q: SQLQuery) => {
     return Boolean(q.rawSql);
   };
@@ -50,6 +52,7 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
       if (isQueryValid(q) && runContextQuery) {
         cachedSql.splice(0, cachedSql.length);
         cachedSql.push(q);
+        setDisplayLabel(q.rawSql || "");
         runContextQuery();
       }
     },
@@ -77,15 +80,22 @@ export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
 
   return (
     <div className={styles.wrapper}>
-      <RawEditor
-        db={sqlDataSource.db}
-        query={orignQuery}
-        queryToValidate={queryToValidate}
-        onChange={onChange}
-        onRunQuery={() => runContextQuery?.()}
-        onValidate={onValidate}
-        range={range}
-     />
+      <Collapse
+        collapsible={true}
+        isOpen={isOpen}
+        onToggle={toggleOpen}
+        label={<div>{displayLabel || orignQuery.rawSql}</div>}
+      >
+        <RawEditor
+          db={sqlDataSource.db}
+          query={orignQuery}
+          queryToValidate={queryToValidate}
+          onChange={onChange}
+          onRunQuery={() => runContextQuery?.()}
+          onValidate={onValidate}
+          range={range}
+        />
+      </Collapse>
     </div>
   );
 }

--- a/packages/grafana-sql/src/components/query-editor-raw/SimpleLogContextUi.tsx
+++ b/packages/grafana-sql/src/components/query-editor-raw/SimpleLogContextUi.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useState } from 'react';
+import { css } from '@emotion/css';
+
+import { applyQueryDefaults, SqlDatasource }from '@grafana/sql';
+import { GrafanaTheme2, LogRowModel, TimeRange } from '@grafana/data';
+import {  useStyles2 } from '@grafana/ui';
+
+import { SQLQuery, QueryRowFilter } from '../../types';
+import { haveColumns } from '../../utils/sql.utils';
+import { RawEditor } from '../query-editor-raw/RawEditor';
+
+export interface SimpleLogContextUiProps {
+  sqlDataSource: SqlDatasource;
+  cachedSql: SQLQuery[];
+  row: LogRowModel;
+  orignQuery: SQLQuery;
+  runContextQuery?: () => void;
+  onContextClose: () => void;
+  range?: TimeRange;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      width: '100%',
+      height: '70%',
+    }),
+  };
+}
+
+
+export function SimpleLogContextUi(props: SimpleLogContextUiProps) {
+  const { sqlDataSource, orignQuery, range, cachedSql, runContextQuery } = props;
+  const styles = useStyles2(getStyles);
+  const queryWithDefaults = applyQueryDefaults(orignQuery);
+  const [queryRowFilter, setQueryRowFilter] = useState<QueryRowFilter>({
+    filter: !!queryWithDefaults.sql?.whereString,
+    group: !!queryWithDefaults.sql?.groupBy?.[0]?.property.name,
+    order: !!queryWithDefaults.sql?.orderBy?.property.name,
+    preview: true,
+  });
+  const [queryToValidate, setQueryToValidate] = useState(queryWithDefaults);
+
+  const isQueryValid = (q: SQLQuery) => {
+    return Boolean(q.rawSql);
+  };
+
+  const processQuery = useCallback(
+    (q: SQLQuery) => {
+      if (isQueryValid(q) && runContextQuery) {
+        cachedSql.splice(0, cachedSql.length);
+        cachedSql.push(q);
+        runContextQuery();
+      }
+    },
+    [runContextQuery]
+  );
+
+  // 定义 onChange 函数
+  const onChange = (query: SQLQuery, process: boolean) => {
+    setQueryToValidate(query);
+    //onChange(query);
+
+    if (haveColumns(query.sql?.columns) && query.sql?.columns.some((c) => c.name) && !queryRowFilter.group) {
+      setQueryRowFilter({ ...queryRowFilter, group: true });
+    }
+
+    if (process) {
+      processQuery(query);
+    }
+  };
+
+  // 定义 onValidate 函数
+  const onValidate = (isValid: boolean) => {
+    console.log("do nothing of validate");
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <RawEditor
+        db={sqlDataSource.db}
+        query={orignQuery}
+        queryToValidate={queryToValidate}
+        onChange={onChange}
+        onRunQuery={() => runContextQuery?.()}
+        onValidate={onValidate}
+        range={range}
+     />
+    </div>
+  );
+}

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -125,6 +125,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     // we must replace ordered keyword, e.g. ASC, DESC
     if (this.cachedSql.length > 0) {
       let sql: SQLQuery = JSON.parse(JSON.stringify(this.cachedSql[0]));
+      this.cachedSql.splice(0,1) // clean cache
       if (direction === LogRowContextQueryDirection.Forward) {
         sql.rawSql = this.processOrderByClause(sql.rawSql || "", 'ASC');
       } else {
@@ -230,12 +231,10 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     const scopedVars: ScopedVars = this.prepareScopeVars(duplicate);
     const sqlExpress: SQLQuery = this.prepareSqlExpress(duplicate, row, orignQuery)
     sqlExpress.rawSql = this.templateSrv.replace(sqlExpress.rawSql, scopedVars, this.interpolateVariable);
-    //sqlExpress.rawSql = sqlExpress.rawSql.replace(/\r?\n|\r/g, '');
+
     // we need to cache this function so that it doesn't get recreated on every render
     const onContextClose = (() => {
-        console.log("clear cached sql, set empty.");
-        this.cachedSql = [];
-      });
+    });
 
     return SimpleLogContextUi(
       {

--- a/public/app/features/logs/components/LogDetails.tsx
+++ b/public/app/features/logs/components/LogDetails.tsx
@@ -8,7 +8,7 @@ import { calculateLogsLabelStats, calculateStats } from '../utils';
 
 import { LogDetailsRow } from './LogDetailsRow';
 import { getLogLevelStyles, LogRowStyles } from './getLogRowStyles';
-import { getAllFields, createLogLineLinks } from './logParser';
+import { getAllFields, createLogLineLinks, FieldDef } from './logParser';
 
 export interface Props extends Themeable2 {
   row: LogRowModel;
@@ -65,12 +65,16 @@ class UnThemedLogDetails extends PureComponent<Props> {
       (displayedFieldsWithLinks && displayedFieldsWithLinks.length > 0) ||
       (fieldsWithLinksFromVariableMap && fieldsWithLinksFromVariableMap.length > 0);
 
-    const fields =
-      row.dataFrame.meta?.type === DataFrameType.LogLines
+    // Some fields has existed in labels with SqlDataSource, then does't need fields
+    let fields: FieldDef[] = []
+    if (Object.keys(labels).length === 0) {
+      fields = row.dataFrame.meta?.type === DataFrameType.LogLines
         ? // for LogLines frames (dataplane) we don't want to show any additional fields besides already extracted labels and links
-          []
+        []
         : // for other frames, do not show the log message unless there is a link attached
-          fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
+        fieldsAndLinks.filter((f) => f.links?.length === 0 && f.fieldIndex !== row.entryFieldIndex).sort();
+    }
+
     const fieldsAvailable = fields && fields.length > 0;
 
     // If logs with error, we are not showing the level color

--- a/public/app/features/logs/logsFrame.ts
+++ b/public/app/features/logs/logsFrame.ts
@@ -35,6 +35,17 @@ const DATAPLANE_SEVERITY_NAME = 'severity';
 const DATAPLANE_ID_NAME = 'id';
 const DATAPLANE_LABELS_NAME = 'labels';
 
+export function transformToLabels(data: FieldWithIndex[]): Labels[] {
+  const length = data[0].values.length;
+
+  return Array.from({ length }, (_, index) => {
+    return data.reduce((acc, field) => {
+      acc[field.name] = field.values[index];
+      return acc;
+    }, {} as Labels);
+  });
+}
+
 export function logFrameLabelsToLabels(logFrameLabels: LogFrameLabels): Labels {
   const result: Labels = {};
 

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -644,7 +644,7 @@ function defaultExtractLevel(dataFrame: DataFrame): LogLevel {
   let valueField;
   try {
     valueField = new FieldCache(dataFrame).getFirstFieldOfType(FieldType.number);
-  } catch { }
+  } catch {}
   return valueField?.labels ? getLogLevelFromLabels(valueField.labels) : LogLevel.unknown;
 }
 


### PR DESCRIPTION
**What is this feature?**

Show context of Logs pannel with SqlDatasource, for example: MySQL

**Why do we need this feature?**

Doesn't support show context of logs with MySQL


**Which issue(s) does this PR fix?**:

Fixes  https://github.com/grafana/grafana/issues/95479

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


**Usage**
- click icon of  Show context, then open a new window
- you can change SQL，and Hit CTRL/CMD+Return to run query


