### PR TITLE
SQL Datasources: Make QueryEditor lazy loaded

### DIFF
--- a/packages/grafana-sql/src/components/QueryEditor.tsx
+++ b/packages/grafana-sql/src/components/QueryEditor.tsx
@@ -14,11 +14,11 @@ import { QueryHeader, QueryHeaderProps } from './QueryHeader';
 import { RawEditor } from './query-editor-raw/RawEditor';
 import { VisualEditor } from './visual-query-builder/VisualEditor';
 
-interface SqlQueryEditorProps extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
+export interface SqlQueryEditorProps extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
   queryHeaderProps?: Pick<QueryHeaderProps, 'dialect'>;
 }
 
-export function SqlQueryEditor({
+export default function SqlQueryEditor({
   datasource,
   query,
   onChange,

--- a/packages/grafana-sql/src/components/QueryEditorLazy.tsx
+++ b/packages/grafana-sql/src/components/QueryEditorLazy.tsx
@@ -1,0 +1,27 @@
+import { css } from '@emotion/css';
+import { lazy, Suspense } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+
+import type { SqlQueryEditorProps } from './QueryEditor';
+
+export function SqlQueryEditorLazy(props: SqlQueryEditorProps) {
+  const styles = useStyles2(getStyles);
+  const LazyComponent = lazy(() => import(/* webpackChunkName: "sql-query-editor" */ './QueryEditor'));
+
+  return (
+    <Suspense fallback={<LoadingPlaceholder text={'Loading editor'} className={styles.container} />}>
+      <LazyComponent {...props} />
+    </Suspense>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      marginBottom: 'unset',
+      marginLeft: theme.spacing(1),
+    }),
+  };
+};

--- a/packages/grafana-sql/src/components/QueryEditorLazy.tsx
+++ b/packages/grafana-sql/src/components/QueryEditorLazy.tsx
@@ -5,14 +5,14 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 
 import type { SqlQueryEditorProps } from './QueryEditor';
+const QueryEditor = lazy(() => import(/* webpackChunkName: "sql-query-editor" */ './QueryEditor'));
 
 export function SqlQueryEditorLazy(props: SqlQueryEditorProps) {
   const styles = useStyles2(getStyles);
-  const LazyComponent = lazy(() => import(/* webpackChunkName: "sql-query-editor" */ './QueryEditor'));
 
   return (
     <Suspense fallback={<LoadingPlaceholder text={'Loading editor'} className={styles.container} />}>
-      <LazyComponent {...props} />
+      <QueryEditor {...props} />
     </Suspense>
   );
 }

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -30,7 +30,7 @@ import {
 } from '@grafana/runtime';
 
 import { ResponseParser } from '../ResponseParser';
-import { SqlQueryEditor } from '../components/QueryEditor';
+import { SqlQueryEditorLazy } from '../components/QueryEditorLazy';
 import { MACRO_NAMES } from '../constants';
 import { DB, SQLQuery, SQLOptions, SqlQueryModel, QueryFormat } from '../types';
 import migrateAnnotation from '../utils/migration';
@@ -63,7 +63,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     this.preconfiguredDatabase = settingsData.database ?? '';
     this.annotations = {
       prepareAnnotation: migrateAnnotation,
-      QueryEditor: SqlQueryEditor,
+      QueryEditor: SqlQueryEditorLazy,
     };
   }
 

--- a/packages/grafana-sql/src/index.ts
+++ b/packages/grafana-sql/src/index.ts
@@ -17,7 +17,7 @@ export { ConnectionLimits } from './components/configuration/ConnectionLimits';
 export { Divider } from './components/configuration/Divider';
 export { TLSSecretsConfig } from './components/configuration/TLSSecretsConfig';
 export { useMigrateDatabaseFields } from './components/configuration/useMigrateDatabaseFields';
-export { SqlQueryEditor } from './components/QueryEditor';
+export { SqlQueryEditorLazy } from './components/QueryEditorLazy';
 export type { QueryHeaderProps } from './components/QueryHeader';
 export { createSelectClause, haveColumns } from './utils/sql.utils';
 export { applyQueryDefaults } from './defaults';

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/PostgresQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/PostgresQueryEditor.tsx
@@ -1,10 +1,10 @@
 import { QueryEditorProps } from '@grafana/data';
-import { SqlQueryEditor, SQLOptions, SQLQuery, QueryHeaderProps } from '@grafana/sql';
+import { SqlQueryEditorLazy, SQLOptions, SQLQuery, QueryHeaderProps } from '@grafana/sql';
 
 import { PostgresDatasource } from './datasource';
 
 const queryHeaderProps: Pick<QueryHeaderProps, 'dialect'> = { dialect: 'postgres' };
 
 export function PostgresQueryEditor(props: QueryEditorProps<PostgresDatasource, SQLQuery, SQLOptions>) {
-  return <SqlQueryEditor {...props} queryHeaderProps={queryHeaderProps} />;
+  return <SqlQueryEditorLazy {...props} queryHeaderProps={queryHeaderProps} />;
 }

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/tsconfig.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "jsx": "react-jsx",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
   "extends": "@grafana/plugin-configs/tsconfig.json",
   "include": ["."]
 }

--- a/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/fsql/FSQLEditor.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { PureComponent } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data/src';
-import { SQLQuery, SqlQueryEditor, applyQueryDefaults } from '@grafana/sql';
+import { SQLQuery, SqlQueryEditorLazy, applyQueryDefaults } from '@grafana/sql';
 import { InlineFormLabel, LinkButton, Themeable2, withTheme2 } from '@grafana/ui/src';
 
 import InfluxDatasource from '../../../../datasource';
@@ -89,7 +89,7 @@ class UnthemedSQLQueryEditor extends PureComponent<Props> {
 
     return (
       <>
-        <SqlQueryEditor
+        <SqlQueryEditorLazy
           datasource={this.datasource}
           query={this.transformQuery(query)}
           onRunQuery={onRunSQLQuery}

--- a/public/app/plugins/datasource/mssql/module.ts
+++ b/public/app/plugins/datasource/mssql/module.ts
@@ -1,5 +1,5 @@
 import { DataSourcePlugin } from '@grafana/data';
-import { SQLQuery, SqlQueryEditor } from '@grafana/sql';
+import { SQLQuery, SqlQueryEditorLazy } from '@grafana/sql';
 
 import { CheatSheet } from './CheatSheet';
 import { ConfigurationEditor } from './configuration/ConfigurationEditor';
@@ -7,6 +7,6 @@ import { MssqlDatasource } from './datasource';
 import { MssqlOptions } from './types';
 
 export const plugin = new DataSourcePlugin<MssqlDatasource, SQLQuery, MssqlOptions>(MssqlDatasource)
-  .setQueryEditor(SqlQueryEditor)
+  .setQueryEditor(SqlQueryEditorLazy)
   .setQueryEditorHelp(CheatSheet)
   .setConfigEditor(ConfigurationEditor);

--- a/public/app/plugins/datasource/mysql/module.ts
+++ b/public/app/plugins/datasource/mysql/module.ts
@@ -1,5 +1,5 @@
 import { DataSourcePlugin } from '@grafana/data';
-import { SQLQuery, SqlQueryEditor } from '@grafana/sql';
+import { SQLQuery, SqlQueryEditorLazy } from '@grafana/sql';
 
 import { CheatSheet } from './CheatSheet';
 import { MySqlDatasource } from './MySqlDatasource';
@@ -7,6 +7,6 @@ import { ConfigurationEditor } from './configuration/ConfigurationEditor';
 import { MySQLOptions } from './types';
 
 export const plugin = new DataSourcePlugin<MySqlDatasource, SQLQuery, MySQLOptions>(MySqlDatasource)
-  .setQueryEditor(SqlQueryEditor)
+  .setQueryEditor(SqlQueryEditorLazy)
   .setQueryEditorHelp(CheatSheet)
   .setConfigEditor(ConfigurationEditor);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR makes the QueryEditor that lives in `@grafana/sql` load only when it needs to be rendered.

**Why do we need this feature?**

To reduce the amount of JS we serve when loading a dashboard.

**Who is this feature for?**

Grafana Users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
