### PR TITLE
[Prototyping] Ensure git branch exists in write operations for github repositories

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -120,6 +120,14 @@ func (r *githubRepository) Read(ctx context.Context, logger *slog.Logger, filePa
 }
 
 func (r *githubRepository) Create(ctx context.Context, logger *slog.Logger, path, ref string, data []byte, comment string) error {
+	if ref == "" {
+		ref = r.config.Spec.GitHub.Branch
+	} else {
+		if err := r.createBranch(ctx, ref); err != nil {
+			return fmt.Errorf("create branch on create: %w", err)
+		}
+	}
+
 	owner := r.config.Spec.GitHub.Owner
 	repo := r.config.Spec.GitHub.Repository
 
@@ -136,6 +144,14 @@ func (r *githubRepository) Create(ctx context.Context, logger *slog.Logger, path
 }
 
 func (r *githubRepository) Update(ctx context.Context, logger *slog.Logger, path, ref string, data []byte, comment string) error {
+	if ref == "" {
+		ref = r.config.Spec.GitHub.Branch
+	} else {
+		if err := r.createBranch(ctx, ref); err != nil {
+			return fmt.Errorf("create branch on update: %w", err)
+		}
+	}
+
 	owner := r.config.Spec.GitHub.Owner
 	repo := r.config.Spec.GitHub.Repository
 
@@ -163,6 +179,14 @@ func (r *githubRepository) Delete(ctx context.Context, logger *slog.Logger, path
 	owner := r.config.Spec.GitHub.Owner
 	repo := r.config.Spec.GitHub.Repository
 
+	if ref == "" {
+		ref = r.config.Spec.GitHub.Branch
+	} else {
+		if err := r.createBranch(ctx, ref); err != nil {
+			return fmt.Errorf("create branch on delete: %w", err)
+		}
+	}
+
 	file, _, err := r.gh.GetContents(ctx, owner, repo, path, ref)
 	if err != nil {
 		if errors.Is(err, pgh.ErrResourceNotFound) {
@@ -177,6 +201,42 @@ func (r *githubRepository) Delete(ctx context.Context, logger *slog.Logger, path
 	}
 
 	return r.gh.DeleteFile(ctx, owner, repo, path, ref, comment, file.GetSHA())
+}
+
+// isValidBranchName checks if a branch name is valid.
+func isValidBranchName(branch string) bool {
+	// TODO: add branch validation here as well as in the frontend using the same restrictions
+	return branch != ""
+}
+
+func (r *githubRepository) createBranch(ctx context.Context, branchName string) error {
+	owner := r.config.Spec.GitHub.Owner
+	repo := r.config.Spec.GitHub.Repository
+
+	if !isValidBranchName(branchName) {
+		return &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Code:    http.StatusBadRequest,
+				Message: "invalid branch name",
+			},
+		}
+	}
+
+	srcBranch := r.config.Spec.GitHub.Branch
+	if err := r.gh.CreateBranch(ctx, owner, repo, srcBranch, branchName); err != nil {
+		if errors.Is(err, pgh.ErrResourceAlreadyExists) {
+			return &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusConflict,
+					Message: "branch already exists",
+				},
+			}
+		}
+
+		return fmt.Errorf("create branch: %w", err)
+	}
+
+	return nil
 }
 
 // Webhook implements provisioning.Repository.

--- a/pkg/registry/apis/provisioning/repository/github/client.go
+++ b/pkg/registry/apis/provisioning/repository/github/client.go
@@ -61,6 +61,8 @@ type Client interface {
 
 	// CreateBranch creates a new branch in the repository.
 	CreateBranch(ctx context.Context, owner, repository, sourceBranch, branchName string) error
+	// BranchExists checks if a branch exists in the repository.
+	BranchExists(ctx context.Context, owner, repository, branchName string) (bool, error)
 
 	ListWebhooks(ctx context.Context, owner, repository string) ([]WebhookConfig, error)
 	CreateWebhook(ctx context.Context, owner, repository string, cfg WebhookConfig) error

--- a/pkg/registry/apis/provisioning/repository/github/client.go
+++ b/pkg/registry/apis/provisioning/repository/github/client.go
@@ -59,6 +59,9 @@ type Client interface {
 	// If ".." appears in the "path", this method will return an error.
 	DeleteFile(ctx context.Context, owner, repository, path, branch, message, hash string) error
 
+	// CreateBranch creates a new branch in the repository.
+	CreateBranch(ctx context.Context, owner, repository, sourceBranch, branchName string) error
+
 	ListWebhooks(ctx context.Context, owner, repository string) ([]WebhookConfig, error)
 	CreateWebhook(ctx context.Context, owner, repository string, cfg WebhookConfig) error
 	DeleteWebhook(ctx context.Context, owner, repository string, webhookID int64) error

--- a/pkg/registry/apis/provisioning/repository/github/client_mock.go
+++ b/pkg/registry/apis/provisioning/repository/github/client_mock.go
@@ -13,6 +13,24 @@ type MockClient struct {
 	mock.Mock
 }
 
+// CreateBranch provides a mock function with given fields: ctx, owner, repository, sourceBranch, branchName
+func (_m *MockClient) CreateBranch(ctx context.Context, owner string, repository string, sourceBranch string, branchName string) error {
+	ret := _m.Called(ctx, owner, repository, sourceBranch, branchName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateBranch")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) error); ok {
+		r0 = rf(ctx, owner, repository, sourceBranch, branchName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CreateFile provides a mock function with given fields: ctx, owner, repository, path, branch, message, content
 func (_m *MockClient) CreateFile(ctx context.Context, owner string, repository string, path string, branch string, message string, content []byte) error {
 	ret := _m.Called(ctx, owner, repository, path, branch, message, content)

--- a/pkg/registry/apis/provisioning/repository/github/client_mock.go
+++ b/pkg/registry/apis/provisioning/repository/github/client_mock.go
@@ -31,6 +31,26 @@ func (_m *MockClient) CreateBranch(ctx context.Context, owner string, repository
 	return r0
 }
 
+func (_m *MockClient) BranchExists(ctx context.Context, owner string, repository string, branchName string) (bool, error) {
+	ret := _m.Called(ctx, owner, repository, branchName)
+	if len(ret) == 0 {
+		panic("no return value specified for BranchExists")
+	}
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) bool); ok {
+		r0 = rf(ctx, owner, repository, branchName)
+	} else {
+		r0 = ret.Bool(0)
+	}
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, owner, repository, branchName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // CreateFile provides a mock function with given fields: ctx, owner, repository, path, branch, message, content
 func (_m *MockClient) CreateFile(ctx context.Context, owner string, repository string, path string, branch string, message string, content []byte) error {
 	ret := _m.Called(ctx, owner, repository, path, branch, message, content)
@@ -213,7 +233,8 @@ func (_m *MockClient) UpdateFile(ctx context.Context, owner string, repository s
 func NewMockClient(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockClient {
+},
+) *MockClient {
 	mock := &MockClient{}
 	mock.Mock.Test(t)
 

--- a/pkg/registry/apis/provisioning/repository/github/real.go
+++ b/pkg/registry/apis/provisioning/repository/github/real.go
@@ -173,17 +173,12 @@ func (r *realImpl) CreateBranch(ctx context.Context, owner, repository, sourceBr
 }
 
 func (r *realImpl) BranchExists(ctx context.Context, owner, repository, branchName string) (bool, error) {
-	_, _, err := r.gh.Repositories.GetBranch(ctx, owner, repository, branchName, 0)
+	_, resp, err := r.gh.Repositories.GetBranch(ctx, owner, repository, branchName, 0)
 	if err == nil {
 		return true, nil
 	}
 
-	var ghErr *github.ErrorResponse
-	if !errors.As(err, &ghErr) {
-		return false, err
-	}
-
-	if ghErr.Response.StatusCode == http.StatusNotFound {
+	if resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	}
 

--- a/pkg/registry/apis/provisioning/repository/github/real.go
+++ b/pkg/registry/apis/provisioning/repository/github/real.go
@@ -172,6 +172,24 @@ func (r *realImpl) CreateBranch(ctx context.Context, owner, repository, sourceBr
 	return nil
 }
 
+func (r *realImpl) BranchExists(ctx context.Context, owner, repository, branchName string) (bool, error) {
+	_, _, err := r.gh.Repositories.GetBranch(ctx, owner, repository, branchName, 0)
+	if err == nil {
+		return true, nil
+	}
+
+	var ghErr *github.ErrorResponse
+	if !errors.As(err, &ghErr) {
+		return false, err
+	}
+
+	if ghErr.Response.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+
+	return false, err
+}
+
 func (r *realImpl) ListWebhooks(ctx context.Context, owner, repository string) ([]WebhookConfig, error) {
 	hooks, _, err := r.gh.Repositories.ListHooks(ctx, owner, repository, nil)
 	if err != nil {

--- a/pkg/registry/apis/provisioning/repository/local.go
+++ b/pkg/registry/apis/provisioning/repository/local.go
@@ -152,6 +152,10 @@ func (r *localRepository) Read(ctx context.Context, logger *slog.Logger, path st
 }
 
 func (r *localRepository) Create(ctx context.Context, logger *slog.Logger, path string, ref string, data []byte, comment string) error {
+	if ref != "" {
+		return apierrors.NewBadRequest("local repository does not support ref")
+	}
+
 	if r.path == "" {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{
@@ -172,6 +176,10 @@ func (r *localRepository) Create(ctx context.Context, logger *slog.Logger, path 
 }
 
 func (r *localRepository) Update(ctx context.Context, logger *slog.Logger, path string, ref string, data []byte, comment string) error {
+	if ref != "" {
+		return apierrors.NewBadRequest("local repository does not support ref")
+	}
+
 	if r.path == "" {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{
@@ -189,6 +197,10 @@ func (r *localRepository) Update(ctx context.Context, logger *slog.Logger, path 
 }
 
 func (r *localRepository) Delete(ctx context.Context, logger *slog.Logger, path string, ref string, comment string) error {
+	if ref != "" {
+		return apierrors.NewBadRequest("local repository does not support ref")
+	}
+
 	if r.path == "" {
 		return &apierrors.StatusError{
 			ErrStatus: metav1.Status{


### PR DESCRIPTION
- Return bad requests for local repository if ref is passed. 
- Use repository branch as default if ref is not passed (and fixed a bug with that). 
- Ensure git branch exists in write operations. The branch will be created out of the branch name. 

## Remarks 
- Validation has been excluded 