### PR TITLE
Chrome: Rename golangci.toml into golangci.yml in docs and scripts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -573,7 +573,7 @@ trigger:
     - docs/**
     - '*.md'
     include:
-    - .golangci.toml
+    - .golangci.yml
     - Makefile
     - pkg/**
     - packaging/**
@@ -5969,6 +5969,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: b164dd562488c482f2e670688fca02ae20dcd2e7841ec80c95838472842b4b5e
+hmac: 673757f6cdea7a0f9b3a97bbaeb8a638e57c144d95465456b43d8739a861331a
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ lint-go-diff: $(GOLANGCI_LINT)
 		$(XARGSR) dirname | \
 		sort -u | \
 		sed 's,^,./,' | \
-		$(XARGSR) $(GOLANGCI_LINT) run --config .golangci.toml
+		$(XARGSR) $(GOLANGCI_LINT) run --config .golangci.yml
 
 # with disabled SC1071 we are ignored some TCL,Expect `/usr/bin/env expect` scripts
 .PHONY: shellcheck

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include .bingo/Variables.mk
 
 GO = go
 GO_VERSION = 1.23.1
-GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)
+GO_LINT_FILES ?= $(shell $(GO) list -m -f '{{.Dir}}' | xargs -I{} sh -c 'test ! -f {}/.nolint && echo {}/...')
 GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 GO_RACE  := $(shell [ -n "$(GO_RACE)" -o -e ".go-race-enabled-locally" ] && echo 1 )

--- a/contribute/backend/style-guide.md
+++ b/contribute/backend/style-guide.md
@@ -14,7 +14,7 @@ To ensure consistency across the Go codebase, we require all code to
 pass a number of linter checks.
 
 We use [GolangCI-Lint](https://github.com/golangci/golangci-lint) with a
-custom configuration [.golangci.toml](/.golangci.toml) to run these
+custom configuration [.golangci.yml](/.golangci.yml) to run these
 checks.
 
 To run all linters, use the `lint-go` Makefile target:

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -123,7 +123,7 @@ def pr_pipelines():
         lint_backend_pipeline(
             get_pr_trigger(
                 include_paths = [
-                    ".golangci.toml",
+                    ".golangci.yml",
                     "Makefile",
                     "pkg/**",
                     "packaging/**",


### PR DESCRIPTION
1. Clean up golangic.toml -> golangci.yml rename in scripts and docs
2. Use `go list` to filter Go modules we want to lint in the Makefile (much like we do on CI now)