### PR TITLE
Alerting: Silence drawer being forcefully closed

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -1,16 +1,18 @@
-import { css } from '@emotion/css';
 import { useMemo } from 'react';
+import { useMeasure } from 'react-use';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { Counter, Pagination, Stack, useStyles2 } from '@grafana/ui';
+import { Counter, LoadingBar, Pagination, Stack } from '@grafana/ui';
 import { DEFAULT_PER_PAGE_PAGINATION } from 'app/core/constants';
 import { CombinedRule, CombinedRuleNamespace } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import { usePagination } from '../../hooks/usePagination';
+import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { AlertRuleListItem } from '../../rule-list/components/AlertRuleListItem';
 import { ListSection } from '../../rule-list/components/ListSection';
+import { getRulesDataSources, GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { createViewLink } from '../../utils/misc';
+import { isAsyncRequestStatePending } from '../../utils/redux';
 import { hashRule } from '../../utils/rule-id';
 import { getRulePluginOrigin, isAlertingRule, isProvisionedRule } from '../../utils/rules';
 import { calculateTotalInstances } from '../rule-viewer/RuleViewer';
@@ -24,7 +26,9 @@ interface Props {
 type GroupedRules = Map<PromAlertingRuleState, CombinedRule[]>;
 
 export const RuleListStateView = ({ namespaces }: Props) => {
-  const styles = useStyles2(getStyles);
+  const [ref, { width }] = useMeasure<HTMLUListElement>();
+
+  const isLoading = useDataSourcesLoadingState();
 
   const groupedRules = useMemo(() => {
     const result: GroupedRules = new Map([
@@ -54,10 +58,13 @@ export const RuleListStateView = ({ namespaces }: Props) => {
   const entries = groupedRules.entries();
 
   return (
-    <ul className={styles.columnStack} role="tree">
-      {Array.from(entries).map(([state, rules]) => (
-        <RulesByState key={state} state={state} rules={rules} />
-      ))}
+    <ul role="tree" ref={ref}>
+      {isLoading && <LoadingBar width={width} />}
+      <Stack direction="column">
+        {Array.from(entries).map(([state, rules]) => (
+          <RulesByState key={state} state={state} rules={rules} />
+        ))}
+      </Stack>
     </ul>
   );
 };
@@ -127,10 +134,24 @@ const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: C
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  columnStack: css({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(1),
-  }),
-});
+function useDataSourcesLoadingState() {
+  const dsConfigs = useUnifiedAlertingSelector((state) => state.dataSources);
+  const promRules = useUnifiedAlertingSelector((state) => state.promRules);
+
+  const rulesDataSources = useMemo(getRulesDataSources, []);
+
+  const grafanaLoading = useUnifiedAlertingSelector((state) => {
+    const promLoading = isAsyncRequestStatePending(state.promRules[GRAFANA_RULES_SOURCE_NAME]);
+    const rulerLoading = isAsyncRequestStatePending(state.rulerRules[GRAFANA_RULES_SOURCE_NAME]);
+
+    return promLoading || rulerLoading;
+  });
+
+  const externalDataSourcesLoading = rulesDataSources.some(
+    (ds) => isAsyncRequestStatePending(promRules[ds.name]) || isAsyncRequestStatePending(dsConfigs[ds.name])
+  );
+
+  const loading = grafanaLoading || externalDataSourcesLoading;
+
+  return loading;
+}

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -71,7 +71,7 @@ const STATE_TITLES: Record<PromAlertingRuleState, string> = {
 const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: CombinedRule[] }) => {
   const { page, pageItems, numberOfPages, onPageChange } = usePagination(rules, 1, DEFAULT_PER_PAGE_PAGINATION);
 
-  const isNotFiringState = state !== PromAlertingRuleState.Firing;
+  const isFiringState = state !== PromAlertingRuleState.Firing;
   const hasRulesMatchingState = rules.length > 0;
 
   return (
@@ -82,7 +82,7 @@ const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: C
           <Counter value={rules.length} />
         </Stack>
       }
-      collapsed={isNotFiringState || hasRulesMatchingState}
+      collapsed={isFiringState || hasRulesMatchingState}
       pagination={
         <Pagination
           currentPage={page}

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -135,9 +135,7 @@ const RulesByState = ({ state, rules }: { state: PromAlertingRuleState; rules: C
 };
 
 function useDataSourcesLoadingState() {
-  const dsConfigs = useUnifiedAlertingSelector((state) => state.dataSources);
   const promRules = useUnifiedAlertingSelector((state) => state.promRules);
-
   const rulesDataSources = useMemo(getRulesDataSources, []);
 
   const grafanaLoading = useUnifiedAlertingSelector((state) => {
@@ -147,9 +145,7 @@ function useDataSourcesLoadingState() {
     return promLoading || rulerLoading;
   });
 
-  const externalDataSourcesLoading = rulesDataSources.some(
-    (ds) => isAsyncRequestStatePending(promRules[ds.name]) || isAsyncRequestStatePending(dsConfigs[ds.name])
-  );
+  const externalDataSourcesLoading = rulesDataSources.some((ds) => isAsyncRequestStatePending(promRules[ds.name]));
 
   const loading = grafanaLoading || externalDataSourcesLoading;
 

--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, userEvent, screen } from 'test/test-utils';
+import { render, userEvent, screen, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { setPluginLinksHook } from '@grafana/runtime';
@@ -39,6 +39,12 @@ const user = userEvent.setup();
 setupMswServer();
 
 describe('RulesTable RBAC', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
   describe('Grafana rules action buttons', () => {
     const grafanaRule = getGrafanaRule({ name: 'Grafana' });
 
@@ -52,7 +58,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
+      await waitFor(() => expect(ui.actionButtons.edit.query()).not.toBeInTheDocument());
     });
 
     it('Should not render Delete button for users without the delete permission', async () => {
@@ -65,7 +71,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      await user.click(ui.actionButtons.more.get());
+      await user.click(await ui.actionButtons.more.find());
 
       expect(ui.moreActionItems.delete.query()).not.toBeInTheDocument();
     });
@@ -80,7 +86,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      expect(ui.actionButtons.edit.get()).toBeInTheDocument();
+      expect(await ui.actionButtons.edit.find()).toBeInTheDocument();
     });
 
     it('Should render Delete button for users with the delete permission', async () => {
@@ -93,8 +99,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      expect(ui.actionButtons.more.get()).toBeInTheDocument();
-      await user.click(ui.actionButtons.more.get());
+      await user.click(await ui.actionButtons.more.find());
       expect(ui.moreActionItems.delete.get()).toBeInTheDocument();
     });
 
@@ -159,7 +164,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
+      await waitFor(() => expect(ui.actionButtons.edit.query()).not.toBeInTheDocument());
     });
 
     it('Should not render Delete button for users without the delete permission', async () => {
@@ -172,7 +177,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      await user.click(ui.actionButtons.more.get());
+      await user.click(await ui.actionButtons.more.find());
       expect(ui.moreActionItems.delete.query()).not.toBeInTheDocument();
     });
 
@@ -186,7 +191,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      expect(ui.actionButtons.edit.get()).toBeInTheDocument();
+      expect(await ui.actionButtons.edit.find()).toBeInTheDocument();
     });
 
     it('Should render Delete button for users with the delete permission', async () => {
@@ -199,8 +204,8 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      await user.click(ui.actionButtons.more.get());
-      expect(ui.moreActionItems.delete.get()).toBeInTheDocument();
+      await user.click(await ui.actionButtons.more.find());
+      expect(await ui.moreActionItems.delete.find()).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, userEvent, screen, waitFor } from 'test/test-utils';
+import { render, userEvent, screen } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { setPluginLinksHook } from '@grafana/runtime';
@@ -39,12 +39,6 @@ const user = userEvent.setup();
 setupMswServer();
 
 describe('RulesTable RBAC', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-    jest.resetAllMocks();
-  });
-
   describe('Grafana rules action buttons', () => {
     const grafanaRule = getGrafanaRule({ name: 'Grafana' });
 
@@ -58,7 +52,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      await waitFor(() => expect(ui.actionButtons.edit.query()).not.toBeInTheDocument());
+      expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
     });
 
     it('Should not render Delete button for users without the delete permission', async () => {
@@ -71,7 +65,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      await user.click(await ui.actionButtons.more.find());
+      await user.click(ui.actionButtons.more.get());
 
       expect(ui.moreActionItems.delete.query()).not.toBeInTheDocument();
     });
@@ -86,7 +80,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      expect(await ui.actionButtons.edit.find()).toBeInTheDocument();
+      expect(ui.actionButtons.edit.get()).toBeInTheDocument();
     });
 
     it('Should render Delete button for users with the delete permission', async () => {
@@ -99,7 +93,8 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[grafanaRule]} />);
 
-      await user.click(await ui.actionButtons.more.find());
+      expect(ui.actionButtons.more.get()).toBeInTheDocument();
+      await user.click(ui.actionButtons.more.get());
       expect(ui.moreActionItems.delete.get()).toBeInTheDocument();
     });
 
@@ -164,7 +159,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      await waitFor(() => expect(ui.actionButtons.edit.query()).not.toBeInTheDocument());
+      expect(ui.actionButtons.edit.query()).not.toBeInTheDocument();
     });
 
     it('Should not render Delete button for users without the delete permission', async () => {
@@ -177,7 +172,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      await user.click(await ui.actionButtons.more.find());
+      await user.click(ui.actionButtons.more.get());
       expect(ui.moreActionItems.delete.query()).not.toBeInTheDocument();
     });
 
@@ -191,7 +186,7 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      expect(await ui.actionButtons.edit.find()).toBeInTheDocument();
+      expect(ui.actionButtons.edit.get()).toBeInTheDocument();
     });
 
     it('Should render Delete button for users with the delete permission', async () => {
@@ -204,8 +199,8 @@ describe('RulesTable RBAC', () => {
 
       render(<RulesTable rules={[cloudRule]} />);
 
-      await user.click(await ui.actionButtons.more.find());
-      expect(await ui.moreActionItems.delete.find()).toBeInTheDocument();
+      await user.click(ui.actionButtons.more.get());
+      expect(ui.moreActionItems.delete.get()).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
**What is this feature?**

This PR does the following two things:

1. It reverts #95045 
2. It adds a loading bar to the state list view

I've split this PR into those two commits so feel free to skip the revert commit.

**Special notes for your reviewer:**

By reverting the PR above we can fix a regression where the silence drawer will be closed when the alert rule list view re-renders because of re-fetching.

I've tried to reproduce the original issue the PR seemed to fix (with @tomratcliffe doing a sanity check too) and we can no longer reproduce it, and this also fixes the silence drawer being forcefully closed when the alert rule list view re-fetches.
