### PR TITLE
Prometheus: Check both error and http status for source of error 

### DIFF
--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -240,7 +240,6 @@ func (s *QueryData) rangeQuery(ctx context.Context, c *client.Client, q *models.
 	if res.StatusCode/100 != 2 {
 		// for differentiating the source of http errors by status code
 		return backend.DataResponse{
-			Error:       err,
 			ErrorSource: backend.ErrorSourceFromHTTPStatus(res.StatusCode),
 		}
 	}
@@ -273,7 +272,6 @@ func (s *QueryData) instantQuery(ctx context.Context, c *client.Client, q *model
 		}
 		// for differentiating the source of http errors by status code
 		return backend.DataResponse{
-			Error:       err,
 			ErrorSource: backend.ErrorSourceFromHTTPStatus(res.StatusCode),
 		}
 	}
@@ -297,7 +295,6 @@ func (s *QueryData) exemplarQuery(ctx context.Context, c *client.Client, q *mode
 	if res.StatusCode/100 != 2 {
 		// for differentiating the source of http errors by status code
 		return backend.DataResponse{
-			Error:       err,
 			ErrorSource: backend.ErrorSourceFromHTTPStatus(res.StatusCode),
 		}
 	}

--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -267,7 +267,8 @@ func (s *QueryData) instantQuery(ctx context.Context, c *client.Client, q *model
 		// add more details to the health check error
 		if q.RefId == "__healthcheck__" {
 			return backend.DataResponse{
-				Error: errors.New(res.Status),
+				Error:       errors.New(res.Status),
+				ErrorSource: backend.ErrorSourceFromHTTPStatus(res.StatusCode),
 			}
 		}
 		// for differentiating the source of http errors by status code


### PR DESCRIPTION
An improved version of this [reverted PR](https://github.com/grafana/grafana/pull/95999) [using this doc](https://docs.google.com/document/d/1FWbHFg6aEYgCo9uSvDaTCPcb9xUub-3rzXpBGjudWxU/edit?tab=t.0) written by @ivanahuckova 

In this, we check the source of the error as well as the status code before labeling as either from downstream or from our code for the plugin.

We use the helper functions below:

`backend.IsDownstreamHTTPError(err)`: check the error to see if the source is downstream or other
`backend.ErrorSourceFromHTTPStatus(res.StatusCode)`: check the status code for error source, down stream or other


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
