### PR TITLE
Dashboards: add showMenuAlways prop to PanelChrome

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -236,6 +236,11 @@ export const Examples = () => {
             title: 'Default title',
             collapsible: true,
           })}
+          {renderPanel('Menu always visible', {
+            title: 'Menu always visible',
+            showMenuAlways: true,
+            menu,
+          })}
           {renderPanel('Panel with action link', {
             title: 'Panel with action link',
             actions: (

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -111,7 +111,7 @@ it('renders panel with a show-on-hover menu icon if prop menu', () => {
   expect(screen.getByTestId('panel-menu-button')).not.toBeVisible();
 });
 
-it('renders panel with an always visible menu icon if prop showMenuOnHover is false', () => {
+it('renders panel with an always visible menu icon if prop showMenuAlways is false', () => {
   setup({ menu: <div> Menu </div>, showMenuAlways: true });
 
   expect(screen.getByTestId('panel-menu-button')).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -111,7 +111,7 @@ it('renders panel with a show-on-hover menu icon if prop menu', () => {
   expect(screen.getByTestId('panel-menu-button')).not.toBeVisible();
 });
 
-it('renders panel with an always visible menu icon if prop showMenuAlways is false', () => {
+it('renders panel with an always visible menu icon if prop showMenuAlways is true', () => {
   setup({ menu: <div> Menu </div>, showMenuAlways: true });
 
   expect(screen.getByTestId('panel-menu-button')).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -111,6 +111,13 @@ it('renders panel with a show-on-hover menu icon if prop menu', () => {
   expect(screen.getByTestId('panel-menu-button')).not.toBeVisible();
 });
 
+it('renders panel with an always visible menu icon if prop showMenuOnHover is false', () => {
+  setup({ menu: <div> Menu </div>, showMenuOnHover: false });
+
+  expect(screen.getByTestId('panel-menu-button')).toBeInTheDocument();
+  expect(screen.getByTestId('panel-menu-button')).toBeVisible();
+});
+
 it('renders error status in the panel header if any given', () => {
   setup({ statusMessage: 'Error test' });
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.test.tsx
@@ -112,7 +112,7 @@ it('renders panel with a show-on-hover menu icon if prop menu', () => {
 });
 
 it('renders panel with an always visible menu icon if prop showMenuOnHover is false', () => {
-  setup({ menu: <div> Menu </div>, showMenuOnHover: false });
+  setup({ menu: <div> Menu </div>, showMenuAlways: true });
 
   expect(screen.getByTestId('panel-menu-button')).toBeInTheDocument();
   expect(screen.getByTestId('panel-menu-button')).toBeVisible();

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -84,6 +84,10 @@ interface Collapsible {
   collapsible: boolean;
   collapsed?: boolean;
   /**
+   * If false, the VizPanelMenu will always be visible in the panel header. Defaults to true.
+   */
+  showMenuOnHover?: boolean;
+  /**
    * callback when collapsing or expanding the panel
    */
   onToggleCollapse?: (collapsed: boolean) => void;
@@ -94,6 +98,7 @@ interface Collapsible {
 interface HoverHeader {
   collapsible?: never;
   collapsed?: never;
+  showMenuOnHover?: never;
   onToggleCollapse?: never;
   hoverHeader?: boolean;
   hoverHeaderOffset?: number;
@@ -134,6 +139,7 @@ export function PanelChrome({
   onFocus,
   onMouseMove,
   onMouseEnter,
+  showMenuOnHover = true,
 }: PanelChromeProps) {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
@@ -150,7 +156,7 @@ export function PanelChrome({
   }
 
   // hover menu is only shown on hover when not on touch devices
-  const showOnHoverClass = 'show-on-hover';
+  const showOnHoverClass = showMenuOnHover ? 'show-on-hover' : 'always-show';
   const isPanelTransparent = displayMode === 'transparent';
 
   const headerHeight = getHeaderHeight(theme, hasHeader);
@@ -389,6 +395,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       height: '100%',
       display: 'flex',
       flexDirection: 'column',
+
+      '.always-show': {
+        background: 'none',
+        '&:focus-visible, &:hover': {
+          background: theme.colors.secondary.shade,
+        },
+      },
 
       '.show-on-hover': {
         opacity: '0',

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -84,9 +84,9 @@ interface Collapsible {
   collapsible: boolean;
   collapsed?: boolean;
   /**
-   * If false, the VizPanelMenu will always be visible in the panel header. Defaults to true.
+   * If true, the VizPanelMenu will always be visible in the panel header. Defaults to false.
    */
-  showMenuOnHover?: boolean;
+  showMenuAlways?: boolean;
   /**
    * callback when collapsing or expanding the panel
    */
@@ -98,7 +98,7 @@ interface Collapsible {
 interface HoverHeader {
   collapsible?: never;
   collapsed?: never;
-  showMenuOnHover?: never;
+  showMenuAlways?: never;
   onToggleCollapse?: never;
   hoverHeader?: boolean;
   hoverHeaderOffset?: number;
@@ -139,7 +139,7 @@ export function PanelChrome({
   onFocus,
   onMouseMove,
   onMouseEnter,
-  showMenuOnHover = true,
+  showMenuAlways = false,
 }: PanelChromeProps) {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
@@ -156,7 +156,7 @@ export function PanelChrome({
   }
 
   // hover menu is only shown on hover when not on touch devices
-  const showOnHoverClass = showMenuOnHover ? 'show-on-hover' : 'always-show';
+  const showOnHoverClass = showMenuAlways ? 'always-show' : 'show-on-hover';
   const isPanelTransparent = displayMode === 'transparent';
 
   const headerHeight = getHeaderHeight(theme, hasHeader);


### PR DESCRIPTION
**What is this feature?**
Adds new showMenuAlways prop which will always show the vizPanelMenu, instead of only showing on hover.

**Why do we need this feature?**
See issue for more [detailed background](https://github.com/grafana/grafana/issues/96865).

TL;DR: Explore apps make use of right aligned actions in panel headers. If the menu icon is only visible on hover, users have the expectation that every panel has a menu on hover, or they don't realize a menu is there at all. Also having empty space next to the primary CTA in the panel header just looks weird.

**Who is this feature for?**
Mostly for users and developers of Explore apps.

**Which issue(s) does this PR fix?**:

Addresses the Grafana core portion of: https://github.com/grafana/grafana/issues/96865

**Special notes for your reviewer:**
Scenes implementation: https://github.com/grafana/scenes/pull/973

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
