### PR TITLE
Zanzana: use namespace when performing reconciliation

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -99,7 +99,7 @@ func ProvideOSSService(
 		log:            log.New("accesscontrol.service"),
 		roles:          accesscontrol.BuildBasicRoleDefinitions(),
 		store:          store,
-		reconciler:     dualwrite.NewZanzanaReconciler(zclient, db, lock),
+		reconciler:     dualwrite.NewZanzanaReconciler(cfg, zclient, db, lock),
 		permRegistry:   permRegistry,
 	}
 

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -123,10 +123,6 @@ type Service struct {
 // Run implements accesscontrol.Service.
 func (s *Service) Run(ctx context.Context) error {
 	if s.features.IsEnabledGlobally(featuremgmt.FlagZanzana) {
-		if err := s.reconciler.Sync(context.Background()); err != nil {
-			s.log.Error("Failed to synchronise permissions to zanzana ", "err", err)
-		}
-
 		return s.reconciler.Reconcile(ctx)
 	}
 	return nil

--- a/pkg/services/accesscontrol/dualwrite/reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/reconciler.go
@@ -68,23 +68,10 @@ func NewZanzanaReconciler(cfg *setting.Cfg, client zanzana.Client, store db.DB, 
 	}
 }
 
-// Sync runs all collectors and tries to write all collected tuples.
-// It will skip over any "sync group" that has already been written.
-func (r *ZanzanaReconciler) Sync(ctx context.Context) error {
-	r.log.Info("Starting zanzana permissions sync")
-	ctx, span := tracer.Start(ctx, "accesscontrol.migrator.Sync")
-	defer span.End()
-
-	r.reconcile(ctx)
-
-	return nil
-}
-
 // Reconcile schedules as job that will run and reconcile resources between
 // legacy access control and zanzana.
 func (r *ZanzanaReconciler) Reconcile(ctx context.Context) error {
-	// FIXME: try to reconcile at start whenever we have moved all syncs to reconcilers
-	// r.reconcile(ctx)
+	r.reconcile(ctx)
 
 	// FIXME:
 	// 1. We should be a bit graceful about reconciliations so we are not hammering dbs

--- a/pkg/services/accesscontrol/dualwrite/reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/reconciler.go
@@ -2,42 +2,42 @@ package dualwrite
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/grafana/authlib/claims"
-	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/accesscontrol/migrator")
-
-// A TupleCollector is responsible to build and store [openfgav1.TupleKey] into provided tuple map.
-// They key used should be a unique group key for the collector so we can skip over an already synced group.
-type TupleCollector func(ctx context.Context, namespace string, tuples map[string][]*openfgav1.TupleKey) error
 
 // ZanzanaReconciler is a component to reconcile RBAC permissions to zanzana.
 // We should rewrite the migration after we have "migrated" all possible actions
 // into our schema.
 type ZanzanaReconciler struct {
-	lock   *serverlock.ServerLockService
-	log    log.Logger
+	cfg *setting.Cfg
+	log log.Logger
+
 	store  db.DB
 	client zanzana.Client
+	lock   *serverlock.ServerLockService
 	// reconcilers are migrations that tries to reconcile the state of grafana db to zanzana store.
 	// These are run periodically to try to maintain a consistent state.
 	reconcilers []resourceReconciler
 }
 
-func NewZanzanaReconciler(client zanzana.Client, store db.DB, lock *serverlock.ServerLockService) *ZanzanaReconciler {
+func NewZanzanaReconciler(cfg *setting.Cfg, client zanzana.Client, store db.DB, lock *serverlock.ServerLockService) *ZanzanaReconciler {
 	return &ZanzanaReconciler{
+		cfg:    cfg,
+		log:    log.New("zanzana.reconciler"),
 		client: client,
 		lock:   lock,
-		log:    log.New("zanzana.reconciler"),
 		store:  store,
 		reconcilers: []resourceReconciler{
 			newResourceReconciler(
@@ -111,24 +111,40 @@ func (r *ZanzanaReconciler) reconcile(ctx context.Context) {
 		r.log.Debug("Finished reconciliation", "elapsed", time.Since(now))
 	}
 
-	orgIds, err := r.getOrgs(ctx)
-	if err != nil {
-		return
-	}
-
-	for _, orgId := range orgIds {
-		ns := claims.OrgNamespaceFormatter(orgId)
-
-		if r.lock == nil {
-			run(ctx, ns)
+	var namespaces []string
+	if r.cfg.StackID != "" {
+		id, err := strconv.ParseInt(r.cfg.StackID, 10, 64)
+		if err != nil {
+			r.log.Error("cannot perform reconciliation, malformed stack id", "id", r.cfg.StackID, "err", err)
 			return
 		}
 
-		// We ignore the error for now
-		_ = r.lock.LockExecuteAndRelease(ctx, "zanzana-reconciliation", 10*time.Hour, func(ctx context.Context) {
-			run(ctx, ns)
-		})
+		namespaces = []string{claims.CloudNamespaceFormatter(id)}
+	} else {
+		ids, err := r.getOrgs(ctx)
+		if err != nil {
+			r.log.Error("cannot perform reconciliation, failed to fetch orgs", "err", err)
+			return
+		}
+
+		for _, id := range ids {
+			namespaces = append(namespaces, claims.OrgNamespaceFormatter(id))
+		}
 	}
+
+	if r.lock == nil {
+		for _, ns := range namespaces {
+			run(ctx, ns)
+		}
+		return
+	}
+
+	// We ignore the error for now
+	_ = r.lock.LockExecuteAndRelease(ctx, "zanzana-reconciliation", 10*time.Hour, func(ctx context.Context) {
+		for _, ns := range namespaces {
+			run(ctx, ns)
+		}
+	})
 }
 
 func (r *ZanzanaReconciler) getOrgs(ctx context.Context) ([]int64, error) {

--- a/pkg/services/accesscontrol/dualwrite/resource_reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/resource_reconciler.go
@@ -8,12 +8,11 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/zanzana/proto/v1"
 )
 
 // legacyTupleCollector collects tuples groupd by object and tupleKey
-type legacyTupleCollector func(ctx context.Context, orgId int64) (map[string]map[string]*openfgav1.TupleKey, error)
+type legacyTupleCollector func(ctx context.Context, orgID int64) (map[string]map[string]*openfgav1.TupleKey, error)
 
 // zanzanaTupleCollector collects tuples from zanzana for given object
 type zanzanaTupleCollector func(ctx context.Context, client zanzana.Client, object string, namespace string) (map[string]*openfgav1.TupleKey, error)
@@ -95,7 +94,7 @@ func (r resourceReconciler) reconcile(ctx context.Context, namespace string) err
 		err := batch(deletes, 100, func(items []*openfgav1.TupleKeyWithoutCondition) error {
 			return r.client.Write(ctx, &authzextv1.WriteRequest{
 				Namespace: namespace,
-				Deletes:   &authzextv1.WriteRequestDeletes{TupleKeys: common.ToAuthzExtTupleKeysWithoutCondition(items)},
+				Deletes:   &authzextv1.WriteRequestDeletes{TupleKeys: zanzana.ToAuthzExtTupleKeysWithoutCondition(items)},
 			})
 		})
 
@@ -108,7 +107,7 @@ func (r resourceReconciler) reconcile(ctx context.Context, namespace string) err
 		err := batch(writes, 100, func(items []*openfgav1.TupleKey) error {
 			return r.client.Write(ctx, &authzextv1.WriteRequest{
 				Namespace: namespace,
-				Writes:    &authzextv1.WriteRequestWrites{TupleKeys: common.ToAuthzExtTupleKeys(items)},
+				Writes:    &authzextv1.WriteRequestWrites{TupleKeys: zanzana.ToAuthzExtTupleKeys(items)},
 			})
 		})
 

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -84,6 +84,18 @@ const (
 	GlobalOrgID = 0
 )
 
+var (
+	ToAuthzExtTupleKey                  = common.ToAuthzExtTupleKey
+	ToAuthzExtTupleKeys                 = common.ToAuthzExtTupleKeys
+	ToAuthzExtTupleKeyWithoutCondition  = common.ToAuthzExtTupleKeyWithoutCondition
+	ToAuthzExtTupleKeysWithoutCondition = common.ToAuthzExtTupleKeysWithoutCondition
+
+	ToOpenFGATuple                    = common.ToOpenFGATuple
+	ToOpenFGATuples                   = common.ToOpenFGATuples
+	ToOpenFGATupleKey                 = common.ToOpenFGATupleKey
+	ToOpenFGATupleKeyWithoutCondition = common.ToOpenFGATupleKeyWithoutCondition
+)
+
 // NewTupleEntry constructs new openfga entry type:id[#relation].
 // Relation allows to specify group of users (subjects) related to type:id
 // (for example, team:devs#member refers to users which are members of team devs)
@@ -130,15 +142,4 @@ func MergeFolderResourceTuples(a, b *openfgav1.TupleKey) {
 	va := a.Condition.Context.Fields["group_resources"]
 	vb := b.Condition.Context.Fields["group_resources"]
 	va.GetListValue().Values = append(va.GetListValue().Values, vb.GetListValue().Values...)
-}
-
-func TranslateFixedRole(role string) string {
-	role = strings.ReplaceAll(role, ":", "_")
-	role = strings.ReplaceAll(role, ".", "_")
-	return role
-}
-
-// Translate "read" for the dashboard into "dashboard_read" for folder
-func TranslateToFolderRelation(relation, objectType string) string {
-	return fmt.Sprintf("%s_%s", objectType, relation)
 }


### PR DESCRIPTION
**What is this feature?**
When we reconcile data from grafana db to openfga we want to seperate the writes to different stores. 

We use different stores for orgs / stacks, so every reconciliation has to work with that. If instance is configured as a stack we only use that namespace otherwise we seperate all namespaces by org.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/identity-access-team/issues/977

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
