### PR TITLE
Scenes: Fix angular migrations that are using the targets property on the old panel model

### DIFF
--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,4 +1,4 @@
-import { defaults } from 'lodash';
+import { defaults, cloneDeep } from 'lodash';
 
 import { PanelModel as PanelModelFromData, PanelPlugin } from '@grafana/data';
 import { autoMigrateAngular, PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -12,6 +12,17 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
 
     if (!oldModel.options || Object.keys(oldModel.options).length === 0) {
       defaults(panel, oldModel.getOptionsToRemember());
+
+      // Some plugins rely on being able to access targets to set up the fieldConfig when migrating from angular.
+      const targetClone = cloneDeep(oldModel.targets);
+      Object.defineProperty(panel, 'targets', {
+        get: function () {
+          console.warn(
+            'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
+          );
+          return targetClone;
+        },
+      });
     }
 
     if (oldModel.autoMigrateFrom) {


### PR DESCRIPTION
**What is this feature?**

This let's an angular migration handler access the targets property when the migration is running under the scenes dashboard architecture.

**Why do we need this feature?**

Some well used plugins use the targets property when migrating from angular.