### PR TITLE
Set CoreServices as codeowners for SQL Expressions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -631,6 +631,9 @@ playwright.config.ts @grafana/plugins-platform-frontend
 # SSE - Server Side Expressions
 /pkg/expr/ @grafana/observability-metrics
 
+# SQL Expressions
+/pkg/expr/sql/ @grafana/grafana-datasources-core-services
+
 # Cloud middleware
 /grafana-mixin/ @grafana/grafana-backend-services-squad
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -629,10 +629,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /pkg/services/rendering/ @grafana/sharing-squad
 
 # SSE - Server Side Expressions
-/pkg/expr/ @grafana/observability-metrics
-
-# SQL Expressions
-/pkg/expr/sql/ @grafana/grafana-datasources-core-services
+/pkg/expr/ @grafana/grafana-datasources-core-services
 
 # Cloud middleware
 /grafana-mixin/ @grafana/grafana-backend-services-squad


### PR DESCRIPTION
I figured I should suggest this change. 
I was surprised to see each of @grafana/observability-metrics, @grafana/grafana-backend-group and @grafana/grafana-app-platform-squad listed as codeowners on my other PR https://github.com/grafana/grafana/pull/96296, so I figured it was probably worth trying to clean this up.