### PR TITLE
WIP: Elasticsearch: add support for runtime fields

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -805,16 +805,36 @@ export class ElasticDatasource
           fieldNameParts.pop();
         }
 
+        // Process runtime fields
+        function getRuntimeFields(mapping: { runtime: Record<string, { type: string }> }) {
+          if (!mapping.runtime) {
+            return;
+          }
+
+          for (const key in mapping.runtime) {
+            const runtimeField = mapping.runtime[key];
+            if (shouldAddField(runtimeField, key)) {
+              fields[key] = {
+                text: key,
+                type: runtimeField.type,
+              };
+            }
+          }
+        }
+
         for (const indexName in result) {
           const index = result[indexName];
           if (index && index.mappings) {
             const mappings = index.mappings;
 
+            // Process regular fields
             const properties = mappings.properties;
             getFieldsRecursively(properties);
+
+            // Process runtime fields
+            getRuntimeFields(mappings);
           }
         }
-
         // transform to array
         return _map(fields, (value) => {
           return value;


### PR DESCRIPTION
**What is this feature?**

This adds support for runtime fields defined in index mappings to be shown in the field selectors.

For example I have an `hour_of_day` field defined as follows:

```
curl --insecure -X PUT -u elastic:"$ELASTIC_PASSWORD" \
  "https://localhost:9200/analytics-development-test/_mapping" \
  -H "Content-Type: application/json" \
  -d '
  {
    "runtime": {
      "hour_of_day": {
        "type": "keyword",
        "script": { "source": "emit(doc[\"@timestamp\"].value.getHour().toString())" }
      }
    }
  }'
```

Then I can query that here:

<img width="885" alt="image" src="https://github.com/user-attachments/assets/a28e1798-d941-4d56-be36-e9577af9104e">

**Why do we need this feature?**

Because runtime fields are not exposed by default and are very useful.

**Who is this feature for?**

Elasticsearch users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #96028

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

TODO:

- [ ] The fields are not visible when I simply output a table of the raw results
- [ ] Add a changelog entry