### PR TITLE
Logs Panel: Limit displayed characters to MAX_CHARACTERS

### DIFF
--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -5,7 +5,7 @@ import { ComponentProps } from 'react';
 import { CoreApp, createTheme, LogLevel, LogRowModel } from '@grafana/data';
 import { IconButton } from '@grafana/ui';
 
-import { LogRowMessage } from './LogRowMessage';
+import { LogRowMessage, MAX_CHARACTERS } from './LogRowMessage';
 import { createLogRow } from './__mocks__/logRow';
 import { getLogRowStyles } from './getLogRowStyles';
 
@@ -219,4 +219,19 @@ line3`;
       expect(onAfter).toHaveBeenCalledWith(expect.anything(), row);
     });
   });
+
+  describe('Extremely long log lines', () => {
+    let entry = '';
+    beforeEach(() => {
+      entry = (new Array(MAX_CHARACTERS)).fill('a').join('')+'b';
+    });
+    it('Displays an ellipsis for log lines above the character limit', async () => {
+      setup({
+        row: createLogRow({ entry, logLevel: LogLevel.error, timeEpochMs: 1546297200000 }),
+      });
+      expect(screen.getByText(/1 more/)).toBeInTheDocument();
+      await userEvent.click(screen.getByText(/1 more/));
+      expect(screen.queryByText(/1 more/)).not.toBeInTheDocument();
+    });
+  })
 });

--- a/public/app/features/logs/components/LogRowMessage.test.tsx
+++ b/public/app/features/logs/components/LogRowMessage.test.tsx
@@ -223,7 +223,7 @@ line3`;
   describe('Extremely long log lines', () => {
     let entry = '';
     beforeEach(() => {
-      entry = (new Array(MAX_CHARACTERS)).fill('a').join('')+'b';
+      entry = new Array(MAX_CHARACTERS).fill('a').join('') + 'b';
     });
     it('Displays an ellipsis for log lines above the character limit', async () => {
       setup({
@@ -233,5 +233,5 @@ line3`;
       await userEvent.click(screen.getByText(/1 more/));
       expect(screen.queryByText(/1 more/)).not.toBeInTheDocument();
     });
-  })
+  });
 });

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -67,7 +67,9 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
   }
   return (
     <>
-      {truncatedEntry}{truncatedEntry}{truncatedEntry}
+      {truncatedEntry}
+      {truncatedEntry}
+      {truncatedEntry}
       {!showFull && <Ellipsis showFull={showFull} toggle={setShowFull} diff={excessCharacters} />}
     </>
   );

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -10,7 +10,7 @@ import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
 
-export const MAX_CHARACTERS = 10;
+export const MAX_CHARACTERS = 100000;
 
 interface Props {
   row: LogRowModel;

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -10,7 +10,7 @@ import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
 
-export const MAX_CHARACTERS = 100000;
+export const MAX_CHARACTERS = 90;
 
 interface Props {
   row: LogRowModel;
@@ -86,7 +86,7 @@ const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
   return (
     <>
       …{' '}
-      <Button fill="text" size="sm" variant="secondary" onClick={handleClick}>
+      <Button fill="outline" size="sm" variant="secondary" onClick={handleClick}>
         {diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>
       </Button>
     </>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -4,12 +4,13 @@ import Highlighter from 'react-highlight-words';
 import { CoreApp, findHighlightChunksInText, LogRowContextOptions, LogRowModel } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 import { PopoverContent } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
 
-export const MAX_CHARACTERS = 100000;
+export const MAX_CHARACTERS = 10;
 
 interface Props {
   row: LogRowModel;
@@ -77,7 +78,7 @@ const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
     e.stopPropagation();
     toggle(true);
   }
-  return <>…{' '}<span onClick={handleClick}>{diff} more</span></>
+  return <>…{' '}<span onClick={handleClick}>({diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>)</span></>
 }
 
 const restructureLog = (

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -1,9 +1,10 @@
+import { css } from '@emotion/css';
 import { memo, ReactNode, SyntheticEvent, useMemo, useState } from 'react';
 import Highlighter from 'react-highlight-words';
 
-import { CoreApp, findHighlightChunksInText, LogRowContextOptions, LogRowModel } from '@grafana/data';
+import { CoreApp, findHighlightChunksInText, GrafanaTheme2, LogRowContextOptions, LogRowModel } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
-import { Button, PopoverContent } from '@grafana/ui';
+import { PopoverContent, useTheme2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
@@ -79,6 +80,7 @@ interface EllipsisProps {
   diff: number;
 }
 const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
+  const styles = getEllipsisStyles(useTheme2());
   const handleClick = (e: SyntheticEvent) => {
     e.stopPropagation();
     toggle(true);
@@ -86,12 +88,30 @@ const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
   return (
     <>
       <Trans i18nKey="logs.log-row-message.ellipsis">… </Trans>
-      <Button fill="outline" size="sm" variant="secondary" onClick={handleClick}>
+      <span className={styles.showMore} onClick={handleClick}>
         {diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>
-      </Button>
+      </span>
     </>
   );
 };
+
+const getEllipsisStyles = (theme: GrafanaTheme2) => ({
+  showMore: css({
+    display: 'inline-flex',
+    fontWeight: theme.typography.fontWeightMedium,
+    fontSize: theme.typography.size.sm,
+    fontFamily: theme.typography.fontFamily,
+    height: theme.spacing(3),
+    padding: theme.spacing(0.25, 1),
+    color: theme.colors.secondary.text,
+    border: `1px solid ${theme.colors.border.strong}`,
+    '&:hover': {
+      background: theme.colors.secondary.transparent,
+      borderColor: theme.colors.emphasize(theme.colors.border.strong, 0.25),
+      color: theme.colors.secondary.text,
+    },
+  }),
+});
 
 const restructureLog = (
   line: string,

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -3,14 +3,14 @@ import Highlighter from 'react-highlight-words';
 
 import { CoreApp, findHighlightChunksInText, LogRowContextOptions, LogRowModel } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
-import { PopoverContent } from '@grafana/ui';
+import { Button, PopoverContent } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
 import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
 
-export const MAX_CHARACTERS = 100000;
+export const MAX_CHARACTERS = 90;
 
 interface Props {
   row: LogRowModel;
@@ -67,7 +67,7 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
   }
   return (
     <>
-      {truncatedEntry}
+      {truncatedEntry}{truncatedEntry}{truncatedEntry}
       {!showFull && <Ellipsis showFull={showFull} toggle={setShowFull} diff={excessCharacters} />}
     </>
   );
@@ -86,9 +86,9 @@ const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
   return (
     <>
       …{' '}
-      <span onClick={handleClick}>
-        ({diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>)
-      </span>
+      <Button fill="text" size="sm" variant="secondary" onClick={handleClick}>
+        {diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>
+      </Button>
     </>
   );
 };

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -10,7 +10,7 @@ import { LogMessageAnsi } from './LogMessageAnsi';
 import { LogRowMenuCell } from './LogRowMenuCell';
 import { LogRowStyles } from './getLogRowStyles';
 
-export const MAX_CHARACTERS = 90;
+export const MAX_CHARACTERS = 100000;
 
 interface Props {
   row: LogRowModel;

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -47,7 +47,7 @@ interface LogMessageProps {
 const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => {
   const excessCharacters = useMemo(() => entry.length - MAX_CHARACTERS, [entry]);
   const needsHighlighter =
-    highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && excessCharacters > 0;
+    highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && excessCharacters <= 0;
   const searchWords = highlights ?? [];
   const [showFull, setShowFull] = useState(excessCharacters < 0);
   const truncatedEntry = useMemo(() => (showFull ? entry : entry.substring(0, MAX_CHARACTERS)), [entry, showFull]);

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -85,7 +85,7 @@ const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
   };
   return (
     <>
-      …{' '}
+      <Trans i18nKey="logs.log-row-message.ellipsis">… </Trans>
       <Button fill="outline" size="sm" variant="secondary" onClick={handleClick}>
         {diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>
       </Button>

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -50,8 +50,8 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
     highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && excessCharacters > 0;
   const searchWords = highlights ?? [];
   const [showFull, setShowFull] = useState(excessCharacters < 0);
-  const truncatedEntry = useMemo(() => showFull ? entry : entry.substring(0, MAX_CHARACTERS), [entry, showFull]);
-  
+  const truncatedEntry = useMemo(() => (showFull ? entry : entry.substring(0, MAX_CHARACTERS)), [entry, showFull]);
+
   if (hasAnsi) {
     const highlight = needsHighlighter ? { searchWords, highlightClassName: styles.logsRowMatchHighLight } : undefined;
     return <LogMessageAnsi value={truncatedEntry} highlight={highlight} />;
@@ -65,7 +65,12 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
       />
     );
   }
-  return <>{truncatedEntry}{!showFull && <Ellipsis showFull={showFull} toggle={setShowFull} diff={excessCharacters} />}</>;
+  return (
+    <>
+      {truncatedEntry}
+      {!showFull && <Ellipsis showFull={showFull} toggle={setShowFull} diff={excessCharacters} />}
+    </>
+  );
 };
 
 interface EllipsisProps {
@@ -77,9 +82,16 @@ const Ellipsis = ({ toggle, diff }: EllipsisProps) => {
   const handleClick = (e: SyntheticEvent) => {
     e.stopPropagation();
     toggle(true);
-  }
-  return <>…{' '}<span onClick={handleClick}>({diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>)</span></>
-}
+  };
+  return (
+    <>
+      …{' '}
+      <span onClick={handleClick}>
+        ({diff} <Trans i18nKey="logs.log-row-message.more">more</Trans>)
+      </span>
+    </>
+  );
+};
 
 const restructureLog = (
   line: string,

--- a/public/app/features/logs/components/LogRowMessage.tsx
+++ b/public/app/features/logs/components/LogRowMessage.tsx
@@ -68,8 +68,6 @@ const LogMessage = ({ hasAnsi, entry, highlights, styles }: LogMessageProps) => 
   return (
     <>
       {truncatedEntry}
-      {truncatedEntry}
-      {truncatedEntry}
       {!showFull && <Ellipsis showFull={showFull} toggle={setShowFull} diff={excessCharacters} />}
     </>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1723,6 +1723,7 @@
       "older-logs": "Older logs"
     },
     "log-row-message": {
+      "ellipsis": "… ",
       "more": "more"
     }
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1721,6 +1721,9 @@
   "logs": {
     "infinite-scroll": {
       "older-logs": "Older logs"
+    },
+    "log-row-message": {
+      "more": "more"
     }
   },
   "migrate-to-cloud": {

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1723,6 +1723,7 @@
       "older-logs": "Øľđęř ľőģş"
     },
     "log-row-message": {
+      "ellipsis": "… ",
       "more": "mőřę"
     }
   },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -1721,6 +1721,9 @@
   "logs": {
     "infinite-scroll": {
       "older-logs": "Øľđęř ľőģş"
+    },
+    "log-row-message": {
+      "more": "mőřę"
     }
   },
   "migrate-to-cloud": {


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/96020

As a measure to improve how the logs panel responds when dealing with excessively long lines, this PR limits the displayed characters to MAX_CHARACTERS, which is currently 100.000.

https://github.com/user-attachments/assets/e586562b-e6a7-4ad7-9b99-054c1fb380e0

