### PR TITLE
Logs: Allow to reach the bottom of the log list before loading more logs

### DIFF
--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -94,7 +94,7 @@ export const InfiniteScroll = ({
       const scrollDirection = shouldLoadMore(event, scrollElement, lastScroll.current);
       lastScroll.current = scrollElement.scrollTop;
 
-      // Give users a change to reach the bottom of the log list
+      // Give users a change to reach the bottom/top of the log list
       if (!scrollOnEdge(scrollElement) || scrollDirection === ScrollDirection.NoScroll) {
         return;
       }

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -41,10 +41,12 @@ export const InfiniteScroll = ({
   const [upperLoading, setUpperLoading] = useState(false);
   const [lowerLoading, setLowerLoading] = useState(false);
   const scrollSize = scrollElement ? scrollElement.scrollHeight - scrollElement.clientHeight : 0;
-  const [onBottomEdge, setOnBottomEdge] = useState(scrollElement?.scrollTop === scrollSize || false);
+  const [onEdge, setOnEdge] = useState(
+    scrollElement?.scrollTop === scrollSize || scrollElement?.scrollTop === 0 || false
+  );
   const rowsRef = useRef<LogRowModel[]>(rows);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
-  const debouncedSetOnBottomEdge = debounce(setOnBottomEdge, 400);
+  const debouncedSetOnEdge = debounce(setOnEdge, 400);
 
   // Reset messages when range/order/rows change
   useEffect(() => {
@@ -108,14 +110,14 @@ export const InfiniteScroll = ({
 
     function scrollOnEdge(scrollElement: HTMLDivElement) {
       const scrollSize = scrollElement ? scrollElement.scrollHeight - scrollElement.clientHeight : 0;
-      debouncedSetOnBottomEdge.cancel();
-      if (scrollElement.scrollTop === scrollSize) {
-        debouncedSetOnBottomEdge(true);
+      debouncedSetOnEdge.cancel();
+      if (scrollElement.scrollTop >= scrollSize || scrollElement.scrollTop <= 0) {
+        debouncedSetOnEdge(true);
       } else {
-        setOnBottomEdge(false);
+        setOnEdge(false);
         return false;
       }
-      return onBottomEdge;
+      return onEdge;
     }
 
     function scrollTop() {
@@ -155,7 +157,19 @@ export const InfiniteScroll = ({
       scrollElement.removeEventListener('scroll', handleScroll);
       scrollElement.removeEventListener('wheel', handleScroll);
     };
-  }, [debouncedSetOnBottomEdge, loadMoreLogs, loading, onBottomEdge, range, rows, scrollElement, scrollSize, sortOrder, timeZone, topScrollEnabled]);
+  }, [
+    debouncedSetOnEdge,
+    loadMoreLogs,
+    loading,
+    onEdge,
+    range,
+    rows,
+    scrollElement,
+    scrollSize,
+    sortOrder,
+    timeZone,
+    topScrollEnabled,
+  ]);
 
   // We allow "now" to move when using relative time, so we hide the message so it doesn't flash.
   const hideTopMessage = sortOrder === LogsSortOrder.Descending && isRelativeTime(range.raw.to);

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -46,7 +46,7 @@ export const InfiniteScroll = ({
   );
   const rowsRef = useRef<LogRowModel[]>(rows);
   const lastScroll = useRef<number>(scrollElement?.scrollTop || 0);
-  const debouncedSetOnEdge = debounce(setOnEdge, 400);
+  const debouncedSetOnEdge = debounce(setOnEdge, 300);
 
   // Reset messages when range/order/rows change
   useEffect(() => {
@@ -110,8 +110,10 @@ export const InfiniteScroll = ({
 
     function scrollOnEdge(scrollElement: HTMLDivElement) {
       const scrollSize = scrollElement ? scrollElement.scrollHeight - scrollElement.clientHeight : 0;
+      const scrollTop = Math.round(scrollElement.scrollTop);
+      const diff = scrollSize - scrollTop;
       debouncedSetOnEdge.cancel();
-      if (scrollElement.scrollTop >= scrollSize || scrollElement.scrollTop <= 0) {
+      if (diff <= 1 || scrollTop <= 0) {
         debouncedSetOnEdge(true);
       } else {
         setOnEdge(false);


### PR DESCRIPTION
As it was proposed in https://github.com/grafana/grafana/pull/84318 (commit https://github.com/grafana/grafana/pull/84318/commits/d876f45c2ea523495f44fe7f4ced5f7ab4e1d7c1) when top scroll used to be enabled, we're adding the edge implementation to the bottom scroll, to give users a chance of reaching the bottom before triggering a new request.

Demo:

https://github.com/user-attachments/assets/e67740ac-22cc-4a9e-b705-b8e7d812a504
