### PR TITLE
POC/Provisioning: Keep settings.Cfg out of the registry

### DIFF
--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -3,6 +3,7 @@ package provisioning
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -153,7 +154,7 @@ func TestIntegrationProvisioning(t *testing.T) {
 		}
 
 		js, _ := json.MarshalIndent(found, "", "  ")
-		// fmt.Printf("%s", string(js))
+		fmt.Printf("%s", string(js))
 		require.JSONEq(t, `{
 			"github-example": {
 				"description": "load resources from github",
@@ -170,7 +171,7 @@ func TestIntegrationProvisioning(t *testing.T) {
 					"repository": "git-ui-sync-demo",
 					"token": "github_pat_dummy",
 					"webhookSecret": "dummyWebhookSecret",
-					"webhookURL": "https://dummyWebhookUrl/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/github-example/webhook"
+					"webhookURL": "http://localhost:3000/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/github-example/webhook"
 				},
 				"title": "Github Example",
 				"type": "github"

--- a/pkg/tests/apis/provisioning/testdata/github-example.yaml
+++ b/pkg/tests/apis/provisioning/testdata/github-example.yaml
@@ -17,5 +17,4 @@ spec:
     branchWorkflow: true
     generateDashboardPreviews: true
     token: "github_pat_dummy"
-    webhookURL: "https://dummyWebhookUrl/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/github-example/webhook"
     webhookSecret: "dummyWebhookSecret"


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/96742 that keep things easy to run in multi-tenant