### PR TITLE
BrowseDashboards: Append orgId to folder URL

### DIFF
--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -6,7 +6,7 @@ import { DashboardViewItem } from 'app/features/search/types';
 
 import { contextSrv } from '../../../core/core';
 import { AccessControlAction } from '../../../types';
-import { isSharedWithMe } from '../components/utils';
+import { getFolderURL, isSharedWithMe } from '../components/utils';
 
 export const PAGE_SIZE = 50;
 
@@ -30,7 +30,6 @@ export async function listFolders(
       limit: pageSize,
     });
   }
-  const subUrlPrefix = config.appSubUrl ?? '';
 
   return folders.map((item) => ({
     kind: 'folder',
@@ -40,7 +39,7 @@ export async function listFolders(
     parentUID,
 
     // URLs from the backend come with subUrlPrefix already included, so match that behaviour here
-    url: isSharedWithMe(item.uid) ? undefined : `${subUrlPrefix}/dashboards/f/${item.uid}/`,
+    url: isSharedWithMe(item.uid) ? undefined : getFolderURL(item.uid),
   }));
 }
 

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -12,7 +12,7 @@ import { Indent } from '../../../core/components/Indent/Indent';
 import { useChildrenByParentUIDState } from '../state';
 import { DashboardsTreeCellProps } from '../types';
 
-import { getFolderURL, makeRowID } from './utils';
+import { makeRowID } from './utils';
 
 const CHEVRON_SIZE = 'md';
 const ICON_SIZE = 'sm';
@@ -93,7 +93,7 @@ export function NameCell({ row: { original: data }, onFolderClick, treeID }: Nam
               onClick={() => {
                 reportInteraction('manage_dashboards_result_clicked');
               }}
-              href={getFolderURL(item.url)}
+              href={item.url}
               className={styles.link}
             >
               {item.title}

--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -12,7 +12,7 @@ import { Indent } from '../../../core/components/Indent/Indent';
 import { useChildrenByParentUIDState } from '../state';
 import { DashboardsTreeCellProps } from '../types';
 
-import { makeRowID } from './utils';
+import { getFolderURL, makeRowID } from './utils';
 
 const CHEVRON_SIZE = 'md';
 const ICON_SIZE = 'sm';
@@ -93,7 +93,7 @@ export function NameCell({ row: { original: data }, onFolderClick, treeID }: Nam
               onClick={() => {
                 reportInteraction('manage_dashboards_result_clicked');
               }}
-              href={item.url}
+              href={getFolderURL(item.url)}
               className={styles.link}
             >
               {item.title}

--- a/public/app/features/browse-dashboards/components/utils.ts
+++ b/public/app/features/browse-dashboards/components/utils.ts
@@ -11,9 +11,12 @@ export function isSharedWithMe(uid: string) {
   return uid === config.sharedWithMeFolderUID;
 }
 
-// Append orgId to the folder URL
-export function getFolderURL(url: string) {
+// Construct folder URL and append orgId to it
+export function getFolderURL(uid: string) {
   const { orgId } = contextSrv.user;
+  const subUrlPrefix = config.appSubUrl ?? '';
+  const url = `${subUrlPrefix}/dashboards/f/${uid}/`;
+
   if (orgId) {
     return `${url}?orgId=${orgId}`;
   }

--- a/public/app/features/browse-dashboards/components/utils.ts
+++ b/public/app/features/browse-dashboards/components/utils.ts
@@ -1,4 +1,5 @@
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/core';
 
 import { DashboardViewItemWithUIItems } from '../types';
 
@@ -8,4 +9,13 @@ export function makeRowID(baseId: string, item: DashboardViewItemWithUIItems) {
 
 export function isSharedWithMe(uid: string) {
   return uid === config.sharedWithMeFolderUID;
+}
+
+// Append orgId to the folder URL
+export function getFolderURL(url: string) {
+  const { orgId } = contextSrv.user;
+  if (orgId) {
+    return `${url}?orgId=${orgId}`;
+  }
+  return url;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add `orgId` URL param to the folder URL to enable sharing folders across orgs. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/90713

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
