### PR TITLE
Folder: Propagate OrgID

### DIFF
--- a/docs/sources/developers/http_api/folder.md
+++ b/docs/sources/developers/http_api/folder.md
@@ -107,6 +107,7 @@ Content-Type: application/json
 {
   "id":1,
   "uid": "nErXDvCkzz",
+  "orgId": 1,
   "title": "Department ABC",
   "url": "/dashboards/f/nErXDvCkzz/department-abc",
   "hasAcl": false,

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -447,6 +447,7 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 		return dtos.Folder{
 			ID:            f.ID, // nolint:staticcheck
 			UID:           f.UID,
+			OrgID:         f.OrgID,
 			Title:         f.Title,
 			URL:           f.URL,
 			HasACL:        f.HasACL,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Propagate the `OrgID` to the Folder DTO.

**Why do we need this feature?**

`OrgID` was added to the Folder DTO in https://github.com/grafana/grafana/pull/78420.
Although the response body of [Get folder by uid](https://grafana.com/docs/grafana/latest/developers/http_api/folder/#get-folder-by-uid) API now includes `orgId`, it always outputs a zero value.
Fix it to output the correct `orgId`.

#### Before
```sh
curl -H 'Content-Type: application/json' -H "Authorization: Bearer $KEY"  http://localhost:3000/api/folders/ee4j31ocvh7nkf -s | jq
{
  "id": 140,
  "uid": "ee4j31ocvh7nkf",
  "orgId": 0,     # Always returns 0
  "title": "sample folder",
  "url": "/dashboards/f/ee4j31ocvh7nkf/sample-folder",
  "hasAcl": false,
  "canSave": false,
  "canEdit": false,
  "canAdmin": false,
  "canDelete": false,
  "createdBy": "Anonymous",
  "created": "2024-11-21T10:05:04.556165+09:00",
  "updatedBy": "Anonymous",
  "updated": "2024-11-21T01:05:04+09:00",
  "version": 1
}
```

#### After
```sh
curl -H 'Content-Type: application/json' -H "Authorization: Bearer $KEY"  http://localhost:3000/api/folders/ee4j31ocvh7nkf -s | jq
{
  "id": 140,
  "uid": "ee4j31ocvh7nkf",
  "orgId": 1,     # Correct orgId
  "title": "sample folder",
  "url": "/dashboards/f/ee4j31ocvh7nkf/sample-folder",
  "hasAcl": false,
  "canSave": false,
  "canEdit": false,
  "canAdmin": false,
  "canDelete": false,
  "createdBy": "Anonymous",
  "created": "2024-11-21T10:05:04.556165+09:00",
  "updatedBy": "Anonymous",
  "updated": "2024-11-21T10:05:04.556165+09:00",
  "version": 1
}
```

**Who is this feature for?**

For API Users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
