### PR TITLE
Prometheus: Add metrics explorer feature tracking for combobox

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx
@@ -12,6 +12,7 @@ import { QueryBuilderLabelFilter } from '../shared/types';
 import { PromVisualQuery } from '../types';
 
 import { MetricsModal } from './metrics-modal';
+import { tracking } from './metrics-modal/state/helpers';
 
 export interface MetricComboboxProps {
   metricLookupDisabled: boolean;
@@ -104,7 +105,10 @@ export function MetricCombobox({
             aria-label="Open metrics explorer"
             variant="secondary"
             icon="book-open"
-            onClick={() => setMetricsModalOpen(true)}
+            onClick={() => {
+              tracking('grafana_prometheus_metric_encyclopedia_open', null, '', query);
+              setMetricsModalOpen(true);
+            }}
           />
         ) : (
           <></>


### PR DESCRIPTION
Adds feature tracking for opening the metrics explorer modal when using the combobox.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
