### PR TITLE
Unified Storage: Adds metric to count indexed docs by kind

### DIFF
--- a/pkg/storage/unified/resource/index.go
+++ b/pkg/storage/unified/resource/index.go
@@ -204,6 +204,9 @@ func (i *Index) InitForTenant(ctx context.Context, namespace string) (int, error
 				return totalObjectsFetched, err
 			}
 
+			// Record the number of objects indexed for the kind
+			IndexServerMetrics.IndexedKinds.WithLabelValues(rt.Key.Resource).Add(float64(len(list.Items)))
+
 			totalObjectsFetched += len(list.Items)
 
 			logger.Debug("indexing batch", "kind", rt.Key.Resource, "count", len(list.Items), "namespace", namespace)
@@ -275,6 +278,9 @@ func (i *Index) Index(ctx context.Context, data *Data) error {
 	if err != nil {
 		return err
 	}
+
+	//record the kind of resource that was indexed
+	IndexServerMetrics.IndexedKinds.WithLabelValues(res.Kind).Inc()
 
 	// record latency from when event was created to when it was indexed
 	latencySeconds := float64(time.Now().UnixMicro()-data.Value.ResourceVersion) / 1e6


### PR DESCRIPTION
Adds metric so we can see counts of indexed objs by kind:
```
# HELP index_server_indexed_kinds Number of indexed documents by kind
# TYPE index_server_indexed_kinds counter
index_server_indexed_kinds{kind="dashboards"} 0
index_server_indexed_kinds{kind="folders"} 0
index_server_indexed_kinds{kind="playlists"} 100002
```