### PR TITLE
Requester: Remove duplicated function

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -129,7 +129,7 @@ func (hs *HTTPServer) AddOrgInvite(c *contextmodel.ReqContext) response.Response
 				"OrgName":   c.SignedInUser.GetOrgName(),
 				"Email":     c.SignedInUser.GetEmail(),
 				"LinkUrl":   setting.ToAbsUrl("invite/" + cmd.Code),
-				"InvitedBy": c.SignedInUser.GetDisplayName(),
+				"InvitedBy": c.SignedInUser.GetName(),
 			},
 		}
 

--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -169,7 +169,7 @@ func (hs *HTTPServer) inviteExistingUserToOrg(c *contextmodel.ReqContext, user *
 			Data: map[string]any{
 				"Name":      user.NameOrFallback(),
 				"OrgName":   c.SignedInUser.GetOrgName(),
-				"InvitedBy": c.SignedInUser.GetDisplayName(),
+				"InvitedBy": c.SignedInUser.GetName(),
 			},
 		}
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -36,7 +36,7 @@ func (hs *HTTPServer) GetSignedInUser(c *contextmodel.ReqContext) response.Respo
 			IsGrafanaAdmin: c.SignedInUser.GetIsGrafanaAdmin(),
 			OrgID:          c.SignedInUser.GetOrgID(),
 			UID:            c.SignedInUser.GetID(),
-			Name:           c.SignedInUser.NameOrFallback(),
+			Name:           c.SignedInUser.GetName(),
 			Email:          c.SignedInUser.GetEmail(),
 			Login:          c.SignedInUser.GetLogin(),
 		})

--- a/pkg/apimachinery/identity/requester.go
+++ b/pkg/apimachinery/identity/requester.go
@@ -23,9 +23,6 @@ type Requester interface {
 	// GetID returns namespaced internalID for the entity
 	// Deprecated: use GetUID instead
 	GetID() string
-	// GetDisplayName returns the display name of the active entity.
-	// The display name is the name if it is set, otherwise the login or email.
-	GetDisplayName() string
 	// GetEmail returns the email of the active entity.
 	// Can be empty.
 	GetEmail() string
@@ -62,6 +59,8 @@ type Requester interface {
 	// IsNil returns true if the identity is nil
 	// FIXME: remove this method once all services are using an interface
 	IsNil() bool
+	// GetIDToken returns a signed token representing the identity that can be forwarded to plugins and external services.
+	GetIDToken() string
 
 	// Legacy
 
@@ -72,8 +71,6 @@ type Requester interface {
 	GetCacheKey() string
 	// HasUniqueId returns true if the entity has a unique id
 	HasUniqueId() bool
-	// GetIDToken returns a signed token representing the identity that can be forwarded to plugins and external services.
-	GetIDToken() string
 }
 
 // IntIdentifier converts a typeID to an int64.

--- a/pkg/apimachinery/identity/static.go
+++ b/pkg/apimachinery/identity/static.go
@@ -22,7 +22,6 @@ type StaticRequester struct {
 	OrgRole         RoleType
 	Login           string
 	Name            string
-	DisplayName     string
 	Email           string
 	EmailVerified   bool
 	AuthID          string
@@ -89,7 +88,13 @@ func (u *StaticRequester) GetGroups() []string {
 
 // GetName implements Requester.
 func (u *StaticRequester) GetName() string {
-	return u.DisplayName
+	if u.Name != "" {
+		return u.Name
+	}
+	if u.Login != "" {
+		return u.Login
+	}
+	return u.Email
 }
 
 func (u *StaticRequester) HasRole(role RoleType) bool {
@@ -211,25 +216,6 @@ func (u *StaticRequester) GetCacheKey() string {
 	return u.CacheKey
 }
 
-// GetDisplayName returns the display name of the active entity
-// The display name is the name if it is set, otherwise the login or email
-func (u *StaticRequester) GetDisplayName() string {
-	if u.DisplayName != "" {
-		return u.DisplayName
-	}
-	if u.Name != "" {
-		return u.Name
-	}
-	if u.Login != "" {
-		return u.Login
-	}
-	return u.Email
-}
-
 func (u *StaticRequester) GetIDToken() string {
 	return u.IDToken
-}
-
-func (u *StaticRequester) GetIDClaims() *authnlib.Claims[authnlib.IDTokenClaims] {
-	return u.IDTokenClaims
 }

--- a/pkg/apimachinery/identity/wrapper.go
+++ b/pkg/apimachinery/identity/wrapper.go
@@ -25,7 +25,7 @@ func (i *IDClaimsWrapper) AuthenticatedBy() string {
 
 // GetDisplayName implements claims.IdentityClaims.
 func (i *IDClaimsWrapper) DisplayName() string {
-	return i.Source.GetDisplayName()
+	return i.Source.GetName()
 }
 
 // GetEmail implements claims.IdentityClaims.

--- a/pkg/expr/testing.go
+++ b/pkg/expr/testing.go
@@ -35,7 +35,7 @@ func (f *fakePluginContextProvider) Get(_ context.Context, pluginID string, user
 	if user != nil {
 		u = &backend.User{
 			Login: user.GetLogin(),
-			Name:  user.GetDisplayName(),
+			Name:  user.GetName(),
 			Email: user.GetEmail(),
 		}
 	}

--- a/pkg/services/auth/idimpl/service.go
+++ b/pkg/services/auth/idimpl/service.go
@@ -105,7 +105,7 @@ func (s *Service) SignIdentity(ctx context.Context, id identity.Requester) (stri
 			idClaims.Rest.EmailVerified = id.IsEmailVerified()
 			idClaims.Rest.AuthenticatedBy = id.GetAuthenticatedBy()
 			idClaims.Rest.Username = id.GetLogin()
-			idClaims.Rest.DisplayName = id.GetDisplayName()
+			idClaims.Rest.DisplayName = id.GetName()
 		}
 
 		token, err := s.signer.SignIDToken(ctx, idClaims)

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -80,7 +80,6 @@ type Identity struct {
 	AccessTokenClaims *authn.Claims[authn.AccessTokenClaims]
 }
 
-// Access implements claims.AuthInfo.
 func (i *Identity) GetAccess() claims.AccessClaims {
 	if i.AccessTokenClaims != nil {
 		return authn.NewAccessClaims(*i.AccessTokenClaims)
@@ -88,7 +87,6 @@ func (i *Identity) GetAccess() claims.AccessClaims {
 	return &identity.IDClaimsWrapper{Source: i}
 }
 
-// Identity implements claims.AuthInfo.
 func (i *Identity) GetIdentity() claims.IdentityClaims {
 	if i.IDTokenClaims != nil {
 		return authn.NewIdentityClaims(*i.IDTokenClaims)
@@ -96,27 +94,22 @@ func (i *Identity) GetIdentity() claims.IdentityClaims {
 	return &identity.IDClaimsWrapper{Source: i}
 }
 
-// GetRawIdentifier implements Requester.
 func (i *Identity) GetRawIdentifier() string {
 	return i.UID
 }
 
-// GetInternalID implements Requester.
 func (i *Identity) GetInternalID() (int64, error) {
 	return identity.IntIdentifier(i.GetID())
 }
 
-// GetIdentityType implements Requester.
 func (i *Identity) GetIdentityType() claims.IdentityType {
 	return i.Type
 }
 
-// GetIdentityType implements Requester.
 func (i *Identity) IsIdentityType(expected ...claims.IdentityType) bool {
 	return claims.IsIdentityType(i.GetIdentityType(), expected...)
 }
 
-// GetExtra implements identity.Requester.
 func (i *Identity) GetExtra() map[string][]string {
 	extra := map[string][]string{}
 	if i.IDToken != "" {
@@ -128,14 +121,18 @@ func (i *Identity) GetExtra() map[string][]string {
 	return extra
 }
 
-// GetGroups implements identity.Requester.
 func (i *Identity) GetGroups() []string {
 	return []string{} // teams?
 }
 
-// GetName implements identity.Requester.
 func (i *Identity) GetName() string {
-	return i.Name
+	if i.Name != "" {
+		return i.Name
+	}
+	if i.Login != "" {
+		return i.Login
+	}
+	return i.Email
 }
 
 func (i *Identity) GetID() string {
@@ -163,10 +160,6 @@ func (i *Identity) GetCacheKey() string {
 	}
 
 	return fmt.Sprintf("%d-%s-%s", i.GetOrgID(), i.Type, id)
-}
-
-func (i *Identity) GetDisplayName() string {
-	return i.Name
 }
 
 func (i *Identity) GetEmail() string {

--- a/pkg/services/live/features/dashboard.go
+++ b/pkg/services/live/features/dashboard.go
@@ -43,7 +43,7 @@ func newUserDisplayDTOFromRequester(requester identity.Requester) *userDisplayDT
 		ID:    userID,
 		UID:   requester.GetRawIdentifier(),
 		Login: requester.GetLogin(),
-		Name:  requester.GetDisplayName(),
+		Name:  requester.GetName(),
 	}
 }
 

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -262,7 +262,7 @@ func (s *ServiceImpl) addHelpLinks(treeRoot *navtree.NavTreeRoot, c *contextmode
 func (s *ServiceImpl) getProfileNode(c *contextmodel.ReqContext) *navtree.NavLink {
 	// Only set login if it's different from the name
 	var login string
-	if c.SignedInUser.GetLogin() != c.SignedInUser.GetDisplayName() {
+	if c.SignedInUser.GetLogin() != c.SignedInUser.GetName() {
 		login = c.SignedInUser.GetLogin()
 	}
 	gravatarURL := dtos.GetGravatarUrl(s.cfg, c.SignedInUser.GetEmail())
@@ -297,7 +297,7 @@ func (s *ServiceImpl) getProfileNode(c *contextmodel.ReqContext) *navtree.NavLin
 	}
 
 	return &navtree.NavLink{
-		Text:       c.SignedInUser.GetDisplayName(),
+		Text:       c.SignedInUser.GetName(),
 		SubTitle:   login,
 		Id:         "profile",
 		Img:        gravatarURL,

--- a/pkg/services/pluginsintegration/adapters/adapters.go
+++ b/pkg/services/pluginsintegration/adapters/adapters.go
@@ -52,7 +52,7 @@ func BackendUserFromSignedInUser(requester identity.Requester) *backend.User {
 	}
 	return &backend.User{
 		Login: requester.GetLogin(),
-		Name:  requester.GetDisplayName(),
+		Name:  requester.GetName(),
 		Email: requester.GetEmail(),
 		Role:  string(requester.GetOrgRole()),
 	}

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -102,7 +102,6 @@ func (u *SignedInUser) IsIdentityType(expected ...claims.IdentityType) bool {
 	return claims.IsIdentityType(u.GetIdentityType(), expected...)
 }
 
-// GetName implements identity.Requester.
 func (u *SignedInUser) GetName() string {
 	// kubernetesAggregator feature flag which allows Cloud Apps to become available
 	// in single tenant Grafana requires that GetName() returns something and not an empty string
@@ -110,11 +109,9 @@ func (u *SignedInUser) GetName() string {
 	if u.Name != "" {
 		return u.Name
 	}
-
 	if u.Login != "" {
 		return u.Login
 	}
-
 	return u.Email
 }
 
@@ -141,16 +138,6 @@ func (u *SignedInUser) GetGroups() []string {
 
 func (u *SignedInUser) ShouldUpdateLastSeenAt() bool {
 	return u.UserID > 0 && time.Since(u.LastSeenAt) > time.Minute*5
-}
-
-func (u *SignedInUser) NameOrFallback() string {
-	if u.Name != "" {
-		return u.Name
-	}
-	if u.Login != "" {
-		return u.Login
-	}
-	return u.Email
 }
 
 func (u *SignedInUser) HasRole(role identity.RoleType) bool {
@@ -322,12 +309,6 @@ func (u *SignedInUser) GetEmail() string {
 
 func (u *SignedInUser) IsEmailVerified() bool {
 	return u.EmailVerified
-}
-
-// GetDisplayName returns the display name of the active entity
-// The display name is the name if it is set, otherwise the login or email
-func (u *SignedInUser) GetDisplayName() string {
-	return u.NameOrFallback()
 }
 
 func (u *SignedInUser) GetIDToken() string {


### PR DESCRIPTION
**What is this feature?**
Since we have `GetName` in the requester interface and its implemented like `GetDisplayName` we can remove the latter and just use `GetName`.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
