### PR TITLE
Alerting: Fix long KeepLast annotations failing to save

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -183,6 +183,14 @@ func addAnnotationMig(mg *Migrator) {
 	mg.AddMigration("Increase tags column to length 4096", NewRawSQLMigration("").
 		Postgres("ALTER TABLE annotation ALTER COLUMN tags TYPE VARCHAR(4096);").
 		Mysql("ALTER TABLE annotation MODIFY tags VARCHAR(4096);"))
+
+	mg.AddMigration("Increase prev_state column to length 40", NewRawSQLMigration("").
+		Postgres("ALTER TABLE annotation ALTER COLUMN prev_state TYPE VARCHAR(40);").
+		Mysql("ALTER TABLE annotation MODIFY prev_state VARCHAR(40);"))
+
+	mg.AddMigration("Increase new_state column to length 40", NewRawSQLMigration("").
+		Postgres("ALTER TABLE annotation ALTER COLUMN new_state TYPE VARCHAR(40);").
+		Mysql("ALTER TABLE annotation MODIFY new_state VARCHAR(40);"))
 }
 
 type AddMakeRegionSingleRowMigration struct {


### PR DESCRIPTION
**What is this feature?**

Increases the column length limit for `annotation.prev_state` and `annotation.new_state` from `25` to `40`.

**Why do we need this feature?**

State transition reasons from the Keep Last State feature are concatenations of `KeepLast` and the previous state. For example, `Alerting (NoData, KeepLast)` or `Normal (Error, KeepLast)`. Certain combinations can exceed the column limit of 25 characters, preventing the annotations from persisting to the database.

**Who is this feature for?**

Users of alerting, panel annotations, and keep last state.

**Which issue(s) does this PR fix?**:

Fixes #91421
