### PR TITLE
K8s/Dashboard: Write dummy dashboard to legacy SQL in v2

### DIFF
--- a/pkg/apis/dashboard/v2alpha1/register.go
+++ b/pkg/apis/dashboard/v2alpha1/register.go
@@ -4,16 +4,20 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
 const (
 	GROUP      = "dashboard.grafana.app"
 	VERSION    = "v2alpha1"
 	APIVERSION = GROUP + "/" + VERSION
+
+	// Dashboard stubs in v0/v1 will use this schemaVersion to indicate
+	PLACEHOLDER_DASHBOARD_SCHEMA_VERSION = 9999
 )
 
 var DashboardResourceInfo = utils.NewResourceInfo(GROUP, VERSION,

--- a/pkg/apiserver/rest/dualwriter_mode3.go
+++ b/pkg/apiserver/rest/dualwriter_mode3.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,13 @@ type DualWriterMode3 struct {
 	*dualWriterMetrics
 	resource string
 	Log      klog.Logger
+}
+
+// Public version (used by dashboards v2 to force mode3)
+func NewDualWriterMode3(legacy LegacyStorage, storage Storage, reg prometheus.Registerer, resource string) *DualWriterMode3 {
+	metrics := &dualWriterMetrics{}
+	metrics.init(reg)
+	return newDualWriterMode3(legacy, storage, metrics, resource)
 }
 
 // newDualWriterMode3 returns a new DualWriter in mode 3.

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -23,6 +23,7 @@ func getDashboardFromEvent(event resource.WriteEvent) (*dashboard.Dashboard, err
 			return dash, nil
 		}
 	}
+
 	dash := &dashboard.Dashboard{}
 	err := json.Unmarshal(event.Value, dash)
 	return dash, err

--- a/pkg/registry/apis/dashboard/legacy/v2_dummy.go
+++ b/pkg/registry/apis/dashboard/legacy/v2_dummy.go
@@ -1,0 +1,34 @@
+package legacy
+
+import (
+	"time"
+
+	dashboardv2alpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v2alpha1"
+)
+
+func newDummyDashboard(uid string) map[string]any {
+	var staticWarningPanel = map[string]interface{}{
+		"gridPos": map[string]interface{}{
+			"h": 13,
+			"w": 24, // full width
+			"x": 0,
+			"y": 0,
+		},
+		"options": map[string]interface{}{
+			"mode": "html",
+			"content": `<div style="background:#eb4438; color:#000; padding:50px; height:1000px;">
+			<h1>This dashboard was saved using schema v2 🎉🎉🎉🎉🎉🎉<h1>
+			<br/>
+			<h1>It is not possible to load v2 dashboards from the SQL database<h1>
+		</div>`,
+		},
+		"transparent": true,
+		"type":        "text",
+	}
+	return map[string]any{
+		"schemaVersion": dashboardv2alpha1.PLACEHOLDER_DASHBOARD_SCHEMA_VERSION, // no more schemaVersion in v2!
+		"title":         "v2alpha1 dashboard " + time.Now().Format(time.DateOnly),
+		"uid":           uid,
+		"panels":        []any{staticWarningPanel},
+	}
+}

--- a/pkg/registry/apis/dashboard/v2alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v2alpha1/register.go
@@ -151,10 +151,11 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		if err != nil {
 			return err
 		}
-		storage[dash.StoragePath()], err = dualWriteBuilder(dash.GroupResource(), legacyStore, store)
-		if err != nil {
-			return err
-		}
+
+		// Force mode3 for v2alpha1
+		// write to storage, then async write to legacy with the funky wrapper
+		storage[dash.StoragePath()] = grafanarest.NewDualWriterMode3(
+			legacyStore, store, opts.MetricsRegister, dash.GroupResource().Resource)
 	}
 
 	// Register the DTO endpoint that will consolidate all dashboard bits

--- a/pkg/tests/apis/dashboard/testdata/dashboard-generate-v2alpha.yaml
+++ b/pkg/tests/apis/dashboard/testdata/dashboard-generate-v2alpha.yaml
@@ -4,4 +4,3 @@ metadata:
   generateName: x 
 spec:
   title: Just a dummy dashboard (v2) without anything
-  description: In legacy SQL storage, this will be replaced with a dummy 

--- a/pkg/tests/apis/dashboard/testdata/dashboard-generate-v2alpha.yaml
+++ b/pkg/tests/apis/dashboard/testdata/dashboard-generate-v2alpha.yaml
@@ -1,0 +1,7 @@
+apiVersion: dashboard.grafana.app/v2alpha1
+kind: Dashboard
+metadata:
+  generateName: x 
+spec:
+  title: Just a dummy dashboard (v2) without anything
+  description: In legacy SQL storage, this will be replaced with a dummy 

--- a/pkg/tests/apis/dashboard/testdata/dashboard-generate.yaml
+++ b/pkg/tests/apis/dashboard/testdata/dashboard-generate.yaml
@@ -3,4 +3,4 @@ kind: Dashboard
 metadata:
   generateName: x # anything is ok here... except yes or true -- they become boolean!
 spec:
-  title: Dashboard with auto generated UID ${NOW}
+  title: Dashboard with auto generated UID


### PR DESCRIPTION
When writing a v2 dashboard into the existing SQL tables, we will write a dummy value so that we do not accidentally start trying to support this conversion!