### PR TITLE
Dashboard Schema V2 - Remove type assertions and anys from schemav2 code

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2163,14 +2163,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "7"],
       [0, 0, 0, "Do not use any type assertions.", "8"]
     ],
-    "public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
-    ],
     "public/app/features/dashboard-scene/settings/DeleteDashboardButton.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],


### PR DESCRIPTION
This PR is my stab at tightening up the scenes to new schema transforms so it doesn't require `as` type assertions or `any`.

It currently won't pass due to an incompatibility with attempting to transform `DataLink`s to `DashboardLink`s - we'll need to figure out what to do with the missing properties.