### PR TITLE
Caching: Add caching example to data source provisioning samples

### DIFF
--- a/conf/provisioning/datasources/sample.yaml
+++ b/conf/provisioning/datasources/sample.yaml
@@ -70,7 +70,7 @@ apiVersion: 1
 #     # Grafana UI.
 #     editable: false
 #     # Grafana Enterprise only - optional query and resource
-#     cache settings for this data source.
+#     # cache settings for this data source.
 #     caching:
 #       # <bool> Enables caching for this data source.
 #       enabled: true

--- a/conf/provisioning/datasources/sample.yaml
+++ b/conf/provisioning/datasources/sample.yaml
@@ -69,3 +69,18 @@ apiVersion: 1
 #     # <bool> Allows users to edit data sources from the
 #     # Grafana UI.
 #     editable: false
+#     # Grafana Enterprise only - optional query and resource
+#     cache settings for this data source.
+#     caching:
+#       # <bool> Enables caching for this data source.
+#       enabled: true
+#       # <bool> Sets whether to use the default query and resource
+#       # cache TTLs configured by the Grafana Operator in the .ini file.
+#       useDefaultTTL: true
+#       # <duration> Sets how long data query results will be cached 
+#       # for if `useDefaultTTL` is set to `false`.
+#       queriesTTL: 5m
+#       # <duration> Sets how long resource query results will be 
+#       # cached for if `useDefaultTTL` is set to `false`.
+#       resourcesTTL: 10m
+

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -170,6 +170,20 @@ datasources:
     # <bool> Allows users to edit data sources from the
     # Grafana UI.
     editable: false
+    # Grafana Enterprise only - optional query and resource
+    # cache settings for this data source.
+    caching:
+      # <bool> Enables caching for this data source.
+      enabled: true
+      # <bool> Sets whether to use the default query and resource
+      # cache TTLs configured by the Grafana Operator in the .ini file.
+      useDefaultTTL: true
+      # <duration> Sets how long data query results will be cached
+      # for if `useDefaultTTL` is set to `false`.
+      queriesTTL: 5m
+      # <duration> Sets how long resource query results will be
+      # cached for if `useDefaultTTL` is set to `false`.
+      resourcesTTL: 10m
 ```
 
 For provisioning examples of specific data sources, refer to that [data source's documentation]({{< relref "../../datasources" >}}).


### PR DESCRIPTION
**What is this feature?**

Updates the sample data source provisioning YAML and Grafana docs with examples for caching config, for which support was added in [this Pull Request](https://github.com/grafana/grafana/pull/96397).