### PR TITLE
ExploreMetrics: Prefer underscores for events

### DIFF
--- a/public/app/features/trails/MetricScene.tsx
+++ b/public/app/features/trails/MetricScene.tsx
@@ -136,7 +136,7 @@ const actionViewsDefinitions: ActionViewDefinition[] = [
 if (relatedLogsFeatureEnabled) {
   actionViewsDefinitions.push({
     displayName: 'Related logs',
-    value: 'related-logs',
+    value: 'related_logs',
     getScene: buildRelatedLogsScene,
     description: 'Relevant logs based on current label filters and time range',
   });

--- a/public/app/features/trails/shared.ts
+++ b/public/app/features/trails/shared.ts
@@ -2,7 +2,7 @@ import { BusEventBase, BusEventWithPayload } from '@grafana/data';
 import { ConstantVariable, SceneObject } from '@grafana/scenes';
 import { VariableHide } from '@grafana/schema';
 
-export type ActionViewType = 'overview' | 'breakdown' | 'label-breakdown' | 'related-logs' | 'related';
+export type ActionViewType = 'overview' | 'breakdown' | 'related_logs' | 'related';
 
 export interface ActionViewDefinition {
   displayName: string;


### PR DESCRIPTION
## What's changing?

- Use `_` instead of `-` to separate words in action view types
- Remove the `'label-breakdown'` action view type, which was added in https://github.com/grafana/grafana/pull/93368 but was unused

## Why make this change?

To validate a hypothesis that hyphens are causing `metric_action_view_changed` events to not work as expected in Fullstory.