### PR TITLE
CloudMonitoring: Improve metric handling for `DISTRIBUTION` value types

### DIFF
--- a/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
@@ -75,7 +75,7 @@ In the case that the metric value type is a distribution, the aggregation will b
 The various metrics are documented [here](https://cloud.google.com/monitoring/api/metrics_gcp) and further details on the kinds and types of metrics can be found [here](https://cloud.google.com/monitoring/api/v3/kinds-and-types).
 
 {{% admonition type="note" %}}
-Distribution metrics are typically best visualized as either a heatmap or histogram. When visualizing in this fashion an aggregatino is not necessary. However, for other visualization types, performance degradation may be observed when attempting to query distribution metrics that are not aggregated due to the number of potential buckets that can be returned. For more information on how to visualize distribution metrics refer to [this](https://cloud.google.com/monitoring/charts/charting-distribution-metrics) documentation.
+Distribution metrics are typically best visualized as either a heatmap or histogram. When visualizing in this way, aggregation is not necessary. However, for other visualization types, performance degradation may be observed when attempting to query distribution metrics that are not aggregated due to the number of potential buckets that can be returned. For more information on how to visualize distribution metrics refer to [this page](https://cloud.google.com/monitoring/charts/charting-distribution-metrics).
 {{% /admonition %}}
 
 

--- a/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
@@ -66,8 +66,18 @@ The metrics query editor helps you select metrics, group and aggregate by labels
 1. _(Optional)_ Use the plus and minus icons in the filter and group-by sections to add and remove filters or group-by clauses.
 
 Google Cloud Monitoring supports several metrics types, such as `GAUGE`, `DELTA,` and `CUMULATIVE`.
-Each supports different aggregation options, such as reducers and aligners.
-The metrics query editor lists available aggregation methods for a selected metric, and sets a default reducer and aligner when you select a metric.
+Each supports different aggregation options, such as reducers and aligners. Additionally, metrics have specific value types that can be either scalar or a distribution.
+
+The metrics query editor lists available aggregation methods for a selected metric, and sets a default aggregation, reducer and aligner when you select a metric.
+
+In the case that the metric value type is a distribution, the aggregation will be set by default to the mean. For scalar value types, there is no aggregation by default.
+
+The various metrics are documented [here](https://cloud.google.com/monitoring/api/metrics_gcp) and further details on the kinds and types of metrics can be found [here](https://cloud.google.com/monitoring/api/v3/kinds-and-types).
+
+{{% admonition type="note" %}}
+Distribution metrics are typically best visualized as either a heatmap or histogram. When visualizing in this fashion an aggregatino is not necessary. However, for other visualization types, performance degradation may be observed when attempting to query distribution metrics that are not aggregated due to the number of potential buckets that can be returned. For more information on how to visualize distribution metrics refer to [this](https://cloud.google.com/monitoring/charts/charting-distribution-metrics) documentation.
+{{% /admonition %}}
+
 
 ### Apply a filter
 

--- a/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/query-editor/index.md
@@ -78,7 +78,6 @@ The various metrics are documented [here](https://cloud.google.com/monitoring/ap
 Distribution metrics are typically best visualized as either a heatmap or histogram. When visualizing in this fashion an aggregatino is not necessary. However, for other visualization types, performance degradation may be observed when attempting to query distribution metrics that are not aggregated due to the number of potential buckets that can be returned. For more information on how to visualize distribution metrics refer to [this](https://cloud.google.com/monitoring/charts/charting-distribution-metrics) documentation.
 {{% /admonition %}}
 
-
 ### Apply a filter
 
 **To add and apply a filter:**

--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
@@ -22,7 +22,13 @@ export const Aggregation = (props: Props) => {
   const selected = useSelectedFromOptions(aggOptions, props);
 
   return (
-    <EditorField label="Group by function" data-testid="cloud-monitoring-aggregation">
+    <EditorField
+      label="Group by function"
+      data-testid="cloud-monitoring-aggregation"
+      tooltip={
+        'Aggregation function used on the metric data. Defaults to none for scalar data and mean for distribution data. Not applying an aggregation to distribution data may lead to performance issues.'
+      }
+    >
       <Select
         width="auto"
         onChange={({ value }) => props.onChange(value!)}

--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
@@ -209,6 +209,11 @@ export function Editor({
     // On metric name change reset query to defaults except project name and filters
     Object.assign(query, {
       ...defaultTimeSeriesList(datasource),
+      // If the metric value type is DISTRIBUTION use REDUCE_MEAN in order to avoid
+      // returning data frames with a large number of frames (as we return a frame per bucket).
+      // DISTRIBUTION metrics only typically make sense with an aggregation performed against them or
+      // when filtered to a specific label value.
+      crossSeriesReducer: valueType === ValueTypes.DISTRIBUTION ? 'REDUCE_MEAN' : 'REDUCE_NONE',
       projectName: query.projectName,
       filters: query.filters,
     });

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -106,7 +106,8 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
             {
               projectName: this.templateSrv.replace(projectName),
               groupBys: this.interpolateGroupBys(aggregation?.groupBys || [], {}),
-              crossSeriesReducer: aggregation?.crossSeriesReducer ?? 'REDUCE_NONE',
+              // Use REDUCE_NONE to retrieve all available labels for the metric
+              crossSeriesReducer: 'REDUCE_NONE',
               view: 'HEADERS',
             },
             this.templateSrv.replace(metricType)


### PR DESCRIPTION
Cloud Monitoring metrics can be of various value types and kinds (see documentation [here](https://cloud.google.com/monitoring/api/v3/kinds-and-types)) for details.

Prior to the logic change here, metric queries did not include any aggregations by default. In the case of the distribution type, this does not make sense and can lead to browser crashes as a frame will be returned per bucket per series, leading to a substantial number of frames.

This change means that any distribution metric will be aggregated by default using the mean of the distribution values. Aggregating the data into a single frame removes the risk of browser crashes.

Additionally, to ensure users can appropriately query, the labels retrieval functionality will now return all labels for a metric pre-aggregation.

To test this:

- Navigate to the Partner Data Sources Grafana instance.
- Navigate to Explore
- Set the data source to a Google Cloud Monitoring data source
- Set the time period to `Last 24 hours`
- Set the service value to `Loadbalancing`

Note that running this query takes some time, the panel also struggles to load, and a large number of series' are returned.

Run the above steps once you've built this PR locally (or via ephemeral instances). You will see that the query is substantially faster and returns only a single aggregated series that is far easier to interpret.

Fixes #90986 