### PR TITLE
Prometheus: Add deprecation message for AMP in Promehteus docs

### DIFF
--- a/docs/sources/datasources/prometheus/_index.md
+++ b/docs/sources/datasources/prometheus/_index.md
@@ -163,17 +163,7 @@ For details about these metrics, refer to [Internal Grafana metrics](ref:set-up-
 
 ## Amazon Managed Service for Prometheus
 
-The Prometheus data source works with Amazon Managed Service for Prometheus.
-
-If you use an AWS Identity and Access Management (IAM) policy to control access to your Amazon Elasticsearch Service domain, you must use AWS Signature Version 4 (AWS SigV4) to sign all requests to that domain.
-
-For details on AWS SigV4, refer to the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
-
-### AWS Signature Version 4 authentication
-
-To connect the Prometheus data source to Amazon Managed Service for Prometheus using SigV4 authentication, refer to the AWS guide to [Set up Grafana open source or Grafana Enterprise for use with AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-query-standalone-grafana.html).
-
-If you run Grafana in an Amazon EKS cluster, follow the AWS guide to [Query using Grafana running in an Amazon EKS cluster](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-query-grafana-7.3.html).
+The Prometheus data source with Amazon Managed Service for Prometheus is deprecated. Please use the [Amazon Managed service for Prometheus data source](https://grafana.com/grafana/plugins/grafana-amazonprometheus-datasource/). Migrations steps are detailed in the link.
 
 ## Azure authentication settings
 


### PR DESCRIPTION
**What is this?**

Adds a message for deprecating the use of Prometheus data source in Grafana for Amazon Managed Service for Prometheus and adds a link to the AMP data source.

**Why?**
SigV4 auth was deprecated in Prometheus and the AMP data source was created for this authentication and for AMP users to have their own data source. This clears up the Prometheus documentation which did not have the deprecation message.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
