### PR TITLE
Revert "Chore: Clean up some excludes and fix makefile"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -230,6 +230,9 @@ issues:
   exclude-dirs:
     - devenv
     - scripts
+  exclude-files:
+    - pkg/util/xorm/*.go
+    - pkg/build/wire/*.go
   exclude-rules:
     - linters:
         - stylecheck

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ test: test-go test-js ## Run all tests.
 golangci-lint: $(GOLANGCI_LINT)
 	@echo "lint via golangci-lint"
 	$(GOLANGCI_LINT) run \
-		--config .golangci.yml \
+		--config .golangci.toml \
 		$(GO_LINT_FILES)
 
 .PHONY: lint-go


### PR DESCRIPTION
Reverts grafana/grafana#96052

Enterprise builds are failing the lint check after https://github.com/grafana/grafana/pull/95471. Reverting this PR so we can cleanly revert the original PR.

example builds:
- https://drone.grafana.net/grafana/grafana-enterprise/78664/4/6
- https://drone.grafana.net/grafana/grafana-enterprise/78665/1/6
- https://drone.grafana.net/grafana/grafana-enterprise/78666/2/6