### PR TITLE
Explore: Sync logs displayed fields with URL state

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -54,6 +54,7 @@ export interface ExploreLogsPanelState {
   labelFieldName?: string;
   // Used for logs table visualisation, contains the refId of the dataFrame that is currently visualized
   refId?: string;
+  displayedFields?: string[];
 }
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -355,8 +355,13 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   });
 
   useUnmount(() => {
-    // If we're unmounting logs (e.g. switching to another datasource), we need to remove the table specific panel state, otherwise it will persist in the explore url
-    if (panelState?.logs?.columns || panelState?.logs?.refId || panelState?.logs?.labelFieldName) {
+    // If we're unmounting logs (e.g. switching to another datasource), we need to remove the logs specific panel state, otherwise it will persist in the explore url
+    if (
+      panelState?.logs?.columns ||
+      panelState?.logs?.refId ||
+      panelState?.logs?.labelFieldName ||
+      panelState?.logs?.displayedFields
+    ) {
       dispatch(
         changePanelState(exploreId, 'logs', {
           ...panelState?.logs,

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -139,7 +139,7 @@ export const LogsMetaRow = memo(
         {
           label: '',
           value: (
-            <Button variant="secondary" size="sm" onClick={clearDetectedFields}>
+            <Button variant="primary" fill="outline" size="sm" onClick={clearDetectedFields}>
               Show original line
             </Button>
           ),

--- a/public/app/features/explore/Logs/utils/logs.ts
+++ b/public/app/features/explore/Logs/utils/logs.ts
@@ -1,3 +1,6 @@
+import { shallowCompare } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
+
 export const SETTINGS_KEYS = {
   showLabels: 'grafana.explore.logs.showLabels',
   showTime: 'grafana.explore.logs.showTime',
@@ -8,3 +11,15 @@ export const SETTINGS_KEYS = {
 };
 
 export const visualisationTypeKey = 'grafana.explore.logs.visualisationType';
+
+export const canKeepDisplayedFields = (logsQueries: DataQuery[] | undefined, prevLogsQueries: DataQuery[]): boolean => {
+  if (!logsQueries) {
+    return false;
+  }
+  for (let i = 0; i < logsQueries.length; i++) {
+    if (!shallowCompare(logsQueries[i], prevLogsQueries[i])) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/public/app/features/logs/components/LogRow.tsx
+++ b/public/app/features/logs/components/LogRow.tsx
@@ -299,6 +299,8 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               pinned={this.props.pinned}
               mouseIsOver={this.state.mouseIsOver}
               onBlur={this.onMouseLeave}
+              logRowMenuIconsBefore={logRowMenuIconsBefore}
+              logRowMenuIconsAfter={logRowMenuIconsAfter}
             />
           ) : (
             <LogRowMessage

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -212,7 +212,6 @@ line3`;
 
       const { row } = setup({ logRowMenuIconsBefore, logRowMenuIconsAfter });
 
-      await userEvent.hover(screen.getByText('test123'));
       await userEvent.click(screen.getByLabelText('Addon before'));
       await userEvent.click(screen.getByLabelText('Addon after'));
 

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.test.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { createTheme, LogLevel } from '@grafana/data';
+import { IconButton } from '@grafana/ui';
 
 import { LogRowMessageDisplayedFields, Props } from './LogRowMessageDisplayedFields';
 import { createLogRow } from './__mocks__/logRow';
@@ -43,5 +45,26 @@ describe('LogRowMessageDisplayedFields', () => {
     expect(screen.queryByText('Logs are wonderful')).not.toBeInTheDocument();
     expect(screen.getByText(/place=Earth/)).toBeInTheDocument();
     expect(screen.getByText(/planet=Mars/)).toBeInTheDocument();
+  });
+
+  describe('With custom buttons', () => {
+    it('supports custom buttons before and after the default options', async () => {
+      const onBefore = jest.fn();
+      const logRowMenuIconsBefore = [
+        <IconButton name="eye-slash" onClick={onBefore} tooltip="Addon before" aria-label="Addon before" key={1} />,
+      ];
+      const onAfter = jest.fn();
+      const logRowMenuIconsAfter = [
+        <IconButton name="rss" onClick={onAfter} tooltip="Addon after" aria-label="Addon after" key={1} />,
+      ];
+
+      const { row } = setup({ logRowMenuIconsBefore, logRowMenuIconsAfter });
+
+      await userEvent.click(screen.getByLabelText('Addon before'));
+      await userEvent.click(screen.getByLabelText('Addon after'));
+
+      expect(onBefore).toHaveBeenCalledWith(expect.anything(), row);
+      expect(onAfter).toHaveBeenCalledWith(expect.anything(), row);
+    });
   });
 });

--- a/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
+++ b/public/app/features/logs/components/LogRowMessageDisplayedFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { memo, useMemo } from 'react';
+import { memo, ReactNode, useMemo } from 'react';
 
 import { LogRowModel, Field, LinkModel, DataFrame } from '@grafana/data';
 
@@ -21,10 +21,23 @@ export interface Props {
   pinned?: boolean;
   mouseIsOver: boolean;
   onBlur: () => void;
+  logRowMenuIconsBefore?: ReactNode[];
+  logRowMenuIconsAfter?: ReactNode[];
 }
 
 export const LogRowMessageDisplayedFields = memo((props: Props) => {
-  const { row, detectedFields, getFieldLinks, wrapLogMessage, styles, mouseIsOver, pinned, ...rest } = props;
+  const {
+    row,
+    detectedFields,
+    getFieldLinks,
+    wrapLogMessage,
+    styles,
+    mouseIsOver,
+    pinned,
+    logRowMenuIconsBefore,
+    logRowMenuIconsAfter,
+    ...rest
+  } = props;
   const wrapClassName = wrapLogMessage ? '' : displayedFieldsStyles.noWrap;
   const fields = useMemo(() => getAllFields(row, getFieldLinks), [getFieldLinks, row]);
   // only single key/value rows are filterable, so we only need the first field key for filtering
@@ -63,6 +76,8 @@ export const LogRowMessageDisplayedFields = memo((props: Props) => {
             styles={styles}
             pinned={pinned}
             mouseIsOver={mouseIsOver}
+            addonBefore={logRowMenuIconsBefore}
+            addonAfter={logRowMenuIconsAfter}
             {...rest}
           />
         )}


### PR DESCRIPTION
This PR adds Explore support to sync diplayed fields with URL state, allowing users to include them when they share links. This also allows other applications like Explore Logs to open Explore with certain displayed fields.

These selected fields are cleared when the user makes a change to the current queries, and the reset button has been changed to be more easily spotted.

![imagen](https://github.com/user-attachments/assets/d33e740a-09ab-434b-868a-f5345de5b1b6)

Additionally, this PR also passes the `addonBefore` and `addonAfter` to `LogRowMessageDisplayedFields`, which was preventing Explore Logs from showing the share icon when displayed fields was being used.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana/issues/89168
Part of https://github.com/grafana/explore-logs/issues/884

**Special notes for your reviewer:**

https://github.com/user-attachments/assets/2965c9ed-b3c9-4a65-aa0a-97cc50553437
