### PR TITLE
MSSQL: Make error consistent with psql and mysql

### DIFF
--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -306,7 +306,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 	if qm.Format == dataQueryFormatSeries {
 		// time series has to have time column
 		if qm.timeIndex == -1 {
-			errAppendDebug("db has no time column", errors.New("no time column found"), interpolatedQuery, backend.ErrorSourceDownstream)
+			errAppendDebug("db has no time column", errors.New("time column is missing; make sure your data includes a time column for time series format or switch to a table format that doesn't require it"), interpolatedQuery, backend.ErrorSourceDownstream)
 			return
 		}
 


### PR DESCRIPTION
we updated the error message in both [postgres](https://github.com/grafana/grafana/blob/main/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go#L304) and [mysql](https://github.com/grafana/grafana/blob/main/pkg/tsdb/mysql/sqleng/sql_engine.go#L300). this pr updates mssql for consistency across all three data sources