### PR TITLE
GAS: Set group attribute sync to private preview

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1486,7 +1486,7 @@ var (
 		{
 			Name:         "groupAttributeSync",
 			Description:  "Enable the groupsync extension for managing Group Attribute Sync feature",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStagePrivatePreview,
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -196,7 +196,7 @@ exploreLogsLimitedTimeRange,experimental,@grafana/observability-logs,false,false
 homeSetupGuide,experimental,@grafana/growth-and-onboarding,false,false,true
 appPlatformGrpcClientAuth,experimental,@grafana/identity-access-team,false,false,false
 appSidecar,experimental,@grafana/explore-squad,false,false,false
-groupAttributeSync,experimental,@grafana/identity-access-team,false,false,false
+groupAttributeSync,privatePreview,@grafana/identity-access-team,false,false,false
 alertingQueryAndExpressionsStepMode,experimental,@grafana/alerting-squad,false,false,true
 improvedExternalSessionHandling,experimental,@grafana/identity-access-team,false,false,false
 useSessionStorageForRedirection,preview,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1510,12 +1510,15 @@
     {
       "metadata": {
         "name": "groupAttributeSync",
-        "resourceVersion": "1725893018130",
-        "creationTimestamp": "2024-09-09T15:29:43Z"
+        "resourceVersion": "1731087176211",
+        "creationTimestamp": "2024-09-09T15:29:43Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-11-08 17:32:56.21158 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the groupsync extension for managing Group Attribute Sync feature",
-        "stage": "experimental",
+        "stage": "privatePreview",
         "codeowner": "@grafana/identity-access-team",
         "hideFromDocs": true
       }


### PR DESCRIPTION
**What is this feature?**

Update GAS feature toggle status to private preview

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/identity-access-team/issues/966
