### PR TITLE
AuthZ: Introduce cloud mode

### DIFF
--- a/pkg/services/authz/README.md
+++ b/pkg/services/authz/README.md
@@ -18,7 +18,7 @@ To configure the authorization server and client, use the "authorization" sectio
 
 The `remote_address` setting, specifies the address where the authorization server is located (ex: `server.example.org:10000`). 
 
-The `mode` setting can be set to either `grpc` or `inproc`. When set to `grpc`, the client will connect to the specified address. When set to `inproc` the client will use inprocgrpc (relying on go channels) to wrap a local instantiation of the server. 
+The `mode` setting can be set to either `cloud`, `grpc` or `inproc`. When set to `cloud` (or `grpc`), the client will connect to the specified address. When set to `inproc` the client will use inprocgrpc (relying on go channels) to wrap a local instantiation of the server. 
 
 The `listen` setting determines whether the authorization server should listen for incoming requests. When set to `true`, the authorization service will be registered to the Grafana GRPC server.
 
@@ -60,7 +60,7 @@ stack_id = 11
 
 [authorization]
 remote_address = "server.example.org:10000"
-mode = "grpc"
+mode = "cloud"
 listen = false
 
 [grpc_client_authentication]

--- a/pkg/services/authz/client.go
+++ b/pkg/services/authz/client.go
@@ -58,16 +58,14 @@ func ProvideAuthZClient(
 			return nil, err
 		}
 	case ModeGRPC:
-		if cfg.StackID == "" {
-			client, err = newGrpcLegacyClient(authCfg)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			client, err = newCloudLegacyClient(authCfg)
-			if err != nil {
-				return nil, err
-			}
+		client, err = newGrpcLegacyClient(authCfg)
+		if err != nil {
+			return nil, err
+		}
+	case ModeCloud:
+		client, err = newCloudLegacyClient(authCfg)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -88,7 +86,7 @@ func ProvideStandaloneAuthZClient(
 		return nil, err
 	}
 
-	if cfg.StackID == "" {
+	if authCfg.mode == ModeGRPC {
 		return newGrpcLegacyClient(authCfg)
 	}
 	return newCloudLegacyClient(authCfg)

--- a/pkg/services/authz/config.go
+++ b/pkg/services/authz/config.go
@@ -10,13 +10,14 @@ type Mode string
 
 func (s Mode) IsValid() bool {
 	switch s {
-	case ModeGRPC, ModeInProc:
+	case ModeGRPC, ModeInProc, ModeCloud:
 		return true
 	}
 	return false
 }
 
 const (
+	ModeCloud  Mode = "cloud"
 	ModeGRPC   Mode = "grpc"
 	ModeInProc Mode = "inproc"
 )
@@ -47,7 +48,7 @@ func ReadCfg(cfg *setting.Cfg) (*Cfg, error) {
 	tokenNamespace := grpcClientAuthSection.Key("token_namespace").MustString("stacks-" + cfg.StackID)
 
 	// When running in cloud mode, the token and tokenExchangeURL are required.
-	if mode == ModeGRPC && cfg.StackID != "" {
+	if mode == ModeCloud {
 		if token == "" || tokenExchangeURL == "" {
 			return nil, fmt.Errorf("authorization:  missing token or tokenExchangeUrl")
 		}


### PR DESCRIPTION
Introduce a new mode as the stackID presence is not enough to know if we want a cloud client or a grpc client