### PR TITLE
POC/Provisioning: Add ref+message to openapi

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -482,28 +482,45 @@ func (b *ProvisioningAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.
 	// update the version with a path
 	sub = oas.Paths.Paths[repoprefix+"/files/{path}"]
 	if sub != nil {
-		sub.Get.Description = "Read value from upstream repository"
-		sub.Get.Parameters = []*spec3.Parameter{
-			{
-				ParameterProps: spec3.ParameterProps{
-					Name:        "commit",
-					In:          "query",
-					Example:     "ca171cc730",
-					Description: "optional commit hash for the requested file",
-					Schema:      spec.StringProperty(),
-					Required:    false,
+		ref := &spec3.Parameter{
+			ParameterProps: spec3.ParameterProps{
+				Name:    "ref",
+				In:      "query",
+				Example: "",
+				Examples: map[string]*spec3.Example{
+					"": {
+						ExampleProps: spec3.ExampleProps{
+							Summary: "The default",
+						},
+					},
+					"branch": {
+						ExampleProps: spec3.ExampleProps{
+							Value:   "my-branch",
+							Summary: "Select branch",
+						},
+					},
+					"commit": {
+						ExampleProps: spec3.ExampleProps{
+							Value:   "7f7cc2153",
+							Summary: "Commit hash (or prefix)",
+						},
+					},
 				},
-			},
-		}
+				Description: "optional branch or commit hash",
+				Schema:      spec.StringProperty(),
+				Required:    false,
+			}}
+
+		sub.Get.Description = "Read value from upstream repository"
+		sub.Get.Parameters = []*spec3.Parameter{ref}
 
 		// Add message to the OpenAPI spec
-		comment := []*spec3.Parameter{
+		comment := []*spec3.Parameter{ref,
 			{
 				ParameterProps: spec3.ParameterProps{
 					Name:        "message",
 					In:          "query",
-					Example:     "My commit message",
-					Description: "for git properties this will be in the commit message",
+					Description: "optional message sent with any changes",
 					Schema:      spec.StringProperty(),
 					Required:    false,
 				},

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -5,10 +5,11 @@ import (
 	"io/fs"
 	"net/http"
 
-	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
+
+	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
 )
 
 var ErrFileNotFound error = fs.ErrNotExist
@@ -57,14 +58,14 @@ type Repository interface {
 
 	// Write a file to the repository.
 	// The data has already been validated and is ready for save
-	Create(ctx context.Context, path, ref string, data []byte, comment string) error
+	Create(ctx context.Context, path, ref string, data []byte, message string) error
 
 	// Update a file in the remote repository
 	// The data has already been validated and is ready for save
-	Update(ctx context.Context, path, ref string, data []byte, comment string) error
+	Update(ctx context.Context, path, ref string, data []byte, message string) error
 
 	// Delete a file in the remote repository
-	Delete(ctx context.Context, path, ref, comment string) error
+	Delete(ctx context.Context, path, ref, message string) error
 
 	// For repositories that support webhooks
 	Webhook(responder rest.Responder) http.HandlerFunc


### PR DESCRIPTION
The frontend client requires openapi to have the right parameters:
<img width="861" alt="image" src="https://github.com/user-attachments/assets/7b857741-4539-413d-80d5-d3c8a15809b3">

