### PR TITLE
Legacy annotations: add dataplane support

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -378,7 +378,7 @@ describe('LokiDatasource', () => {
     });
   });
 
-  describe.only('when calling annotationQuery', () => {
+  describe('when calling annotationQuery', () => {
     const getTestContext = (frame: DataFrame, options = {}) => {
       const query = makeAnnotationQueryRequest(options);
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -378,7 +378,7 @@ describe('LokiDatasource', () => {
     });
   });
 
-  describe('when calling annotationQuery', () => {
+  describe.only('when calling annotationQuery', () => {
     const getTestContext = (frame: DataFrame, options = {}) => {
       const query = makeAnnotationQueryRequest(options);
 
@@ -442,9 +442,74 @@ describe('LokiDatasource', () => {
       expect(res.length).toBe(2);
       expect(res[0].text).toBe('hello');
       expect(res[0].tags).toEqual(['value']);
+      expect(res[0].time).toEqual(1);
 
       expect(res[1].text).toBe('hello 2');
       expect(res[1].tags).toEqual(['value2']);
+      expect(res[1].time).toEqual(2);
+    });
+
+    it('should transform the loki dataplane data to annotation response', async () => {
+      const originalDataplaneState = config.featureToggles.lokiLogsDataplane;
+      config.featureToggles.lokiLogsDataplane = true;
+      const testFrame: DataFrame = {
+        refId: 'A',
+        fields: [
+          {
+            name: 'timestamp',
+            type: FieldType.time,
+            config: {},
+            values: [1, 2],
+          },
+          {
+            name: 'body',
+            type: FieldType.string,
+            config: {},
+            values: ['hello', 'hello 2'],
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            config: {},
+            values: [
+              {
+                label: 'value',
+                label2: 'value ',
+              },
+              {
+                label: '',
+                label2: 'value2',
+                label3: ' ',
+              },
+            ],
+          },
+          {
+            name: 'tsNs',
+            type: FieldType.string,
+            config: {},
+            values: ['1000000', '2000000'],
+          },
+          {
+            name: 'id',
+            type: FieldType.string,
+            config: {},
+            values: ['id1', 'id2'],
+          },
+        ],
+        length: 2,
+      };
+      const res = await getTestContext(testFrame, { stepInterval: '15s' });
+
+      expect(res.length).toBe(2);
+      expect(res[0].text).toBe('hello');
+      expect(res[0].tags).toEqual(['value']);
+      expect(res[0].time).toEqual(1);
+
+      expect(res[1].text).toBe('hello 2');
+      expect(res[1].tags).toEqual(['value2']);
+      expect(res[1].time).toEqual(2);
+
+      config.featureToggles.lokiLogsDataplane = originalDataplaneState;
     });
 
     describe('Formatting', () => {


### PR DESCRIPTION
The annotationQuery implementation was reliant on field names, so when `lokiLogsDataplane` was enabled it didn't work as expected.

![imagen](https://github.com/user-attachments/assets/99e63132-8bca-4834-804f-cf46bcab9793)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/94169

**Special notes for your reviewer:**

- In a dashboard
- Go to settings, annotations
- Create a Loki query annotation
- Back to the dashboard, the annotations should work as expected with and without the feature flag enabled.