### PR TITLE
Caching: specify uid for cloudwatch datasource

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -238,6 +238,7 @@ datasources:
       database: grafanadstest
 
   - name: gdev-cloudwatch
+    uid: gdev-cloudwatch
     type: cloudwatch
     editable: true
     jsonData:


### PR DESCRIPTION
**What is this feature?**

Specifies uid for the provisioned cloudwatch datasource.

**Why do we need this feature?**

Need to access an editable datasource for e2e testing.
More details in the enterprise PR: https://github.com/grafana/grafana-enterprise/pull/7605

**Who is this feature for?**

Enterprise feature.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/7552

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
