### PR TITLE
GrafanaUI: Fix inconsistent controlled/uncontrolled state in AutoSizeInput

### DIFF
--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
@@ -1,4 +1,6 @@
 import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 
 import { measureText } from '../../utils/measureText';
 
@@ -13,15 +15,214 @@ jest.mock('../../utils/measureText', () => {
   return { measureText };
 });
 
+// The length calculation should be (text.length * 14) + 24
+const FIXTURES = {
+  'Initial value': '206px',
+  'Initial value with more text': '416px',
+  'A new value': '178px',
+  'Placeholder text': '248px',
+  _emptyString: '80px', // min width
+  foo: '80px', // min width
+} as const;
+
 describe('AutoSizeInput', () => {
-  it('should support default Input API', () => {
-    const onChange = jest.fn();
-    render(<AutoSizeInput onChange={onChange} value="" />);
+  it('all the test fixture strings should be a different length', () => {
+    const lengths = Object.keys(FIXTURES).map((key) => key.length);
 
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-    fireEvent.change(input, { target: { value: 'foo' } });
+    // The unique number of lengths should be the same as the number of items in the object
+    const uniqueLengths = new Set(lengths);
+    expect(uniqueLengths.size).toBe(lengths.length);
+  });
 
-    expect(onChange).toHaveBeenCalled();
+  describe('as an uncontrolled component', () => {
+    it('renders an initial value prop with correct width', async () => {
+      render(<AutoSizeInput value="Initial value" />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      expect(input.value).toBe('Initial value');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Initial value']);
+    });
+
+    it('renders an updated value prop with correct width', () => {
+      const { rerender } = render(<AutoSizeInput value="Initial value" />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      rerender(<AutoSizeInput value="A new value" />);
+
+      expect(input.value).toBe('A new value');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['A new value']);
+    });
+
+    it('renders the user typing in the input with correct width', async () => {
+      render(<AutoSizeInput value="" />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      await userEvent.type(input, 'Initial value with more text');
+
+      expect(input.value).toBe('Initial value with more text');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Initial value with more text']);
+    });
+
+    it('renders correctly after the user clears the input', async () => {
+      render(<AutoSizeInput value="Initial value" />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      await userEvent.clear(input);
+
+      expect(input.value).toBe('');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES._emptyString);
+    });
+
+    it('renders correctly with a placeholder after the user clears the input', async () => {
+      render(<AutoSizeInput value="Initial value" placeholder="Placeholder text" />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      await userEvent.clear(input);
+
+      expect(input.value).toBe('');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Placeholder text']);
+    });
+
+    it('emits onCommitChange when you blur the input', () => {
+      const onCommitChange = jest.fn();
+      render(<AutoSizeInput value="Initial value" onCommitChange={onCommitChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+      fireEvent.blur(input);
+
+      expect(onCommitChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits onBlur instead of onCommitChange when you blur the input', () => {
+      const onCommitChange = jest.fn();
+      const onBlur = jest.fn();
+      render(<AutoSizeInput value="Initial value" onCommitChange={onCommitChange} onBlur={onBlur} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+      fireEvent.blur(input);
+
+      expect(onCommitChange).not.toHaveBeenCalled();
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits the value when you press enter', async () => {
+      const onCommitChange = jest.fn();
+      render(<AutoSizeInput value="Initial value" onCommitChange={onCommitChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+      await userEvent.type(input, '{enter}');
+
+      expect(onCommitChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('as a controlled component', () => {
+    function ControlledAutoSizeInputExample() {
+      const [value, setValue] = useState('');
+      return <AutoSizeInput value={value} onChange={(event) => setValue(event.currentTarget.value)} />;
+    }
+
+    // AutoSizeInput is considered controlled when it has both value and onChange props
+
+    it('renders a value prop with correct width', () => {
+      const onChange = jest.fn();
+      render(<AutoSizeInput value="Initial value" onChange={onChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      expect(input.value).toBe('Initial value');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Initial value']);
+    });
+
+    it('renders an updated value prop with correct width', () => {
+      const onChange = jest.fn();
+      const { rerender } = render(<AutoSizeInput value="Initial value" onChange={onChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      rerender(<AutoSizeInput value="A new value" onChange={onChange} />);
+
+      expect(input.value).toBe('A new value');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['A new value']);
+    });
+
+    it('as a user types, the value is not updated because it is controlled', async () => {
+      const onChange = jest.fn();
+      render(<AutoSizeInput value="Initial value" onChange={onChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      await userEvent.type(input, ' and more text');
+
+      expect(input.value).toBe('Initial value');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Initial value']);
+    });
+
+    it('functions correctly as a controlled input', async () => {
+      render(<ControlledAutoSizeInputExample />);
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+      const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
+
+      await userEvent.type(input, 'Initial value with more text');
+      expect(input.value).toBe('Initial value with more text');
+      expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Initial value with more text']);
+    });
+
+    it('emits onCommitChange when you blur the input', () => {
+      const onCommitChange = jest.fn();
+      const onChange = jest.fn();
+      render(<AutoSizeInput value="Initial value" onCommitChange={onCommitChange} onChange={onChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+      fireEvent.blur(input);
+
+      expect(onCommitChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits onBlur instead of onCommitChange when you blur the input', () => {
+      const onCommitChange = jest.fn();
+      const onBlur = jest.fn();
+      const onChange = jest.fn();
+      render(
+        <AutoSizeInput value="Initial value" onCommitChange={onCommitChange} onBlur={onBlur} onChange={onChange} />
+      );
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+      fireEvent.blur(input);
+
+      expect(onCommitChange).not.toHaveBeenCalled();
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits the value when you press enter', async () => {
+      const onCommitChange = jest.fn();
+      const onChange = jest.fn();
+      render(<AutoSizeInput value="Initial value" onCommitChange={onCommitChange} onChange={onChange} />);
+
+      const input: HTMLInputElement = screen.getByTestId('autosize-input');
+
+      await userEvent.type(input, '{enter}');
+
+      expect(onCommitChange).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should have default minWidth when empty', () => {
@@ -30,101 +231,37 @@ describe('AutoSizeInput', () => {
     const input: HTMLInputElement = screen.getByTestId('autosize-input');
     const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
 
-    fireEvent.change(input, { target: { value: '' } });
-
     expect(input.value).toBe('');
-    expect(getComputedStyle(inputWrapper).width).toBe('80px');
+    expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES._emptyString);
   });
 
   it('should have default minWidth for short content', () => {
-    render(<AutoSizeInput />);
+    render(<AutoSizeInput value="foo" />);
 
     const input: HTMLInputElement = screen.getByTestId('autosize-input');
     const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
-
-    fireEvent.change(input, { target: { value: 'foo' } });
 
     expect(input.value).toBe('foo');
-    expect(getComputedStyle(inputWrapper).width).toBe('80px');
-  });
-
-  it('should change width for long content', () => {
-    render(<AutoSizeInput />);
-
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-    const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
-
-    fireEvent.change(input, { target: { value: 'very very long value' } });
-    expect(getComputedStyle(inputWrapper).width).toBe('304px');
+    expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['foo']);
   });
 
   it('should use placeholder for width if input is empty', () => {
-    render(<AutoSizeInput placeholder="very very long value" />);
+    render(<AutoSizeInput value="" placeholder="Placeholder text" />);
 
     const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
-    expect(getComputedStyle(inputWrapper).width).toBe('304px');
+    expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Placeholder text']);
   });
 
   it('should use value for width even with a placeholder', () => {
-    render(<AutoSizeInput value="less long value" placeholder="very very long value" />);
+    render(<AutoSizeInput value="Initial value" placeholder="Placeholder text" />);
 
     const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
 
-    expect(getComputedStyle(inputWrapper).width).toBe('234px');
-  });
-
-  it('should call onBlur if set when blurring', () => {
-    const onBlur = jest.fn();
-    const onCommitChange = jest.fn();
-    render(<AutoSizeInput onBlur={onBlur} onCommitChange={onCommitChange} />);
-
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-
-    fireEvent.blur(input);
-
-    expect(onBlur).toHaveBeenCalled();
-    expect(onCommitChange).not.toHaveBeenCalled();
-  });
-
-  it('should call onCommitChange if not set when blurring', () => {
-    const onCommitChange = jest.fn();
-    render(<AutoSizeInput onCommitChange={onCommitChange} />);
-
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-
-    fireEvent.blur(input);
-
-    expect(onCommitChange).toHaveBeenCalled();
-  });
-
-  it('should call onKeyDown if set when keydown', () => {
-    const onKeyDown = jest.fn();
-    const onCommitChange = jest.fn();
-    render(<AutoSizeInput onKeyDown={onKeyDown} onCommitChange={onCommitChange} />);
-
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-
-    fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(onKeyDown).toHaveBeenCalled();
-    expect(onCommitChange).not.toHaveBeenCalled();
-  });
-
-  it('should call onCommitChange if not set when keydown', () => {
-    const onCommitChange = jest.fn();
-    render(<AutoSizeInput onCommitChange={onCommitChange} />);
-
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-
-    fireEvent.keyDown(input, { key: 'Enter' });
-
-    expect(onCommitChange).toHaveBeenCalled();
+    expect(getComputedStyle(inputWrapper).width).toBe(FIXTURES['Initial value']);
   });
 
   it('should respect min width', async () => {
     render(<AutoSizeInput minWidth={4} defaultValue="" />);
-
-    await waitFor(() => expect(measureText).toHaveBeenCalled());
 
     expect(getComputedStyle(screen.getByTestId('input-wrapper')).width).toBe('32px');
   });
@@ -141,32 +278,6 @@ describe('AutoSizeInput', () => {
     await waitFor(() => expect(measureText).toHaveBeenCalled());
 
     expect(getComputedStyle(screen.getByTestId('input-wrapper')).width).toBe('32px');
-  });
-
-  it('should update the input value if the value prop changes', () => {
-    const { rerender } = render(<AutoSizeInput value="Initial" />);
-
-    // Get a handle on the original input element (to catch if it's unmounted)
-    // And check the initial value
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-    expect(input.value).toBe('Initial');
-
-    // Rerender and make sure it clears the input
-    rerender(<AutoSizeInput value="Updated" />);
-    expect(input.value).toBe('Updated');
-  });
-
-  it('should clear the input when the value is changed to an empty string', () => {
-    const { rerender } = render(<AutoSizeInput value="Initial" />);
-
-    // Get a handle on the original input element (to catch if it's unmounted)
-    // And check the initial value
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
-    expect(input.value).toBe('Initial');
-
-    // Rerender and make sure it clears the input
-    rerender(<AutoSizeInput value="" />);
-    expect(input.value).toBe('');
   });
 
   it('should render string values as expected', () => {

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.test.tsx
@@ -68,11 +68,9 @@ describe('AutoSizeInput', () => {
   it('should use value for width even with a placeholder', () => {
     render(<AutoSizeInput value="less long value" placeholder="very very long value" />);
 
-    const input: HTMLInputElement = screen.getByTestId('autosize-input');
     const inputWrapper: HTMLDivElement = screen.getByTestId('input-wrapper');
 
-    fireEvent.change(input, { target: { value: 'very very long value' } });
-    expect(getComputedStyle(inputWrapper).width).toBe('304px');
+    expect(getComputedStyle(inputWrapper).width).toBe('234px');
   });
 
   it('should call onBlur if set when blurring', () => {

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as React from 'react';
 
 import { measureText } from '../../utils/measureText';
@@ -28,7 +28,7 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
     placeholder,
     ...restProps
   } = props;
-  const [inputState, setInputValue] = useControlledState(controlledValue);
+  const [inputState, setInputValue] = useControlledState(controlledValue, onChange);
   const inputValue = inputState || defaultValue;
 
   // Update input width when `value`, `minWidth`, or `maxWidth` change
@@ -100,8 +100,8 @@ AutoSizeInput.displayName = 'AutoSizeInput';
  * If the initial value is not undefined, then the value will be controlled by the parent
  * for the lifetime of the component and calls to setState will be ignored.
  */
-function useControlledState<T>(controlledValue: T): [T, (newValue: T) => void] {
-  const isControlledNow = controlledValue !== undefined;
+function useControlledState<T>(controlledValue: T, onChange: Function | undefined): [T, (newValue: T) => void] {
+  const isControlledNow = controlledValue !== undefined && onChange !== undefined;
   const isControlledRef = useRef(isControlledNow); // set the initial value - we never change this
 
   const hasLoggedControlledWarning = useRef(false);
@@ -113,6 +113,12 @@ function useControlledState<T>(controlledValue: T): [T, (newValue: T) => void] {
   }
 
   const [internalValue, setInternalValue] = React.useState(controlledValue);
+
+  useEffect(() => {
+    if (!isControlledRef.current) {
+      setInternalValue(controlledValue);
+    }
+  }, [controlledValue]);
 
   const handleChange = useCallback((newValue: T) => {
     if (!isControlledRef.current) {


### PR DESCRIPTION
AutoSizeInput has a weird history with how it's state management worked.

Intially it was not a reactive component - you could specify an initial value for the input, but otherwise the `value` prop was ignored and it would maintain it's internal input state.

Then it got changed to a semi-controlled component https://github.com/grafana/grafana/pull/92997, allowing consumers to pass in `value`, which would be synced to the internal state. This was mostly fine, but due to the input state being one render 'behind' it's parent when using controlled state (parent passing in `value`), it let to some issues.

This PR changes AutoSizeInput to act as either a controlled or uncontrolled input for the life of the component, depending on the value prop on first render:
 - If `value` and `onChange` is initially NOT `undefined`, then it's considered a controlled component and the incomming `value` prop is passed in directly to the Input.
 - Otherwise, then it's considered an _un_controlled component and it will maintain internal state to pass to Input
 - If the controlled state changes, a warning is logged to the console.

This is technically a breaking change - instances that pass in both a `value` and `onChange`, but don't use that `onChange` to update the value, then the text box will no longer update as the user types. Given that the value prop was only introduced in Sep in 11.3 https://github.com/grafana/grafana/pull/92997, and we have no known public usage of AutoSizeInput, I think this is safe to ship.

To fix flickering width issue reported in https://github.com/grafana/grafana/pull/96575#issuecomment-2485727593 