### PR TITLE
Storage: Replace CDK backend with a raw in-memory version

### DIFF
--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/klog/v2"
 
@@ -31,6 +33,9 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 	}
 	if obj.GetResourceVersion() != "" {
 		return nil, storage.ErrResourceVersionSetOnCreate
+	}
+	if obj.GetUID() == "" {
+		obj.SetUID(types.UID(uuid.NewString()))
 	}
 
 	obj.SetGenerateName("") // Clear the random name field

--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"gocloud.dev/blob/fileblob"
-	"gocloud.dev/blob/memblob"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -43,9 +42,7 @@ func NewRESTOptionsGetterForClient(client resource.ResourceClient, original stor
 }
 
 func NewRESTOptionsGetterMemory(originalStorageConfig storagebackend.Config, features map[string]any) (*RESTOptionsGetter, error) {
-	backend, err := resource.NewCDKBackend(context.Background(), resource.CDKBackendOptions{
-		Bucket: memblob.OpenBucket(&memblob.Options{}),
-	})
+	backend, err := resource.NewMemoryBackend()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -7,14 +7,11 @@ package apistore
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gocloud.dev/blob/fileblob"
-	"gocloud.dev/blob/memblob"
 	"k8s.io/apimachinery/pkg/api/apitesting"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,25 +95,12 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 		Resource: "pods",
 	}
 
-	bucket := memblob.OpenBucket(nil)
-	if true {
-		tmp, err := os.MkdirTemp("", "xxx-*")
-		require.NoError(t, err)
-
-		bucket, err = fileblob.OpenBucket(tmp, &fileblob.Options{
-			CreateDir: true,
-			Metadata:  fileblob.MetadataDontWrite, // skip
-		})
-		require.NoError(t, err)
-	}
 	ctx := storagetesting.NewContext()
 
 	var server resource.ResourceServer
 	switch setupOpts.storageType {
 	case StorageTypeFile:
-		backend, err := resource.NewCDKBackend(ctx, resource.CDKBackendOptions{
-			Bucket: bucket,
-		})
+		backend, err := resource.NewMemoryBackend()
 		require.NoError(t, err)
 
 		server, err = resource.NewResourceServer(resource.ResourceServerOptions{

--- a/pkg/storage/unified/resource/memory_backend.go
+++ b/pkg/storage/unified/resource/memory_backend.go
@@ -1,0 +1,307 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewMemoryBackend() (StorageBackend, error) {
+	backend := &memoryBackend{
+		tree: make(map[string]*memoryResource),
+	}
+	backend.rv.Swap(time.Now().UnixMilli())
+	return backend, nil
+}
+
+type memoryBackend struct {
+	mutex sync.Mutex
+	rv    atomic.Int64
+	tree  map[string]*memoryResource
+
+	// Simple watch stream -- NOTE, this only works for single tenant!
+	broadcaster Broadcaster[*WrittenEvent]
+	stream      chan<- *WrittenEvent
+}
+
+func (s *memoryBackend) Namespaces(ctx context.Context) ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *memoryBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv int64, err error) {
+	rv = s.rv.Add(1)
+
+	// Scope the lock
+	{
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		tree := s.getResourceTree(event.Key)
+
+		switch event.Type {
+		case WatchEvent_ADDED:
+			val := tree.get(event.Key)
+			if val != nil {
+				return 0, fmt.Errorf("key already exists")
+			}
+			err = tree.add(event.Key, &memoryValue{
+				rv:     rv,
+				ns:     event.Key.Namespace,
+				name:   event.Key.Name,
+				folder: event.Object.GetFolder(),
+				value:  event.Value,
+			})
+
+		case WatchEvent_MODIFIED:
+			val := tree.get(event.Key)
+			if val == nil {
+				return 0, fmt.Errorf("not found")
+			}
+			val.rv = rv
+			val.value = event.Value
+			val.folder = event.Object.GetFolder()
+
+		case WatchEvent_DELETED:
+			ns, ok := tree.namespaces[event.Key.Namespace]
+			if !ok {
+				return 0, fmt.Errorf("namespace no found")
+			}
+			if _, ok := ns.names[event.Key.Name]; ok {
+				delete(ns.names, event.Key.Name)
+				return rv, nil
+			}
+			return 0, fmt.Errorf("name no found")
+
+		// ignore
+		default:
+			return rv, nil //
+		}
+	}
+
+	// Async notify all subscribers
+	if s.stream != nil {
+		go func() {
+			write := &WrittenEvent{
+				WriteEvent:      event,
+				Timestamp:       time.Now().UnixMilli(),
+				ResourceVersion: rv,
+			}
+			s.stream <- write
+		}()
+	}
+	return rv, err
+}
+
+func (s *memoryBackend) ReadResource(ctx context.Context, req *ReadRequest) *ReadResponse {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	tree := s.getResourceTree(req.Key)
+	val := tree.get(req.Key)
+	if val == nil {
+		return &ReadResponse{Error: NewNotFoundError(req.Key)}
+	}
+	if req.ResourceVersion > 0 {
+		if req.ResourceVersion > s.rv.Load() {
+			return &ReadResponse{
+				Error: &ErrorResult{
+					Code:    http.StatusGatewayTimeout,
+					Reason:  string(metav1.StatusReasonTimeout), // match etcd behavior
+					Message: "ResourceVersion is larger than max",
+					Details: &ErrorDetails{
+						Causes: []*ErrorCause{
+							{
+								Reason:  string(metav1.CauseTypeResourceVersionTooLarge),
+								Message: fmt.Sprintf("requested: %d, current %d", req.ResourceVersion, s.rv.Load()),
+							},
+						},
+					},
+				},
+			}
+		}
+	}
+
+	return &ReadResponse{
+		ResourceVersion: val.rv,
+		Value:           val.value,
+	}
+}
+
+func (s *memoryBackend) ListIterator(ctx context.Context, req *ListRequest, cb func(ListIterator) error) (int64, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	key := req.Options.Key
+	tree := s.getResourceTree(key)
+	iter := &memoryListIterator{
+		index: -1,
+		rv:    s.rv.Load(),
+	}
+
+	if key.Namespace == "" {
+		for _, ns := range tree.namespaces {
+			iter.add(ns)
+		}
+	} else {
+		ns, ok := tree.namespaces[key.Namespace]
+		if ok {
+			iter.add(ns)
+		}
+	}
+	// sort?
+	return iter.rv, cb(iter)
+}
+
+func (s *memoryBackend) WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.broadcaster == nil {
+		var err error
+		s.broadcaster, err = NewBroadcaster(context.Background(), func(c chan<- *WrittenEvent) error {
+			s.stream = c
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return s.broadcaster.Subscribe(ctx)
+}
+
+// This must be called inside a locked mutex
+func (s *memoryBackend) getResourceTree(key *ResourceKey) *memoryResource {
+	prefix := fmt.Sprintf("%s/%s", key.Group, key.Resource)
+	tree, ok := s.tree[prefix]
+	if !ok {
+		tree = &memoryResource{
+			group:      key.Group,
+			resource:   key.Resource,
+			namespaces: make(map[string]*memoryNamespace),
+		}
+		s.tree[prefix] = tree
+	}
+	return tree
+}
+
+// Only the latest version of each
+// group > resource > namespace > name > versions
+type memoryResource struct {
+	group    string
+	resource string
+
+	namespaces map[string]*memoryNamespace
+}
+
+func (v *memoryResource) get(key *ResourceKey) *memoryValue {
+	ns, ok := v.namespaces[key.Namespace]
+	if ok {
+		return ns.get(key)
+	}
+	return nil
+}
+
+func (v *memoryResource) add(key *ResourceKey, val *memoryValue) error {
+	ns, ok := v.namespaces[key.Namespace]
+	if !ok {
+		ns = &memoryNamespace{
+			names: make(map[string]*memoryValue),
+		}
+		v.namespaces[key.Namespace] = ns
+	}
+	return ns.add(key, val)
+}
+
+type memoryNamespace struct {
+	names map[string]*memoryValue
+}
+
+func (v *memoryNamespace) get(key *ResourceKey) *memoryValue {
+	vv, ok := v.names[key.Name]
+	if ok {
+		return vv
+	}
+	return nil
+}
+
+func (v *memoryNamespace) add(key *ResourceKey, val *memoryValue) error {
+	_, ok := v.names[key.Name]
+	if ok {
+		return fmt.Errorf("key already exists")
+	}
+	v.names[key.Name] = val
+	return nil
+}
+
+type memoryValue struct {
+	rv     int64
+	ns     string
+	name   string
+	folder string
+	value  []byte
+}
+
+type memoryListIterator struct {
+	rv      int64 // the RV at list time
+	err     error
+	index   int
+	values  []*memoryValue
+	current *memoryValue
+}
+
+func (c *memoryListIterator) add(ns *memoryNamespace) {
+	for _, v := range ns.names {
+		c.values = append(c.values, v)
+	}
+}
+
+// Next implements ListIterator.
+func (c *memoryListIterator) Next() bool {
+	if c.err != nil {
+		return false
+	}
+	c.current = nil
+	c.index += 1
+	if c.index >= len(c.values) {
+		return false
+	}
+	c.current = c.values[c.index]
+	return true
+}
+
+// Error implements ListIterator.
+func (c *memoryListIterator) Error() error {
+	return c.err
+}
+
+// ResourceVersion implements ListIterator.
+func (c *memoryListIterator) ResourceVersion() int64 {
+	return c.current.rv
+}
+
+// Value implements ListIterator.
+func (c *memoryListIterator) Value() []byte {
+	return c.current.value
+}
+
+// ContinueToken implements ListIterator.
+func (c *memoryListIterator) ContinueToken() string {
+	return fmt.Sprintf("index:%d", c.index)
+}
+
+// Name implements ListIterator.
+func (c *memoryListIterator) Name() string {
+	return c.current.name
+}
+
+// Namespace implements ListIterator.
+func (c *memoryListIterator) Namespace() string {
+	return c.current.name
+}
+
+var _ ListIterator = (*memoryListIterator)(nil)

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -3,18 +3,15 @@ package resource
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/stretchr/testify/require"
-	"gocloud.dev/blob/fileblob"
-	"gocloud.dev/blob/memblob"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestSimpleServer(t *testing.T) {
@@ -28,21 +25,7 @@ func TestSimpleServer(t *testing.T) {
 	}
 	ctx := claims.WithClaims(context.Background(), testUserA)
 
-	bucket := memblob.OpenBucket(nil)
-	if false {
-		tmp, err := os.MkdirTemp("", "xxx-*")
-		require.NoError(t, err)
-
-		bucket, err = fileblob.OpenBucket(tmp, &fileblob.Options{
-			CreateDir: true,
-			Metadata:  fileblob.MetadataDontWrite, // skip
-		})
-		require.NoError(t, err)
-		fmt.Printf("ROOT: %s\n\n", tmp)
-	}
-	store, err := NewCDKBackend(ctx, CDKBackendOptions{
-		Bucket: bucket,
-	})
+	store, err := NewMemoryBackend()
 	require.NoError(t, err)
 
 	server, err := NewResourceServer(ResourceServerOptions{
@@ -57,6 +40,7 @@ func TestSimpleServer(t *testing.T) {
 			"metadata": {
 				"name": "fdgsv37qslr0ga",
 				"namespace": "default",
+				"uid": "xxxxxx",
 				"annotations": {
 					"grafana.app/originName": "elsewhere",
 					"grafana.app/originPath": "path/to/item",
@@ -172,6 +156,7 @@ func TestSimpleServer(t *testing.T) {
 			"metadata": {
 				"name": "fdgsv37qslr0ga",
 				"namespace": "default",
+				"uid": "dummyuid",
 				"annotations": {
 					"grafana.app/originName": "elsewhere",
 					"grafana.app/originPath": "path/to/item",


### PR DESCRIPTION
WIP -- the SQL backend is now stable enough that we do not need another funky implementation.

There are still good reasons for an in-memory version (internal aggregation and some simple tests), so lets replace the CDK version with a direct in-memory version

TODO
- [ ] Remove CDK implementation
- [ ] Remove the "file" type from unified storage settings -- fallback to SQL?