### PR TITLE
Serviceaccounts: FIX nul for field for `toString`

### DIFF
--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
-import { dateTimeFormat, GrafanaTheme2, OrgRole, TimeZone } from '@grafana/data';
+import { GrafanaTheme2, OrgRole, TimeZone, dateTimeFormat } from '@grafana/data';
 import { Label, TextLink, useStyles2 } from '@grafana/ui';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/core';
@@ -50,7 +50,13 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
       <h3>Information</h3>
       <table className="filter-table">
         <tbody>
-          <ServiceAccountProfileRow label="Numerical identifier" value={serviceAccount.id.toString()} disabled={true} />
+          {serviceAccount.id && (
+            <ServiceAccountProfileRow
+              label="Numerical identifier"
+              value={serviceAccount.id.toString()}
+              disabled={true}
+            />
+          )}
           <ServiceAccountProfileRow
             label="Name"
             value={serviceAccount.name}


### PR DESCRIPTION
We changed so routes are built on UID for serviceaccounts, this changes it so that we are building the profilerow from UID

https://github.com/grafana/grafana/pull/95401