### PR TITLE
Transformations: Check for exact refId match

### DIFF
--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -14,7 +14,7 @@ const refIdMatcher: FrameMatcherInfo<string> = {
   get: (pattern: string) => {
     const regex = stringToJsRegex(pattern);
     return (frame: DataFrame) => {
-      return regex.test(frame.refId || '');
+      return regex.test(frame.refId || '') || pattern === frame.refId;
     };
   },
 


### PR DESCRIPTION
For DataFrame refIdMatcher in transformations, some strings will fail the regex.test due to certain characters (like parentheses for example). This PR simply checks for an exact match if the regex.test fails.

Before (transformation is not applied to filtered dataFrame):
![image](https://github.com/user-attachments/assets/a21821ea-809f-44b8-a69b-a0d0989630cf)

After (transformation is applied):
![image](https://github.com/user-attachments/assets/d159f582-03a4-4b4a-9a24-3ca5cb1026c7)

[refIdMatcherTest.json](https://github.com/user-attachments/files/17682428/refIdMatcherTest.json)


Closes #https://github.com/grafana/hyperion-planning/issues/91

