### PR TITLE
Loki: skip tests that are flaking in CI

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryCodeEditor.test.tsx
@@ -27,7 +27,8 @@ const createDefaultProps = () => {
   return props;
 };
 
-describe('LokiQueryCodeEditor', () => {
+// Tests with Monaco are occasionally flaking in CI see #incident-2024-11-13-enterprise-drone-pipeline-failing. Skipping for now.
+describe.skip('LokiQueryCodeEditor', () => {
   it('shows explain section when showExplain is true', async () => {
     const props = createDefaultProps();
     props.showExplain = true;


### PR DESCRIPTION
**What is this feature?**
Skipping tests that are occasionally flaking in CI. 

**Why do we need this feature?**
To prevent failures in CI. These particular tests aren't critical, and can be temporarily skipped while we figure out how to reproduce the failure and find time to harden the tests.

**Special notes for your reviewer:**
More info: in `#incident-2024-11-13-enterprise-drone-pipeline-failing`
https://raintank-corp.slack.com/archives/C080GGYL24W/p1731579907266399

Follow up issue to mock and re-enable: https://github.com/grafana/grafana/issues/96552

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
