### PR TITLE
Azure Monitor: Add a feature flag to toggle user auth for Azure Monitor only

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -81,6 +81,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `azureMonitorDisableLogLimit`          | Disables the log limit restriction for Azure Monitor when true. The limit is enabled by default.                                                                   |                    |
 | `preinstallAutoUpdate`                 | Enables automatic updates for pre-installed plugins                                                                                                                | Yes                |
 | `alertingUIOptimizeReducer`            | Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query                                                           | Yes                |
+| `azureMonitorEnableUserAuth`           | Enables user auth for Azure Monitor datasource only                                                                                                                | Yes                |
 
 ## Public preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -240,5 +240,6 @@ export interface FeatureToggles {
   jaegerBackendMigration?: boolean;
   reportingUseRawTimeRange?: boolean;
   alertingUIOptimizeReducer?: boolean;
+  azureMonitorEnableUserAuth?: boolean;
   alertingNotificationsStepMode?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1659,6 +1659,13 @@ var (
 			Expression:   "true", // enabled by default
 		},
 		{
+			Name:        "azureMonitorEnableUserAuth",
+			Description: "Enables user auth for Azure Monitor datasource only",
+			Stage:       FeatureStageGeneralAvailability,
+			Owner:       grafanaPartnerPluginsSquad,
+			Expression:  "true", // Enabled by default for now
+		},
+		{
 			Name:         "alertingNotificationsStepMode",
 			Description:  "Enables simplified step mode in the notifications section",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -221,4 +221,5 @@ crashDetection,experimental,@grafana/observability-traces-and-profiling,false,fa
 jaegerBackendMigration,experimental,@grafana/oss-big-tent,false,false,false
 reportingUseRawTimeRange,preview,@grafana/sharing-squad,false,false,false
 alertingUIOptimizeReducer,GA,@grafana/alerting-squad,false,false,true
+azureMonitorEnableUserAuth,GA,@grafana/partner-datasources,false,false,false
 alertingNotificationsStepMode,experimental,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -895,6 +895,10 @@ const (
 	// Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query
 	FlagAlertingUIOptimizeReducer = "alertingUIOptimizeReducer"
 
+	// FlagAzureMonitorEnableUserAuth
+	// Enables user auth for Azure Monitor datasource only
+	FlagAzureMonitorEnableUserAuth = "azureMonitorEnableUserAuth"
+
 	// FlagAlertingNotificationsStepMode
 	// Enables simplified step mode in the notifications section
 	FlagAlertingNotificationsStepMode = "alertingNotificationsStepMode"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -662,6 +662,22 @@
     },
     {
       "metadata": {
+        "name": "azureMonitorEnableUserAuth",
+        "resourceVersion": "1732189410576",
+        "creationTimestamp": "2024-11-21T11:42:29Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2024-11-21 11:43:30.576196 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables user auth for Azure Monitor datasource only",
+        "stage": "GA",
+        "codeowner": "@grafana/partner-datasources",
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "azureMonitorLogLimit",
         "resourceVersion": "1727696791818",
         "creationTimestamp": "2024-09-30T11:45:45Z",

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -137,6 +138,10 @@ func NewInstanceSettings(clientProvider *httpclient.Provider, executors map[stri
 		routesForModel, err := getAzureMonitorRoutes(azureSettings, credentials, settings.JSONData)
 		if err != nil {
 			return nil, err
+		}
+
+		if credentials.AzureAuthType() == azcredentials.AzureAuthCurrentUserIdentity && !backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled("azureMonitorEnableUserAuth") {
+			return nil, backend.DownstreamError(errors.New("current user authentication is not enabled for azure monitor"))
 		}
 
 		model := types.DatasourceInfo{

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 
@@ -59,26 +60,28 @@ func TestNewInstanceSettings(t *testing.T) {
 	tests := []struct {
 		name          string
 		settings      backend.DataSourceInstanceSettings
-		expectedModel types.DatasourceInfo
+		expectedModel *types.DatasourceInfo
 		Err           require.ErrorAssertionFunc
+		setupContext  func(ctx context.Context) context.Context
 	}{
 		{
-			name: "creates an instance",
+			name: "current user authentication disabled by feature toggle",
 			settings: backend.DataSourceInstanceSettings{
-				JSONData:                []byte(`{"azureAuthType":"msi"}`),
-				DecryptedSecureJSONData: map[string]string{"key": "value"},
-				ID:                      40,
+				JSONData:                []byte(`{"azureAuthType":"currentuser"}`),
+				DecryptedSecureJSONData: map[string]string{},
+				ID:                      60,
 			},
-			expectedModel: types.DatasourceInfo{
-				Credentials:             &azcredentials.AzureManagedIdentityCredentials{},
-				Settings:                types.AzureMonitorSettings{},
-				Routes:                  testRoutes,
-				JSONData:                map[string]any{"azureAuthType": "msi"},
-				DatasourceID:            40,
-				DecryptedSecureJSONData: map[string]string{"key": "value"},
-				Services:                map[string]types.DatasourceService{},
+			expectedModel: nil,
+			Err: func(t require.TestingT, err error, _ ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "current user authentication is not enabled for azure monitor")
 			},
-			Err: require.NoError,
+			setupContext: func(ctx context.Context) context.Context {
+				featureToggles := backend.NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures: "", // No enabled features
+				})
+				return backend.WithGrafanaConfig(ctx, featureToggles)
+			},
 		},
 		{
 			name: "creates an instance for customized cloud",
@@ -87,7 +90,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
 				ID:                      50,
 			},
-			expectedModel: types.DatasourceInfo{
+			expectedModel: &types.DatasourceInfo{
 				Credentials: &azcredentials.AzureClientSecretCredentials{
 					AzureCloud:   "AzureCustomizedCloud",
 					ClientSecret: "secret",
@@ -117,11 +120,23 @@ func TestNewInstanceSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.setupContext != nil {
+				ctx = tt.setupContext(ctx)
+			}
+
 			factory := NewInstanceSettings(&httpclient.Provider{}, map[string]azDatasourceExecutor{}, log.DefaultLogger)
-			instance, err := factory(context.Background(), tt.settings)
+			instance, err := factory(ctx, tt.settings)
+
 			tt.Err(t, err)
-			if !cmp.Equal(instance, tt.expectedModel) {
-				t.Errorf("Unexpected instance: %v", cmp.Diff(instance, tt.expectedModel))
+
+			if tt.expectedModel == nil {
+				require.Nil(t, instance, "Expected instance to be nil")
+			} else {
+				require.NotNil(t, instance, "Expected instance to be created")
+				if !cmp.Equal(instance, *tt.expectedModel) {
+					t.Errorf("Unexpected instance: %v", cmp.Diff(instance, *tt.expectedModel))
+				}
 			}
 		})
 	}

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -84,6 +84,24 @@ func TestNewInstanceSettings(t *testing.T) {
 			},
 		},
 		{
+			name: "creates an instance",
+			settings: backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"azureAuthType":"msi"}`),
+				DecryptedSecureJSONData: map[string]string{"key": "value"},
+				ID:                      40,
+			},
+			expectedModel: &types.DatasourceInfo{
+				Credentials:             &azcredentials.AzureManagedIdentityCredentials{},
+				Settings:                types.AzureMonitorSettings{},
+				Routes:                  testRoutes,
+				JSONData:                map[string]any{"azureAuthType": "msi"},
+				DatasourceID:            40,
+				DecryptedSecureJSONData: map[string]string{"key": "value"},
+				Services:                map[string]types.DatasourceService{},
+			},
+			Err: require.NoError,
+		},
+		{
 			name: "creates an instance for customized cloud",
 			settings: backend.DataSourceInstanceSettings{
 				JSONData:                []byte(`{"cloudName":"customizedazuremonitor","customizedRoutes":{"Route":{"URL":"url"}},"azureAuthType":"clientsecret"}`),

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -75,15 +75,15 @@ export const AzureCredentialsForm = (props: Props) => {
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
     const defaultAuthType = (() => {
       if (managedIdentityEnabled) {
-        return 'msi'
+        return 'msi';
       }
 
       if (workloadIdentityEnabled) {
-        return 'workloadidentity'
+        return 'workloadidentity';
       }
 
       if (userIdentityEnabled) {
-        return 'currentuser'
+        return 'currentuser';
       }
 
       return 'clientsecret';

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -73,17 +73,27 @@ export const AzureCredentialsForm = (props: Props) => {
   }, [managedIdentityEnabled, workloadIdentityEnabled, userIdentityEnabled]);
 
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
-    const defaultAuthType = managedIdentityEnabled
-      ? 'msi'
-      : workloadIdentityEnabled
-        ? 'workloadidentity'
-        : userIdentityEnabled
-          ? 'currentuser'
-          : 'clientsecret';
+    const defaultAuthType = (() => {
+      if (managedIdentityEnabled) {
+        return 'msi'
+      }
+
+      if (workloadIdentityEnabled) {
+        return 'workloadidentity'
+      }
+
+      if (userIdentityEnabled) {
+        return 'currentuser'
+      }
+
+      return 'clientsecret';
+    })();
+
     const updated: AzureCredentials = {
       ...credentials,
       authType: selected.value || defaultAuthType,
     };
+
     onCredentialsChange(updated);
   };
 

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -122,7 +122,6 @@ export const AzureCredentialsForm = (props: Props) => {
           disabled={disabled}
           managedIdentityEnabled={managedIdentityEnabled}
           workloadIdentityEnabled={workloadIdentityEnabled}
-          userIdentityEnabled={userIdentityEnabled}
         />
       )}
     </ConfigSection>

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.test.tsx
@@ -10,7 +10,6 @@ const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
     managedIdentityEnabled: true,
     workloadIdentityEnabled: true,
-    userIdentityEnabled: true,
     credentials: { authType: 'currentuser' },
     azureCloudOptions: [
       { value: 'AzureCloud', label: 'Azure' },

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
@@ -13,7 +13,6 @@ import { AppRegistrationCredentials } from './AppRegistrationCredentials';
 export interface Props {
   managedIdentityEnabled: boolean;
   workloadIdentityEnabled: boolean;
-  userIdentityEnabled: boolean;
   credentials: AadCurrentUserCredentials;
   azureCloudOptions?: SelectableValue[];
   onCredentialsChange: (updatedCredentials: AzureCredentials) => void;

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
@@ -74,7 +74,11 @@ describe('MonitorConfig', () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByText((content, element) => element?.tagName?.toLowerCase() === 'span' && /Current User/i.test(content))).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          (content, element) => element?.tagName?.toLowerCase() === 'span' && /Current User/i.test(content)
+        )
+      ).toBeInTheDocument();
     });
   });
 

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
@@ -1,21 +1,37 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+
+import { config } from '@grafana/runtime';
 
 import { createMockDatasourceSettings } from '../../__mocks__/datasourceSettings';
 
 import { MonitorConfig, Props } from './MonitorConfig';
 
-const mockDatasourceSettings = createMockDatasourceSettings();
-
 const defaultProps: Props = {
-  options: mockDatasourceSettings,
+  options: createMockDatasourceSettings(),
   updateOptions: jest.fn(),
   getSubscriptions: jest.fn().mockResolvedValue([]),
 };
 
 describe('MonitorConfig', () => {
+  beforeEach(() => {
+    config.azure = {
+      ...config.azure,
+      managedIdentityEnabled: false,
+      workloadIdentityEnabled: false,
+      userIdentityEnabled: false,
+    };
+    config.featureToggles = {
+      azureMonitorEnableUserAuth: false,
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
   it('should render component', () => {
     render(<MonitorConfig {...defaultProps} />);
-
     expect(screen.getByText('Azure Cloud')).toBeInTheDocument();
   });
 
@@ -29,6 +45,7 @@ describe('MonitorConfig', () => {
     expect(defaultProps.updateOptions).toHaveBeenCalled();
     expect(screen.getByText('Azure Cloud')).toBeInTheDocument();
   });
+
   expect(defaultProps.options.jsonData.azureAuthType).toBe('clientsecret');
 
   it('should render component and set the default subscription if specified', async () => {
@@ -38,5 +55,38 @@ describe('MonitorConfig', () => {
 
     expect(screen.getByText('Azure Cloud')).toBeInTheDocument();
     await waitFor(() => expect(screen.getByText('Test Sub')).toBeInTheDocument());
+  });
+
+  it('should render with user identity enabled when feature toggle is true', async () => {
+    config.azure.userIdentityEnabled = true;
+    config.featureToggles.azureMonitorEnableUserAuth = true;
+
+    const optionsWithUserAuth = createMockDatasourceSettings({
+      jsonData: { azureAuthType: 'currentuser' },
+    });
+
+    render(<MonitorConfig {...defaultProps} options={optionsWithUserAuth} />);
+
+    const authDropdownInput = screen.getByTestId('data-testid auth-type').querySelector('input');
+
+    if (authDropdownInput) {
+      fireEvent.mouseDown(authDropdownInput);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText((content, element) => element?.tagName?.toLowerCase() === 'span' && /Current User/i.test(content))).toBeInTheDocument();
+    });
+  });
+
+  it('should render with user identity disabled when feature toggle is false', async () => {
+    config.azure.userIdentityEnabled = true;
+    config.featureToggles.azureMonitorEnableUserAuth = false;
+
+    render(<MonitorConfig {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Authentication')).toBeInTheDocument();
+      expect(screen.queryByText(/Current User/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx
@@ -48,15 +48,12 @@ export const MonitorConfig = (props: Props) => {
     }
   });
 
-  // feature flag to enable/disable user auth only for Azure Monitor
-  const azureMonitorAuthEnabled = config.featureToggles.azureMonitorEnableUserAuth ?? true;
-
   return (
     <>
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
         workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
-        userIdentityEnabled={config.azure.userIdentityEnabled && azureMonitorAuthEnabled}
+        userIdentityEnabled={config.azure.userIdentityEnabled && !!config.featureToggles.azureMonitorEnableUserAuth}
         credentials={credentials}
         azureCloudOptions={getAzureCloudOptions()}
         onCredentialsChange={onCredentialsChange}

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx
@@ -48,12 +48,15 @@ export const MonitorConfig = (props: Props) => {
     }
   });
 
+  // feature flag to enable/disable user auth only for Azure Monitor
+  const azureMonitorAuthEnabled = config.featureToggles.azureMonitorEnableUserAuth ?? true;
+
   return (
     <>
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
         workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
-        userIdentityEnabled={config.azure.userIdentityEnabled}
+        userIdentityEnabled={config.azure.userIdentityEnabled && azureMonitorAuthEnabled}
         credentials={credentials}
         azureCloudOptions={getAzureCloudOptions()}
         onCredentialsChange={onCredentialsChange}


### PR DESCRIPTION
**What is this feature?**

This PR allows Grafana operators to enable or disable Azure Monitor user-based authentication independently from other Azure data sources. 

A new feature toggle `azureMonitorEnableUserAuth` has been introduced within the `config.featureToggles` object. 

The feature toggle is checked alongside the existing configuration options (`config.azure.userIdentityEnabled`) to determine if user-based authentication for Azure Monitor is available.

**Which issue(s) does this PR fix?**:

Fixes #96650.
