### PR TITLE
Preinstall: Allow to extend default list

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1756,7 +1756,8 @@ hide_angular_deprecation =
 # Comma separated list of plugin ids for which environment variables should be forwarded. Used only when feature flag pluginsSkipHostEnvVars is enabled.
 forward_host_env_vars =
 # Comma separated list of plugin ids to install as part of the startup process.
-preinstall = grafana-lokiexplore-app
+# By default, the following plugins will be preinstalled: "grafana-lokiexplore-app"
+preinstall =
 # Controls whether preinstall plugins asynchronously (in the background) or synchronously (blocking). Useful when preinstalled plugins are used with provisioning.
 preinstall_async = true
 # Disables preinstall feature. It has the same effect as setting preinstall to an empty list.

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -26,6 +26,13 @@ func extractPluginSettings(sections []*ini.Section) PluginSettings {
 	return psMap
 }
 
+var (
+	defaultPreinstallPlugins = map[string]InstallPlugin{
+		// Default preinstalled plugins
+		"grafana-lokiexplore-app": {"grafana-lokiexplore-app", ""},
+	}
+)
+
 func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	pluginsSection := iniFile.Section("plugins")
 
@@ -42,15 +49,22 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	disablePreinstall := pluginsSection.Key("preinstall_disabled").MustBool(false)
 	if !disablePreinstall {
 		rawInstallPlugins := util.SplitString(pluginsSection.Key("preinstall").MustString(""))
-		cfg.PreinstallPlugins = make([]InstallPlugin, len(rawInstallPlugins))
-		for i, plugin := range rawInstallPlugins {
+		preinstallPlugins := defaultPreinstallPlugins
+		for _, plugin := range rawInstallPlugins {
 			parts := strings.Split(plugin, "@")
 			id := parts[0]
 			v := ""
 			if len(parts) == 2 {
 				v = parts[1]
 			}
-			cfg.PreinstallPlugins[i] = InstallPlugin{id, v}
+			preinstallPlugins[id] = InstallPlugin{id, v}
+		}
+		// Remove from the list the plugins that have been disabled
+		for _, disabledPlugin := range cfg.DisablePlugins {
+			delete(preinstallPlugins, disabledPlugin)
+		}
+		for _, plugin := range preinstallPlugins {
+			cfg.PreinstallPlugins = append(cfg.PreinstallPlugins, plugin)
 		}
 		cfg.PreinstallPluginsAsync = pluginsSection.Key("preinstall_async").MustBool(true)
 	}

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -49,7 +49,12 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 	disablePreinstall := pluginsSection.Key("preinstall_disabled").MustBool(false)
 	if !disablePreinstall {
 		rawInstallPlugins := util.SplitString(pluginsSection.Key("preinstall").MustString(""))
-		preinstallPlugins := defaultPreinstallPlugins
+		preinstallPlugins := make(map[string]InstallPlugin)
+		// Add the default preinstalled plugins
+		for _, plugin := range defaultPreinstallPlugins {
+			preinstallPlugins[plugin.ID] = plugin
+		}
+		// Add the plugins defined in the configuration
 		for _, plugin := range rawInstallPlugins {
 			parts := strings.Split(plugin, "@")
 			id := parts[0]

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -99,8 +99,10 @@ func Test_readPluginSettings(t *testing.T) {
 
 	t.Run("when plugins.preinstall is defined", func(t *testing.T) {
 		defaultPreinstallPluginsList := make([]InstallPlugin, 0, len(defaultPreinstallPlugins))
+		defaultPreinstallPluginsIDs := []string{}
 		for _, p := range defaultPreinstallPlugins {
 			defaultPreinstallPluginsList = append(defaultPreinstallPluginsList, p)
+			defaultPreinstallPluginsIDs = append(defaultPreinstallPluginsIDs, p.ID)
 		}
 		tests := []struct {
 			name              string
@@ -130,6 +132,12 @@ func Test_readPluginSettings(t *testing.T) {
 				rawInput:       "plugin1",
 				disablePlugins: "plugin1",
 				expected:       defaultPreinstallPluginsList,
+			},
+			{
+				name:           "it should remove default plugins",
+				rawInput:       "",
+				disablePlugins: strings.Join(defaultPreinstallPluginsIDs, ","),
+				expected:       nil,
 			},
 			{
 				name:              "should ignore input when preinstall is disabled",

--- a/pkg/setting/setting_plugins_test.go
+++ b/pkg/setting/setting_plugins_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,6 +93,83 @@ func Test_readPluginSettings(t *testing.T) {
 				require.Equal(t, []string{"plugin1", "plugin2"}, cfg.DisablePlugins)
 				require.Equal(t, []string{"plugin3", "plugin1", "plugin2"}, cfg.PluginCatalogHiddenPlugins)
 				require.Equal(t, []string{"a", "b", "c"}, cfg.HideAngularDeprecation)
+			})
+		}
+	})
+
+	t.Run("when plugins.preinstall is defined", func(t *testing.T) {
+		defaultPreinstallPluginsList := make([]InstallPlugin, 0, len(defaultPreinstallPlugins))
+		for _, p := range defaultPreinstallPlugins {
+			defaultPreinstallPluginsList = append(defaultPreinstallPluginsList, p)
+		}
+		tests := []struct {
+			name              string
+			rawInput          string
+			disablePreinstall bool
+			expected          []InstallPlugin
+			disableAsync      bool
+			disablePlugins    string
+		}{
+			{
+				name:     "should add the default preinstalled plugin",
+				rawInput: "",
+				expected: defaultPreinstallPluginsList,
+			},
+			{
+				name:     "should add the default preinstalled plugin and the one defined",
+				rawInput: "plugin1",
+				expected: append(defaultPreinstallPluginsList, InstallPlugin{"plugin1", ""}),
+			},
+			{
+				name:     "should add the default preinstalled plugin and the one defined with version",
+				rawInput: "plugin1@1.0.0",
+				expected: append(defaultPreinstallPluginsList, InstallPlugin{"plugin1", "1.0.0"}),
+			},
+			{
+				name:           "it should remove the disabled plugin",
+				rawInput:       "plugin1",
+				disablePlugins: "plugin1",
+				expected:       defaultPreinstallPluginsList,
+			},
+			{
+				name:              "should ignore input when preinstall is disabled",
+				rawInput:          "plugin1",
+				disablePreinstall: true,
+				expected:          nil,
+			},
+			{
+				name:         "should mark preinstall as sync",
+				rawInput:     "plugin1",
+				disableAsync: true,
+				expected:     append(defaultPreinstallPluginsList, InstallPlugin{"plugin1", ""}),
+			},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := NewCfg()
+				sec, err := cfg.Raw.NewSection("plugins")
+				require.NoError(t, err)
+				_, err = sec.NewKey("preinstall", tc.rawInput)
+				require.NoError(t, err)
+				if tc.disablePreinstall {
+					_, err = sec.NewKey("preinstall_disabled", "true")
+					require.NoError(t, err)
+				}
+				if tc.disableAsync {
+					_, err = sec.NewKey("preinstall_async", "false")
+					require.NoError(t, err)
+				}
+				if tc.disablePlugins != "" {
+					_, err = sec.NewKey("disable_plugins", tc.disablePlugins)
+					require.NoError(t, err)
+				}
+
+				err = cfg.readPluginSettings(cfg.Raw)
+				require.NoError(t, err)
+				assert.ElementsMatch(t, cfg.PreinstallPlugins, tc.expected)
+				if tc.disableAsync {
+					require.Equal(t, cfg.PreinstallPluginsAsync, false)
+				}
 			})
 		}
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR allows for people to start using the `preinstall` configuration without the risk of missing on new preinstalled plugins suggested by Grafana by default.

Before this change, if someone modifies the `preinstall` list (e.g. `grafana-lokiexplore-app, myorg-myplugin-datasource`), they will never get new plugins because the default list is no longer in use.

To avoid this, the list of Grafana plugin suggested to be preinstalled is now hardcoded in `setting_plugins.go`. This list is then merged with whatever the user set up. Note that it's still possible to opt-out from a plugin install by either setting `preinstall_disabled = true` (this will disable all plugins) or by setting `disable_plugins = <plugin_id>`.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Cont: https://github.com/grafana/grafana-community-team/issues/251

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
