### PR TITLE
PanelEdit: Fixes issue with repeat options

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptions.tsx
@@ -25,7 +25,13 @@ interface Props {
 export const PanelOptions = React.memo<Props>(({ panel, searchQuery, listMode, data }) => {
   const { options, fieldConfig, _pluginInstanceState } = panel.useState();
 
-  const panelFrameOptions = useMemo(() => getPanelFrameCategory2(panel), [panel]);
+  const layoutElement = panel.parent!;
+  const layoutElementState = layoutElement.useState();
+
+  const panelFrameOptions = useMemo(
+    () => getPanelFrameCategory2(panel, layoutElementState),
+    [panel, layoutElementState]
+  );
 
   const visualizationOptions = useMemo(() => {
     const plugin = panel.getPlugin();

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -1,7 +1,7 @@
 import { SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
-import { SceneTimeRangeLike, VizPanel } from '@grafana/scenes';
+import { SceneObjectState, SceneTimeRangeLike, VizPanel } from '@grafana/scenes';
 import { DataLinksInlineEditor, Input, TextArea, Switch, RadioButtonGroup, Select } from '@grafana/ui';
 import { GenAIPanelDescriptionButton } from 'app/features/dashboard/components/GenAI/GenAIPanelDescriptionButton';
 import { GenAIPanelTitleButton } from 'app/features/dashboard/components/GenAI/GenAIPanelTitleButton';
@@ -17,7 +17,10 @@ import { vizPanelToPanel, transformSceneToSaveModel } from '../serialization/tra
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../utils/utils';
 
-export function getPanelFrameCategory2(panel: VizPanel): OptionsPaneCategoryDescriptor {
+export function getPanelFrameCategory2(
+  panel: VizPanel,
+  layoutElementState: SceneObjectState
+): OptionsPaneCategoryDescriptor {
   const descriptor = new OptionsPaneCategoryDescriptor({
     title: 'Panel options',
     id: 'Panel options',


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/95768 accidentally introduced a bug by removing an unused function argument, and the corresponding argument to a dependency array (hook dependency arrays again a pain and cause of bugs). 

https://github.com/grafana/grafana/pull/96203 refactors the panel options rendering so we do not need to rebuild the options (and can remove this unused useMemo dependency) 