### PR TITLE
CloudMigrations: add parent folder name to alert rule resource

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -696,6 +696,7 @@ func TestGetParentNames(t *testing.T) {
 		folders             []folder.CreateFolderCommand
 		dashboards          []dashboards.Dashboard
 		libraryElements     []libraryElement
+		alertRules          []alertRule
 		expectedParentNames map[cloudmigration.MigrateDataType][]string
 	}{
 		{
@@ -716,10 +717,15 @@ func TestGetParentNames(t *testing.T) {
 				{UID: "libraryElementUID-0", FolderUID: &libraryElementFolderUID},
 				{UID: "libraryElementUID-1"},
 			},
+			alertRules: []alertRule{
+				{UID: "alertRuleUID-0", FolderUID: ""},
+				{UID: "alertRuleUID-1", FolderUID: "folderUID-B"},
+			},
 			expectedParentNames: map[cloudmigration.MigrateDataType][]string{
 				cloudmigration.DashboardDataType:      {"", "Folder A", "Folder B"},
 				cloudmigration.FolderDataType:         {"Folder A"},
 				cloudmigration.LibraryElementDataType: {"Folder A"},
+				cloudmigration.AlertRuleType:          {"Folder B"},
 			},
 		},
 	}
@@ -727,7 +733,7 @@ func TestGetParentNames(t *testing.T) {
 	for _, tc := range testcases {
 		s.folderService = &foldertest.FakeService{ExpectedFolders: tc.fakeFolders}
 
-		dataUIDsToParentNamesByType, err := s.getParentNames(ctx, user, tc.dashboards, tc.folders, tc.libraryElements)
+		dataUIDsToParentNamesByType, err := s.getParentNames(ctx, user, tc.dashboards, tc.folders, tc.libraryElements, tc.alertRules)
 		require.NoError(t, err)
 
 		for dataType, expectedParentNames := range tc.expectedParentNames {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -195,7 +195,7 @@ func (s *Service) getMigrationDataJSON(ctx context.Context, signedInUser *user.S
 	}
 
 	// Obtain the names of parent elements for Dashboard and Folders data types
-	parentNamesByType, err := s.getParentNames(ctx, signedInUser, dashs, folders, libraryElements)
+	parentNamesByType, err := s.getParentNames(ctx, signedInUser, dashs, folders, libraryElements, alertRules)
 	if err != nil {
 		s.log.Error("Failed to get parent folder names", "err", err)
 	}
@@ -662,7 +662,14 @@ func (s *Service) getFolderNamesForFolderUIDs(ctx context.Context, signedInUser 
 
 // getParentNames finds the parent names for resources and returns a map of data type: {data UID : parentName}
 // for dashboards, folders and library elements - the parent is the parent folder
-func (s *Service) getParentNames(ctx context.Context, signedInUser *user.SignedInUser, dashboards []dashboards.Dashboard, folders []folder.CreateFolderCommand, libraryElements []libraryElement) (map[cloudmigration.MigrateDataType]map[string](string), error) {
+func (s *Service) getParentNames(
+	ctx context.Context,
+	signedInUser *user.SignedInUser,
+	dashboards []dashboards.Dashboard,
+	folders []folder.CreateFolderCommand,
+	libraryElements []libraryElement,
+	alertRules []alertRule,
+) (map[cloudmigration.MigrateDataType]map[string](string), error) {
 	parentNamesByType := make(map[cloudmigration.MigrateDataType]map[string]string)
 	for _, dataType := range currentMigrationTypes {
 		parentNamesByType[dataType] = make(map[string]string)
@@ -682,6 +689,11 @@ func (s *Service) getParentNames(ctx context.Context, signedInUser *user.SignedI
 	for _, libraryElement := range libraryElements {
 		if libraryElement.FolderUID != nil {
 			parentFolderUIDsSet[*libraryElement.FolderUID] = struct{}{}
+		}
+	}
+	for _, alertRule := range alertRules {
+		if alertRule.FolderUID != "" {
+			parentFolderUIDsSet[alertRule.FolderUID] = struct{}{}
 		}
 	}
 	parentFolderUIDsSlice := make([]string, 0, len(parentFolderUIDsSet))
@@ -706,6 +718,11 @@ func (s *Service) getParentNames(ctx context.Context, signedInUser *user.SignedI
 	for _, libraryElement := range libraryElements {
 		if libraryElement.FolderUID != nil {
 			parentNamesByType[cloudmigration.LibraryElementDataType][libraryElement.UID] = foldersUIDsToFolderName[*libraryElement.FolderUID]
+		}
+	}
+	for _, alertRule := range alertRules {
+		if alertRule.FolderUID != "" {
+			parentNamesByType[cloudmigration.AlertRuleType][alertRule.UID] = foldersUIDsToFolderName[alertRule.FolderUID]
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

Adds parent folder name to Alert Rules in the migration assistant's resource list.

![Screenshot 2024-11-13 at 10 07 56](https://github.com/user-attachments/assets/504cb0d8-7f71-4770-9367-881c3966ab39)


**Why do we need this feature?**

Clearer visualization of where an Alert Rule is stored.

**Who is this feature for?**

Migration Assistant users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
