### PR TITLE
Docs: Clean up basic auth, anonymous access and main pages for auth configuration

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -19,21 +19,21 @@ Grafana provides many ways to authenticate users. Some authentication integratio
 
 The following table shows all supported authentication providers and the features available for them. [Team sync]({{< relref "../configure-team-sync" >}}) and [active sync]({{< relref "./enhanced-ldap#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
 
-| Authentication method                                  | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
-| :----------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
-| [Anonymouse access]({{< relref "./anonymous-auth" >}}) | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
-| [Auth Proxy]({{< relref "./auth-proxy" >}})            | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
-| [Azure AD OAuth]({{< relref "./azuread" >}})           | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [Basic auth]({{< relref "./grafana" >}})               | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
-| [Generic OAuth]({{< relref "./generic-oauth" >}})      | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           |
-| [GitHub OAuth]({{< relref "./github" >}})              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [GitLab OAuth]({{< relref "./gitlab" >}})              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [Google OAuth]({{< relref "./google" >}})              | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           |
-| [Grafana.com OAuth]({{< relref "./grafana-cloud" >}})  | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           |
-| [Okta OAuth]({{< relref "./okta" >}})                  | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [SAML]({{< relref "./saml" >}}) (Enterprise only)      | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [LDAP]({{< relref "./ldap" >}})                        | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           |
-| [JWT Proxy]({{< relref "./jwt" >}})                    | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           |
+| Authentication method                                 | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
+|:------------------------------------------------------| :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
+| [Anonymous access]({{< relref "./anonymous-auth" >}}) | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
+| [Auth Proxy]({{< relref "./auth-proxy" >}})           | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
+| [Azure AD OAuth]({{< relref "./azuread" >}})          | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [Basic auth]({{< relref "./grafana" >}})              | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
+| [Generic OAuth]({{< relref "./generic-oauth" >}})     | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           |
+| [GitHub OAuth]({{< relref "./github" >}})             | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [GitLab OAuth]({{< relref "./gitlab" >}})             | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [Google OAuth]({{< relref "./google" >}})             | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           |
+| [Grafana.com OAuth]({{< relref "./grafana-cloud" >}}) | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           |
+| [Okta OAuth]({{< relref "./okta" >}})                 | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [SAML]({{< relref "./saml" >}}) (Enterprise only)     | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [LDAP]({{< relref "./ldap" >}})                       | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           |
+| [JWT Proxy]({{< relref "./jwt" >}})                   | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           |
 
 Fields explanation:
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -19,31 +19,25 @@ Grafana provides many ways to authenticate users. Some authentication integratio
 
 The following table shows all supported authentication providers and the features available for them. [Team sync]({{< relref "../configure-team-sync" >}}) and [active sync]({{< relref "./enhanced-ldap#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
 
-| Provider                                              | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
-| :---------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
-| [Auth Proxy]({{< relref "./auth-proxy" >}})           | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
-| [Azure AD OAuth]({{< relref "./azuread" >}})          | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [Generic OAuth]({{< relref "./generic-oauth" >}})     | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           |
-| [GitHub OAuth]({{< relref "./github" >}})             | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [GitLab OAuth]({{< relref "./gitlab" >}})             | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [Google OAuth]({{< relref "./google" >}})             | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           |
-| [Grafana.com OAuth]({{< relref "./grafana-cloud" >}}) | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           |
-| [Okta OAuth]({{< relref "./okta" >}})                 | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [SAML]({{< relref "./saml" >}}) (Enterprise only)     | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
-| [LDAP]({{< relref "./ldap" >}})                       | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           |
-| [JWT Proxy]({{< relref "./jwt" >}})                   | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           |
+| Authentication method                                  | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
+| :----------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
+| [Anonymouse access]({{< relref "./anonymous-auth" >}}) | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
+| [Auth Proxy]({{< relref "./auth-proxy" >}})            | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
+| [Azure AD OAuth]({{< relref "./azuread" >}})           | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [Basic auth]({{< relref "./grafana" >}})               | yes               | N/A          | yes          | yes                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
+| [Generic OAuth]({{< relref "./generic-oauth" >}})      | yes               | yes          | yes          | yes                   | yes       | no             | N/A         | yes                  | yes        | yes           |
+| [GitHub OAuth]({{< relref "./github" >}})              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [GitLab OAuth]({{< relref "./gitlab" >}})              | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [Google OAuth]({{< relref "./google" >}})              | yes               | no           | no           | no                    | yes       | no             | N/A         | no                   | yes        | yes           |
+| [Grafana.com OAuth]({{< relref "./grafana-cloud" >}})  | no                | no           | yes          | no                    | N/A       | N/A            | N/A         | yes                  | yes        | yes           |
+| [Okta OAuth]({{< relref "./okta" >}})                  | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [SAML]({{< relref "./saml" >}}) (Enterprise only)      | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |
+| [LDAP]({{< relref "./ldap" >}})                        | yes               | yes          | yes          | yes                   | yes       | yes            | yes         | no                   | N/A        | N/A           |
+| [JWT Proxy]({{< relref "./jwt" >}})                    | no                | yes          | yes          | yes                   | no        | no             | N/A         | no                   | N/A        | N/A           |
 
-N/A = Not applicable
+Fields explanation:
 
-## Auth Proxy
-
-| Feature           | Supported? |
-| :---------------- | :--------- |
-| Multi Org Mapping | no         |
-| Enforce Sync      | N/A        |
-| Role Mapping      | yes        |
-
-**Multi Org Mapping:** Able to add a user and role map him to multiple orgs
+**Multi Org Mapping:** Able to add a user and map roles to multiple organizations
 
 **Enforce Sync:** If the information provided by the identity provider is empty, does the integration skip setting that user’s field or does it enforce a default.
 
@@ -82,15 +76,9 @@ If users want to use the same email address with multiple identity providers (fo
 
 To enable this option, refer to the [Enable email lookup](#enable-email-lookup) section.
 
-## Grafana Auth
+## Login and short-lived tokens
 
-Grafana of course has a built in user authentication system with password authentication enabled by default. You can
-disable authentication by enabling anonymous access. You can also hide the login form and only allow login through an auth
-provider (listed above). There are also options for allowing self sign up.
-
-### Login and short-lived tokens
-
-> The following applies when using Grafana's built in user authentication, LDAP (without Auth proxy) or OAuth integration.
+> The following applies when using Grafana's basic authentication, LDAP (without Auth proxy) or OAuth integration.
 
 Grafana uses short-lived tokens as a mechanism for verifying authenticated users.
 These short-lived tokens are rotated on an interval specified by `token_rotation_interval_minutes` for active authenticated users.
@@ -98,11 +86,6 @@ These short-lived tokens are rotated on an interval specified by `token_rotation
 Inactive authenticated users will remain logged in for a duration specified by `login_maximum_inactive_lifetime_duration`.
 This means that a user can close a Grafana window and return before `now + login_maximum_inactive_lifetime_duration` to continue their session.
 This is true as long as the time since last user login is less than `login_maximum_lifetime_duration`.
-
-#### Remote logout
-
-You can logout from other devices by removing login sessions from the bottom of your profile page. If you are
-a Grafana admin user, you can also do the same for any user from the Server Admin / Edit User view.
 
 ## Settings
 
@@ -130,50 +113,7 @@ api_key_max_seconds_to_live = -1
 oauth_allow_insecure_email_lookup = false
 ```
 
-### Anonymous authentication
-
-You can make Grafana accessible without any login required by enabling anonymous access in the configuration file.
-
-Example:
-
-```bash
-[auth.anonymous]
-enabled = true
-
-{{< admonition type="note" >}}
-Enabling anonymous access is a disallowed configuration setting on Hosted Grafana and not recommended due [security implications](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/#implications-of-enabling-anonymous-access-to-dashboards).
-For sharing dashboards with a wider audience, consider using the [public dashboard feature](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/) instead.
-{{< /admonition >}}
-
-# Organization name that should be used for unauthenticated users
-org_name = Main Org.
-
-# Role for unauthenticated users, other valid values are `Editor` and `Admin`
-org_role = Viewer
-```
-
-If you change your organization name in the Grafana UI, this setting needs to be updated to match the new name.
-
-### Basic authentication
-
-Basic auth is enabled by default and works with the built-in Grafana user-password authentication system and LDAP
-authentication integration.
-
-To disable basic auth:
-
-```bash
-[auth.basic]
-enabled = false
-```
-
-### Disable login form
-
-Hide the Grafana login form using the below configuration settings.
-
-```bash
-[auth]
-disable_login_form = true
-```
+## Extended authentication settings
 
 ### Enable email lookup
 
@@ -243,6 +183,11 @@ Example for Generic OAuth:
 [auth.generic_oauth]
 signout_redirect_url =
 ```
+
+### Remote logout
+
+You can logout from other devices by removing login sessions from the bottom of your profile page. If you are
+a Grafana admin user, you can also do the same for any user from the Server Admin / Edit User view.
 
 ### Protected roles
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -20,7 +20,7 @@ Grafana provides many ways to authenticate users. Some authentication integratio
 The following table shows all supported authentication providers and the features available for them. [Team sync]({{< relref "../configure-team-sync" >}}) and [active sync]({{< relref "./enhanced-ldap#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
 
 | Authentication method                                 | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
-|:------------------------------------------------------| :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
+| :---------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |
 | [Anonymous access]({{< relref "./anonymous-auth" >}}) | N/A               | N/A          | N/A          | N/A                   | N/A       | N/A            | N/A         | N/A                  | N/A        | N/A           |
 | [Auth Proxy]({{< relref "./auth-proxy" >}})           | no                | yes          | yes          | no                    | yes       | no             | N/A         | no                   | N/A        | N/A           |
 | [Azure AD OAuth]({{< relref "./azuread" >}})          | yes               | yes          | yes          | yes                   | yes       | yes            | N/A         | yes                  | yes        | yes           |

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -17,7 +17,7 @@ weight: 200
 
 Grafana provides many ways to authenticate users. Some authentication integrations also enable syncing user permissions and org memberships.
 
-The following table shows all supported authentication providers and the features available for them. [Team sync]({{< relref "../configure-team-sync" >}}) and [active sync]({{< relref "./enhanced-ldap#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
+The following table shows all supported authentication methods and the features available for them. [Team sync]({{< relref "../configure-team-sync" >}}) and [active sync]({{< relref "./enhanced-ldap#active-ldap-synchronization" >}}) are only available in Grafana Enterprise.
 
 | Authentication method                                 | Multi Org Mapping | Enforce Sync | Role Mapping | Grafana Admin Mapping | Team Sync | Allowed groups | Active Sync | Skip OrgRole mapping | Auto Login | Single Logout |
 | :---------------------------------------------------- | :---------------- | :----------- | :----------- | :-------------------- | :-------- | :------------- | :---------- | :------------------- | :--------- | :------------ |

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -186,7 +186,7 @@ signout_redirect_url =
 
 ### Remote logout
 
-You can logout from other devices by removing login sessions from the bottom of your profile page. If you are
+You can log out from other devices by removing login sessions from the bottom of your profile page. If you are
 a Grafana admin user, you can also do the same for any user from the Server Admin / Edit User view.
 
 ### Protected roles

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/anonymous-auth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/anonymous-auth/index.md
@@ -1,0 +1,61 @@
+---
+aliases:
+  - ../../../auth/anonymous-auth/
+description: Learn how to configure anonymous access in Grafana
+labels:
+  products:
+    - enterprise
+    - oss
+menuTitle: Anonymous access
+title: Configure anonymous access
+weight: 250
+---
+
+# Anonymous authentication
+
+You can make Grafana accessible without any login required by enabling anonymous access in the configuration file.
+
+{{< admonition type="note" >}}
+Anonymous users are charged as active users in Grafana Enterprise
+{{< /admonition >}}
+
+## Anonymous devices
+
+The anonymous devices feature enhances the management and monitoring of anonymous access within your Grafana instance. This feature is part of ongoing efforts to provide more control and transparency over anonymous usage.
+
+Users can now view anonymous usage statistics, including the count of devices and users over the last 30 days.
+
+- Go to **Administration -> Users** to access the anonymous devices tab.
+- A new stat for the usage stats page -> Usage & Stats page shows the active anonymous devices last 30 days.
+
+The number of anonymous devices is not limited by default. The configuration option `device_limit` allows you to enforce a limit on the number of anonymous devices. This enables you to have greater control over the usage within your Grafana instance and keep the usage within the limits of your environment. Once the limit is reached, any new devices that try to access Grafana will be denied access.
+
+To display anonymous users and devices for versions 10.2, 10.3, 10.4, you need to enable the feature toggle `displayAnonymousStats`
+
+```bash
+[feature_toggles]
+enable = displayAnonymousStats
+```
+
+## Configuration
+
+Example:
+
+```bash
+[auth.anonymous]
+enabled = true
+
+# Organization name that should be used for unauthenticated users
+org_name = Main Org.
+
+# Role for unauthenticated users, other valid values are `Editor` and `Admin`
+org_role = Viewer
+
+# Hide the Grafana version text from the footer and help tooltip for unauthenticated users (default: false)
+hide_version = true
+
+# Setting this limits the number of anonymous devices in your instance. Any new anonymous devices added after the limit has been reached will be denied access.
+device_limit =
+```
+
+If you change your organization name in the Grafana UI this setting needs to be updated to match the new name.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/grafana/index.md
@@ -1,127 +1,32 @@
 ---
 aliases:
   - ../../../auth/grafana/
-description: Grafana OAuthentication Guide
+description: Learn how to configure basic authentication in Grafana
 labels:
   products:
     - enterprise
     - oss
 menuTitle: Basic auth
-title: Configure Grafana authentication
+title: Configure basic authentication
 weight: 200
 ---
 
-## Configure Grafana authentication
+# Configure basic authentication
 
-Grafana of course has a built in user authentication system with password authentication enabled by default. You can
-disable authentication by enabling anonymous access. You can also hide login form and only allow login through an auth
-provider (listed above). There is also options for allowing self sign up.
+Grafana provides a basic authentication system with password authentication enabled by default. This document details configuration options to manage and enhance basic authentication.
 
-### Login and short-lived tokens
+## Disable basic authentication
 
-> The following applies when using Grafana's built in user authentication, LDAP (without Auth proxy) or OAuth integration.
-
-Grafana uses short-lived tokens as a mechanism for verifying authenticated users.
-These short-lived tokens are rotated each `token_rotation_interval_minutes` for an active authenticated user.
-
-An active authenticated user that gets it token rotated will extend the `login_maximum_inactive_lifetime_duration` time from "now" that Grafana will remember the user.
-This means that a user can close its browser and come back before `now + login_maximum_inactive_lifetime_duration` and still being authenticated.
-This is true as long as the time since user login is less than `login_maximum_lifetime_duration`.
-
-#### Remote logout
-
-You can logout from other devices by removing login sessions from the bottom of your profile page. If you are
-a Grafana admin user you can also do the same for any user from the Server Admin / Edit User view.
-
-## Settings
-
-Example:
-
-```bash
-[auth]
-
-# Login cookie name
-login_cookie_name = grafana_session
-
-# The lifetime (days) an authenticated user can be inactive before being required to login at next visit. Default is 7 days.
-login_maximum_inactive_lifetime_duration = 7d
-
-# The maximum lifetime (days) an authenticated user can be logged in since login time before being required to login. Default is 30 days.
-login_maximum_lifetime_duration = 30d
-
-# How often should auth tokens be rotated for authenticated users when being active. The default is each 10 minutes.
-token_rotation_interval_minutes = 10
-
-# The maximum lifetime (seconds) an api key can be used. If it is set all the api keys should have limited lifetime that is lower than this value.
-api_key_max_seconds_to_live = -1
-```
-
-### Anonymous authentication
-
-You can make Grafana accessible without any login required by enabling anonymous access in the configuration file. For more information, refer to [Anonymous authentication]({{< relref "../../configure-authentication#anonymous-authentication" >}}).
-
-#### Anonymous devices
-
-The anonymous devices feature enhances the management and monitoring of anonymous access within your Grafana instance. This feature is part of ongoing efforts to provide more control and transparency over anonymous usage.
-
-Users can now view anonymous usage statistics, including the count of devices and users over the last 30 days.
-
-- Go to **Administration -> Users** to access the anonymous devices tab.
-- A new stat for the usage stats page -> Usage & Stats page shows the active anonymous devices last 30 days.
-
-The number of anonymous devices is not limited by default. The configuration option `device_limit` allows you to enforce a limit on the number of anonymous devices. This enables you to have greater control over the usage within your Grafana instance and keep the usage within the limits of your environment. Once the limit is reached, any new devices that try to access Grafana will be denied access.
-
-To display anonymous users and devices for versions 10.2, 10.3, 10.4, you need to enable the feature toggle `displayAnonymousStats`
-
-```bash
-[feature_toggles]
-enable = displayAnonymousStats
-```
-
-#### Anonymous users
-
-{{< admonition type="note" >}}
-Anonymous users are charged as active users in Grafana Enterprise
-{{< /admonition >}}
-
-#### Configuration
-
-Example:
-
-```bash
-[auth.anonymous]
-enabled = true
-
-# Organization name that should be used for unauthenticated users
-org_name = Main Org.
-
-# Role for unauthenticated users, other valid values are `Editor` and `Admin`
-org_role = Viewer
-
-# Hide the Grafana version text from the footer and help tooltip for unauthenticated users (default: false)
-hide_version = true
-
-# Setting this limits the number of anonymous devices in your instance. Any new anonymous devices added after the limit has been reached will be denied access.
-device_limit =
-```
-
-If you change your organization name in the Grafana UI this setting needs to be updated to match the new name.
-
-### Basic authentication
-
-Basic auth is enabled by default and works with the built in Grafana user password authentication system and LDAP
-authentication integration.
-
-To disable basic auth:
+To disable basic authentication, use the following configuration:
 
 ```bash
 [auth.basic]
 enabled = false
 ```
 
-### Strong password policy
+## Password policy
 
-By default, the password policy for all basic auth users is set to a minimum of four characters. You can enable a stronger password policy with the `password_policy` configuration option.
+By default, Grafana’s password policy requires a minimum of four characters for basic auth users. For a stronger password policy, enable the `password_policy` configuration option.
 
 With the `password_policy` option enabled, new and updated passwords must meet the following criteria:
 
@@ -137,63 +42,16 @@ password_policy = true
 ```
 
 {{% admonition type="note" %}}
-Existing passwords that don't comply with the new password policy will not be impacted until the user updates their password.
+Existing passwords that do not comply with the new password policy will not be affected until the user updates their password.
 {{% /admonition %}}
 
-### Disable login form
+## Disable login form
 
-You can hide the Grafana login form using the below configuration settings.
+To hide the Grafana login form, use the following configuration setting:
 
 ```bash
 [auth]
 disable_login_form = true
 ```
 
-### Automatic OAuth login
-
-Set to true to attempt login with specific OAuth provider automatically, skipping the login screen.
-This setting is ignored if multiple auth providers are configured to use auto login.
-Defaults to `false`.
-
-```bash
-[auth.generic_oauth]
-auto_login = true
-```
-
-### Hide sign-out menu
-
-Set the option detailed below to true to hide sign-out menu link. Useful if you use an auth proxy or JWT authentication.
-
-```bash
-[auth]
-disable_signout_menu = true
-```
-
-### URL redirect after signing out
-
-The URL to redirect the user to after signing out from Grafana can be configured under `[auth]` or under a specific OAuth provider section (for example, `[auth.generic_oauth]`). The URL configured under a specific OAuth provider section takes precedence over the URL configured in `[auth]` section. This can, for example, enable signout from the OAuth provider.
-
-```bash
-[auth.generic_oauth]
-signout_redirect_url =
-
-[auth]
-signout_redirect_url =
-```
-
-### Protected roles
-
-{{% admonition type="note" %}}
-Available in [Grafana Enterprise]({{< relref "../../../../introduction/grafana-enterprise" >}}) and [Grafana Cloud]({{< relref "../../../../introduction/grafana-cloud" >}}).
-{{% /admonition %}}
-
-By default, after you configure an authorization provider, Grafana will adopt existing users into the new authentication scheme. For example, if you have created a user with basic authentication having the login `jsmith@example.com`, then set up SAML authentication where `jsmith@example.com` is an account, the user's authentication type will be changed to SAML if they perform a SAML sign-in.
-
-You can disable this user adoption for certain roles using the `protected_roles` property:
-
-```bash
-[auth.security]
-protected_roles = server_admins org_admins
-```
-
-The value of `protected_roles` should be a list of roles to protect, separated by spaces. Valid roles are `viewers`, `editors`, `org_admins`, `server_admins`, and `all` (a superset of the other roles).
+This can be helpful in setups where authentication is handled entirely through external mechanisms or single sign-on (SSO).


### PR DESCRIPTION
**What is this feature?**

- Adds a new sub-page for configuring anonymous access
- Remove duplicated information from the primary landing page for auth configuration. We already had basic auth sub-page with the same information, which also contained information for anonymous access
- Updates the table with auth providers to cover basic auth and anonymous access as well.

