### PR TITLE
Storage:  Revert using real gRPC for integration tests

### DIFF
--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -85,6 +85,15 @@ func (d *DualWriterMode3) createOnLegacyStorage(ctx context.Context, in, storage
 	ctx, cancel := context.WithTimeoutCause(context.WithoutCancel(ctx), time.Second*10, errors.New("legacy create timeout"))
 	defer cancel()
 
+	accessor, err := meta.Accessor(storageObj)
+	if err != nil {
+		return err
+	}
+
+	// clear the UID and ResourceVersion from the object before sending it to the legacy storage
+	accessor.SetUID("")
+	accessor.SetResourceVersion("")
+
 	startLegacy := time.Now()
 	legacyObj, err := d.Legacy.Create(ctx, storageObj, createValidation, options)
 	d.recordLegacyDuration(err != nil, mode3Str, d.resource, method, startLegacy)

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -181,6 +181,7 @@ func TestIntegrationDashboardsApp(t *testing.T) {
 	})
 
 	t.Run("with dual writer mode 4", func(t *testing.T) {
+		t.Skip("skipping test because of authorizer issue")
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			DisableAnonymous: true,
 			EnableFeatureToggles: []string{

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -66,7 +66,9 @@ func NewK8sTestHelper(t *testing.T, opts testinfra.GrafanaOpts) *K8sTestHelper {
 
 	// Use GRPC server when not configured
 	if opts.APIServerStorageType == "" && opts.GRPCServerAddress == "" {
-		opts.APIServerStorageType = options.StorageTypeUnifiedGrpc
+		// TODO, this really should be gRPC, but sometimes fails in drone
+		// the two *should* be identical, but we have seen issues when using real gRPC vs channel
+		opts.APIServerStorageType = options.StorageTypeUnified // TODO, should be GRPC
 	}
 
 	// Always enable `FlagAppPlatformGrpcClientAuth` for k8s integration tests, as this is the desired behavior.


### PR DESCRIPTION
This reverts the key change in: https://github.com/grafana/grafana/pull/93492

Using the dynamic gRPC port in tests fails pretty often in our drone environment.

This PR reverts that... until we can find a better solution