### PR TITLE
POC/Provisioning: Include the ref parameter everywhere

### DIFF
--- a/pkg/registry/apis/provisioning/export.go
+++ b/pkg/registry/apis/provisioning/export.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"path/filepath"
 
-	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
-	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 	"gopkg.in/yaml.v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +16,9 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/dynamic"
+
+	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
+	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 )
 
 type exportConnector struct {
@@ -147,7 +148,7 @@ func (c *exportConnector) Connect(
 
 			fileName := filepath.Join(folder.CreatePath(), baseFileName)
 			// TODO: Upsert
-			if err := repo.Create(ctx, fileName, marshalledBody, "export of dashboard "+name+" in namespace "+ns); err != nil {
+			if err := repo.Create(ctx, fileName, "", marshalledBody, "export of dashboard "+name+" in namespace "+ns); err != nil {
 				slog.ErrorContext(ctx, "failed to write dashboard model to repository",
 					"err", err,
 					"repository", repo.Config().GetName(),

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -191,9 +191,9 @@ func (s *filesConnector) doWrite(ctx context.Context, update bool, repo Reposito
 	}
 
 	if update {
-		err = repo.Update(ctx, path, data, message)
+		err = repo.Update(ctx, path, ref, data, message)
 	} else {
-		err = repo.Create(ctx, path, data, message)
+		err = repo.Create(ctx, path, ref, data, message)
 	}
 	if err != nil {
 		return nil, err
@@ -226,7 +226,7 @@ func (s *filesConnector) doDelete(ctx context.Context, repo Repository, path str
 		return nil, apierrors.NewForbidden(provisioning.RepositoryResourceInfo.GroupResource(), "deleting is not supported", nil)
 	}
 
-	err := repo.Delete(ctx, path, message)
+	err := repo.Delete(ctx, path, ref, message)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apis/provisioning/github.go
+++ b/pkg/registry/apis/provisioning/github.go
@@ -124,7 +124,7 @@ func (r *githubRepository) Read(ctx context.Context, filePath string, ref string
 	}, nil
 }
 
-func (r *githubRepository) Create(ctx context.Context, path string, data []byte, comment string) error {
+func (r *githubRepository) Create(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	if _, _, err := r.githubClient.Repositories.CreateFile(ctx, r.config.Spec.GitHub.Owner, r.config.Spec.GitHub.Repository, path, &github.RepositoryContentFileOptions{
 		Message: github.String(comment),
 		Content: data,
@@ -146,7 +146,7 @@ func (r *githubRepository) Create(ctx context.Context, path string, data []byte,
 	return nil
 }
 
-func (r *githubRepository) Update(ctx context.Context, path string, data []byte, comment string) error {
+func (r *githubRepository) Update(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	file, _, _, err := r.githubClient.Repositories.GetContents(ctx, r.config.Spec.GitHub.Owner, r.config.Spec.GitHub.Repository, path, &github.RepositoryContentGetOptions{
 		Ref: r.config.Spec.GitHub.Branch,
 	})
@@ -177,7 +177,7 @@ func (r *githubRepository) Update(ctx context.Context, path string, data []byte,
 	return nil
 }
 
-func (r *githubRepository) Delete(ctx context.Context, path string, comment string) error {
+func (r *githubRepository) Delete(ctx context.Context, path string, ref string, comment string) error {
 	file, _, _, err := r.githubClient.Repositories.GetContents(ctx, r.config.Spec.GitHub.Owner, r.config.Spec.GitHub.Repository, path, &github.RepositoryContentGetOptions{
 		Ref: r.config.Spec.GitHub.Branch,
 	})

--- a/pkg/registry/apis/provisioning/local.go
+++ b/pkg/registry/apis/provisioning/local.go
@@ -150,7 +150,7 @@ func (r *localRepository) Read(ctx context.Context, path string, ref string) (*F
 	}, nil
 }
 
-func (r *localRepository) Create(ctx context.Context, path string, data []byte, comment string) error {
+func (r *localRepository) Create(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	if r.path == "" {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{
@@ -170,7 +170,7 @@ func (r *localRepository) Create(ctx context.Context, path string, data []byte, 
 	return fmt.Errorf("file already exists")
 }
 
-func (r *localRepository) Update(ctx context.Context, path string, data []byte, comment string) error {
+func (r *localRepository) Update(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	if r.path == "" {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{
@@ -187,7 +187,7 @@ func (r *localRepository) Update(ctx context.Context, path string, data []byte, 
 	return os.WriteFile(path, data, 0600)
 }
 
-func (r *localRepository) Delete(ctx context.Context, path string, comment string) error {
+func (r *localRepository) Delete(ctx context.Context, path string, ref string, comment string) error {
 	if r.path == "" {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{

--- a/pkg/registry/apis/provisioning/s3.go
+++ b/pkg/registry/apis/provisioning/s3.go
@@ -60,7 +60,7 @@ func (r *s3Repository) Read(ctx context.Context, path string, ref string) (*File
 	}
 }
 
-func (r *s3Repository) Create(ctx context.Context, path string, data []byte, comment string) error {
+func (r *s3Repository) Create(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "write file is not yet implemented",
@@ -69,7 +69,7 @@ func (r *s3Repository) Create(ctx context.Context, path string, data []byte, com
 	}
 }
 
-func (r *s3Repository) Update(ctx context.Context, path string, data []byte, comment string) error {
+func (r *s3Repository) Update(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "write file is not yet implemented",
@@ -78,7 +78,7 @@ func (r *s3Repository) Update(ctx context.Context, path string, data []byte, com
 	}
 }
 
-func (r *s3Repository) Delete(ctx context.Context, path string, comment string) error {
+func (r *s3Repository) Delete(ctx context.Context, path string, ref string, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "delete file not yet implemented",

--- a/pkg/registry/apis/provisioning/types.go
+++ b/pkg/registry/apis/provisioning/types.go
@@ -60,14 +60,14 @@ type Repository interface {
 
 	// Write a file to the repository.
 	// The data has already been validated and is ready for save
-	Create(ctx context.Context, path string, data []byte, comment string) error
+	Create(ctx context.Context, path string, ref string, data []byte, comment string) error
 
 	// Update a file in the remote repository
 	// The data has already been validated and is ready for save
-	Update(ctx context.Context, path string, data []byte, comment string) error
+	Update(ctx context.Context, path string, ref string, data []byte, comment string) error
 
 	// Delete a file in the remote repository
-	Delete(ctx context.Context, path string, comment string) error
+	Delete(ctx context.Context, path string, ref string, comment string) error
 
 	// For repositories that support webhooks
 	Webhook(responder rest.Responder) http.HandlerFunc
@@ -120,7 +120,7 @@ func (r *unknownRepository) Read(ctx context.Context, path string, ref string) (
 	}
 }
 
-func (r *unknownRepository) Create(ctx context.Context, path string, data []byte, comment string) error {
+func (r *unknownRepository) Create(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "write file is not yet implemented",
@@ -129,7 +129,7 @@ func (r *unknownRepository) Create(ctx context.Context, path string, data []byte
 	}
 }
 
-func (r *unknownRepository) Update(ctx context.Context, path string, data []byte, comment string) error {
+func (r *unknownRepository) Update(ctx context.Context, path string, ref string, data []byte, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "write file is not yet implemented",
@@ -138,7 +138,7 @@ func (r *unknownRepository) Update(ctx context.Context, path string, data []byte
 	}
 }
 
-func (r *unknownRepository) Delete(ctx context.Context, path string, comment string) error {
+func (r *unknownRepository) Delete(ctx context.Context, path string, ref string, comment string) error {
 	return &errors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: "delete file not yet implemented",


### PR DESCRIPTION
Read already has "ref", this PR adds it to Create, Update, and Delete

This should simplify supporting something like https://github.com/grafana/grafana/pull/96783
