### PR TITLE
Alerting: Add alertingOptimizeReducerInUI feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -80,6 +80,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `cloudwatchMetricInsightsCrossAccount` | Enables cross account observability for Cloudwatch Metric Insights query builder                                                                                          | Yes                |
 | `azureMonitorDisableLogLimit`          | Disables the log limit restriction for Azure Monitor when true. The limit is enabled by default.                                                                          |                    |
 | `preinstallAutoUpdate`                 | Enables automatic updates for pre-installed plugins                                                                                                                       | Yes                |
+| `alertingUIOptimizeReducer`            | Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query                                                                  | Yes                |
 
 ## Public preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -239,4 +239,5 @@ export interface FeatureToggles {
   crashDetection?: boolean;
   jaegerBackendMigration?: boolean;
   reportingUseRawTimeRange?: boolean;
+  alertingUIOptimizeReducer?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1650,6 +1650,14 @@ var (
 			Owner:       grafanaSharingSquad,
 			Expression:  "false", // disabled by default
 		},
+		{
+			Name:         "alertingUIOptimizeReducer",
+			Description:  "Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query",
+			Stage:        FeatureStageGeneralAvailability,
+			FrontendOnly: true,
+			Owner:        grafanaAlertingSquad,
+			Expression:   "true", // enabled by default
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -220,3 +220,4 @@ enableSCIM,experimental,@grafana/identity-access-team,false,false,false
 crashDetection,experimental,@grafana/observability-traces-and-profiling,false,false,true
 jaegerBackendMigration,experimental,@grafana/oss-big-tent,false,false,false
 reportingUseRawTimeRange,preview,@grafana/sharing-squad,false,false,false
+alertingUIOptimizeReducer,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -890,4 +890,8 @@ const (
 	// FlagReportingUseRawTimeRange
 	// Uses the original report or dashboard time range instead of making an absolute transformation
 	FlagReportingUseRawTimeRange = "reportingUseRawTimeRange"
+
+	// FlagAlertingUIOptimizeReducer
+	// Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query
+	FlagAlertingUIOptimizeReducer = "alertingUIOptimizeReducer"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -316,6 +316,23 @@
     },
     {
       "metadata": {
+        "name": "alertingUIOptimizeReducer",
+        "resourceVersion": "1731923458730",
+        "creationTimestamp": "2024-11-18T09:06:02Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-11-18 09:50:58.730825 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query",
+        "stage": "GA",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertmanagerRemoteOnly",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2023-10-30T16:27:08Z"

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -272,6 +272,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
   );
 
   const updateExpressionAndDatasource = useSetExpressionAndDataSource();
+  const isOptimizeReducerEnabled = config.featureToggles.alertingUIOptimizeReducer ?? false;
 
   const onChangeQueries = useCallback(
     (updatedQueries: AlertQuery[]) => {
@@ -287,7 +288,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
 
       // we only remove or add the reducer(optimize reducer) expression when creating a new alert.
       // When editing an alert, we assume the user wants to manually adjust expressions and queries for more control and customization.
-      if (!editingExistingRule) {
+      if (!editingExistingRule && isOptimizeReducerEnabled) {
         dispatch(optimizeReduceExpression({ updatedQueries, expressionQueries }));
       }
 
@@ -300,7 +301,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
         dispatch(rewireExpressions({ oldRefId, newRefId }));
       }
     },
-    [queries, updateExpressionAndDatasource, getValues, setValue, editingExistingRule]
+    [queries, updateExpressionAndDatasource, getValues, setValue, editingExistingRule, isOptimizeReducerEnabled]
   );
 
   const onChangeRecordingRulesQueries = useCallback(


### PR DESCRIPTION
**What is this feature?**

After merging [the optimization for reduce expressions in the UI](https://github.com/grafana/grafana/pull/94246), we need a way to control this new feature in case of issues or customers that prefer not using it?

**Why do we need this feature?**

To manage a new feature availability.

**Who is this feature for?**

Devs.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
