### PR TITLE
[DOC] Remove simple configuration in Tempo data source docs

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source.md
@@ -154,21 +154,7 @@ Trace to logs can also be used with other tracing data sources, such as Jaeger a
 
 ![Trace to logs settings](/media/docs/grafana/data-sources/tempo/tempo-data-source-trace-to-logs.png)
 
-There are two ways to configure the trace to logs feature:
-
-- Use a simplified configuration with default query, or
-- Configure a custom query where you can use a [template language](ref:variable-syntax) to interpolate variables from the trace or span.
-
-### Use a simple configuration
-
-1. Select the target data source from the drop-down list.
-
-   You can also click **Open advanced data source picker** to see more options, including adding a data source.
-
-1. Set start and end time shift. As the logs timestamps may not exactly match the timestamps of the spans in trace it may be necessary to search in larger or shifted time range to find the desired logs.
-1. Select which tags to use in the logs query.
-   The tags you configure must be present in the span's attributes or resources for a trace to logs span link to appear. You can optionally configure a new name for the tag. This is useful, for example, if the tag has dots in the name and the target data source does not allow using dots in labels. In that case, you can for example remap `http.status` (the span attribute) to `http_status` (the data source field). "Data source" in this context can refer to Loki, or another log data source.
-1. Optional: If your logs consistently trace or span IDs, you can use one or both of the **Filter by trace ID** and **Filter by span ID** settings.
+You can configure a custom query where you can use a [template language](ref:variable-syntax) to interpolate variables from the trace or span.
 
 ### Configure a custom query
 
@@ -323,7 +309,9 @@ You can configure the **Hide search** setting to hide the search query option in
 
 ### TraceID query
 
-The **TraceID query** setting modifies how TraceID queries are run. The time range can be used when there are performance issues or timeouts since it will narrow down the search to the defined range. This setting is disabled by default.
+The **TraceID query** setting modifies how TraceID queries are run.
+The time range can be used when there are performance issues or timeouts since it narrows down the search to the defined range.
+This setting is disabled by default.
 
 You can configure this setting as follows:
 

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -106,7 +106,7 @@ To add a tag, follow these steps:
 
 {{% admonition type="warning" %}}
 Metrics summary API and the **Aggregate by** feature are deprecated in Grafana Cloud and Grafana 11.3 and later.
-It will be removed in a future release.
+It will be removed in a Grafana 11.5.
 {{% /admonition %}}
 
 Using **Aggregate by**, you can calculate RED metrics (total span count, percent erroring spans, and latency information) for spans of `kind=server` that match your filter criteria, grouped by one or more attributes.

--- a/docs/sources/shared/datasources/tempo-search-traceql.md
+++ b/docs/sources/shared/datasources/tempo-search-traceql.md
@@ -106,7 +106,7 @@ To add a tag, follow these steps:
 
 {{% admonition type="warning" %}}
 Metrics summary API and the **Aggregate by** feature are deprecated in Grafana Cloud and Grafana 11.3 and later.
-It will be removed in a Grafana 11.5.
+It will be removed in a future release.
 {{% /admonition %}}
 
 Using **Aggregate by**, you can calculate RED metrics (total span count, percent erroring spans, and latency information) for spans of `kind=server` that match your filter criteria, grouped by one or more attributes.


### PR DESCRIPTION
**What is this feature?**

Removes the "Simplified configuration" from the Tempo data source doc. This section is incorrect. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
