### PR TITLE
[Provisioning] Add mutation hook to generate webhook URL and secret

### DIFF
--- a/pkg/registry/apis/provisioning/github.go
+++ b/pkg/registry/apis/provisioning/github.go
@@ -56,6 +56,9 @@ func (r *githubRepository) Validate() (list field.ErrorList) {
 	if gh.Repository == "" {
 		list = append(list, field.Required(field.NewPath("spec", "github", "repository"), "a github repo name is required"))
 	}
+	if gh.Branch == "" {
+		list = append(list, field.Required(field.NewPath("spec", "github", "branch"), "a github branch is required"))
+	}
 	if gh.Token == "" {
 		list = append(list, field.Required(field.NewPath("spec", "github", "token"), "a github access token is required"))
 	}
@@ -181,16 +184,9 @@ func (r *githubRepository) onPushEvent(ctx context.Context, event *github.PushEv
 		return fmt.Errorf("repository mismatch")
 	}
 
-	branch := r.config.Spec.GitHub.Branch
-	if branch == "" {
-		// Default to main if no branch is specified
-		// TODO: should this be a mutation hook instead?
-		branch = "main"
-	}
-
 	// Skip silently if the event is not for the main/master branch
 	// as we cannot configure the webhook to only publish events for the main branch
-	if event.GetRef() != fmt.Sprintf("refs/heads/%s", branch) {
+	if event.GetRef() != fmt.Sprintf("refs/heads/%s", r.config.Spec.GitHub.Branch) {
 		return nil
 	}
 


### PR DESCRIPTION

- Make `webhookURL` and `webhookSecret` optional by generating the URL and the secret in a mutation hook. 
- Use the mutation hook to set the branch to `main`. 
- The generated secret will be based on the token and the grafana instance secret key. This will generate a consistent secret key for us until app platform secrets are available. 
- Use `root_url` for the webhook URL generation so that we can put there any public domain. E.g: 
  ```
  [server]
  root_url = https://d60d-83-33-235-30.ngrok-free.app
  ```
- Spec defaults are defined / generated in the mutation hook. 

Example config: 

```yaml
apiVersion: provisioning.grafana.app/v0alpha1
kind: Repository
metadata:
  name: github-ui-sync-demo
spec:
  title: Github UI Sync Demo
  description: load resources from github
  type: github
  github:
    owner: grafana
    repository: git-ui-sync-demo
    token: some-token
```