### PR TITLE
Shard query splitting: stop querying on failure

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -18,6 +18,10 @@ jest.mock('uuid', () => ({
 }));
 
 const originalShardingFlagState = config.featureToggles.lokiShardSplitting;
+const originalErr = console.error;
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
 beforeAll(() => {
   // @ts-expect-error
   jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
@@ -28,6 +32,7 @@ beforeAll(() => {
 afterAll(() => {
   jest.mocked(global.setTimeout).mockReset();
   config.featureToggles.lokiShardSplitting = originalShardingFlagState;
+  console.error = originalErr;
 });
 
 describe('runSplitQuery()', () => {

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -138,9 +138,9 @@ export function isRetriableError(errorResponse: DataQueryResponse) {
     : (errorResponse.error?.message ?? '');
   if (message.includes('timeout')) {
     return true;
-  } else if (message.includes('parse error')) {
-    // If the error is a parse error, we want to signal to stop querying.
-    throw new Error(message);
+  } else if (errorResponse.data.length > 0 && errorResponse.data[0].fields.length > 0) {
+    // Error response but we're receiving data, continue querying.
+    return false;
   }
-  return false;
+  throw new Error(message);
 }

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -203,7 +203,7 @@ describe('runShardSplitQuery()', () => {
       callback();
     });
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith((response: DataQueryResponse[]) => {
-      expect(datasource.runQuery).toHaveBeenCalledTimes(2);
+      expect(datasource.runQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -14,6 +14,7 @@ jest.mock('uuid', () => ({
 
 const originalLog = console.log;
 const originalWarn = console.warn;
+const originalErr = console.error;
 beforeEach(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -22,6 +23,7 @@ beforeEach(() => {
 afterAll(() => {
   console.log = originalLog;
   console.warn = originalWarn;
+  console.error = originalErr;
 });
 
 describe('runShardSplitQuery()', () => {


### PR DESCRIPTION
With the current retry implementation we were not stopping on errors that should stop the query execution. Changing the logic to prevent extra unnecessary failing queries as it shows in the following demo with a "maximum series reached" response.

https://github.com/user-attachments/assets/7fa9ec47-8c3d-4c12-aaab-6ec215c56cf0

