### PR TITLE
LBAC for datasources: FIX adds missing uid in endpoint url

### DIFF
--- a/docs/sources/developers/http_api/datasource_lbac_rules.md
+++ b/docs/sources/developers/http_api/datasource_lbac_rules.md
@@ -26,7 +26,7 @@ LBAC (Label-Based Access Control) rules can be set for teams.
 
 ## Get LBAC rules for a data source
 
-`GET /api/datasources/:uid/lbac/teams`
+`GET /api/datasources/uid/:uid/lbac/teams`
 
 Gets all existing LBAC rules for the data source with the given `uid`.
 
@@ -41,7 +41,7 @@ Gets all existing LBAC rules for the data source with the given `uid`.
 **Example request:**
 
 ```
-GET /api/datasources/:uid/lbac/teams HTTP/1.1
+GET /api/datasources/uid/my_datasource/lbac/teams HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
@@ -74,7 +74,7 @@ Content-Length: 131
 
 ## Update LBAC rules for a data source
 
-`PUT /api/datasources/:uid/lbac/teams`
+`PUT /api/datasources/uid/:uid/lbac/teams`
 
 Updates LBAC rules for teams associated with the data source with the given `uid`. Here you submit a list of teams and the rules for each team.
 Deleting a team from the list will remove the team's LBAC rules. You have to submit all teams and their rules to be updated, to remove a team's rules, you have to submit the current list of rules without the team.
@@ -91,7 +91,7 @@ Deleting a team from the list will remove the team's LBAC rules. You have to sub
 **Example request:**
 
 ```http
-PUT /api/datasources/my_datasource/lbac/teams
+PUT /api/datasources/uid/my_datasource/lbac/teams
 Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk


### PR DESCRIPTION
adds missing /uid/ in the endpoints for the docs of LBAC for datasources