### PR TITLE
POC/Provisioning: rename "file" to "files"

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -151,7 +151,7 @@ func (b *ProvisioningAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserv
 		getter: b,
 		client: b.client.identities,
 	}
-	storage[provisioning.RepositoryResourceInfo.StoragePath("file")] = &readConnector{
+	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = &filesConnector{
 		getter: b,
 	}
 	apiGroupInfo.VersionedResourcesStorageMap[provisioning.VERSION] = storage
@@ -397,10 +397,10 @@ func (b *ProvisioningAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.
 	}
 
 	// hide the version with no path
-	delete(oas.Paths.Paths, repoprefix+"/file")
+	delete(oas.Paths.Paths, repoprefix+"/files")
 
 	// update the version with a path
-	sub = oas.Paths.Paths[repoprefix+"/file/{path}"]
+	sub = oas.Paths.Paths[repoprefix+"/files/{path}"]
 	if sub != nil {
 		sub.Get.Description = "Read value from upstream repository"
 		sub.Get.Parameters = []*spec3.Parameter{

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -73,7 +73,7 @@ func TestIntegrationProvisioning(t *testing.T) {
 					]
 				},
 				{
-					"name": "repositories/file",
+					"name": "repositories/files",
 					"singularName": "",
 					"namespaced": true,
 					"kind": "ResourceWrapper",


### PR DESCRIPTION
Use the plural name "files" for the "file" sub-resource.  This is more consistent with all the other plural names we have