### PR TITLE
Revert "Prometheus: Fix escaping of quotation marks for variables"

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -289,16 +289,6 @@ describe('PrometheusDatasource', () => {
           operator: '=~',
           value: `v'.*`,
         },
-        {
-          key: 'k3',
-          operator: '=~',
-          value: `v".*`,
-        },
-        {
-          key: 'k4',
-          operator: '=~',
-          value: `\\v.*`,
-        },
       ];
       ds.query({
         interval: '15s',
@@ -308,7 +298,7 @@ describe('PrometheusDatasource', () => {
       } as DataQueryRequest<PromQuery>);
       const [result] = fetchMockCalledWith(fetchMock);
       expect(result).toMatchObject({
-        expr: `metric{job="foo", k1=~"v.*", k2=~"v'.*", k3=~"v\\".*", k4=~"\\\\v.*"} - metric{k1=~"v.*", k2=~"v'.*", k3=~"v\\".*", k4=~"\\\\v.*"}`,
+        expr: `metric{job="foo", k1=~"v.*", k2=~"v\\\\'.*"} - metric{k1=~"v.*", k2=~"v\\\\'.*"}`,
       });
     });
   });
@@ -488,12 +478,8 @@ describe('PrometheusDatasource', () => {
       expect(prometheusRegularEscape('cryptodepression')).toEqual('cryptodepression');
     });
 
-    it("should not escape '", () => {
-      expect(prometheusRegularEscape("looking'glass")).toEqual("looking'glass");
-    });
-
-    it('should escape "', () => {
-      expect(prometheusRegularEscape('looking"glass')).toEqual('looking\\"glass');
+    it("should escape '", () => {
+      expect(prometheusRegularEscape("looking'glass")).toEqual("looking\\\\'glass");
     });
 
     it('should escape \\', () => {
@@ -501,11 +487,11 @@ describe('PrometheusDatasource', () => {
     });
 
     it('should escape multiple characters', () => {
-      expect(prometheusRegularEscape('"looking"glass"')).toEqual('\\"looking\\"glass\\"');
+      expect(prometheusRegularEscape("'looking'glass'")).toEqual("\\\\'looking\\\\'glass\\\\'");
     });
 
     it('should escape multiple different characters', () => {
-      expect(prometheusRegularEscape('"loo\\king"glass"')).toEqual('\\"loo\\\\king\\"glass\\"');
+      expect(prometheusRegularEscape("'loo\\king'glass'")).toEqual("\\\\'loo\\\\king\\\\'glass\\\\'");
     });
   });
 
@@ -514,9 +500,8 @@ describe('PrometheusDatasource', () => {
       expect(prometheusSpecialRegexEscape('cryptodepression')).toEqual('cryptodepression');
     });
 
-    it('should escape $^*+?.()|\\"', () => {
+    it('should escape $^*+?.()|\\', () => {
       expect(prometheusSpecialRegexEscape("looking'glass")).toEqual("looking\\\\'glass");
-      expect(prometheusSpecialRegexEscape('looking"glass')).toEqual('looking\\\\\\"glass');
       expect(prometheusSpecialRegexEscape('looking{glass')).toEqual('looking\\\\{glass');
       expect(prometheusSpecialRegexEscape('looking}glass')).toEqual('looking\\\\}glass');
       expect(prometheusSpecialRegexEscape('looking[glass')).toEqual('looking\\\\[glass');
@@ -564,8 +549,8 @@ describe('PrometheusDatasource', () => {
     });
 
     describe('and value is a string', () => {
-      it('should only escape double quotes and backslashes', () => {
-        expect(ds.interpolateQueryExpr('abc\'"$^*{}[]+?.()|\\', customVariable)).toEqual('abc\'\\"$^*{}[]+?.()|\\\\');
+      it('should only escape single quotes', () => {
+        expect(ds.interpolateQueryExpr("abc'$^*{}[]+?.()|", customVariable)).toEqual("abc\\\\'$^*{}[]+?.()|");
       });
     });
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -640,7 +640,7 @@ export class PrometheusDatasource
 
     const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({
       label: f.key,
-      value: prometheusRegularEscape(f.value),
+      value: f.value,
       op: f.operator,
     }));
     const expr = promQueryModeller.renderLabels(labelFilters);
@@ -672,7 +672,7 @@ export class PrometheusDatasource
 
     const labelFilters: QueryBuilderLabelFilter[] = options.filters.map((f) => ({
       label: f.key,
-      value: prometheusRegularEscape(f.value),
+      value: f.value,
       op: f.operator,
     }));
 
@@ -1045,14 +1045,9 @@ export function extractRuleMappingFromGroups(groups: RawRecordingRules[]): RuleQ
 // in language_utils.ts, but they are not exactly the same algorithm, and we found
 // no way to reuse one in the another or vice versa.
 export function prometheusRegularEscape<T>(value: T) {
-  return typeof value === 'string' ? value.replace(/\\/g, '\\\\').replace(/"/g, '\\"') : value;
+  return typeof value === 'string' ? value.replace(/\\/g, '\\\\').replace(/'/g, "\\\\'") : value;
 }
 
 export function prometheusSpecialRegexEscape<T>(value: T) {
-  return typeof value === 'string'
-    ? value
-        .replace(/\\/g, '\\\\\\\\')
-        .replace(/"/g, '\\\\\\"')
-        .replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&')
-    : value;
+  return typeof value === 'string' ? value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&') : value;
 }


### PR DESCRIPTION
Reverts grafana/grafana#93415

This is causing issues with the Explore Metrics queries. 