### PR TITLE
Secret Service: draft design prototyping

### DIFF
--- a/pkg/storage/secret/encryption/encryption.go
+++ b/pkg/storage/secret/encryption/encryption.go
@@ -1,0 +1,11 @@
+package encryption
+
+import "context"
+
+// This is a service that only manages encrypting and decrypting data.
+// Copies the interface from: https://pkg.go.dev/gocloud.dev@v0.40.0/secrets#Keeper, specially for remote encryption/decryption.
+// It could also be a "local" encryption implementation, say a private/public key pair defined in the config that is used instead.
+type EncryptionService interface {
+	Encrypt(ctx context.Context, plaintext []byte) (ciphertext []byte, err error)
+	Decrypt(ctx context.Context, ciphertext []byte) (plaintext []byte, err error)
+}

--- a/pkg/storage/secret/keeper/keeper.go
+++ b/pkg/storage/secret/keeper/keeper.go
@@ -1,0 +1,34 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/storage/secret/encryption"
+	"github.com/grafana/grafana/pkg/storage/secret/vaultstorage"
+)
+
+// SecretKeeperService encapsulates two things:
+// 1- A service that encrypts and decrypts data.
+// 2- A service that stores and retrieves data, but this data is an encrypted value, which does not need to be encrypted in (1).
+type SecretKeeperService interface {
+	Encryption() encryption.EncryptionService
+	VaultStorage() vaultstorage.VaultStorageService
+}
+
+// This is the list of remote keepers we support.
+// e.g. for AWS:
+// -  Encryption() fulfilled by AWS KMS.
+// -  VaultStorage() fulfilled by AWS Secrets Manager.
+type SecretKeeperRemoteProvider string
+
+const (
+	SecretKeeperRemoteProviderAWS = SecretKeeperRemoteProvider("aws")
+)
+
+func NewRemoteProvider(raw string) (SecretKeeperRemoteProvider, error) {
+	if raw == "aws" {
+		return SecretKeeperRemoteProviderAWS, nil
+	}
+
+	return "", fmt.Errorf("not found")
+}

--- a/pkg/storage/secret/keeper/local_value_keeper.go
+++ b/pkg/storage/secret/keeper/local_value_keeper.go
@@ -1,0 +1,26 @@
+package keeper
+
+import (
+	"github.com/grafana/grafana/pkg/storage/secret/encryption"
+	"github.com/grafana/grafana/pkg/storage/secret/vaultstorage"
+)
+
+var _ SecretKeeperService = (*LocalValueKeeper)(nil)
+
+// LocalValueKeeper, the encryption is done by another service here and the vault storage is a SQL table.
+type LocalValueKeeper struct {
+	encryption encryption.EncryptionService
+	store      vaultstorage.VaultStorageService
+}
+
+func NewLocalValueKeeper(encryption encryption.EncryptionService, store vaultstorage.VaultStorageService) *LocalValueKeeper {
+	return &LocalValueKeeper{encryption, store}
+}
+
+func (k *LocalValueKeeper) Encryption() encryption.EncryptionService {
+	return k.encryption
+}
+
+func (k *LocalValueKeeper) VaultStorage() vaultstorage.VaultStorageService {
+	return k.store
+}

--- a/pkg/storage/secret/manager/manager.go
+++ b/pkg/storage/secret/manager/manager.go
@@ -1,0 +1,175 @@
+package manager
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+
+	secret "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	"github.com/grafana/grafana/pkg/storage/secret/keeper"
+	"github.com/grafana/grafana/pkg/storage/secret/metastorage"
+)
+
+// This is the entrypoint for a securevalue.
+// Here it gets encrypted and decrypted.
+// Here it gets stored and retrieved.
+// Many strategies available, local and remote for each.
+type SecretsManagerService struct {
+	metadataStore metastorage.SecretMetadataStore
+	localKeeper   keeper.SecretKeeperService
+	remoteKeepers map[keeper.SecretKeeperRemoteProvider]keeper.SecretKeeperService
+}
+
+// TODO: initialization of this thing.
+func NewSecretsManagerService(
+	metadataStore metastorage.SecretMetadataStore,
+	localKeeper keeper.SecretKeeperService,
+	remoteKeepers map[keeper.SecretKeeperRemoteProvider]keeper.SecretKeeperService,
+) (*SecretsManagerService, error) {
+	return &SecretsManagerService{metadataStore, localKeeper, remoteKeepers}, nil
+}
+
+// Create will encrypt a plaintext value and store it in a vault storage.
+// TODO: what to return apart from the error?
+func (s *SecretsManagerService) Create(ctx context.Context, securevalue *secret.SecureValue) (any, error) {
+	// 1. Just a value is provided, use the local keeper to encrypt and store in SQL.
+	if securevalue.Spec.Value != "" && securevalue.Spec.Manager == "" {
+		ciphertext, err := s.localKeeper.Encryption().Encrypt(ctx, []byte(securevalue.Spec.Value))
+		if err != nil {
+			return nil, fmt.Errorf("could not encrypt: %w", err)
+		}
+
+		if err := s.localKeeper.VaultStorage().Store(ctx, ciphertext); err != nil {
+			return nil, fmt.Errorf("could not store: %w", err)
+		}
+	}
+
+	// 2. A `value` and a `key`, use remote keeper to encrypt and store in SQL.
+	if securevalue.Spec.Value != "" && securevalue.Spec.Manager != "" {
+		provider, _ := keeper.NewRemoteProvider(securevalue.Spec.Manager)
+
+		remoteKeeper, ok := s.remoteKeepers[provider]
+		if !ok {
+			return nil, fmt.Errorf("could not find provider %v", provider)
+		}
+
+		ciphertext, err := remoteKeeper.Encryption().Encrypt(ctx, []byte(securevalue.Spec.Value))
+		if err != nil {
+			return nil, fmt.Errorf("could not remotely encrypt: %w", err)
+		}
+
+		if err := s.localKeeper.VaultStorage().Store(ctx, ciphertext); err != nil {
+			return nil, fmt.Errorf("could not locally store: %w", err)
+		}
+	}
+
+	// 3. Otherwise delegate everything to the remote keeper.
+	// Path is not really what we want, maybe `securevalue.Spec.Store`, but we don't have it in the spec currently.
+	if securevalue.Spec.Value == "" && securevalue.Spec.Manager != "" && securevalue.Spec.Path != "" {
+		provider, _ := keeper.NewRemoteProvider(securevalue.Spec.Manager)
+
+		remoteKeeper, ok := s.remoteKeepers[provider]
+		if !ok {
+			return nil, fmt.Errorf("could not find provider %v", provider)
+		}
+
+		ciphertext, err := remoteKeeper.Encryption().Encrypt(ctx, []byte(securevalue.Spec.Value))
+		if err != nil {
+			return nil, fmt.Errorf("could not encrypt: %w", err)
+		}
+
+		if err := remoteKeeper.VaultStorage().Store(ctx, ciphertext); err != nil {
+			return nil, fmt.Errorf("could not store: %w", err)
+		}
+	}
+
+	// 4. Just referencing a secret externally, not creating it.
+	// TODO: here we bypass the keeper, and just store metadata.
+
+	// also update the meta storage
+	encryptionProvider := cmp.Or(securevalue.Spec.Manager, "local")
+	vaultStorageProvider := cmp.Or(securevalue.Spec.Manager, "local")
+
+	_ = s.metadataStore.Store(ctx, metastorage.SecureValueMetadata{
+		UID:                  string(securevalue.UID),
+		Name:                 securevalue.Name,
+		Namespace:            securevalue.Namespace,
+		EncryptionProvider:   encryptionProvider,   // where we encrypted it?
+		VaultStorageProvider: vaultStorageProvider, // where we stored the secret?
+	})
+
+	// where was this encrypted?
+	// where was this secret stored?
+	// remote id to map back to our domain?
+
+	return "", fmt.Errorf("todo")
+}
+
+// Decrypt will fetch from vault storage and decrypt the ciphertext.
+func (s *SecretsManagerService) Decrypt(ctx context.Context, securevalue *secret.SecureValue) (string, error) {
+	// How to know from where to fetch it from?
+	meta, err := s.metadataStore.Retrieve(ctx, securevalue.Name, securevalue.Namespace)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch secret metadata: %w", err)
+	}
+
+	var ciphertext string
+
+	// First we retrieve the encrypted secret.
+	if meta.EncryptionProvider == "" { // Locally stored (SQL DB).
+		ciphertext, _ = s.localKeeper.VaultStorage().Retrieve(ctx, "some-id")
+	} else { // Remotely stored (HashiVault, AWSSecretsManager).
+		keeper := s.remoteKeepers[keeper.SecretKeeperRemoteProvider(meta.EncryptionProvider)]
+		ciphertext, _ = keeper.VaultStorage().Retrieve(ctx, "some-id")
+	}
+
+	var plaintext []byte
+
+	// Second we decrypt the secret.
+	if meta.VaultStorageProvider == "" { // Local keeper did the encryption.
+		plaintext, _ = s.localKeeper.Encryption().Decrypt(ctx, []byte(ciphertext))
+	} else { // Remote keeper did the encryption.
+		keeper := s.remoteKeepers[keeper.SecretKeeperRemoteProvider(meta.VaultStorageProvider)]
+		plaintext, _ = keeper.Encryption().Decrypt(ctx, []byte(ciphertext))
+	}
+
+	// TODO: we might want a proper CRD here.
+	return string(plaintext), nil
+}
+
+// Update a securevalue metadata and potentially its raw value.
+func (s *SecretsManagerService) Update(ctx context.Context, securevalue *secret.SecureValue) (any, error) {
+	// TODO: do we want to always override? do we want to decrypt the secret here and compare? maybe not a good idea.
+	return s.Create(ctx, securevalue)
+}
+
+// Delete the securevalue from vault storage and metadata storage.
+func (s *SecretsManagerService) Delete(ctx context.Context, ns string, name string) error {
+	// 1. Delete from vault storage. (should we??? what about secrets that are created by someone else and we just read it?)
+	// 2. Delete from metadata storage.
+	return nil
+}
+
+// Reads the securevalue but does not decrypt it. Essentially only returns metadata.
+func (s *SecretsManagerService) Read(ctx context.Context, ns string, name string) (*secret.SecureValue, error) {
+	// Completely offload to metadata storage
+	meta, err := s.metadataStore.Retrieve(ctx, name, ns)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve securevalue meta")
+	}
+	_ = meta
+
+	return &secret.SecureValue{}, nil
+}
+
+// List of securevalues but does not decrypt them. Essentially only returns metadata.
+func (s *SecretsManagerService) List() (*secret.SecureValueList, error) {
+	// TODO: call metadata store for this
+	return new(secret.SecureValueList), nil
+}
+
+// History audit-log-like of changes to the securevalue (who when what)
+func (s *SecretsManagerService) History() (*secret.SecureValueActivityList, error) {
+	// TODO: call metadata store for this
+	return new(secret.SecureValueActivityList), nil
+}

--- a/pkg/storage/secret/metastorage/metastorage.go
+++ b/pkg/storage/secret/metastorage/metastorage.go
@@ -1,0 +1,23 @@
+package metastorage
+
+import (
+	"context"
+)
+
+// This is supposed to keep secure value metadata.
+// It needs enough data to be able to know how to retrieve the data from the underlying "vault storage" (where the secret is kept),
+// and how to decrypt it (either remotely or locally).
+type SecretMetadataStore interface {
+	// how do we request this?
+	Retrieve(ctx context.Context, name, namespace string) (SecureValueMetadata, error)
+	Store(ctx context.Context, meta SecureValueMetadata) error
+}
+
+type SecureValueMetadata struct {
+	EncryptionProvider   string
+	VaultStorageProvider string
+	UID                  string
+	Name                 string
+	Namespace            string
+	// what else do we need here?
+}

--- a/pkg/storage/secret/vaultstorage/storage.go
+++ b/pkg/storage/secret/vaultstorage/storage.go
@@ -1,0 +1,11 @@
+package vaultstorage
+
+import "context"
+
+// This is where we store an encrypted secret and retrieve it back.
+// It can be local (i.e. SQL table) or remote (i.e. AWS, GCP, Vault).
+type VaultStorageService interface {
+	// what is something?
+	Store(ctx context.Context, something any) (err error)
+	Retrieve(ctx context.Context, something any) (ciphertext string, err error)
+}


### PR DESCRIPTION
> [!CAUTION]
> This is a prototype and shouldn't be merged

## Context
I've decided to write some throwaway code based on my understanding of the directions we want to go with respect to the secrets project.

This doesn't prescribe the usage of unified storage or not, simply calls it a "metadata storage" for securevalues.

Another caveat is that I am not changing the current `spec` of `securevalue`, which means we don't have all the potential fields we may want, so I've worked with what we had to illustrate some of the different scenarios we need to support.

The idea is to have two separate services, one responsible for encryption/decryption `EncryptionService`, and another for storing the securevalue after encryption (and being retrieved) `VaultStorageService` (mind this is not `vault` the project, but `vault` meaning a secure storage place abstraction).

A `SecretKeeper` would then encapsulate both services. Further, and not very polished (nothing about this is TBH), is the notion of a "remote" `SecretKeeper`, which would not be supported by OSS.

Then we have a `SecretsManagerService`, which would handle the different scenarios we might have.

Not contemplated here would be the notion of securevalues that already exist in a remote keeper, that are just being saved as references.
In this case, when creating the securevalue, we should completely bypass the `SecretKeeper`, and just store metadata. For decryption it would follow the usual flow.

Below are some diagrams with examples of the use-cases. Many details are omitted for simplicity.

## Potential Spec
This is more or less the spec I was thinking of while working on the prototype. Again, just a draft, I am committing to nothing here.
```go
type RawSecureValueSpec struct {
	// ---REQUIRED--- \\

	// Visible title for this securevalue.
	Title string `json:"title"`

	// The raw value for the securevalue.
	Value *string `json:"value,omitempty"`

	// In case you don't want to create a securevalue but reference and existing one.
	// Cannot set both `value` and `path`. MUST have either one set.
	// For path also requires having a non-default storage (and encryption perhaps?).
	Path *string `json:"path,omitempty"`

	// The audiences that are allowed to decrypt this secret.
	Audiences []string `json:"audiences"`

	// ---OPTIONAL--- \\

	// Defines the encryption strategy.
	// Optional but default is "default", if not set.
	Encryption *EncryptionSpec `json:"encryption,omitempty"`

	// Where the secure value is stored (after being encrypted).
	// Optional but default is "default", if not set.
	Storage *StorageSpec `json:"storage,omitempty"`
}

// Available encryption strategies.
type EncryptionSpec struct {
	Default struct{} `json:"default,omitempty"`

	AwsKms struct {
		KeyID *string `json:"key_id,omitempty"`
	} `json:"aws_kms,omitempty"`
}

// Available storage strategies.
type StorageSpec struct {
	Default struct{} `json:"default,omitempty"`

	AwsSecretsManager struct {
		// How the value will be stored in Secrets Manager.
		SecretID *string `json:"secret_id,omitempty"`
	} `json:"aws_secrets_manager,omitempty"`
}
```

## Use-cases
### Operator can create a securevalue
```mermaid
sequenceDiagram
    title Operator can create a securevalue

    actor Operator
    participant Entrypoint as Entrypoint
    participant K8S as Kubernetes Layer
    participant SMS as Secrets Manager Service
    participant ES as Encryption Service
    participant VS as Vault Storage
    participant MS as Metadata Storage

    Operator->>+Entrypoint: Create securevalue
    Entrypoint->>+K8S: Validation, authnz etc

    K8S->>+SMS: Store(securevalue)

    SMS->>SMS: Figure out encryption (svc) strategy
    SMS->>+ES: Encrypt(plaintext)
    ES->>-SMS: ciphertext

    SMS->>SMS: Figure out vault storage (svc) strategy
    SMS->>+VS: Store(ciphertext)
    VS->>-SMS: OK

    SMS->>+MS: Store(metadata from securevalue)
    MS->>-SMS: OK

    SMS->>-K8S: OK
    K8S->>-Entrypoint: 201 Created
    Entrypoint->>-Operator: securevalue Created
```

### Audience can decrypt a securevalue
```mermaid
sequenceDiagram
    title Audience can decrypt a securevalue

    actor Audience
    participant Entrypoint as Entrypoint
    participant K8S as Kubernetes Layer
    participant SMS as Secrets Manager Service
    participant ES as Encryption Service
    participant VS as Vault Storage
    participant MS as Metadata Storage

    Audience->>+Entrypoint: Decrypt securevalue/xyz
    Entrypoint->>+K8S: Validation, authnz etc

    K8S->>+SMS: Retrieve(securevalue)

    SMS->>+MS: Retrieve metadata from securevalue
    MS->>-SMS: OK

    SMS->>SMS: Figure out vault storage (svc) strategy
    SMS->>+VS: Retrieve(with metadata)
    VS->>-SMS: ciphertext

    SMS->>SMS: Figure out encryption (svc) strategy
    SMS->>+ES: Decrypt(ciphertext)
    ES->>-SMS: plaintext

    SMS->>-K8S: plaintext
    K8S->>-Entrypoint: 200 OK
    Entrypoint->>-Audience: securevalue Decyprted
```