### PR TITLE
WIP: add folder watcher to delete nested folders

### DIFF
--- a/apps/folders/watchers/watcher_folder.go
+++ b/apps/folders/watchers/watcher_folder.go
@@ -1,0 +1,63 @@
+package watchers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana-app-sdk/resource"
+	folder "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+)
+
+type FolderWatcher struct {
+	storage grafanarest.Storage
+}
+
+func NewFolderWatcher(s grafanarest.Storage) (*FolderWatcher, error) {
+	return &FolderWatcher{
+		storage: s,
+	}, nil
+}
+
+// Delete handles delete events for folder.Folder resources.
+func (w *FolderWatcher) Delete(ctx context.Context, rObj resource.Object) error {
+	metadata := rObj.GetStaticMetadata()
+	if metadata.Kind != folder.RESOURCE {
+		return fmt.Errorf("provided object is not of type *folder.Folder (name=%s, namespace=%s, kind=%s)",
+			metadata.Name, metadata.Namespace, metadata.Kind)
+	}
+
+	// find all children of the object that just got deleted
+	parent := rObj.GetName()
+	namespace := rObj.GetNamespace()
+	matched, err := w.storage.List(ctx, &internalversion.ListOptions{TypeMeta: meta.TypeMeta{Kind: folder.RESOURCE}, FieldSelector: fields.AndSelectors(
+		fields.OneTermEqualSelector("metadata.annotations.grafana.app/folder", parent),
+		fields.OneTermEqualSelector("metadata.namespace", namespace),
+	)})
+	if err != nil {
+		klog.InfoS("could not list resources", "error", err)
+	}
+
+	obj, ok := matched.(resource.Object)
+	if !ok {
+		return err
+	}
+
+	name := obj.GetName()
+	if err != nil {
+		klog.Error("could not access metadata", "error", err)
+		return err
+	}
+
+	if _, _, err := w.storage.Delete(ctx, name, func(context.Context, runtime.Object) error { return nil }, &meta.DeleteOptions{}); err != nil {
+		klog.Error("could not delete folder child", "error", err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a POC to implement a folder watcher to delete nested folders.


This PR is still not wired: I want to use this as a chance to discuss how can we properly wire storage API to watchers and how to properly use filters.

**What is this feature?**

[Add a brief description of what the feature or update does.]

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
