### PR TITLE
POC/Provisioning:  Support rendering from a nested path 

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -21,7 +21,8 @@ export interface Props
 
 export function DashboardScenePage({ route, queryParams, location }: Props) {
   const params = useParams();
-  const { type, slug, uid, path } = params;
+  const { type, slug, uid } = params;
+  const path = params['*'];
   const prevMatch = usePrevious({ params });
   const stateManager = getDashboardScenePageStateManager();
   const { dashboard, isLoading, loadError } = stateManager.useState();
@@ -31,9 +32,15 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   useEffect(() => {
     if (route.routeName === DashboardRoutes.Normal && type === 'snapshot') {
       stateManager.loadSnapshot(slug!);
+    } if (route.routeName === DashboardRoutes.Provisioning) {
+      stateManager.loadDashboard({
+        uid: path ?? '', // the * parameter
+        slug: slug,
+        route: route.routeName as DashboardRoutes,
+      });
     } else {
       stateManager.loadDashboard({
-        uid: path ?? uid ?? '',
+        uid: uid ?? '',
         slug: slug,
         route: route.routeName as DashboardRoutes,
         urlFolderUid: queryParams.folderUid,

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -64,7 +64,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
-      path: '/dashboard/provisioning/:slug/:path/*',
+      path: '/admin/provisioning/:slug/dashboard/*',
       pageClass: 'page-dashboard',
       routeName: DashboardRoutes.Provisioning,
       component: SafeDynamicImport(


### PR DESCRIPTION
The dashboard render from repo currently only works when the file is at the root 😢 

This updates the path so we can see nested files 🎉 