### PR TITLE
Logs Panel: Allow text selection without changing Log Details state

### DIFF
--- a/public/app/features/logs/components/LogRows.test.tsx
+++ b/public/app/features/logs/components/LogRows.test.tsx
@@ -275,4 +275,26 @@ describe('Popover menu', () => {
     expect(onClickFilterOutString).toHaveBeenCalledTimes(1);
     expect(onClickFilterString).toHaveBeenCalledTimes(1);
   });
+  describe('Interacting with log details', () => {
+    it('Allows text selection even if the popover menu is not available', async () => {
+      setup({
+        onClickFilterOutString: undefined,
+        onClickFilterString: undefined,
+      });
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+      expect(screen.queryByText(/details/)).not.toBeInTheDocument();
+    });
+
+    it('Displays Log Details if there is no text selection', async () => {
+      jest.spyOn(document, 'getSelection').mockReturnValue(null);
+      setup({
+        onClickFilterOutString: undefined,
+        onClickFilterString: undefined,
+      });
+      await userEvent.click(screen.getByText('log message 1'));
+      expect(screen.queryByText('Copy selection')).not.toBeInTheDocument();
+      expect(screen.getByText(/details/)).toBeInTheDocument();
+    });
+  });
 });

--- a/public/app/features/logs/components/LogRows.tsx
+++ b/public/app/features/logs/components/LogRows.tsx
@@ -115,13 +115,15 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   }
 
   handleSelection = (e: MouseEvent<HTMLTableRowElement>, row: LogRowModel): boolean => {
-    if (this.popoverMenuSupported() === false) {
-      return false;
-    }
     const selection = document.getSelection()?.toString();
     if (!selection) {
       return false;
     }
+    if (this.popoverMenuSupported() === false) {
+      // This signals onRowClick inside LogRow to skip the event because the user is selecting text
+      return selection ? true : false;
+    }
+
     if (!this.logRowsRef.current) {
       return false;
     }
@@ -247,7 +249,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                   pinLineButtonTooltipTitle={this.props.pinLineButtonTooltipTitle}
                   pinned={this.props.pinnedRowId === row.uid || pinnedLogs?.some((logId) => logId === row.rowId)}
                   isFilterLabelActive={this.props.isFilterLabelActive}
-                  handleTextSelection={this.popoverMenuSupported() ? this.handleSelection : undefined}
+                  handleTextSelection={this.handleSelection}
                   {...rest}
                 />
               ))}
@@ -270,7 +272,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                   pinLineButtonTooltipTitle={this.props.pinLineButtonTooltipTitle}
                   pinned={this.props.pinnedRowId === row.uid || pinnedLogs?.some((logId) => logId === row.rowId)}
                   isFilterLabelActive={this.props.isFilterLabelActive}
-                  handleTextSelection={this.popoverMenuSupported() ? this.handleSelection : undefined}
+                  handleTextSelection={this.handleSelection}
                   {...rest}
                 />
               ))}


### PR DESCRIPTION
Fixes #94468
Related with https://github.com/grafana/grafana/pull/88144

Before these changes users were not able to select multi-line text when logs were expanded. Demo:

https://github.com/user-attachments/assets/15478592-a5a6-4d08-9e38-d1ef18c350de

