### PR TITLE
POC/Provisioning: create folder if it does not exist

### DIFF
--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -280,9 +281,12 @@ func TestIntegrationProvisioning(t *testing.T) {
 
 	t.Run("creating repository creates folder", func(t *testing.T) {
 		// Just make sure the folder doesn't exist in advance.
-		_ = folderClient.Resource.Delete(ctx, "thisisafolderref", metav1.DeleteOptions{})
+		err := folderClient.Resource.Delete(ctx, "thisisafolderref", metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			require.NoError(t, err, "deletion should either be OK or fail with NotFound")
+		}
 
-		_, err := client.Resource.Update(ctx,
+		_, err = client.Resource.Update(ctx,
 			helper.LoadYAMLOrJSONFile("testdata/github-example.yaml"),
 			metav1.UpdateOptions{},
 		)

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -12,10 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	folderv0alpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
-	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -33,16 +30,9 @@ func TestIntegrationProvisioning(t *testing.T) {
 	ctx := context.Background()
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		AppModeProduction: false, // required for experimental APIs
-		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-			folderv0alpha1.RESOURCEGROUP: {
-				DualWriterMode: grafanarest.Mode5,
-			},
-		},
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs, // Required to start the example service
 			featuremgmt.FlagKubernetesFolders,                    // Required for tests that deal with folders.
-			featuremgmt.FlagKubernetesDashboards,
-			featuremgmt.FlagKubernetesDashboardsAPI,
 		},
 	})
 

--- a/pkg/tests/apis/provisioning/testdata/github-example.yaml
+++ b/pkg/tests/apis/provisioning/testdata/github-example.yaml
@@ -6,6 +6,7 @@ spec:
   title: Github Example
   description: load resources from github
   type: github
+  folder: thisisafolderref
   editing:
     create: true
     update: true

--- a/pkg/tests/apis/provisioning/testdata/local-devenv.yaml
+++ b/pkg/tests/apis/provisioning/testdata/local-devenv.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   title: Load devenv dashboards
   description: load https://github.com/grafana/grafana/tree/main/devenv/dev-dashboards
+  folder: testingtesting
   editing:
     create: true
     update: true


### PR DESCRIPTION
Ensures that the folder selected (or given via the REST API, e.g. via `kubectl create`) actually exists. If it does not, we try to create it.

I'll be implementing some rudamentary integration test for this, too.