### PR TITLE
GrafanaUI: Size AutoSizeInput correctly when used with suffix/prefix

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { measureText } from '../../utils/measureText';
 
+import { AutoSizeInputContext } from './AutoSizeInputContext';
 import { Input, Props as InputProps } from './Input';
 
 export interface Props extends InputProps {
@@ -44,34 +45,38 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
   }, [placeholder, value, minWidth, maxWidth]);
 
   return (
-    <Input
-      {...restProps}
-      placeholder={placeholder}
-      ref={ref}
-      value={value.toString()}
-      onChange={(event) => {
-        if (onChange) {
-          onChange(event);
-        }
-        setValue(event.currentTarget.value);
-      }}
-      width={inputWidth}
-      onBlur={(event) => {
-        if (onBlur) {
-          onBlur(event);
-        } else if (onCommitChange) {
-          onCommitChange(event);
-        }
-      }}
-      onKeyDown={(event) => {
-        if (onKeyDown) {
-          onKeyDown(event);
-        } else if (event.key === 'Enter' && onCommitChange) {
-          onCommitChange(event);
-        }
-      }}
-      data-testid={'autosize-input'}
-    />
+    // Used to tell Input to increase the width properly of the input to fit the text.
+    // See comment in Input.tsx for more details
+    <AutoSizeInputContext.Provider value={true}>
+      <Input
+        {...restProps}
+        placeholder={placeholder}
+        ref={ref}
+        value={value.toString()}
+        onChange={(event) => {
+          if (onChange) {
+            onChange(event);
+          }
+          setValue(event.currentTarget.value);
+        }}
+        onBlur={(event) => {
+          if (onBlur) {
+            onBlur(event);
+          } else if (onCommitChange) {
+            onCommitChange(event);
+          }
+        }}
+        onKeyDown={(event) => {
+          if (onKeyDown) {
+            onKeyDown(event);
+          } else if (event.key === 'Enter' && onCommitChange) {
+            onCommitChange(event);
+          }
+        }}
+        width={inputWidth}
+        data-testid="autosize-input"
+      />
+    </AutoSizeInputContext.Provider>
   );
 });
 

--- a/packages/grafana-ui/src/components/Input/AutoSizeInputContext.ts
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInputContext.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// Used to tell Input to increase the width properly of the input to fit the text.
+// See comment in Input.tsx for more details
+export const AutoSizeInputContext = React.createContext(false);
+AutoSizeInputContext.displayName = 'AutoSizeInputContext';

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -53,10 +53,7 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
   const [prefixRef, prefixRect] = useMeasure<HTMLDivElement>();
   const [suffixRef, suffixRect] = useMeasure<HTMLDivElement>();
 
-  // When AutoSizeInput is used with a suffix/prefix, the text is clipped because the suffix take up some of the
-  // specified space. This is because speci
-
-  // Specifying a width on Input controls the external size of the input, which is taken up by the text input itself,
+  // Specifying a width on Input controls the external size of the input, which is taken up by the text input itself
   // and suffix and prefix.
   // However AutoSizeInput wants to pass in a width to control the size of the text input itself, but suffix/prefix
   // eats up that space and makes the text clip

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { forwardRef, HTMLProps, ReactNode } from 'react';
+import { forwardRef, HTMLProps, ReactNode, useContext } from 'react';
 import useMeasure from 'react-use/lib/useMeasure';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -7,6 +7,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { stylesFactory, useTheme2 } from '../../themes';
 import { getFocusStyle, sharedInputStyle } from '../Forms/commonStyles';
 import { Spinner } from '../Spinner/Spinner';
+
+import { AutoSizeInputContext } from './AutoSizeInputContext';
 
 export interface Props extends Omit<HTMLProps<HTMLInputElement>, 'prefix' | 'size'> {
   /** Sets the width to a multiple of 8px. Should only be used with inline forms. Setting width of the container is preferred in other cases.*/
@@ -32,7 +34,17 @@ interface StyleDeps {
 }
 
 export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { className, addonAfter, addonBefore, prefix, suffix, invalid, loading, width = 0, ...restProps } = props;
+  const {
+    className,
+    addonAfter,
+    addonBefore,
+    prefix,
+    suffix: suffixProp,
+    invalid,
+    loading,
+    width = 0,
+    ...restProps
+  } = props;
   /**
    * Prefix & suffix are positioned absolutely within inputWrapper. We use client rects below to apply correct padding to the input
    * when prefix/suffix is larger than default (28px = 16px(icon) + 12px(left/right paddings)).
@@ -41,13 +53,28 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
   const [prefixRef, prefixRect] = useMeasure<HTMLDivElement>();
   const [suffixRef, suffixRect] = useMeasure<HTMLDivElement>();
 
+  // When AutoSizeInput is used with a suffix/prefix, the text is clipped because the suffix take up some of the
+  // specified space. This is because speci
+
+  // Specifying a width on Input controls the external size of the input, which is taken up by the text input itself,
+  // and suffix and prefix.
+  // However AutoSizeInput wants to pass in a width to control the size of the text input itself, but suffix/prefix
+  // eats up that space and makes the text clip
+  // To fix this, we have private context that tells Input when it's being used in an AutoSizeInput and increases
+  // the width by the size of the suffix/prefix
+  const isInAutoSizeInput = useContext(AutoSizeInputContext);
+  const accessoriesWidth = (prefixRect.width || 0) + (suffixRect.width || 0);
+  const finalWidth = isInAutoSizeInput && width ? width + accessoriesWidth / 8 : width;
+
   const theme = useTheme2();
-  const styles = getInputStyles({ theme, invalid: !!invalid, width });
+
+  const styles = getInputStyles({ theme, invalid: !!invalid, width: finalWidth });
+
+  const suffix = suffixProp || (loading && <Spinner inline={true} />);
 
   return (
-    <div className={cx(styles.wrapper, className)} data-testid={'input-wrapper'}>
+    <div className={cx(styles.wrapper, className)} data-testid="input-wrapper">
       {!!addonBefore && <div className={styles.addon}>{addonBefore}</div>}
-
       <div className={styles.inputWrapper}>
         {prefix && (
           <div className={styles.prefix} ref={prefixRef}>
@@ -65,14 +92,12 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
           }}
         />
 
-        {(suffix || loading) && (
+        {suffix && (
           <div className={styles.suffix} ref={suffixRef}>
-            {loading && <Spinner className={styles.loadingIndicator} inline={true} />}
             {suffix}
           </div>
         )}
       </div>
-
       {!!addonAfter && <div className={styles.addon}>{addonAfter}</div>}
     </div>
   );

--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -53,12 +53,11 @@ export const Input = forwardRef<HTMLInputElement, Props>((props, ref) => {
   const [prefixRef, prefixRect] = useMeasure<HTMLDivElement>();
   const [suffixRef, suffixRect] = useMeasure<HTMLDivElement>();
 
-  // Specifying a width on Input controls the external size of the input, which is taken up by the text input itself
-  // and suffix and prefix.
-  // However AutoSizeInput wants to pass in a width to control the size of the text input itself, but suffix/prefix
-  // eats up that space and makes the text clip
-  // To fix this, we have private context that tells Input when it's being used in an AutoSizeInput and increases
-  // the width by the size of the suffix/prefix
+  // Yes, this is gross - When Input is being wrapped by AutoSizeInput, add the suffix/prefix width to the overall width
+  // so the text content is not clipped. The intention is to make all the input's text appear without overflow/clipping,
+  // which isn't normally how width is used in this component.
+  // This behaviour is not controlled via a prop so we can limit API surface, and remove this as a 'breaking change' later
+  // if a better solution is found.
   const isInAutoSizeInput = useContext(AutoSizeInputContext);
   const accessoriesWidth = (prefixRect.width || 0) + (suffixRect.width || 0);
   const finalWidth = isInAutoSizeInput && width ? width + accessoriesWidth / 8 : width;


### PR DESCRIPTION
Specifying a width on Input controls the external size of the input, which is taken up by the text input itself and suffix and prefix.

However AutoSizeInput wants to pass in a width to control the size of the text input itself, but suffix/prefix eats up that space and makes the text clip.

To fix this, we have private context that tells Input when it's being used in an AutoSizeInput and increases the width by the size of the suffix/prefix

Fixes https://github.com/grafana/grafana/issues/96346
