### PR TITLE
Caching: Delete caching before delete provisioning 

### DIFF
--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -508,12 +508,15 @@ func TestDatasourceCachingConfig(t *testing.T) {
 		correlationsStore := &mockCorrelationsStore{}
 		dc := newDatasourceProvisioner(store, correlationsStore, orgFake)
 
-		resCachingConfigs, err := dc.getCachingConfigs(context.Background(), cacheEnabledConfig)
+		resDeleteCachingConfigs, err := dc.getDeleteCachingConfigs(context.Background(), cacheEnabledConfig)
 		require.NoError(t, err)
-		require.NotNil(t, resCachingConfigs)
+		require.NotNil(t, resDeleteCachingConfigs)
+		resCreateCachingConfigs, err := dc.getCreateCachingConfigs(context.Background(), cacheEnabledConfig)
+		require.NoError(t, err)
+		require.NotNil(t, resDeleteCachingConfigs)
 
-		require.Equal(t, len(resCachingConfigs.DeleteDatasourceUIDs), len(expectedDatasourceUIDs))
-		require.ElementsMatch(t, resCachingConfigs.DatasourceCachingConfigs, expectedConfigs)
+		require.Equal(t, len(resDeleteCachingConfigs), len(expectedDatasourceUIDs))
+		require.ElementsMatch(t, resCreateCachingConfigs, expectedConfigs)
 	})
 
 	t.Run("get datasource caching config with missing caching", func(t *testing.T) {
@@ -536,12 +539,15 @@ func TestDatasourceCachingConfig(t *testing.T) {
 		correlationsStore := &mockCorrelationsStore{}
 		dc := newDatasourceProvisioner(store, correlationsStore, orgFake)
 
-		resCachingConfigs, err := dc.getCachingConfigs(context.Background(), cacheDisabledConfig)
+		resDeleteCachingConfigs, err := dc.getDeleteCachingConfigs(context.Background(), cacheDisabledConfig)
 		require.NoError(t, err)
-		require.NotNil(t, resCachingConfigs)
+		require.NotNil(t, resDeleteCachingConfigs)
+		resCreateCachingConfigs, err := dc.getCreateCachingConfigs(context.Background(), cacheDisabledConfig)
+		require.NoError(t, err)
+		require.NotNil(t, resCreateCachingConfigs)
 
-		require.Equal(t, len(resCachingConfigs.DeleteDatasourceUIDs), len(expectedDatasourceUIDs))
-		require.ElementsMatch(t, resCachingConfigs.DatasourceCachingConfigs, expectedConfigs)
+		require.Equal(t, len(resDeleteCachingConfigs), len(expectedDatasourceUIDs))
+		require.ElementsMatch(t, resCreateCachingConfigs, expectedConfigs)
 	})
 }
 

--- a/pkg/services/provisioning/provisioning_mock.go
+++ b/pkg/services/provisioning/provisioning_mock.go
@@ -15,7 +15,8 @@ type Calls struct {
 	GetDashboardProvisionerResolvedPath []any
 	GetAllowUIUpdatesFromConfig         []any
 	Run                                 []any
-	GetCachingConfigs                   []any
+	GetCachingDeleteConfigs             []any
+	GetCachingCreateConfigs             []any
 }
 
 type ProvisioningServiceMock struct {
@@ -27,7 +28,8 @@ type ProvisioningServiceMock struct {
 	GetDashboardProvisionerResolvedPathFunc func(name string) string
 	GetAllowUIUpdatesFromConfigFunc         func(name string) bool
 	RunFunc                                 func(ctx context.Context) error
-	GetCachingConfigsFunc                   func(ctx context.Context) (*datasources.DatasourceCachingInfo, error)
+	GetCachingDeleteConfigsFunc             func(ctx context.Context) ([]string, error)
+	GetCachingCreateConfigsFunc             func(ctx context.Context) ([]datasources.DatasourceCachingConfig, error)
 }
 
 func NewProvisioningServiceMock(ctx context.Context) *ProvisioningServiceMock {
@@ -97,10 +99,18 @@ func (mock *ProvisioningServiceMock) Run(ctx context.Context) error {
 	return nil
 }
 
-func (mock *ProvisioningServiceMock) GetCachingConfigs(ctx context.Context) (*datasources.DatasourceCachingInfo, error) {
-	mock.Calls.GetCachingConfigs = append(mock.Calls.GetCachingConfigs, nil)
-	if mock.GetCachingConfigsFunc != nil {
-		return mock.GetCachingConfigsFunc(ctx)
+func (mock *ProvisioningServiceMock) GetCachingDeleteConfigs(ctx context.Context) ([]string, error) {
+	mock.Calls.GetCachingDeleteConfigs = append(mock.Calls.GetCachingDeleteConfigs, nil)
+	if mock.GetCachingDeleteConfigsFunc != nil {
+		return mock.GetCachingDeleteConfigsFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (mock *ProvisioningServiceMock) GetCachingCreateConfigs(ctx context.Context) ([]datasources.DatasourceCachingConfig, error) {
+	mock.Calls.GetCachingCreateConfigs = append(mock.Calls.GetCachingCreateConfigs, nil)
+	if mock.GetCachingCreateConfigsFunc != nil {
+		return mock.GetCachingCreateConfigsFunc(ctx)
 	}
 	return nil, nil
 }

--- a/pkg/services/provisioning/values/values.go
+++ b/pkg/services/provisioning/values/values.go
@@ -366,10 +366,6 @@ func (val *DurationMsValue) UnmarshalYAML(unmarshal func(interface{}) error) err
 		// To keep the same behaviour as the yaml lib which just does not set the value if it is empty.
 		return nil
 	}
-	// if interpolated.value == "" {
-	// 	// To keep the same behaviour as the yaml lib which just does not set the value if it is empty.
-	// 	return nil
-	// }
 	val.Raw = interpolated.raw
 
 	duration, err := time.ParseDuration(interpolated.value)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Separate obtaining caching config into two methods, one to get the datasources ids for deletion and one to obtain caching configs of the new datasources.

**Why do we need this feature?**

Caching needs to be deleted before OSS provisioning happens, therefore this work separates the caching provisioning into two actions.

**Who is this feature for?**

Enterprise and Grafana cloud customers.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/4663

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Enterprise PR https://github.com/grafana/grafana-enterprise/pull/7598

Enterprise main caching PR: https://github.com/grafana/grafana-enterprise/pull/7524
OSS main caching PR https://github.com/grafana/grafana/pull/96397
