### PR TITLE
Logs: Let `level` label take precedence over `detected_level`

### DIFF
--- a/public/app/features/logs/legacyLogsFrame.ts
+++ b/public/app/features/logs/legacyLogsFrame.ts
@@ -45,7 +45,7 @@ export function parseLegacyLogsFrame(frame: DataFrame): LogsFrame | null {
   }
 
   const timeNanosecondField = cache.getFieldByName('tsNs') ?? null;
-  const severityField = cache.getFieldByName('detected_level') ?? cache.getFieldByName('level') ?? null;
+  const severityField = cache.getFieldByName('level') ?? cache.getFieldByName('detected_level') ?? null;
   const idField = cache.getFieldByName('id') ?? null;
 
   // extracting the labels is done very differently for old-loki-style and simple-style

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -426,7 +426,7 @@ export function logSeriesToLogsModel(
       }
 
       let logLevel = LogLevel.unknown;
-      const logLevelKey = (logLevelField && logLevelField.values[j]) || (labels?.detected_level ?? labels?.level);
+      const logLevelKey = (logLevelField && logLevelField.values[j]) || (labels?.level ?? labels?.detected_level);
       if (typeof logLevelKey === 'number' || typeof logLevelKey === 'string') {
         logLevel = getLogLevelFromKey(logLevelKey);
       } else {
@@ -643,7 +643,7 @@ function defaultExtractLevel(dataFrame: DataFrame): LogLevel {
 }
 
 function getLogLevelFromLabels(labels: Labels): LogLevel {
-  const level = labels['detected_level'] ?? labels['level'] ?? labels['lvl'] ?? labels['loglevel'] ?? '';
+  const level = labels['level'] ?? labels['detected_level'] ?? labels['lvl'] ?? labels['loglevel'] ?? '';
   return level ? getLogLevelFromKey(level) : LogLevel.unknown;
 }
 

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -122,7 +122,7 @@ export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | n
   // Find first level-like label
   for (let labels of labelsArray) {
     const label = Object.keys(labels).find(
-      (label) => label === 'detected_level' || label === 'level' || label === 'lvl' || label.includes('level')
+      (label) => label === 'level' || label === 'detected_level' || label === 'lvl' || label.includes('level')
     );
     if (label) {
       levelLikeLabel = label;


### PR DESCRIPTION
**What is this feature?**

There might be cases where Loki writes a `detected_level` with `unknown`, but a nested `level` label will contain something like `WARN`. Before this PR, `detected_level` took precedence and the histogram would be grey:
![image](https://github.com/user-attachments/assets/003ef407-6662-453e-8374-abf909ee8944)


With this change, `level` takes precedence:
![image](https://github.com/user-attachments/assets/64b2fa1a-94c2-4595-ad9e-819dcec54847)
