### PR TITLE
Extensions: Only log warnings to the console in DEV

### DIFF
--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -4,6 +4,8 @@ import { Observable, ReplaySubject } from 'rxjs';
 
 import { Labels, LogLevel } from '@grafana/data';
 
+import { isGrafanaDevMode } from '../utils';
+
 export type ExtensionsLogItem = {
   level: LogLevel;
   timestamp: number;
@@ -32,13 +34,16 @@ export class ExtensionsLog {
   }
 
   warning(message: string, labels?: Labels): void {
-    console.warn(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
+
+    if (isGrafanaDevMode()) {
+      console.warn(message, { ...this.baseLabels, ...labels });
+    }
   }
 
   error(message: string, labels?: Labels): void {
-    console.error(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
+    console.error(message, { ...this.baseLabels, ...labels });
   }
 
   debug(message: string, labels?: Labels): void {


### PR DESCRIPTION
### What changed?

Right now we have a lot of extensions related warnings in the console that probably shouldn't be visible in production (the devs these warnings are targeting are more likely to find these in dev I think).

This PR stops logging the extensions related **warnings** to the console _(they are still visible on the extensions admin page)_.

**Ops Grafana**
<img width="1568" alt="Screenshot 2024-11-07 at 15 34 27" src="https://github.com/user-attachments/assets/f14dd5c4-168a-4de0-ada7-21ebf87e639e">
