### PR TITLE
docs: Fix `Pending period` description in alerting page

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useFormContext, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Input, Select, useStyles2 } from '@grafana/ui';
@@ -27,7 +27,7 @@ export const CloudEvaluationBehavior = () => {
     <RuleEditorSection stepNo={3} title="Set evaluation behavior">
       <Field
         label="Pending period"
-        description='The period in which the threshold condition must be met. Selecting "None" triggers the alert immediately once the condition is met.'
+        description='Period during which the threshold condition must be met to trigger an alert. Selecting "None" triggers the alert immediately once the condition is met.'
       >
         <div className={styles.flexRow}>
           <Field invalid={!!errors.forTime?.message} error={errors.forTime?.message} className={styles.inlineField}>

--- a/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CloudEvaluationBehavior.tsx
@@ -27,7 +27,7 @@ export const CloudEvaluationBehavior = () => {
     <RuleEditorSection stepNo={3} title="Set evaluation behavior">
       <Field
         label="Pending period"
-        description='Period the threshold condition must be met to trigger the alert. Selecting "None" triggers the alert immediately once the condition is met.'
+        description='The period in which the threshold condition must be met. Selecting "None" triggers the alert immediately once the condition is met.'
       >
         <div className={styles.flexRow}>
           <Field invalid={!!errors.forTime?.message} error={errors.forTime?.message} className={styles.inlineField}>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -603,7 +603,7 @@ export function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
         label={
           <Label
             htmlFor={evaluateForId}
-            description='Period the threshold condition must be met to trigger the alert. Selecting "None" triggers the alert immediately once the condition is met.'
+            description='The period in which the threshold condition must be met. Selecting "None" triggers the alert immediately once the condition is met.'
           >
             <Trans i18nKey="alerting.rule-form.evaluation-behaviour.pending-period">Pending period</Trans>
           </Label>

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -603,7 +603,7 @@ export function ForInput({ evaluateEvery }: { evaluateEvery: string }) {
         label={
           <Label
             htmlFor={evaluateForId}
-            description='The period in which the threshold condition must be met. Selecting "None" triggers the alert immediately once the condition is met.'
+            description='Period during which the threshold condition must be met to trigger an alert. Selecting "None" triggers the alert immediately once the condition is met.'
           >
             <Trans i18nKey="alerting.rule-form.evaluation-behaviour.pending-period">Pending period</Trans>
           </Label>


### PR DESCRIPTION
**What is this feature?**

Fixes `Pending period` description in the alerting page.

**Why do we need this feature?**

The way the description stands now is difficult to understand and should be rewarded.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

