### PR TITLE
Alerting: Force refetch prom rules when refreshing panel

### DIFF
--- a/public/app/features/dashboard-scene/scene/AlertStatesDataLayer.ts
+++ b/public/app/features/dashboard-scene/scene/AlertStatesDataLayer.ts
@@ -73,10 +73,13 @@ export class AlertStatesDataLayer
     }
     const fetchData: () => Promise<RuleNamespace[]> = async () => {
       const promRules = await dispatch(
-        alertRuleApi.endpoints.prometheusRuleNamespaces.initiate({
-          ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
-          dashboardUid: uid,
-        })
+        alertRuleApi.endpoints.prometheusRuleNamespaces.initiate(
+          {
+            ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
+            dashboardUid: uid,
+          },
+          { forceRefetch: true }
+        )
       );
       if (promRules.error) {
         throw new Error(`Unexpected alert rules response.`);

--- a/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/UnifiedAlertStatesWorker.ts
@@ -61,10 +61,13 @@ export class UnifiedAlertStatesWorker implements DashboardQueryRunnerWorker {
     const { dashboard } = options;
     const fetchData: () => Promise<RuleNamespace[]> = async () => {
       const promRules = await dispatch(
-        alertRuleApi.endpoints.prometheusRuleNamespaces.initiate({
-          ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
-          dashboardUid: dashboard.uid,
-        })
+        alertRuleApi.endpoints.prometheusRuleNamespaces.initiate(
+          {
+            ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
+            dashboardUid: dashboard.uid,
+          },
+          { forceRefetch: true }
+        )
       );
       return promRules.data;
     };


### PR DESCRIPTION
**What is this feature?**

This PR forces refetch prom rules when refreshing panel. After introducing RTKQ here we forgot the need of skipping RTKQ cache in this case.

**Why do we need this feature?**

Alert state icon is not refreshed when user clicks refresh button.

**Who is this feature for?**

All dashboard/alerting users.

**Which issue(s) does this PR fix?**:

Related to this [escalation](https://github.com/grafana/support-escalations/issues/13069)

**Special notes for your reviewer:**

After the fix:


https://github.com/user-attachments/assets/cf42ab9f-bc6d-4020-86c4-055e94023c31



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
