### PR TITLE
Explore Metrics: Persist otel experience toggle state in local storage

### DIFF
--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -34,6 +34,7 @@ import { StatusWrapper } from '../StatusWrapper';
 import { Node, Parser } from '../groop/parser';
 import { getMetricDescription } from '../helpers/MetricDatasourceHelper';
 import { reportExploreMetrics } from '../interactions';
+import { setOtelExperienceToggleState } from '../services/store';
 import {
   getVariablesWithMetricConstant,
   MetricSelectedEvent,
@@ -485,6 +486,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
     const trail = getTrailFor(this);
     const useOtelExperience = trail.state.useOtelExperience;
 
+    setOtelExperienceToggleState(!useOtelExperience);
     trail.setState({ useOtelExperience: !useOtelExperience });
   };
 

--- a/public/app/features/trails/services/store.ts
+++ b/public/app/features/trails/services/store.ts
@@ -1,4 +1,4 @@
-import { TRAIL_BREAKDOWN_VIEW_KEY, TRAIL_BREAKDOWN_SORT_KEY } from '../shared';
+import { TRAIL_BREAKDOWN_VIEW_KEY, TRAIL_BREAKDOWN_SORT_KEY, OTEL_EXPERIENCE_ENABLED_KEY } from '../shared';
 
 export function getVewByPreference() {
   return localStorage.getItem(TRAIL_BREAKDOWN_VIEW_KEY) ?? 'grid';
@@ -22,4 +22,13 @@ export function setSortByPreference(target: string, sortBy: string) {
   if (sortBy) {
     localStorage.setItem(`${TRAIL_BREAKDOWN_SORT_KEY}.${target}.by`, `${sortBy}`);
   }
+}
+
+export function getOtelExperienceToggleState(): boolean {
+  const val = localStorage.getItem(OTEL_EXPERIENCE_ENABLED_KEY);
+  return val !== null ? JSON.parse(val) : true;
+}
+
+export function setOtelExperienceToggleState(value: boolean) {
+  return localStorage.setItem(OTEL_EXPERIENCE_ENABLED_KEY, value.toString());
 }

--- a/public/app/features/trails/shared.ts
+++ b/public/app/features/trails/shared.ts
@@ -3,6 +3,7 @@ import { ConstantVariable, SceneObject } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
 
 export type ActionViewType = 'overview' | 'breakdown' | 'label-breakdown' | 'related-logs' | 'related';
+
 export interface ActionViewDefinition {
   displayName: string;
   value: ActionViewType;
@@ -44,6 +45,7 @@ export const RECENT_TRAILS_KEY = 'grafana.trails.recent';
 export const TRAIL_BOOKMARKS_KEY = 'grafana.trails.bookmarks';
 export const TRAIL_BREAKDOWN_VIEW_KEY = 'grafana.trails.breakdown.view';
 export const TRAIL_BREAKDOWN_SORT_KEY = 'grafana.trails.breakdown.sort';
+export const OTEL_EXPERIENCE_ENABLED_KEY = 'grafana.trails.otel.experience.enabled';
 
 export const MDP_METRIC_PREVIEW = 250;
 export const MDP_METRIC_OVERVIEW = 500;


### PR DESCRIPTION
**What is this feature?**

Persist the OTel experience toggle state in localStorage.

**Who is this feature for?**

OTel consumers in Explore Metrics 
