### PR TITLE
Codeowners: reflect changed ownership for explore squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -122,7 +122,7 @@
 /pkg/services/apikey/ @grafana/identity-squad
 /pkg/services/cleanup/ @grafana/grafana-backend-group
 /pkg/services/contexthandler/ @grafana/grafana-backend-group @grafana/grafana-app-platform-squad
-/pkg/services/correlations/ @grafana/explore-squad
+/pkg/services/correlations/ @grafana/dataviz-squad
 /pkg/services/dashboardimport/ @grafana/grafana-backend-group
 /pkg/services/dashboards/ @grafana/grafana-app-platform-squad
 /pkg/services/dashboardversion/ @grafana/grafana-backend-group
@@ -162,7 +162,7 @@
 /pkg/tests/apis/ @grafana/grafana-app-platform-squad
 /pkg/tests/apis/query @grafana/grafana-datasources-core-services
 /pkg/tests/apis/alerting @grafana/grafana-app-platform-squad @grafana/alerting-backend
-/pkg/tests/api/correlations/ @grafana/explore-squad
+/pkg/tests/api/correlations/ @grafana/dataviz-squad
 /pkg/tsdb/grafanads/ @grafana/grafana-backend-group
 /pkg/tsdb/opentsdb/ @grafana/partner-datasources
 /pkg/util/ @grafana/grafana-backend-group
@@ -432,7 +432,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/features/visualization/data-hover/ @grafana/dataviz-squad
 /public/app/features/commandPalette/ @grafana/grafana-frontend-platform
 /public/app/features/connections/ @grafana/plugins-platform-frontend
-/public/app/features/correlations/ @grafana/explore-squad
+/public/app/features/correlations/ @grafana/dataviz-squad
 /public/app/features/dashboard/ @grafana/dashboards-squad
 /public/app/features/dashboard/components/TransformationsEditor/ @grafana/dataviz-squad
 /public/app/features/dashboard-scene/ @grafana/dashboards-squad
@@ -456,7 +456,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/features/playlist/ @grafana/dashboards-squad
 /public/app/features/plugins/ @grafana/plugins-platform-frontend
 /public/app/features/profile/ @grafana/grafana-frontend-platform
-/public/app/features/query-library/ @grafana/explore-squad
+/public/app/features/query-library/ @grafana/grafana-frontend-platform
 /public/app/features/runtime/ @ryantxu
 /public/app/features/query/ @grafana/dashboards-squad
 /public/app/features/sandbox/ @grafana/grafana-frontend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@
 
 /docs/sources/alerting/                                                           @brendamuir
 /docs/sources/dashboards/                                                         @imatwawana
-/docs/sources/explore/                                                            @grafana/explore-squad @lwandz13
+/docs/sources/explore/                                                            @grafana/observability-traces-and-profiling @lwandz13
 /docs/sources/panels-visualizations/                                              @imatwawana
 /docs/sources/release-notes/                                                      @irenerl24 @GrafanaWriter
 /docs/sources/upgrade-guide/                                                      @imatwawana
@@ -140,7 +140,7 @@
 /pkg/services/provisioning/ @grafana/grafana-search-and-storage
 /pkg/services/provisioning/alerting/ @grafana/alerting-backend
 /pkg/services/query/ @grafana/grafana-app-platform-squad
-/pkg/services/queryhistory/ @grafana/explore-squad
+/pkg/services/queryhistory/ @grafana/observability-traces-and-profiling
 /pkg/services/quota/ @grafana/grafana-search-and-storage
 /pkg/services/screenshot/ @grafana/grafana-backend-group
 /pkg/services/search/ @grafana/grafana-search-and-storage
@@ -417,7 +417,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/core/components/OptionsUI/ @grafana/dashboards-squad @grafana/dataviz-squad
 
 
-/public/app/core/history/ @grafana/explore-squad
+/public/app/core/history/ @grafana/observability-traces-and-profiling
 /public/app/features/admin/ @grafana/identity-access-team
 
 # Temp owners until Enterprise team takes over
@@ -440,7 +440,7 @@ playwright.config.ts @grafana/plugins-platform-frontend
 /public/app/features/datasources/ @grafana/plugins-platform-frontend
 /public/app/features/dimensions/ @grafana/dataviz-squad
 /public/app/features/dataframe-import/ @grafana/dataviz-squad
-/public/app/features/explore/ @grafana/explore-squad
+/public/app/features/explore/ @grafana/observability-traces-and-profiling
 /public/app/features/expressions/ @grafana/observability-metrics
 /public/app/features/folders/ @grafana/grafana-frontend-platform
 /public/app/features/inspector/ @grafana/dashboards-squad

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -7,7 +7,6 @@ type codeowner string
 const (
 	grafanaAppPlatformSquad                     codeowner = "@grafana/grafana-app-platform-squad"
 	grafanaDashboardsSquad                      codeowner = "@grafana/dashboards-squad"
-	grafanaExploreSquad                         codeowner = "@grafana/explore-squad"
 	grafanaDatavizSquad                         codeowner = "@grafana/dataviz-squad"
 	grafanaFrontendPlatformSquad                codeowner = "@grafana/grafana-frontend-platform"
 	grafanaBackendGroup                         codeowner = "@grafana/grafana-backend-group"

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -96,7 +96,7 @@ var (
 			Name:           "correlations",
 			Description:    "Correlations page",
 			Stage:          FeatureStageGeneralAvailability,
-			Owner:          grafanaExploreSquad,
+			Owner:          grafanaDatavizSquad,
 			Expression:     "true", // enabled by default
 			AllowSelfServe: true,
 		},
@@ -1224,7 +1224,7 @@ var (
 			Name:           "queryLibrary",
 			Description:    "Enables Query Library feature in Explore",
 			Stage:          FeatureStageExperimental,
-			Owner:          grafanaExploreSquad,
+			Owner:          grafanaFrontendPlatformSquad,
 			FrontendOnly:   false,
 			AllowSelfServe: false,
 		},
@@ -1492,7 +1492,7 @@ var (
 			Name:        "appSidecar",
 			Description: "Enable the app sidecar feature that allows rendering 2 apps at the same time",
 			Stage:       FeatureStageExperimental,
-			Owner:       grafanaExploreSquad,
+			Owner:       grafanaFrontendPlatformSquad,
 		},
 		{
 			Name:         "groupAttributeSync",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -9,7 +9,7 @@ publicDashboardsScene,GA,@grafana/sharing-squad,false,false,true
 lokiExperimentalStreaming,experimental,@grafana/observability-logs,false,false,false
 featureHighlights,GA,@grafana/grafana-as-code,false,false,false
 storage,experimental,@grafana/search-and-storage,false,false,false
-correlations,GA,@grafana/explore-squad,false,false,false
+correlations,GA,@grafana/dataviz-squad,false,false,false
 autoMigrateOldPanels,preview,@grafana/dataviz-squad,false,false,true
 autoMigrateGraphPanel,preview,@grafana/dataviz-squad,false,false,true
 autoMigrateTablePanel,preview,@grafana/dataviz-squad,false,false,true
@@ -160,7 +160,7 @@ cloudWatchNewLabelParsing,GA,@grafana/aws-datasources,false,false,false
 accessActionSets,GA,@grafana/identity-access-team,false,false,false
 disableNumericMetricsSortingInExpressions,experimental,@grafana/observability-metrics,false,true,false
 grafanaManagedRecordingRules,experimental,@grafana/alerting-squad,false,false,false
-queryLibrary,experimental,@grafana/explore-squad,false,false,false
+queryLibrary,experimental,@grafana/grafana-frontend-platform,false,false,false
 logsExploreTableDefaultVisualization,experimental,@grafana/observability-logs,false,false,true
 newDashboardSharingComponent,GA,@grafana/sharing-squad,false,false,true
 alertingListViewV2,experimental,@grafana/alerting-squad,false,false,true
@@ -196,7 +196,7 @@ exploreLogsAggregatedMetrics,experimental,@grafana/observability-logs,false,fals
 exploreLogsLimitedTimeRange,experimental,@grafana/observability-logs,false,false,true
 homeSetupGuide,experimental,@grafana/growth-and-onboarding,false,false,true
 appPlatformGrpcClientAuth,experimental,@grafana/identity-access-team,false,false,false
-appSidecar,experimental,@grafana/explore-squad,false,false,false
+appSidecar,experimental,@grafana/grafana-frontend-platform,false,false,false
 groupAttributeSync,privatePreview,@grafana/identity-access-team,false,false,false
 alertingQueryAndExpressionsStepMode,experimental,@grafana/alerting-squad,false,false,true
 improvedExternalSessionHandling,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -415,13 +415,16 @@
     {
       "metadata": {
         "name": "appSidecar",
-        "resourceVersion": "1722872007883",
-        "creationTimestamp": "2024-09-09T12:45:05Z"
+        "resourceVersion": "1731608393499",
+        "creationTimestamp": "2024-09-09T12:45:05Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-11-14 18:19:53.499798 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enable the app sidecar feature that allows rendering 2 apps at the same time",
         "stage": "experimental",
-        "codeowner": "@grafana/explore-squad"
+        "codeowner": "@grafana/grafana-frontend-platform"
       }
     },
     {
@@ -842,16 +845,16 @@
     {
       "metadata": {
         "name": "correlations",
-        "resourceVersion": "1720021873452",
+        "resourceVersion": "1731608393499",
         "creationTimestamp": "2022-09-16T13:14:27Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2024-07-03 15:51:13.452477 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2024-11-14 18:19:53.499798 +0000 UTC"
         }
       },
       "spec": {
         "description": "Correlations page",
         "stage": "GA",
-        "codeowner": "@grafana/explore-squad",
+        "codeowner": "@grafana/dataviz-squad",
         "allowSelfServe": true,
         "expression": "true"
       }
@@ -2847,14 +2850,17 @@
     {
       "metadata": {
         "name": "queryLibrary",
-        "resourceVersion": "1718727528075",
+        "resourceVersion": "1731609408207",
         "creationTimestamp": "2022-10-07T18:31:45Z",
-        "deletionTimestamp": "2023-03-20T16:00:14Z"
+        "deletionTimestamp": "2023-03-20T16:00:14Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-11-14 18:36:48.207329 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables Query Library feature in Explore",
         "stage": "experimental",
-        "codeowner": "@grafana/explore-squad"
+        "codeowner": "@grafana/grafana-frontend-platform"
       }
     },
     {


### PR DESCRIPTION
Reflect changes in ownership. 

Everything with correlations goes to dataviz. Everything with query library and sidecar goes with frontend platform. All remaining explore squad items go to traces and profiling.

Updating the feature flags shows that a deleted feature flag retains the ownership at the time of deletion, so we will continue to have explore ownership marked for content outline's feature flag (`exploreContentOutline`). I don't think this will affect anything.