### PR TITLE
Chore: Make ResizeObserver test mock only emit if an element is being observed

### DIFF
--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.test.tsx
@@ -20,6 +20,19 @@ jest.mock('react-virtualized-auto-sizer', () => {
     });
 });
 
+// Mock useMeasure from LogTimelineViewer > TimelineChart > GraphNG > VizLayout
+// so it always renders the chart
+jest.mock('react-use', () => {
+  const reactUse = jest.requireActual('react-use');
+  return {
+    ...reactUse,
+    useMeasure: () => {
+      const setRef = () => {};
+      return [setRef, { height: 300, width: 500 }];
+    },
+  };
+});
+
 beforeAll(() => {
   server.use(
     http.get('/api/v1/rules/history', () =>

--- a/public/test/jest-setup.ts
+++ b/public/test/jest-setup.ts
@@ -88,34 +88,52 @@ throwUnhandledRejections();
 
 // Used by useMeasure
 global.ResizeObserver = class ResizeObserver {
+  static #observationEntry: ResizeObserverEntry = {
+    contentRect: {
+      x: 1,
+      y: 2,
+      width: 500,
+      height: 500,
+      top: 100,
+      bottom: 0,
+      left: 100,
+      right: 0,
+    },
+    target: {
+      // Needed for react-virtual to work in tests
+      getAttribute: () => 1,
+    },
+  } as unknown as ResizeObserverEntry;
+
+  #isObserving = false;
+  #callback: ResizeObserverCallback;
+
   constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+  }
+
+  #emitObservation() {
     setTimeout(() => {
-      callback(
-        [
-          {
-            contentRect: {
-              x: 1,
-              y: 2,
-              width: 500,
-              height: 500,
-              top: 100,
-              bottom: 0,
-              left: 100,
-              right: 0,
-            },
-            target: {
-              // Needed for react-virtual to work in tests
-              getAttribute: () => 1,
-            },
-          } as unknown as ResizeObserverEntry,
-        ],
-        this
-      );
+      if (!this.#isObserving) {
+        return;
+      }
+
+      this.#callback([ResizeObserver.#observationEntry], this);
     });
   }
-  observe() {}
-  disconnect() {}
-  unobserve() {}
+
+  observe() {
+    this.#isObserving = true;
+    this.#emitObservation();
+  }
+
+  disconnect() {
+    this.#isObserving = false;
+  }
+
+  unobserve() {
+    this.#isObserving = false;
+  }
 };
 
 global.BroadcastChannel = class BroadcastChannel {


### PR DESCRIPTION
The current ResizeObserver is a bit annoying because it will always emit a resize event even if an element has not been observed. This is currently a secret problem with Input when only renders an observed element conditionally, such as 

```ts
const [suffixRef, suffixRect] = useMeasure<HTMLDivElement>();
{suffix && (
  <div className={styles.suffix} ref={suffixRef}>
     {suffix}
  </div>
)}
```

This PR updates the mock to more closely, but not precisely, mimic the real behaviour of ResizeObserver. Instead of 'immedaitely' (next tick) emitting a resize observation after construction, it will instead only emit it after `observe()` was called.