### PR TITLE
Chore: Rename the sorting option in explore metrics

### DIFF
--- a/public/app/features/trails/Breakdown/SortByScene.tsx
+++ b/public/app/features/trails/Breakdown/SortByScene.tsx
@@ -31,7 +31,7 @@ export class SortByScene extends SceneObjectBase<SortBySceneState> {
       options: [
         {
           value: 'outliers',
-          label: 'Outlying Values',
+          label: 'Outlying series',
           description: 'Prioritizes values that show distinct behavior from others within the same label',
         },
         {


### PR DESCRIPTION
**What is this feature?**

Just a rename

The slack discussion: https://raintank-corp.slack.com/archives/C0630AYC4SY/p1731012871057899?thread_ts=1730815868.075449&cid=C0630AYC4SY
