### PR TITLE
authn: grpcutils: Mark ID Tokens optional in cloud mode in gRPC Authenticator

### DIFF
--- a/pkg/services/authn/grpcutils/grpc_authenticator.go
+++ b/pkg/services/authn/grpcutils/grpc_authenticator.go
@@ -49,14 +49,20 @@ func NewGrpcAuthenticator(cfg *setting.Cfg, tracer tracing.Tracer) (*authnlib.Gr
 	keyRetriever := authnlib.NewKeyRetriever(grpcAuthCfg.KeyRetrieverConfig, authnlib.WithHTTPClientKeyRetrieverOpt(client))
 
 	grpcOpts := []authnlib.GrpcAuthenticatorOption{
-		authnlib.WithIDTokenAuthOption(true),
 		authnlib.WithKeyRetrieverOption(keyRetriever),
 		authnlib.WithTracerAuthOption(tracer),
 	}
-	if authCfg.Mode == ModeOnPrem {
+	switch authCfg.Mode {
+	case ModeOnPrem:
 		grpcOpts = append(grpcOpts,
 			// Access token are not yet available on-prem
 			authnlib.WithDisableAccessTokenAuthOption(),
+			authnlib.WithIDTokenAuthOption(true),
+		)
+	case ModeCloud:
+		grpcOpts = append(grpcOpts,
+			// ID tokens are enabled but not required in cloud
+			authnlib.WithIDTokenAuthOption(false),
 		)
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This patch marks ID tokens as not required when initalising a gRPC Authenticator to be used in `cloud` mode. ID Tokens are still enabled in `cloud` mode, but the `Required` option is set to `false`.

**Why do we need this feature?**

This is needed for MT services like Cloud API Server to authenticate against gRPC services like Resource Store with only an Access Token.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to grafana/grafana-org#343
