### PR TITLE
Alerting: fix the bug of Incorrect KeepLast indication for rules with…

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -541,7 +541,9 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 func resultStateReason(result eval.Result, rule *ngModels.AlertRule) string {
 	if rule.ExecErrState == ngModels.KeepLastErrState || rule.NoDataState == ngModels.KeepLast {
-		return ngModels.ConcatReasons(result.State.String(), ngModels.StateReasonKeepLast)
+		rule.NoDataState != ngModels.Alerting {
+			return ngModels.ConcatReasons(result.State.String(), ngModels.StateReasonKeepLast)
+		}
 	}
 
 	return result.State.String()

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -541,7 +541,7 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 func resultStateReason(result eval.Result, rule *ngModels.AlertRule) string {
 	if rule.ExecErrState == ngModels.KeepLastErrState || rule.NoDataState == ngModels.KeepLast {
-		rule.NoDataState != ngModels.Alerting {
+		if rule.NoDataState != ngModels.Alerting {
 			return ngModels.ConcatReasons(result.State.String(), ngModels.StateReasonKeepLast)
 		}
 	}


### PR DESCRIPTION
What this PR does:

This PR fixes an issue with the annotation for alert rules where the NoData state is incorrectly marked as "NoData, KeepLast" when NoDataState = Alerting and ExecErrState = KeepLastState. The annotation should be just "NoData" in this case, and "NoData, KeepLast" should only be added when NoDataState is not Alerting.

Key changes:

Modified resultStateReason function in manager.go to correctly handle the case when NoDataState = Alerting.
Ensured that when NoDataState is Alerting, the annotation is only "NoData", and "KeepLast" is not appended.
Added a condition to append "KeepLast" only when NoDataState is not Alerting.

Why this is important:

This change addresses the issue where an incorrect annotation is being sent when using external alert managers that rely on the "grafana_state_reason" annotation. The correct behavior is critical for systems that depend on the accurate interpretation of the alert state, especially when integrating with systems that handle alert prolongation based on the state.

Fixes #93601 