### PR TITLE
Auth: Add None role to Viewer case

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/org_role.go
+++ b/pkg/services/apiserver/auth/authorizer/org_role.go
@@ -37,15 +37,13 @@ func (auth orgRoleAuthorizer) Authorize(ctx context.Context, a authorizer.Attrib
 		default:
 			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
 		}
-	case org.RoleViewer:
+	case org.RoleViewer, org.RoleNone:
 		switch a.GetVerb() {
 		case "get", "list", "watch":
 			return authorizer.DecisionAllow, "", nil
 		default:
 			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
 		}
-	case org.RoleNone:
-		return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
 	}
 	return authorizer.DecisionDeny, "", nil
 }


### PR DESCRIPTION
**What is this feature?**

This includes the None role under Viewer's rules for authorizing users.

**Why do we need this feature?**

The None role was intentionally ignored, resulting in rejection despite being assigned the same permissions as a Viewer role. This is a bug since it has created an escalation.

**Who is this feature for?**

IAM and Platform teams

Escalation - [link](https://github.com/grafana/support-escalations/issues/13482)

**Special notes for your reviewer:**

We might want to reconsider this logic since lower raking roles might be paired with higher-ranking roles; thus, rendering the authorization to role values only might not be valid enough.