### PR TITLE
Revert "PanelQueryRunner: Use rxjs merge, not lodash merge (#96881)"

### DIFF
--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -1,5 +1,5 @@
-import { cloneDeep, isEqual } from 'lodash';
-import { Observable, of, ReplaySubject, Unsubscribable, merge } from 'rxjs';
+import { cloneDeep, merge, isEqual } from 'lodash';
+import { Observable, of, ReplaySubject, Unsubscribable } from 'rxjs';
 import { map, mergeMap, catchError } from 'rxjs/operators';
 
 import {


### PR DESCRIPTION
This reverts commit a8b6c81d12648c0bf44ab38c0c0be6847c567e6b.

this broke some transforms (with scenes disabled) :grimacing: 

e.g.:

http://localhost:3000/d/fGWBVW4k/transforms-filters?orgId=1&from=now-6h&to=now&timezone=browser&scenes=false
http://localhost:3000/d/PMtIInink/transforms-rows-to-fields?orgId=1&from=now-6h&to=now&timezone=browser&scenes=false