### PR TITLE
RBAC: Remove folder name scope resolver

### DIFF
--- a/pkg/services/dashboards/accesscontrol_test.go
+++ b/pkg/services/dashboards/accesscontrol_test.go
@@ -2,104 +2,16 @@ package dashboards
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
-	"github.com/grafana/grafana/pkg/util"
 )
-
-func TestNewFolderNameScopeResolver(t *testing.T) {
-	t.Run("prefix should be expected", func(t *testing.T) {
-		prefix, _ := NewFolderNameScopeResolver(foldertest.NewFakeFolderStore(t), folder.NewFakeStore())
-		require.Equal(t, "folders:name:", prefix)
-	})
-
-	t.Run("resolver should convert to uid scope", func(t *testing.T) {
-		orgId := rand.Int63()
-		title := "Very complex :title with: and /" + util.GenerateShortUID()
-		db := &folder.Folder{Title: title, UID: util.GenerateShortUID()}
-		folderStore := foldertest.NewFakeFolderStore(t)
-		folderStore.On("GetFolderByTitle", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(db, nil).Once()
-
-		scope := "folders:name:" + title
-
-		_, resolver := NewFolderNameScopeResolver(folderStore, folder.NewFakeStore())
-		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
-		require.NoError(t, err)
-		require.Len(t, resolvedScopes, 1)
-		require.Equal(t, fmt.Sprintf("folders:uid:%v", db.UID), resolvedScopes[0])
-		folderStore.AssertCalled(t, "GetFolderByTitle", mock.Anything, orgId, title, mock.Anything)
-	})
-	t.Run("resolver should include inherited scopes if any", func(t *testing.T) {
-		orgId := rand.Int63()
-		title := "Very complex :title with: and /" + util.GenerateShortUID()
-
-		db := &folder.Folder{Title: title, UID: util.GenerateShortUID()}
-
-		folderStore := foldertest.NewFakeFolderStore(t)
-		folderStore.On("GetFolderByTitle", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(db, nil).Once()
-
-		scope := "folders:name:" + title
-
-		fStore := folder.NewFakeStore()
-		fStore.ExpectedParentFolders = []*folder.Folder{
-			{
-				UID: "parent",
-			},
-			{
-				UID: "grandparent",
-			},
-		}
-		_, resolver := NewFolderNameScopeResolver(folderStore, fStore)
-
-		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
-		require.NoError(t, err)
-		require.Len(t, resolvedScopes, 3)
-
-		if diff := cmp.Diff([]string{
-			fmt.Sprintf("folders:uid:%v", db.UID),
-			"folders:uid:parent",
-			"folders:uid:grandparent",
-		}, resolvedScopes); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		folderStore.AssertCalled(t, "GetFolderByTitle", mock.Anything, orgId, title, mock.Anything)
-	})
-	t.Run("resolver should fail if input scope is not expected", func(t *testing.T) {
-		_, resolver := NewFolderNameScopeResolver(foldertest.NewFakeFolderStore(t), folder.NewFakeStore())
-
-		_, err := resolver.Resolve(context.Background(), rand.Int63(), "folders:id:123")
-		require.ErrorIs(t, err, ac.ErrInvalidScope)
-	})
-	t.Run("resolver should fail if resource of input scope is empty", func(t *testing.T) {
-		_, resolver := NewFolderNameScopeResolver(foldertest.NewFakeFolderStore(t), folder.NewFakeStore())
-
-		_, err := resolver.Resolve(context.Background(), rand.Int63(), "folders:name:")
-		require.ErrorIs(t, err, ac.ErrInvalidScope)
-	})
-	t.Run("returns 'not found' if folder does not exist", func(t *testing.T) {
-		folderStore := foldertest.NewFakeFolderStore(t)
-		_, resolver := NewFolderNameScopeResolver(folderStore, folder.NewFakeStore())
-
-		orgId := rand.Int63()
-		folderStore.On("GetFolderByTitle", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, ErrDashboardNotFound).Once()
-
-		scope := "folders:name:" + util.GenerateShortUID()
-
-		resolvedScopes, err := resolver.Resolve(context.Background(), orgId, scope)
-		require.ErrorIs(t, err, ErrDashboardNotFound)
-		require.Nil(t, resolvedScopes)
-	})
-}
 
 func TestNewFolderIDScopeResolver(t *testing.T) {
 	t.Run("prefix should be expected", func(t *testing.T) {

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -95,7 +95,6 @@ func ProvideService(
 
 	supportBundles.RegisterSupportItemCollector(srv.supportBundleCollector())
 
-	ac.RegisterScopeAttributeResolver(dashboards.NewFolderNameScopeResolver(folderStore, store))
 	ac.RegisterScopeAttributeResolver(dashboards.NewFolderIDScopeResolver(folderStore, store))
 	ac.RegisterScopeAttributeResolver(dashboards.NewFolderUIDScopeResolver(store))
 	return srv

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -68,7 +68,7 @@ func TestIntegrationProvideFolderService(t *testing.T) {
 		ProvideService(store, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), nil, nil, db,
 			featuremgmt.WithFeatures(), cfg, folderPermissions, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 
-		require.Len(t, ac.Calls.RegisterAttributeScopeResolver, 3)
+		require.Len(t, ac.Calls.RegisterAttributeScopeResolver, 2)
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Folder name scope resolver was introduced in https://github.com/grafana/grafana/pull/46380, but it doesn't look like it is used anywhere.

**Why do we need this feature?**

Cleaning up the code.