### PR TITLE
Chore: Don't require exemplar query for instant query when "Both" query type is selected

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -405,6 +405,7 @@ export class PrometheusDatasource
           ...processedTarget,
           refId: processedTarget.refId + InstantQueryRefIdIndex,
           range: false,
+          exemplar: false,
         }
       );
     } else {


### PR DESCRIPTION
**What is this feature?**

This was originally introduced by @vjsamuel in this PR: https://github.com/grafana/grafana/pull/93378
But the CI/CD was failing so we couldn't merge it. 

When `Both` type is selected and `exemplars` toggle is enabled we won't require exemplars for instant query anymore.  Exemplars are required with `range` queries. 

Here is the @vjsamuel 's description:
> Today with Prometheus Explore UI when a user selects Both and says show exemplars, the two independent range and instant queries both fire exemplar queries. ideally the instant query doesnt need to request exemplars. this PR removes the need for that.

Thank you for the PR and contribution @vjsamuel 

**Why do we need this feature?**

It removes the wasted API call to Prometheus

**Who is this feature for?**

Folks who use Prometheus explore UI
