### PR TITLE
docs: Fixed title wording from bar gauge to canvas

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/panels-visualizations/visualizations/canvas/index.md
@@ -43,7 +43,7 @@ With all of these dynamic elements, there's almost no limit to what a canvas can
 We'd love your feedback on the canvas visualization. Please check out the [open Github issues](https://github.com/grafana/grafana/issues?page=1&q=is%3Aopen+is%3Aissue+label%3Aarea%2Fpanel%2Fcanvas) and [submit a new feature request](https://github.com/grafana/grafana/issues/new?assignees=&labels=type%2Ffeature-request,area%2Fpanel%2Fcanvas&title=Canvas:&projects=grafana-dataviz&template=1-feature_requests.md) as needed.
 {{< /admonition >}}
 
-## Configure a bar gauge visualization
+## Configure a canvas visualization
 
 The following video shows you how to create and configure a canvas visualization:
 


### PR DESCRIPTION
**What is this feature?**

Fixed an error in the title for the canvas documentation video.

**Why do we need this feature?**

The title was wrong copied from another doc.

**Who is this feature for?**

Everyone accessing the canvas documentation.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
