### PR TITLE
PanelInspectDrawer: Fix issue where closing inspect drawer on home dashboard redirects to new dashboard

### DIFF
--- a/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
+++ b/public/app/features/dashboard-scene/inspect/PanelInspectDrawer.tsx
@@ -92,6 +92,8 @@ export class PanelInspectDrawer extends SceneObjectBase<PanelInspectDrawerState>
 
   onClose = () => {
     const dashboard = getDashboardSceneFor(this);
+    const meta = dashboard.state.meta;
+
     locationService.push(
       getDashboardUrl({
         uid: dashboard.state.uid,
@@ -101,6 +103,7 @@ export class PanelInspectDrawer extends SceneObjectBase<PanelInspectDrawerState>
           inspect: null,
           inspectTab: null,
         },
+        isHomeDashboard: !meta.url && !meta.slug && !meta.isNew,
       })
     );
   };


### PR DESCRIPTION
Fixes an issue where closing a panel inspect drawer while on the home dashboard causes a redirect to a new dashboard.

The issue:

https://github.com/user-attachments/assets/5f3f2db0-93c3-4842-8f23-4b8e749e10d0

