### PR TITLE
Annotations: Hide edit/delete if annotations are from loki

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -22,8 +22,10 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
   const { canEditAnnotations = retFalse, canDeleteAnnotations = retFalse, onAnnotationDelete } = usePanelContext();
 
   const dashboardUID = annoVals.dashboardUID?.[annoIdx];
-  const canEdit = canEditAnnotations(dashboardUID);
-  const canDelete = canDeleteAnnotations(dashboardUID) && onAnnotationDelete != null;
+
+  // grafana can be configured to load alert rules from loki. Those annotations cannot be edited or deleted. The id being 0 is the best indicator the annotation came from loki
+  const canEdit = annoId !== 0 && canEditAnnotations(dashboardUID);
+  const canDelete = annoId !== 0 && canDeleteAnnotations(dashboardUID) && onAnnotationDelete != null;
 
   const timeFormatter = (value: number) =>
     dateTimeFormat(value, {


### PR DESCRIPTION
**What is this feature?**

Grafana can be configured to load alert annotations from Loki. This is the default configuration for alert annotations in Grafana cloud. These annotations cannot be edited or deleted, but the edit and delete icons still show on their tooltips. The api call fails, which is a bad user experience.

**Why do we need this feature?**
 
We should be straightforward about what actions a user can perform.

**Which issue(s) does this PR fix?**:

Fixes #94651
Related to https://github.com/grafana/support-escalations/issues/12702

**Special notes for your reviewer:**

The id not equaling zero seems a little magic number-y for me, but that is what was advised here https://github.com/grafana/grafana/issues/94651#issuecomment-2452402880 

We will have to talk with the alerting team if we want better logic for this.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
