### PR TITLE
Zanzana: Optimize batch check

### DIFF
--- a/pkg/services/authz/zanzana/common/info.go
+++ b/pkg/services/authz/zanzana/common/info.go
@@ -11,14 +11,14 @@ type TypeInfo struct {
 }
 
 var typedResources = map[string]TypeInfo{
-	NewNamespaceResourceIdent(
+	FormatGroupResource(
 		folderalpha1.FolderResourceInfo.GroupResource().Group,
 		folderalpha1.FolderResourceInfo.GroupResource().Resource,
 	): {Type: "folder"},
 }
 
 func GetTypeInfo(group, resource string) (TypeInfo, bool) {
-	info, ok := typedResources[NewNamespaceResourceIdent(group, resource)]
+	info, ok := typedResources[FormatGroupResource(group, resource)]
 	return info, ok
 }
 

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -37,8 +37,8 @@ type Server struct {
 }
 
 type storeInfo struct {
-	Id                   string
-	AuthorizationModelId string
+	ID      string
+	ModelID string
 }
 
 type ServerOption func(s *Server)

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -49,24 +49,15 @@ func (s *Server) batchCheckItem(
 	store *storeInfo,
 	groupResourceAccess map[string]bool,
 ) (*authzv1.CheckResponse, error) {
-	req := &authzv1.CheckRequest{
-		Subject:     r.GetSubject(),
-		Verb:        item.GetVerb(),
-		Group:       item.GetGroup(),
-		Resource:    item.GetResource(),
-		Name:        item.GetName(),
-		Folder:      item.GetFolder(),
-		Subresource: item.GetSubresource(),
-	}
 
 	var (
 		relation      = common.VerbMapping[item.GetVerb()]
-		groupResource = common.FormatGroupResource(req.GetGroup(), req.GetResource())
+		groupResource = common.FormatGroupResource(item.GetGroup(), item.GetResource())
 	)
 
 	allowed, ok := groupResourceAccess[groupResource]
 	if !ok {
-		res, err := s.checkNamespace(ctx, req, store, relation)
+		res, err := s.checkNamespace(ctx, r.GetSubject(), relation, item.GetGroup(), item.GetResource(), store)
 		if err != nil {
 			return nil, err
 		}
@@ -78,8 +69,8 @@ func (s *Server) batchCheckItem(
 	}
 
 	if info, ok := common.GetTypeInfo(item.GetGroup(), item.GetResource()); ok {
-		return s.checkTyped(ctx, req, info, store, relation)
+		return s.checkTyped(ctx, r.GetSubject(), relation, item.GetName(), info, store)
 	}
-	return s.checkGeneric(ctx, req, store, relation)
+	return s.checkGeneric(ctx, r.GetSubject(), relation, item.GetGroup(), item.GetResource(), item.GetName(), item.GetFolder(), store)
 
 }

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -49,7 +49,6 @@ func (s *Server) batchCheckItem(
 	store *storeInfo,
 	groupResourceAccess map[string]bool,
 ) (*authzv1.CheckResponse, error) {
-
 	var (
 		relation      = common.VerbMapping[item.GetVerb()]
 		groupResource = common.FormatGroupResource(item.GetGroup(), item.GetResource())
@@ -72,5 +71,4 @@ func (s *Server) batchCheckItem(
 		return s.checkTyped(ctx, r.GetSubject(), relation, item.GetName(), info, store)
 	}
 	return s.checkGeneric(ctx, r.GetSubject(), relation, item.GetGroup(), item.GetResource(), item.GetName(), item.GetFolder(), store)
-
 }

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -14,7 +14,6 @@ func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.C
 	ctx, span := tracer.Start(ctx, "authzServer.Check")
 	defer span.End()
 
-	// Check if subject has access through namespace
 	store, err := s.getStoreInfo(ctx, r.GetNamespace())
 	if err != nil {
 		return nil, err
@@ -22,6 +21,7 @@ func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.C
 
 	relation := common.VerbMapping[r.GetVerb()]
 
+	// Check if subject has access through namespace
 	res, err := s.checkNamespace(ctx, r, store, relation)
 	if err != nil {
 		return nil, err

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -40,8 +40,8 @@ func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.C
 // checkNamespace checks if subject has access through namespace
 func (s *Server) checkNamespace(ctx context.Context, r *authzv1.CheckRequest, store *storeInfo, relation string) (*authzv1.CheckResponse, error) {
 	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              store.Id,
-		AuthorizationModelId: store.AuthorizationModelId,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
 			Relation: relation,
@@ -58,8 +58,8 @@ func (s *Server) checkNamespace(ctx context.Context, r *authzv1.CheckRequest, st
 func (s *Server) checkTyped(ctx context.Context, r *authzv1.CheckRequest, info common.TypeInfo, store *storeInfo, relation string) (*authzv1.CheckResponse, error) {
 	// Check if subject has direct access to resource
 	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              store.Id,
-		AuthorizationModelId: store.AuthorizationModelId,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
 			Relation: relation,
@@ -81,8 +81,8 @@ func (s *Server) checkGeneric(ctx context.Context, r *authzv1.CheckRequest, stor
 
 	// Check if subject has direct access to resource
 	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              store.Id,
-		AuthorizationModelId: store.AuthorizationModelId,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
 			Relation: relation,
@@ -109,8 +109,8 @@ func (s *Server) checkGeneric(ctx context.Context, r *authzv1.CheckRequest, stor
 
 	// Check if subject has access as a sub resource for the folder
 	res, err = s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              store.Id,
-		AuthorizationModelId: store.AuthorizationModelId,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
 			Relation: common.FolderResourceRelation(relation),

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -16,31 +16,22 @@ func (s *Server) List(ctx context.Context, r *authzextv1.ListRequest) (*authzext
 	ctx, span := tracer.Start(ctx, "authzServer.List")
 	defer span.End()
 
-	if info, ok := common.GetTypeInfo(r.GetGroup(), r.GetResource()); ok {
-		return s.listTyped(ctx, r, info)
-	}
-
-	return s.listGeneric(ctx, r)
-}
-
-func (s *Server) listTyped(ctx context.Context, r *authzextv1.ListRequest, info common.TypeInfo) (*authzextv1.ListResponse, error) {
-	storeInf, err := s.getStoreInfo(ctx, r.Namespace)
+	store, err := s.getStoreInfo(ctx, r.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	relation := common.VerbMapping[r.GetVerb()]
 
-	// 1. check if subject has access through namespace because then they can read all of them
-	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              storeInf.ID,
-		AuthorizationModelId: storeInf.ModelID,
-		TupleKey: &openfgav1.CheckRequestTupleKey{
-			User:     r.GetSubject(),
-			Relation: relation,
-			Object:   common.NewNamespaceResourceIdent(r.GetGroup(), r.GetResource()),
-		},
-	})
+	res, err := s.checkNamespace(
+		ctx,
+		r.GetSubject(),
+		relation,
+		r.GetGroup(),
+		r.GetResource(),
+		store,
+	)
+
 	if err != nil {
 		return nil, err
 	}
@@ -49,13 +40,21 @@ func (s *Server) listTyped(ctx context.Context, r *authzextv1.ListRequest, info 
 		return &authzextv1.ListResponse{All: true}, nil
 	}
 
-	// 2. List all resources user has access too
+	if info, ok := common.GetTypeInfo(r.GetGroup(), r.GetResource()); ok {
+		return s.listTyped(ctx, r.GetSubject(), relation, info, store)
+	}
+
+	return s.listGeneric(ctx, r.GetSubject(), relation, r.GetGroup(), r.GetResource(), store)
+}
+
+func (s *Server) listTyped(ctx context.Context, subject, relation string, info common.TypeInfo, store *storeInfo) (*authzextv1.ListResponse, error) {
+	// List all resources user has access too
 	listRes, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              storeInf.ID,
-		AuthorizationModelId: storeInf.ModelID,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		Type:                 info.Type,
 		Relation:             relation,
-		User:                 r.GetSubject(),
+		User:                 subject,
 	})
 	if err != nil {
 		return nil, err
@@ -66,42 +65,19 @@ func (s *Server) listTyped(ctx context.Context, r *authzextv1.ListRequest, info 
 	}, nil
 }
 
-func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*authzextv1.ListResponse, error) {
-	storeInf, err := s.getStoreInfo(ctx, r.Namespace)
-	if err != nil {
-		return nil, err
-	}
+func (s *Server) listGeneric(ctx context.Context, subject, relation, group, resource string, store *storeInfo) (*authzextv1.ListResponse, error) {
+	groupResource := structpb.NewStringValue(common.FormatGroupResource(group, resource))
 
-	relation := common.VerbMapping[r.GetVerb()]
-
-	// 1. check if subject has access through namespace because then they can read all of them
-	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              storeInf.ID,
-		AuthorizationModelId: storeInf.ModelID,
-		TupleKey: &openfgav1.CheckRequestTupleKey{
-			User:     r.GetSubject(),
-			Relation: relation,
-			Object:   common.NewNamespaceResourceIdent(r.GetGroup(), r.GetResource()),
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Allowed {
-		return &authzextv1.ListResponse{All: true}, nil
-	}
-
-	// 2. List all folders subject has access to resource type in
+	// 1. List all folders subject has access to resource type in
 	folders, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              storeInf.ID,
-		AuthorizationModelId: storeInf.ModelID,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		Type:                 common.TypeFolder,
 		Relation:             common.FolderResourceRelation(relation),
-		User:                 r.GetSubject(),
+		User:                 subject,
 		Context: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"requested_group": structpb.NewStringValue(common.FormatGroupResource(r.GetGroup(), r.GetResource())),
+				"requested_group": groupResource,
 			},
 		},
 	})
@@ -109,16 +85,16 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 		return nil, err
 	}
 
-	// 3. List all resource directly assigned to subject
+	// 2. List all resource directly assigned to subject
 	direct, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              storeInf.ID,
-		AuthorizationModelId: storeInf.ModelID,
+		StoreId:              store.ID,
+		AuthorizationModelId: store.ModelID,
 		Type:                 common.TypeResource,
 		Relation:             relation,
-		User:                 r.GetSubject(),
+		User:                 subject,
 		Context: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"requested_group": structpb.NewStringValue(common.FormatGroupResource(r.GetGroup(), r.GetResource())),
+				"requested_group": groupResource,
 			},
 		},
 	})
@@ -128,7 +104,7 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 
 	return &authzextv1.ListResponse{
 		Folders: folderObject(folders.GetObjects()),
-		Items:   directObjects(r.GetGroup(), r.GetResource(), direct.GetObjects()),
+		Items:   directObjects(group, resource, direct.GetObjects()),
 	}, nil
 }
 

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -33,8 +33,8 @@ func (s *Server) listTyped(ctx context.Context, r *authzextv1.ListRequest, info 
 
 	// 1. check if subject has access through namespace because then they can read all of them
 	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
 			Relation: relation,
@@ -51,8 +51,8 @@ func (s *Server) listTyped(ctx context.Context, r *authzextv1.ListRequest, info 
 
 	// 2. List all resources user has access too
 	listRes, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 		Type:                 info.Type,
 		Relation:             relation,
 		User:                 r.GetSubject(),
@@ -76,8 +76,8 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 
 	// 1. check if subject has access through namespace because then they can read all of them
 	res, err := s.openfga.Check(ctx, &openfgav1.CheckRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 		TupleKey: &openfgav1.CheckRequestTupleKey{
 			User:     r.GetSubject(),
 			Relation: relation,
@@ -94,8 +94,8 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 
 	// 2. List all folders subject has access to resource type in
 	folders, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 		Type:                 common.TypeFolder,
 		Relation:             common.FolderResourceRelation(relation),
 		User:                 r.GetSubject(),
@@ -111,8 +111,8 @@ func (s *Server) listGeneric(ctx context.Context, r *authzextv1.ListRequest) (*a
 
 	// 3. List all resource directly assigned to subject
 	direct, err := s.openfga.ListObjects(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 		Type:                 common.TypeResource,
 		Relation:             relation,
 		User:                 r.GetSubject(),

--- a/pkg/services/authz/zanzana/server/server_read.go
+++ b/pkg/services/authz/zanzana/server/server_read.go
@@ -19,7 +19,7 @@ func (s *Server) Read(ctx context.Context, req *authzextv1.ReadRequest) (*authze
 	}
 
 	res, err := s.openfga.Read(ctx, &openfgav1.ReadRequest{
-		StoreId: storeInf.Id,
+		StoreId: storeInf.ID,
 		TupleKey: &openfgav1.ReadRequestTupleKey{
 			User:     req.GetTupleKey().GetUser(),
 			Relation: req.GetTupleKey().GetRelation(),

--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -30,8 +30,8 @@ func (s *Server) getStoreInfo(ctx context.Context, namespace string) (*storeInfo
 	}
 
 	info = storeInfo{
-		Id:                   store.GetId(),
-		AuthorizationModelId: modelID,
+		ID:      store.GetId(),
+		ModelID: modelID,
 	}
 
 	s.stores[namespace] = info

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -71,8 +71,8 @@ func setup(t *testing.T, testDB db.DB, cfg *setting.Cfg) *Server {
 
 	// seed tuples
 	_, err = openfga.Write(context.Background(), &openfgav1.WriteRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 		Writes: &openfgav1.WriteRequestWrites{
 			TupleKeys: []*openfgav1.TupleKey{
 				common.NewResourceTuple("user:1", "read", dashboardGroup, dashboardResource, "1"),

--- a/pkg/services/authz/zanzana/server/server_write.go
+++ b/pkg/services/authz/zanzana/server/server_write.go
@@ -29,8 +29,8 @@ func (s *Server) Write(ctx context.Context, req *authzextv1.WriteRequest) (*auth
 	}
 
 	writeReq := &openfgav1.WriteRequest{
-		StoreId:              storeInf.Id,
-		AuthorizationModelId: storeInf.AuthorizationModelId,
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
 	}
 	if len(writeTuples) > 0 {
 		writeReq.Writes = &openfgav1.WriteRequestWrites{


### PR DESCRIPTION
**What is this feature?**
Adding some optimizations for batch check. Before this check we called `getStoreInfo` for every item in the batch, this results in taking a mutex lock and hashing a key. Batch request are always performed within the same namespace so we only need to do this once.

The second optimization is to only check "namespace" access for a given `GroupResource` once during the batch a cache the result. If we have access to given `GroupResource` we can return early for that item otherwise we can perform other checks.


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
