### PR TITLE
Chore: Refactor colorManipulator to use tinycolor where possible

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -129,8 +129,7 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-data/src/themes/colorManipulator.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-data/src/themes/createColors.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -246,7 +246,7 @@ export function emphasize(color: string, coefficient = 0.15) {
  * @beta
  */
 export function alpha(color: string, value: number) {
-  return tinycolor(color).setAlpha(value).toHex8String();
+  return tinycolor(color).setAlpha(value).toRgbString();
 }
 
 /**

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -79,7 +79,7 @@ $code-tag-border: $dark-9;
 
 // cards
 $card-background: #22252b;
-$card-background-hover: rgb(40, 43, 49);
+$card-background-hover: rgb(41, 44, 49);
 $card-shadow: none;
 
 // Lists


### PR DESCRIPTION
Small refactor of `colorManipulator` to use tinycolor's methods instead of rolling our own where possible.
The colors produced by the `emphasize` utility are _very_ slightly different from before (rgb values are at most +-1 different), but the difference is so minute I don't think it's anything to worry about.