### PR TITLE
Internationalisation: Add basic e2e test to ensure languages load correctly

### DIFF
--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -5,6 +5,7 @@ describe('Verify i18n', () => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
   });
 
+  // map between languages in the language picker and the corresponding translation of the 'Language' label
   const languageMap = {
     Deutsch: 'Sprache',
     English: 'Language',
@@ -15,21 +16,19 @@ describe('Verify i18n', () => {
     'Pseudo-locale': 'Ŀäŉģūäģę',
   };
 
+  // basic test which loops through the defined languages in the picker
+  // and verifies that the corresponding label is translated correctly
   it('loads all the languages correctly', () => {
-    cy.intercept('GET', '/api/user/preferences').as('preferences');
+    cy.intercept('/api/user/preferences').as('preferences');
     cy.visit('/profile');
 
     cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
       // TODO investigate why we need to wait for 6 (SIX!) calls to the preferences API
-      cy.wait('@preferences');
-      cy.wait('@preferences');
-      cy.wait('@preferences');
-      cy.wait('@preferences');
-      cy.wait('@preferences');
-      cy.wait('@preferences');
+      cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
       cy.get('[id="locale-select"]').click();
       cy.get('[id="locale-select"]').type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();
+      cy.wait('@preferences');
       cy.contains('label', label).should('be.visible');
     });
   });

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -26,7 +26,7 @@ describe('Verify i18n', () => {
       // TODO investigate why we need to wait for 5 (FIVE!) calls to the preferences API
       cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
       cy.get('[id="locale-select"]').click();
-      cy.get('[id="locale-select"]').type(language).type('{downArrow}{enter}');
+      cy.get('[id="locale-select"]').clear().type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();
       cy.wait('@preferences');
       cy.contains('label', label).should('be.visible');

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -20,6 +20,7 @@ describe('Verify i18n', () => {
     cy.visit('/profile');
 
     cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
+      // TODO investigate why we need to wait for 6 (SIX!) calls to the preferences API
       cy.wait('@preferences');
       cy.wait('@preferences');
       cy.wait('@preferences');

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -6,15 +6,18 @@ describe('Verify i18n', () => {
   });
 
   // map between languages in the language picker and the corresponding translation of the 'Language' label
-  const languageMap = {
+  const languageMap: Record<string, string> = {
     Deutsch: 'Sprache',
     English: 'Language',
     Español: 'Idioma',
     Français: 'Langue',
     'Português Brasileiro': 'Idioma',
     '中文（简体）': '语言',
-    'Pseudo-locale': 'Ŀäŉģūäģę',
   };
+
+  if (process.env.NODE_ENV === 'development') {
+    languageMap['Pseudo-locale'] = 'Ŀäŉģūäģę';
+  }
 
   // basic test which loops through the defined languages in the picker
   // and verifies that the corresponding label is translated correctly

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -50,16 +50,18 @@ describe('Verify i18n', () => {
   // basic test which loops through the defined languages in the picker
   // and verifies that the corresponding label is translated correctly
   it('loads all the languages correctly', () => {
+    const LANGUAGE_SELECTOR = '[id="locale-select"]';
     cy.intercept('/api/user/preferences').as('preferences');
     cy.visit('/profile');
+    // wait for all the preferences calls to settle before interacting with the UI
+    cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
 
-    cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
-      // TODO investigate why we need to wait for 6 (SIX!) calls to the preferences API
-      cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
-      cy.get('[id="locale-select"]').click();
-      cy.get('[id="locale-select"]').clear().type(language).type('{downArrow}{enter}');
+    cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string], index) => {
+      cy.get(LANGUAGE_SELECTOR).click();
+      cy.get(LANGUAGE_SELECTOR).clear().type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();
       cy.contains('label', label).should('be.visible');
+      cy.get(LANGUAGE_SELECTOR).should('have.value', language);
     });
   });
 });

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -1,0 +1,35 @@
+import { e2e } from '../utils';
+
+describe('Verify i18n', () => {
+  beforeEach(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+  });
+
+  const languageMap = {
+    Deutsch: 'Sprache',
+    English: 'Language',
+    Español: 'Idioma',
+    Français: 'Langue',
+    'Português Brasileiro': 'Idioma',
+    '中文（简体）': '语言',
+    'Pseudo-locale': 'Ŀäŉģūäģę',
+  };
+
+  it('loads all the languages correctly', () => {
+    cy.intercept('GET', '/api/user/preferences').as('preferences');
+    cy.visit('/profile');
+
+    cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
+      cy.wait('@preferences');
+      cy.wait('@preferences');
+      cy.wait('@preferences');
+      cy.wait('@preferences');
+      cy.wait('@preferences');
+      cy.wait('@preferences');
+      cy.get('[id="locale-select"]').click();
+      cy.get('[id="locale-select"]').type(language).type('{downArrow}{enter}');
+      e2e.components.UserProfile.preferencesSaveButton().click();
+      cy.contains('label', label).should('be.visible');
+    });
+  });
+});

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -54,6 +54,7 @@ describe('Verify i18n', () => {
     const LANGUAGE_SELECTOR = '[id="locale-select"]';
 
     cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
+      cy.get(LANGUAGE_SELECTOR).should('not.be.disabled');
       cy.get(LANGUAGE_SELECTOR).click();
       cy.get(LANGUAGE_SELECTOR).clear().type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -23,8 +23,8 @@ describe('Verify i18n', () => {
     cy.visit('/profile');
 
     cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
-      // TODO investigate why we need to wait for 6 (SIX!) calls to the preferences API
-      cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
+      // TODO investigate why we need to wait for 5 (FIVE!) calls to the preferences API
+      cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
       cy.get('[id="locale-select"]').click();
       cy.get('[id="locale-select"]').type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -54,12 +54,11 @@ describe('Verify i18n', () => {
     cy.visit('/profile');
 
     cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
-      // TODO investigate why we need to wait for 5 (FIVE!) calls to the preferences API
-      cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
+      // TODO investigate why we need to wait for 6 (SIX!) calls to the preferences API
+      cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
       cy.get('[id="locale-select"]').click();
       cy.get('[id="locale-select"]').clear().type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();
-      cy.wait('@preferences');
       cy.contains('label', label).should('be.visible');
     });
   });

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -15,11 +15,6 @@ describe('Verify i18n', () => {
     '中文（简体）': '语言',
   };
 
-  // pseudo locale is not available in CI
-  if (!process.env.CI) {
-    languageMap['Pseudo-locale'] = 'Ŀäŉģūäģę';
-  }
-
   // basic test which loops through the defined languages in the picker
   // and verifies that the corresponding label is translated correctly
   it('loads all the languages correctly', () => {

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -53,8 +53,6 @@ describe('Verify i18n', () => {
     const LANGUAGE_SELECTOR = '[id="locale-select"]';
     cy.intercept('/api/user/preferences').as('preferences');
     cy.visit('/profile');
-    // wait for all the preferences calls to settle before interacting with the UI
-    cy.wait(['@preferences', '@preferences', '@preferences', '@preferences', '@preferences']);
 
     cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string], index) => {
       cy.get(LANGUAGE_SELECTOR).click();

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -15,7 +15,8 @@ describe('Verify i18n', () => {
     '中文（简体）': '语言',
   };
 
-  if (process.env.NODE_ENV === 'development') {
+  // pseudo locale is not available in CI
+  if (!process.env.CI) {
     languageMap['Pseudo-locale'] = 'Ŀäŉģūäģę';
   }
 

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -50,11 +50,10 @@ describe('Verify i18n', () => {
   // basic test which loops through the defined languages in the picker
   // and verifies that the corresponding label is translated correctly
   it('loads all the languages correctly', () => {
-    const LANGUAGE_SELECTOR = '[id="locale-select"]';
-    cy.intercept('/api/user/preferences').as('preferences');
     cy.visit('/profile');
+    const LANGUAGE_SELECTOR = '[id="locale-select"]';
 
-    cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string], index) => {
+    cy.wrap(Object.entries(languageMap)).each(([language, label]: [string, string]) => {
       cy.get(LANGUAGE_SELECTOR).click();
       cy.get(LANGUAGE_SELECTOR).clear().type(language).type('{downArrow}{enter}');
       e2e.components.UserProfile.preferencesSaveButton().click();

--- a/e2e/various-suite/verify-i18n.spec.ts
+++ b/e2e/various-suite/verify-i18n.spec.ts
@@ -1,8 +1,40 @@
 import { e2e } from '../utils';
+import { fromBaseUrl } from '../utils/support/url';
 
 describe('Verify i18n', () => {
-  beforeEach(() => {
+  const I18N_USER = 'i18n-test';
+  const I18N_PASSWORD = 'i18n-test';
+
+  // create a new user to isolate the language changes from other tests
+  before(() => {
     e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+    cy.request({
+      method: 'POST',
+      url: fromBaseUrl('/api/admin/users'),
+      body: {
+        email: I18N_USER,
+        login: I18N_USER,
+        name: I18N_USER,
+        password: I18N_PASSWORD,
+      },
+    }).then((response) => {
+      cy.wrap(response.body.uid).as('uid');
+    });
+  });
+
+  // remove the user created in the before hook
+  after(() => {
+    e2e.flows.login(Cypress.env('USERNAME'), Cypress.env('PASSWORD'));
+    cy.get('@uid').then((uid) => {
+      cy.request({
+        method: 'DELETE',
+        url: fromBaseUrl(`/api/admin/users/${uid}`),
+      });
+    });
+  });
+
+  beforeEach(() => {
+    e2e.flows.login(I18N_USER, I18N_PASSWORD);
   });
 
   // map between languages in the language picker and the corresponding translation of the 'Language' label

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -162,22 +162,28 @@ export class SharedPreferences extends PureComponent<Props, State> {
     const styles = getStyles();
     const languages = getLanguageOptions();
     const currentThemeOption = this.themeOptions.find((x) => x.value === theme) ?? this.themeOptions[0];
+    const themeId = 'shared-preferences-theme-select';
+    const homeDashboardId = 'home-dashboard-select';
+    const timezoneId = 'shared-preferences-timezone-picker';
+    const weekStartId = 'shared-preferences-week-start-picker';
+    const languageId = 'locale-select';
 
     return (
       <form onSubmit={this.onSubmitForm} className={styles.form}>
         <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>} disabled={disabled}>
-          <Field label={t('shared-preferences.fields.theme-label', 'Interface theme')}>
+          <Field htmlFor={themeId} label={t('shared-preferences.fields.theme-label', 'Interface theme')}>
             <FieldSkeletonLoader isLoading={isLoading}>
               <Combobox
                 options={this.themeOptions}
                 value={currentThemeOption.value}
                 onChange={this.onThemeChanged}
-                id="shared-preferences-theme-select"
+                id={themeId}
               />
             </FieldSkeletonLoader>
           </Field>
 
           <Field
+            htmlFor={homeDashboardId}
             label={
               <Label htmlFor="home-dashboard-select">
                 <span className={styles.labelText}>
@@ -194,12 +200,13 @@ export class SharedPreferences extends PureComponent<Props, State> {
                 defaultOptions={true}
                 isClearable={true}
                 placeholder={t('shared-preferences.fields.home-dashboard-placeholder', 'Default dashboard')}
-                inputId="home-dashboard-select"
+                inputId={homeDashboardId}
               />
             </FieldSkeletonLoader>
           </Field>
 
           <Field
+            htmlFor={timezoneId}
             label={t('shared-dashboard.fields.timezone-label', 'Timezone')}
             data-testid={selectors.components.TimeZonePicker.containerV2}
           >
@@ -208,25 +215,23 @@ export class SharedPreferences extends PureComponent<Props, State> {
                 includeInternal={true}
                 value={timezone}
                 onChange={this.onTimeZoneChanged}
-                inputId="shared-preferences-timezone-picker"
+                inputId={timezoneId}
               />
             </FieldSkeletonLoader>
           </Field>
 
           <Field
+            htmlFor={weekStartId}
             label={t('shared-preferences.fields.week-start-label', 'Week start')}
             data-testid={selectors.components.WeekStartPicker.containerV2}
           >
             <FieldSkeletonLoader isLoading={isLoading}>
-              <WeekStartPicker
-                value={weekStart || ''}
-                onChange={this.onWeekStartChanged}
-                inputId={'shared-preferences-week-start-picker'}
-              />
+              <WeekStartPicker value={weekStart || ''} onChange={this.onWeekStartChanged} inputId={weekStartId} />
             </FieldSkeletonLoader>
           </Field>
 
           <Field
+            htmlFor={languageId}
             label={
               <Label htmlFor="locale-select">
                 <span className={styles.labelText}>
@@ -243,7 +248,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                 onChange={(lang: ComboboxOption | null) => this.onLanguageChanged(lang?.value ?? '')}
                 options={languages}
                 placeholder={t('shared-preferences.fields.locale-placeholder', 'Choose language')}
-                id="locale-select"
+                id={languageId}
               />
             </FieldSkeletonLoader>
           </Field>

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
-import { PropsWithChildren, PureComponent } from 'react';
+import { PureComponent } from 'react';
 import * as React from 'react';
-import Skeleton from 'react-loading-skeleton';
 
 import { FeatureState, getBuiltInThemes, ThemeRegistryItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -18,9 +17,7 @@ import {
   FeatureBadge,
   Combobox,
   ComboboxOption,
-  useStyles2,
 } from '@grafana/ui';
-import { skeletonAnimation } from '@grafana/ui/src/unstable';
 import { DashboardPicker } from 'app/core/components/Select/DashboardPicker';
 import { t, Trans } from 'app/core/internationalization';
 import { LANGUAGES, PSEUDO_LOCALE } from 'app/core/internationalization/constants';
@@ -162,28 +159,22 @@ export class SharedPreferences extends PureComponent<Props, State> {
     const styles = getStyles();
     const languages = getLanguageOptions();
     const currentThemeOption = this.themeOptions.find((x) => x.value === theme) ?? this.themeOptions[0];
-    const themeId = 'shared-preferences-theme-select';
-    const homeDashboardId = 'home-dashboard-select';
-    const timezoneId = 'shared-preferences-timezone-picker';
-    const weekStartId = 'shared-preferences-week-start-picker';
-    const languageId = 'locale-select';
 
     return (
       <form onSubmit={this.onSubmitForm} className={styles.form}>
         <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>} disabled={disabled}>
-          <Field htmlFor={themeId} label={t('shared-preferences.fields.theme-label', 'Interface theme')}>
-            <FieldSkeletonLoader isLoading={isLoading}>
-              <Combobox
-                options={this.themeOptions}
-                value={currentThemeOption.value}
-                onChange={this.onThemeChanged}
-                id={themeId}
-              />
-            </FieldSkeletonLoader>
+          <Field label={t('shared-preferences.fields.theme-label', 'Interface theme')}>
+            <Combobox
+              loading={isLoading}
+              disabled={isLoading}
+              options={this.themeOptions}
+              value={currentThemeOption.value}
+              onChange={this.onThemeChanged}
+              id="shared-preferences-theme-select"
+            />
           </Field>
 
           <Field
-            htmlFor={homeDashboardId}
             label={
               <Label htmlFor="home-dashboard-select">
                 <span className={styles.labelText}>
@@ -193,45 +184,44 @@ export class SharedPreferences extends PureComponent<Props, State> {
             }
             data-testid="User preferences home dashboard drop down"
           >
-            <FieldSkeletonLoader isLoading={isLoading}>
-              <DashboardPicker
-                value={homeDashboardUID}
-                onChange={(v) => this.onHomeDashboardChanged(v?.uid ?? '')}
-                defaultOptions={true}
-                isClearable={true}
-                placeholder={t('shared-preferences.fields.home-dashboard-placeholder', 'Default dashboard')}
-                inputId={homeDashboardId}
-              />
-            </FieldSkeletonLoader>
+            <DashboardPicker
+              isLoading={isLoading}
+              disabled={isLoading}
+              value={homeDashboardUID}
+              onChange={(v) => this.onHomeDashboardChanged(v?.uid ?? '')}
+              defaultOptions={true}
+              isClearable={true}
+              placeholder={t('shared-preferences.fields.home-dashboard-placeholder', 'Default dashboard')}
+              inputId="home-dashboard-select"
+            />
           </Field>
 
           <Field
-            htmlFor={timezoneId}
             label={t('shared-dashboard.fields.timezone-label', 'Timezone')}
             data-testid={selectors.components.TimeZonePicker.containerV2}
           >
-            <FieldSkeletonLoader isLoading={isLoading}>
-              <TimeZonePicker
-                includeInternal={true}
-                value={timezone}
-                onChange={this.onTimeZoneChanged}
-                inputId={timezoneId}
-              />
-            </FieldSkeletonLoader>
+            <TimeZonePicker
+              disabled={isLoading}
+              includeInternal={true}
+              value={timezone}
+              onChange={this.onTimeZoneChanged}
+              inputId="shared-preferences-timezone-picker"
+            />
           </Field>
 
           <Field
-            htmlFor={weekStartId}
             label={t('shared-preferences.fields.week-start-label', 'Week start')}
             data-testid={selectors.components.WeekStartPicker.containerV2}
           >
-            <FieldSkeletonLoader isLoading={isLoading}>
-              <WeekStartPicker value={weekStart || ''} onChange={this.onWeekStartChanged} inputId={weekStartId} />
-            </FieldSkeletonLoader>
+            <WeekStartPicker
+              disabled={isLoading}
+              value={weekStart || ''}
+              onChange={this.onWeekStartChanged}
+              inputId="shared-preferences-week-start-picker"
+            />
           </Field>
 
           <Field
-            htmlFor={languageId}
             label={
               <Label htmlFor="locale-select">
                 <span className={styles.labelText}>
@@ -242,15 +232,15 @@ export class SharedPreferences extends PureComponent<Props, State> {
             }
             data-testid="User preferences language drop down"
           >
-            <FieldSkeletonLoader isLoading={isLoading}>
-              <Combobox
-                value={languages.find((lang) => lang.value === language)?.value || ''}
-                onChange={(lang: ComboboxOption | null) => this.onLanguageChanged(lang?.value ?? '')}
-                options={languages}
-                placeholder={t('shared-preferences.fields.locale-placeholder', 'Choose language')}
-                id={languageId}
-              />
-            </FieldSkeletonLoader>
+            <Combobox
+              loading={isLoading}
+              disabled={isLoading}
+              value={languages.find((lang) => lang.value === language)?.value || ''}
+              onChange={(lang: ComboboxOption | null) => this.onLanguageChanged(lang?.value ?? '')}
+              options={languages}
+              placeholder={t('shared-preferences.fields.locale-placeholder', 'Choose language')}
+              id="locale-select"
+            />
           </Field>
         </FieldSet>
         <Button type="submit" variant="primary" data-testid={selectors.components.UserProfile.preferencesSaveButton}>
@@ -260,27 +250,6 @@ export class SharedPreferences extends PureComponent<Props, State> {
     );
   }
 }
-
-const FieldSkeletonLoader = ({
-  children,
-  isLoading,
-}: PropsWithChildren<{
-  isLoading: boolean;
-}>) => {
-  const styles = useStyles2(getSkeletonStyles);
-  return isLoading ? (
-    <Skeleton height={32} containerClassName={styles.skeletonContainer} style={skeletonAnimation} />
-  ) : (
-    children
-  );
-};
-
-const getSkeletonStyles = () => ({
-  skeletonContainer: css({
-    display: 'block',
-    lineHeight: 1,
-  }),
-});
 
 export default SharedPreferences;
 

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -163,10 +163,12 @@ export class SharedPreferences extends PureComponent<Props, State> {
     return (
       <form onSubmit={this.onSubmitForm} className={styles.form}>
         <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>} disabled={disabled}>
-          <Field label={t('shared-preferences.fields.theme-label', 'Interface theme')}>
+          <Field
+            loading={isLoading}
+            disabled={isLoading}
+            label={t('shared-preferences.fields.theme-label', 'Interface theme')}
+          >
             <Combobox
-              loading={isLoading}
-              disabled={isLoading}
               options={this.themeOptions}
               value={currentThemeOption.value}
               onChange={this.onThemeChanged}
@@ -175,6 +177,8 @@ export class SharedPreferences extends PureComponent<Props, State> {
           </Field>
 
           <Field
+            loading={isLoading}
+            disabled={isLoading}
             label={
               <Label htmlFor="home-dashboard-select">
                 <span className={styles.labelText}>
@@ -185,8 +189,6 @@ export class SharedPreferences extends PureComponent<Props, State> {
             data-testid="User preferences home dashboard drop down"
           >
             <DashboardPicker
-              isLoading={isLoading}
-              disabled={isLoading}
               value={homeDashboardUID}
               onChange={(v) => this.onHomeDashboardChanged(v?.uid ?? '')}
               defaultOptions={true}
@@ -197,11 +199,12 @@ export class SharedPreferences extends PureComponent<Props, State> {
           </Field>
 
           <Field
+            loading={isLoading}
+            disabled={isLoading}
             label={t('shared-dashboard.fields.timezone-label', 'Timezone')}
             data-testid={selectors.components.TimeZonePicker.containerV2}
           >
             <TimeZonePicker
-              disabled={isLoading}
               includeInternal={true}
               value={timezone}
               onChange={this.onTimeZoneChanged}
@@ -210,11 +213,12 @@ export class SharedPreferences extends PureComponent<Props, State> {
           </Field>
 
           <Field
+            loading={isLoading}
+            disabled={isLoading}
             label={t('shared-preferences.fields.week-start-label', 'Week start')}
             data-testid={selectors.components.WeekStartPicker.containerV2}
           >
             <WeekStartPicker
-              disabled={isLoading}
               value={weekStart || ''}
               onChange={this.onWeekStartChanged}
               inputId="shared-preferences-week-start-picker"
@@ -222,6 +226,8 @@ export class SharedPreferences extends PureComponent<Props, State> {
           </Field>
 
           <Field
+            loading={isLoading}
+            disabled={isLoading}
             label={
               <Label htmlFor="locale-select">
                 <span className={styles.labelText}>
@@ -233,8 +239,6 @@ export class SharedPreferences extends PureComponent<Props, State> {
             data-testid="User preferences language drop down"
           >
             <Combobox
-              loading={isLoading}
-              disabled={isLoading}
               value={languages.find((lang) => lang.value === language)?.value || ''}
               onChange={(lang: ComboboxOption | null) => this.onLanguageChanged(lang?.value ?? '')}
               options={languages}

--- a/public/app/core/internationalization/constants.test.ts
+++ b/public/app/core/internationalization/constants.test.ts
@@ -21,7 +21,7 @@ describe('internationalization constants', () => {
     expect(GERMAN_GERMANY).toBe('de-DE');
     expect(BRAZILIAN_PORTUGUESE).toBe('pt-BR');
     expect(CHINESE_SIMPLIFIED).toBe('zh-Hans');
-    expect(PSEUDO_LOCALE).toBe('pseudo-LOCALE');
+    expect(PSEUDO_LOCALE).toBe('pseudo');
     expect(DEFAULT_LANGUAGE).toBe(ENGLISH_US);
   });
 

--- a/public/app/core/internationalization/constants.ts
+++ b/public/app/core/internationalization/constants.ts
@@ -7,7 +7,7 @@ export const SPANISH_SPAIN = 'es-ES';
 export const GERMAN_GERMANY = 'de-DE';
 export const BRAZILIAN_PORTUGUESE = 'pt-BR';
 export const CHINESE_SIMPLIFIED = 'zh-Hans';
-export const PSEUDO_LOCALE = 'pseudo-LOCALE';
+export const PSEUDO_LOCALE = 'pseudo';
 
 export const DEFAULT_LANGUAGE = ENGLISH_US;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adjusts the pseudo locale id to be just `pseudo`
  - latest version of i18next has some code that attempts to verify the language code is correct if it contains a `-`
  - `pseudo-LOCALE` fails this check and doesn't work anymore
- adds an e2e test to verify prod translations load correctly
- disables inputs whilst loading preferences: 
![image](https://github.com/user-attachments/assets/6fd30dcd-673e-4e8b-918a-814655175022)


**Why do we need this feature?**

- bumping i18next broke pseudo translations (see [this PR](https://github.com/grafana/grafana/pull/96392))
- prevent regressions in i18n
- fix pseudo translations

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
