### PR TITLE
NPM Releases: Make e2e package private

### DIFF
--- a/packages/grafana-e2e/package.json
+++ b/packages/grafana-e2e/package.json
@@ -2,6 +2,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "name": "@grafana/e2e",
+  "private": true,
   "version": "11.0.8",
   "description": "Grafana End-to-End Test Library",
   "keywords": [


### PR DESCRIPTION
**What is this feature?**

Make previous [attempt](https://github.com/grafana/grafana/pull/95350) to stop publishing the `grafana/e2e` package only stopped moving the tags. This PR should stop publishing the package by changing it to be private. 

**Why do we need this feature?**

To prevent new releases of this package being published every time 11.0.x and 10.4.x are being patched. 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
