### PR TITLE
MySQL: Fix tls skip verify option

### DIFF
--- a/pkg/tsdb/mysql/mysql.go
+++ b/pkg/tsdb/mysql/mysql.go
@@ -123,6 +123,8 @@ func NewInstanceSettings(logger log.Logger) datasource.InstanceFactoryFunc {
 				return nil, err
 			}
 			cnnstr += "&tls=" + tlsConfigString
+		} else if tlsConfig.InsecureSkipVerify {
+			cnnstr += "&tls=skip-verify"
 		}
 
 		if dsInfo.JsonData.Timezone != "" {


### PR DESCRIPTION
**What is this feature?**

This PR fixes a bug that prevented the TLS Skip Verification option working without actually providing a certificate. This is part of https://github.com/grafana/grafana/issues/76375

To try it out:

1. Change the `command` property in `devenv/docker/blocks/mysql/docker-compose.yaml` to `command: [mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb_monitor_enable=all, --require_secure_transport=ON]`
2. Run `make devenv sources=mysql`
3. Run grafana
4. Create a new mysql data source with the credentials in the docker file
5. Test it with skip tls enabled and disabled


Fixes #63429
