### PR TITLE
POC/Provisioning: Support ping event

### DIFF
--- a/pkg/registry/apis/provisioning/github.go
+++ b/pkg/registry/apis/provisioning/github.go
@@ -213,6 +213,7 @@ func (r *githubRepository) Webhook(responder rest.Responder) http.HandlerFunc {
 			return
 		}
 
+		eventType := github.WebHookType(req)
 		event, err := github.ParseWebHook(github.WebHookType(req), payload)
 		if err != nil {
 			responder.Error(apierrors.NewBadRequest("invalid payload"))
@@ -230,8 +231,13 @@ func (r *githubRepository) Webhook(responder rest.Responder) http.HandlerFunc {
 				Message: "event processed",
 				Code:    http.StatusOK,
 			})
+		case *github.PingEvent:
+			responder.Object(200, &metav1.Status{
+				Message: "ping received",
+				Code:    http.StatusOK,
+			})
 		default:
-			responder.Error(apierrors.NewBadRequest("unsupported event type"))
+			responder.Error(apierrors.NewBadRequest("unsupported event type: " + eventType))
 		}
 	}
 }


### PR DESCRIPTION
Github sends a ping event as soon as you configure the webhook. Lets support the ping event explicitly so that people don't wonder why things are failing despite the webhook configuration being correct

![image](https://github.com/user-attachments/assets/6384092f-d7da-4cef-bfe3-bbf0227b4a26)
