### PR TITLE
Alerting docs: reuse `Additional configuration` page for Cloud docs

### DIFF
--- a/docs/sources/alerting/set-up/_index.md
+++ b/docs/sources/alerting/set-up/_index.md
@@ -2,51 +2,15 @@
 aliases:
   - unified-alerting/set-up/ # /docs/grafana/<GRAFANA_VERSION>/alerting/unified-alerting/set-up/
 canonical: https://grafana.com/docs/grafana/latest/alerting/set-up/
-description: Advanced configuration for Grafana Alerting
+description: Additional configuration for Grafana Alerting
 labels:
   products:
+    - cloud
+    - enterprise
     - oss
 menuTitle: Additional configuration
 title: Additional configuration
 weight: 160
-refs:
-  terraform-provisioning:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/terraform-provisioning/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/provision-alerting-resources/terraform-provisioning/
-  configure-high-availability:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-high-availability/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-high-availability/
-  configure-alertmanager:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-alertmanager/
-  data-source-management:
-    - pattern: /docs/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
-  data-source-alerting:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/#supported-data-sources
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/#supported-data-sources
-  file-provisioning:
-    - pattern: /docs/
-      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/provision-alerting-resources/file-provisioning/
-  alerting-permissions:
-    - pattern: /docs/
-    - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-roles//alerting/set-up/configure-roles/
-  alerting-rbac:
-    - pattern: /docs/
-    - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-rbac/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-rbac/
-  alert-state-history:
-    - pattern: /docs/
-    - destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/
 ---
 
 # Additional configuration
@@ -55,10 +19,4 @@ Grafana Alerting offers a variety of advanced configuration options to further t
 
 The following topics provide you with advanced configuration options for Grafana Alerting.
 
-- [Configure roles and permissions](ref:alerting-permissions)
-- [Configure RBAC](ref:alerting-rbac)
-- [Configure alert state history](ref:alert-state-history)
-- [Use configuration files to provision](ref:file-provisioning)
-- [Use Terraform to provision](ref:terraform-provisioning)
-- [Configure Alertmanagers](ref:configure-alertmanager)
-- [Configure high availability](ref:configure-high-availability)
+{{< section >}}


### PR DESCRIPTION
With these changes, we could reuse this page for Cloud docs.

`{{< section >}}` will only display Cloud configuration pages.
