### PR TITLE
LBAC for datasources: Adds teamUID to lbac rules for terraform resource consumption

### DIFF
--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -7824,6 +7824,9 @@
         },
         "teamId": {
           "type": "string"
+        },
+        "teamUid": {
+          "type": "string"
         }
       }
     },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -21100,6 +21100,9 @@
         },
         "teamId": {
           "type": "string"
+        },
+        "teamUid": {
+          "type": "string"
         }
       }
     },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -11057,6 +11057,9 @@
           },
           "teamId": {
             "type": "string"
+          },
+          "teamUid": {
+            "type": "string"
           }
         },
         "type": "object"


### PR DESCRIPTION
This adds the TeamUID to lbac rules model for openapi client in order to develop the terraform resource with TeamUID as we evaluate how to add the team UID in the enterprise code