### PR TITLE
POC: Open GitHub PR from dashboard drawer

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboard.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboard.tsx
@@ -127,7 +127,7 @@ export function SaveProvisionedDashboard({ meta, drawer, changeInfo, dashboard }
             Cancel
           </Button>
           {isGitHub && (
-            <LinkButton variant="secondary" href={href} fill="outline">
+            <LinkButton variant="secondary" href={href} fill="outline" target={'_blank'} rel={'noreferrer noopener'}>
               Open pull request
             </LinkButton>
           )}

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboard.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboard.tsx
@@ -104,7 +104,7 @@ export function SaveProvisionedDashboard({ meta, drawer, changeInfo, dashboard }
         </Field>
 
         {isGitHub && (
-          <Field label="Branch" description="Only supported by GitHub right now">
+          <Field label="Branch" description="Branch name in GitHub">
             <Input {...register('ref')} />
           </Field>
         )}

--- a/public/app/features/provisioning/api/types.ts
+++ b/public/app/features/provisioning/api/types.ts
@@ -6,6 +6,7 @@ export type GitHubRepositoryConfig = {
   owner: string;
   repository: string;
   token?: string;
+  branch?: string;
 };
 
 export type LocalRepositoryConfig = {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a button to open a GH PR when saving dashboard. 

![Screenshot 2024-11-25 at 18 04 14](https://github.com/user-attachments/assets/a0f4fa81-757e-4e47-99c4-abbaf71dff27)

