### PR TITLE
Datasources: Allow clearing trace to logs, metrics and profiles datasource pickers

### DIFF
--- a/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx
@@ -126,6 +126,7 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
                 datasourceUid: ds.uid,
               })
             }
+            onClear={() => updateTracesToLogs({ datasourceUid: undefined })}
           />
         </InlineField>
       </InlineFieldRow>

--- a/packages/grafana-o11y-ds-frontend/src/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -57,24 +57,14 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
                 datasourceUid: ds.uid,
               })
             }
-          />
-        </InlineField>
-        {options.jsonData.tracesToMetrics?.datasourceUid ? (
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            fill="text"
-            onClick={() => {
+            onClear={() =>
               updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
                 ...options.jsonData.tracesToMetrics,
                 datasourceUid: undefined,
-              });
-            }}
-          >
-            Clear
-          </Button>
-        ) : null}
+              })
+            }
+          />
+        </InlineField>
       </InlineFieldRow>
 
       <InlineFieldRow>

--- a/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx
+++ b/packages/grafana-o11y-ds-frontend/src/TraceToProfiles/TraceToProfilesSettings.tsx
@@ -81,6 +81,12 @@ export function TraceToProfilesSettings({ options, onOptionsChange }: Props) {
                 datasourceUid: ds.uid,
               });
             }}
+            onClear={() => {
+              updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToProfiles', {
+                ...options.jsonData.tracesToProfiles,
+                datasourceUid: undefined,
+              });
+            }}
           />
         </InlineField>
       </InlineFieldRow>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It's currently not possible to reset the datasource from the Trace to Logs, Trace to Metrics and Trace to Profiles which means that once a datasource is selected the config can never fully be removed. This is an issue because the buttons still appear in the Trace View if a datasource is selected but no other config is set. This PR allows an admin to clear the datasource to disable the Trace to ... config completely. 

**Who is this feature for?**

Users of the tracing datasources.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
