### PR TITLE
Loki query option: fix step validation

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -123,8 +123,9 @@ describe('LokiQueryBuilderOptions', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows correct options for metric query with invalid step', async () => {
-    setup({ expr: 'rate({foo="bar"}[5m]', step: 'abc' });
+  it.each(['abc', 10])('shows correct options for metric query with invalid step', async (step: string | number) => {
+    // @ts-expect-error Expected for backward compatibility test
+    setup({ expr: 'rate({foo="bar"}[5m]', step });
     expect(screen.queryByText('Line limit: 20')).not.toBeInTheDocument();
     expect(screen.getByText('Type: Range')).toBeInTheDocument();
     expect(screen.getByText('Step: Invalid value')).toBeInTheDocument();

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -102,13 +102,13 @@ describe('LokiQueryBuilderOptions', () => {
     expect(screen.queryByText(/Direction/)).not.toBeInTheDocument();
   });
 
-  it('does not shows resolution field if resolution is not set', async () => {
+  it('does not show resolution field if resolution is not set', async () => {
     setup({ expr: 'rate({foo="bar"}[5m]' });
     await userEvent.click(screen.getByRole('button', { name: /Options/ }));
     expect(screen.queryByText('Resolution')).not.toBeInTheDocument();
   });
 
-  it('does not shows resolution field if resolution is set to default value 1', async () => {
+  it('does not show resolution field if resolution is set to default value 1', async () => {
     setup({ expr: 'rate({foo="bar"}[5m]', resolution: 1 });
     await userEvent.click(screen.getByRole('button', { name: /Options/ }));
     expect(screen.queryByText('Resolution')).not.toBeInTheDocument();
@@ -137,19 +137,19 @@ describe('LokiQueryBuilderOptions', () => {
     expect(screen.getByText(/Invalid step/)).toBeInTheDocument();
   });
 
-  it('does not shows error when valid value in step', async () => {
+  it('does not show error when valid value in step', async () => {
     setup({ expr: 'rate({foo="bar"}[5m]', step: '1m' });
     await userEvent.click(screen.getByRole('button', { name: /Options/ }));
     expect(screen.queryByText(/Invalid step/)).not.toBeInTheDocument();
   });
 
-  it('does not shows error when valid millisecond value in step', async () => {
+  it('does not show error when valid millisecond value in step', async () => {
     setup({ expr: 'rate({foo="bar"}[5m]', step: '1ms' });
     await userEvent.click(screen.getByRole('button', { name: /Options/ }));
     expect(screen.queryByText(/Invalid step/)).not.toBeInTheDocument();
   });
 
-  it('does not shows error when valid day value in step', async () => {
+  it('does not show error when valid day value in step', async () => {
     setup({ expr: 'rate({foo="bar"}[5m]', step: '1d' });
     await userEvent.click(screen.getByRole('button', { name: /Options/ }));
     expect(screen.queryByText(/Invalid step/)).not.toBeInTheDocument();
@@ -164,6 +164,14 @@ describe('LokiQueryBuilderOptions', () => {
     setup({ expr: '{foo="bar"}', step: '1m' });
     await userEvent.click(screen.getByRole('button', { name: /Options/ }));
     expect(screen.queryByText(/Instant/)).not.toBeInTheDocument();
+  });
+
+  it('allows to clear step input', async () => {
+    setup({ expr: 'rate({foo="bar"}[5m]', step: '4s' });
+    await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+    expect(screen.getByDisplayValue('4s')).toBeInTheDocument();
+    await userEvent.clear(screen.getByDisplayValue('4s'));
+    expect(screen.queryByDisplayValue('4s')).not.toBeInTheDocument();
   });
 });
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -173,9 +173,20 @@ describe('LokiQueryBuilderOptions', () => {
     await userEvent.clear(screen.getByDisplayValue('4s'));
     expect(screen.queryByDisplayValue('4s')).not.toBeInTheDocument();
   });
+
+  it('should transform non duration numbers to duration', async () => {
+    const onChange = jest.fn();
+    setup({ expr: 'rate({foo="bar"}[5m]', step: '4' }, onChange);
+    await userEvent.click(screen.getByRole('button', { name: /Options/ }));
+    expect(onChange).toHaveBeenCalledWith({
+      refId: 'A',
+      expr: 'rate({foo="bar"}[5m]',
+      step: '4s',
+    });
+  });
 });
 
-function setup(queryOverrides: Partial<LokiQuery> = {}) {
+function setup(queryOverrides: Partial<LokiQuery> = {}, onChange = jest.fn()) {
   const props = {
     query: {
       refId: 'A',
@@ -183,7 +194,7 @@ function setup(queryOverrides: Partial<LokiQuery> = {}) {
       ...queryOverrides,
     },
     onRunQuery: jest.fn(),
-    onChange: jest.fn(),
+    onChange,
     maxLines: 20,
     queryStats: { streams: 0, chunks: 0, bytes: 0, entries: 0 },
   };

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -93,10 +93,10 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
     }
 
     const isValidStep = useMemo(() => {
-      if (!query.step || isValidGrafanaDuration(query.step) || !isNaN(Number(query.step))) {
+      if (!query.step) {
         return true;
       }
-      return false;
+      return typeof query.step === 'string' && isValidGrafanaDuration(query.step) && !isNaN(parseInt(query.step, 10));
     }, [query.step]);
 
     return (

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -1,5 +1,5 @@
 import { trim } from 'lodash';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 
 import { CoreApp, isValidDuration, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
@@ -29,6 +29,15 @@ export interface Props {
 export const LokiQueryBuilderOptions = React.memo<Props>(
   ({ app, query, onChange, onRunQuery, maxLines, queryStats }) => {
     const [splitDurationValid, setSplitDurationValid] = useState(true);
+
+    useEffect(() => {
+      if (query.step && !isValidGrafanaDuration(`${query.step}`) && parseInt(query.step, 10)) {
+        onChange({
+          ...query,
+          step: `${parseInt(query.step, 10)}s`,
+        });
+      }
+    }, [onChange, query]);
 
     const onQueryTypeChange = (value: LokiQueryType) => {
       onChange({ ...query, queryType: value });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -152,7 +152,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
                   className="width-6"
                   placeholder={'auto'}
                   type="string"
-                  defaultValue={query.step ?? ''}
+                  value={query.step ?? ''}
                   onCommitChange={onStepChange}
                 />
               </EditorField>


### PR DESCRIPTION
Fixes #92574 

The step validation was improperly implemented and throwed when numeric steps were used.

![Invalid](https://github.com/user-attachments/assets/e0660b8f-73f3-4499-b958-490123f35467)

![Validation](https://github.com/user-attachments/assets/d805322e-bcf4-4de2-986e-a6dbfcc93d8a)

![Valid](https://github.com/user-attachments/assets/dd06932b-3846-467b-96ad-973d0cf939e3)

![Invalid again](https://github.com/user-attachments/assets/48704d15-dd93-4c8d-b7e6-16b515de059a)

To better reproduce the bug, follow the instructions in the reported issue and assign a numeric step in the json editor.

Additionally, fixes a bug that prevented the input to be cleared. Regression test:

![regression](https://github.com/user-attachments/assets/14717b44-10d8-43e8-92d2-d0675e9b9e14)
