### PR TITLE
Update JWT docs

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -188,7 +188,7 @@ key_id = my-key-id
 By default, only `"exp"`, `"nbf"` and `"iat"` claims are validated.
 
 Consider validating that other claims match your expectations by using the `expect_claims` configuration option.
-Token claims will need to match the values set here exactly.
+Token claims must match exactly the values set here.
 
 ```ini
 # This can be seen as a required "subset" of a JWT Claims Set.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -187,7 +187,7 @@ key_id = my-key-id
 
 By default, only `"exp"`, `"nbf"` and `"iat"` claims are validated.
 
-You might also want to validate that other claims are really what you expect them to be, which you can do by setting the `expect_claims` configuration option.
+Consider validating that other claims match your expectations by using the `expect_claims` configuration option.
 Token claims will need to match the values set here exactly.
 
 ```ini

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -23,6 +23,10 @@ This method of authentication is useful for integrating with other systems that
 use JWKS but can't directly integrate with Grafana or if you want to use pass-through
 authentication in an app embedding Grafana.
 
+{{% admonition type="note" %}}
+Grafana does not currently support refresh tokens.
+{{% /admonition %}}
+
 ## Enable JWT
 
 To use JWT authentication:
@@ -183,7 +187,8 @@ key_id = my-key-id
 
 By default, only `"exp"`, `"nbf"` and `"iat"` claims are validated.
 
-You might also want to validate that other claims are really what you expect them to be.
+You might also want to validate that other claims are really what you expect them to be, which you can do by setting the `expect_claims` configuration option.
+Token claims will need to match the values set here exactly.
 
 ```ini
 # This can be seen as a required "subset" of a JWT Claims Set.


### PR DESCRIPTION
Update https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/jwt
Add that:
* Grafana does not support refresh tokens
* Claim validation through the `expect_claims` config option only supports exact matching. Pattern matching is **not** supported.