### PR TITLE
POC/Provisioning: View dashboard from repository

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -154,7 +154,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/dashboard/script/*", reqSignedIn, hs.Index)
 	r.Get("/dashboard/new", reqSignedIn, hs.Index)
 	r.Get("/dashboard-solo/snapshot/*", hs.Index)
-	r.Get("/dashboard/repo/*", reqSignedIn, hs.Index) // ??? admin only?
+	r.Get("/dashboard/provisioning/*", reqSignedIn, hs.Index)
 	r.Get("/d-solo/:uid/:slug", reqSignedIn, hs.Index)
 	r.Get("/d-solo/:uid", reqSignedIn, hs.Index)
 	r.Get("/dashboard-solo/script/*", reqSignedIn, hs.Index)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -154,6 +154,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/dashboard/script/*", reqSignedIn, hs.Index)
 	r.Get("/dashboard/new", reqSignedIn, hs.Index)
 	r.Get("/dashboard-solo/snapshot/*", hs.Index)
+	r.Get("/dashboard/repo/*", reqSignedIn, hs.Index) // ??? admin only?
 	r.Get("/d-solo/:uid/:slug", reqSignedIn, hs.Index)
 	r.Get("/d-solo/:uid", reqSignedIn, hs.Index)
 	r.Get("/dashboard-solo/script/*", reqSignedIn, hs.Index)

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -21,8 +21,7 @@ export interface Props
 
 export function DashboardScenePage({ route, queryParams, location }: Props) {
   const params = useParams();
-  const { type, slug, uid } = params;
-  const starparam = params["*"] // used to select a dashboard by path
+  const { type, slug, uid, path } = params;
   const prevMatch = usePrevious({ params });
   const stateManager = getDashboardScenePageStateManager();
   const { dashboard, isLoading, loadError } = stateManager.useState();
@@ -34,7 +33,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
       stateManager.loadSnapshot(slug!);
     } else {
       stateManager.loadDashboard({
-        uid: starparam ?? uid ?? '',
+        uid: path ?? uid ?? '',
         slug: slug,
         route: route.routeName as DashboardRoutes,
         urlFolderUid: queryParams.folderUid,
@@ -44,7 +43,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
     return () => {
       stateManager.clearState();
     };
-  }, [stateManager, uid, route.routeName, queryParams.folderUid, routeReloadCounter, slug, type, starparam]);
+  }, [stateManager, uid, route.routeName, queryParams.folderUid, routeReloadCounter, slug, type, path]);
 
   if (!dashboard) {
     return (

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -22,6 +22,7 @@ export interface Props
 export function DashboardScenePage({ route, queryParams, location }: Props) {
   const params = useParams();
   const { type, slug, uid } = params;
+  const starparam = params["*"] // used to select a dashboard by path
   const prevMatch = usePrevious({ params });
   const stateManager = getDashboardScenePageStateManager();
   const { dashboard, isLoading, loadError } = stateManager.useState();
@@ -33,7 +34,8 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
       stateManager.loadSnapshot(slug!);
     } else {
       stateManager.loadDashboard({
-        uid: uid ?? '',
+        uid: starparam ?? uid ?? '',
+        slug: slug,
         route: route.routeName as DashboardRoutes,
         urlFolderUid: queryParams.folderUid,
       });
@@ -42,7 +44,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
     return () => {
       stateManager.clearState();
     };
-  }, [stateManager, uid, route.routeName, queryParams.folderUid, routeReloadCounter, slug, type]);
+  }, [stateManager, uid, route.routeName, queryParams.folderUid, routeReloadCounter, slug, type, starparam]);
 
   if (!dashboard) {
     return (

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -104,8 +104,8 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
 
           break;
 
-        case DashboardRoutes.Repo: {
-          return await dashboardLoaderSrv.loadDashboard('repo', slug, uid);
+        case DashboardRoutes.Provisioning: {
+          return await dashboardLoaderSrv.loadDashboard('provisioning', slug, uid);
         }
         case DashboardRoutes.Public: {
           return await dashboardLoaderSrv.loadDashboard('public', '', uid);

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -43,6 +43,7 @@ interface DashboardCacheEntry {
 export interface LoadDashboardOptions {
   uid: string;
   route: DashboardRoutes;
+  slug?: string;
   urlFolderUid?: string;
   params?: {
     version: number;
@@ -68,6 +69,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
     route,
     urlFolderUid,
     params,
+    slug,
   }: LoadDashboardOptions): Promise<DashboardDTO | null> {
     const cacheKey = route === DashboardRoutes.Home ? HOME_DASHBOARD_CACHE_KEY : uid;
 
@@ -101,6 +103,10 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
           }
 
           break;
+
+        case DashboardRoutes.Repo: {
+          return await dashboardLoaderSrv.loadDashboard('repo', slug, uid);
+        }
         case DashboardRoutes.Public: {
           return await dashboardLoaderSrv.loadDashboard('public', '', uid);
         }

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.tsx
@@ -48,7 +48,7 @@ export class SaveDashboardDrawer extends SceneObjectBase<SaveDashboardDrawerStat
     const changesCount = diffCount + (hasFolderChanges ? 1 : 0);
     const dashboard = model.state.dashboardRef.resolve();
     const { meta } = dashboard.useState();
-    const { provisioned: isProvisioned, folderTitle } = meta;
+    const { provisioned: isProvisioned, folderTitle, repository } = meta;
 
     const tabs = (
       <TabsBar>
@@ -83,6 +83,14 @@ export class SaveDashboardDrawer extends SceneObjectBase<SaveDashboardDrawerStat
             newFolder={folderTitle}
           />
         );
+      }
+
+      if (repository) {
+        return <div>
+          <h1>SAVE FOR REPOSITORY!</h1>
+          <h3>{repository.title}</h3>
+          <a href={repository.url}>{repository.url}</a>
+        </div>
       }
 
       if (saveAsCopy || changeInfo.isNew) {

--- a/public/app/features/provisioning/dashboard.ts
+++ b/public/app/features/provisioning/dashboard.ts
@@ -1,0 +1,51 @@
+import { config, getBackendSrv } from '@grafana/runtime';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
+
+import { Resource } from '../apiserver/types';
+
+/**
+ * Load a dashboard from repository
+ */
+export async function loadDashboardFromProvisioning(repo: string, path: string): Promise<DashboardDTO> {
+  const params = new URLSearchParams(window.location.search);
+  const ref = params.get('ref') ?? undefined; // commit hash or branch
+
+  const url = `apis/provisioning.grafana.app/v0alpha1/namespaces/${config.namespace}/repositories/${repo}/files/${path}`;
+  return getBackendSrv()
+    .get(url, ref ? { ref } : undefined)
+    .then((v) => {
+      // Load the results from dryRun
+      const dryRun = v.resource.dryRun as Resource<DashboardDataDTO, 'Dashboard'>;
+      if (!dryRun) {
+        return Promise.reject("failed to read provisioned dashboard")
+      }
+
+      if (!dryRun.apiVersion.startsWith("dashboard.grafana.app")) {
+        return Promise.reject("unexpected resource type: "+dryRun.apiVersion)
+      }
+
+      return {
+        meta: {
+          canStar: false,
+          isSnapshot: false,
+          canShare: false,
+
+          // Should come from the repo settings
+          canDelete: true,
+          canSave: true,
+          canEdit: true,
+
+          // Includes additional k8s metadata
+          k8s: dryRun.metadata,
+
+          // lookup info
+          provisioning: {
+            file: url,
+            ref: ref,
+            repo: repo,
+          }
+        },
+        dashboard: dryRun.spec
+      }
+    });
+}

--- a/public/app/features/provisioning/types.ts
+++ b/public/app/features/provisioning/types.ts
@@ -8,3 +8,10 @@ export type RepositoryFormData = GitHubRepositoryConfig &
     folder?: string;
     type: 'github' | 'local' | 's3';
   };
+
+// Added to DashboardDTO to help editor
+export interface ProvisioningPreview {
+  repo: string;
+  file: string;
+  ref?: string;
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -64,9 +64,9 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
-      path: '/dashboard/repo/:slug/:path/*',
+      path: '/dashboard/provisioning/:slug/:path/*',
       pageClass: 'page-dashboard',
-      routeName: DashboardRoutes.Repo,
+      routeName: DashboardRoutes.Provisioning,
       component: SafeDynamicImport(
         () =>
           import(/* webpackChunkName: "DashboardScenePage" */ '../features/dashboard-scene/pages/DashboardScenePage')

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -64,6 +64,14 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/dashboard/repo/:slug/*',
+      pageClass: 'page-dashboard',
+      routeName: DashboardRoutes.Repo,
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "DashboardScenePage" */ '../features/dashboard-scene/pages/DashboardScenePage')
+      ),
+    },
+    {
       path: '/dashboard/:type/:slug',
       pageClass: 'page-dashboard',
       routeName: DashboardRoutes.Normal,

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -64,11 +64,12 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
-      path: '/dashboard/repo/:slug/*',
+      path: '/dashboard/repo/:slug/:path/*',
       pageClass: 'page-dashboard',
       routeName: DashboardRoutes.Repo,
       component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "DashboardScenePage" */ '../features/dashboard-scene/pages/DashboardScenePage')
+        () =>
+          import(/* webpackChunkName: "DashboardScenePage" */ '../features/dashboard-scene/pages/DashboardScenePage')
       ),
     },
     {

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -74,10 +74,19 @@ export interface DashboardMeta {
   // until we use the resource as the main container
   k8s?: Partial<ObjectMeta>;
 
+  // If the dashboard was loaded from a remote repository
+  repository?: RepositoryInfo;
+
   // This is a property added specifically for edge cases where dashboards should be reloaded on scopes, time range or variables changes
   // This property is not persisted in the DB but its existence is controlled by the API
   reloadOnParamsChange?: boolean;
 }
+
+export interface RepositoryInfo {
+  url: string
+  title: string
+}
+
 
 export interface AnnotationActions {
   canAdd: boolean;

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -2,6 +2,7 @@ import { DataQuery } from '@grafana/data';
 import { Dashboard, DataSourceRef } from '@grafana/schema';
 import { ObjectMeta } from 'app/features/apiserver/types';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
+import { ProvisioningPreview } from 'app/features/provisioning/types';
 
 export interface DashboardDTO {
   redirectUri?: string;
@@ -75,17 +76,13 @@ export interface DashboardMeta {
   k8s?: Partial<ObjectMeta>;
 
   // If the dashboard was loaded from a remote repository
-  repository?: RepositoryInfo;
+  provisioning?: ProvisioningPreview;
 
   // This is a property added specifically for edge cases where dashboards should be reloaded on scopes, time range or variables changes
   // This property is not persisted in the DB but its existence is controlled by the API
   reloadOnParamsChange?: boolean;
 }
 
-export interface RepositoryInfo {
-  url: string
-  title: string
-}
 
 
 export interface AnnotationActions {
@@ -110,8 +107,7 @@ export enum DashboardRoutes {
   Home = 'home-dashboard',
   New = 'new-dashboard',
   Normal = 'normal-dashboard',
-  Path = 'path-dashboard',
-  Repo = 'repo-dashboard',
+  Provisioning = 'provisioning-dashboard',
   Scripted = 'scripted-dashboard',
   Public = 'public-dashboard',
   Embedded = 'embedded-dashboard',

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -101,6 +101,8 @@ export enum DashboardRoutes {
   Home = 'home-dashboard',
   New = 'new-dashboard',
   Normal = 'normal-dashboard',
+  Path = 'path-dashboard',
+  Repo = 'repo-dashboard',
   Scripted = 'scripted-dashboard',
   Public = 'public-dashboard',
   Embedded = 'embedded-dashboard',


### PR DESCRIPTION
This updates the UI to load values dashboards from the repo 🎉 

Assuming:
```
kubectl apply -f pkg/tests/apis/provisioning/testdata/local-devenv.yaml
```

http://localhost:3000/dashboard/provisioning/local-devenv/all-panels.json

<img width="685" alt="image" src="https://github.com/user-attachments/assets/4a24b69f-3102-4b4d-8eb8-ac921283d668">

NOTE: we should only target the scenes framework... no need to use the legacy version

TODO:
- [ ] Add repo info to the metadata
- [ ] Show repo info in header
- [ ] Show repo info in save model
