### PR TITLE
MySQL: Datasource health check error message improvements

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3054,13 +3054,6 @@ exports[`better eslint`] = {
     "public/app/features/datasources/components/DataSourcePluginState.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
-    "public/app/features/datasources/components/DataSourceTestingStatus.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
-    ],
     "public/app/features/datasources/components/DataSourceTypeCard.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"]
     ],

--- a/pkg/tsdb/mysql/sqleng/handler_checkhealth.go
+++ b/pkg/tsdb/mysql/sqleng/handler_checkhealth.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -14,8 +17,8 @@ func (e *DataSourceHandler) CheckHealth(ctx context.Context, req *backend.CheckH
 	err := e.db.Ping()
 	if err != nil {
 		logCheckHealthError(ctx, e.dsInfo, err, e.log)
-		if req.PluginContext.User.Role == "Admin" {
-			return &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: err.Error()}, nil
+		if strings.EqualFold(req.PluginContext.User.Role, "Admin") {
+			return ErrToHealthCheckResult(err)
 		}
 		var driverErr *mysql.MySQLError
 		if errors.As(err, &driverErr) {
@@ -26,7 +29,41 @@ func (e *DataSourceHandler) CheckHealth(ctx context.Context, req *backend.CheckH
 	return &backend.CheckHealthResult{Status: backend.HealthStatusOk, Message: "Database Connection OK"}, nil
 }
 
-func logCheckHealthError(ctx context.Context, dsInfo DataSourceInfo, err error, logger log.Logger) {
+// ErrToHealthCheckResult converts error into user friendly health check message
+// This should be called with non nil error. If the err parameter is empty, we will send Internal Server Error
+func ErrToHealthCheckResult(err error) (*backend.CheckHealthResult, error) {
+	if err == nil {
+		return &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: "Internal Server Error"}, nil
+	}
+	res := &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: err.Error()}
+	details := map[string]string{}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		res.Message = "Network error: Failed to connect to the server"
+		if opErr, ok := err.(*net.OpError); ok && opErr != nil && opErr.Err != nil {
+			res.Message += fmt.Sprintf(". Error message: %s", opErr.Err.Error())
+		}
+		details["verboseMessage"] = err.Error()
+		details["moreDetailsLink"] = "https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source"
+	}
+	var driverErr *mysql.MySQLError
+	if errors.As(err, &driverErr) {
+		res.Message = "Database error: Failed to connect to the MySQL server"
+		if driverErr, ok := err.(*mysql.MySQLError); ok && driverErr != nil && driverErr.Number > 0 {
+			res.Message += fmt.Sprintf(". MySQL error number: %d", driverErr.Number)
+		}
+		details["verboseMessage"] = err.Error()
+		details["moreDetailsLink"] = "https://dev.mysql.com/doc/mysql-errors/8.4/en/"
+	}
+	detailBytes, marshalErr := json.Marshal(details)
+	if marshalErr != nil {
+		return res, nil
+	}
+	res.JSONDetails = detailBytes
+	return res, nil
+}
+
+func logCheckHealthError(_ context.Context, dsInfo DataSourceInfo, err error, logger log.Logger) {
 	configSummary := map[string]any{
 		"config_url_length":                 len(dsInfo.URL),
 		"config_user_length":                len(dsInfo.User),

--- a/pkg/tsdb/mysql/sqleng/handler_checkhealth.go
+++ b/pkg/tsdb/mysql/sqleng/handler_checkhealth.go
@@ -40,7 +40,7 @@ func ErrToHealthCheckResult(err error) (*backend.CheckHealthResult, error) {
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
 		res.Message = "Network error: Failed to connect to the server"
-		if opErr, ok := err.(*net.OpError); ok && opErr != nil && opErr.Err != nil {
+		if opErr != nil && opErr.Err != nil {
 			res.Message += fmt.Sprintf(". Error message: %s", opErr.Err.Error())
 		}
 		details["verboseMessage"] = err.Error()
@@ -49,7 +49,7 @@ func ErrToHealthCheckResult(err error) (*backend.CheckHealthResult, error) {
 	var driverErr *mysql.MySQLError
 	if errors.As(err, &driverErr) {
 		res.Message = "Database error: Failed to connect to the MySQL server"
-		if driverErr, ok := err.(*mysql.MySQLError); ok && driverErr != nil && driverErr.Number > 0 {
+		if driverErr != nil && driverErr.Number > 0 {
 			res.Message += fmt.Sprintf(". MySQL error number: %d", driverErr.Number)
 		}
 		details["verboseMessage"] = err.Error()

--- a/pkg/tsdb/mysql/sqleng/handler_checkhealth.go
+++ b/pkg/tsdb/mysql/sqleng/handler_checkhealth.go
@@ -44,7 +44,7 @@ func ErrToHealthCheckResult(err error) (*backend.CheckHealthResult, error) {
 			res.Message += fmt.Sprintf(". Error message: %s", opErr.Err.Error())
 		}
 		details["verboseMessage"] = err.Error()
-		details["moreDetailsLink"] = "https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source"
+		details["errorDetailsLink"] = "https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source"
 	}
 	var driverErr *mysql.MySQLError
 	if errors.As(err, &driverErr) {
@@ -53,7 +53,7 @@ func ErrToHealthCheckResult(err error) (*backend.CheckHealthResult, error) {
 			res.Message += fmt.Sprintf(". MySQL error number: %d", driverErr.Number)
 		}
 		details["verboseMessage"] = err.Error()
-		details["moreDetailsLink"] = "https://dev.mysql.com/doc/mysql-errors/8.4/en/"
+		details["errorDetailsLink"] = "https://dev.mysql.com/doc/mysql-errors/8.4/en/"
 	}
 	detailBytes, marshalErr := json.Marshal(details)
 	if marshalErr != nil {

--- a/pkg/tsdb/mysql/sqleng/handler_checkhealth_test.go
+++ b/pkg/tsdb/mysql/sqleng/handler_checkhealth_test.go
@@ -26,7 +26,7 @@ func TestErrToHealthCheckResult(t *testing.T) {
 			err:  errors.Join(errors.New("foo"), &net.OpError{Op: "read", Net: "tcp", Err: errors.New("some op")}),
 			want: &backend.CheckHealthResult{
 				Status:      backend.HealthStatusError,
-				Message:     "Network error: Failed to connect to the server",
+				Message:     "Network error: Failed to connect to the server. Error message: some op",
 				JSONDetails: []byte(`{"moreDetailsLink":"https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source","verboseMessage":"foo\nread tcp: some op"}`),
 			},
 		},
@@ -35,7 +35,7 @@ func TestErrToHealthCheckResult(t *testing.T) {
 			err:  errors.Join(errors.New("foo"), &mysql.MySQLError{Number: uint16(1045), Message: "Access denied for user"}),
 			want: &backend.CheckHealthResult{
 				Status:      backend.HealthStatusError,
-				Message:     "Database error: Failed to connect to the MySQL server",
+				Message:     "Database error: Failed to connect to the MySQL server. MySQL error number: 1045",
 				JSONDetails: []byte(`{"moreDetailsLink":"https://dev.mysql.com/doc/mysql-errors/8.4/en/","verboseMessage":"foo\nError 1045: Access denied for user"}`),
 			},
 		},

--- a/pkg/tsdb/mysql/sqleng/handler_checkhealth_test.go
+++ b/pkg/tsdb/mysql/sqleng/handler_checkhealth_test.go
@@ -1,0 +1,60 @@
+package sqleng
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrToHealthCheckResult(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want *backend.CheckHealthResult
+	}{
+		{
+			name: "without error",
+			want: &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: "Internal Server Error"},
+		},
+		{
+			name: "network error",
+			err:  errors.Join(errors.New("foo"), &net.OpError{Op: "read", Net: "tcp", Err: errors.New("some op")}),
+			want: &backend.CheckHealthResult{
+				Status:      backend.HealthStatusError,
+				Message:     "Network error: Failed to connect to the server",
+				JSONDetails: []byte(`{"moreDetailsLink":"https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source","verboseMessage":"foo\nread tcp: some op"}`),
+			},
+		},
+		{
+			name: "db error",
+			err:  errors.Join(errors.New("foo"), &mysql.MySQLError{Number: uint16(1045), Message: "Access denied for user"}),
+			want: &backend.CheckHealthResult{
+				Status:      backend.HealthStatusError,
+				Message:     "Database error: Failed to connect to the MySQL server",
+				JSONDetails: []byte(`{"moreDetailsLink":"https://dev.mysql.com/doc/mysql-errors/8.4/en/","verboseMessage":"foo\nError 1045: Access denied for user"}`),
+			},
+		},
+		{
+			name: "regular error",
+			err:  errors.New("internal server error"),
+			want: &backend.CheckHealthResult{
+				Status:      backend.HealthStatusError,
+				Message:     "internal server error",
+				JSONDetails: []byte(`{}`),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ErrToHealthCheckResult(tt.err)
+			require.Nil(t, err)
+			assert.Equal(t, string(tt.want.JSONDetails), string(got.JSONDetails))
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/tsdb/mysql/sqleng/handler_checkhealth_test.go
+++ b/pkg/tsdb/mysql/sqleng/handler_checkhealth_test.go
@@ -27,7 +27,7 @@ func TestErrToHealthCheckResult(t *testing.T) {
 			want: &backend.CheckHealthResult{
 				Status:      backend.HealthStatusError,
 				Message:     "Network error: Failed to connect to the server. Error message: some op",
-				JSONDetails: []byte(`{"moreDetailsLink":"https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source","verboseMessage":"foo\nread tcp: some op"}`),
+				JSONDetails: []byte(`{"errorDetailsLink":"https://grafana.com/docs/grafana/latest/datasources/mysql/#configure-the-data-source","verboseMessage":"foo\nread tcp: some op"}`),
 			},
 		},
 		{
@@ -36,7 +36,7 @@ func TestErrToHealthCheckResult(t *testing.T) {
 			want: &backend.CheckHealthResult{
 				Status:      backend.HealthStatusError,
 				Message:     "Database error: Failed to connect to the MySQL server. MySQL error number: 1045",
-				JSONDetails: []byte(`{"moreDetailsLink":"https://dev.mysql.com/doc/mysql-errors/8.4/en/","verboseMessage":"foo\nError 1045: Access denied for user"}`),
+				JSONDetails: []byte(`{"errorDetailsLink":"https://dev.mysql.com/doc/mysql-errors/8.4/en/","verboseMessage":"foo\nError 1045: Access denied for user"}`),
 			},
 		},
 		{

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -73,6 +73,48 @@ const AlertSuccessMessage = ({ title, exploreUrl, dataSourceId, onDashboardLinkC
 
 AlertSuccessMessage.displayName = 'AlertSuccessMessage';
 
+interface AlertErrorMessageProps extends HTMLAttributes<HTMLDivElement> {
+  moreDetailsLink?: string;
+}
+
+const AlertErrorMessage = ({ moreDetailsLink }: AlertErrorMessageProps) => {
+  const theme = useTheme2();
+  const styles = {
+    content: css({
+      color: theme.colors.text.secondary,
+      paddingBlock: theme.spacing(1),
+      maxHeight: '50vh',
+      overflowY: 'auto',
+    }),
+  };
+  if (!moreDetailsLink) {
+    return <></>;
+  }
+  const isValidUrl = /^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/.test(
+    moreDetailsLink
+  );
+  if (!isValidUrl) {
+    return <></>;
+  }
+  return (
+    <div className={styles.content}>
+      Click{' '}
+      <Link
+        aria-label={`More details about the error`}
+        className={'external-link'}
+        href={moreDetailsLink}
+        target="_blank"
+        rel="noreferrer"
+      >
+        here
+      </Link>{' '}
+      to learn more about this error.
+    </div>
+  );
+};
+
+AlertErrorMessage.displayName = 'AlertErrorMessage';
+
 const alertVariants = new Set(['success', 'info', 'warning', 'error']);
 const isAlertVariant = (str: string): str is AlertVariant => alertVariants.has(str);
 const getAlertVariant = (status: string): AlertVariant => {
@@ -87,6 +129,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
   const message = testingStatus?.message;
   const detailsMessage = testingStatus?.details?.message;
   const detailsVerboseMessage = testingStatus?.details?.verboseMessage;
+  const moreDetailsLink = testingStatus?.details?.moreDetailsLink;
   const onDashboardLinkClicked = () => {
     trackCreateDashboardClicked({
       grafana_version: config.buildInfo.version,
@@ -103,7 +146,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
         <Alert severity={severity} title={message} data-testid={e2eSelectors.pages.DataSource.alert}>
           {testingStatus?.details && (
             <>
-              {detailsMessage}
+              {detailsMessage ? <>{String(detailsMessage)}</> : null}
               {severity === 'success' ? (
                 <AlertSuccessMessage
                   title={message}
@@ -111,7 +154,9 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
                   dataSourceId={dataSource.uid}
                   onDashboardLinkClicked={onDashboardLinkClicked}
                 />
-              ) : null}
+              ) : (
+                <AlertErrorMessage moreDetailsLink={String(moreDetailsLink)} />
+              )}
               {detailsVerboseMessage ? (
                 <details style={{ whiteSpace: 'pre-wrap' }}>{String(detailsVerboseMessage)}</details>
               ) : null}
@@ -128,5 +173,8 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
 const getTestingStatusStyles = (theme: GrafanaTheme2) => ({
   container: css({
     paddingTop: theme.spacing(3),
+  }),
+  moreLink: css({
+    marginBlock: theme.spacing(1),
   }),
 });

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -76,11 +76,11 @@ const AlertSuccessMessage = ({ title, exploreUrl, dataSourceId, onDashboardLinkC
 
 AlertSuccessMessage.displayName = 'AlertSuccessMessage';
 
-interface AlertErrorMessageProps extends HTMLAttributes<HTMLDivElement> {
-  moreDetailsLink?: string;
+interface ErrorDetailsLinkProps extends HTMLAttributes<HTMLDivElement> {
+  errorDetailsLink?: string;
 }
 
-const AlertErrorMessage = ({ moreDetailsLink }: AlertErrorMessageProps) => {
+const ErrorDetailsLink = ({ errorDetailsLink }: ErrorDetailsLinkProps) => {
   const theme = useTheme2();
   const styles = {
     content: css({
@@ -90,11 +90,11 @@ const AlertErrorMessage = ({ moreDetailsLink }: AlertErrorMessageProps) => {
       overflowY: 'auto',
     }),
   };
-  if (!moreDetailsLink) {
+  if (!errorDetailsLink) {
     return <></>;
   }
   const isValidUrl = /^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/.test(
-    moreDetailsLink
+    errorDetailsLink
   );
   if (!isValidUrl) {
     return <></>;
@@ -106,7 +106,7 @@ const AlertErrorMessage = ({ moreDetailsLink }: AlertErrorMessageProps) => {
         <Link
           aria-label={`More details about the error`}
           className={'external-link'}
-          href={moreDetailsLink}
+          href={errorDetailsLink}
           target="_blank"
           rel="noreferrer"
         >
@@ -118,7 +118,7 @@ const AlertErrorMessage = ({ moreDetailsLink }: AlertErrorMessageProps) => {
   );
 };
 
-AlertErrorMessage.displayName = 'AlertErrorMessage';
+ErrorDetailsLink.displayName = 'ErrorDetailsLink';
 
 const alertVariants = new Set(['success', 'info', 'warning', 'error']);
 const isAlertVariant = (str: string): str is AlertVariant => alertVariants.has(str);
@@ -134,7 +134,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
   const message = testingStatus?.message;
   const detailsMessage = testingStatus?.details?.message;
   const detailsVerboseMessage = testingStatus?.details?.verboseMessage;
-  const moreDetailsLink = testingStatus?.details?.moreDetailsLink;
+  const errorDetailsLink = testingStatus?.details?.errorDetailsLink;
   const onDashboardLinkClicked = () => {
     trackCreateDashboardClicked({
       grafana_version: config.buildInfo.version,
@@ -159,9 +159,10 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
                   dataSourceId={dataSource.uid}
                   onDashboardLinkClicked={onDashboardLinkClicked}
                 />
-              ) : (
-                <AlertErrorMessage moreDetailsLink={String(moreDetailsLink)} />
-              )}
+              ) : null}
+              {severity === 'error' && errorDetailsLink ? (
+                <ErrorDetailsLink errorDetailsLink={String(errorDetailsLink)} />
+              ) : null}
               {detailsVerboseMessage ? (
                 <details style={{ whiteSpace: 'pre-wrap' }}>{String(detailsVerboseMessage)}</details>
               ) : null}

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -5,6 +5,7 @@ import { DataSourceSettings as DataSourceSettingsType, GrafanaTheme2 } from '@gr
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { TestingStatus, config } from '@grafana/runtime';
 import { AlertVariant, Alert, useTheme2, Link, useStyles2 } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
 
 import { contextSrv } from '../../../core/core';
 import { trackCreateDashboardClicked } from '../tracking';
@@ -46,27 +47,29 @@ const AlertSuccessMessage = ({ title, exploreUrl, dataSourceId, onDashboardLinkC
 
   return (
     <div className={styles.content}>
-      Next, you can start to visualize data by{' '}
-      <Link
-        aria-label={`Create a dashboard`}
-        href={`/dashboard/new-with-ds/${dataSourceId}`}
-        className="external-link"
-        onClick={onDashboardLinkClicked}
-      >
-        building a dashboard
-      </Link>
-      , or by querying data in the{' '}
-      <Link
-        aria-label={`Explore data`}
-        className={cx('external-link', {
-          [`${styles.disabled}`]: !canExploreDataSources,
-          'test-disabled': !canExploreDataSources,
-        })}
-        href={exploreUrl}
-      >
-        Explore view
-      </Link>
-      .
+      <Trans i18nKey="data-source-testing-status-page.success-more-details-links">
+        Next, you can start to visualize data by{' '}
+        <Link
+          aria-label={`Create a dashboard`}
+          href={`/dashboard/new-with-ds/${dataSourceId}`}
+          className="external-link"
+          onClick={onDashboardLinkClicked}
+        >
+          building a dashboard
+        </Link>
+        , or by querying data in the{' '}
+        <Link
+          aria-label={`Explore data`}
+          className={cx('external-link', {
+            [`${styles.disabled}`]: !canExploreDataSources,
+            'test-disabled': !canExploreDataSources,
+          })}
+          href={exploreUrl}
+        >
+          Explore view
+        </Link>
+        .
+      </Trans>
     </div>
   );
 };
@@ -98,17 +101,19 @@ const AlertErrorMessage = ({ moreDetailsLink }: AlertErrorMessageProps) => {
   }
   return (
     <div className={styles.content}>
-      Click{' '}
-      <Link
-        aria-label={`More details about the error`}
-        className={'external-link'}
-        href={moreDetailsLink}
-        target="_blank"
-        rel="noreferrer"
-      >
-        here
-      </Link>{' '}
-      to learn more about this error.
+      <Trans i18nKey="data-source-testing-status-page.error-more-details-link">
+        Click{' '}
+        <Link
+          aria-label={`More details about the error`}
+          className={'external-link'}
+          href={moreDetailsLink}
+          target="_blank"
+          rel="noreferrer"
+        >
+          here
+        </Link>{' '}
+        to learn more about this error.
+      </Trans>
     </div>
   );
 };

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -77,10 +77,10 @@ const AlertSuccessMessage = ({ title, exploreUrl, dataSourceId, onDashboardLinkC
 AlertSuccessMessage.displayName = 'AlertSuccessMessage';
 
 interface ErrorDetailsLinkProps extends HTMLAttributes<HTMLDivElement> {
-  errorDetailsLink?: string;
+  link?: string;
 }
 
-const ErrorDetailsLink = ({ errorDetailsLink }: ErrorDetailsLinkProps) => {
+const ErrorDetailsLink = ({ link }: ErrorDetailsLinkProps) => {
   const theme = useTheme2();
   const styles = {
     content: css({
@@ -90,12 +90,10 @@ const ErrorDetailsLink = ({ errorDetailsLink }: ErrorDetailsLinkProps) => {
       overflowY: 'auto',
     }),
   };
-  if (!errorDetailsLink) {
+  if (!link) {
     return <></>;
   }
-  const isValidUrl = /^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/.test(
-    errorDetailsLink
-  );
+  const isValidUrl = /^(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/.test(link);
   if (!isValidUrl) {
     return <></>;
   }
@@ -106,7 +104,7 @@ const ErrorDetailsLink = ({ errorDetailsLink }: ErrorDetailsLinkProps) => {
         <Link
           aria-label={`More details about the error`}
           className={'external-link'}
-          href={errorDetailsLink}
+          href={link}
           target="_blank"
           rel="noreferrer"
         >
@@ -160,9 +158,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
                   onDashboardLinkClicked={onDashboardLinkClicked}
                 />
               ) : null}
-              {severity === 'error' && errorDetailsLink ? (
-                <ErrorDetailsLink errorDetailsLink={String(errorDetailsLink)} />
-              ) : null}
+              {severity === 'error' && errorDetailsLink ? <ErrorDetailsLink link={String(errorDetailsLink)} /> : null}
               {detailsVerboseMessage ? (
                 <details style={{ whiteSpace: 'pre-wrap' }}>{String(detailsVerboseMessage)}</details>
               ) : null}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -869,6 +869,10 @@
     },
     "open-advanced-button": "Open advanced data source picker"
   },
+  "data-source-testing-status-page": {
+    "error-more-details-link": "Click <2>here</2> to learn more about this error.",
+    "success-more-details-links": "Next, you can start to visualize data by <2>building a dashboard</2>, or by querying data in the <5>Explore view</5>."
+  },
   "data-sources": {
     "datasource-add-button": {
       "label": "Add new data source"

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -869,6 +869,10 @@
     },
     "open-advanced-button": "Øpęŉ äđväŉčęđ đäŧä şőūřčę pįčĸęř"
   },
+  "data-source-testing-status-page": {
+    "error-more-details-link": "Cľįčĸ <2>ĥęřę</2> ŧő ľęäřŉ mőřę äþőūŧ ŧĥįş ęřřőř.",
+    "success-more-details-links": "Ńęχŧ, yőū čäŉ şŧäřŧ ŧő vįşūäľįžę đäŧä þy <2>þūįľđįŉģ ä đäşĥþőäřđ</2>, őř þy qūęřyįŉģ đäŧä įŉ ŧĥę <5>Ēχpľőřę vįęŵ</5>."
+  },
   "data-sources": {
     "datasource-add-button": {
       "label": "Åđđ ŉęŵ đäŧä şőūřčę"


### PR DESCRIPTION
**What is this feature?**

Add user friendly health check messages and help link for health check errors to MySQL data source plugin.

Also removes some unique identifiers in the error message. ( with unique strings such as ip, port, username in error message, it is hard to group the error messages in analytics )

## Before

<img width="600" alt="image" src="https://github.com/user-attachments/assets/837e4507-e94d-4e23-af4a-4353b84b5a7f">

## After

#### Network error
<img width="831" alt="image" src="https://github.com/user-attachments/assets/e9212924-2ee9-4ece-9cd3-03922bcb7788">

#### Another network error
<img width="825" alt="image" src="https://github.com/user-attachments/assets/07376884-dec4-4809-9ac2-d2e529767707">

#### Database error
<img width="742" alt="image" src="https://github.com/user-attachments/assets/203101d1-9b9a-46cd-994d-2c7446101483">

#### Error without the help link ( prometheus datasource ) 
behaviour unchanged

<img width="858" alt="image" src="https://github.com/user-attachments/assets/99b856a0-7f6c-4bae-b5fd-c6f877015082">

#### Success message
behaviour unchanged

<img width="801" alt="image" src="https://github.com/user-attachments/assets/fe5c86bd-9734-4d54-a9a4-49c3e8d5ed21">

