### PR TITLE
UPlot: don't use state to hold reference to uplot instance

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -31,19 +31,16 @@ type UPlotChartState = {
 export class UPlotChart extends Component<PlotProps, UPlotChartState> {
   plotContainer = createRef<HTMLDivElement>();
   plotCanvasBBox = createRef<DOMRect>();
+  plotInstance: uPlot | null = null;
 
   constructor(props: PlotProps) {
     super(props);
-
-    this.state = {
-      plot: null,
-    };
   }
 
   reinitPlot() {
     let { width, height, plotRef } = this.props;
 
-    this.state.plot?.destroy();
+    this.plotInstance?.destroy();
 
     if (width === 0 && height === 0) {
       return;
@@ -69,7 +66,7 @@ export class UPlotChart extends Component<PlotProps, UPlotChartState> {
       plotRef(plot);
     }
 
-    this.setState({ plot });
+    this.plotInstance = plot;
   }
 
   componentDidMount() {
@@ -77,21 +74,19 @@ export class UPlotChart extends Component<PlotProps, UPlotChartState> {
   }
 
   componentWillUnmount() {
-    this.state.plot?.destroy();
+    this.plotInstance?.destroy();
   }
 
   componentDidUpdate(prevProps: PlotProps) {
-    let { plot } = this.state;
-
     if (!sameDims(prevProps, this.props)) {
-      plot?.setSize({
+      this.plotInstance?.setSize({
         width: Math.floor(this.props.width),
         height: Math.floor(this.props.height),
       });
     } else if (!sameConfig(prevProps, this.props)) {
       this.reinitPlot();
     } else if (!sameData(prevProps, this.props)) {
-      plot?.setData(this.props.data as AlignedData);
+      this.plotInstance?.setData(this.props.data as AlignedData);
     }
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- stops holding the uplot instance in state
  - paired with @leeoniya and we realised that because the `setState` call is asynchronous, the cleanup in `componentWillUnmount` does not get properly called
  - there is no reason to hold this instance in state, so let's not 😄 
- this fixes rendering on all `uPlot` based charts in grafana in `StrictMode`. there is still an outstanding bug with the geomap panel

**Why do we need this feature?**

- so cleanup is properly run in `StrictMode`

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/95428

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
