### PR TITLE
Zanzana: Add setting zanzana reconciliation interval

### DIFF
--- a/pkg/services/accesscontrol/dualwrite/reconciler.go
+++ b/pkg/services/accesscontrol/dualwrite/reconciler.go
@@ -98,9 +98,8 @@ func (r *ZanzanaReconciler) Reconcile(ctx context.Context) error {
 	r.reconcile(ctx)
 
 	// FIXME:
-	// 1. We should be a bit graceful about reconciliations so we are not hammering dbs
-	// 2. We should be able to configure reconciliation interval
-	ticker := time.NewTicker(1 * time.Hour)
+	// We should be a bit graceful about reconciliations so we are not hammering dbs
+	ticker := time.NewTicker(r.cfg.RBAC.ZanzanaReconciliationInterval)
 	for {
 		select {
 		case <-ticker.C:

--- a/pkg/setting/settings_rbac.go
+++ b/pkg/setting/settings_rbac.go
@@ -1,6 +1,9 @@
 package setting
 
 import (
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -13,6 +16,9 @@ type RBACSettings struct {
 	ResetBasicRoles bool
 	// RBAC single organization. This configuration option is subject to change.
 	SingleOrganization bool
+	// If zanzana feature toggle is enabled this controls how often we
+	// run the zanzana reconciliation loop.
+	ZanzanaReconciliationInterval time.Duration
 
 	OnlyStoreAccessActionSets bool
 
@@ -45,6 +51,12 @@ func (cfg *Cfg) readRBACSettings() {
 	s.resourcesWithWildcardSeed = map[string]struct{}{}
 	for _, resource := range resources {
 		s.resourcesWithWildcardSeed[resource] = struct{}{}
+	}
+
+	var err error
+	s.ZanzanaReconciliationInterval, err = gtime.ParseDuration(rbac.Key("zanzana_reconciliation_interval").MustString("1h"))
+	if err != nil {
+		s.ZanzanaReconciliationInterval = 1 * time.Hour
 	}
 
 	cfg.RBAC = s


### PR DESCRIPTION
**What is this feature?**
Add a setting to control how often we try to start zanzana reconciliation loop. This will only happen if `zanzana` feature toggle is enabled.

I intentionally left it out from ini files and documentation 
**Why do we need this feature?**


**Who is this feature for?**


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/958

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
