### PR TITLE
chore: bump `@bsull/augurs` to v0.6.0

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4305,9 +4305,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
-    "public/app/features/trails/services/sorting.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "yargs": "^17.5.1"
   },
   "dependencies": {
-    "@bsull/augurs": "0.4.2",
+    "@bsull/augurs": "^0.6.0",
     "@emotion/css": "11.13.4",
     "@emotion/react": "11.13.3",
     "@fingerprintjs/fingerprintjs": "^3.4.2",

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -1,4 +1,4 @@
-import init from '@bsull/augurs';
+import init from '@bsull/augurs/outlier';
 import { css } from '@emotion/css';
 import { isNumber, max, min, throttle } from 'lodash';
 import { useEffect } from 'react';

--- a/public/app/features/trails/services/sorting.ts
+++ b/public/app/features/trails/services/sorting.ts
@@ -1,4 +1,4 @@
-import { OutlierDetector, OutlierOutput } from '@bsull/augurs';
+import { OutlierDetector, OutlierOutput } from '@bsull/augurs/outlier';
 import { memoize } from 'lodash';
 
 import { DataFrame, doStandardCalcs, fieldReducers, FieldType, outerJoinDataFrames, ReducerID } from '@grafana/data';
@@ -81,11 +81,10 @@ const initOutlierDetector = (series: DataFrame[]) => {
 
   // Get number fields: these are our series.
   const joinedSeries = joined.fields.filter((f) => f.type === FieldType.number);
-  const nTimestamps = joinedSeries[0].values.length;
-  const points = new Float64Array(joinedSeries.flatMap((series) => series.values as number[]));
+  const points = joinedSeries.map((series) => new Float64Array(series.values));
 
   try {
-    const detector = OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points, nTimestamps);
+    const detector = OutlierDetector.dbscan({ sensitivity: 0.4 }).preprocess(points);
     outliers = detector.detect();
   } catch (e) {
     console.error(e);

--- a/public/test/mocks/augurs.ts
+++ b/public/test/mocks/augurs.ts
@@ -3,7 +3,7 @@ import type {
   OutlierDetector as AugursOutlierDetector,
   OutlierDetectorOptions,
   OutlierOutput,
-} from '@bsull/augurs';
+} from '@bsull/augurs/outlier';
 
 export default function init() {}
 
@@ -18,7 +18,7 @@ export class OutlierDetector implements AugursOutlierDetector {
   detect(): OutlierOutput {
     return dummyOutliers;
   }
-  preprocess(y: Float64Array, nTimestamps: number): AugursLoadedOutlierDetector {
+  preprocess(y: number[][] | Float64Array[]): AugursLoadedOutlierDetector {
     return new LoadedOutlierDetector();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,10 +1703,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bsull/augurs@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@bsull/augurs@npm:0.4.2"
-  checksum: 10/b4806fed1daf76380577b4ca86c2bf94c00ce1033df0b8365229a55ff16bd2f864d3f9ca3f92faf284e62013b68e953be65ee78968931ba342be0e1c054c2e63
+"@bsull/augurs@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@bsull/augurs@npm:0.6.0"
+  checksum: 10/0ba2ea0432f7d4c44ccec4d112e672f8d5d977407be42ff5995e1d6641b4b0238f97b9cdf13bc1fc066559bbd54e6fb00ad1f418014823a6c22af619e7a29c6a
   languageName: node
   linkType: hard
 
@@ -18680,7 +18680,7 @@ __metadata:
     "@betterer/betterer": "npm:5.4.0"
     "@betterer/cli": "npm:5.4.0"
     "@betterer/eslint": "npm:5.4.0"
-    "@bsull/augurs": "npm:0.4.2"
+    "@bsull/augurs": "npm:^0.6.0"
     "@cypress/webpack-preprocessor": "npm:6.0.2"
     "@emotion/css": "npm:11.13.4"
     "@emotion/eslint-plugin": "npm:11.12.0"


### PR DESCRIPTION
This just bumps the version of `@bsull/augurs` to v0.6.0 and fixes imports & usage.

This release includes separate entry points for the various parts of the library, which should reduce the amount of WebAssembly that needs to be loaded by the user.

It also fixes build warnings related to circular dependencies.

Before:
![image](https://github.com/user-attachments/assets/5a67beb4-8265-4473-b5ac-2ab42e3bc49b)

After:
![image](https://github.com/user-attachments/assets/38c1ccbd-a0f8-48bb-a962-62e5db833f26)
