### PR TITLE
Dashboards: Set uid to empty if not found

### DIFF
--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -98,7 +98,7 @@ export class DashboardLoaderSrv {
         })
         .catch(() => {
           const dash = this._dashboardLoadFailed('Not found', true);
-          dash.dashboard.uid = uid;
+          dash.dashboard.uid = "";
           return dash;
         });
     } else {

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -98,7 +98,7 @@ export class DashboardLoaderSrv {
         })
         .catch(() => {
           const dash = this._dashboardLoadFailed('Not found', true);
-          dash.dashboard.uid = "";
+          dash.dashboard.uid = '';
           return dash;
         });
     } else {


### PR DESCRIPTION
**What is this feature?**

This PR sets the uid to an empty string if the dashboard is not found.

**Why do we need this feature?**

As we migrate from using dashboard id to dashboard uid, we are checking if dashboard uid is an empty string to mean that the dashboard does not exist. For example, in the dashboard views, we do not want to add view events to the database if the dashboard does not exist, but if we made that check today, the uid would be set as the invalid uid.

This PR instead sets it to an empty string:
![Screenshot 2024-11-25 at 4 37 02 PM](https://github.com/user-attachments/assets/ccf98038-3e05-4b4f-b212-196748c945c7)
