### PR TITLE
Org: Fix redirection logic to work consistently

### DIFF
--- a/pkg/middleware/org_redirect.go
+++ b/pkg/middleware/org_redirect.go
@@ -50,7 +50,7 @@ func OrgRedirect(cfg *setting.Cfg, userSvc user.Service) web.Handler {
 			qs = fmt.Sprintf("%s&kiosk", urlParams.Encode())
 		}
 
-		newURL := fmt.Sprintf("%s%s?%s", cfg.AppURL, strings.TrimPrefix(c.Req.URL.Path, "/"), qs)
+		newURL := fmt.Sprintf("%s%s?%s", cfg.AppSubURL, strings.TrimPrefix(c.Req.URL.Path, "/"), qs)
 
 		c.Redirect(newURL, 302)
 	}


### PR DESCRIPTION
Fixes #96262

i change `cfg.AppURL` to `cfg.AppSubURL`, bacause `cfg.AppURL` contain domain and port . it will change domain and port. if just redirect path, it's ok.