### PR TITLE
Unistore: fix fodler migration

### DIFF
--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -114,11 +114,11 @@ func initResourceTables(mg *migrator.Migrator) string {
 	}))
 
 	mg.AddMigration("Add column folder in resource_history", migrator.NewAddColumnMigration(resource_history_table, &migrator.Column{
-		Name: "folder", Type: migrator.DB_NVarchar, Length: 253, Nullable: false, Default: "",
+		Name: "folder", Type: migrator.DB_NVarchar, Length: 253, Nullable: false, Default: "''",
 	}))
 
 	mg.AddMigration("Add column folder in resource", migrator.NewAddColumnMigration(resource_table, &migrator.Column{
-		Name: "folder", Type: migrator.DB_NVarchar, Length: 253, Nullable: false, Default: "",
+		Name: "folder", Type: migrator.DB_NVarchar, Length: 253, Nullable: false, Default: "''",
 	}))
 
 	return marker


### PR DESCRIPTION
Fix folder migration reporting the following error in sqlite :
> error="initialize Resource Server: initialize resource DB: run migrations: migration failed (id = Add column folder in resource_history): Cannot add a NOT NULL column with default value NULL"


Tested with sqlite/mysql and postgres