### PR TITLE
Azure/GCM: Improve error display

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor-resource-handler.go
@@ -116,9 +116,13 @@ func (s *Service) getDataSourceFromHTTPReq(req *http.Request) (types.DatasourceI
 	return ds, nil
 }
 
-func writeResponse(rw http.ResponseWriter, code int, msg string) {
+func writeErrorResponse(rw http.ResponseWriter, code int, msg string) {
 	rw.WriteHeader(http.StatusBadRequest)
-	_, err := rw.Write([]byte(msg))
+	errorBody := map[string]string{
+		"error": msg,
+	}
+	json, _ := json.Marshal(errorBody)
+	_, err := rw.Write(json)
 	if err != nil {
 		backend.Logger.Error("Unable to write HTTP response", "error", err)
 	}
@@ -130,20 +134,20 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 
 		newPath, err := getTarget(req.URL.Path)
 		if err != nil {
-			writeResponse(rw, http.StatusBadRequest, err.Error())
+			writeErrorResponse(rw, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		dsInfo, err := s.getDataSourceFromHTTPReq(req)
 		if err != nil {
-			writeResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
+			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
 			return
 		}
 
 		service := dsInfo.Services[subDataSource]
 		serviceURL, err := url.Parse(service.URL)
 		if err != nil {
-			writeResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
+			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
 			return
 		}
 		req.URL.Path = newPath
@@ -152,7 +156,7 @@ func (s *Service) handleResourceReq(subDataSource string) func(rw http.ResponseW
 
 		rw, err = s.executors[subDataSource].ResourceRequest(rw, req, service.HTTPClient)
 		if err != nil {
-			writeResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
+			writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("unexpected error %v", err))
 			return
 		}
 	}

--- a/pkg/tsdb/cloud-monitoring/resource_handler.go
+++ b/pkg/tsdb/cloud-monitoring/resource_handler.go
@@ -38,13 +38,13 @@ func (s *Service) newResourceMux() *http.ServeMux {
 func (s *Service) getGCEDefaultProject(rw http.ResponseWriter, req *http.Request) {
 	project, err := s.gceDefaultProjectGetter(req.Context(), resourceManagerScope)
 	if err != nil {
-		writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err))
+		writeErrorResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err))
 		return
 	}
 
 	encoded, err := json.Marshal(project)
 	if err != nil {
-		writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("error retrieving default project %v", err))
+		writeErrorResponse(rw, http.StatusBadRequest, fmt.Sprintf("error retrieving default project %v", err))
 		return
 	}
 	writeResponseBytes(rw, http.StatusOK, encoded)
@@ -54,7 +54,7 @@ func (s *Service) handleResourceReq(subDataSource string, responseFn processResp
 	return func(rw http.ResponseWriter, req *http.Request) {
 		client, code, err := s.setRequestVariables(req, subDataSource)
 		if err != nil {
-			writeResponse(rw, code, fmt.Sprintf("unexpected error %v", err))
+			writeErrorResponse(rw, code, fmt.Sprintf("unexpected error %v", err))
 			return
 		}
 		getResources(rw, req, client, responseFn)
@@ -63,19 +63,19 @@ func (s *Service) handleResourceReq(subDataSource string, responseFn processResp
 
 func getResources(rw http.ResponseWriter, req *http.Request, cli *http.Client, responseFn processResponse) http.ResponseWriter {
 	if responseFn == nil {
-		writeResponse(rw, http.StatusInternalServerError, "responseFn should not be nil")
+		writeErrorResponse(rw, http.StatusInternalServerError, "responseFn should not be nil")
 		return rw
 	}
 
 	responses, headers, encoding, code, err := getResponses(req, cli, responseFn)
 	if err != nil {
-		writeResponse(rw, code, fmt.Sprintf("unexpected error %v", err))
+		writeErrorResponse(rw, code, fmt.Sprintf("unexpected error %v", err))
 		return rw
 	}
 
 	body, err := buildResponse(responses, encoding)
 	if err != nil {
-		writeResponse(rw, http.StatusInternalServerError, fmt.Sprintf("error formatting responose %v", err))
+		writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("error formatting responose %v", err))
 		return rw
 	}
 	writeResponseBytes(rw, code, body)
@@ -390,8 +390,12 @@ func writeResponseBytes(rw http.ResponseWriter, code int, msg []byte) {
 	}
 }
 
-func writeResponse(rw http.ResponseWriter, code int, msg string) {
-	writeResponseBytes(rw, code, []byte(msg))
+func writeErrorResponse(rw http.ResponseWriter, code int, msg string) {
+	errorBody := map[string]string{
+		"error": msg,
+	}
+	json, _ := json.Marshal(errorBody)
+	writeResponseBytes(rw, code, json)
 }
 
 func (s *Service) getDataSourceFromHTTPReq(req *http.Request) (*datasourceInfo, error) {


### PR DESCRIPTION
Currently, many errors from the resource handler endpoint lead to an uninformative error alert to the user as below:

![image](https://github.com/user-attachments/assets/f28ea800-3b3a-402e-8632-ff7abbd48048)

This is because the response is expected to be JSON whereas we typically return string values. These strings then can't be correctly parsed and throw an error in the frontend to that effect.

This change constructs a JSON object that contains the error message, allowing the underlying error to be appropriately displayed to users.

![image](https://github.com/user-attachments/assets/147c9eb5-b889-4452-a757-2bc16c6ace3c)

I've also renamed the function to make it clearer that it's handling errors and not any generic response body.