### PR TITLE
[Cloud Migrations] Fix panic in unit tests

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -83,8 +83,8 @@ func Test_CreateGetAndDeleteToken(t *testing.T) {
 func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	s := setUpServiceTest(t, false).(*Service)
 
-	gmsClientMock := &gmsClientMock{}
-	s.gmsClient = gmsClientMock
+	gmsClientFake := &gmsClientMock{}
+	s.gmsClient = gmsClientFake
 
 	// Insert a session and snapshot into the database before we start
 	createTokenResp, err := s.CreateToken(context.Background())
@@ -112,7 +112,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, cloudmigration.SnapshotStatusCreating, snapshot.Status)
-	assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 0 }, time.Second, 10*time.Millisecond)
+	assert.Never(t, func() bool { return gmsClientFake.GetSnapshotStatusCallCount() > 0 }, time.Second, 10*time.Millisecond)
 
 	// Make the status pending processing and ensure GMS gets called
 	err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
@@ -123,11 +123,12 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	assert.NoError(t, err)
 
 	cleanupFunc := func() {
-		gmsClientMock.getStatusCalled = 0
 		if s.cancelFunc != nil {
 			s.cancelFunc()
 		}
-		gmsClientMock.getSnapshotResponse = nil
+
+		gmsClientFake = &gmsClientMock{}
+		s.gmsClient = gmsClientFake
 
 		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
 			UID:       uid,
@@ -152,7 +153,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	}
 
 	t.Run("test case: gms snapshot initialized", func(t *testing.T) {
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateInitialized,
 		}
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -161,12 +162,12 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusPendingProcessing), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
+		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
 
 	t.Run("test case: gms snapshot processing", func(t *testing.T) {
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateProcessing,
 		}
 		_, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -175,12 +176,12 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
+		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
 		t.Cleanup(cleanupFunc)
 	})
 
 	t.Run("test case: gms snapshot finished", func(t *testing.T) {
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateFinished,
 		}
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -189,13 +190,13 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
+		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
 	})
 
 	t.Run("test case: gms snapshot canceled", func(t *testing.T) {
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateCanceled,
 		}
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -204,13 +205,13 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusCanceled), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
+		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
 	})
 
 	t.Run("test case: gms snapshot error", func(t *testing.T) {
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateError,
 		}
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -219,13 +220,13 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		require.Eventually(t, checkStatusSync(cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientMock.GetSnapshotStatusCallCount())
+		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
 
 		t.Cleanup(cleanupFunc)
 	})
 
 	t.Run("test case: gms snapshot unknown", func(t *testing.T) {
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateUnknown,
 		}
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
@@ -235,7 +236,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		assert.NoError(t, err)
 		// snapshot status should remain unchanged
 
-		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return gmsClientFake.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
@@ -249,7 +250,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 	t.Run("GMS results applied to local snapshot", func(t *testing.T) {
 		t.Skip("This test is flaky and needs to be fixed")
 
-		gmsClientMock.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
+		gmsClientFake.getSnapshotResponse = &cloudmigration.GetSnapshotStatusResponse{
 			State: cloudmigration.SnapshotStateFinished,
 			Results: []cloudmigration.CloudMigrationResource{
 				{
@@ -268,7 +269,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { return gmsClientFake.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 
 		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -2,6 +2,7 @@ package cloudmigrationimpl
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"os"
 	"path/filepath"
@@ -123,10 +124,10 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 
 	cleanupFunc := func() {
 		gmsClientMock.getStatusCalled = 0
-		gmsClientMock.getSnapshotResponse = nil
 		if s.cancelFunc != nil {
 			s.cancelFunc()
 		}
+		gmsClientMock.getSnapshotResponse = nil
 
 		err = s.store.UpdateSnapshot(context.Background(), cloudmigration.UpdateSnapshotCmd{
 			UID:       uid,
@@ -941,6 +942,9 @@ func (m *gmsClientMock) GetSnapshotStatus(_ context.Context, _ cloudmigration.Cl
 	m.mu.Lock()
 	m.getStatusCalled++
 	m.mu.Unlock()
+	if m.getSnapshotResponse == nil {
+		return nil, errors.New("no response set")
+	}
 
 	return m.getSnapshotResponse, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes a panic that occurs when the go routine calls GetSnapshot after the tests has ended and the response object is set to nil.

**Why do we need this feature?**

CI is breaking.

**Who is this feature for?**

Maintainers :)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/grafana-operator-experience-squad/issues/1108

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
