### PR TITLE
Cloud Aggregation: make it work for users with no name

### DIFF
--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -106,10 +106,16 @@ func (u *SignedInUser) IsIdentityType(expected ...claims.IdentityType) bool {
 func (u *SignedInUser) GetName() string {
 	// kubernetesAggregator feature flag which allows Cloud Apps to become available
 	// in single tenant Grafana requires that GetName() returns something and not an empty string
+	// the logic below ensures that something is returned
 	if u.Name != "" {
 		return u.Name
 	}
-	return u.GetRawIdentifier() // returns "u000000002" for "user:2"
+
+	if u.Login != "" {
+		return u.Login
+	}
+
+	return u.Email
 }
 
 // GetExtra implements Requester.

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -104,7 +104,12 @@ func (u *SignedInUser) IsIdentityType(expected ...claims.IdentityType) bool {
 
 // GetName implements identity.Requester.
 func (u *SignedInUser) GetName() string {
-	return u.Name
+	// kubernetesAggregator feature flag which allows Cloud Apps to become available
+	// in single tenant Grafana requires that GetName() returns something and not an empty string
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.GetRawIdentifier() // returns "u000000002" for "user:2"
 }
 
 // GetExtra implements Requester.

--- a/pkg/services/user/identity_test.go
+++ b/pkg/services/user/identity_test.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentityGetName(t *testing.T) {
+	tt := []struct {
+		name string
+		user *SignedInUser
+	}{
+		{
+			name: "GetName on a user with empty name returns raw identifier",
+			user: &SignedInUser{
+				UserUID: "u000000002",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		user := tc.user
+		require.Equal(t, user.GetName(), user.GetRawIdentifier(), tc.name)
+	}
+}

--- a/pkg/services/user/identity_test.go
+++ b/pkg/services/user/identity_test.go
@@ -8,19 +8,29 @@ import (
 
 func TestIdentityGetName(t *testing.T) {
 	tt := []struct {
-		name string
-		user *SignedInUser
+		name     string
+		user     *SignedInUser
+		expected string
 	}{
 		{
-			name: "GetName on a user with empty name returns raw identifier",
+			name: "GetName on a user with empty name returns Login, if set",
 			user: &SignedInUser{
-				UserUID: "u000000002",
+				Login: "userLogin",
+				Email: "user@grafana.com",
 			},
+			expected: "userLogin",
+		},
+		{
+			name: "GetName on a user with empty name returns Email, if no Login is set",
+			user: &SignedInUser{
+				Email: "user@grafana.com",
+			},
+			expected: "user@grafana.com",
 		},
 	}
 
 	for _, tc := range tt {
 		user := tc.user
-		require.Equal(t, user.GetName(), user.GetRawIdentifier(), tc.name)
+		require.Equal(t, user.GetName(), tc.expected, tc.name)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

While working on delivering Cloud Aggregation in September, we ran into this issue on Grafana users with no name. They couldn't use the aggregation feature. While we were all stumped at first, it came down to Requester (which is SignedInUser) returning an empty Name on `GetName` (the correct behavior should be to return something, or aggregation which depends on X-Remote-User header, doesn't work). [See slack thread](https://raintank-corp.slack.com/archives/C037H5GAY9L/p1725479660977659?thread_ts=1722433605.876979&cid=C037H5GAY9L).

@peterholmberg and his squad has been working around this issue ever since by simply not using a Grafana login with this issue. However, this feature is getting shipped soon and this blocks it.

Here in this PR, I am putting a fix in for such users. Wdyt?

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Unblocks Grafana users with no name set so they can use the new servicemodel feature in Cloud Apps directly as part of kubectl access against their HG instance.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
