### PR TITLE
unistore: wire the authz client

### DIFF
--- a/pkg/services/apiserver/standalone/runtime.go
+++ b/pkg/services/apiserver/standalone/runtime.go
@@ -17,7 +17,7 @@ func (a RuntimeConfig) String() string {
 
 // Supported options are:
 //
-//	<group>/<version>=true|false for a specific API group and version (e.g. dashboards.grafana.app/v0alpha1=true)
+//	<group>/<version>=true|false for a specific API group and version (e.g. dashboard.grafana.app/v0alpha1=true)
 //	api/all=true|false controls all API versions
 //	api/ga=true|false controls all API versions of the form v[0-9]+
 //	api/beta=true|false controls all API versions of the form v[0-9]+beta[0-9]+

--- a/pkg/services/apiserver/standalone/runtime_test.go
+++ b/pkg/services/apiserver/standalone/runtime_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestReadRuntimeCOnfig(t *testing.T) {
-	out, err := ReadRuntimeConfig("all/all=true,dashboards.grafana.app/v0alpha1=false")
+	out, err := ReadRuntimeConfig("all/all=true,dashboard.grafana.app/v0alpha1=false")
 	require.NoError(t, err)
 	require.Equal(t, []RuntimeConfig{
 		{Group: "all", Version: "all", Enabled: true},
-		{Group: "dashboards.grafana.app", Version: "v0alpha1", Enabled: false},
+		{Group: "dashboard.grafana.app", Version: "v0alpha1", Enabled: false},
 	}, out)
 	require.Equal(t, "all/all=true", fmt.Sprintf("%v", out[0]))
 

--- a/pkg/services/authz/client.go
+++ b/pkg/services/authz/client.go
@@ -88,23 +88,9 @@ func ProvideStandaloneAuthZClient(
 		return nil, err
 	}
 
-	return newGrpcLegacyClient(authCfg)
-}
-
-// ProvideCloudAuthZClient provides a standalone AuthZ client for Cloud.
-// You need to provide a remote address in the configuration
-func ProvideCloudAuthZClient(
-	cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
-) (Client, error) {
-	if !features.IsEnabledGlobally(featuremgmt.FlagAuthZGRPCServer) {
-		return nil, nil
+	if cfg.StackID == "" {
+		return newGrpcLegacyClient(authCfg)
 	}
-
-	authCfg, err := ReadCfg(cfg)
-	if err != nil {
-		return nil, err
-	}
-
 	return newCloudLegacyClient(authCfg)
 }
 

--- a/pkg/services/authz/client.go
+++ b/pkg/services/authz/client.go
@@ -91,6 +91,23 @@ func ProvideStandaloneAuthZClient(
 	return newGrpcLegacyClient(authCfg)
 }
 
+// ProvideCloudAuthZClient provides a standalone AuthZ client for Cloud.
+// You need to provide a remote address in the configuration
+func ProvideCloudAuthZClient(
+	cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
+) (Client, error) {
+	if !features.IsEnabledGlobally(featuremgmt.FlagAuthZGRPCServer) {
+		return nil, nil
+	}
+
+	authCfg, err := ReadCfg(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return newCloudLegacyClient(authCfg)
+}
+
 func newInProcLegacyClient(server *legacyServer) (authzlib.AccessChecker, error) {
 	noAuth := func(ctx context.Context) (context.Context, error) {
 		return ctx, nil

--- a/pkg/services/authz/mappers/rbac_mapper.go
+++ b/pkg/services/authz/mappers/rbac_mapper.go
@@ -2,10 +2,10 @@ package mappers
 
 type VerbToAction map[string]string                            // e.g. "get" -> "read"
 type ResourceVerbToAction map[string]VerbToAction              // e.g. "dashboards" -> VerbToAction
-type GroupResourceVerbToAction map[string]ResourceVerbToAction // e.g. "dashboards.grafana.app" -> ResourceVerbToAction
+type GroupResourceVerbToAction map[string]ResourceVerbToAction // e.g. "dashboard.grafana.app" -> ResourceVerbToAction
 
 type ResourceToAttribute map[string]string                   // e.g. "dashboards" -> "uid"
-type GroupResourceToAttribute map[string]ResourceToAttribute // e.g. "dashboards.grafana.app" -> ResourceToAttribute
+type GroupResourceToAttribute map[string]ResourceToAttribute // e.g. "dashboard.grafana.app" -> ResourceToAttribute
 
 type K8sRbacMapper struct {
 	DefaultActions   VerbToAction
@@ -28,8 +28,8 @@ func NewK8sRbacMapper() *K8sRbacMapper {
 		},
 		DefaultAttribute: "uid",
 		Actions: GroupResourceVerbToAction{
-			"dashboards.grafana.app": ResourceVerbToAction{"dashboards": VerbToAction{}},
-			"folders.grafana.app":    ResourceVerbToAction{"folders": VerbToAction{}},
+			"dashboard.grafana.app": ResourceVerbToAction{"dashboards": VerbToAction{}},
+			"folder.grafana.app":    ResourceVerbToAction{"folders": VerbToAction{}},
 		},
 	}
 }

--- a/pkg/services/authz/server_test.go
+++ b/pkg/services/authz/server_test.go
@@ -60,7 +60,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Name:      "dash1",
 				Namespace: "org-2",
@@ -74,7 +74,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Name:      "dash1",
 				Namespace: "org-2",
@@ -88,7 +88,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Name:      "dash1",
 				Namespace: "org-2",
@@ -106,7 +106,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Namespace: "org-2",
 			},
@@ -131,7 +131,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Name:      "dash1",
 				Namespace: "org-2",
 			},
@@ -141,7 +141,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			name: "should return error when verb is not set",
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Name:      "dash1",
 				Namespace: "org-2",
@@ -152,7 +152,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			name: "should return error when subject is not set",
 			req: &authzv1.CheckRequest{
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Name:      "dash1",
 				Namespace: "org-2",
@@ -164,7 +164,7 @@ func Test_legacyServer_Check(t *testing.T) {
 			req: &authzv1.CheckRequest{
 				Subject:   "user:1",
 				Verb:      "get",
-				Group:     "dashboards.grafana.app",
+				Group:     "dashboard.grafana.app",
 				Resource:  "dashboards",
 				Name:      "dash1",
 				Namespace: "stacks-2",

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -31,7 +31,7 @@ func newBatch(subject, group, resource string, items []*authzextv1.BatchCheckIte
 }
 
 func testBatchCheck(t *testing.T, server *Server) {
-	t.Run("user:1 should only be able to read resource:dashboards.grafana.app/dashboards/1", func(t *testing.T) {
+	t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
 		groupPrefix := zanzana.FormatGroupResource(dashboardGroup, dashboardResource)
 		res, err := server.BatchCheck(context.Background(), newBatch("user:1", dashboardGroup, dashboardResource, []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
@@ -44,7 +44,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 		assert.False(t, res.Groups[groupPrefix].Items["2"])
 	})
 
-	t.Run("user:2 should be able to read resource:dashboards.grafana.app/dashboards/{1,2} through namespace", func(t *testing.T) {
+	t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/{1,2} through namespace", func(t *testing.T) {
 		groupPrefix := zanzana.FormatGroupResource(dashboardGroup, dashboardResource)
 		res, err := server.BatchCheck(context.Background(), newBatch("user:2", dashboardGroup, dashboardResource, []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
@@ -54,7 +54,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 		assert.Len(t, res.Groups[groupPrefix].Items, 2)
 	})
 
-	t.Run("user:3 should be able to read resource:dashboards.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
+	t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
 		groupPrefix := zanzana.FormatGroupResource(dashboardGroup, dashboardResource)
 		res, err := server.BatchCheck(context.Background(), newBatch("user:3", dashboardGroup, dashboardResource, []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
@@ -67,7 +67,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 		assert.False(t, res.Groups[groupPrefix].Items["2"])
 	})
 
-	t.Run("user:4 should be able to read all dashboards.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
+	t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
 		groupPrefix := zanzana.FormatGroupResource(dashboardGroup, dashboardResource)
 		res, err := server.BatchCheck(context.Background(), newBatch("user:4", dashboardGroup, dashboardResource, []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
@@ -82,7 +82,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 		assert.False(t, res.Groups[groupPrefix].Items["3"])
 	})
 
-	t.Run("user:5 should be able to read resource:dashboards.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
+	t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
 		groupPrefix := zanzana.FormatGroupResource(dashboardGroup, dashboardResource)
 		res, err := server.BatchCheck(context.Background(), newBatch("user:5", dashboardGroup, dashboardResource, []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -24,7 +24,7 @@ func testCheck(t *testing.T, server *Server) {
 		}
 	}
 
-	t.Run("user:1 should only be able to read resource:dashboards.grafana.app/dashboards/1", func(t *testing.T) {
+	t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
 		res, err := server.Check(context.Background(), newRead("user:1", dashboardGroup, dashboardResource, "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
@@ -35,13 +35,13 @@ func testCheck(t *testing.T, server *Server) {
 		assert.False(t, res.GetAllowed())
 	})
 
-	t.Run("user:2 should be able to read resource:dashboards.grafana.app/dashboards/1 through namespace", func(t *testing.T) {
+	t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/1 through namespace", func(t *testing.T) {
 		res, err := server.Check(context.Background(), newRead("user:2", dashboardGroup, dashboardResource, "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
-	t.Run("user:3 should be able to read resource:dashboards.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
+	t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
 		res, err := server.Check(context.Background(), newRead("user:3", dashboardGroup, dashboardResource, "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
@@ -52,7 +52,7 @@ func testCheck(t *testing.T, server *Server) {
 		assert.False(t, res.GetAllowed())
 	})
 
-	t.Run("user:4 should be able to read all dashboards.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
+	t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
 		res, err := server.Check(context.Background(), newRead("user:4", dashboardGroup, dashboardResource, "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
@@ -71,7 +71,7 @@ func testCheck(t *testing.T, server *Server) {
 		assert.False(t, res.GetAllowed())
 	})
 
-	t.Run("user:5 should be able to read resource:dashboards.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
+	t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
 		res, err := server.Check(context.Background(), newRead("user:5", dashboardGroup, dashboardResource, "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -22,7 +22,7 @@ func testList(t *testing.T, server *Server) {
 		}
 	}
 
-	t.Run("user:1 should list resource:dashboards.grafana.app/dashboards/1", func(t *testing.T) {
+	t.Run("user:1 should list resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
 		res, err := server.List(context.Background(), newList("user:1", dashboardGroup, dashboardResource))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 1)
@@ -38,7 +38,7 @@ func testList(t *testing.T, server *Server) {
 		assert.Len(t, res.GetFolders(), 0)
 	})
 
-	t.Run("user:3 should be able to list resource:dashboards.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
+	t.Run("user:3 should be able to list resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
 		res, err := server.List(context.Background(), newList("user:3", dashboardGroup, dashboardResource))
 		require.NoError(t, err)
 
@@ -47,7 +47,7 @@ func testList(t *testing.T, server *Server) {
 		assert.Equal(t, res.GetItems()[0], "1")
 	})
 
-	t.Run("user:4 should be able to list all dashboards.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
+	t.Run("user:4 should be able to list all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
 		res, err := server.List(context.Background(), newList("user:4", dashboardGroup, dashboardResource))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)
@@ -64,7 +64,7 @@ func testList(t *testing.T, server *Server) {
 		assert.Equal(t, second, "3")
 	})
 
-	t.Run("user:5 should be get list all dashboards.grafana.app/dashboards in folder 1 with set relation", func(t *testing.T) {
+	t.Run("user:5 should be get list all dashboard.grafana.app/dashboards in folder 1 with set relation", func(t *testing.T) {
 		res, err := server.List(context.Background(), newList("user:5", dashboardGroup, dashboardResource))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/services/authn/grpcutils"
+	"github.com/grafana/grafana/pkg/services/authz"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -32,6 +33,7 @@ func ProvideUnifiedStorageClient(
 	db infraDB.DB,
 	tracer tracing.Tracer,
 	reg prometheus.Registerer,
+	authzc authz.Client,
 ) (resource.ResourceClient, error) {
 	// See: apiserver.ApplyGrafanaConfig(cfg, features, o)
 	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
@@ -95,7 +97,7 @@ func ProvideUnifiedStorageClient(
 
 	// Use the local SQL
 	default:
-		server, err := sql.NewResourceServer(ctx, db, cfg, features, tracer, reg)
+		server, err := sql.NewResourceServer(ctx, db, cfg, features, tracer, reg, authzc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/authlib/authz"
 	"github.com/grafana/authlib/claims"
@@ -24,3 +25,68 @@ func (c *staticAuthzClient) Compile(ctx context.Context, id claims.AuthInfo, req
 }
 
 var _ authz.AccessClient = &staticAuthzClient{}
+
+type resourceGroup map[string]map[string]interface{}
+
+// authzLimitedClient is a client that enforces RBAC for the limited number of groups and resources.
+// This is a temporary solution until the authz service is fully implemented.
+// The authz service will be responsible for enforcing RBAC.
+// For now, it makes one call to the authz service for each list items. This is known to be inefficient.
+type authzLimitedClient struct {
+	client authz.AccessChecker
+	// whitelist is a map of group to resources that are compatible with RBAC.
+	whitelist resourceGroup
+}
+
+// NewAuthzLimitedClient creates a new authzLimitedClient.
+func NewAuthzLimitedClient(client authz.AccessChecker) authz.AccessClient {
+	return &authzLimitedClient{
+		client: client,
+		whitelist: resourceGroup{
+			"dashboard.grafana.app": map[string]interface{}{"dashboards": nil},
+			"folder.grafana.app":    map[string]interface{}{"folders": nil},
+		},
+	}
+}
+
+// Check implements authz.AccessClient.
+func (c authzLimitedClient) Check(ctx context.Context, id claims.AuthInfo, req authz.CheckRequest) (authz.CheckResponse, error) {
+	if !c.IsCompatibleWithRBAC(req.Group, req.Resource) {
+		return authz.CheckResponse{Allowed: true}, nil
+	}
+	return c.client.Check(ctx, id, req)
+}
+
+// Compile implements authz.AccessClient.
+func (c authzLimitedClient) Compile(ctx context.Context, id claims.AuthInfo, req authz.ListRequest) (authz.ItemChecker, error) {
+	return func(namespace string, name, folder string) bool {
+		// TODO: Implement For now we perform the check for each item.
+		if !c.IsCompatibleWithRBAC(req.Group, req.Resource) {
+			return true
+		}
+		fmt.Println("TODO: Implement authzLimitedClient.Compile")
+		r, err := c.client.Check(ctx, id, authz.CheckRequest{
+			Verb:      "get",
+			Group:     req.Group,
+			Resource:  req.Resource,
+			Namespace: namespace,
+			Name:      name,
+			Folder:    folder,
+		})
+		if err != nil {
+			return false
+		}
+		return r.Allowed
+	}, nil
+}
+
+func (c authzLimitedClient) IsCompatibleWithRBAC(group, resource string) bool {
+	if _, ok := c.whitelist[group]; ok {
+		if _, ok := c.whitelist[group][resource]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+var _ authz.AccessClient = &authzLimitedClient{}

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -2,7 +2,6 @@ package resource
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/grafana/authlib/authz"
 	"github.com/grafana/authlib/claims"
@@ -64,7 +63,6 @@ func (c authzLimitedClient) Compile(ctx context.Context, id claims.AuthInfo, req
 		if !c.IsCompatibleWithRBAC(req.Group, req.Resource) {
 			return true
 		}
-		fmt.Println("TODO: Implement authzLimitedClient.Compile")
 		r, err := c.client.Check(ctx, id, authz.CheckRequest{
 			Verb:      "get",
 			Group:     req.Group,

--- a/pkg/storage/unified/resource/access_test.go
+++ b/pkg/storage/unified/resource/access_test.go
@@ -1,0 +1,62 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/authlib/authz"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthzLimitedClient_Check(t *testing.T) {
+	mockClient := &staticAuthzClient{allowed: false}
+	client := NewAuthzLimitedClient(mockClient)
+
+	tests := []struct {
+		group    string
+		resource string
+		expected bool
+	}{
+		{"dashboard.grafana.app", "dashboards", false},
+		{"folder.grafana.app", "folders", false},
+		{"unknown.group", "unknown.resource", true},
+	}
+
+	for _, test := range tests {
+		req := authz.CheckRequest{
+			Group:    test.group,
+			Resource: test.resource,
+		}
+		resp, err := client.Check(context.Background(), nil, req)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, resp.Allowed)
+	}
+}
+
+func TestAuthzLimitedClient_Compile(t *testing.T) {
+	mockClient := &staticAuthzClient{allowed: false}
+	client := NewAuthzLimitedClient(mockClient)
+
+	tests := []struct {
+		group    string
+		resource string
+		expected bool
+	}{
+		{"dashboard.grafana.app", "dashboards", false},
+		{"folder.grafana.app", "folders", false},
+		{"unknown.group", "unknown.resource", true},
+	}
+
+	for _, test := range tests {
+		req := authz.ListRequest{
+			Group:    test.group,
+			Resource: test.resource,
+		}
+		checker, err := client.Compile(context.Background(), nil, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, checker)
+
+		result := checker("namespace", "name", "folder")
+		assert.Equal(t, test.expected, result)
+	}
+}

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -7,18 +7,67 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	authzlib "github.com/grafana/authlib/authz"
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/authz"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 )
 
+var _ authzlib.AccessClient = &authzClient{}
+
+type resourceGroup map[string]map[string]interface{}
+type authzClient struct {
+	client                  authz.Client
+	supportedGroupResources resourceGroup
+}
+
+// Check implements authz.AccessClient.
+func (c authzClient) Check(ctx context.Context, id claims.AuthInfo, req authzlib.CheckRequest) (authzlib.CheckResponse, error) {
+	if !c.EnforeRBAC(req.Group, req.Resource) {
+		return authzlib.CheckResponse{Allowed: true}, nil
+	}
+	return c.client.Check(ctx, id, req)
+}
+
+// Compile implements authz.AccessClient.
+func (c authzClient) Compile(ctx context.Context, id claims.AuthInfo, req authzlib.ListRequest) (authzlib.ItemChecker, error) {
+	return func(namespace string, name, folder string) bool {
+		// TODO: Implement For now we perform the check for each item.
+		if !c.EnforeRBAC(req.Group, req.Resource) {
+			return true
+		}
+		r, err := c.client.Check(ctx, id, authzlib.CheckRequest{
+			Verb:      "get",
+			Group:     req.Group,
+			Resource:  req.Resource,
+			Namespace: namespace,
+			Name:      name,
+			Folder:    folder,
+		})
+		if err != nil {
+			return false
+		}
+		return r.Allowed
+	}, nil
+}
+
+func (c authzClient) EnforeRBAC(group, resource string) bool {
+	if _, ok := c.supportedGroupResources[group]; ok {
+		if _, ok := c.supportedGroupResources[group][resource]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // Creates a new ResourceServer
-func NewResourceServer(ctx context.Context, db infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, reg prometheus.Registerer) (resource.ResourceServer, error) {
+func NewResourceServer(ctx context.Context, db infraDB.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer, reg prometheus.Registerer, ac authz.Client) (resource.ResourceServer, error) {
 	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
 	opts := resource.ResourceServerOptions{
 		Tracer: tracer,
@@ -27,7 +76,19 @@ func NewResourceServer(ctx context.Context, db infraDB.DB, cfg *setting.Cfg, fea
 		},
 		Reg: reg,
 	}
-
+	if ac != nil {
+		opts.AccessClient = authzClient{
+			client: ac,
+			supportedGroupResources: resourceGroup{
+				"dashboard.grafana.app": map[string]interface{}{
+					"dashboards": nil,
+				},
+				"folder.grafana.app": map[string]interface{}{
+					"folders": nil,
+				},
+			},
+		}
+	}
 	// Support local file blob
 	if strings.HasPrefix(opts.Blob.URL, "./data/") {
 		dir := strings.Replace(opts.Blob.URL, "./data", cfg.DataPath, 1)

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -94,7 +94,6 @@ func ProvideUnifiedStorageGrpcService(
 }
 
 func (s *service) start(ctx context.Context) error {
-
 	authzClient, err := authz.ProvideStandaloneAuthZClient(s.cfg, s.features, s.tracing)
 	if err != nil {
 		return err

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -95,7 +95,7 @@ func ProvideUnifiedStorageGrpcService(
 
 func (s *service) start(ctx context.Context) error {
 
-	authzClient, err := authz.ProvideCloudAuthZClient(s.cfg, s.features, s.tracing)
+	authzClient, err := authz.ProvideStandaloneAuthZClient(s.cfg, s.features, s.tracing)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/services/authn/grpcutils"
+	"github.com/grafana/grafana/pkg/services/authz"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/grpcserver/interceptors"
@@ -93,8 +94,13 @@ func ProvideUnifiedStorageGrpcService(
 }
 
 func (s *service) start(ctx context.Context) error {
-	// TODO: Wire the remote authz client.
-	server, err := NewResourceServer(ctx, s.db, s.cfg, s.features, s.tracing, s.reg, nil)
+
+	authzClient, err := authz.ProvideCloudAuthZClient(s.cfg, s.features, s.tracing)
+	if err != nil {
+		return err
+	}
+
+	server, err := NewResourceServer(ctx, s.db, s.cfg, s.features, s.tracing, s.reg, authzClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -93,7 +93,8 @@ func ProvideUnifiedStorageGrpcService(
 }
 
 func (s *service) start(ctx context.Context) error {
-	server, err := NewResourceServer(ctx, s.db, s.cfg, s.features, s.tracing, s.reg)
+	// TODO: Wire the remote authz client.
+	server, err := NewResourceServer(ctx, s.db, s.cfg, s.features, s.tracing, s.reg, nil)
 	if err != nil {
 		return err
 	}

--- a/public/app/features/dashboard/api/dashboard_api.ts
+++ b/public/app/features/dashboard/api/dashboard_api.ts
@@ -50,7 +50,7 @@ interface DashboardWithAccessInfo extends Resource<DashboardDataDTO, 'DashboardW
   access: Object; // TODO...
 }
 
-// Implemented using /apis/dashboards.grafana.app/*
+// Implemented using /apis/dashboard.grafana.app/*
 class K8sDashboardAPI implements DashboardAPI {
   private client: ResourceClient<DashboardDataDTO>;
 


### PR DESCRIPTION
**What is this feature?**

Enforce RBAC checks in unistore for folder and dashboards only (other resources are not compatible with .
This is behind the FlagAuthZGRPCServer feature toggle and works both in ST grafana and MT unistore.

Note: The compile is extremely inefficient for now, but this should be good enough to test until we implement the efficient implementation (WIP). 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
