### PR TITLE
Cloudwatch: Fix parsing for ec2 resource attributes

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -96,52 +96,14 @@ func (e *cloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, 
 	result := make([]suggestData, 0)
 	dupCheck := make(map[string]bool)
 	for _, reservation := range instances.Reservations {
-	instanceLoop:
 		for _, instance := range reservation.Instances {
-			tags := make(map[string]string)
-			for _, tag := range instance.Tags {
-				tags[*tag.Key] = *tag.Value
+			data, found, err := getInstanceAttributeValue(attributeName, instance)
+			if err != nil {
+				return nil, err
 			}
-
-			var data string
-			if strings.Index(attributeName, "Tags.") == 0 {
-				tagName := attributeName[5:]
-				data = tags[tagName]
-			} else {
-				attributePath := strings.Split(attributeName, ".")
-				v := reflect.ValueOf(instance)
-				for _, key := range attributePath {
-					if v.Kind() == reflect.Ptr {
-						if v.IsNil() {
-							continue instanceLoop
-						}
-						v = v.Elem()
-					}
-					if v.Kind() != reflect.Struct {
-						return nil, errors.New("invalid attribute path")
-					}
-					v = v.FieldByName(key)
-					if !v.IsValid() {
-						return nil, errors.New("invalid attribute path")
-					}
-				}
-
-				if v.Kind() == reflect.Ptr && v.IsNil() {
-					continue
-				}
-				if attr, ok := v.Interface().(*string); ok {
-					data = *attr
-				} else if attr, ok := v.Interface().(*time.Time); ok {
-					data = attr.String()
-				} else if _, ok := v.Interface().(*bool); ok {
-					data = fmt.Sprint(v.Elem().Bool())
-				} else if v.Kind() == reflect.Ptr && v.Elem().CanInt() {
-					data = fmt.Sprint(v.Elem().Int())
-				} else {
-					return nil, errors.New("cannot parse attribute")
-				}
+			if !found {
+				continue
 			}
-
 			if _, exists := dupCheck[data]; exists {
 				continue
 			}
@@ -156,6 +118,54 @@ func (e *cloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, 
 	})
 
 	return result, nil
+}
+
+func getInstanceAttributeValue(attributeName string, instance *ec2.Instance) (value string, found bool, err error) {
+	tags := make(map[string]string)
+	for _, tag := range instance.Tags {
+		tags[*tag.Key] = *tag.Value
+	}
+
+	var data string
+	if strings.Index(attributeName, "Tags.") == 0 {
+		tagName := attributeName[5:]
+		data = tags[tagName]
+	} else {
+		attributePath := strings.Split(attributeName, ".")
+		v := reflect.ValueOf(instance)
+		for _, key := range attributePath {
+			if v.Kind() == reflect.Ptr {
+				if v.IsNil() {
+					return "", false, nil
+				}
+				v = v.Elem()
+			}
+			if v.Kind() != reflect.Struct {
+				return "", false, errors.New("invalid attribute path")
+			}
+			v = v.FieldByName(key)
+			if !v.IsValid() {
+				return "", false, errors.New("invalid attribute path")
+			}
+		}
+
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			return "", false, nil
+		}
+		if attr, ok := v.Interface().(*string); ok {
+			data = *attr
+		} else if attr, ok := v.Interface().(*time.Time); ok {
+			data = attr.String()
+		} else if _, ok := v.Interface().(*bool); ok {
+			data = fmt.Sprint(v.Elem().Bool())
+		} else if v.Kind() == reflect.Ptr && v.Elem().CanInt() {
+			data = fmt.Sprint(v.Elem().Int())
+		} else {
+			return "", false, errors.New("cannot parse attribute")
+		}
+	}
+
+	return data, true, nil
 }
 
 func (e *cloudWatchExecutor) handleGetResourceArns(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -83,7 +83,7 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 
 	t.Run("Get different types", func(t *testing.T) {
 		var expectedInt int64 = 3
-		var expectedBool bool = true
+		var expectedBool = true
 		var expectedArn = "arn"
 		cli = oldEC2Client{
 			reservations: []*ec2.Reservation{
@@ -141,7 +141,6 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 		}
 		for _, tc := range testcases {
 			t.Run(tc.name, func(t *testing.T) {
-
 				filterMap := map[string][]string{}
 				filterJson, err := json.Marshal(filterMap)
 				require.NoError(t, err)

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -80,6 +80,87 @@ func TestQuery_InstanceAttributes(t *testing.T) {
 		}
 		assert.Equal(t, expResponse, resp)
 	})
+
+	t.Run("Get different types", func(t *testing.T) {
+		var expectedInt int64 = 3
+		var expectedBool bool = true
+		var expectedArn = "arn"
+		cli = oldEC2Client{
+			reservations: []*ec2.Reservation{
+				{
+					Instances: []*ec2.Instance{
+						{
+							AmiLaunchIndex: &expectedInt,
+							EbsOptimized:   &expectedBool,
+							IamInstanceProfile: &ec2.IamInstanceProfile{
+								Arn: &expectedArn,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		im := datasource.NewInstanceManager(func(ctx context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return DataSource{Settings: models.CloudWatchSettings{}, sessions: &fakeSessionCache{}}, nil
+		})
+
+		executor := newExecutor(im, log.NewNullLogger())
+
+		testcases := []struct {
+			name          string
+			attributeName string
+			expResponse   []suggestData
+		}{
+			{
+				"int field",
+				"AmiLaunchIndex",
+				[]suggestData{
+					{Text: "3", Value: "3", Label: "3"},
+				},
+			},
+			{
+				"bool field",
+				"EbsOptimized",
+				[]suggestData{
+					{Text: "true", Value: "true", Label: "true"},
+				},
+			},
+			{
+				"nested field",
+				"IamInstanceProfile.Arn",
+				[]suggestData{
+					{Text: expectedArn, Value: expectedArn, Label: expectedArn},
+				},
+			},
+			{
+				"nil field",
+				"InstanceLifecycle",
+				[]suggestData{},
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+
+				filterMap := map[string][]string{}
+				filterJson, err := json.Marshal(filterMap)
+				require.NoError(t, err)
+
+				resp, err := executor.handleGetEc2InstanceAttribute(
+					context.Background(),
+					backend.PluginContext{
+						DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+					}, url.Values{
+						"region":        []string{"us-east-1"},
+						"attributeName": []string{tc.attributeName},
+						"filters":       []string{string(filterJson)},
+					},
+				)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expResponse, resp)
+			})
+		}
+	})
 }
 
 func TestQuery_EBSVolumeIDs(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes parsing for ec2 instance attribute resource requests for nil, bool, and int values. Now we handle all the fields listed in the [docs](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/template-variables/#use-ec2_instance_attribute), with the exception of `IamInstanceProfile` where they will need to query `IamInstanceProfile.Arn` or `IamInstanceProfile.Name` depending on which part they want.
This is a quicker fix because its a support escalation. In the long term I think we could refactor this- as the user points out, we could do a dropdown with known attribute fields and let users set custom fields for the other values. Also we don't need to be doing reflection for the known fields of `ec2.Instance`- we already know what types they are. Though we should cross reference this with the v2 sdk to make sure we're not doing work that will immediately be obselete

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #96489

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
