### PR TITLE
TraceQL: Further optimize autosuggest / tag completions

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -6,8 +6,7 @@ import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
 import { Scope, TempoJsonData } from '../types';
 
-import { completionItemsToSuggestions, CompletionProvider } from './autocomplete';
-import { completionItems } from './completionItems';
+import { CompletionProvider } from './autocomplete';
 import { intrinsicsV1, scopes } from './traceql';
 
 const emptyPosition = {} as monacoTypes.Position;
@@ -214,24 +213,6 @@ describe('CompletionProvider', () => {
     expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
       CompletionProvider.spansetOps.map((s) => expect.objectContaining({ label: s.label, insertText: s.insertText }))
     );
-  });
-
-  it('completionItemsToSuggestions', async () => {
-    console.time('completionItemsToSuggestions');
-    const modelValue = '{resource.name=~"vendor"} | count_over_time() by (span.)';
-    const range = {
-      startLineNumber: 1,
-      startColumn: 56,
-      endLineNumber: 1,
-      endColumn: 56,
-    };
-    const offset = 55;
-    const registerInteractionCommandId = 'DYNAMIC_1';
-
-    completionItemsToSuggestions(completionItems, range, registerInteractionCommandId, modelValue, offset);
-    console.timeEnd('completionItemsToSuggestions');
-
-    expect(1).toEqual(1);
   });
 
   it.each([

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -6,7 +6,8 @@ import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
 import { Scope, TempoJsonData } from '../types';
 
-import { CompletionProvider } from './autocomplete';
+import { completionItemsToSuggestions, CompletionProvider } from './autocomplete';
+import { completionItems } from './completionItems';
 import { intrinsicsV1, scopes } from './traceql';
 
 const emptyPosition = {} as monacoTypes.Position;
@@ -213,6 +214,24 @@ describe('CompletionProvider', () => {
     expect((result! as monacoTypes.languages.CompletionList).suggestions).toEqual(
       CompletionProvider.spansetOps.map((s) => expect.objectContaining({ label: s.label, insertText: s.insertText }))
     );
+  });
+
+  it('completionItemsToSuggestions', async () => {
+    console.time('completionItemsToSuggestions');
+    const modelValue = '{resource.name=~"vendor"} | count_over_time() by (span.)';
+    const range = {
+      startLineNumber: 1,
+      startColumn: 56,
+      endLineNumber: 1,
+      endColumn: 56,
+    };
+    const offset = 55;
+    const registerInteractionCommandId = 'DYNAMIC_1';
+
+    completionItemsToSuggestions(completionItems, range, registerInteractionCommandId, modelValue, offset);
+    console.timeEnd('completionItemsToSuggestions');
+
+    expect(1).toEqual(1);
   });
 
   it.each([

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -1,4 +1,4 @@
-import { IMarkdownString } from 'monaco-editor';
+import { IMarkdownString, languages } from 'monaco-editor';
 
 import { SelectableValue } from '@grafana/data';
 import { isFetchError } from '@grafana/runtime';
@@ -276,29 +276,13 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
     const completionItems = situation != null ? this.getCompletions(situation, this.setAlertText) : Promise.resolve([]);
 
     return completionItems.then((items) => {
-      // monaco by-default alphabetically orders the items.
-      // to stop it, we use a number-as-string sortkey,
-      // so that monaco keeps the order we use
-      const maxIndexDigits = items.length.toString().length;
-      const suggestions: monacoTypes.languages.CompletionItem[] = items.map((item, index) => {
-        const suggestion: monacoTypes.languages.CompletionItem = {
-          kind: getMonacoCompletionItemKind(item.type, this.monaco!),
-          label: item.label,
-          insertText: item.insertText,
-          insertTextRules: item.insertTextRules,
-          detail: item.detail,
-          documentation: item.documentation,
-          sortText: index.toString().padStart(maxIndexDigits, '0'), // to force the order we have
-          range,
-          command: {
-            id: this.registerInteractionCommandId || 'noOp',
-            title: 'Report Interaction',
-            arguments: [item.label, item.type],
-          },
-        };
-        fixSuggestion(suggestion, item.type, model, offset);
-        return suggestion;
-      });
+      const suggestions = completionItemsToSuggestions(
+        items,
+        range,
+        this.registerInteractionCommandId ?? undefined,
+        model.getValue(),
+        offset
+      );
       return { suggestions };
     });
   }
@@ -368,7 +352,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
       case 'SPANSET_PIPELINE_AFTER_OPERATOR':
         const functions = CompletionProvider.functions.map((key) => ({
           ...key,
-          insertTextRules: this.monaco?.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
+          insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
           type: 'FUNCTION' as const,
         }));
         const tags = this.getScopesCompletions()
@@ -435,7 +419,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
       label: key,
       insertText: (prepend || '') + key + (append || ''),
       type: 'KEYWORD',
-      insertTextRules: this.monaco?.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
+      insertTextRules: languages.CompletionItemInsertTextRule?.InsertAsSnippet,
     }));
   }
 
@@ -444,7 +428,7 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
       label: key,
       insertText: (prepend || '') + key + (append || ''),
       type: 'SCOPE',
-      insertTextRules: this.monaco?.languages.CompletionItemInsertTextRule?.InsertAsSnippet,
+      insertTextRules: languages.CompletionItemInsertTextRule?.InsertAsSnippet,
     }));
   }
 
@@ -461,23 +445,20 @@ export class CompletionProvider implements monacoTypes.languages.CompletionItemP
  * @param type
  * @param monaco
  */
-function getMonacoCompletionItemKind(
-  type: CompletionItemType,
-  monaco: Monaco
-): monacoTypes.languages.CompletionItemKind {
+function getMonacoCompletionItemKind(type: CompletionItemType): languages.CompletionItemKind {
   switch (type) {
     case 'TAG_NAME':
-      return monaco.languages.CompletionItemKind.Enum;
+      return languages.CompletionItemKind.Enum;
     case 'KEYWORD':
-      return monaco.languages.CompletionItemKind.Keyword;
+      return languages.CompletionItemKind.Keyword;
     case 'OPERATOR':
-      return monaco.languages.CompletionItemKind.Operator;
+      return languages.CompletionItemKind.Operator;
     case 'TAG_VALUE':
-      return monaco.languages.CompletionItemKind.EnumMember;
+      return languages.CompletionItemKind.EnumMember;
     case 'SCOPE':
-      return monaco.languages.CompletionItemKind.Class;
+      return languages.CompletionItemKind.Class;
     case 'FUNCTION':
-      return monaco.languages.CompletionItemKind.Function;
+      return languages.CompletionItemKind.Function;
     default:
       throw new Error(`Unexpected CompletionItemType: ${type}`);
   }
@@ -505,6 +486,41 @@ function getRangeAndOffset(monaco: Monaco, model: monacoTypes.editor.ITextModel,
   return { offset, range };
 }
 
+/** @internal */
+export function completionItemsToSuggestions(
+  items: CompletionItem[],
+  range: monacoTypes.IRange | languages.CompletionItemRanges,
+  registerInteractionCommandId = 'noOp',
+  modelValue: string,
+  offset: number
+) {
+  // monaco by-default alphabetically orders the items.
+  // to stop it, we use a number-as-string sortkey,
+  // so that monaco keeps the order we use
+  const maxIndexDigits = items.length.toString().length;
+  const suggestions: languages.CompletionItem[] = items.map((item, index) => {
+    const suggestion: languages.CompletionItem = {
+      kind: getMonacoCompletionItemKind(item.type),
+      label: item.label,
+      insertText: item.insertText,
+      insertTextRules: item.insertTextRules,
+      detail: item.detail,
+      documentation: item.documentation,
+      sortText: index.toString().padStart(maxIndexDigits, '0'), // to force the order we have
+      range,
+      command: {
+        id: registerInteractionCommandId,
+        title: 'Report Interaction',
+        arguments: [item.label, item.type],
+      },
+    };
+    fixSuggestion(suggestion, item.type, modelValue, offset);
+    return suggestion;
+  });
+
+  return suggestions;
+}
+
 /**
  * Fix the suggestions range and insert text. For the range we have to adjust because monaco by default replaces just
  * the last word which stops at dot while traceQL tags contain dots themselves and we want to replace the whole tag
@@ -515,12 +531,11 @@ function getRangeAndOffset(monaco: Monaco, model: monacoTypes.editor.ITextModel,
 function fixSuggestion(
   suggestion: monacoTypes.languages.CompletionItem,
   itemType: CompletionItemType,
-  model: monacoTypes.editor.ITextModel,
+  modelValue: string,
   offset: number
 ) {
   if (itemType === 'TAG_NAME') {
-    const match = model
-      .getValue()
+    const match = modelValue
       .substring(0, offset)
       .match(/(event\.|instrumentation\.|link\.|resource\.|span\.|\.)?([\w./-]*)$/);
 

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -517,7 +517,7 @@ function completionItemsToSuggestions(
       },
     };
 
-    if (tag != null && item.type === 'TAG_NAME') {
+    if (tag && item.type === 'TAG_NAME') {
       fixSuggestion(suggestion, offset, tag, scope);
     }
 

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -488,8 +488,7 @@ function getRangeAndOffset(monaco: Monaco, model: monacoTypes.editor.ITextModel,
 
 const SUGGEST_REGEXP = /(event\.|instrumentation\.|link\.|resource\.|span\.|\.)?([\w./-]*)$/;
 
-/** @internal */
-export function completionItemsToSuggestions(
+function completionItemsToSuggestions(
   items: CompletionItem[],
   range: monacoTypes.IRange | languages.CompletionItemRanges,
   registerInteractionCommandId = 'noOp',

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.ts
@@ -498,7 +498,7 @@ function completionItemsToSuggestions(
   // monaco by-default alphabetically orders the items.
   // to stop it, we use a number-as-string sortkey,
   // so that monaco keeps the order we use
-  const [scope, tag] = modelValue.substring(0, offset).match(SUGGEST_REGEXP) ?? [];
+  const [_, scope, tag] = modelValue.substring(0, offset).match(SUGGEST_REGEXP) ?? [];
   const maxIndexDigits = items.length.toString().length;
   const suggestions: languages.CompletionItem[] = items.map((item, index) => {
     const suggestion: languages.CompletionItem = {


### PR DESCRIPTION
after https://github.com/grafana/grafana/pull/96862, looking at the new profile on the live instance showed two more items high on the profile.

`provideCompletionItems()` did a lot of things in the items loop that could be pulled out of the loop, such as re-compiling and running a regexp for the unchanging monaco input. locally, a jest test shows a 10x+ improvement per keystroke (25ms -> 2ms). as with the previous PR, it's tricky to test thoroughly without a live environment, but this change should bring feel-able improvement.

i'm not sure if we can do anything about `fuzzyScore` since it's a monaco internal fn. maybe i'll upstream an improvement based on [uFuzzy](https://github.com/leeoniya/uFuzzy) :stuck_out_tongue_closed_eyes: 

note: might be easier to review one commit at a time.

![Screenshot_20241122_143833](https://github.com/user-attachments/assets/d21eec51-19c5-4a76-8aaf-9c4b7ef9a8e0)

![Screenshot_20241122_143615-2](https://github.com/user-attachments/assets/42ed5435-07c2-4fac-a2a1-b87967d13132)