### PR TITLE
Serviceaccounts: FIX adds qoute for user UID query for postgres

### DIFF
--- a/pkg/services/serviceaccounts/database/store.go
+++ b/pkg/services/serviceaccounts/database/store.go
@@ -222,7 +222,7 @@ func (s *ServiceAccountsStoreImpl) RetrieveServiceAccount(ctx context.Context, q
 		}
 
 		if query.UID != "" {
-			whereConditions = append(whereConditions, "user.uid = ?")
+			whereConditions = append(whereConditions, fmt.Sprintf("%s.uid = ?", s.sqlStore.GetDialect().Quote("user")))
 			whereParams = append(whereParams, query.UID)
 		}
 

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -265,10 +265,10 @@ func TestIntegrationStore_RetrieveServiceAccount(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 	cases := []struct {
-		desc        string
-		user        tests.TestUser
-		expectedUID string
-		expectedErr error
+		desc          string
+		user          tests.TestUser
+		retrieveByUID bool
+		expectedErr   error
 	}{
 		{
 			desc:        "service accounts should exist and get retrieved",
@@ -276,10 +276,10 @@ func TestIntegrationStore_RetrieveServiceAccount(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc:        "service accounts should be able to be retrieved with uid",
-			user:        tests.TestUser{Login: "test1@admin", IsServiceAccount: false, UID: "test-uid"},
-			expectedErr: nil,
-			expectedUID: "test-uid",
+			desc:          "service accounts should be able to be retrieved with uid",
+			user:          tests.TestUser{Login: "test1@admin", IsServiceAccount: true},
+			expectedErr:   nil,
+			retrieveByUID: true,
 		},
 		{
 			desc:        "service accounts is false should not retrieve user",
@@ -294,7 +294,7 @@ func TestIntegrationStore_RetrieveServiceAccount(t *testing.T) {
 			var err error
 			db, store := setupTestDatabase(t)
 			user := tests.SetupUserServiceAccount(t, db, store.cfg, c.user)
-			if c.expectedUID != "" {
+			if c.retrieveByUID {
 				dto, err = store.RetrieveServiceAccount(context.Background(), &serviceaccounts.GetServiceAccountQuery{
 					OrgID: user.OrgID,
 					UID:   user.UID,
@@ -311,8 +311,8 @@ func TestIntegrationStore_RetrieveServiceAccount(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, c.user.Login, dto.Login)
 				require.Len(t, dto.Teams, 0)
-				if c.expectedUID != "" {
-					require.Equal(t, c.expectedUID, dto.UID)
+				if c.retrieveByUID {
+					require.Equal(t, user.UID, dto.UID)
 				}
 			}
 		})

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -267,12 +267,19 @@ func TestIntegrationStore_RetrieveServiceAccount(t *testing.T) {
 	cases := []struct {
 		desc        string
 		user        tests.TestUser
+		expectedUID string
 		expectedErr error
 	}{
 		{
 			desc:        "service accounts should exist and get retrieved",
 			user:        tests.TestUser{Login: "servicetest1@admin", IsServiceAccount: true},
 			expectedErr: nil,
+		},
+		{
+			desc:        "service accounts should be able to be retrieved with uid",
+			user:        tests.TestUser{Login: "test1@admin", IsServiceAccount: false, UID: "test-uid"},
+			expectedErr: nil,
+			expectedUID: "test-uid",
 		},
 		{
 			desc:        "service accounts is false should not retrieve user",
@@ -283,18 +290,30 @@ func TestIntegrationStore_RetrieveServiceAccount(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
+			var dto *serviceaccounts.ServiceAccountProfileDTO
+			var err error
 			db, store := setupTestDatabase(t)
 			user := tests.SetupUserServiceAccount(t, db, store.cfg, c.user)
-			dto, err := store.RetrieveServiceAccount(context.Background(), &serviceaccounts.GetServiceAccountQuery{
-				OrgID: user.OrgID,
-				ID:    user.ID,
-			})
+			if c.expectedUID != "" {
+				dto, err = store.RetrieveServiceAccount(context.Background(), &serviceaccounts.GetServiceAccountQuery{
+					OrgID: user.OrgID,
+					UID:   user.UID,
+				})
+			} else {
+				dto, err = store.RetrieveServiceAccount(context.Background(), &serviceaccounts.GetServiceAccountQuery{
+					OrgID: user.OrgID,
+					ID:    user.ID,
+				})
+			}
 			if c.expectedErr != nil {
 				require.ErrorIs(t, err, c.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, c.user.Login, dto.Login)
 				require.Len(t, dto.Teams, 0)
+				if c.expectedUID != "" {
+					require.Equal(t, c.expectedUID, dto.UID)
+				}
 			}
 		})
 	}

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -25,6 +25,7 @@ type TestUser struct {
 	Role             string
 	Login            string
 	IsServiceAccount bool
+	UID              string
 }
 
 type TestApiKey struct {
@@ -57,6 +58,7 @@ func SetupUserServiceAccount(t *testing.T, db db.DB, cfg *setting.Cfg, testUser 
 	require.NoError(t, err)
 
 	u1, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{
+		UID:              testUser.UID,
 		Login:            testUser.Login,
 		IsServiceAccount: testUser.IsServiceAccount,
 		DefaultOrgRole:   role,

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -58,7 +58,6 @@ func SetupUserServiceAccount(t *testing.T, db db.DB, cfg *setting.Cfg, testUser 
 	require.NoError(t, err)
 
 	u1, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{
-		UID:              testUser.UID,
 		Login:            testUser.Login,
 		IsServiceAccount: testUser.IsServiceAccount,
 		DefaultOrgRole:   role,


### PR DESCRIPTION
After a fix for ID `toString()` https://github.com/grafana/grafana/pull/96267 we noticed that service accounts page was still receiving an error when loading or creating service accounts for some instances.

When testing out locally, we found that sqlite, mysql worked great. But postgres did not. Classic ⚡ 

What this does it to add `user` qouta for the different databases.

Shoutout to @joshhunt for being consistent on bug reports!!!

#### prior to this change, postgres were not able to find the service account:
![image](https://github.com/user-attachments/assets/cd8cbecb-e672-4a81-bdb5-ea9d613dc8c1)
