### PR TITLE
Alerting: Fix annotation state migration to retain nullability on MySQL

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -184,13 +184,13 @@ func addAnnotationMig(mg *Migrator) {
 		Postgres("ALTER TABLE annotation ALTER COLUMN tags TYPE VARCHAR(4096);").
 		Mysql("ALTER TABLE annotation MODIFY tags VARCHAR(4096);"))
 
-	mg.AddMigration("Increase prev_state column to length 40", NewRawSQLMigration("").
-		Postgres("ALTER TABLE annotation ALTER COLUMN prev_state TYPE VARCHAR(40);").
-		Mysql("ALTER TABLE annotation MODIFY prev_state VARCHAR(40);"))
+	mg.AddMigration("Increase prev_state column to length 40 not null", NewRawSQLMigration("").
+		Postgres("ALTER TABLE annotation ALTER COLUMN prev_state TYPE VARCHAR(40);"). // Does not modify nullability.
+		Mysql("ALTER TABLE annotation MODIFY prev_state VARCHAR(40) NOT NULL;"))
 
-	mg.AddMigration("Increase new_state column to length 40", NewRawSQLMigration("").
-		Postgres("ALTER TABLE annotation ALTER COLUMN new_state TYPE VARCHAR(40);").
-		Mysql("ALTER TABLE annotation MODIFY new_state VARCHAR(40);"))
+	mg.AddMigration("Increase new_state column to length 40 not null", NewRawSQLMigration("").
+		Postgres("ALTER TABLE annotation ALTER COLUMN new_state TYPE VARCHAR(40);"). // Does not modify nullability.
+		Mysql("ALTER TABLE annotation MODIFY new_state VARCHAR(40) NOT NULL;"))
 }
 
 type AddMakeRegionSingleRowMigration struct {


### PR DESCRIPTION
Followup to https://github.com/grafana/grafana/pull/96503 which unintentionally removed the nullability constraint on the columns in MySQL. This will modify the MySQL portion of the migration to retain the nullability by adding the missing `NOT NULL`.

PSQL: `ALTER TABLE annotation ALTER COLUMN new_state TYPE VARCHAR(40);` retains nullability.
MySQL: `ALTER TABLE annotation MODIFY new_state VARCHAR(40);` resets nullability.