### PR TITLE
Update commands.json file to route `area/backend/db/sql` to search & storage team

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -728,7 +728,7 @@
     "name": "area/backend/db/sql",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/457"
+      "url": "https://github.com/orgs/grafana/projects/599"
     }
   },
   {


### PR DESCRIPTION
The issues labeled with  `area/backend/db/sql` are routed to our big tent data sources project, but this label is not ours and the issues are not related to sql data source, but rather grafana database.  I have found that `area/backend/db/sqlite` is routed to search & storage team so I am routing this to them as well. 