### PR TITLE
[Prototyping] Add submit change for github repository

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -150,7 +150,7 @@ type ResourceWrapper struct {
 	Path string `json:"path,omitempty"`
 
 	// The ref hash (if exists)
-	Ref string `json:"commit,omitempty"`
+	Ref string `json:"ref,omitempty"`
 
 	// Resource from the upstream repository
 	Resource common.Unstructured `json:"resource"`

--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -149,8 +149,8 @@ type ResourceWrapper struct {
 	// Path to the remote file
 	Path string `json:"path,omitempty"`
 
-	// The commit hash (if exists)
-	Commit string `json:"commit,omitempty"`
+	// The ref hash (if exists)
+	Ref string `json:"commit,omitempty"`
 
 	// Resource from the upstream repository
 	Resource common.Unstructured `json:"resource"`

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -397,7 +397,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ResourceWrapper(ref common.ReferenceC
 					},
 					"commit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The commit hash (if exists)",
+							Description: "The ref hash (if exists)",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -395,7 +395,7 @@ func schema_pkg_apis_provisioning_v0alpha1_ResourceWrapper(ref common.ReferenceC
 							Format:      "",
 						},
 					},
-					"commit": {
+					"ref": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The ref hash (if exists)",
 							Type:        []string{"string"},

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -1,1 +1,2 @@
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,RepositorySpec,GitHub
+API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,ResourceWrapper,Ref

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -1,2 +1,1 @@
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,RepositorySpec,GitHub
-API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,ResourceWrapper,Ref

--- a/pkg/registry/apis/provisioning/local.go
+++ b/pkg/registry/apis/provisioning/local.go
@@ -116,9 +116,9 @@ func (r *localRepository) Test(ctx context.Context) error {
 }
 
 // ReadResource implements provisioning.Repository.
-func (r *localRepository) Read(ctx context.Context, path string, commit string) ([]byte, error) {
-	if commit != "" {
-		return nil, apierrors.NewBadRequest("local repository does not support commits")
+func (r *localRepository) Read(ctx context.Context, path string, ref string) ([]byte, error) {
+	if ref != "" {
+		return nil, apierrors.NewBadRequest("local repository does not support refs")
 	}
 	if r.path == "" {
 		return nil, &apierrors.StatusError{
@@ -150,6 +150,15 @@ func (r *localRepository) Create(ctx context.Context, path string, data []byte, 
 	return fmt.Errorf("file already exists")
 }
 
+func (r *localRepository) SubmitCreate(ctx context.Context, path string, data []byte, comment string) error {
+	return &apierrors.StatusError{
+		ErrStatus: v1.Status{
+			Message: "submit create not supported for local repository",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
 func (r *localRepository) Update(ctx context.Context, path string, data []byte, comment string) error {
 	if r.path == "" {
 		return &apierrors.StatusError{
@@ -167,6 +176,15 @@ func (r *localRepository) Update(ctx context.Context, path string, data []byte, 
 	return os.WriteFile(path, data, 0600)
 }
 
+func (r *localRepository) SubmitUpdate(ctx context.Context, path string, data []byte, comment string) error {
+	return &apierrors.StatusError{
+		ErrStatus: v1.Status{
+			Message: "submit update not supported for local repository",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
 func (r *localRepository) Delete(ctx context.Context, path string, comment string) error {
 	if r.path == "" {
 		return &apierrors.StatusError{
@@ -178,6 +196,15 @@ func (r *localRepository) Delete(ctx context.Context, path string, comment strin
 	}
 
 	return os.Remove(filepath.Join(r.path, path))
+}
+
+func (r *localRepository) SubmitDelete(ctx context.Context, path string, comment string) error {
+	return &apierrors.StatusError{
+		ErrStatus: v1.Status{
+			Message: "submit delete not supported for local repository",
+			Code:    http.StatusNotImplemented,
+		},
+	}
 }
 
 // Webhook implements provisioning.Repository.

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -406,10 +406,10 @@ func (b *ProvisioningAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.
 		sub.Get.Parameters = []*spec3.Parameter{
 			{
 				ParameterProps: spec3.ParameterProps{
-					Name:        "commit",
+					Name:        "ref",
 					In:          "query",
 					Example:     "ca171cc730",
-					Description: "optional commit hash for the requested file",
+					Description: "optional reference for the requested file",
 					Schema:      spec.StringProperty(),
 					Required:    false,
 				},
@@ -417,21 +417,33 @@ func (b *ProvisioningAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.
 		}
 
 		// Add message to the OpenAPI spec
-		comment := []*spec3.Parameter{
+		writeParameters := []*spec3.Parameter{
 			{
 				ParameterProps: spec3.ParameterProps{
 					Name:        "message",
 					In:          "query",
 					Example:     "My commit message",
-					Description: "for git properties this will be in the commit message",
+					Description: "for git repositories this will be in the commit message",
 					Schema:      spec.StringProperty(),
 					Required:    false,
 				},
 			},
+			{
+				ParameterProps: spec3.ParameterProps{
+					// TODO: is there a better name for this?
+					Name:        "submit",
+					In:          "query",
+					Example:     "true",
+					Description: "for git repositories this will submit changes to a new branch",
+					Schema:      spec.BooleanProperty(),
+					Required:    false,
+				},
+			},
 		}
-		sub.Delete.Parameters = comment
-		sub.Post.Parameters = comment
-		sub.Put.Parameters = comment
+
+		sub.Delete.Parameters = writeParameters
+		sub.Post.Parameters = writeParameters
+		sub.Put.Parameters = writeParameters
 		sub.Post.RequestBody = &spec3.RequestBody{
 			RequestBodyProps: spec3.RequestBodyProps{
 				Content: map[string]*spec3.MediaType{

--- a/pkg/registry/apis/provisioning/s3.go
+++ b/pkg/registry/apis/provisioning/s3.go
@@ -51,7 +51,7 @@ func (r *s3Repository) Test(ctx context.Context) error {
 }
 
 // ReadResource implements provisioning.Repository.
-func (r *s3Repository) Read(ctx context.Context, path string, commit string) ([]byte, error) {
+func (r *s3Repository) Read(ctx context.Context, path string, ref string) ([]byte, error) {
 	return nil, &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "read resource is not yet implemented",
@@ -69,10 +69,28 @@ func (r *s3Repository) Create(ctx context.Context, path string, data []byte, com
 	}
 }
 
+func (r *s3Repository) SubmitCreate(ctx context.Context, path string, data []byte, comment string) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "submit create s3 file is not yet implemented",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
 func (r *s3Repository) Update(ctx context.Context, path string, data []byte, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
-			Message: "write file is not yet implemented",
+			Message: "write s3 file is not yet implemented",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
+func (r *s3Repository) SubmitUpdate(ctx context.Context, path string, data []byte, comment string) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "submit update s3 file is not yet implemented",
 			Code:    http.StatusNotImplemented,
 		},
 	}
@@ -81,7 +99,15 @@ func (r *s3Repository) Update(ctx context.Context, path string, data []byte, com
 func (r *s3Repository) Delete(ctx context.Context, path string, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
-			Message: "delete file not yet implemented",
+			Message: "delete s3 file not yet implemented",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+func (r *s3Repository) SubmitDelete(ctx context.Context, path string, comment string) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "submit delete s3 file not yet implemented",
 			Code:    http.StatusNotImplemented,
 		},
 	}

--- a/pkg/registry/apis/provisioning/types.go
+++ b/pkg/registry/apis/provisioning/types.go
@@ -43,7 +43,7 @@ type Repository interface {
 
 	// Read a file from the resource
 	// This data will be parsed and validated before it is shown to end users
-	Read(ctx context.Context, path string, commit string) ([]byte, error)
+	Read(ctx context.Context, path string, ref string) ([]byte, error)
 
 	// Write a file to the repository.
 	// The data has already been validated and is ready for save
@@ -55,6 +55,13 @@ type Repository interface {
 
 	// Delete a file in the remote repository
 	Delete(ctx context.Context, path string, comment string) error
+
+	// SubmitCreate is called when a user submits a create request
+	SubmitCreate(ctx context.Context, path string, data []byte, comment string) error
+	// SubmitUpdate is called when a user submits an update request
+	SubmitUpdate(ctx context.Context, path string, data []byte, comment string) error
+	// SubmitDelete is called when a user submits a delete request
+	SubmitDelete(ctx context.Context, path string, comment string) error
 
 	// For repositories that support webhooks
 	Webhook(responder rest.Responder) http.HandlerFunc
@@ -98,7 +105,7 @@ func (r *unknownRepository) Test(ctx context.Context) error {
 }
 
 // ReadResource implements provisioning.Repository.
-func (r *unknownRepository) Read(ctx context.Context, path string, commit string) ([]byte, error) {
+func (r *unknownRepository) Read(ctx context.Context, path string, ref string) ([]byte, error) {
 	return nil, &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "read resource is not yet implemented",
@@ -116,10 +123,28 @@ func (r *unknownRepository) Create(ctx context.Context, path string, data []byte
 	}
 }
 
+func (r *unknownRepository) SubmitCreate(ctx context.Context, path string, data []byte, comment string) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "submit create file is not yet implemented",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
 func (r *unknownRepository) Update(ctx context.Context, path string, data []byte, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
-			Message: "write file is not yet implemented",
+			Message: "update file is not yet implemented",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
+func (r *unknownRepository) SubmitUpdate(ctx context.Context, path string, data []byte, comment string) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "submit update file is not yet implemented",
 			Code:    http.StatusNotImplemented,
 		},
 	}
@@ -129,6 +154,15 @@ func (r *unknownRepository) Delete(ctx context.Context, path string, comment str
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "delete file not yet implemented",
+			Code:    http.StatusNotImplemented,
+		},
+	}
+}
+
+func (r *unknownRepository) SubmitDelete(ctx context.Context, path string, comment string) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "submit delete file not yet implemented",
 			Code:    http.StatusNotImplemented,
 		},
 	}


### PR DESCRIPTION
- Change `Commit` to `Ref` in `ResourceWrapper` to be a more generic concept. It could be a branch, a commit or an ID.
- Add boolean query param `submit` to write operations to distinguish when we want to 
- Generate branch names automatically based on the file name (e.g. `grafana/somefile-12bac8be`). 
- Add `SubmitCreate` `SubmitUpdate` `SubmitDelete` methods in `Repository` interface to not mess up with the ones that directly push to the configured branch. 


**Missing**: 
- [ ] Return reference back to callers in our API (we may have to change the signature of `Repository` methods). This can be done in a separate PR. 


![Screenshot 2024-11-20 at 18 01 03](https://github.com/user-attachments/assets/dd57e789-9503-40bf-a32f-3183eabd0713)
![Screenshot 2024-11-20 at 18 01 16](https://github.com/user-attachments/assets/aad267b6-10b7-4c4c-be02-19ae50b9374e)

