### PR TITLE
Zanzana: Use correct namespace when evaluating permission

### DIFF
--- a/pkg/services/accesscontrol/acimpl/accesscontrol.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol.go
@@ -8,8 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 
-	"github.com/grafana/authlib/claims"
-
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -133,8 +131,7 @@ func (a *AccessControl) evaluateZanzana(ctx context.Context, user identity.Reque
 			_, _, parentFolder = accesscontrol.SplitScope(scopes[1])
 		}
 
-		namespace := claims.OrgNamespaceFormatter(user.GetOrgID())
-		req, ok := zanzana.TranslateToCheckRequest(namespace, action, kind, parentFolder, identifier)
+		req, ok := zanzana.TranslateToCheckRequest(user.GetNamespace(), action, kind, parentFolder, identifier)
 		if !ok {
 			// unsupported translation
 			return false, errAccessNotImplemented


### PR DESCRIPTION
**What is this feature?**
In https://github.com/grafana/grafana/pull/96230 I made sure we always set namespace on Identities regardless of authentication method used. We can use that one to get the correct namespace when evaluating permissions.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
