### PR TITLE
LocalSigner: Remove unused dependency

### DIFF
--- a/pkg/services/auth/idimpl/signer.go
+++ b/pkg/services/auth/idimpl/signer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 
 	"github.com/grafana/grafana/pkg/services/auth"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/signingkeys"
 )
 
@@ -18,12 +17,11 @@ const (
 
 var _ auth.IDSigner = (*LocalSigner)(nil)
 
-func ProvideLocalSigner(keyService signingkeys.Service, features featuremgmt.FeatureToggles) (*LocalSigner, error) {
-	return &LocalSigner{features, keyService}, nil
+func ProvideLocalSigner(keyService signingkeys.Service) (*LocalSigner, error) {
+	return &LocalSigner{keyService}, nil
 }
 
 type LocalSigner struct {
-	features   featuremgmt.FeatureToggles
 	keyService signingkeys.Service
 }
 


### PR DESCRIPTION
This pull request removes unused `features` field from the `LocalSigner`.

* Removed the import of `featuremgmt` package from the `import` block.
* Updated the `ProvideLocalSigner` function to no longer require the `features` parameter.
* Removed the `features` field from the `LocalSigner` struct.