### PR TITLE
Select: Log options in select component if exceeding recommended amount

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -15,6 +15,7 @@ import Creatable from 'react-select/creatable';
 import { SelectableValue, toOption } from '@grafana/data';
 
 import { useTheme2 } from '../../themes';
+import { logOptions } from '../../utils';
 import { Trans } from '../../utils/i18n';
 import { Icon } from '../Icon/Icon';
 import { Spinner } from '../Spinner/Spinner';
@@ -78,6 +79,8 @@ interface SelectPropsWithExtras extends ReactSelectProps {
   showAllSelectedWhenOpen: boolean;
   noMultiValueWrap?: boolean;
 }
+
+const RECOMMENDED_ITEMS_AMOUNT = 10_000;
 
 function determineToggleAllState(selectedValue: SelectableValue[], options: SelectableValue[]) {
   if (options.length === selectedValue.length) {
@@ -162,6 +165,21 @@ export function SelectBase<T, Rest = {}>({
   const [closeToBottom, setCloseToBottom] = useState<boolean>(false);
   const selectStyles = useCustomSelectStyles(theme, width);
   const [hasInputValue, setHasInputValue] = useState<boolean>(!!inputValue);
+
+  // log a warning if the amount of items exceeds the recommended amount
+  const warningLogRefOptions = useRef<boolean>(false);
+  if (!warningLogRefOptions.current) {
+    const updateRef = logOptions(options.length, RECOMMENDED_ITEMS_AMOUNT, id, ariaLabel);
+    warningLogRefOptions.current = updateRef;
+  }
+
+  // is there a way to get the amount in loadOptions?
+  // for now, default options can be used to log a warning if it is not a boolean
+  const warningLogRefDefaultOptions = useRef<boolean>(false);
+  if (!warningLogRefDefaultOptions.current && defaultOptions && typeof defaultOptions !== 'boolean') {
+    const updateRef = logOptions(options.length, RECOMMENDED_ITEMS_AMOUNT, id, ariaLabel);
+    warningLogRefDefaultOptions.current = updateRef;
+  }
 
   // Infer the menu position for asynchronously loaded options. menuPlacement="auto" doesn't work when the menu is
   // automatically opened when the component is created (it happens in SegmentSelect by setting menuIsOpen={true}).

--- a/packages/grafana-ui/src/utils/logOptions.ts
+++ b/packages/grafana-ui/src/utils/logOptions.ts
@@ -10,7 +10,7 @@ export function logOptions(
   recommendedAmount: number,
   id: string | undefined,
   ariaLabelledBy: string | undefined
-): void {
+): boolean {
   if (amount > recommendedAmount) {
     const msg = `[Combobox] Items exceed the recommended amount ${recommendedAmount}.`;
     console.warn(msg, {
@@ -19,5 +19,7 @@ export function logOptions(
       'aria-labelledby': ariaLabelledBy ?? '',
       id: id ?? '',
     });
+    return true;
   }
+  return false;
 }


### PR DESCRIPTION
**What is this?**
Log a warning if the options provided to the Select component exceed the recommended amount.

**Why?**
If devs are using the Select component and exceeding the recommended amount of options, it would be help to log a warning about this. If they are, they can limit the options or move to the COmboBox.

**For the reviewers**
Is this the best place to get the options length for async select? Is there anyway to get that length other than defaultOptions? Can you get the amount of options returned from loadOptions?


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
