### PR TITLE
Prometheus: Performant Code Mode autocomplete with long metric names

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.test.ts
@@ -3,8 +3,8 @@ import { config } from '@grafana/runtime';
 import { SUGGESTIONS_LIMIT } from '../../../language_provider';
 import { FUNCTIONS } from '../../../promql';
 
-import { getCompletions } from './completions';
-import { DataProvider, DataProviderParams } from './data_provider';
+import { filterMetricNames, getCompletions } from './completions';
+import { DataProvider, type DataProviderParams } from './data_provider';
 import type { Situation } from './situation';
 
 const history: string[] = ['previous_metric_name_1', 'previous_metric_name_2', 'previous_metric_name_3'];
@@ -39,6 +39,144 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.restoreAllMocks();
+});
+
+describe('filterMetricNames', () => {
+  const sampleMetrics = [
+    'http_requests_total',
+    'http_requests_failed',
+    'node_cpu_seconds_total',
+    'node_memory_usage_bytes',
+    'very_long_metric_name_with_many_underscores_and_detailed_description',
+    'complex_metric_with_extra_terms_for_testing_complexity_included',
+  ];
+
+  describe('simple queries (intraMode: 1)', () => {
+    it('should return all metrics when input is empty', () => {
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: '',
+        limit: 10,
+      });
+      expect(result).toEqual(sampleMetrics.slice(0, 10));
+    });
+
+    it('should match exact substrings', () => {
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'requests',
+        limit: 10,
+      });
+      expect(result).toContainEqual('http_requests_total');
+      expect(result).toContainEqual('http_requests_failed');
+    });
+
+    it('should match with single character errors', () => {
+      // Test single substitution
+      let result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'raquests', // 'e' replaced with 'a'
+        limit: 10,
+      });
+      expect(result).toContainEqual('http_requests_total');
+
+      // Test single transposition
+      result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'reqeusts', // 'u' and 'e' swapped
+        limit: 10,
+      });
+      expect(result).toContainEqual('http_requests_total');
+
+      // Test single deletion
+      result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'rquests', // 'e' deleted
+        limit: 10,
+      });
+      expect(result).toContainEqual('http_requests_total');
+
+      // Test single insertion
+      result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'reqquests', // extra 'q' inserted
+        limit: 10,
+      });
+      expect(result).toContainEqual('http_requests_total');
+    });
+
+    it('should not match with multiple errors', () => {
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'raqests', // Two errors: 'e' replaced with 'a' and 'u' deleted
+        limit: 10,
+      });
+      expect(result).not.toContainEqual('http_requests_total');
+    });
+  });
+
+  describe('complex queries (intraMode: 0)', () => {
+    it('should use substring matching for queries with many terms', () => {
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'metric with extra terms for complexity',
+        limit: 10,
+      });
+      expect(result).toContainEqual('complex_metric_with_extra_terms_for_testing_complexity_included');
+      expect(result).not.toContainEqual('http_requests_total'); // Shouldn't match partial terms
+    });
+
+    it('should use substring matching for long copy-pasted queries', () => {
+      const longQuery = 'very_long_metric_name_with_many_underscores_and_detailed_description';
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: longQuery,
+        limit: 10,
+      });
+      expect(result).toContainEqual(longQuery);
+    });
+
+    it('should match characters in sequence for long queries', () => {
+      // This tests intraMode: 0 behavior where characters must appear in sequence
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'h r t', // Should match because these letters appear in sequence in http_requests_total
+        limit: 10,
+      });
+      expect(result).toContainEqual('http_requests_total');
+    });
+
+    it('should use substring matching for long copy-pasted queries', () => {
+      const longQuery = 'very_long_metric_name_with_many_underscores_and_detailed_description';
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: longQuery,
+        limit: 10,
+      });
+      expect(result).toContainEqual(longQuery);
+    });
+
+    it('should handle no matches gracefully', () => {
+      const result = filterMetricNames({
+        metricNames: sampleMetrics,
+        inputText: 'nonexistentmetricname',
+        limit: 10,
+      });
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  it('should respect the limit parameter', () => {
+    // Create array with many matching items
+    const manyMetrics = Array.from({ length: 100 }, (_, i) => `http_requests_total_${i}`);
+
+    const result = filterMetricNames({
+      metricNames: manyMetrics,
+      inputText: 'requests',
+      limit: 5,
+    });
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
 });
 
 type MetricNameSituation = Extract<Situation['type'], 'AT_ROOT' | 'EMPTY' | 'IN_FUNCTION'>;
@@ -114,5 +252,40 @@ describe.each(metricNameCompletionSituations)('metric name completions in situat
     dataProvider.monacoSettings.setInputInRange('name_1');
     await getCompletions(situation, dataProvider);
     expect(dataProvider.monacoSettings.suggestionsIncomplete).toBe(true);
+  });
+
+  it('should handle complex queries efficiently', async () => {
+    const situation: Situation = {
+      type: situationType,
+    };
+
+    jest.spyOn(dataProvider, 'getAllMetricNames').mockReturnValue(metrics.beyondLimit);
+
+    // Test with a complex (long) query
+    dataProvider.monacoSettings.setInputInRange('metric_name_1_with_many_extra_terms_to_trigger_complex_handling');
+    const completions = await getCompletions(situation, dataProvider);
+
+    // Should still respect the suggestions limit
+    const expectedCompletionsCount = getSuggestionCountForSituation(situationType, metrics.beyondLimit.length);
+    expect(completions.length).toBeLessThanOrEqual(expectedCompletionsCount);
+
+    // Results should contain relevant matches
+    const metricCompletions = completions.filter((c) => c.type === 'METRIC_NAME');
+    expect(metricCompletions.some((c) => c.label.includes('metric_name_1'))).toBe(true);
+  });
+
+  it('should handle multiple term queries efficiently', async () => {
+    const situation: Situation = {
+      type: situationType,
+    };
+
+    jest.spyOn(dataProvider, 'getAllMetricNames').mockReturnValue(metrics.beyondLimit);
+
+    // Test with multiple terms
+    dataProvider.monacoSettings.setInputInRange('metric name 1 2 3 4 5');
+    const completions = await getCompletions(situation, dataProvider);
+
+    const expectedCompletionsCount = getSuggestionCountForSituation(situationType, metrics.beyondLimit.length);
+    expect(completions.length).toBeLessThanOrEqual(expectedCompletionsCount);
   });
 });

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -41,17 +41,19 @@ export function filterMetricNames({ metricNames, inputText, limit }: MetricFilte
   if (isComplexSearch) {
     // for complex searches, prioritize performance by using substring matching
     const matches: string[] = [];
+    const lowerTerms = terms.map((term) => term.toLowerCase());
 
-    for (const metric of metricNames) {
+    for (let i = 0; i < metricNames.length; i++) {
+      const metric = metricNames[i];
       const lowercaseMetric = metric.toLowerCase();
-      if (terms.every((term) => lowercaseMetric.includes(term))) {
+
+      if (lowerTerms.every((term) => lowercaseMetric.includes(term))) {
         matches.push(metric);
-      }
-      if (matches.length > limit) {
-        break;
+        if (matches.length >= limit) {
+          break;
+        }
       }
     }
-
     return matches;
   }
 

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -22,6 +22,7 @@ type Completion = {
   triggerOnInsert?: boolean;
 };
 
+const metricNamesSearchSimple = new UFuzzy();
 const metricNamesSearch = new UFuzzy({ intraMode: 1 });
 
 interface MetricFilterOptions {
@@ -40,21 +41,7 @@ export function filterMetricNames({ metricNames, inputText, limit }: MetricFilte
 
   if (isComplexSearch) {
     // for complex searches, prioritize performance by using substring matching
-    const matches: string[] = [];
-    const lowerTerms = terms.map((term) => term.toLowerCase());
-
-    for (let i = 0; i < metricNames.length; i++) {
-      const metric = metricNames[i];
-      const lowercaseMetric = metric.toLowerCase();
-
-      if (lowerTerms.every((term) => lowercaseMetric.includes(term))) {
-        matches.push(metric);
-        if (matches.length >= limit) {
-          break;
-        }
-      }
-    }
-    return matches;
+    return metricNamesSearchSimple.filter(metricNames, inputText)?.map((idx) => metricNames[idx]) ?? [];
   }
 
   // for simple searches, prioritize flexibility by using fuzzy search

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -41,14 +41,10 @@ export function filterMetricNames({ metricNames, inputText, limit }: MetricFilte
 
   const terms = metricNamesSearch.multiInsert.split(inputText); // e.g. 'some_metric_name or-another' -> ['some', 'metric', 'name', 'or', 'another']
   const isComplexSearch = terms.length > 4;
+  const fuzzyResults = isComplexSearch
+    ? metricNamesSearch.multiInsert.filter(metricNames, inputText) // for complex searches, prioritize performance by using MultiInsert fuzzy search
+    : metricNamesSearch.singleError.filter(metricNames, inputText); // for simple searches, prioritize flexibility by using SingleError fuzzy search
 
-  if (isComplexSearch) {
-    // for complex searches, prioritize performance by using MultiInsert fuzzy search
-    return metricNamesSearch.multiInsert.filter(metricNames, inputText)?.map((idx) => metricNames[idx]) ?? [];
-  }
-
-  // for simple searches, prioritize flexibility by using SingleError fuzzy search
-  const fuzzyResults = metricNamesSearch.singleError.filter(metricNames, inputText);
   return fuzzyResults ? fuzzyResults.slice(0, limit).map((idx) => metricNames[idx]) : [];
 }
 

--- a/packages/grafana-prometheus/tsconfig.json
+++ b/packages/grafana-prometheus/tsconfig.json
@@ -6,7 +6,8 @@
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "allowJs": true,
-    "rootDirs": ["."]
+    "rootDirs": ["."],
+    "resolveJsonModule": true
   },
   "exclude": ["dist/**/*"],
   "extends": "@grafana/tsconfig",


### PR DESCRIPTION
## What is this change?

First, a little history: in https://github.com/grafana/grafana/pull/85396, we used fuzzy search to boost the performance of Code Mode autocomplete when dealing with a Prometheus data source with many (tens of thousands, or more) metric names. This change is behind the `prometheusCodeModeMetricNamesSearch` [feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles).

This PR builds on those changes, with a focus on achieving great autocomplete performance when dealing with very long metric names, in cases where it's impractical to include all metric names to the Monaco code editor. It achieves this goal by only using [uFuzzy](https://github.com/leeoniya/uFuzzy?tab=readme-ov-file#how-it-works)'s `SingleError` fuzzy search for relatively simple metric names (`four_parts_or_less`). When the metric names `become_four_parts_or_larger`, we instead use uFuzzy's `MultiInsert` mode, which is stricter but more performant. Unlike `SingleError` mode (which allows for a variety of errors), `MultiInsert` mode only allows additional characters in the same sequence. For examples, see [the uFuzzy README](https://github.com/leeoniya/uFuzzy?tab=readme-ov-file#how-it-works).

## Why do we need this change?

We can't use https://github.com/leeoniya/uFuzzy with [`intraMode: 1`](https://github.com/leeoniya/uFuzzy?tab=readme-ov-file#how-it-works) when dealing with metric names `with_many_many_many_many_parts`, because it can take hundreds of milliseconds (or more) to generate incredibly complex `RegExp`s associated with single-error fuzzy search.

## Who is this feature for?

Prometheus data source users, especially those with:
- enormous numbers of metric names (hundreds of thousands, or more)
- very long metric names

## Which issue(s) does this PR fix?

Fixes #96349

## Special notes for your reviewer

To play with this locally, first ensure that the `prometheusCodeModeMetricNamesSearch` feature toggle is enabled. Second, it helps to have a huge number of metric names. I recommend following these steps locally to experience this change with 500,000 synthetic metric names:

1. Download [synthetic_metric_names.json.zip](https://github.com/user-attachments/files/17778886/synthetic_metric_names.json.zip), which contains 500,000 metric names generated by https://gist.github.com/NWRichmond/bcdbbe493ce91f52078b5cf6a63e19d9 
2. Extract the zipped JSON into `packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider`
3. In `packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts`, import the JSON file we just downloaded and return it from `getAllMetricNames`:

```ts
import heckinBigJson from './synthetic_metric_names.json';

export class DataProvider {
// ...

getAllMetricNames(): string[] {
  // return this.languageProvider.metrics;
  return heckinBigJson as string[];
}

// ...
}
```

4. Open Explore and select any Prometheus DS
5. Ensure that autocomplete works smoothly, no matter how long the metric name is. For example:

https://github.com/user-attachments/assets/aaba54e7-b588-4097-8428-a6bf5ad99b0e

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
