### PR TITLE
Elasticsearch: Replace error source http client with a new error source methods

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	exp "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
@@ -179,7 +178,7 @@ func (c *baseClientImpl) ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearch
 	clientRes, err := c.executeBatchRequest("_msearch", queryParams, multiRequests)
 	if err != nil {
 		status := "error"
-		if backend.IsDownstreamError(err) {
+		if errors.Is(err, context.Canceled) {
 			status = "cancelled"
 		}
 		lp := []any{"error", err, "status", status, "duration", time.Since(start), "stage", StageDatabaseRequest}
@@ -193,7 +192,6 @@ func (c *baseClientImpl) ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearch
 		c.logger.Error("Error received from Elasticsearch", lp...)
 		return nil, err
 	}
-
 	res := clientRes
 	defer func() {
 		if err := res.Body.Close(); err != nil {

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -84,7 +84,7 @@ func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 	}
 
 	if res.Status/100 != 2 {
-		errWithSource := errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("unexpected status code %d", res.Status), false)
+		errWithSource := errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("unexpected status code: %d", res.Status), false)
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, errWithSource), nil
 	}
 

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -78,7 +78,7 @@ func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 	res, err := e.client.ExecuteMultisearch(req)
 	if err != nil {
 		if backend.IsDownstreamHTTPError(err) {
-			return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, errorsource.DownstreamError(err, false)), nil
+			err = errorsource.DownstreamError(err, false)
 		}
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, err), nil
 	}

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -83,7 +83,7 @@ func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, err), nil
 	}
 
-	if res.Status%100 != 2 {
+	if res.Status/100 != 2 {
 		status := backend.ErrorSourceFromHTTPStatus(res.Status)
 		errWithSource := errorsource.SourceError(status, fmt.Errorf("unexpected status code %d", res.Status), false)
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, errWithSource), nil

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -83,7 +83,7 @@ func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, err), nil
 	}
 
-	if res.Status/100 != 2 {
+	if res.Status >= 400 {
 		errWithSource := errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("unexpected status code: %d", res.Status), false)
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, errWithSource), nil
 	}

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -84,8 +84,7 @@ func (e *elasticsearchDataQuery) execute() (*backend.QueryDataResponse, error) {
 	}
 
 	if res.Status/100 != 2 {
-		status := backend.ErrorSourceFromHTTPStatus(res.Status)
-		errWithSource := errorsource.SourceError(status, fmt.Errorf("unexpected status code %d", res.Status), false)
+		errWithSource := errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(res.Status), fmt.Errorf("unexpected status code %d", res.Status), false)
 		return errorsource.AddErrorToResponse(e.dataQueries[0].RefID, response, errWithSource), nil
 	}
 

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	exp "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
-	exphttpclient "github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource/httpclient"
 
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 )
@@ -90,10 +89,7 @@ func newInstanceSettings(httpClientProvider *httpclient.Provider) datasource.Ins
 			httpCliOpts.SigV4.Service = "es"
 		}
 
-		// set the default middlewars from the httpClientProvider
-		httpCliOpts.Middlewares = httpClientProvider.Opts.Middlewares
-		// enable experimental http client to support errors with source
-		httpCli, err := exphttpclient.New(httpCliOpts)
+		httpCli, err := httpClientProvider.New(httpCliOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/elasticsearch/error_handling_test.go
+++ b/pkg/tsdb/elasticsearch/error_handling_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +45,7 @@ func TestErrorAvgMissingField(t *testing.T) {
 
 	// FIXME: we should return the received error message
 	require.Equal(t, "unexpected status code: 400", result.response.Responses["A"].Error.Error())
+	require.Equal(t, backend.ErrorSourceDownstream, result.response.Responses["A"].ErrorSource)
 }
 
 func TestErrorAvgMissingFieldNoDetailedErrors(t *testing.T) {

--- a/pkg/tsdb/elasticsearch/error_handling_test.go
+++ b/pkg/tsdb/elasticsearch/error_handling_test.go
@@ -43,7 +43,7 @@ func TestErrorAvgMissingField(t *testing.T) {
 	require.NoError(t, err)
 
 	// FIXME: we should return the received error message
-	require.Len(t, result.response.Responses, 0)
+	require.Equal(t, "unexpected status code: 400", result.response.Responses["A"].Error.Error())
 }
 
 func TestErrorAvgMissingFieldNoDetailedErrors(t *testing.T) {
@@ -71,7 +71,7 @@ func TestErrorAvgMissingFieldNoDetailedErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	// FIXME: we should return the received error message
-	require.Len(t, result.response.Responses, 0)
+	require.Equal(t, "unexpected status code: 400", result.response.Responses["A"].Error.Error())
 }
 
 func TestErrorTooManyDateHistogramBuckets(t *testing.T) {


### PR DESCRIPTION
We want to deprecate and get rid of `errorsource/httpclient` as a part of https://github.com/grafana/grafana-plugin-sdk-go/issues/1105, as error source middleware implemented in experimental error source httpclient is turning any non-200 response to error and hiding original message. 

 Instead of that we have introduced 2 methods developers can use:
 - `backend.ErrorSourceFromHTTPStatus` to get error source from http code
 - `backend.IsDownstreamHTTPError` to get error source from http error

In this PR we are removing `errorsource/httpclient` and instead just using those methods. 