### PR TITLE
Provisioning: Remove obsolete code

### DIFF
--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -254,34 +254,6 @@ func (fr *FileReader) saveDashboard(ctx context.Context, path string, folderID i
 	// nolint:staticcheck
 	provisioningMetadata.identity = dashboardIdentity{title: dash.Dashboard.Title, folderID: dash.Dashboard.FolderID}
 
-	// fix empty folder_uid from already provisioned dashboards
-	if upToDate && folderUID != "" {
-		// search for root dashboard with the specified uid or title
-		d, err := fr.dashboardStore.GetDashboard(
-			ctx,
-			&dashboards.GetDashboardQuery{
-				OrgID:     jsonFile.dashboard.OrgID,
-				UID:       jsonFile.dashboard.Dashboard.UID,
-				FolderUID: util.Pointer(""),
-
-				// provisioning depends on unique names
-				//nolint:staticcheck
-				Title: &jsonFile.dashboard.Dashboard.Title,
-			},
-		)
-		if err != nil {
-			// if no problematic entry is found it's safe to ignore
-			if !errors.Is(err, dashboards.ErrDashboardNotFound) {
-				return provisioningMetadata, err
-			}
-		} else {
-			// inconsistency is detected so force updating the dashboard
-			if d.FolderUID != folderUID {
-				upToDate = false
-			}
-		}
-	}
-
 	if upToDate {
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Provisioning).Inc()
 		// nolint:staticcheck


### PR DESCRIPTION
This code was introduced [for fixing a bug back in 10.2.3](https://github.com/grafana/grafana/pull/77637); this version is no more supported
