### PR TITLE
POC/Provisioning: Fail read/write when we can not find a valid GVR

### DIFF
--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -158,6 +158,15 @@ func (s *filesConnector) doRead(ctx context.Context, logger *slog.Logger, repo r
 		return 0, nil, err
 	}
 
+	// GVR will exist for anything we can actually save (dashboard/playlist for now)
+	if parsed.gvr == nil {
+		if parsed.gvk != nil {
+			parsed.errors = append(parsed.errors, fmt.Errorf("unknown resource for Kind: "+parsed.gvk.Kind))
+		} else {
+			parsed.errors = append(parsed.errors, fmt.Errorf("unknown resource"))
+		}
+	}
+
 	code := http.StatusOK
 	if len(parsed.errors) > 0 {
 		code = http.StatusNotAcceptable
@@ -196,6 +205,11 @@ func (s *filesConnector) doWrite(ctx context.Context, logger *slog.Logger, updat
 			return nil, apierrors.NewBadRequest("unable to read the request as a resource")
 		}
 		return nil, err
+	}
+
+	// GVR will exist for anything we can actually save (dashboard/playlist for now)
+	if parsed.gvr == nil {
+		return nil, apierrors.NewBadRequest("The payload does not map to a known resource")
 	}
 
 	data, err = parsed.ToSaveBytes()


### PR DESCRIPTION
Our git example repository got in a weird state when we saved a non-resource.   We saved a `ResourceWrapper` rather than the resource itself.  This PR makes sure we can resolve a resource, or returns an error:

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/27d76b83-9e0f-4572-9975-3504acbb5ad0">
