### PR TITLE
feat: export metadata-less YAML resources

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -87,6 +87,11 @@ type RepositorySpec struct {
 	// The value is a reference to the Kubernetes metadata name of the folder in the same namespace.
 	Folder string `json:"folder,omitempty"`
 
+	// Should we prefer emitting YAML for this repository, e.g. upon export?
+	// Editing existing dashboards will continue to emit the file format used in the repository. (TODO: implement this)
+	// If you delete and then recreate a dashboard, it will switch to the preferred format.
+	PreferYAML bool `json:"preferYaml,omitempty"`
+
 	// Edit options within the repository
 	Editing EditingOptions `json:"editing"`
 

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -304,6 +304,13 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositorySpec(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"preferYaml": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Should we prefer emitting YAML for this repository, e.g. upon export? Editing existing dashboards will continue to emit the file format used in the repository. (TODO: implement this) If you delete and then recreate a dashboard, it will switch to the preferred format.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"editing": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Edit options within the repository",

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -1,1 +1,2 @@
 API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,RepositorySpec,GitHub
+API rule violation: names_match,github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1,RepositorySpec,PreferYAML


### PR DESCRIPTION
Removes the metadata field and exports as YAML instead of JSON.