### PR TITLE
Sidecar: Always hide at `/login` page

### DIFF
--- a/packages/grafana-runtime/src/services/SidecarContext_EXPERIMENTAL.ts
+++ b/packages/grafana-runtime/src/services/SidecarContext_EXPERIMENTAL.ts
@@ -1,11 +1,14 @@
 import { createContext, useContext } from 'react';
 import { useObservable } from 'react-use';
 
+import { locationService as mainLocationService } from './LocationService';
 import { SidecarService_EXPERIMENTAL, sidecarServiceSingleton_EXPERIMENTAL } from './SidecarService_EXPERIMENTAL';
 
 export const SidecarContext_EXPERIMENTAL = createContext<SidecarService_EXPERIMENTAL>(
   sidecarServiceSingleton_EXPERIMENTAL
 );
+
+const HIDDEN_ROUTES = ['/login'];
 
 /**
  * This is the main way to interact with the sidecar service inside a react context. It provides a wrapper around the
@@ -24,17 +27,33 @@ export function useSidecar_EXPERIMENTAL() {
   const initialContext = useObservable(service.initialContextObservable, service.initialContext);
   const activePluginId = useObservable(service.activePluginIdObservable, service.activePluginId);
   const locationService = service.getLocationService();
+  const forceHidden = HIDDEN_ROUTES.includes(mainLocationService.getLocation().pathname);
 
   return {
-    activePluginId,
-    initialContext,
+    activePluginId: forceHidden ? undefined : activePluginId,
+    initialContext: forceHidden ? undefined : initialContext,
     locationService,
     // TODO: currently this allows anybody to open any app, in the future we should probably scope this to the
     //  current app but that means we will need to incorporate this better into the plugin platform APIs which
     //  we will do once the functionality is reasonably stable
-    openApp: (pluginId: string, context?: unknown) => service.openApp(pluginId, context),
-    openAppV2: (pluginId: string, path?: string) => service.openAppV2(pluginId, path),
+    openApp: (pluginId: string, context?: unknown) => {
+      if (forceHidden) {
+        return;
+      }
+      return service.openApp(pluginId, context);
+    },
+    openAppV2: (pluginId: string, path?: string) => {
+      if (forceHidden) {
+        return;
+      }
+      return service.openAppV2(pluginId, path);
+    },
     closeApp: () => service.closeApp(),
-    isAppOpened: (pluginId: string) => service.isAppOpened(pluginId),
+    isAppOpened: (pluginId: string) => {
+      if (forceHidden) {
+        return false;
+      }
+      return service.isAppOpened(pluginId);
+    },
   };
 }


### PR DESCRIPTION
**What is this feature?**

If sidecar apps were in an "opened" state and the user's session would time out, they would be open at the `/login` page too:
<img width="1455" alt="image" src="https://github.com/user-attachments/assets/7f2d960a-af26-45c7-991d-6b76dd788ab9">

This PR just hides sidecar if the main location is `/login`.