### PR TITLE
Zanzana: resource sets on folder grants read on all children

### DIFF
--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -10,9 +10,41 @@ import (
 )
 
 const (
-	TypeResource  = "resource"
-	TypeFolder    = "folder"
-	TypeNamespace = "namespace"
+	TypeUser      string = "user"
+	TypeTeam      string = "team"
+	TypeRole      string = "role"
+	TypeFolder    string = "folder"
+	TypeResource  string = "resource"
+	TypeNamespace        = "namespace"
+)
+
+const (
+	RelationTeamMember string = "member"
+	RelationTeamAdmin  string = "admin"
+	RelationParent     string = "parent"
+	RelationAssignee   string = "assignee"
+
+	RelationSetView  string = "view"
+	RelationSetEdit  string = "edit"
+	RelationSetAdmin string = "admin"
+
+	RelationRead             string = "read"
+	RelationWrite            string = "write"
+	RelationCreate           string = "create"
+	RelationDelete           string = "delete"
+	RelationPermissionsRead  string = "permissions_read"
+	RelationPermissionsWrite string = "permissions_write"
+
+	RelationFolderResourceSetView  string = "resource_" + RelationSetView
+	RelationFolderResourceSetEdit  string = "resource_" + RelationSetEdit
+	RelationFolderResourceSetAdmin string = "resource_" + RelationSetAdmin
+
+	RelationFolderResourceRead             string = "resource_" + RelationRead
+	RelationFolderResourceWrite            string = "resource_" + RelationWrite
+	RelationFolderResourceCreate           string = "resource_" + RelationCreate
+	RelationFolderResourceDelete           string = "resource_" + RelationDelete
+	RelationFolderResourcePermissionsRead  string = "resource_" + RelationPermissionsRead
+	RelationFolderResourcePermissionsWrite string = "resource_" + RelationPermissionsWrite
 )
 
 func FolderResourceRelation(relation string) string {
@@ -55,12 +87,17 @@ func NewResourceTuple(subject, relation, group, resource, name string) *openfgav
 	}
 }
 
+func isFolderResourceRelationSet(relation string) bool {
+	return relation == RelationFolderResourceSetView ||
+		relation == RelationFolderResourceSetEdit ||
+		relation == RelationFolderResourceSetAdmin
+}
+
 func NewFolderResourceTuple(subject, relation, group, resource, folder string) *openfgav1.TupleKey {
-	return &openfgav1.TupleKey{
-		User:     subject,
-		Relation: FolderResourceRelation(relation),
-		Object:   NewFolderIdent(folder),
-		Condition: &openfgav1.RelationshipCondition{
+	relation = FolderResourceRelation(relation)
+	var condition *openfgav1.RelationshipCondition
+	if !isFolderResourceRelationSet(relation) {
+		condition = &openfgav1.RelationshipCondition{
 			Name: "folder_group_filter",
 			Context: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -69,7 +106,14 @@ func NewFolderResourceTuple(subject, relation, group, resource, folder string) *
 					}),
 				},
 			},
-		},
+		}
+	}
+
+	return &openfgav1.TupleKey{
+		User:      subject,
+		Relation:  relation,
+		Object:    NewFolderIdent(folder),
+		Condition: condition,
 	}
 }
 

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -15,7 +15,7 @@ const (
 	TypeRole      string = "role"
 	TypeFolder    string = "folder"
 	TypeResource  string = "resource"
-	TypeNamespace        = "namespace"
+	TypeNamespace string = "namespace"
 )
 
 const (

--- a/pkg/services/authz/zanzana/schema/schema_folder.fga
+++ b/pkg/services/authz/zanzana/schema/schema_folder.fga
@@ -15,7 +15,3 @@ type folder
     define delete: [user, team#member, role#assignee] or edit or delete from parent
     define permissions_read: [user, team#member, role#assignee] or admin or permissions_read from parent
     define permissions_write: [user, team#member, role#assignee] or admin or permissions_write from parent
-
-
-
-

--- a/pkg/services/authz/zanzana/schema/schema_resource.fga
+++ b/pkg/services/authz/zanzana/schema/schema_resource.fga
@@ -2,9 +2,9 @@ module resource
 
 extend type folder
   relations
-    define resource_view: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_view from parent
-    define resource_edit: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin or resource_edit from parent
-    define resource_admin: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin from parent
+    define resource_view: [user, team#member, role#assignee] or resource_edit or resource_view from parent
+    define resource_edit: [user, team#member, role#assignee] or resource_admin or resource_edit from parent
+    define resource_admin: [user, team#member, role#assignee] or resource_admin from parent
 
     define resource_read: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_view or resource_read from parent
     define resource_create: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_create from parent
@@ -12,7 +12,6 @@ extend type folder
     define resource_delete: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_edit or resource_delete from parent
     define resource_permissions_read: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin or resource_permissions_read from parent
     define resource_permissions_write: [user with folder_group_filter, team#member with folder_group_filter, role#assignee with folder_group_filter] or resource_admin or resource_permissions_write from parent
-
 
 type resource
   relations
@@ -27,7 +26,6 @@ type resource
     define permissions_read: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
     define permissions_write: [user with group_filter, team#member with group_filter, role#assignee with group_filter] or admin
 
-
 condition group_filter(requested_group: string, group_resource: string) {
   requested_group == group_resource
 }
@@ -35,4 +33,3 @@ condition group_filter(requested_group: string, group_resource: string) {
 condition folder_group_filter(requested_group: string, group_resources: list<string>) {
   requested_group in group_resources
 }
-

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -81,7 +81,7 @@ func setup(t *testing.T, testDB db.DB, cfg *setting.Cfg) *Server {
 				common.NewNamespaceResourceTuple("user:7", "read", folderGroup, folderResource),
 				common.NewFolderParentTuple("5", "4"),
 				common.NewFolderParentTuple("6", "5"),
-				common.NewFolderResourceTuple("user:8", "read", dashboardGroup, dashboardResource, "5"),
+				common.NewFolderResourceTuple("user:8", "view", dashboardGroup, dashboardResource, "5"),
 			},
 		},
 	})

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
-// FIXME: REEXPORT
 const (
 	TypeUser      = common.TypeUser
 	TypeTeam      = common.TypeTeam

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -9,41 +9,63 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
+// FIXME: REEXPORT
 const (
-	TypeUser     string = "user"
-	TypeTeam     string = "team"
-	TypeRole     string = "role"
-	TypeFolder   string = "folder"
-	TypeResource string = "resource"
+	TypeUser      = common.TypeUser
+	TypeTeam      = common.TypeTeam
+	TypeRole      = common.TypeRole
+	TypeFolder    = common.TypeFolder
+	TypeResource  = common.TypeResource
+	TypeNamespace = common.TypeNamespace
 )
 
 const (
-	RelationTeamMember string = "member"
-	RelationTeamAdmin  string = "admin"
-	RelationParent     string = "parent"
-	RelationAssignee   string = "assignee"
-	RelationOrg        string = "org"
+	RelationTeamMember = common.RelationTeamMember
+	RelationTeamAdmin  = common.RelationTeamAdmin
+	RelationParent     = common.RelationParent
+	RelationAssignee   = common.RelationAssignee
 
-	// FIXME action sets
-	RelationAdmin            string = "admin"
-	RelationRead             string = "read"
-	RelationWrite            string = "write"
-	RelationCreate           string = "create"
-	RelationDelete           string = "delete"
-	RelationPermissionsRead  string = "permissions_read"
-	RelationPermissionsWrite string = "permissions_write"
+	RelationSetView  = common.RelationSetView
+	RelationSetEdit  = common.RelationSetEdit
+	RelationSetAdmin = common.RelationSetAdmin
 
-	FolderResourceRelationAdmin            string = "resource_admin"
-	FolderResourceRelationRead             string = "resource_read"
-	FolderResourceRelationWrite            string = "resource_write"
-	FolderResourceRelationCreate           string = "resource_create"
-	FolderResourceRelationDelete           string = "resource_delete"
-	FolderResourceRelationPermissionsRead  string = "resource_permissions_read"
-	FolderResourceRelationPermissionsWrite string = "resource_permissions_write"
+	RelationRead             = common.RelationRead
+	RelationWrite            = common.RelationWrite
+	RelationCreate           = common.RelationCreate
+	RelationDelete           = common.RelationDelete
+	RelationPermissionsRead  = common.RelationPermissionsRead
+	RelationPermissionsWrite = common.RelationPermissionsWrite
+
+	RelationFolderResourceSetView  = common.RelationFolderResourceSetView
+	RelationFolderResourceSetEdit  = common.RelationFolderResourceSetEdit
+	RelationFolderResourceSetAdmin = common.RelationFolderResourceSetAdmin
+
+	RelationFolderResourceRead             = common.RelationFolderResourceRead
+	RelationFolderResourceWrite            = common.RelationFolderResourceWrite
+	RelationFolderResourceCreate           = common.RelationFolderResourceCreate
+	RelationFolderResourceDelete           = common.RelationFolderResourceDelete
+	RelationFolderResourcePermissionsRead  = common.RelationFolderResourcePermissionsRead
+	RelationFolderResourcePermissionsWrite = common.RelationFolderResourcePermissionsWrite
 )
 
-var ResourceRelations = []string{RelationRead, RelationWrite, RelationCreate, RelationDelete, RelationPermissionsRead, RelationPermissionsWrite}
-var FolderRelations = append(ResourceRelations, FolderResourceRelationRead, FolderResourceRelationWrite, FolderResourceRelationCreate, FolderResourceRelationDelete, FolderResourceRelationPermissionsRead, FolderResourceRelationPermissionsWrite)
+var ResourceRelations = []string{
+	RelationRead,
+	RelationWrite,
+	RelationCreate,
+	RelationDelete,
+	RelationPermissionsRead,
+	RelationPermissionsWrite,
+}
+
+var FolderRelations = append(
+	ResourceRelations,
+	RelationFolderResourceRead,
+	RelationFolderResourceWrite,
+	RelationFolderResourceCreate,
+	RelationFolderResourceDelete,
+	RelationFolderResourcePermissionsRead,
+	RelationFolderResourcePermissionsWrite,
+)
 
 const (
 	KindDashboards string = "dashboards"


### PR DESCRIPTION
**What is this feature?**
Restructure schema so that `resource_{view, edit, admin}` grants access for all children.

This is how we can solve action sets. For these we don't have to store the `GroupResource` in context metadata. 

Most of the changes in this pr is moving constants to common package and restructure them.

**Why do we need this feature?**

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/806

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
