### PR TITLE
Chore: Move betterer eslint rules to separate file and allow opting in

### DIFF
--- a/.betterer.eslint.config.js
+++ b/.betterer.eslint.config.js
@@ -1,0 +1,45 @@
+// @ts-check
+/**
+ * @type {Array<import('eslint').Linter.Config>}
+ */
+module.exports = [
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@grafana/no-aria-label-selectors': 'error',
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@grafana/ui*', '*/Layout/*'],
+              importNames: ['Layout', 'HorizontalGroup', 'VerticalGroup'],
+              message: 'Use Stack component instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    ignores: ['**/*.{test,spec}.{ts,tsx}', '**/__mocks__/**', '**/public/test/**'],
+    rules: {
+      '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
+    },
+  },
+  {
+    files: ['public/app/**/*.{ts,tsx}'],
+    rules: {
+      'no-barrel-files/no-barrel-files': 'error',
+    },
+  },
+  {
+    files: ['public/**/*.tsx', 'packages/grafana-ui/**/*.tsx'],
+    ignores: ['public/app/plugins/**', '**/*.story.tsx', '**/*.{test,spec}.{ts,tsx}', '**/__mocks__/', 'public/test'],
+    rules: {
+      '@grafana/no-untranslated-strings': 'error',
+    },
+  },
+];

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -1,6 +1,8 @@
 import { BettererFileTest } from '@betterer/betterer';
-import { ESLint, Linter } from 'eslint';
+import { ESLint } from 'eslint';
 import { promises as fs } from 'fs';
+
+import config from './.betterer.eslint.config';
 
 // Why are we ignoring these?
 // They're all deprecated/being removed so doesn't make sense to fix types
@@ -80,56 +82,6 @@ function countEslintErrors() {
     }
 
     const { baseDirectory } = resolver;
-
-    const baseRules: Partial<Linter.RulesRecord> = {
-      '@typescript-eslint/no-explicit-any': 'error',
-      '@grafana/no-aria-label-selectors': 'error',
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['@grafana/ui*', '*/Layout/*'],
-              importNames: ['Layout', 'HorizontalGroup', 'VerticalGroup'],
-              message: 'Use Stack component instead.',
-            },
-          ],
-        },
-      ],
-    };
-
-    const config: Linter.Config[] = [
-      {
-        files: ['**/*.{js,jsx,ts,tsx}'],
-        rules: baseRules,
-      },
-      {
-        files: ['**/*.{ts,tsx}'],
-        ignores: ['**/*.{test,spec}.{ts,tsx}', '**/__mocks__/**', '**/public/test/**'],
-        rules: {
-          '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
-        },
-      },
-      {
-        files: ['public/app/**/*.{ts,tsx}'],
-        rules: {
-          'no-barrel-files/no-barrel-files': 'error',
-        },
-      },
-      {
-        files: ['public/**/*.tsx', 'packages/grafana-ui/**/*.tsx'],
-        ignores: [
-          'public/app/plugins/**',
-          '**/*.story.tsx',
-          '**/*.{test,spec}.{ts,tsx}',
-          '**/__mocks__/',
-          'public/test',
-        ],
-        rules: {
-          '@grafana/no-untranslated-strings': 'error',
-        },
-      },
-    ];
 
     const runner = new ESLint({
       overrideConfig: config,

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -384,6 +384,7 @@
 /tsconfig.json @grafana/frontend-ops
 /.editorconfig @grafana/frontend-ops
 /eslint.config.js @grafana/frontend-ops
+/.betterer.eslint.config.js @grafana/frontend-ops
 /.gitattributes @grafana/frontend-ops
 /.gitignore @grafana/frontend-ops
 /.nvmrc @grafana/frontend-ops

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2028,3 +2028,6 @@ fail_tests_on_console = true
 # Whether or not to enable the MSW mock API, which intercepts requests and returns mock data
 # Should only be used for local development or demo purposes
 mock_api = false
+# Whether to enable betterer eslint rules for local development
+# Useful if you want to always see betterer rules that we're trying to fix so they're more prevalent
+betterer_eslint_rules = false

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,12 @@ const unicornPlugin = require('eslint-plugin-unicorn');
 const grafanaConfig = require('@grafana/eslint-config/flat');
 const grafanaPlugin = require('@grafana/eslint-plugin');
 
+const bettererConfig = require('./.betterer.eslint.config');
+const getEnvConfig = require('./scripts/webpack/env-util');
+
+const envConfig = getEnvConfig();
+const enableBettererRules = envConfig.frontend_dev_betterer_eslint_rules;
+
 /**
  * @type {Array<import('eslint').Linter.Config>}
  */
@@ -43,6 +49,8 @@ module.exports = [
       'scripts/grafana-server/tmp',
     ],
   },
+  // Conditionally run the betterer rules if enabled in dev's config
+  ...(enableBettererRules ? bettererConfig : []),
   grafanaConfig,
   {
     name: 'react/jsx-runtime',


### PR DESCRIPTION
**What is this feature?**
Moves the betterer rules to separate eslint.config file and allows opting in to seeing them locally if you have `frontend_dev.betterer_eslint_rules` set in your `ini` config file

**Why do we need this feature?**
To allow devs to more easily see the betterer rules we're trying to fix. Currently, if you add an untranslated string, or a type assertion, you can easily miss it until it comes to committing. Also, existing issues are not always visible. By allowing to opt into it, hopefully people can notice the problems more easily, and we'll see a decrease in the betterer issues 🙏 

**Who is this feature for?**

Any UI dev in this repo!
