### PR TITLE
loki: disable flaky tests for scopes injection

### DIFF
--- a/pkg/tsdb/loki/scopes_test.go
+++ b/pkg/tsdb/loki/scopes_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestInjectScopesIntoLokiQuery(t *testing.T) {
+	// skipping since its flaky.
+	t.Skip()
+
 	tests := []struct {
 		name         string
 		query        string


### PR DESCRIPTION
Disables the test since its flaky. Looks like a map race condition but I will investigate. 