### PR TITLE
Unified Storage: Add support for verify-full in postgres

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
@@ -70,9 +70,13 @@ func getEnginePostgres(getter confGetter) (*xorm.Engine, error) {
 		"user": getter.String("user"),
 		// accept the core Grafana jargon of `password` as well, originally
 		// Unified Storage used `pass`
-		"password": cmp.Or(getter.String("pass"), getter.String("password")),
-		"dbname":   getter.String("name"),
-		"sslmode":  cmp.Or(getter.String("ssl_mode"), "disable"),
+		"password":    cmp.Or(getter.String("pass"), getter.String("password")),
+		"dbname":      getter.String("name"),
+		"sslmode":     cmp.Or(getter.String("ssl_mode"), "disable"),
+		"sslsni":      getter.String("ssl_sni"),
+		"sslrootcert": getter.String("ca_cert_path"),
+		"sslkey":      getter.String("client_key_path"),
+		"sslcert":     getter.String("client_cert_path"),
 	}
 
 	// TODO: probably interesting:
@@ -84,8 +88,7 @@ func getEnginePostgres(getter confGetter) (*xorm.Engine, error) {
 	//	dsnKV["enable_experimental_alter_column_type_general"] = "true"
 
 	// TODO: do we want to support these options in the DSN as well?
-	//	"sslkey", "sslcert", "sslrootcert", "sslpassword", "sslsni", "krbspn",
-	//	"krbsrvname", "target_session_attrs", "service", "servicefile"
+	//	"sslpassword", "krbspn", "krbsrvname", "target_session_attrs", "service", "servicefile"
 
 	// More on Postgres connection string parameters:
 	//	https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING


### PR DESCRIPTION
Add support for verify-full in postgres unistore.

This adds support to the ssl_sni / ca_cert_path / client_key_path / client_cert_path.
Reusing the same notation as grafana (see [here](https://github.com/grafana/grafana/blob/4a4c3eb54e4bfcec476d0a868c600d06ed3b8735/pkg/services/sqlstore/database_config.go#L173-L182))

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
