### PR TITLE
Combobox: Support undefined, null value and improve typing

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -68,10 +68,11 @@ const BasicWithState: StoryFn<typeof Combobox> = (args) => {
         id="test-combobox"
         {...args}
         value={value}
-        onChange={(val) => {
+        onChange={(val: ComboboxOption) => {
           setValue(val?.value || null);
           action('onChange')(val);
         }}
+        isClearable={args.isClearable}
       />
     </Field>
   );

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -4,16 +4,16 @@ import React, { ComponentProps, useCallback, useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 
-import { useTheme2 } from '../../themes/ThemeContext';
 import { Alert } from '../Alert/Alert';
-import { Divider } from '../Divider/Divider';
 import { Field } from '../Forms/Field';
-import { AsyncSelect, Select } from '../Select/Select';
+import { AsyncSelect } from '../Select/Select';
 
 import { Combobox, ComboboxOption } from './Combobox';
 import mdx from './Combobox.mdx';
 
-type PropsAndCustomArgs = ComponentProps<typeof Combobox> & { numberOfOptions: number };
+type PropsAndCustomArgs<T extends string | number = string> = ComponentProps<typeof Combobox<T>> & {
+  numberOfOptions: number;
+};
 
 const meta: Meta<PropsAndCustomArgs> = {
   title: 'Forms/Combobox',
@@ -27,6 +27,7 @@ const meta: Meta<PropsAndCustomArgs> = {
     loading: undefined,
     invalid: undefined,
     width: undefined,
+    isClearable: false,
     placeholder: 'Select an option...',
     options: [
       { label: 'Apple', value: 'apple' },
@@ -45,12 +46,6 @@ const meta: Meta<PropsAndCustomArgs> = {
       { label: 'Honeydew', value: 'honeydew' },
       { label: 'Iceberg Lettuce', value: 'iceberg-lettuce' },
       { label: 'Jackfruit', value: 'jackfruit' },
-      { label: '1', value: 1 },
-      { label: '2', value: 2 },
-      { label: '3', value: 3 },
-      { label: '4', value: 4 },
-      { label: '5', value: 5 },
-      { label: '6', value: 6 },
     ],
     value: 'banana',
   },
@@ -59,17 +54,15 @@ const meta: Meta<PropsAndCustomArgs> = {
   decorators: [InDevDecorator],
 };
 
-const BasicWithState: StoryFn<typeof Combobox> = (args) => {
-  const [value, setValue] = useState(args.value);
-
+const BasicWithState: StoryFn<PropsAndCustomArgs> = (args) => {
   return (
     <Field label="Test input" description="Input with a few options">
       <Combobox
         id="test-combobox"
         {...args}
-        value={value}
-        onChange={(val: ComboboxOption) => {
-          setValue(val?.value || null);
+        onChange={(val: ComboboxOption | null) => {
+          // TODO: Figure out how to update value on args
+          // setValue(val?.value || null);
           action('onChange')(val);
         }}
         isClearable={args.isClearable}
@@ -89,7 +82,7 @@ async function generateOptions(amount: number): Promise<ComboboxOption[]> {
   }));
 }
 
-const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...args }) => {
+const ManyOptionsStory: StoryFn<PropsAndCustomArgs<string>> = ({ numberOfOptions, ...args }) => {
   const [value, setValue] = useState<string | null>(null);
   const [options, setOptions] = useState<ComboboxOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -104,143 +97,18 @@ const ManyOptionsStory: StoryFn<PropsAndCustomArgs> = ({ numberOfOptions, ...arg
     }, 1000);
   }, [numberOfOptions]);
 
+  const { onChange, ...rest } = args;
   return (
     <Combobox
-      {...args}
+      {...rest}
       loading={isLoading}
       options={options}
       value={value}
-      onChange={(opt) => {
+      onChange={(opt: ComboboxOption | null) => {
         setValue(opt?.value || null);
         action('onChange')(opt);
       }}
     />
-  );
-};
-
-const SelectComparisonStory: StoryFn<typeof Combobox> = (args) => {
-  const [comboboxValue, setComboboxValue] = useState(args.value);
-  const theme = useTheme2();
-
-  if (typeof args.options === 'function') {
-    throw new Error('This story does not support async options');
-  }
-
-  return (
-    <div style={{ border: '1px solid ' + theme.colors.border.weak, padding: 16 }}>
-      <Field label="Combobox with default size">
-        <Combobox
-          {...args}
-          id="combobox-default-size"
-          value={comboboxValue}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Select with default size">
-        <Select
-          id="select-default-size"
-          value={comboboxValue}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Divider />
-
-      <Field label="Combobox with explicit size (25)">
-        {/*@ts-ignore minWidth and maxWidth has never, which is incompatible with args. It lacks the context that width=25 on the component*/}
-        <Combobox
-          {...args}
-          id="combobox-explicit-size"
-          width={25}
-          value={comboboxValue}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Select with explicit size (25)">
-        <Select
-          id="select-explicit-size"
-          width={25}
-          value={comboboxValue}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Divider />
-
-      <Field label="Combobox with auto width, minWidth 15">
-        <Combobox
-          {...args}
-          id="combobox-auto-size"
-          width="auto"
-          minWidth={15}
-          value={comboboxValue}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Select with auto width">
-        <Select
-          id="select-auto-size"
-          width="auto"
-          value={comboboxValue}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Combobox with auto width, minWidth 15, empty value">
-        <Combobox
-          {...args}
-          id="combobox-auto-size-empty"
-          width="auto"
-          minWidth={15}
-          value={null}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-
-      <Field label="Select with auto width, empty value">
-        <Select
-          id="select-auto-size-empty"
-          width="auto"
-          value={null}
-          options={args.options}
-          onChange={(val) => {
-            setComboboxValue(val?.value || null);
-            action('onChange')(val);
-          }}
-        />
-      </Field>
-    </div>
   );
 };
 
@@ -295,6 +163,8 @@ const AsyncStory: StoryFn<PropsAndCustomArgs> = (args) => {
     }
   }, []);
 
+  const { onChange, ...rest } = args;
+
   return (
     <>
       <Field
@@ -302,12 +172,12 @@ const AsyncStory: StoryFn<PropsAndCustomArgs> = (args) => {
         description="This tests when options have both a label and a value. Consumers are required to pass in a full ComboboxOption as a value with a label"
       >
         <Combobox
-          {...args}
+          {...rest}
           id="test-combobox-one"
           placeholder="Select an option"
           options={loadOptionsWithLabels}
           value={selectedOption}
-          onChange={(val) => {
+          onChange={(val: ComboboxOption | null) => {
             action('onChange')(val);
             setSelectedOption(val);
           }}
@@ -325,7 +195,7 @@ const AsyncStory: StoryFn<PropsAndCustomArgs> = (args) => {
           placeholder="Select an option"
           options={loadOptionsOnlyValues}
           value={selectedOption?.value ?? null}
-          onChange={(val) => {
+          onChange={(val: ComboboxOption | null) => {
             action('onChange')(val);
             setSelectedOption(val);
           }}
@@ -367,7 +237,7 @@ const AsyncStory: StoryFn<PropsAndCustomArgs> = (args) => {
           placeholder="Select an option"
           options={loadOptionsWithErrors}
           value={selectedOption}
-          onChange={(val) => {
+          onChange={(val: ComboboxOption | null) => {
             action('onChange')(val);
             setSelectedOption(val);
           }}
@@ -425,13 +295,6 @@ const PositioningTestStory: StoryFn<PropsAndCustomArgs> = (args) => {
 
 export const PositioningTest: StoryObj<PropsAndCustomArgs> = {
   render: PositioningTestStory,
-};
-
-export const ComparisonToSelect: StoryObj<PropsAndCustomArgs> = {
-  args: {
-    numberOfOptions: 100,
-  },
-  render: SelectComparisonStory,
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -55,17 +55,18 @@ const meta: Meta<PropsAndCustomArgs> = {
 };
 
 const BasicWithState: StoryFn<PropsAndCustomArgs> = (args) => {
+  const [value, setValue] = useState<string | null>();
   return (
     <Field label="Test input" description="Input with a few options">
       <Combobox
         id="test-combobox"
         {...args}
+        value={value}
         onChange={(val: ComboboxOption | null) => {
           // TODO: Figure out how to update value on args
-          // setValue(val?.value || null);
+          setValue(val?.value || null);
           action('onChange')(val);
         }}
-        isClearable={args.isClearable}
       />
     </Field>
   );

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -49,8 +49,17 @@ describe('Combobox', () => {
     expect(onChangeHandler).toHaveBeenCalledWith(options[0]);
   });
 
-  it("shows the placeholder with the menu open when there's no value", async () => {
+  it('shows the placeholder with the menu open when value is null', async () => {
     render(<Combobox options={options} value={null} onChange={onChangeHandler} placeholder="Select an option" />);
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+
+    expect(input).toHaveAttribute('placeholder', 'Select an option');
+  });
+
+  it('shows the placeholder with the menu open when value is undefined', async () => {
+    render(<Combobox options={options} value={undefined} onChange={onChangeHandler} placeholder="Select an option" />);
 
     const input = screen.getByRole('combobox');
     await userEvent.click(input);

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -116,7 +116,7 @@ describe('Combobox', () => {
     expect(screen.queryByDisplayValue('Option 2')).not.toBeInTheDocument();
   });
 
-  it.each(['', 0])('should handle an option with %p as a value', async (val) => {
+  it.each(['very valid value', '', 0])('should handle an option with %p as a value', async (val) => {
     const options = [
       { label: 'Second option', value: '2' },
       { label: 'Default', value: val },

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -116,14 +116,14 @@ describe('Combobox', () => {
     expect(screen.queryByDisplayValue('Option 2')).not.toBeInTheDocument();
   });
 
-  it('should handle an option with an empty string as value', async () => {
+  it.each(['', 0])('should handle an option with %p as a value', async (val) => {
     const options = [
       { label: 'Second option', value: '2' },
-      { label: 'Default', value: '' },
+      { label: 'Default', value: val },
     ];
 
     const ControlledCombobox = () => {
-      const [value, setValue] = React.useState<string | null>(null);
+      const [value, setValue] = React.useState<string | number | null>(null);
 
       return (
         <Combobox

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 
 import { Combobox, ComboboxOption } from './Combobox';
 
@@ -113,6 +114,38 @@ describe('Combobox', () => {
 
     expect(onChangeHandler).toHaveBeenCalledWith(null);
     expect(screen.queryByDisplayValue('Option 2')).not.toBeInTheDocument();
+  });
+
+  it('should handle an option with an empty string as value', async () => {
+    const options = [
+      { label: 'Second option', value: '2' },
+      { label: 'Default', value: '' },
+    ];
+
+    const ControlledCombobox = () => {
+      const [value, setValue] = React.useState<string | null>(null);
+
+      return (
+        <Combobox
+          options={options}
+          value={value}
+          onChange={(opt) => {
+            setValue(opt.value);
+          }}
+        />
+      );
+    };
+
+    render(<ControlledCombobox />);
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.click(screen.getByRole('option', { name: 'Default' }));
+    expect(screen.queryByDisplayValue('Default')).toBeInTheDocument();
+
+    await userEvent.click(input);
+
+    expect(screen.getByRole('option', { name: 'Default' })).toHaveAttribute('aria-selected', 'true');
   });
 
   describe('size support', () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -115,6 +115,41 @@ describe('Combobox', () => {
     expect(screen.queryByDisplayValue('Option 2')).not.toBeInTheDocument();
   });
 
+  describe('size support', () => {
+    it('should require minWidth to be set with auto width', () => {
+      // @ts-expect-error
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} width="auto" />);
+    });
+
+    it('should change width when typing things with auto width', async () => {
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} width="auto" minWidth={2} />);
+
+      const input = screen.getByRole('combobox');
+      const inputWrapper = screen.getByTestId('input-wrapper');
+      const initialWidth = getComputedStyle(inputWrapper).width;
+
+      fireEvent.change(input, { target: { value: 'very very long value' } });
+
+      const newWidth = getComputedStyle(inputWrapper).width;
+
+      expect(initialWidth).not.toBe(newWidth);
+    });
+
+    it('should not change width when typing things with fixed width', async () => {
+      render(<Combobox options={options} value={null} onChange={onChangeHandler} width={2} />);
+      const input = screen.getByRole('combobox');
+
+      const inputWrapper = screen.getByTestId('input-wrapper');
+      const initialWidth = getComputedStyle(inputWrapper).width;
+
+      fireEvent.change(input, { target: { value: 'very very long value' } });
+
+      const newWidth = getComputedStyle(inputWrapper).width;
+
+      expect(initialWidth).toBe(newWidth);
+    });
+  });
+
   describe('with a value already selected', () => {
     it('shows an empty text input when opening the menu', async () => {
       const selectedValue = options[0].value;

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -39,7 +39,7 @@ interface ComboboxBaseProps<T extends string | number> {
   /**
    * The onChange handler is called with `null` when clearing the Combobox.
    */
-  onChange: (option: ComboboxOption<T> | null) => void;
+  onChange: (option: ComboboxOption<T>) => void;
   /**
    * Most consumers should pass value in as a scalar string | number. However, sometimes with Async because we don't
    * have the full options loaded to match the value to, consumers may also pass in an Option with a label to display.

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -9,7 +9,7 @@ import { logOptions } from '../../utils';
 import { t, Trans } from '../../utils/i18n';
 import { Icon } from '../Icon/Icon';
 import { AutoSizeInput } from '../Input/AutoSizeInput';
-import { Input } from '../Input/Input';
+import { Input, Props as InputProps } from '../Input/Input';
 import { Box } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
@@ -26,7 +26,11 @@ export type ComboboxOption<T extends string | number = string> = {
 
 // TODO: It would be great if ComboboxOption["label"] was more generic so that if consumers do pass it in (for async),
 // then the onChange handler emits ComboboxOption with the label as non-undefined.
-interface ComboboxBaseProps<T extends string | number> {
+interface ComboboxBaseProps<T extends string | number>
+  extends Pick<
+    InputProps,
+    'placeholder' | 'autoFocus' | 'id' | 'aria-labelledby' | 'disabled' | 'loading' | 'invalid'
+  > {
   /**
    * An `X` appears in the UI, which clears the input and sets the value to `null`. Do not use if you have no `null` case.
    */
@@ -49,10 +53,7 @@ interface ComboboxBaseProps<T extends string | number> {
    * Defaults to 100%. Number is a multiple of 8px. 'auto' will size the input to the content.
    * */
   width?: number | 'auto';
-  placeholder?: string;
-  'aria-labelledby'?: string;
-  id?: string;
-  autoFocus?: boolean;
+  onBlur?: () => void;
 }
 
 const RECOMMENDED_ITEMS_AMOUNT = 100_000;
@@ -128,6 +129,10 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     maxWidth,
     'aria-labelledby': ariaLabelledBy,
     autoFocus,
+    onBlur,
+    disabled,
+    loading,
+    invalid,
   } = props;
 
   // Value can be an actual scalar Value (string or number), or an Option (value + label), so
@@ -369,6 +374,10 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         width={isAutoSize ? undefined : width}
         {...(isAutoSize ? { minWidth, maxWidth } : {})}
         autoFocus={autoFocus}
+        onBlur={onBlur}
+        disabled={disabled}
+        loading={loading}
+        invalid={invalid}
         className={styles.input}
         suffix={
           <>

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -52,6 +52,7 @@ interface ComboboxBaseProps<T extends string | number> {
   placeholder?: string;
   'aria-labelledby'?: string;
   id?: string;
+  autoFocus?: boolean;
 }
 
 const RECOMMENDED_ITEMS_AMOUNT = 100_000;
@@ -126,6 +127,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     minWidth,
     maxWidth,
     'aria-labelledby': ariaLabelledBy,
+    autoFocus,
   } = props;
 
   // Value can be an actual scalar Value (string or number), or an Option (value + label), so
@@ -366,6 +368,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       <InputComponent
         width={isAutoSize ? undefined : width}
         {...(isAutoSize ? { minWidth, maxWidth } : {})}
+        autoFocus={autoFocus}
         className={styles.input}
         suffix={
           <>

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -175,7 +175,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
   }, [options, value, isAsync]);
 
   const selectedItem = useMemo(() => {
-    if (valueProp === undefined) {
+    if (!valueProp) {
       return undefined;
     }
 
@@ -451,15 +451,5 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         )}
       </div>
     </div>
-  );
-};
-
-const MessageRow = ({ children }: { children: ReactNode }) => {
-  return (
-    <Box padding={2} color="secondary">
-      <Stack justifyContent="center" alignItems="center">
-        {children}
-      </Stack>
-    </Box>
   );
 };

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -123,6 +123,8 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     createCustomValue = false,
     id,
     width,
+    minWidth,
+    maxWidth,
     'aria-labelledby': ariaLabelledBy,
   } = props;
 
@@ -346,7 +348,9 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
 
   const { inputRef, floatingRef, floatStyles, scrollRef } = useComboboxFloat(items, rowVirtualizer.range, isOpen);
 
-  const InputComponent = width === 'auto' ? AutoSizeInput : Input;
+  const isAutoSize = width === 'auto';
+
+  const InputComponent = isAutoSize ? AutoSizeInput : Input;
 
   const suffixIcon = asyncLoading
     ? 'spinner'
@@ -360,7 +364,8 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
   return (
     <div>
       <InputComponent
-        width={width === 'auto' ? undefined : width}
+        width={isAutoSize ? undefined : width}
+        {...(isAutoSize ? { minWidth, maxWidth } : {})}
         className={styles.input}
         suffix={
           <>

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -36,7 +36,10 @@ interface ComboboxBaseProps<T extends string | number> {
    */
   createCustomValue?: boolean;
   options: Array<ComboboxOption<T>> | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
-  onChange: (option?: ComboboxOption<T>) => void;
+  /**
+   * The onChange handler is called with `null` when clearing the Combobox.
+   */
+  onChange: (option: ComboboxOption<T> | null) => void;
   /**
    * Most consumers should pass value in as a scalar string | number. However, sometimes with Async because we don't
    * have the full options loaded to match the value to, consumers may also pass in an Option with a label to display.
@@ -52,6 +55,13 @@ interface ComboboxBaseProps<T extends string | number> {
 }
 
 const RECOMMENDED_ITEMS_AMOUNT = 100_000;
+
+type ClearableConditionals<T extends number | string> =
+  | {
+      isClearable: true;
+      onChange: (option: ComboboxOption<T> | null) => void;
+    }
+  | { isClearable?: false; onChange: (option: ComboboxOption<T>) => void };
 
 type AutoSizeConditionals =
   | {
@@ -71,7 +81,7 @@ type AutoSizeConditionals =
       maxWidth?: never;
     };
 
-type ComboboxProps<T extends string | number> = ComboboxBaseProps<T> & AutoSizeConditionals;
+type ComboboxProps<T extends string | number> = ComboboxBaseProps<T> & AutoSizeConditionals & ClearableConditionals<T>;
 
 function itemToString<T extends string | number>(item?: ComboboxOption<T> | null) {
   if (!item) {
@@ -114,7 +124,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     id,
     width,
     'aria-labelledby': ariaLabelledBy,
-    ...restProps
   } = props;
 
   // Value can be an actual scalar Value (string or number), or an Option (value + label), so
@@ -376,7 +385,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
             <Icon name={suffixIcon} />
           </>
         }
-        {...restProps}
         {...getInputProps({
           ref: inputRef,
           /*  Empty onCall to avoid TS error
@@ -451,5 +459,15 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         )}
       </div>
     </div>
+  );
+};
+
+const MessageRow = ({ children }: { children: ReactNode }) => {
+  return (
+    <Box padding={2} color="secondary">
+      <Stack justifyContent="center" alignItems="center">
+        {children}
+      </Stack>
+    </Box>
   );
 };

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -173,7 +173,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       return null;
     }
 
-    if (!value) {
+    if (valueProp === undefined || valueProp === null) {
       return null;
     }
 
@@ -183,11 +183,11 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     }
 
     return index;
-  }, [options, value, isAsync]);
+  }, [valueProp, options, value, isAsync]);
 
   const selectedItem = useMemo(() => {
-    if (!valueProp) {
-      return undefined;
+    if (valueProp === undefined || valueProp === null) {
+      return null;
     }
 
     if (selectedItemIndex !== null && !isAsync) {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -162,7 +162,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       return null;
     }
 
-    if (value === undefined) {
+    if (!value) {
       return null;
     }
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -9,7 +9,7 @@ import { logOptions } from '../../utils';
 import { t, Trans } from '../../utils/i18n';
 import { Icon } from '../Icon/Icon';
 import { AutoSizeInput } from '../Input/AutoSizeInput';
-import { Input, Props as InputProps } from '../Input/Input';
+import { Input } from '../Input/Input';
 import { Box } from '../Layout/Box/Box';
 import { Stack } from '../Layout/Stack/Stack';
 import { ScrollContainer } from '../ScrollContainer/ScrollContainer';
@@ -49,9 +49,9 @@ interface ComboboxBaseProps<T extends string | number> {
    * Defaults to 100%. Number is a multiple of 8px. 'auto' will size the input to the content.
    * */
   width?: number | 'auto';
-  placeholder?: InputProps['placeholder'];
-  'aria-labelledby'?: InputProps['aria-labelledby'];
-  id?: InputProps['id'];
+  placeholder?: string;
+  'aria-labelledby'?: string;
+  id?: string;
 }
 
 const RECOMMENDED_ITEMS_AMOUNT = 100_000;

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -84,7 +84,7 @@ type AutoSizeConditionals =
 type ComboboxProps<T extends string | number> = ComboboxBaseProps<T> & AutoSizeConditionals & ClearableConditionals<T>;
 
 function itemToString<T extends string | number>(item?: ComboboxOption<T> | null) {
-  if (!item) {
+  if (item === null || item === undefined) {
     return '';
   }
   if (item.label?.includes('Custom value: ')) {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -40,9 +40,6 @@ interface ComboboxBaseProps<T extends string | number>
    */
   createCustomValue?: boolean;
   options: Array<ComboboxOption<T>> | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
-  /**
-   * The onChange handler is called with `null` when clearing the Combobox.
-   */
   onChange: (option: ComboboxOption<T>) => void;
   /**
    * Most consumers should pass value in as a scalar string | number. However, sometimes with Async because we don't
@@ -61,6 +58,9 @@ const RECOMMENDED_ITEMS_AMOUNT = 100_000;
 type ClearableConditionals<T extends number | string> =
   | {
       isClearable: true;
+      /**
+       * The onChange handler is called with `null` when clearing the Combobox.
+       */
       onChange: (option: ComboboxOption<T> | null) => void;
     }
   | { isClearable?: false; onChange: (option: ComboboxOption<T>) => void };

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -84,7 +84,7 @@ type AutoSizeConditionals =
 type ComboboxProps<T extends string | number> = ComboboxBaseProps<T> & AutoSizeConditionals & ClearableConditionals<T>;
 
 function itemToString<T extends string | number>(item?: ComboboxOption<T> | null) {
-  if (item === null || item === undefined) {
+  if (!item) {
     return '';
   }
   if (item.label?.includes('Custom value: ')) {

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -112,9 +112,6 @@ export class SharedPreferences extends PureComponent<Props, State> {
   };
 
   onThemeChanged = (value: ComboboxOption<string>) => {
-    if (!value) {
-      return;
-    }
     this.setState({ theme: value.value });
 
     if (value.value) {

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -111,7 +111,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
     }
   };
 
-  onThemeChanged = (value: ComboboxOption<string> | null) => {
+  onThemeChanged = (value: ComboboxOption<string>) => {
     if (!value) {
       return;
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Handle `undefined` and `null` values properly
- Conditional typing for onChange depending on `isClearable`
- Remove extension of input props

**Why do we need this feature?**

A lot of places us it as a "nothing"-value.

We don't want to extend input props, as it may lead us to support use cases we don't want to.

**Who is this feature for?**

Devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
