### PR TITLE
Explore metrics: Fix default datasource bug, add test coverage

### DIFF
--- a/public/app/features/trails/utils.ts
+++ b/public/app/features/trails/utils.ts
@@ -103,7 +103,9 @@ export function getDatasourceForNewTrail(): string | undefined {
   }
   const promDatasources = getDatasourceSrv().getList({ type: 'prometheus' });
   if (promDatasources.length > 0) {
-    return promDatasources.find((mds) => mds.uid === config.defaultDatasource)?.uid ?? promDatasources[0].uid;
+    const defaultDatasource = promDatasources.find((mds) => mds.isDefault);
+
+    return defaultDatasource?.uid ?? promDatasources[0].uid;
   }
   return undefined;
 }


### PR DESCRIPTION
Bug:
The default data source selection was comparing the uid in the Prom ds list to the `config.defaultDatasource` which was by 'name.' This always resulted in not selecting a default data source. The fallback to this was picking the first, or most newly added prom data source. Customers who had default Prometheus data sources were not seeing these first selected in new explore metrics explorations.

Fix:
Use the `isDefault` field in the list of data sources.

Extra test coverage:
1. Should select most recent exploration prom data source
2. If no recent exploration, select default prom data source.
3. If no default data source select most recently added prom data source.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
