### PR TITLE
Chore: avoid redirect in test

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -964,6 +964,7 @@ export const versionedPages = {
     },
     org: {
       url: {
+        '10.2.0': '/admin/users',
         '9.5.0': '/org/users',
       },
     },


### PR DESCRIPTION
According to https://github.com/grafana/grafana/pull/91051 the `/org/users` was moved to `/admin/users` . There is a redirect in place, but to avoid complications, we update the test to access the correct url