### PR TITLE
[v9.5.x] Fixes busybox and openssl CVEs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -69,7 +69,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -120,7 +120,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -221,7 +221,7 @@ steps:
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -296,7 +296,7 @@ steps:
   name: clone-enterprise
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -383,7 +383,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -470,7 +470,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -564,7 +564,7 @@ steps:
     GF_APP_MODE: development
     GF_SERVER_HTTP_PORT: "3001"
     GF_SERVER_ROUTER_LOGGING: "1"
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: grafana-server
 - commands:
   - ./bin/build e2e-tests --port 3001 --suite dashboards-suite
@@ -687,7 +687,7 @@ steps:
   - /src/grafana-build artifacts -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --go-version=1.22.5 --ubuntu-base=ubuntu:22.04
-    --alpine-base=alpine:3.19.1 --tag-format='{{ .version_base }}-{{ .buildID }}-{{
+    --alpine-base=alpine:3.19.2 --tag-format='{{ .version_base }}-{{ .buildID }}-{{
     .arch }}' --grafana-dir=$$PWD --ubuntu-tag-format='{{ .version_base }}-{{ .buildID
     }}-ubuntu-{{ .arch }}' > docker.txt
   - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
@@ -832,7 +832,7 @@ steps:
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1004,7 +1004,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -1300,7 +1300,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -1375,7 +1375,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -1433,7 +1433,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -1486,7 +1486,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1567,7 +1567,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -1633,7 +1633,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -1726,7 +1726,7 @@ steps:
     GF_APP_MODE: development
     GF_SERVER_HTTP_PORT: "3001"
     GF_SERVER_ROUTER_LOGGING: "1"
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: grafana-server
 - commands:
   - ./bin/build e2e-tests --port 3001 --suite dashboards-suite
@@ -1885,7 +1885,7 @@ steps:
   - /src/grafana-build artifacts -a docker:grafana:linux/amd64 -a docker:grafana:linux/amd64:ubuntu
     -a docker:grafana:linux/arm64 -a docker:grafana:linux/arm64:ubuntu --yarn-cache=$$YARN_CACHE_FOLDER
     --build-id=$$DRONE_BUILD_NUMBER --go-version=1.22.5 --ubuntu-base=ubuntu:22.04
-    --alpine-base=alpine:3.19.1 --tag-format='{{ .version_base }}-{{ .buildID }}-{{
+    --alpine-base=alpine:3.19.2 --tag-format='{{ .version_base }}-{{ .buildID }}-{{
     .arch }}' --grafana-dir=$$PWD --ubuntu-tag-format='{{ .version_base }}-{{ .buildID
     }}-ubuntu-{{ .arch }}' > docker.txt
   - find ./dist -name '*docker*.tar.gz' -type f | xargs -n1 docker load -i
@@ -2092,7 +2092,7 @@ steps:
   name: compile-build-cmd
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2393,7 +2393,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -2524,7 +2524,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - mkdir -p bin
@@ -3183,7 +3183,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.19.1
+    ALPINE_BASE: alpine:3.19.2
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -3300,7 +3300,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -3356,7 +3356,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3439,7 +3439,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.19.1
+    ALPINE_BASE: alpine:3.19.2
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -3622,7 +3622,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.19.1
+    ALPINE_BASE: alpine:3.19.2
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -3724,7 +3724,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - yarn install --immutable
@@ -3778,7 +3778,7 @@ services: []
 steps:
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3859,7 +3859,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.19.1
+    ALPINE_BASE: alpine:3.19.2
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4006,7 +4006,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-    ALPINE_BASE: alpine:3.19.1
+    ALPINE_BASE: alpine:3.19.2
     CDN_DESTINATION:
       from_secret: rgm_cdn_destination
     DESTINATION:
@@ -4217,7 +4217,7 @@ steps:
   name: grabpl
 - commands:
   - echo $DRONE_RUNNER_NAME
-  image: alpine:3.19.1
+  image: alpine:3.19.2
   name: identify-runner
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4697,7 +4697,7 @@ steps:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:18.12.0-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM grafana/grafana-ci-deploy:1.3.3
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.19.1
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine:3.19.2
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM ubuntu:22.04
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM byrnedo/alpine-curl:0.1.8
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM plugins/slack
@@ -4733,7 +4733,7 @@ steps:
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:18.12.0-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
   - trivy --exit-code 1 --severity HIGH,CRITICAL grafana/grafana-ci-deploy:1.3.3
-  - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.19.1
+  - trivy --exit-code 1 --severity HIGH,CRITICAL alpine:3.19.2
   - trivy --exit-code 1 --severity HIGH,CRITICAL ubuntu:22.04
   - trivy --exit-code 1 --severity HIGH,CRITICAL byrnedo/alpine-curl:0.1.8
   - trivy --exit-code 1 --severity HIGH,CRITICAL plugins/slack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=alpine:3.19.1
+ARG BASE_IMAGE=alpine:3.19.2
 ARG JS_IMAGE=node:18-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GO_IMAGE=golang:1.21.10-alpine

--- a/scripts/drone/utils/images.star
+++ b/scripts/drone/utils/images.star
@@ -15,7 +15,7 @@ images = {
     "node": "node:{}-alpine".format(nodejs_version),
     "cloudsdk": "google/cloud-sdk:431.0.0",
     "publish": "grafana/grafana-ci-deploy:1.3.3",
-    "alpine": "alpine:3.19.1",
+    "alpine": "alpine:3.19.2",
     "ubuntu": "ubuntu:22.04",
     "curl": "byrnedo/alpine-curl:0.1.8",
     "plugins_slack": "plugins/slack",


### PR DESCRIPTION
Update alpine version to fix some image scanning errors

OPENSSL

[CVE-2024-2511](https://security.alpinelinux.org/vuln/CVE-2024-2511)
[CVE-2024-4603](https://security.alpinelinux.org/vuln/CVE-2024-4603)
BUSYBOX

[CVE-2023-42363](https://security.alpinelinux.org/vuln/CVE-2023-42363)
[CVE-2023-42364](https://security.alpinelinux.org/vuln/CVE-2023-42364)
[CVE-2023-42365](https://security.alpinelinux.org/vuln/CVE-2023-42365)
[CVE-2023-42366](https://security.alpinelinux.org/vuln/CVE-2023-42366)

https://alpinelinux.org/posts/Alpine-3.17.8-3.18.7-3.19.2-released.html

