### PR TITLE
Loki: Adds a `suggestions` resource call that inject scopes for finding label/labelvalues

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -134,7 +134,7 @@ func callResource(ctx context.Context, req *backend.CallResourceRequest, sender 
 	var err error
 
 	// suggestions is a resource endpoint that will return label and label value suggestions based
-	// on queries and the existing scope. But moving this to the backend we can use the logql parser to
+	// on queries and the existing scope. By moving this to the backend we can use the logql parser to
 	// rewrite queries safely.
 	if strings.EqualFold(req.Path, "suggestions") {
 		rawLokiResponse, err = GetSuggestions(ctx, api, req)

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -136,7 +136,7 @@ func callResource(ctx context.Context, req *backend.CallResourceRequest, sender 
 	// suggestions is a resource endpoint that will return label and label value suggestions based
 	// on queries and the existing scope. By moving this to the backend we can use the logql parser to
 	// rewrite queries safely.
-	if strings.EqualFold(req.Path, "suggestions") {
+	if req.Method == http.MethodPost && strings.EqualFold(req.Path, "suggestions") {
 		rawLokiResponse, err = GetSuggestions(ctx, api, req)
 		if err != nil {
 			span.RecordError(err)

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -129,13 +130,30 @@ func callResource(ctx context.Context, req *backend.CallResourceRequest, sender 
 
 	api := newLokiAPI(dsInfo.HTTPClient, dsInfo.URL, plog, tracer, false)
 
-	rawLokiResponse, err := api.RawQuery(ctx, lokiURL)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		plog.Error("Failed resource call from loki", "err", err, "url", lokiURL)
-		return err
+	var rawLokiResponse RawLokiResponse
+	var err error
+
+	// suggestions is a resource endpoint that will return label and label value suggestions based
+	// on queries and the existing scope. But moving this to the backend we can use the logql parser to
+	// rewrite queries safely.
+	if strings.EqualFold(req.Path, "suggestions") {
+		rawLokiResponse, err = GetSuggestions(ctx, api, req)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			plog.FromContext(ctx).Error("Failed to get suggestions from loki", "err", err)
+			return err
+		}
+	} else {
+		rawLokiResponse, err = api.RawQuery(ctx, lokiURL)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			plog.Error("Failed resource call from loki", "err", err, "url", lokiURL)
+			return err
+		}
 	}
+
 	respHeaders := map[string][]string{
 		"content-type": {"application/json"},
 	}

--- a/pkg/tsdb/loki/scopes.go
+++ b/pkg/tsdb/loki/scopes.go
@@ -1,11 +1,80 @@
 package loki
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/promlib/models"
+	"github.com/grafana/grafana/pkg/tsdb/loki/kinds/dataquery"
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
+	"github.com/prometheus/prometheus/promql/parser"
 )
+
+// SuggestionRequest is the request body for the GetSuggestions resource.
+type SuggestionRequest struct {
+	// LabelName, if provided, will result in label values being returned for the given label name.
+	LabelName string `json:"labelName"`
+
+	Query string `json:"query"`
+
+	Scopes       []models.ScopeFilter `json:"scopes"`
+	AdhocFilters []models.ScopeFilter `json:"adhocFilters"`
+
+	// Start and End are proxied directly to the prometheus endpoint (which is rfc3339 | unix_timestamp)
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+// GetSuggestions returns label names or label values for the given queries and scopes.
+func GetSuggestions(ctx context.Context, lokiAPI *LokiAPI, req *backend.CallResourceRequest) (RawLokiResponse, error) {
+	sugReq := SuggestionRequest{}
+	err := json.Unmarshal(req.Body, &sugReq)
+	if err != nil {
+		return RawLokiResponse{}, fmt.Errorf("error unmarshalling suggestion request: %v", err)
+	}
+
+	values := url.Values{}
+	if sugReq.Query != "" {
+		interpolatedQuery := interpolateVariables(sugReq.Query, time.Minute, time.Minute, dataquery.LokiQueryTypeRange, time.Minute)
+
+		if len(sugReq.Scopes) > 0 {
+			rewrittenQuery, err := ApplyScopes(interpolatedQuery, sugReq.Scopes)
+			if err == nil {
+				values.Add("query", rewrittenQuery)
+			} else {
+				values.Add("query", interpolatedQuery)
+			}
+		}
+	} else if len(sugReq.Scopes) > 0 {
+		matchers, err := models.FiltersToMatchers(sugReq.Scopes, sugReq.AdhocFilters)
+		if err != nil {
+			return RawLokiResponse{}, fmt.Errorf("error converting filters to matchers: %v", err)
+		}
+		vs := parser.VectorSelector{LabelMatchers: matchers}
+		values.Add("query", vs.String())
+	}
+
+	if sugReq.Start != "" {
+		values.Add("start", sugReq.Start)
+	}
+
+	if sugReq.End != "" {
+		values.Add("end", sugReq.End)
+	}
+
+	var path string
+	if sugReq.LabelName != "" {
+		path = "/loki/api/v1/label/" + sugReq.LabelName + "/values?" + values.Encode()
+	} else {
+		path = "/loki/api/v1/labels?" + values.Encode()
+	}
+
+	return lokiAPI.RawQuery(ctx, path)
+}
 
 // ApplyScopes applies the given scope filters to the given raw expression.
 func ApplyScopes(rawExpr string, scopeFilters []models.ScopeFilter) (string, error) {

--- a/pkg/tsdb/loki/scopes.go
+++ b/pkg/tsdb/loki/scopes.go
@@ -39,6 +39,8 @@ func GetSuggestions(ctx context.Context, lokiAPI *LokiAPI, req *backend.CallReso
 
 	values := url.Values{}
 	if sugReq.Query != "" {
+		// the query is used to find label/labelvalues the duration and interval does not matter.
+		// If the user want to filter values based on time it should used the `start` and `end` fields
 		interpolatedQuery := interpolateVariables(sugReq.Query, time.Minute, time.Minute, dataquery.LokiQueryTypeRange, time.Minute)
 
 		if len(sugReq.Scopes) > 0 {

--- a/pkg/tsdb/loki/scopes.go
+++ b/pkg/tsdb/loki/scopes.go
@@ -70,7 +70,7 @@ func GetSuggestions(ctx context.Context, lokiAPI *LokiAPI, req *backend.CallReso
 
 	var path string
 	if sugReq.LabelName != "" {
-		path = "/loki/api/v1/label/" + sugReq.LabelName + "/values?" + values.Encode()
+		path = "/loki/api/v1/label/" + url.QueryEscape(sugReq.LabelName) + "/values?" + values.Encode()
 	} else {
 		path = "/loki/api/v1/labels?" + values.Encode()
 	}


### PR DESCRIPTION
This is a resource handler that makes it easier to inject scopes into label/labelvalue queries. It rewrites expressions using the same code that we are using for rewriting log/metric loki queries. 

If no query is passed to the handler it will render the selected scope as query to make sure the scope matchers are always applied. 

`/api/datasources/uid/be385p0ph7668d/resources/suggestions` 
```go
type SuggestionRequest struct {
	// LabelName, if provided, will result in label values being returned for the given label name.
	LabelName string `json:"labelName"`

	Query string `json:"query"`

	Scopes       []models.ScopeFilter `json:"scopes"`
	AdhocFilters []models.ScopeFilter `json:"adhocFilters"`

	// Start and End are proxied directly to the prometheus endpoint (which is rfc3339 | unix_timestamp)
	Start string `json:"start"`
	End   string `json:"end"`
}
```


These commands can be used for local testing. (remember to replace the cluster value in the json)

```bash
curl -X POST http://admin:admin@localhost:3000/api/datasources/uid/<datasource_uid>/resources/suggestions \
   -H 'Content-Type: application/json' \
   -d '{"labelName": "slug", "scopes": [ { "key": "cluster", "value": "cluster-Name", "operator": "equals"} ]}'
```

```bash
curl -X POST http://admin:admin@localhost:3000/api/datasources/uid/<datasource_uid>/resources/suggestions \
   -H 'Content-Type: application/json' \
   -d '{"scopes": [ { "key": "cluster", "value": "cluster-Name", "operator": "equals"} ]}'
```

