### PR TITLE
ElementSelection: New element selection context to support selecting elements

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3776,7 +3776,8 @@ exports[`better eslint`] = {
     "public/app/features/sandbox/TestStuffPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/scopes/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./instance\`)", "0"],

--- a/packages/grafana-ui/src/components/ElementSelectionContext/ElementSelectionContext.tsx
+++ b/packages/grafana-ui/src/components/ElementSelectionContext/ElementSelectionContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useCallback, useContext } from 'react';
+
+/** @alpha */
+export interface ElementSelectionContextState {
+  /**
+   * Turn on selection mode & show selection state
+   */
+  enabled?: boolean;
+  /** List of currently selected elements */
+  selected: ElementSelectionContextItem[];
+  onSelect: (item: ElementSelectionContextItem, multi?: boolean) => void;
+}
+
+export interface ElementSelectionContextItem {
+  id: string;
+}
+
+export const ElementSelectionContext = createContext<ElementSelectionContextState | undefined>(undefined);
+
+export interface UseElementSelectionResult {
+  isSelected?: boolean;
+  isSelectable?: boolean;
+  onSelect?: (evt: React.PointerEvent) => void;
+}
+
+export function useElementSelection(id: string | undefined): UseElementSelectionResult {
+  if (!id) {
+    return {};
+  }
+
+  const context = useContext(ElementSelectionContext);
+  if (!context) {
+    return {};
+  }
+
+  const isSelected = context.selected.some((item) => item.id === id);
+  const onSelect = useCallback<React.PointerEventHandler>(
+    (evt) => {
+      if (!context.enabled) {
+        return;
+      }
+
+      // To prevent this click form clearing the selection
+      evt.stopPropagation();
+
+      context.onSelect({ id }, evt.shiftKey);
+    },
+    [context, id]
+  );
+
+  return { isSelected, onSelect, isSelectable: context.enabled };
+}

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -9,6 +9,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2, useTheme2 } from '../../themes';
 import { getFocusStyles } from '../../themes/mixins';
 import { DelayRender } from '../../utils/DelayRender';
+import { useElementSelection } from '../ElementSelectionContext/ElementSelectionContext';
 import { Icon } from '../Icon/Icon';
 import { LoadingBar } from '../LoadingBar/LoadingBar';
 import { Text } from '../Text/Text';
@@ -33,6 +34,7 @@ interface BaseProps {
   menu?: ReactElement | (() => ReactElement);
   dragClass?: string;
   dragClassCancel?: string;
+  selectionId?: string;
   /**
    * Use only to indicate loading or streaming data in the panel.
    * Any other values of loadingState are ignored.
@@ -126,6 +128,7 @@ export function PanelChrome({
   statusMessageOnClick,
   leftItems,
   actions,
+  selectionId,
   onCancelQuery,
   onOpenMenu,
   collapsible = false,
@@ -139,6 +142,7 @@ export function PanelChrome({
   const styles = useStyles2(getStyles);
   const panelContentId = useId();
   const panelTitleId = useId().replace(/:/g, '_');
+  const { isSelected, onSelect } = useElementSelection(selectionId);
 
   const hasHeader = !hoverHeader;
 
@@ -257,7 +261,11 @@ export function PanelChrome({
   return (
     // tabIndex={0} is needed for keyboard accessibility in the plot area
     <section
-      className={cx(styles.container, { [styles.transparentContainer]: isPanelTransparent })}
+      className={cx(
+        styles.container,
+        isPanelTransparent && styles.transparentContainer,
+        isSelected && 'dashboard-selected-element'
+      )}
       style={containerStyles}
       aria-labelledby={!!title ? panelTitleId : undefined}
       data-testid={testid}
@@ -294,7 +302,12 @@ export function PanelChrome({
       )}
 
       {hasHeader && (
-        <div className={cx(styles.headerContainer, dragClass)} style={headerStyles} data-testid="header-container">
+        <div
+          className={cx(styles.headerContainer, dragClass)}
+          style={headerStyles}
+          data-testid="header-container"
+          onPointerUp={onSelect}
+        >
           {statusMessage && (
             <div className={dragClassCancel}>
               <PanelStatus message={statusMessage} onClick={statusMessageOnClick} ariaLabel="Panel status" />

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -322,3 +322,9 @@ export { type GraphNGLegendEvent } from '../graveyard/GraphNG/types';
 
 export { ZoomPlugin } from '../graveyard/uPlot/plugins/ZoomPlugin';
 export { TooltipPlugin } from '../graveyard/uPlot/plugins/TooltipPlugin';
+
+export {
+  ElementSelectionContext,
+  useElementSelection,
+  type ElementSelectionContextState,
+} from './ElementSelectionContext/ElementSelectionContext';

--- a/packages/grafana-ui/src/themes/GlobalStyles/dashboardGrid.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/dashboardGrid.ts
@@ -67,5 +67,11 @@ export function getDashboardGridStyles(theme: GrafanaTheme2) {
         },
       },
     },
+
+    '.dashboard-selected-element': {
+      outline: `2px dashed ${theme.colors.primary.border}`,
+      outlineOffset: '0px',
+      borderRadius: '2px',
+    },
   });
 }

--- a/public/app/features/sandbox/TestStuffPage.tsx
+++ b/public/app/features/sandbox/TestStuffPage.tsx
@@ -1,6 +1,18 @@
+import { ReactSVG, useState } from 'react';
+
 import { NavModelItem } from '@grafana/data';
 import { getPluginExtensions, isPluginExtensionLink } from '@grafana/runtime';
-import { Button, LinkButton, Stack } from '@grafana/ui';
+import { VizGridLayout } from '@grafana/scenes-react';
+import {
+  Button,
+  Checkbox,
+  ElementSelectionContext,
+  ElementSelectionContextState,
+  LinkButton,
+  PanelChrome,
+  Stack,
+  Text,
+} from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useAppNotification } from 'app/core/copy/appNotification';
 
@@ -14,26 +26,93 @@ export const TestStuffPage = () => {
   };
 
   const notifyApp = useAppNotification();
+  const [elementSelectionState, setElementSelectionState] = useState<ElementSelectionContextState>({
+    selected: [],
+    enabled: true,
+    onSelect: (item, multi) => {
+      setElementSelectionState((state) => {
+        const selected = state.selected;
+        const isSelected = selected.some((selectedItem) => selectedItem.id === item.id);
+
+        if (multi) {
+          if (isSelected) {
+            return {
+              ...state,
+              selected: selected.filter((selectedItem) => selectedItem.id !== item.id),
+            };
+          } else {
+            return {
+              ...state,
+              selected: [...selected, item],
+            };
+          }
+        } else {
+          return {
+            ...state,
+            selected: isSelected ? [] : [item],
+          };
+        }
+      });
+    },
+  });
+
+  const onToggleElementSelection = () => {
+    setElementSelectionState({ ...elementSelectionState, enabled: !elementSelectionState.enabled });
+  };
+
+  const onClearSelection = (evt: React.PointerEvent) => {
+    setElementSelectionState({ ...elementSelectionState, selected: [] });
+  };
 
   return (
     <Page navModel={{ node: node, main: node }}>
-      <Stack>
+      <Stack direction={'column'} gap={2} onPointerUp={onClearSelection}>
         <LinkToBasicApp extensionPointId="grafana/sandbox/testing" />
-        <Button onClick={() => notifyApp.success('Success toast', 'some more text goes here')} variant="primary">
-          Success
-        </Button>
-        <Button
-          onClick={() => notifyApp.warning('Warning toast', 'some more text goes here', 'bogus-trace-99999')}
-          variant="secondary"
-        >
-          Warning
-        </Button>
-        <Button
-          onClick={() => notifyApp.error('Error toast', 'some more text goes here', 'bogus-trace-fdsfdfsfds')}
-          variant="destructive"
-        >
-          Error
-        </Button>
+        <Text variant="h5">Application notifications (toasts) testing</Text>
+        <Stack>
+          <Button onClick={() => notifyApp.success('Success toast', 'some more text goes here')} variant="primary">
+            Success
+          </Button>
+          <Button
+            onClick={() => notifyApp.warning('Warning toast', 'some more text goes here', 'bogus-trace-99999')}
+            variant="secondary"
+          >
+            Warning
+          </Button>
+          <Button
+            onClick={() => notifyApp.error('Error toast', 'some more text goes here', 'bogus-trace-fdsfdfsfds')}
+            variant="destructive"
+          >
+            Error
+          </Button>
+        </Stack>
+        <Stack gap={3} alignItems={'center'}>
+          <Checkbox
+            label="Enable element selection"
+            value={elementSelectionState.enabled}
+            onChange={() => onToggleElementSelection()}
+          />
+          Selected:
+          {elementSelectionState.selected.map((item) => (
+            <span key={item.id}>{item.id}</span>
+          ))}
+        </Stack>
+        <ElementSelectionContext.Provider value={elementSelectionState}>
+          <VizGridLayout>
+            <PanelChrome title={'Panel title 1'} selectionId="panel-1">
+              Hello
+            </PanelChrome>
+            <PanelChrome title={'Panel title 2'} selectionId="panel-2">
+              Hello
+            </PanelChrome>
+            <PanelChrome title={'Panel title 3'} selectionId="panel-3">
+              Hello
+            </PanelChrome>
+            <PanelChrome title={'Panel title 4'} selectionId="panel-4">
+              Hello
+            </PanelChrome>
+          </VizGridLayout>
+        </ElementSelectionContext.Provider>
       </Stack>
     </Page>
   );

--- a/public/app/features/sandbox/TestStuffPage.tsx
+++ b/public/app/features/sandbox/TestStuffPage.tsx
@@ -1,18 +1,6 @@
-import { ReactSVG, useState } from 'react';
-
 import { NavModelItem } from '@grafana/data';
 import { getPluginExtensions, isPluginExtensionLink } from '@grafana/runtime';
-import { VizGridLayout } from '@grafana/scenes-react';
-import {
-  Button,
-  Checkbox,
-  ElementSelectionContext,
-  ElementSelectionContextState,
-  LinkButton,
-  PanelChrome,
-  Stack,
-  Text,
-} from '@grafana/ui';
+import { Button, LinkButton, Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useAppNotification } from 'app/core/copy/appNotification';
 
@@ -26,93 +14,27 @@ export const TestStuffPage = () => {
   };
 
   const notifyApp = useAppNotification();
-  const [elementSelectionState, setElementSelectionState] = useState<ElementSelectionContextState>({
-    selected: [],
-    enabled: true,
-    onSelect: (item, multi) => {
-      setElementSelectionState((state) => {
-        const selected = state.selected;
-        const isSelected = selected.some((selectedItem) => selectedItem.id === item.id);
-
-        if (multi) {
-          if (isSelected) {
-            return {
-              ...state,
-              selected: selected.filter((selectedItem) => selectedItem.id !== item.id),
-            };
-          } else {
-            return {
-              ...state,
-              selected: [...selected, item],
-            };
-          }
-        } else {
-          return {
-            ...state,
-            selected: isSelected ? [] : [item],
-          };
-        }
-      });
-    },
-  });
-
-  const onToggleElementSelection = () => {
-    setElementSelectionState({ ...elementSelectionState, enabled: !elementSelectionState.enabled });
-  };
-
-  const onClearSelection = (evt: React.PointerEvent) => {
-    setElementSelectionState({ ...elementSelectionState, selected: [] });
-  };
 
   return (
     <Page navModel={{ node: node, main: node }}>
-      <Stack direction={'column'} gap={2} onPointerUp={onClearSelection}>
-        <LinkToBasicApp extensionPointId="grafana/sandbox/testing" />
-        <Text variant="h5">Application notifications (toasts) testing</Text>
-        <Stack>
-          <Button onClick={() => notifyApp.success('Success toast', 'some more text goes here')} variant="primary">
-            Success
-          </Button>
-          <Button
-            onClick={() => notifyApp.warning('Warning toast', 'some more text goes here', 'bogus-trace-99999')}
-            variant="secondary"
-          >
-            Warning
-          </Button>
-          <Button
-            onClick={() => notifyApp.error('Error toast', 'some more text goes here', 'bogus-trace-fdsfdfsfds')}
-            variant="destructive"
-          >
-            Error
-          </Button>
-        </Stack>
-        <Stack gap={3} alignItems={'center'}>
-          <Checkbox
-            label="Enable element selection"
-            value={elementSelectionState.enabled}
-            onChange={() => onToggleElementSelection()}
-          />
-          Selected:
-          {elementSelectionState.selected.map((item) => (
-            <span key={item.id}>{item.id}</span>
-          ))}
-        </Stack>
-        <ElementSelectionContext.Provider value={elementSelectionState}>
-          <VizGridLayout>
-            <PanelChrome title={'Panel title 1'} selectionId="panel-1">
-              Hello
-            </PanelChrome>
-            <PanelChrome title={'Panel title 2'} selectionId="panel-2">
-              Hello
-            </PanelChrome>
-            <PanelChrome title={'Panel title 3'} selectionId="panel-3">
-              Hello
-            </PanelChrome>
-            <PanelChrome title={'Panel title 4'} selectionId="panel-4">
-              Hello
-            </PanelChrome>
-          </VizGridLayout>
-        </ElementSelectionContext.Provider>
+      <LinkToBasicApp extensionPointId="grafana/sandbox/testing" />
+      <Text variant="h5">Application notifications (toasts) testing</Text>
+      <Stack>
+        <Button onClick={() => notifyApp.success('Success toast', 'some more text goes here')} variant="primary">
+          Success
+        </Button>
+        <Button
+          onClick={() => notifyApp.warning('Warning toast', 'some more text goes here', 'bogus-trace-99999')}
+          variant="secondary"
+        >
+          Warning
+        </Button>
+        <Button
+          onClick={() => notifyApp.error('Error toast', 'some more text goes here', 'bogus-trace-fdsfdfsfds')}
+          variant="destructive"
+        >
+          Error
+        </Button>
       </Stack>
     </Page>
   );


### PR DESCRIPTION
A quick proof of concept of an element selection solution. 

We are exploring an edit pane in dashboards that shows actions & options for any element or elements (multiple) selected. See first POC here: https://github.com/grafana/grafana/pull/96895 

In that POC, I used a very hacky global onClick handler and element attributes to mark elements as selectable and selected. However, because it relied on DOM element manipulation to add the selected state class, the selection state is visually lost whenever react re-renders. This PR is exploring a more robust react approach to element selection via a context. 

Context has 
* Current selected elements
* Select an element (or multiple via shift key) 
* Enable/disable selection (needed in dashboards when we go into edit mode or leave edit mode)

Point of feedback
* Is there a different / better way to do this? 
* How to clear selection, Currently I have a top level click handler and when an element is selected propagation is stopped. Another way would be to have a timer so that we do not clear selection if the selection was done in the last few milliseconds (somehow need to make sure the clear selection click is not triggered by an actual selection click). 
* Should the context come with a "Provider" implementation that handles the selection state & callback or should we leave that up to each implementation to handle? 
 
Outside the scope of this PR (So ignore)
* How to make it clear an element is selectable (cursor or other affordance)
* How to make an element that is both draggable and selectable and differentiate between the two (going to be a bit tricky with Panel but we solved it in the past) 


https://github.com/user-attachments/assets/663bae3b-19a1-4d27-80d4-d04c6aed5e37

