### PR TITLE
Alerting: Change the description for the 'Message' field in webhooks

### DIFF
--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -959,7 +959,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				},
 				{ // New in 9.3.
 					Label:        "Message",
-					Description:  "Custom message. You can use template variables.",
+					Description:  "Templated message to be used in the payload's \"message\" field.",
 					Element:      ElementTypeTextArea,
 					PropertyName: "message",
 					Placeholder:  alertingTemplates.DefaultMessageEmbed,

--- a/public/app/features/alerting/unified/mockGrafanaNotifiers.ts
+++ b/public/app/features/alerting/unified/mockGrafanaNotifiers.ts
@@ -1750,7 +1750,7 @@ export const grafanaAlertNotifiers: Record<GrafanaNotifierType, NotifierDTO> = {
         element: 'textarea',
         inputType: '',
         label: 'Message',
-        description: 'Custom message. You can use template variables.',
+        description: 'Templated message to be used in the payload\'s "message" field.',
         placeholder: '{{ template "default.message" . }}',
         propertyName: 'message',
         selectOptions: null,


### PR DESCRIPTION
Our current description is a bit misleading, it gives the impression that users can set a custom JSON payload using this field.
This PR changes the description to make it clear that the string will be executed as a template and used in the `message` field of the resulting payload.