### PR TITLE
Alerting: Skip sanitizing labels when sending alerts to the remote Alertmanager

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -942,8 +942,9 @@ services:
     path: /var/lib/mysql
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
+    -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine:r304-3872ccb
+  image: grafana/mimir-alpine-r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -1383,8 +1384,9 @@ services:
     path: /var/lib/mysql
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
+    -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine:r304-3872ccb
+  image: grafana/mimir-alpine-r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -2455,8 +2457,9 @@ services:
     path: /var/lib/mysql
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
+    -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine:r304-3872ccb
+  image: grafana/mimir-alpine-r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -3039,8 +3042,9 @@ services:
     path: /var/lib/mysql
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
+    -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine:r304-3872ccb
+  image: grafana/mimir-alpine-r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -4978,8 +4982,9 @@ services:
     path: /var/lib/mysql
 - commands:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
+    -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine:r304-3872ccb
+  image: grafana/mimir-alpine-r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -5451,7 +5456,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM python:3.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir-alpine:r304-3872ccb
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir-alpine-r316-55f47f8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:8.0.32
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM redis:6.2.11-alpine
@@ -5489,7 +5494,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL python:3.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir-alpine:r304-3872ccb
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir-alpine-r316-55f47f8
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:8.0.32
   - trivy --exit-code 1 --severity HIGH,CRITICAL redis:6.2.11-alpine
@@ -5735,6 +5740,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 250d3c2ae9ddf7cbfd2a9fed01fe81312a882ba09b8f8725f4704629da00a774
+hmac: 5b9dd31f2796729e39cedf7f2a8d0daed4fb2edd75bfe972f0eaa5a09efc7cdf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -944,7 +944,7 @@ services:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
     -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine-r316-55f47f8
+  image: grafana/mimir-alpine:r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -1386,7 +1386,7 @@ services:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
     -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine-r316-55f47f8
+  image: grafana/mimir-alpine:r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -2459,7 +2459,7 @@ services:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
     -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine-r316-55f47f8
+  image: grafana/mimir-alpine:r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -3044,7 +3044,7 @@ services:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
     -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine-r316-55f47f8
+  image: grafana/mimir-alpine:r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -4984,7 +4984,7 @@ services:
   - /bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled
     -alertmanager.utf8-strict-mode-enabled
   environment: {}
-  image: grafana/mimir-alpine-r316-55f47f8
+  image: grafana/mimir-alpine:r316-55f47f8
   name: mimir_backend
 - environment: {}
   image: redis:6.2.11-alpine
@@ -5456,7 +5456,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM python:3.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM postgres:12.3-alpine
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir-alpine-r316-55f47f8
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/mimir-alpine:r316-55f47f8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:5.7.39
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM mysql:8.0.32
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM redis:6.2.11-alpine
@@ -5494,7 +5494,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack
   - trivy --exit-code 1 --severity HIGH,CRITICAL python:3.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL postgres:12.3-alpine
-  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir-alpine-r316-55f47f8
+  - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/mimir-alpine:r316-55f47f8
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:5.7.39
   - trivy --exit-code 1 --severity HIGH,CRITICAL mysql:8.0.32
   - trivy --exit-code 1 --severity HIGH,CRITICAL redis:6.2.11-alpine
@@ -5740,6 +5740,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: 5b9dd31f2796729e39cedf7f2a8d0daed4fb2edd75bfe972f0eaa5a09efc7cdf
+hmac: bb28bcd274c9d2ce724db12659ed6e3dcc461f8a07ae0eb9385a64ca5daad4de
 
 ...

--- a/devenv/docker/blocks/mimir_backend/docker-compose.yaml
+++ b/devenv/docker/blocks/mimir_backend/docker-compose.yaml
@@ -1,9 +1,10 @@
   mimir_backend:
-    image: grafana/mimir-alpine:r304-3872ccb
+    image: grafana/mimir-alpine:r316-55f47f8
     container_name: mimir_backend
     command:
       - -target=backend
       - -alertmanager.grafana-alertmanager-compatibility-enabled
+      - -alertmanager.utf8-strict-mode-enabled
   nginx:
     environment:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -150,7 +150,12 @@ func NewAlertmanager(cfg AlertmanagerConfig, store stateStore, decryptFn Decrypt
 		return c.Do(req.WithContext(ctx))
 	}
 	senderLogger := log.New("ngalert.sender.external-alertmanager")
-	s, err := sender.NewExternalAlertmanagerSender(senderLogger, prometheus.NewRegistry(), sender.WithDoFunc(doFunc))
+	s, err := sender.NewExternalAlertmanagerSender(
+		senderLogger,
+		prometheus.NewRegistry(),
+		sender.WithDoFunc(doFunc),
+		sender.WithUTF8Labels(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/drone/services/services.star
+++ b/scripts/drone/services/services.star
@@ -57,7 +57,7 @@ def integration_test_services():
             "name": "mimir_backend",
             "image": images["mimir"],
             "environment": {},
-            "commands": ["/bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled"],
+            "commands": ["/bin/mimir -target=backend -alertmanager.grafana-alertmanager-compatibility-enabled -alertmanager.utf8-strict-mode-enabled"],
         },
         {
             "name": "redis",

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -22,7 +22,7 @@ images = {
     "plugins_slack": "plugins/slack",
     "python": "python:3.8",
     "postgres_alpine": "postgres:12.3-alpine",
-    "mimir": "grafana/mimir-alpine:r304-3872ccb",
+    "mimir": "grafana/mimir-alpine-r316-55f47f8",
     "mysql5": "mysql:5.7.39",
     "mysql8": "mysql:8.0.32",
     "redis_alpine": "redis:6.2.11-alpine",

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -22,7 +22,7 @@ images = {
     "plugins_slack": "plugins/slack",
     "python": "python:3.8",
     "postgres_alpine": "postgres:12.3-alpine",
-    "mimir": "grafana/mimir-alpine-r316-55f47f8",
+    "mimir": "grafana/mimir-alpine:r316-55f47f8",
     "mysql5": "mysql:5.7.39",
     "mysql8": "mysql:8.0.32",
     "redis_alpine": "redis:6.2.11-alpine",


### PR DESCRIPTION
The `ExternalAlertmanager` struct is used to forward alerts to a set of external Alertmanagers. It has a `sanitizeLabelSet` function to clean up label names that don't match the ` ^[a-zA-Z_][a-zA-Z0-9_]*$` regex before forwarding the alert.

This sanitization is not needed in newer versions of the Alertmanager that support UTF-8 labels, and it could cause inconsistencies between the Grafana Alertmanager and the external one as modifying the label set changes the identity of an alert.

This PR adds a `WithUTF8Labels` option to the `ExternalAlertmanager` struct. This option replaces the label processing function for a no-op, thus skipping label sanitization.

It also updates our Mimir images in our devenv blocks and Drone, and adds the `-alertmanager.utf8-strict-mode-enabled` flag.
