### PR TITLE
Dashboards: Update docs of the `overwrite` param in Save Dashboard API Call

### DIFF
--- a/docs/sources/developers/http_api/dashboard.md
+++ b/docs/sources/developers/http_api/dashboard.md
@@ -83,7 +83,7 @@ JSON Body schema:
 - **dashboard.refresh** - Set the dashboard refresh interval. If this is lower than [the minimum refresh interval]({{< relref "/docs/grafana/latest/setup-grafana/configure-grafana#min_refresh_interval" >}}), then Grafana will ignore it and will enforce the minimum refresh interval.
 - **folderId** – The id of the folder to save the dashboard in.
 - **folderUid** – The UID of the folder to save the dashboard in. Overrides the `folderId`.
-- **overwrite** – Set to true if you want to overwrite existing dashboard with newer version, same dashboard title in folder or same dashboard uid.
+- **overwrite** – Set to true if you want to overwrite an existing dashboard with a given dashboard UID.
 - **message** - Set a commit message for the version history.
 
 **Example Request for updating a dashboard**:

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -18,8 +18,7 @@ export interface SaveDashboardOptions {
   message?: string;
   /** The UID of the folder to save the dashboard in. Overrides `folderId`. */
   folderUid?: string;
-  /** Set to `true` if you want to overwrite existing dashboard with newer version,
-   *  same dashboard title in folder or same dashboard uid. */
+  /** Set to `true` if you want to overwrite an existing dashboard with a given dashboard UID. */
   overwrite?: boolean;
   /** Set the dashboard refresh interval.
    *  If this is lower than the minimum refresh interval, Grafana will ignore it and will enforce the minimum refresh interval. */


### PR DESCRIPTION
This change clarifies the meaning of the `overwrite` param in the Save Dashboard API Call. Following https://github.com/grafana/grafana/pull/90687, the dashboard title is no longer unique thus `overwrite` doesn't allow for overriding a dashboard just based on its title