### PR TITLE
Loki: Fix healthcheck logger always appending `endpoint`

### DIFF
--- a/pkg/plugins/backendplugin/coreplugin/registry.go
+++ b/pkg/plugins/backendplugin/coreplugin/registry.go
@@ -186,8 +186,9 @@ func (l *logWrapper) Level() sdklog.Level {
 }
 
 func (l *logWrapper) With(args ...any) sdklog.Logger {
-	l.logger = l.logger.New(args...)
-	return l
+	return &logWrapper{
+		logger: l.logger.New(args...),
+	}
 }
 
 func (l *logWrapper) FromContext(ctx context.Context) sdklog.Logger {

--- a/pkg/plugins/backendplugin/coreplugin/registry_test.go
+++ b/pkg/plugins/backendplugin/coreplugin/registry_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/plugins/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
@@ -61,4 +62,15 @@ func TestNewPlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogger(t *testing.T) {
+	t.Run("logger.With should create a new logger", func(t *testing.T) {
+		wrapper := &logWrapper{
+			logger: log.New("test"),
+		}
+		newLogger := wrapper.With("key", "value")
+
+		require.NotSame(t, newLogger.(*logWrapper).logger, wrapper.logger, "`With` should not return the same instance")
+	})
 }

--- a/pkg/tsdb/loki/healthcheck.go
+++ b/pkg/tsdb/loki/healthcheck.go
@@ -20,7 +20,7 @@ const (
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult,
 	error) {
-	logger := s.logger.With("endpoint", "CheckHealth")
+	logger := s.logger.With("endpoint", "checkHealth")
 	ds, err := s.im.Get(ctx, req.PluginContext)
 	// check that the datasource exists
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

The logger used by Loki's healthcheck was calling `logger.With`, which usually creates a new sub-logger. There was a bug with the logger, that did not create a new logger, but changed the reference in place. That lead to situations, where `endpoint=CheckHealth` was appended multiple times. 

To reproduce without the fix:
1. Go to a Loki data source settings page
2. Hit the `Save & Test` button a couple of times
3. Do a proper Loki query.
4. Observe that multiple `endpoint=CheckHealth` attributes are logged, together with the correct `endpoint=queryData` attribute.

This can also be observed in e.g. https://github.com/grafana/grafana/issues/88527#issuecomment-2474681691
