### PR TITLE
AdminUserTable: Add some basic render tests

### DIFF
--- a/public/app/features/admin/Users/UsersTable.test.tsx
+++ b/public/app/features/admin/Users/UsersTable.test.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
 
 import { UserDTO } from '../../../types';
 
 import { UsersTable, UsersTableProps } from './UsersTable';
-import { MemoryRouter } from 'react-router-dom-v5-compat';
 
 const setup = (propOverrides?: object) => {
   const props: UsersTableProps = {

--- a/public/app/features/admin/Users/UsersTable.test.tsx
+++ b/public/app/features/admin/Users/UsersTable.test.tsx
@@ -29,7 +29,7 @@ describe('Render', () => {
     expect(() => setup()).not.toThrow();
   });
 
-  it('should render when one user has licensed role None', () => {
+  it('should render when user has licensed role None', () => {
     expect(() =>
       setup({
         users: [
@@ -42,6 +42,25 @@ describe('Render', () => {
             isGrafanaAdmin: false,
             isDisabled: false,
             licensedRole: 'None',
+          },
+        ],
+      })
+    ).not.toThrow();
+  });
+
+  it('should render when user belongs to org', () => {
+    expect(() =>
+      setup({
+        users: [
+          {
+            id: 1,
+            uid: '1',
+            login: '1',
+            email: '1',
+            name: '1',
+            isGrafanaAdmin: false,
+            isDisabled: false,
+            orgs: [{ name: 'test', url: 'test' }],
           },
         ],
       })

--- a/public/app/features/admin/Users/UsersTable.test.tsx
+++ b/public/app/features/admin/Users/UsersTable.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+
+import { UserDTO } from '../../../types';
+
+import { UsersTable, UsersTableProps } from './UsersTable';
+import { MemoryRouter } from 'react-router-dom-v5-compat';
+
+const setup = (propOverrides?: object) => {
+  const props: UsersTableProps = {
+    users: [] as UserDTO[],
+    showPaging: true,
+    totalPages: 1,
+    onChangePage: jest.fn(),
+    currentPage: 1,
+    fetchData: jest.fn(),
+  };
+
+  Object.assign(props, propOverrides);
+
+  render(
+    <MemoryRouter>
+      <UsersTable {...props} />
+    </MemoryRouter>
+  );
+};
+
+describe('Render', () => {
+  it('should render component', () => {
+    expect(() => setup()).not.toThrow();
+  });
+
+  it('should render when one user has licensed role None', () => {
+    expect(() =>
+      setup({
+        users: [
+          {
+            id: 1,
+            uid: '1',
+            login: '1',
+            email: '1',
+            name: '1',
+            isGrafanaAdmin: false,
+            isDisabled: false,
+            licensedRole: 'None',
+          },
+        ],
+      })
+    ).not.toThrow();
+  });
+});

--- a/public/app/features/admin/Users/UsersTable.tsx
+++ b/public/app/features/admin/Users/UsersTable.tsx
@@ -23,7 +23,7 @@ import { OrgUnits } from './OrgUnits';
 
 type Cell<T extends keyof UserDTO = keyof UserDTO> = CellProps<UserDTO, UserDTO[T]>;
 
-interface UsersTableProps {
+export interface UsersTableProps {
   users: UserDTO[];
   showPaging?: boolean;
   totalPages: number;


### PR DESCRIPTION
**What is this feature?**
User table was throwing an error if a user had `licensedRole = None`. This is adds 3 basic test to this table:

1. Test to render the table without any data
2. Test to render the table when at least one user has  licensedRole None (this was the issue before).
3. Test to render the table when at least one user belongs to an org.


**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
