### PR TITLE
Alerting UI: Update help button and descriptions for recording rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertRuleNameInput.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertRuleNameInput.tsx
@@ -72,7 +72,7 @@ export const AlertRuleNameAndMetric = () => {
                 pattern: recordingRuleNameValidationPattern(RuleFormType.grafanaRecording),
               })}
               aria-label="metric"
-              placeholder={`Give your metric a name`}
+              placeholder={`Give the name of the new recorded metric`}
             />
           </Field>
         )}

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/descriptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/descriptions.tsx
@@ -13,14 +13,14 @@ export const DESCRIPTIONS: Record<RuleFormType, FormDescriptions> = {
     helpLabel: 'Define your recording rule',
     helpContent:
       'Pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series.',
-    helpLink: '',
+    helpLink: 'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/',
   },
   [RuleFormType.grafanaRecording]: {
     sectionTitle: 'Define recording rule',
     helpLabel: 'Define your recording rule',
     helpContent:
       'Pre-compute frequently needed or computationally expensive expressions and save their result as a new set of time series.',
-    helpLink: '',
+    helpLink: 'https://grafana.com/docs/grafana/latest/alerting/alerting-rules/create-recording-rules/',
   },
   [RuleFormType.grafana]: {
     sectionTitle: 'Define query and alert condition',

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.tsx
@@ -7,7 +7,7 @@ import { CombinedRule } from 'app/types/unified-alerting';
 
 import { usePendingPeriod } from '../../hooks/rules/usePendingPeriod';
 import { useCleanAnnotations } from '../../utils/annotations';
-import { isGrafanaRecordingRule } from '../../utils/rules';
+import { isGrafanaRecordingRule, isRecordingRule, isRecordingRulerRule } from '../../utils/rules';
 import { isNullDate } from '../../utils/time';
 import { AlertLabels } from '../AlertLabels';
 import { DetailsField } from '../DetailsField';
@@ -53,9 +53,15 @@ export const RuleDetails = ({ rule }: Props) => {
           <RuleDetailsDataSources rulesSource={rulesSource} rule={rule} />
         </div>
       </div>
-      <DetailsField label="Instances" horizontal={true}>
-        <RuleDetailsMatchingInstances rule={rule} itemsDisplayLimit={INSTANCES_DISPLAY_LIMIT} />
-      </DetailsField>
+      {!(
+        isRecordingRulerRule(rule.rulerRule) ||
+        isRecordingRule(rule.promRule) ||
+        isGrafanaRecordingRule(rule.rulerRule)
+      ) && (
+        <DetailsField label="Instances" horizontal={true}>
+          <RuleDetailsMatchingInstances rule={rule} itemsDisplayLimit={INSTANCES_DISPLAY_LIMIT} />
+        </DetailsField>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- [Make the Metric input placeholder more explicit for recording rules](https://github.com/grafana/grafana/commit/94ab0aa0bba19b00d1c457093131a7f0126af211)

   `Give your metric a name` -> `Give the name of the new recorded metric`
   
    ![Screenshot 2024-11-07 at 17 31 57](https://github.com/user-attachments/assets/facd03aa-abf5-4779-9179-baf862fa91b1)

   

- [Alerting UI: add helpLink to Recording Rules docs](https://github.com/grafana/grafana/commit/c14ff28aa84eb33a62751d46d6067e2d42690db1)

    ![Screenshot 2024-11-07 at 17 08 40](https://github.com/user-attachments/assets/1ab64cad-eed2-46d1-a622-183aaa325e55)


- [Hide Instances field in RuleDetails view for recording rules](https://github.com/grafana/grafana/commit/62a74deef25c67945f40f1cfc61f4ca88c12a9c8)

    **Before**

    ![Screenshot 2024-11-07 at 16 33 00](https://github.com/user-attachments/assets/e8b3b968-7afa-458f-8ec2-78604de69752)
 
    ![Screenshot 2024-11-07 at 16 32 50](https://github.com/user-attachments/assets/2e700076-15ff-445e-a992-b74a8ff101c3)


    **After**
    
    ![Screenshot 2024-11-07 at 16 32 04](https://github.com/user-attachments/assets/369b8a5c-5c56-49ed-80c2-8db04b83e1a6)

    ![Screenshot 2024-11-07 at 16 32 12](https://github.com/user-attachments/assets/ee957d7f-f5ff-45f8-a85b-5c3e0770b462)

    
    