### PR TITLE
[v11.3.x] Fix dashboards listing table appearing distorted

### DIFF
--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -114,7 +114,7 @@ export function PluginDetailsBody({ plugin, queryParams, pageId }: Props): JSX.E
 
   if (pageId === PluginTabIds.USAGE && pluginConfig) {
     return (
-      <div>
+      <div className={styles.wrap}>
         <PluginUsage plugin={pluginConfig?.meta} />
       </div>
     );
@@ -136,6 +136,10 @@ export function PluginDetailsBody({ plugin, queryParams, pageId }: Props): JSX.E
 }
 
 export const getStyles = (theme: GrafanaTheme2) => ({
+  wrap: css({
+    width: '100%',
+    height: '50vh',
+  }),
   readme: css({
     '& img': {
       maxWidth: '100%',

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -115,6 +115,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     // Needed due to block formatting context
     tabContent: css({
       paddingLeft: '5px',
+      width: '100%',
     }),
   };
 };

--- a/public/app/features/plugins/admin/components/PluginUsage.tsx
+++ b/public/app/features/plugins/admin/components/PluginUsage.tsx
@@ -88,7 +88,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrap: css`
       width: 100%;
-      height: 100%;
+      height: 90%;
     `,
     info: css`
       padding-bottom: 30px;


### PR DESCRIPTION
Backport 19c04168c34d9ace5fcba9a1ea43cac6de13c173 from #96371

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a bug where the listing in plugin admin - usage page is too small to view anything in there.

![Screenshot 2024-11-13 at 11 53 12](https://github.com/user-attachments/assets/c9d1f3d7-6784-4e26-b868-c2e25b77bfac)


**Why do we need this feature?**

Fixes the bug

**Who is this feature for?**

Everyone

**Special notes for your reviewer:**

Tested with ff `pluginsDetailsRightPanel`, seems to work fine
![Screenshot 2024-11-13 at 15 08 18](https://github.com/user-attachments/assets/1a922a69-6baa-4f7c-b74e-58469853db84)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
