### PR TITLE
SQL Expressions: Simplify where code is being stubbed out

### DIFF
--- a/pkg/expr/sql/db.go
+++ b/pkg/expr/sql/db.go
@@ -9,10 +9,6 @@ import (
 type DB struct {
 }
 
-func (db *DB) TablesList(rawSQL string) ([]string, error) {
-	return nil, errors.New("not implemented")
-}
-
 func (db *DB) RunCommands(commands []string) (string, error) {
 	return "", errors.New("not implemented")
 }

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -20,10 +20,10 @@ var logger = log.New("sql_expr")
 
 // TablesList returns a list of tables for the sql statement
 func TablesList(rawSQL string) ([]string, error) {
-	duckDB := NewInMemoryDB()
+	db := NewInMemoryDB()
 	rawSQL = strings.Replace(rawSQL, "'", "''", -1)
 	cmd := fmt.Sprintf("SELECT json_serialize_sql('%s')", rawSQL)
-	ret, err := duckDB.RunCommands([]string{cmd})
+	ret, err := db.RunCommands([]string{cmd})
 	if err != nil {
 		logger.Error("error serializing sql", "error", err.Error(), "sql", rawSQL, "cmd", cmd)
 		return nil, fmt.Errorf("error serializing sql: %s", err.Error())


### PR DESCRIPTION
Very small and simple PR to make a couple of tiny improvements, to clean up a bit:

- **Rename from DuckDB**
- **Remove unused function**
