### PR TITLE
Secret: move rest storage package and rename structs

### DIFF
--- a/pkg/registry/apis/secret/reststorage/decrypt_storage.go
+++ b/pkg/registry/apis/secret/reststorage/decrypt_storage.go
@@ -23,12 +23,11 @@ var (
 type DecryptStorage struct {
 	config *setting.Cfg
 
-	// TODO: we can use composition and only expose the `Decrypt` method this uses.
-	store secretstore.SecureValueStore
+	store secretstore.SecureValueStoreDecrypt
 }
 
 // NewDecryptStorage is a returns a constructed `*DecryptStorage`.
-func NewDecryptStorage(config *setting.Cfg, store secretstore.SecureValueStore) *DecryptStorage {
+func NewDecryptStorage(config *setting.Cfg, store secretstore.SecureValueStoreDecrypt) *DecryptStorage {
 	return &DecryptStorage{config, store}
 }
 

--- a/pkg/registry/apis/secret/reststorage/generic_storage.go
+++ b/pkg/registry/apis/secret/reststorage/generic_storage.go
@@ -32,14 +32,13 @@ var (
 
 // GenericStorage is an implementation of CRUDL operations on a `securevalue` backed by a persistence layer `store`.
 type GenericStorage struct {
-	// TODO: do we want another interface that is less broad here? meaning that it doesn't have the `Decrypt` method at all.
-	store          secretstore.SecureValueStore
+	store          secretstore.SecureValueStoreCRUDL
 	resource       utils.ResourceInfo
 	tableConverter rest.TableConvertor
 }
 
 // NewGenericStorage is a returns a constructed `*GenericStorage`.
-func NewGenericStorage(store secretstore.SecureValueStore, resource utils.ResourceInfo) *GenericStorage {
+func NewGenericStorage(store secretstore.SecureValueStoreCRUDL, resource utils.ResourceInfo) *GenericStorage {
 	return &GenericStorage{store, resource, resource.TableConverter()}
 }
 

--- a/pkg/registry/apis/secret/reststorage/history_storage.go
+++ b/pkg/registry/apis/secret/reststorage/history_storage.go
@@ -22,12 +22,11 @@ var (
 
 // HistoryStorage implements the methods for the "history" subresource. This is exposed via HTTP, not gRPC.
 type HistoryStorage struct {
-	// TODO: we can use composition and only expose the `History` method this uses.
-	store secretstore.SecureValueStore
+	store secretstore.SecureValueStoreHistory
 }
 
 // NewHistoryStorage is a returns a constructed `*HistoryStorage`.
-func NewHistoryStorage(store secretstore.SecureValueStore) *HistoryStorage {
+func NewHistoryStorage(store secretstore.SecureValueStoreHistory) *HistoryStorage {
 	return &HistoryStorage{store}
 }
 

--- a/pkg/registry/apis/secret/reststorage/history_storage.go
+++ b/pkg/registry/apis/secret/reststorage/history_storage.go
@@ -1,4 +1,4 @@
-package secret
+package reststorage
 
 import (
 	"context"
@@ -14,54 +14,59 @@ import (
 
 // TODO: what really do we need to implement in this case?
 var (
-	_ rest.Storage         = (*secretHistory)(nil)
-	_ rest.Scoper          = (*secretHistory)(nil)
-	_ rest.Connecter       = (*secretHistory)(nil)
-	_ rest.StorageMetadata = (*secretHistory)(nil)
+	_ rest.Storage         = (*HistoryStorage)(nil)
+	_ rest.Scoper          = (*HistoryStorage)(nil)
+	_ rest.Connecter       = (*HistoryStorage)(nil)
+	_ rest.StorageMetadata = (*HistoryStorage)(nil)
 )
 
-// secretHistory implements the methods for the "history" subresource. This is exposed via HTTP, not gRPC.
-type secretHistory struct {
+// HistoryStorage implements the methods for the "history" subresource. This is exposed via HTTP, not gRPC.
+type HistoryStorage struct {
 	// TODO: we can use composition and only expose the `History` method this uses.
 	store secretstore.SecureValueStore
 }
 
+// NewHistoryStorage is a returns a constructed `*HistoryStorage`.
+func NewHistoryStorage(store secretstore.SecureValueStore) *HistoryStorage {
+	return &HistoryStorage{store}
+}
+
 // New returns an empty `*SecureValueActivityList` that is required to be implemented by any storage.
-func (r *secretHistory) New() runtime.Object {
+func (r *HistoryStorage) New() runtime.Object {
 	return &secret.SecureValueActivityList{}
 }
 
 // Destroy is a no-op.
-func (r *secretHistory) Destroy() {}
+func (r *HistoryStorage) Destroy() {}
 
 // NamespaceScoped returns `true` because the storage is namespaced (== org).
-func (r *secretHistory) NamespaceScoped() bool {
+func (r *HistoryStorage) NamespaceScoped() bool {
 	return true
 }
 
 // ConnectMethods returns the list of HTTP methods we accept for this subresource.
-func (r *secretHistory) ConnectMethods() []string {
+func (r *HistoryStorage) ConnectMethods() []string {
 	return []string{http.MethodGet}
 }
 
 // NewConnectOptions returns some custom options that is passed in the `opts` field used by `Connect`.
-func (r *secretHistory) NewConnectOptions() (runtime.Object, bool, string) {
+func (r *HistoryStorage) NewConnectOptions() (runtime.Object, bool, string) {
 	return nil, false, ""
 }
 
 // ProducesMIMETypes returns the `Content-Type` used by `Connect`.
-func (r *secretHistory) ProducesMIMETypes(verb string) []string {
+func (r *HistoryStorage) ProducesMIMETypes(verb string) []string {
 	return []string{"application/json"}
 }
 
 // ProducesObject returns the concrete type (marshable with `json` tags) used by `Connect`.
-func (r *secretHistory) ProducesObject(verb string) interface{} {
+func (r *HistoryStorage) ProducesObject(verb string) interface{} {
 	return &secret.SecureValueActivityList{}
 }
 
 // Connect returns an http.Handler that will handle the request/response for a given API invocation.
 // See other methods implemented for supporting/optional functionality.
-func (r *secretHistory) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+func (r *HistoryStorage) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	ns := request.NamespaceValue(ctx)
 
 	// TODO: should this be inside the HTTP handler?

--- a/pkg/registry/apis/secret/reststorage/history_storage_test.go
+++ b/pkg/registry/apis/secret/reststorage/history_storage_test.go
@@ -1,0 +1,99 @@
+package reststorage_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	secret "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	"github.com/grafana/grafana/pkg/registry/apis/secret/reststorage"
+)
+
+func TestHistoryStorageConnect(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("when the history store returns a valid history, the http handler responds with it", func(t *testing.T) {
+		t.Parallel()
+
+		rr := httptest.NewRecorder()
+
+		historyStore := &fakeStore{}
+		responder := &fakeResponder{w: rr}
+
+		storage := reststorage.NewHistoryStorage(historyStore)
+
+		handler, err := storage.Connect(ctx, "name", nil, responder)
+		require.NoError(t, err)
+		require.NotNil(t, handler)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+		require.NoError(t, err)
+		require.NotNil(t, req)
+
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		require.Equal(t, 1, historyStore.historyCalls)
+		require.Equal(t, 1, responder.objectCalls)
+	})
+
+	t.Run("when the history store returns an error, the http handler is `nil` and the error is returned", func(t *testing.T) {
+		t.Parallel()
+
+		fakeErr := errors.New("some error")
+		historyStore := &fakeStore{historyErr: fakeErr}
+
+		storage := reststorage.NewHistoryStorage(historyStore)
+
+		handler, err := storage.Connect(ctx, "name", nil, nil)
+		require.ErrorIs(t, err, fakeErr)
+		require.Nil(t, handler)
+	})
+}
+
+type fakeResponder struct {
+	w           http.ResponseWriter
+	objectCalls int
+	m           sync.Mutex
+}
+
+func (r *fakeResponder) Object(statusCode int, obj runtime.Object) {
+	r.m.Lock()
+	r.objectCalls++
+	r.m.Unlock()
+
+	r.w.WriteHeader(statusCode)
+}
+
+func (r *fakeResponder) Error(err error) {}
+
+type fakeStore struct {
+	historyErr   error
+	historyCalls int
+	m            sync.Mutex
+}
+
+func (s *fakeStore) History(ctx context.Context, ns string, name string, continueToken string) (*secret.SecureValueActivityList, error) {
+	s.m.Lock()
+	s.historyCalls++
+	s.m.Unlock()
+
+	if s.historyErr != nil {
+		return nil, s.historyErr
+	}
+
+	return &secret.SecureValueActivityList{
+		Items: []secret.SecureValueActivity{
+			{Timestamp: 1, Action: "create", Identity: "user", Details: "details"},
+		},
+	}, nil
+}

--- a/pkg/storage/secret/store.go
+++ b/pkg/storage/secret/store.go
@@ -22,20 +22,28 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type SecureValueStore interface {
+type SecureValueStoreCRUDL interface {
 	Create(ctx context.Context, s *secret.SecureValue) (*secret.SecureValue, error)
+	Read(ctx context.Context, ns string, name string) (*secret.SecureValue, error) // The value will not be included
 	Update(ctx context.Context, s *secret.SecureValue) (*secret.SecureValue, error)
 	Delete(ctx context.Context, ns string, name string) (*secret.SecureValue, bool, error)
 	List(ctx context.Context, ns string, options *internalversion.ListOptions) (*secret.SecureValueList, error)
+}
 
-	// The value will not be included
-	Read(ctx context.Context, ns string, name string) (*secret.SecureValue, error)
-
-	// Return a version that has the secure value visible
-	Decrypt(ctx context.Context, ns string, name string) (*secret.SecureValue, error)
-
+type SecureValueStoreHistory interface {
 	// Show the history for a single value
 	History(ctx context.Context, ns string, name string, continueToken string) (*secret.SecureValueActivityList, error)
+}
+
+type SecureValueStoreDecrypt interface {
+	// Return a version that has the secure value visible
+	Decrypt(ctx context.Context, ns string, name string) (*secret.SecureValue, error)
+}
+
+type SecureValueStore interface {
+	SecureValueStoreCRUDL
+	SecureValueStoreHistory
+	SecureValueStoreDecrypt
 }
 
 // ProvideSecureValueStore is used in the wiring.


### PR DESCRIPTION
This is just to organize the code a little bit more by moving all the "rest storage" related code to its own package.

I also updated the `store` interface they are using to restrict to the minimum methods each needs.

And added a unit test to test (pun intended) how we'd like to be testing these interfaces. Seems like the k8s stuff is not often unit tested.