### PR TITLE
[v11.3.x] Alerting: Update state manager to have immutable state in cache

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -71,59 +71,7 @@ func (c *cache) countAlertsBy(state eval.State) float64 {
 	return count
 }
 
-func (c *cache) getOrCreate(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
-	// Calculation of state ID involves label and annotation expansion, which may be resource intensive operations, and doing it in the context guarded by mtxStates may create a lot of contention.
-	// Instead of just calculating ID we create an entire state - a candidate. If rule states already hold a state with this ID, this candidate will be discarded and the existing one will be returned.
-	// Otherwise, this candidate will be added to the rule states and returned.
-	stateCandidate := calculateState(ctx, log, alertRule, result, extraLabels, externalURL)
-
-	c.mtxStates.Lock()
-	defer c.mtxStates.Unlock()
-
-	var orgStates map[string]*ruleStates
-	var ok bool
-	if orgStates, ok = c.states[stateCandidate.OrgID]; !ok {
-		orgStates = make(map[string]*ruleStates)
-		c.states[stateCandidate.OrgID] = orgStates
-	}
-	var states *ruleStates
-	if states, ok = orgStates[stateCandidate.AlertRuleUID]; !ok {
-		states = &ruleStates{states: make(map[data.Fingerprint]*State)}
-		c.states[stateCandidate.OrgID][stateCandidate.AlertRuleUID] = states
-	}
-	return states.getOrAdd(stateCandidate, log)
-}
-
-func (rs *ruleStates) getOrAdd(stateCandidate State, log log.Logger) *State {
-	state, ok := rs.states[stateCandidate.CacheID]
-	// Check if the state with this ID already exists.
-	if !ok {
-		rs.states[stateCandidate.CacheID] = &stateCandidate
-		return &stateCandidate
-	}
-
-	// Annotations can change over time, however we also want to maintain
-	// certain annotations across evaluations
-	for k, v := range state.Annotations {
-		if _, ok := ngModels.InternalAnnotationNameSet[k]; ok {
-			// If the annotation is not present then it should be copied from the
-			// previous state to the next state
-			if _, ok := stateCandidate.Annotations[k]; !ok {
-				stateCandidate.Annotations[k] = v
-			}
-		}
-	}
-	state.Annotations = stateCandidate.Annotations
-	state.Values = stateCandidate.Values
-	if state.ResultFingerprint != stateCandidate.ResultFingerprint {
-		log.Info("Result fingerprint has changed", "oldFingerprint", state.ResultFingerprint, "newFingerprint", stateCandidate.ResultFingerprint, "cacheID", state.CacheID, "stateLabels", state.Labels.String())
-		state.ResultFingerprint = stateCandidate.ResultFingerprint
-	}
-	rs.states[stateCandidate.CacheID] = state
-	return state
-}
-
-func calculateState(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) State {
+func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) (data.Labels, data.Labels) {
 	var reserved []string
 	resultLabels := result.Instance
 	if len(resultLabels) > 0 {
@@ -192,23 +140,82 @@ func calculateState(ctx context.Context, log log.Logger, alertRule *ngModels.Ale
 	if len(dupes) > 0 {
 		log.Debug("Evaluation result contains either reserved labels or labels declared in the rules. Those labels from the result will be ignored", "labels", dupes)
 	}
+	return lbs, annotations
+}
+
+func (c *cache) create(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
+	lbs, annotations := expandAnnotationsAndLabels(ctx, log, alertRule, result, extraLabels, externalURL)
 
 	cacheID := lbs.Fingerprint()
-
 	// For new states, we set StartsAt & EndsAt to EvaluatedAt as this is the
 	// expected value for a Normal state during state transition.
 	newState := State{
-		AlertRuleUID:       alertRule.UID,
-		OrgID:              alertRule.OrgID,
-		CacheID:            cacheID,
-		Labels:             lbs,
-		Annotations:        annotations,
-		EvaluationDuration: result.EvaluationDuration,
-		StartsAt:           result.EvaluatedAt,
-		EndsAt:             result.EvaluatedAt,
-		ResultFingerprint:  result.Instance.Fingerprint(), // remember original result fingerprint
+		OrgID:                alertRule.OrgID,
+		AlertRuleUID:         alertRule.UID,
+		CacheID:              cacheID,
+		State:                eval.Normal,
+		StateReason:          "",
+		ResultFingerprint:    result.Instance.Fingerprint(), // remember original result fingerprint
+		LatestResult:         nil,
+		Error:                nil,
+		Image:                nil,
+		Annotations:          annotations,
+		Labels:               lbs,
+		Values:               nil,
+		StartsAt:             result.EvaluatedAt,
+		EndsAt:               result.EvaluatedAt,
+		ResolvedAt:           nil,
+		LastSentAt:           nil,
+		LastEvaluationString: "",
+		LastEvaluationTime:   result.EvaluatedAt,
+		EvaluationDuration:   result.EvaluationDuration,
 	}
-	return newState
+
+	existingState := c.get(alertRule.OrgID, alertRule.UID, cacheID)
+	if existingState == nil {
+		return &newState
+	}
+	// if there is existing state, copy over the current values that may be needed to determine the final state.
+	// TODO remove some unnecessary assignments below because they are overridden in setNextState
+	newState.State = existingState.State
+	newState.StateReason = existingState.StateReason
+	newState.Image = existingState.Image
+	newState.LatestResult = existingState.LatestResult
+	newState.Error = existingState.Error
+	newState.Values = existingState.Values
+	newState.LastEvaluationString = existingState.LastEvaluationString
+	newState.StartsAt = existingState.StartsAt
+	newState.EndsAt = existingState.EndsAt
+	newState.ResolvedAt = existingState.ResolvedAt
+	newState.LastSentAt = existingState.LastSentAt
+	// Annotations can change over time, however we also want to maintain
+	// certain annotations across evaluations
+	for key := range ngModels.InternalAnnotationNameSet { // Changing in
+		value, ok := existingState.Annotations[key]
+		if !ok {
+			continue
+		}
+		// If the annotation is not present then it should be copied from
+		// the current state to the new state
+		if _, ok = newState.Annotations[key]; !ok {
+			newState.Annotations[key] = value
+		}
+	}
+
+	// if the current state is "data source error" then it may have additional labels that may not exist in the new state.
+	// See https://github.com/grafana/grafana/blob/c7fdf8ce706c2c9d438f5e6eabd6e580bac4946b/pkg/services/ngalert/state/state.go#L161-L163
+	// copy known labels over to the new instance, it can help reduce flapping
+	// TODO fix this?
+	if existingState.State == eval.Error && result.State == eval.Error {
+		setIfExist := func(lbl string) {
+			if v, ok := existingState.Labels[lbl]; ok {
+				newState.Labels[lbl] = v
+			}
+		}
+		setIfExist("datasource_uid")
+		setIfExist("ref_id")
+	}
+	return &newState
 }
 
 // expand returns the expanded templates of all annotations or labels for the template data.
@@ -255,10 +262,13 @@ func (c *cache) deleteRuleStates(ruleKey ngModels.AlertRuleKey, predicate func(s
 	return nil
 }
 
-func (c *cache) setAllStates(newStates map[int64]map[string]*ruleStates) {
+func (c *cache) setRuleStates(ruleKey ngModels.AlertRuleKey, s ruleStates) {
 	c.mtxStates.Lock()
 	defer c.mtxStates.Unlock()
-	c.states = newStates
+	if _, ok := c.states[ruleKey.OrgID]; !ok {
+		c.states[ruleKey.OrgID] = make(map[string]*ruleStates)
+	}
+	c.states[ruleKey.OrgID][ruleKey.UID] = &s
 }
 
 func (c *cache) set(entry *State) {

--- a/pkg/services/ngalert/state/cache_bench_test.go
+++ b/pkg/services/ngalert/state/cache_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkGetOrCreateTest(b *testing.B) {
 	// values := make([]int64, count)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = cache.getOrCreate(ctx, log, rule, result, nil, u)
+			_ = cache.create(ctx, log, rule, result, nil, u)
 		}
 	})
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -137,7 +137,6 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader) {
 	}
 
 	statesCount := 0
-	states := make(map[int64]map[string]*ruleStates, len(orgIds))
 	for _, orgId := range orgIds {
 		// Get Rules
 		ruleCmd := ngModels.ListAlertRulesQuery{
@@ -168,9 +167,6 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader) {
 			}
 		}
 
-		orgStates := make(map[string]*ruleStates, len(ruleByUID))
-		states[orgId] = orgStates
-
 		// Get Instances
 		cmd := ngModels.ListAlertInstancesQuery{
 			RuleOrgID: orgId,
@@ -191,12 +187,6 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader) {
 			annotations := ruleForEntry.Annotations
 			if annotations == nil {
 				annotations = make(map[string]string)
-			}
-
-			rulesStates, ok := orgStates[entry.RuleUID]
-			if !ok {
-				rulesStates = &ruleStates{states: make(map[data.Fingerprint]*State)}
-				orgStates[entry.RuleUID] = rulesStates
 			}
 
 			lbs := map[string]string(entry.Labels)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -209,7 +209,7 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader) {
 				}
 				resultFp = data.Fingerprint(fp)
 			}
-			rulesStates.states[cacheID] = &State{
+			state := &State{
 				AlertRuleUID:         entry.RuleUID,
 				OrgID:                entry.RuleOrgID,
 				CacheID:              cacheID,
@@ -225,11 +225,11 @@ func (st *Manager) Warm(ctx context.Context, rulesReader RuleReader) {
 				ResolvedAt:           entry.ResolvedAt,
 				LastSentAt:           entry.LastSentAt,
 			}
+			st.cache.set(state)
 			statesCount++
 		}
 	}
 
-	st.cache.setAllStates(states)
 	st.log.Info("State cache has been initialized", "states", statesCount, "duration", time.Since(startTime))
 }
 
@@ -398,46 +398,50 @@ func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.
 				}
 			}
 		}
-		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger)
+		annotations := map[string]string{
+			"datasource_uid": datasourceUIDs.String(),
+			"ref_id":         refIds.String(),
+		}
+		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, annotations)
 		if len(transitions) > 0 {
-			for _, t := range transitions {
-				if t.State.Annotations == nil {
-					t.State.Annotations = make(map[string]string)
-				}
-				t.State.Annotations["datasource_uid"] = datasourceUIDs.String()
-				t.State.Annotations["ref_id"] = refIds.String()
-			}
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
 	}
 	if st.applyNoDataAndErrorToAllStates && results.IsError() && (alertRule.ExecErrState == ngModels.AlertingErrState || alertRule.ExecErrState == ngModels.OkErrState || alertRule.ExecErrState == ngModels.KeepLastErrState) {
 		// TODO squash all errors into one, and provide as annotation
-		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger)
+		transitions := st.setNextStateForAll(ctx, alertRule, results[0], logger, nil)
 		if len(transitions) > 0 {
 			return transitions // if there are no current states for the rule. Create ones for each result
 		}
 	}
 	transitions := make([]StateTransition, 0, len(results))
 	for _, result := range results {
-		currentState := st.cache.getOrCreate(ctx, logger, alertRule, result, extraLabels, st.externalURL)
-		s := st.setNextState(ctx, alertRule, currentState, result, logger)
+		currentState := st.cache.create(ctx, logger, alertRule, result, extraLabels, st.externalURL)
+		s := st.setNextState(ctx, alertRule, currentState, result, nil, logger)
+		st.cache.set(currentState) // replace the existing state with the new one
 		transitions = append(transitions, s)
 	}
 	return transitions
 }
 
-func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, logger log.Logger) []StateTransition {
+func (st *Manager) setNextStateForAll(ctx context.Context, alertRule *ngModels.AlertRule, result eval.Result, logger log.Logger, extraAnnotations data.Labels) []StateTransition {
 	currentStates := st.cache.getStatesForRuleUID(alertRule.OrgID, alertRule.UID, false)
 	transitions := make([]StateTransition, 0, len(currentStates))
+	updated := ruleStates{
+		states: make(map[data.Fingerprint]*State, len(currentStates)),
+	}
 	for _, currentState := range currentStates {
-		t := st.setNextState(ctx, alertRule, currentState, result, logger)
+		newState := currentState.Copy()
+		t := st.setNextState(ctx, alertRule, newState, result, extraAnnotations, logger)
+		updated.states[newState.CacheID] = newState
 		transitions = append(transitions, t)
 	}
+	st.cache.setRuleStates(alertRule.GetKey(), updated)
 	return transitions
 }
 
 // Set the current state based on evaluation results
-func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, logger log.Logger) StateTransition {
+func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRule, currentState *State, result eval.Result, extraAnnotations data.Labels, logger log.Logger) StateTransition {
 	start := st.clock.Now()
 
 	currentState.LastEvaluationTime = result.EvaluatedAt
@@ -525,7 +529,9 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 		}
 	}
 
-	st.cache.set(currentState)
+	for key, val := range extraAnnotations {
+		currentState.Annotations[key] = val
+	}
 
 	nextState := StateTransition{
 		State:               currentState,

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"strings"
 	"time"
@@ -73,6 +74,36 @@ type State struct {
 	LastEvaluationString string
 	LastEvaluationTime   time.Time
 	EvaluationDuration   time.Duration
+}
+
+// Copy creates a shallow copy of the State except for labels and annotations.
+func (a *State) Copy() *State {
+	// Deep copy annotations and labels
+	annotationsCopy := make(map[string]string, len(a.Annotations))
+	maps.Copy(annotationsCopy, a.Annotations)
+	labelsCopy := make(data.Labels, len(a.Labels))
+	maps.Copy(labelsCopy, a.Labels)
+	return &State{
+		OrgID:                a.OrgID,
+		AlertRuleUID:         a.AlertRuleUID,
+		CacheID:              a.CacheID,
+		State:                a.State,
+		StateReason:          a.StateReason,
+		ResultFingerprint:    a.ResultFingerprint,
+		LatestResult:         a.LatestResult,
+		Error:                a.Error,
+		Image:                a.Image,
+		Annotations:          annotationsCopy,
+		Labels:               labelsCopy,
+		Values:               a.Values,
+		StartsAt:             a.StartsAt,
+		EndsAt:               a.EndsAt,
+		ResolvedAt:           a.ResolvedAt,
+		LastSentAt:           a.LastSentAt,
+		LastEvaluationString: a.LastEvaluationString,
+		LastEvaluationTime:   a.LastEvaluationTime,
+		EvaluationDuration:   a.EvaluationDuration,
+	}
 }
 
 func (a *State) GetRuleKey() models.AlertRuleKey {


### PR DESCRIPTION
Backport 420db99d16e1002ab6f9c5ac4a38ee2ca12dd095 from #95985

---

**What is this feature?**
This PR updates state manager to avoid mutation of state that was put into the cache. Instead, during processing evaluation results, the state manager creates a new instance of the `state.State`, fetches the current state from the cache, and copies over the values. When the state processing is complete, the current state gets replaced with a new instance in the cache. 

**Why do we need this feature?**
This will make the instance of `state.State` to be thread-safe to read and possibly open way for further improvement and consolidation of the state management. 

**Who is this feature for?**
Everyone who uses alerting


**Special notes for your reviewer:**
This is basically a refactoring. As you can see none of the tests changed (except for getOrAdd, which was eliminated). However, there are some strange things popped up that were hidden by the fact that we always mutated existing states. For sake of simplicity of this PR, I would like to keep those changes visible and address it in future refactorings, which are overdue in that area.

Fixes: https://github.com/grafana/alerting-squad/issues/858

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
