### PR TITLE
Dashboard: Fix dashboard reload behavior

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -218,7 +218,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
     };
 
     // We shouldn't check all params since:
-    // - version doesn't impact the new dashboard and it's there for increased compatibility
+    // - version doesn't impact the new dashboard, and it's there for increased compatibility
     // - time range is almost always different for relative time ranges and absolute time ranges do not trigger subsequent reloads
     // - other params don't affect the dashboard content
     if (

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -234,20 +234,6 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
       const rsp = await this.fetchDashboard(options);
       const fromCache = this.getSceneFromCache(options.uid);
 
-      // This is here for testing purposes and should be removed before merging
-      // if (rsp?.dashboard && params?.variables) {
-      //   rsp.dashboard.version =
-      //     params.variables['var-custom1'] === '1' && params.variables['var-custom2'] === 'a'
-      //       ? 3
-      //       : params.variables['var-custom1'] === '2' && params.variables['var-custom2'] === 'a'
-      //         ? 4
-      //         : params.variables['var-custom1'] === '1' && params.variables['var-custom2'] === 'b'
-      //           ? 5
-      //           : params.variables['var-custom1'] === '2' && params.variables['var-custom2'] === 'b'
-      //             ? 6
-      //             : 3;
-      // }
-
       if (fromCache && fromCache.state.version === rsp?.dashboard.version) {
         this.setState({ isLoading: false });
         return;
@@ -256,49 +242,6 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
       if (!rsp?.dashboard) {
         this.setState({ isLoading: false, loadError: 'Dashboard not found' });
         return;
-      }
-
-      // This is here for testing purposes and should be removed before merging
-      // This emulates the passed variables being set as the current value of a variable
-      if (rsp.dashboard.templating?.list && options.params?.variables) {
-        const vars = Object.entries(options.params.variables).reduce<Record<string, string | string[]>>(
-          (acc, [key, value]) => {
-            const actualKey = key.replace('var-', '');
-            const actualValue = Array.isArray(value)
-              ? value.map((v) => {
-                  switch (typeof v) {
-                    case 'number':
-                      return String(v);
-                    case 'string':
-                      return v;
-                    case 'boolean':
-                      return v ? 'true' : 'false';
-                  }
-                })
-              : String(value);
-
-            acc[actualKey] = acc[actualKey]
-              ? Array.isArray(acc[actualKey])
-                ? [...acc[actualKey], ...(Array.isArray(actualValue) ? actualValue : [actualValue])]
-                : [acc[actualKey], ...(Array.isArray(actualValue) ? actualValue : [actualValue])]
-              : actualValue;
-
-            return acc;
-          },
-          {}
-        );
-
-        rsp.dashboard.templating.list = rsp.dashboard.templating.list.map((variable) => {
-          if (variable.name in vars && vars[variable.name] && !isEqual(variable.current?.value, vars[variable.name])) {
-            const opt = variable.options?.find((option) => isEqual(option.value, vars[variable.name]));
-
-            variable.current = opt
-              ? { value: opt.value, text: opt.text }
-              : { value: vars[variable.name], text: vars[variable.name] };
-          }
-
-          return variable;
-        });
       }
 
       const scene = transformSaveModelToScene(rsp);

--- a/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
@@ -14,9 +14,6 @@ export interface DashboardReloadBehaviorState extends SceneObjectState {
 
 export class DashboardReloadBehavior extends SceneObjectBase<DashboardReloadBehaviorState> {
   constructor(state: DashboardReloadBehaviorState) {
-    // This is here for testing purposes and should be removed before merging
-    // state.reloadOnParamsChange = true;
-
     const shouldReload = state.reloadOnParamsChange && state.uid;
 
     super(state);

--- a/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
@@ -1,8 +1,8 @@
-import { isEqual } from 'lodash';
+import { debounce, isEqual } from 'lodash';
 
 import { UrlQueryMap } from '@grafana/data';
 import { sceneGraph, SceneObjectBase, SceneObjectState, VariableDependencyConfig } from '@grafana/scenes';
-import { getClosestScopesFacade, ScopesFacade } from 'app/features/scopes';
+import { getClosestScopesFacade } from 'app/features/scopes';
 
 import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
 
@@ -13,25 +13,26 @@ export interface DashboardReloadBehaviorState extends SceneObjectState {
 }
 
 export class DashboardReloadBehavior extends SceneObjectBase<DashboardReloadBehaviorState> {
-  private _scopesFacade: ScopesFacade | null = null;
-
   constructor(state: DashboardReloadBehaviorState) {
+    // This is here for testing purposes and should be removed before merging
+    state.reloadOnParamsChange = true;
+
     const shouldReload = state.reloadOnParamsChange && state.uid;
 
     super(state);
 
-    this.reloadDashboard = this.reloadDashboard.bind(this);
+    // Sometimes the reload is triggered multiple subsequent times
+    // Debouncing it prevents double/triple reloads
+    this.reloadDashboard = debounce(this.reloadDashboard).bind(this);
 
     if (shouldReload) {
       this.addActivationHandler(() => {
-        this._scopesFacade = getClosestScopesFacade(this);
+        getClosestScopesFacade(this)?.setState({
+          handler: this.reloadDashboard,
+        });
 
         this._variableDependency = new VariableDependencyConfig(this, {
           onAnyVariableChanged: this.reloadDashboard,
-        });
-
-        this._scopesFacade?.setState({
-          handler: this.reloadDashboard,
         });
 
         this._subs.add(
@@ -41,6 +42,8 @@ export class DashboardReloadBehavior extends SceneObjectBase<DashboardReloadBeha
             }
           })
         );
+
+        this.reloadDashboard();
       });
     }
   }
@@ -59,21 +62,25 @@ export class DashboardReloadBehavior extends SceneObjectBase<DashboardReloadBeha
     if (!this.isEditing() && !this.isWaitingForVariables()) {
       const timeRange = sceneGraph.getTimeRange(this);
 
-      let params: UrlQueryMap = {
-        version: this.state.version,
-        scopes: this._scopesFacade?.value.map((scope) => scope.metadata.name),
-        ...timeRange.urlSync?.getUrlState(),
-      };
-
-      params = sceneGraph.getVariables(this).state.variables.reduce<UrlQueryMap>(
-        (acc, variable) => ({
-          ...acc,
-          ...variable.urlSync?.getUrlState(),
-        }),
-        params
-      );
-
-      getDashboardScenePageStateManager().reloadDashboard(params);
+      // This is wrapped in setTimeout in order to allow variables and scopes to be set in the URL before actually reloading the dashboard
+      setTimeout(() => {
+        getDashboardScenePageStateManager().reloadDashboard({
+          version: this.state.version!,
+          scopes: getClosestScopesFacade(this)?.value.map((scope) => scope.metadata.name) ?? [],
+          // We're not using the getUrlState from timeRange since it makes more sense to pass the absolute timestamps as opposed to relative time
+          timeRange: {
+            from: timeRange.state.value.from.toISOString(),
+            to: timeRange.state.value.to.toISOString(),
+          },
+          variables: sceneGraph.getVariables(this).state.variables.reduce<UrlQueryMap>(
+            (acc, variable) => ({
+              ...acc,
+              ...variable.urlSync?.getUrlState(),
+            }),
+            {}
+          ),
+        });
+      });
     }
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
@@ -15,7 +15,7 @@ export interface DashboardReloadBehaviorState extends SceneObjectState {
 export class DashboardReloadBehavior extends SceneObjectBase<DashboardReloadBehaviorState> {
   constructor(state: DashboardReloadBehaviorState) {
     // This is here for testing purposes and should be removed before merging
-    state.reloadOnParamsChange = true;
+    // state.reloadOnParamsChange = true;
 
     const shouldReload = state.reloadOnParamsChange && state.uid;
 


### PR DESCRIPTION
**What is this feature?**

This PR brings multiple fixes for the dashboard reload behavior:
- allows scopes to be set in the URL when the dashboard is reloaded due to scope change
- prevents subsequent reloads in some edge cases (i.e. setting multiple variables in a cascading manner)
- always pass absolute time range as opposed to relative time range

I also took time to test a behavior: when reloading a dashboard due to a variable change, the new value should be passed in the `current` property of variable in the dashboard JSON. Without this, we would end up in a endless loop given that the scene is loaded with the `current` as the default value and then switches to the new value due to URL sync.

**Why do we need this feature?**

The description above is pretty self explanatory.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

I left some code in the PR that allows you to test the PR properly. This code should be removed before merging.

Please note that you need a dashboard with two custom variables: `custom1` (with values `1` and `2`) and `custom2` (with values `3` and `4`).

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
