### PR TITLE
TraceQL: Speed up autocomplete tag processing by 100x

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -6,7 +6,8 @@ import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
 import { Scope, TempoJsonData } from '../types';
 
-import { CompletionProvider } from './autocomplete';
+import { CompletionProvider, tagsToObjs, tagsToObjsFaster } from './autocomplete';
+import { testTags } from './testTags';
 import { intrinsicsV1, scopes } from './traceql';
 
 const emptyPosition = {} as monacoTypes.Position;
@@ -16,6 +17,17 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('CompletionProvider', () => {
+  it('prepares tags', async () => {
+    console.time('tagsToObjs');
+    tagsToObjs(testTags);
+    console.timeEnd('tagsToObjs');
+
+
+    console.time('tagsToObjsFaster');
+    tagsToObjsFaster(testTags);
+    console.timeEnd('tagsToObjsFaster');
+  });
+
   it('suggests tags, intrinsics and scopes (API v1)', async () => {
     const { provider, model } = setup('{}', 1, v1Tags);
     const result = await provider.provideCompletionItems(model, emptyPosition);

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -6,8 +6,7 @@ import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
 import { Scope, TempoJsonData } from '../types';
 
-import { CompletionProvider, tagsToObjs, tagsToObjsFaster } from './autocomplete';
-import { testTags } from './testTags';
+import { CompletionProvider } from './autocomplete';
 import { intrinsicsV1, scopes } from './traceql';
 
 const emptyPosition = {} as monacoTypes.Position;
@@ -17,17 +16,6 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('CompletionProvider', () => {
-  it('prepares tags', async () => {
-    console.time('tagsToObjs');
-    tagsToObjs(testTags);
-    console.timeEnd('tagsToObjs');
-
-
-    console.time('tagsToObjsFaster');
-    tagsToObjsFaster(testTags);
-    console.timeEnd('tagsToObjsFaster');
-  });
-
   it('suggests tags, intrinsics and scopes (API v1)', async () => {
     const { provider, model } = setup('{}', 1, v1Tags);
     const result = await provider.provideCompletionItems(model, emptyPosition);

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -427,13 +427,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
 
   private getTagsCompletions(prepend?: string, scope?: string): CompletionItem[] {
     const tags = this.languageProvider.getTraceqlAutocompleteTags(scope);
-    return tags
-      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'accent' }))
-      .map((key) => ({
-        label: key,
-        insertText: (prepend || '') + key,
-        type: 'TAG_NAME',
-      }));
+    return tagsToObjsFaster(tags, prepend);
   }
 
   private getIntrinsicsCompletions(prepend?: string, append?: string): CompletionItem[] {
@@ -548,4 +542,24 @@ function fixSuggestion(
       }
     }
   }
+}
+
+export function tagsToObjs(tags: string[], prepend?: string): CompletionItem[] {
+  return tags
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'accent' }))
+    .map((key) => ({
+      label: key,
+      insertText: (prepend || '') + key,
+      type: 'TAG_NAME',
+    }));
+}
+
+const collator = new Intl.Collator('en', { sensitivity: 'accent' });
+
+export function tagsToObjsFaster(tags: string[], prepend = ''): CompletionItem[] {
+  return tags.sort(collator.compare).map((key) => ({
+    label: key,
+    insertText: `${prepend}${key}`,
+    type: 'TAG_NAME',
+  }));
 }

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -427,7 +427,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
 
   private getTagsCompletions(prepend?: string, scope?: string): CompletionItem[] {
     const tags = this.languageProvider.getTraceqlAutocompleteTags(scope);
-    return tagsToObjsFaster(tags, prepend);
+    return tagsToCompletionItems(tags, prepend);
   }
 
   private getIntrinsicsCompletions(prepend?: string, append?: string): CompletionItem[] {
@@ -544,19 +544,9 @@ function fixSuggestion(
   }
 }
 
-export function tagsToObjs(tags: string[], prepend?: string): CompletionItem[] {
-  return tags
-    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'accent' }))
-    .map((key) => ({
-      label: key,
-      insertText: (prepend || '') + key,
-      type: 'TAG_NAME',
-    }));
-}
-
 const collator = new Intl.Collator('en', { sensitivity: 'accent' });
 
-export function tagsToObjsFaster(tags: string[], prepend = ''): CompletionItem[] {
+function tagsToCompletionItems(tags: string[], prepend = ''): CompletionItem[] {
   return tags.sort(collator.compare).map((key) => ({
     label: key,
     insertText: `${prepend}${key}`,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/96847
Fixes https://github.com/grafana/support-escalations/issues/13320

TraceQL autocomplete exhibited a bottleneck in tag processing, this is for ~30k tags:

![image](https://github.com/user-attachments/assets/07d8f024-56fa-4dbb-a9ba-55cdad7807aa)

after refactoring we get about 100x speedup:

![image](https://github.com/user-attachments/assets/514c98ef-bb93-467c-83b2-a8f8ef670c90)