### PR TITLE
[CloudMigrations] Fetch cloud migration status asynchronously

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -622,7 +622,7 @@ func (s *Service) fetchSnapshotStatusFromGMS(ctx context.Context, session *cloud
 	}
 
 	if snapshotMeta.State == cloudmigration.SnapshotStateUnknown {
-		return fmt.Errorf("grafana migration service is unavailable")
+		return fmt.Errorf("Grafana Migration Service is unavailable. Snapshot state is unknown")
 	}
 
 	localStatus, ok := gmsStateToLocalStatus[snapshotMeta.State]

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -622,7 +622,7 @@ func (s *Service) fetchSnapshotStatusFromGMS(ctx context.Context, session *cloud
 	}
 
 	if snapshotMeta.State == cloudmigration.SnapshotStateUnknown {
-		return fmt.Errorf("Grafana Migration Service is unavailable. Snapshot state is unknown")
+		return fmt.Errorf("grafana migration service is unavailable")
 	}
 
 	localStatus, ok := gmsStateToLocalStatus[snapshotMeta.State]

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -48,10 +49,13 @@ type Service struct {
 	log *log.ConcreteLogger
 	cfg *setting.Cfg
 
+	// FIXME: the concurrency control implemented here only works for a single session / snapshot
 	buildSnapshotMutex sync.Mutex
 
 	cancelMutex sync.Mutex
 	cancelFunc  context.CancelFunc
+
+	isSyncSnapshotStatusFromGMSRunning int32
 
 	features      featuremgmt.FeatureToggles
 	gmsClient     gmsclient.Client
@@ -546,58 +550,111 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		return nil, fmt.Errorf("fetching session for uid %s: %w", sessionUid, err)
 	}
 
-	// Ask GMS for snapshot status while the source of truth is in the cloud
-	if snapshot.ShouldQueryGMS() {
-		// Calculate offset based on how many results we currently have responses for
-		pending := snapshot.StatsRollup.CountsByStatus[cloudmigration.ItemStatusPending]
-		snapshotMeta, err := s.gmsClient.GetSnapshotStatus(ctx, *session, *snapshot, snapshot.StatsRollup.Total-pending)
-		if err != nil {
-			return snapshot, fmt.Errorf("error fetching snapshot status from GMS: sessionUid: %s, snapshotUid: %s", sessionUid, snapshotUid)
-		}
+	asyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
+	go s.syncSnapshotStatusFromGMSUntilDone(asyncCtx, session, snapshot)
 
-		if snapshotMeta.State == cloudmigration.SnapshotStateUnknown {
-			// If a status from Grafana Migration Service is unavailable, return the snapshot as-is
-			return snapshot, nil
-		}
+	return snapshot, nil
+}
 
-		localStatus, ok := gmsStateToLocalStatus[snapshotMeta.State]
-		if !ok {
-			s.log.Error("unexpected GMS snapshot state: %s", snapshotMeta.State)
-			return snapshot, nil
-		}
+func (s *Service) syncSnapshotStatusFromGMSUntilDone(ctx context.Context, session *cloudmigration.CloudMigrationSession, snapshot *cloudmigration.CloudMigrationSnapshot) {
+	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.syncSnapshotStatusFromGMSUntilDone")
+	span.SetAttributes(
+		attribute.String("sessionUID", session.UID),
+		attribute.String("snapshotUID", snapshot.UID),
+	)
+	defer span.End()
 
-		// For 11.2 we only support core data sources. Apply a warning for any non-core ones before storing.
-		resources, err := s.getResourcesWithPluginWarnings(ctx, snapshotMeta.Results)
-		if err != nil {
-			// treat this as non-fatal since the migration still succeeded
-			s.log.Error("error applying plugin warnings, please open a bug report: %w", err)
-		}
+	// Ensure only one in-flight sync running
+	if !atomic.CompareAndSwapInt32(&s.isSyncSnapshotStatusFromGMSRunning, 0, 1) {
+		s.log.Info("synchronize snapshot status already running", "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+		return
+	}
+	defer atomic.StoreInt32(&s.isSyncSnapshotStatusFromGMSRunning, 0)
 
-		// Log the errors for resources with errors at migration
-		for _, resource := range resources {
-			if resource.Status == cloudmigration.ItemStatusError && resource.Error != "" {
-				s.log.Error("Could not migrate resource", "resourceID", resource.RefID, "error", resource.Error)
+	s.cancelMutex.Lock()
+	defer func() {
+		s.cancelFunc = nil
+		s.cancelMutex.Unlock()
+	}()
+
+	ctx, s.cancelFunc = context.WithCancel(ctx)
+
+	tick := time.NewTicker(5 * time.Second)
+
+	for snapshot.ShouldQueryGMS() {
+		// FIXME: missing close on graceful shutdown
+		select {
+		case <-ctx.Done():
+			s.log.Info("cancelling snapshot status polling", "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+			return
+		case <-tick.C:
+			err := s.fetchSnapshotStatusFromGMS(ctx, session, snapshot)
+			if err != nil {
+				s.log.Error("error fetching snapshot status from GMS", "error", err, "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+				continue
+			}
+
+			snapshot, err = s.store.GetSnapshotByUID(ctx, session.UID, snapshot.UID, 0, 0)
+			if err != nil {
+				s.log.Error("error refetching updated snapshot", "error", err, "sessionUID", session.UID, "snapshotUID", snapshot.UID)
 			}
 		}
+	}
+}
 
-		// We need to update the snapshot in our db before reporting anything
-		if err := s.store.UpdateSnapshot(ctx, cloudmigration.UpdateSnapshotCmd{
-			UID:       snapshot.UID,
-			SessionID: sessionUid,
-			Status:    localStatus,
-			Resources: resources,
-		}); err != nil {
-			return nil, fmt.Errorf("error updating snapshot status: %w", err)
-		}
+func (s *Service) fetchSnapshotStatusFromGMS(ctx context.Context, session *cloudmigration.CloudMigrationSession, snapshot *cloudmigration.CloudMigrationSnapshot) error {
+	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.fetchSnapshotStatusFromGMS")
+	pending := snapshot.StatsRollup.CountsByStatus[cloudmigration.ItemStatusPending]
+	span.SetAttributes(
+		attribute.String("sessionUID", session.UID),
+		attribute.String("snapshotUID", snapshot.UID),
+		attribute.Int("pending", pending),
+	)
 
-		// Refresh the snapshot after the update
-		snapshot, err = s.store.GetSnapshotByUID(ctx, sessionUid, snapshotUid, query.ResultPage, query.ResultLimit)
-		if err != nil {
-			return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
+	defer span.End()
+
+	s.log.Info("fetching snapshot status from GMS", "sessionUID", session.UID, "snapshotUID", snapshot.UID, "pending", pending)
+
+	// Calculate offset based on how many results we currently have responses for
+	snapshotMeta, err := s.gmsClient.GetSnapshotStatus(ctx, *session, *snapshot, snapshot.StatsRollup.Total-pending)
+	if err != nil {
+		return fmt.Errorf("error fetching snapshot status from GMS: %w", err)
+	}
+
+	if snapshotMeta.State == cloudmigration.SnapshotStateUnknown {
+		return fmt.Errorf("Grafana Migration Service is unavailable. Snapshot state is unknown")
+	}
+
+	localStatus, ok := gmsStateToLocalStatus[snapshotMeta.State]
+	if !ok {
+		return fmt.Errorf("unexpected GMS snapshot state: %s", snapshotMeta.State)
+	}
+
+	// For 11.2 we only support core data sources. Apply a warning for any non-core ones before storing.
+	resources, err := s.getResourcesWithPluginWarnings(ctx, snapshotMeta.Results)
+	if err != nil {
+		// treat this as non-fatal since the migration still succeeded
+		s.log.Error("error applying plugin warnings, please open a bug report", "error", err, "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+	}
+
+	// Log the errors for resources with errors at migration
+	for _, resource := range resources {
+		if resource.Status == cloudmigration.ItemStatusError && resource.Error != "" {
+			s.log.Error("Could not migrate resource", "resourceID", resource.RefID, "error", resource.Error, "sessionUID", session.UID, "snapshotUID", snapshot.UID)
 		}
 	}
 
-	return snapshot, nil
+	// We need to update the snapshot in our db before reporting anything
+	if err := s.store.UpdateSnapshot(ctx, cloudmigration.UpdateSnapshotCmd{
+		UID:       snapshot.UID,
+		SessionID: session.UID,
+		Status:    localStatus,
+		Resources: resources,
+	}); err != nil {
+		return fmt.Errorf("updating snapshot status: %w", err)
+	}
+
+	return nil
 }
 
 var gmsStateToLocalStatus map[cloudmigration.SnapshotState]cloudmigration.SnapshotStatus = map[cloudmigration.SnapshotState]cloudmigration.SnapshotStatus{
@@ -694,6 +751,12 @@ func (s *Service) UploadSnapshot(ctx context.Context, sessionUid string, snapsho
 		}
 
 		s.report(asyncCtx, session, gmsclient.EventDoneUploadingSnapshot, time.Since(start), err)
+
+		// Create a context out the span context to ensure the trace is propagated
+		asyncSyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
+		// Sync snapshot results from GMS if the one created after upload is not running (e.g. due to a restart)
+		// and anybody is interested in the status.
+		go s.syncSnapshotStatusFromGMSUntilDone(asyncSyncCtx, session, snapshot)
 	}()
 
 	return nil

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -52,6 +53,8 @@ type Service struct {
 
 	cancelMutex sync.Mutex
 	cancelFunc  context.CancelFunc
+
+	isSyncSnapshotStatusFromGMSRunning int32
 
 	features      featuremgmt.FeatureToggles
 	gmsClient     gmsclient.Client
@@ -546,8 +549,8 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		return nil, fmt.Errorf("fetching session for uid %s: %w", sessionUid, err)
 	}
 
-	// Ask GMS for snapshot status while the source of truth is in the cloud
-	if snapshot.ShouldQueryGMS() {
+	// FIXME: this function should be a method
+	syncStatus := func(ctx context.Context, session *cloudmigration.CloudMigrationSession, snapshot *cloudmigration.CloudMigrationSnapshot) (*cloudmigration.CloudMigrationSnapshot, error) {
 		// Calculate offset based on how many results we currently have responses for
 		pending := snapshot.StatsRollup.CountsByStatus[cloudmigration.ItemStatusPending]
 		snapshotMeta, err := s.gmsClient.GetSnapshotStatus(ctx, *session, *snapshot, snapshot.StatsRollup.Total-pending)
@@ -595,9 +598,60 @@ func (s *Service) GetSnapshot(ctx context.Context, query cloudmigration.GetSnaps
 		if err != nil {
 			return nil, fmt.Errorf("fetching snapshot for uid %s: %w", snapshotUid, err)
 		}
+		return snapshot, nil
 	}
 
+	// Create a context out the span context to ensure the trace is propagated
+	asyncSyncCtx := trace.ContextWithSpanContext(context.Background(), span.SpanContext())
+	// Sync snapshot results from GMS if the one created after upload is not running (e.g. due to a restart)
+	// and anybody is interested in the status.
+	go s.syncSnapshotStatusFromGMSUntilDone(asyncSyncCtx, session, snapshot, syncStatus)
+
 	return snapshot, nil
+}
+
+// FIXME: this definition should not exist once the function is GetSnapshot is converted to a method
+type syncStatusFunc func(context.Context, *cloudmigration.CloudMigrationSession, *cloudmigration.CloudMigrationSnapshot) (*cloudmigration.CloudMigrationSnapshot, error)
+
+func (s *Service) syncSnapshotStatusFromGMSUntilDone(ctx context.Context, session *cloudmigration.CloudMigrationSession, snapshot *cloudmigration.CloudMigrationSnapshot, syncStatus syncStatusFunc) {
+	ctx, span := s.tracer.Start(ctx, "CloudMigrationService.syncSnapshotStatusFromGMSUntilDone")
+	span.SetAttributes(
+		attribute.String("sessionUID", session.UID),
+		attribute.String("snapshotUID", snapshot.UID),
+	)
+	defer span.End()
+
+	// Ensure only one in-flight sync running
+	if !atomic.CompareAndSwapInt32(&s.isSyncSnapshotStatusFromGMSRunning, 0, 1) {
+		s.log.Info("synchronize snapshot status already running", "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+		return
+	}
+	defer atomic.StoreInt32(&s.isSyncSnapshotStatusFromGMSRunning, 0)
+
+	s.cancelMutex.Lock()
+	defer func() {
+		s.cancelFunc = nil
+		s.cancelMutex.Unlock()
+	}()
+
+	ctx, s.cancelFunc = context.WithCancel(ctx)
+
+	tick := time.NewTicker(5 * time.Second)
+
+	for snapshot.ShouldQueryGMS() {
+		select {
+		case <-ctx.Done():
+			s.log.Info("cancelling snapshot status polling", "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+			return
+		case <-tick.C:
+			updatedSnapshot, err := syncStatus(ctx, session, snapshot)
+			if err != nil {
+				s.log.Error("error fetching snapshot status from GMS", "error", err, "sessionUID", session.UID, "snapshotUID", snapshot.UID)
+				continue
+			}
+			snapshot = updatedSnapshot
+		}
+	}
 }
 
 var gmsStateToLocalStatus map[cloudmigration.SnapshotState]cloudmigration.SnapshotStatus = map[cloudmigration.SnapshotState]cloudmigration.SnapshotStatus{

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -647,7 +647,7 @@ func (s *Service) syncSnapshotStatusFromGMSUntilDone(ctx context.Context, sessio
 		snapshot = updatedSnapshot
 	}
 
-	tick := time.NewTicker(5 * time.Second)
+	tick := time.NewTicker(10 * time.Second)
 	defer tick.Stop()
 
 	for snapshot.ShouldQueryGMS() {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -111,7 +112,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
-	assert.Equal(t, 0, gmsClientMock.getStatusCalled)
+	assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 0 }, time.Second, 10*time.Millisecond)
 
 	// Make the status pending processing and ensure GMS gets called
 	err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
@@ -123,12 +124,31 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 
 	cleanupFunc := func() {
 		gmsClientMock.getStatusCalled = 0
+		gmsClientMock.getSnapshotResponse = nil
+		if s.cancelFunc != nil {
+			s.cancelFunc()
+		}
+
 		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
 			UID:       uid,
 			SessionID: sess.UID,
 			Status:    cloudmigration.SnapshotStatusPendingProcessing,
 		})
 		assert.NoError(t, err)
+	}
+
+	checkStatusSync := func(status cloudmigration.SnapshotStatus) func() bool {
+		return func() bool {
+			snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+				SnapshotUID: uid,
+				SessionUID:  sess.UID,
+			})
+			if err != nil {
+				return false
+			}
+
+			return snapshot.Status == status
+		}
 	}
 
 	t.Run("test case: gms snapshot initialized", func(t *testing.T) {
@@ -140,9 +160,8 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusPendingProcessing, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
-
+		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatus(cloudmigration.SnapshotStatusPendingProcessing)), time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
 
@@ -150,14 +169,13 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateProcessing,
 		}
-		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+		_, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusProcessing, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
-
+		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
 
@@ -170,8 +188,8 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusFinished, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
+		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
 	})
@@ -185,8 +203,8 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusCanceled, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
+		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusCanceled), time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
 	})
@@ -200,8 +218,8 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusError, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
+		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
+		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
 	})
@@ -210,14 +228,20 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateUnknown,
 		}
-		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
 		// snapshot status should remain unchanged
+
+		assert.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
+		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+			SnapshotUID: uid,
+			SessionUID:  sess.UID,
+		})
+		assert.NoError(t, err)
 		assert.Equal(t, cloudmigration.SnapshotStatusPendingProcessing, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled)
 
 		t.Cleanup(cleanupFunc)
 	})
@@ -237,13 +261,19 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		}
 
 		// ensure it is persisted
+		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+			SnapshotUID: uid,
+			SessionUID:  sess.UID,
+		})
+		assert.NoError(t, err)
+		assert.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
+
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, cloudmigration.SnapshotStatusFinished, snapshot.Status)
-		assert.Equal(t, 1, gmsClientMock.getStatusCalled) // shouldn't have queried GMS again now that it is finished
+
 		assert.Len(t, snapshot.Resources, 1)
 		assert.Equal(t, "A", snapshot.Resources[0].RefID)
 		assert.Equal(t, "fake", snapshot.Resources[0].Error)
@@ -300,7 +330,7 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 0, gmsClientMock.getStatusCalled)
+		assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 0 }, time.Second, 10*time.Millisecond)
 	}
 
 	// make sure GMS is called when snapshot is pending processing or processing
@@ -319,8 +349,9 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, i+1, gmsClientMock.getStatusCalled)
+		assert.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 }, time.Second, 10*time.Millisecond)
 	}
+	assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 2 }, time.Second, 10*time.Millisecond)
 }
 
 func Test_DeletedDashboardsNotMigrated(t *testing.T) {
@@ -470,15 +501,25 @@ func Test_NonCoreDataSourcesHaveWarning(t *testing.T) {
 		},
 	}
 
-	// Retrieve the snapshot with results
-	snapshot, err := s.GetSnapshot(ctxWithSignedInUser(), cloudmigration.GetSnapshotsQuery{
-		SnapshotUID: snapshotUid,
-		SessionUID:  sess.UID,
-		ResultPage:  1,
-		ResultLimit: 10,
-	})
-	assert.NoError(t, err)
-	assert.Len(t, snapshot.Resources, 4)
+	var snapshot *cloudmigration.CloudMigrationSnapshot
+	hasFourResources := func() bool {
+		// Retrieve the snapshot with results
+		var err error
+		snapshot, err = s.GetSnapshot(ctxWithSignedInUser(), cloudmigration.GetSnapshotsQuery{
+			SnapshotUID: snapshotUid,
+			SessionUID:  sess.UID,
+			ResultPage:  1,
+			ResultLimit: 10,
+		})
+
+		if !assert.NoError(t, err) {
+			return false
+		}
+
+		return len(snapshot.Resources) == 4
+	}
+
+	require.Eventually(t, hasFourResources, time.Second, 10*time.Millisecond)
 
 	findRef := func(id string) *cloudmigration.CloudMigrationResource {
 		for _, r := range snapshot.Resources {
@@ -579,6 +620,7 @@ func TestReportEvent(t *testing.T) {
 		require.Equal(t, 1, gmsMock.reportEventCalled)
 	})
 }
+
 func TestGetFolderNamesForFolderUIDs(t *testing.T) {
 	s := setUpServiceTest(t, false).(*Service)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -802,7 +844,7 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 	)
 	require.NoError(t, err)
 
-	var validConfig = `{
+	validConfig := `{
 		"alertmanager_config": {
 			"route": {
 				"receiver": "grafana-default-email"
@@ -850,6 +892,8 @@ func setUpServiceTest(t *testing.T, withDashboardMock bool) cloudmigration.Servi
 }
 
 type gmsClientMock struct {
+	mu sync.RWMutex
+
 	validateKeyCalled     int
 	startSnapshotCalled   int
 	getStatusCalled       int
@@ -874,7 +918,10 @@ func (m *gmsClientMock) StartSnapshot(_ context.Context, _ cloudmigration.CloudM
 }
 
 func (m *gmsClientMock) GetSnapshotStatus(_ context.Context, _ cloudmigration.CloudMigrationSession, _ cloudmigration.CloudMigrationSnapshot, _ int) (*cloudmigration.GetSnapshotStatusResponse, error) {
+	m.mu.Lock()
 	m.getStatusCalled++
+	m.mu.Unlock()
+
 	return m.getSnapshotResponse, nil
 }
 
@@ -885,4 +932,11 @@ func (m *gmsClientMock) CreatePresignedUploadUrl(ctx context.Context, session cl
 
 func (m *gmsClientMock) ReportEvent(context.Context, cloudmigration.CloudMigrationSession, gmsclient.EventRequestDTO) {
 	m.reportEventCalled++
+}
+
+func (m *gmsClientMock) GetSnapshotStatusCallCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.getStatusCalled
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -160,7 +160,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatus(cloudmigration.SnapshotStatusPendingProcessing)), time.Second, 10*time.Millisecond)
+		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatus(cloudmigration.SnapshotStatusPendingProcessing)), time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
@@ -174,7 +174,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
+		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
@@ -188,7 +188,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
+		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
@@ -203,7 +203,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusCanceled), time.Second, 10*time.Millisecond)
+		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusCanceled), time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
@@ -218,7 +218,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
+		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
@@ -235,7 +235,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		assert.NoError(t, err)
 		// snapshot status should remain unchanged
 
-		assert.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
@@ -266,7 +266,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
@@ -349,7 +349,7 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		assert.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 }, time.Second, 10*time.Millisecond)
 	}
 	assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 2 }, time.Second, 10*time.Millisecond)
 }

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -160,7 +160,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatus(cloudmigration.SnapshotStatusPendingProcessing)), time.Second, 10*time.Millisecond)
+		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusPendingProcessing), time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
@@ -228,7 +228,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateUnknown,
 		}
-		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
 		})
@@ -261,7 +261,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		}
 
 		// ensure it is persisted
-		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
 		})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fetch cloud migration status asynchronously to the API call. 

**Why do we need this feature?**

The snapshot/ endpoint to get snapshot status during upload and migration becomes very slow (more than 30 seconds) and times out in the k6 script. From the user perspective there is no visible impact if they don't refresh the page, but if they refresh the page , they won't be able to see the state of the snapshot for a very long time or until it finishes.

This is due to the synchronous fetching results of the migration on that endpoint:

https://github.com/grafana/grafana/blob/b0e6539f81d79295636f1774f795484cc461fc9b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go?plain=1#L549-L591

That synchronous way of fetching the information can also result in unintended consequences as you may have 2 or more requests to that endpoint that trigger that fetching of information and as far as I understood we don't have any locking mechanism.

More context can be found in: https://github.com/grafana/grafana-operator-experience-squad/issues/1032#issuecomment-2459803194

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1098


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
