### PR TITLE
K8s: dashboards: fix conversion

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1866,15 +1866,21 @@ grpc_port =
 license_path =
 
 [feature_toggles]
-kubernetesDashboards = true ; Fron the UI
-grafanaAPIServerWithExperimentalAPIs = true
-grafanaAPIServerEnsureKubectlAccess = true
+# there are currently two ways to enable feature toggles in the `grafana.ini`.
+# you can either pass an array of feature you want to enable to the `enable` field or
+# configure each toggle by setting the name of the toggle to true/false. Toggles set to true/false
+# will take precedence over toggles in the `enable` list.
 
-[unified_storage.dashboards.dashboard.grafana.app]
-dualWriterMode = 5
+# enable = feature1,feature2
+enable =
 
-[grafana-apiserver]
-storage_type=unified
+# Some features are enabled by default, see:
+# https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/feature-toggles/
+# To enable features by default, set `Expression:  "true"` in:
+# https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go
+
+# feature1 = true
+# feature2 = false
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1866,21 +1866,15 @@ grpc_port =
 license_path =
 
 [feature_toggles]
-# there are currently two ways to enable feature toggles in the `grafana.ini`.
-# you can either pass an array of feature you want to enable to the `enable` field or
-# configure each toggle by setting the name of the toggle to true/false. Toggles set to true/false
-# will take precedence over toggles in the `enable` list.
+kubernetesDashboards = true ; Fron the UI
+grafanaAPIServerWithExperimentalAPIs = true
+grafanaAPIServerEnsureKubectlAccess = true
 
-# enable = feature1,feature2
-enable =
+[unified_storage.dashboards.dashboard.grafana.app]
+dualWriterMode = 5
 
-# Some features are enabled by default, see:
-# https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/feature-toggles/
-# To enable features by default, set `Expression:  "true"` in:
-# https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go
-
-# feature1 = true
-# feature2 = false
+[grafana-apiserver]
+storage_type=unified
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/

--- a/pkg/registry/apis/dashboard/v0alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v0alpha1/register.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 
+	dashboardinternal "github.com/grafana/grafana/pkg/apis/dashboard"
 	dashboardv0alpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -114,14 +115,27 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		return err
 	}
 
+	defaultOpts, err := optsGetter.GetRESTOptions(b.legacy.Resource.GroupResource(), &dashboardinternal.Dashboard{})
+	if err != nil {
+		return err
+	}
+	storageOpts := apistore.StorageOptions{
+		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
+			internal := &dashboardinternal.Dashboard{}
+			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)
+
+			scheme.Convert(obj, desiredObj, nil)
+			return desiredObj, err
+		}),
+	}
+
 	// Split dashboards when they are large
 	var largeObjects apistore.LargeObjectSupport
 	if b.legacy.Features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
 		largeObjects = dashboard.NewDashboardLargeObjectSupport(scheme)
-		opts.StorageOptions(dash.GroupResource(), apistore.StorageOptions{
-			LargeObjectSupport: largeObjects,
-		})
+		storageOpts.LargeObjectSupport = largeObjects
 	}
+	opts.StorageOptions(dash.GroupResource(), storageOpts)
 
 	storage := map[string]rest.Storage{}
 	storage[dash.StoragePath()] = legacyStore

--- a/pkg/registry/apis/dashboard/v0alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v0alpha1/register.go
@@ -123,8 +123,11 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
 			internal := &dashboardinternal.Dashboard{}
 			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)
+			if err != nil {
+				return nil, err
+			}
 
-			scheme.Convert(obj, desiredObj, nil)
+			err = scheme.Convert(obj, desiredObj, nil)
 			return desiredObj, err
 		}),
 	}

--- a/pkg/registry/apis/dashboard/v1alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v1alpha1/register.go
@@ -121,8 +121,11 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
 			internal := &dashboardinternal.Dashboard{}
 			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)
+			if err != nil {
+				return nil, err
+			}
 
-			scheme.Convert(obj, desiredObj, nil)
+			err = scheme.Convert(obj, desiredObj, nil)
 			return desiredObj, err
 		}),
 	}

--- a/pkg/registry/apis/dashboard/v1alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v1alpha1/register.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 
+	dashboardinternal "github.com/grafana/grafana/pkg/apis/dashboard"
 	dashboardv1alpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v1alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -112,14 +113,27 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		return err
 	}
 
+	defaultOpts, err := optsGetter.GetRESTOptions(b.legacy.Resource.GroupResource(), &dashboardinternal.Dashboard{})
+	if err != nil {
+		return err
+	}
+	storageOpts := apistore.StorageOptions{
+		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
+			internal := &dashboardinternal.Dashboard{}
+			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)
+
+			scheme.Convert(obj, desiredObj, nil)
+			return desiredObj, err
+		}),
+	}
+
 	// Split dashboards when they are large
 	var largeObjects apistore.LargeObjectSupport
 	if b.legacy.Features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
 		largeObjects = dashboard.NewDashboardLargeObjectSupport(scheme)
-		opts.StorageOptions(dash.GroupResource(), apistore.StorageOptions{
-			LargeObjectSupport: largeObjects,
-		})
+		storageOpts.LargeObjectSupport = largeObjects
 	}
+	opts.StorageOptions(dash.GroupResource(), storageOpts)
 
 	storage := map[string]rest.Storage{}
 	storage[dash.StoragePath()] = legacyStore

--- a/pkg/registry/apis/dashboard/v2alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v2alpha1/register.go
@@ -121,8 +121,11 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
 			internal := &dashboardinternal.Dashboard{}
 			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)
+			if err != nil {
+				return nil, err
+			}
 
-			scheme.Convert(obj, desiredObj, nil)
+			err = scheme.Convert(obj, desiredObj, nil)
 			return desiredObj, err
 		}),
 	}

--- a/pkg/registry/apis/dashboard/v2alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v2alpha1/register.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 
+	dashboardinternal "github.com/grafana/grafana/pkg/apis/dashboard"
 	dashboardv2alpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v2alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -112,14 +113,27 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		return err
 	}
 
+	defaultOpts, err := optsGetter.GetRESTOptions(b.legacy.Resource.GroupResource(), &dashboardinternal.Dashboard{})
+	if err != nil {
+		return err
+	}
+	storageOpts := apistore.StorageOptions{
+		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
+			internal := &dashboardinternal.Dashboard{}
+			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)
+
+			scheme.Convert(obj, desiredObj, nil)
+			return desiredObj, err
+		}),
+	}
+
 	// Split dashboards when they are large
 	var largeObjects apistore.LargeObjectSupport
 	if b.legacy.Features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageBigObjectsSupport) {
 		largeObjects = dashboard.NewDashboardLargeObjectSupport(scheme)
-		opts.StorageOptions(dash.GroupResource(), apistore.StorageOptions{
-			LargeObjectSupport: largeObjects,
-		})
+		storageOpts.LargeObjectSupport = largeObjects
 	}
+	opts.StorageOptions(dash.GroupResource(), storageOpts)
 
 	storage := map[string]rest.Storage{}
 	storage[dash.StoragePath()] = legacyStore


### PR DESCRIPTION
**What is this feature?**

Follow up to https://github.com/grafana/grafana/pull/96415. This PR fixes kubectl 
 / allows it to convert from v0 to v2, through the internal version.

Before:
![Screenshot 2024-11-18 at 3 14 19 PM](https://github.com/user-attachments/assets/d0cb545a-9b28-45e0-92e9-64299aafd7be)

After:
![Screenshot 2024-11-18 at 3 13 08 PM](https://github.com/user-attachments/assets/435a2677-e26b-4b48-884b-1bb2aceb4917)