### PR TITLE
POC/v2 schema: Add v1<-> v2 transformers

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -21,8 +21,8 @@ import appEvents from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
 import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
 import { loadUrlToken } from 'app/core/utils/urlToken';
+import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
-import { isDashboardResource } from 'app/features/dashboard/api/utils';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { DashboardSearchItem } from 'app/features/search/types';
 import { TokenRevokedModal } from 'app/features/users/TokenRevokedModal';
@@ -515,13 +515,11 @@ export class BackendSrv implements BackendService {
     // NOTE: When this is removed, we can also remove most instances of:
     // jest.mock('app/features/live/dashboard/dashboardWatcher
     deprecationWarning('backend_srv', 'getDashboardByUid(uid)', 'getDashboardAPI().getDashboardDTO(uid)');
+
     const dashboard = await getDashboardAPI().getDashboardDTO(uid);
 
-    // TODO[schema]: should we support v2 in this deprecated method? Should we convert v2->v1 here?
-    if (isDashboardResource(dashboard)) {
-      throw new Error('v2 dashboard schema not supported');
-    }
-    return dashboard;
+    // Since we have a deprecated method here, let's transoform the response to the format that the consumers are using (v1 schema)
+    return ResponseTransformers.transformV2ToV1(dashboard);
   }
 
   validateDashboard(dashboard: DashboardModel): Promise<ValidateDashboardResponse> {

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -33,7 +33,7 @@ export function transformCursorSynctoEnum(cursorSync?: DashboardCursorSyncV1): D
   }
 }
 
-function transformDashboardLinkTypeToEnum(linkType: DashboardLinkTypeV1): DashboardLinkType {
+export function transformDashboardLinkTypeToEnum(linkType: DashboardLinkTypeV1): DashboardLinkType {
   switch (linkType) {
     case 'link':
       return DashboardLinkType.Link;

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1,0 +1,202 @@
+import { DashboardCursorSync, DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
+import { DashboardDTO } from 'app/types';
+
+import { ResponseTransformers } from './ResponseTransformers';
+import { DashboardWithAccessInfo } from './types';
+
+describe('ResponseTransformers', () => {
+  describe('v1 transformation', () => {
+    it('should transform DashboardDTO to DashboardWithAccessInfo<DashboardV2Spec>', () => {
+      const dashboardDTO: DashboardDTO = {
+        meta: {
+          created: '2023-01-01T00:00:00Z',
+          createdBy: 'user1',
+          updated: '2023-01-02T00:00:00Z',
+          updatedBy: 'user2',
+          folderUid: 'folder1',
+          slug: 'dashboard-slug',
+          url: '/d/dashboard-slug',
+          canAdmin: true,
+          canDelete: true,
+          canEdit: true,
+          canSave: true,
+          canShare: true,
+          canStar: true,
+          annotationsPermissions: {
+            dashboard: { canAdd: true, canEdit: true, canDelete: true },
+            organization: { canAdd: true, canEdit: true, canDelete: true },
+          },
+        },
+        dashboard: {
+          uid: 'dashboard1',
+          title: 'Dashboard Title',
+          description: 'Dashboard Description',
+          tags: ['tag1', 'tag2'],
+          schemaVersion: 1,
+          graphTooltip: 0,
+          preload: true,
+          liveNow: false,
+          editable: true,
+          time: { from: 'now-6h', to: 'now' },
+          timezone: 'browser',
+          refresh: '5m',
+          timepicker: {
+            refresh_intervals: ['5s', '10s', '30s'],
+            hidden: false,
+            time_options: ['5m', '15m', '1h'],
+            nowDelay: '1m',
+          },
+          fiscalYearStartMonth: 1,
+          weekStart: 'monday',
+          version: 1,
+          links: [],
+          annotations: {
+            list: [],
+          },
+        },
+      };
+
+      const transformed = ResponseTransformers.transformV1ToV2(dashboardDTO);
+
+      expect(transformed.apiVersion).toBe('v2alpha1');
+      expect(transformed.kind).toBe('DashboardWithAccessInfo');
+      expect(transformed.metadata.creationTimestamp).toBe(dashboardDTO.meta.created);
+      expect(transformed.metadata.name).toBe(dashboardDTO.dashboard.uid);
+      expect(transformed.metadata.resourceVersion).toBe(dashboardDTO.dashboard.version?.toString());
+      expect(transformed.metadata.annotations?.['grafana.app/createdBy']).toBe(dashboardDTO.meta.createdBy);
+      expect(transformed.metadata.annotations?.['grafana.app/updatedBy']).toBe(dashboardDTO.meta.updatedBy);
+      expect(transformed.metadata.annotations?.['grafana.app/updatedTimestamp']).toBe(dashboardDTO.meta.updated);
+      expect(transformed.metadata.annotations?.['grafana.app/folder']).toBe(dashboardDTO.meta.folderUid);
+      expect(transformed.metadata.annotations?.['grafana.app/slug']).toBe(dashboardDTO.meta.slug);
+
+      const spec = transformed.spec;
+      expect(spec.title).toBe(dashboardDTO.dashboard.title);
+      expect(spec.description).toBe(dashboardDTO.dashboard.description);
+      expect(spec.tags).toEqual(dashboardDTO.dashboard.tags);
+      expect(spec.schemaVersion).toBe(dashboardDTO.dashboard.schemaVersion);
+      expect(spec.cursorSync).toBe('Off'); // Assuming transformCursorSynctoEnum(0) returns 'Off'
+      expect(spec.preload).toBe(dashboardDTO.dashboard.preload);
+      expect(spec.liveNow).toBe(dashboardDTO.dashboard.liveNow);
+      expect(spec.editable).toBe(dashboardDTO.dashboard.editable);
+      expect(spec.timeSettings.from).toBe(dashboardDTO.dashboard.time?.from);
+      expect(spec.timeSettings.to).toBe(dashboardDTO.dashboard.time?.to);
+      expect(spec.timeSettings.timezone).toBe(dashboardDTO.dashboard.timezone);
+      expect(spec.timeSettings.autoRefresh).toBe(dashboardDTO.dashboard.refresh);
+      expect(spec.timeSettings.autoRefreshIntervals).toEqual(dashboardDTO.dashboard.timepicker?.refresh_intervals);
+      expect(spec.timeSettings.hideTimepicker).toBe(dashboardDTO.dashboard.timepicker?.hidden);
+      expect(spec.timeSettings.quickRanges).toEqual(dashboardDTO.dashboard.timepicker?.time_options);
+      expect(spec.timeSettings.nowDelay).toBe(dashboardDTO.dashboard.timepicker?.nowDelay);
+      expect(spec.timeSettings.fiscalYearStartMonth).toBe(dashboardDTO.dashboard.fiscalYearStartMonth);
+      expect(spec.timeSettings.weekStart).toBe(dashboardDTO.dashboard.weekStart);
+      expect(spec.links).toEqual([]); // Assuming transformDashboardLinksToEnums([]) returns []
+      expect(spec.annotations).toEqual([]);
+    });
+  });
+
+  describe('v2 transformation', () => {
+    it('should transform DashboardWithAccessInfo<DashboardV2Spec> to DashboardDTO', () => {
+      const dashboardV2: DashboardWithAccessInfo<DashboardV2Spec> = {
+        apiVersion: 'v2alpha1',
+        kind: 'DashboardWithAccessInfo',
+        metadata: {
+          creationTimestamp: '2023-01-01T00:00:00Z',
+          name: 'dashboard1',
+          resourceVersion: '1',
+          annotations: {
+            'grafana.app/createdBy': 'user1',
+            'grafana.app/updatedBy': 'user2',
+            'grafana.app/updatedTimestamp': '2023-01-02T00:00:00Z',
+            'grafana.app/folder': 'folder1',
+            'grafana.app/slug': 'dashboard-slug',
+          },
+        },
+        spec: {
+          title: 'Dashboard Title',
+          description: 'Dashboard Description',
+          tags: ['tag1', 'tag2'],
+          schemaVersion: 1,
+          cursorSync: DashboardCursorSync.Off,
+          preload: true,
+          liveNow: false,
+          editable: true,
+          timeSettings: {
+            from: 'now-6h',
+            to: 'now',
+            timezone: 'browser',
+            autoRefresh: '5m',
+            autoRefreshIntervals: ['5s', '10s', '30s'],
+            hideTimepicker: false,
+            quickRanges: ['5m', '15m', '1h'],
+            nowDelay: '1m',
+            fiscalYearStartMonth: 1,
+            weekStart: 'monday',
+          },
+          links: [],
+          annotations: [],
+          variables: [],
+          elements: {},
+          layout: {
+            kind: 'GridLayout',
+            spec: {
+              items: [],
+            },
+          },
+        },
+        access: {
+          url: '/d/dashboard-slug',
+          canAdmin: true,
+          canDelete: true,
+          canEdit: true,
+          canSave: true,
+          canShare: true,
+          canStar: true,
+          slug: 'dashboard-slug',
+          annotationsPermissions: {
+            dashboard: { canAdd: true, canEdit: true, canDelete: true },
+            organization: { canAdd: true, canEdit: true, canDelete: true },
+          },
+        },
+      };
+
+      const transformed = ResponseTransformers.transformV2ToV1(dashboardV2);
+
+      expect(transformed.meta.created).toBe(dashboardV2.metadata.creationTimestamp);
+      expect(transformed.meta.createdBy).toBe(dashboardV2.metadata.annotations?.['grafana.app/createdBy']);
+      expect(transformed.meta.updated).toBe(dashboardV2.metadata.annotations?.['grafana.app/updatedTimestamp']);
+      expect(transformed.meta.updatedBy).toBe(dashboardV2.metadata.annotations?.['grafana.app/updatedBy']);
+      expect(transformed.meta.folderUid).toBe(dashboardV2.metadata.annotations?.['grafana.app/folder']);
+      expect(transformed.meta.slug).toBe(dashboardV2.metadata.annotations?.['grafana.app/slug']);
+      expect(transformed.meta.url).toBe(dashboardV2.access.url);
+      expect(transformed.meta.canAdmin).toBe(dashboardV2.access.canAdmin);
+      expect(transformed.meta.canDelete).toBe(dashboardV2.access.canDelete);
+      expect(transformed.meta.canEdit).toBe(dashboardV2.access.canEdit);
+      expect(transformed.meta.canSave).toBe(dashboardV2.access.canSave);
+      expect(transformed.meta.canShare).toBe(dashboardV2.access.canShare);
+      expect(transformed.meta.canStar).toBe(dashboardV2.access.canStar);
+      expect(transformed.meta.annotationsPermissions).toEqual(dashboardV2.access.annotationsPermissions);
+
+      const dashboard = transformed.dashboard;
+      expect(dashboard.uid).toBe(dashboardV2.metadata.name);
+      expect(dashboard.title).toBe(dashboardV2.spec.title);
+      expect(dashboard.description).toBe(dashboardV2.spec.description);
+      expect(dashboard.tags).toEqual(dashboardV2.spec.tags);
+      expect(dashboard.schemaVersion).toBe(dashboardV2.spec.schemaVersion);
+      //   expect(dashboard.graphTooltip).toBe(0); // Assuming transformCursorSynctoEnum('Off') returns 0
+      expect(dashboard.preload).toBe(dashboardV2.spec.preload);
+      expect(dashboard.liveNow).toBe(dashboardV2.spec.liveNow);
+      expect(dashboard.editable).toBe(dashboardV2.spec.editable);
+      expect(dashboard.time?.from).toBe(dashboardV2.spec.timeSettings.from);
+      expect(dashboard.time?.to).toBe(dashboardV2.spec.timeSettings.to);
+      expect(dashboard.timezone).toBe(dashboardV2.spec.timeSettings.timezone);
+      expect(dashboard.refresh).toBe(dashboardV2.spec.timeSettings.autoRefresh);
+      expect(dashboard.timepicker?.refresh_intervals).toEqual(dashboardV2.spec.timeSettings.autoRefreshIntervals);
+      expect(dashboard.timepicker?.hidden).toBe(dashboardV2.spec.timeSettings.hideTimepicker);
+      expect(dashboard.timepicker?.time_options).toEqual(dashboardV2.spec.timeSettings.quickRanges);
+      expect(dashboard.timepicker?.nowDelay).toBe(dashboardV2.spec.timeSettings.nowDelay);
+      expect(dashboard.fiscalYearStartMonth).toBe(dashboardV2.spec.timeSettings.fiscalYearStartMonth);
+      expect(dashboard.weekStart).toBe(dashboardV2.spec.timeSettings.weekStart);
+      expect(dashboard.links).toEqual([]); // Assuming transformDashboardLinksToEnums([]) returns []
+      expect(dashboard.annotations).toEqual({ list: [] });
+    });
+  });
+});

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,0 +1,147 @@
+import {
+  DashboardV2Spec,
+  defaultDashboardV2Spec,
+  defaultTimeSettingsSpec,
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
+import {
+  transformCursorSynctoEnum,
+  transformDashboardLinksToEnums,
+} from 'app/features/dashboard-scene/serialization/transformToV2TypesUtils';
+import { DashboardDTO } from 'app/types';
+
+import { DashboardWithAccessInfo } from './types';
+import { isDashboardResource } from './utils';
+
+export function transformV1ToV2(
+  dto: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>
+): DashboardWithAccessInfo<DashboardV2Spec> {
+  if (isDashboardResource(dto)) {
+    return dto;
+  }
+
+  const timeSettingsDefaults = defaultTimeSettingsSpec();
+  const dashboardDefaults = defaultDashboardV2Spec();
+
+  const spec: DashboardV2Spec = {
+    title: dto.dashboard.title,
+    description: dto.dashboard.description,
+    tags: dto.dashboard.tags,
+    schemaVersion: dto.dashboard.schemaVersion,
+    cursorSync: transformCursorSynctoEnum(dto.dashboard.graphTooltip),
+    preload: dto.dashboard.preload || dashboardDefaults.preload,
+    liveNow: dto.dashboard.liveNow,
+    editable: dto.dashboard.editable,
+    timeSettings: {
+      from: dto.dashboard.time?.from || timeSettingsDefaults.from,
+      to: dto.dashboard.time?.to || timeSettingsDefaults.to,
+      timezone: dto.dashboard.timezone || timeSettingsDefaults.timezone,
+      autoRefresh: dto.dashboard.refresh || timeSettingsDefaults.autoRefresh,
+      autoRefreshIntervals: dto.dashboard.timepicker?.refresh_intervals || timeSettingsDefaults.autoRefreshIntervals,
+      fiscalYearStartMonth: dto.dashboard.fiscalYearStartMonth || timeSettingsDefaults.fiscalYearStartMonth,
+      hideTimepicker: dto.dashboard.timepicker?.hidden || timeSettingsDefaults.hideTimepicker,
+      quickRanges: dto.dashboard.timepicker?.time_options || timeSettingsDefaults.quickRanges,
+      weekStart: dto.dashboard.weekStart || timeSettingsDefaults.weekStart,
+      nowDelay: dto.dashboard.timepicker?.nowDelay || timeSettingsDefaults.nowDelay,
+    },
+    links: transformDashboardLinksToEnums(dto.dashboard.links || []),
+    annotations: [], // TODO
+    variables: [], // todo
+    elements: {}, // todo
+    layout: {
+      // todo
+      kind: 'GridLayout',
+      spec: {
+        items: [],
+      },
+    },
+  };
+
+  return {
+    apiVersion: 'v2alpha1',
+    kind: 'DashboardWithAccessInfo',
+    metadata: {
+      creationTimestamp: dto.meta.created || '', // TODO verify this empty string is valid
+      name: dto.dashboard.uid,
+      resourceVersion: dto.dashboard.version?.toString() || '0',
+      annotations: {
+        'grafana.app/createdBy': dto.meta.createdBy,
+        'grafana.app/updatedBy': dto.meta.updatedBy,
+        'grafana.app/updatedTimestamp': dto.meta.updated,
+        'grafana.app/folder': dto.meta.folderUid,
+        'grafana.app/slug': dto.meta.slug,
+      },
+    },
+    spec,
+    access: {
+      url: dto.meta.url || '',
+      canAdmin: dto.meta.canAdmin,
+      canDelete: dto.meta.canDelete,
+      canEdit: dto.meta.canEdit,
+      canSave: dto.meta.canSave,
+      canShare: dto.meta.canShare,
+      canStar: dto.meta.canStar,
+      slug: dto.meta.slug,
+      annotationsPermissions: dto.meta.annotationsPermissions,
+    },
+  };
+}
+
+export function transformV2ToV1(dashboard: DashboardWithAccessInfo<DashboardV2Spec> | DashboardDTO): DashboardDTO {
+  if (!isDashboardResource(dashboard)) {
+    return dashboard;
+  }
+  const spec = dashboard.spec;
+
+  return {
+    meta: {
+      created: dashboard.metadata.creationTimestamp,
+      createdBy: dashboard.metadata.annotations?.['grafana.app/createdBy'] ?? '',
+      updated: dashboard.metadata.annotations?.['grafana.app/updatedTimestamp'],
+      updatedBy: dashboard.metadata.annotations?.['grafana.app/updatedBy'],
+      folderUid: dashboard.metadata.annotations?.['grafana.app/folder'],
+      slug: dashboard.metadata.annotations?.['grafana.app/slug'],
+      url: dashboard.access.url,
+      canAdmin: dashboard.access.canAdmin,
+      canDelete: dashboard.access.canDelete,
+      canEdit: dashboard.access.canEdit,
+      canSave: dashboard.access.canSave,
+      canShare: dashboard.access.canShare,
+      canStar: dashboard.access.canStar,
+      annotationsPermissions: dashboard.access.annotationsPermissions,
+    },
+    dashboard: {
+      uid: dashboard.metadata.name,
+      title: spec.title,
+      description: spec.description,
+      tags: spec.tags,
+      schemaVersion: spec.schemaVersion,
+      // @ts-ignore TODO: Use transformers for these enums
+      //   graphTooltip: spec.cursorSync, // Assuming transformCursorSynctoEnum is reversible
+      preload: spec.preload,
+      liveNow: spec.liveNow,
+      editable: spec.editable,
+      time: {
+        from: spec.timeSettings.from,
+        to: spec.timeSettings.to,
+      },
+      timezone: spec.timeSettings.timezone,
+      refresh: spec.timeSettings.autoRefresh,
+      timepicker: {
+        refresh_intervals: spec.timeSettings.autoRefreshIntervals,
+        hidden: spec.timeSettings.hideTimepicker,
+        time_options: spec.timeSettings.quickRanges,
+        nowDelay: spec.timeSettings.nowDelay,
+      },
+      fiscalYearStartMonth: spec.timeSettings.fiscalYearStartMonth,
+      weekStart: spec.timeSettings.weekStart,
+      version: parseInt(dashboard.metadata.resourceVersion, 10),
+      links: spec.links, // Assuming transformDashboardLinksToEnums is reversible
+      annotations: { list: [] }, // TODO
+    },
+  };
+}
+
+export const ResponseTransformers = {
+  transformV1ToV2,
+  transformV2ToV1,
+};

--- a/public/app/features/dashboard/api/types.ts
+++ b/public/app/features/dashboard/api/types.ts
@@ -1,7 +1,7 @@
 import { UrlQueryMap } from '@grafana/data';
 import { Resource } from 'app/features/apiserver/types';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
-import { SaveDashboardResponseDTO } from 'app/types';
+import { AnnotationsPermissions, SaveDashboardResponseDTO } from 'app/types';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
@@ -17,6 +17,14 @@ export interface DashboardAPI<G> {
 // Implemented using /api/dashboards/*
 export interface DashboardWithAccessInfo<T> extends Resource<T, 'DashboardWithAccessInfo'> {
   access: {
-    url: string;
+    url?: string;
+    slug?: string;
+    canSave?: boolean;
+    canEdit?: boolean;
+    canDelete?: boolean;
+    canShare?: boolean;
+    canStar?: boolean;
+    canAdmin?: boolean;
+    annotationsPermissions?: AnnotationsPermissions;
   }; // TODO...
 }

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -35,3 +35,7 @@ export function isDashboardResource(
 
   return 'kind' in obj && obj.kind === 'DashboardWithAccessInfo';
 }
+
+export function isDashboardV2Spec(obj: any): obj is DashboardV2Spec {
+  return 'elements' in obj;
+}

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -7,10 +7,10 @@ import { SaveDashboardResponseDTO } from 'app/types';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
+import { ResponseTransformers } from './ResponseTransformers';
 import { DashboardAPI, DashboardWithAccessInfo } from './types';
 
 export class K8sDashboardV2APIStub implements DashboardAPI<DashboardWithAccessInfo<DashboardV2Spec>> {
-  // @ts-ignore
   private client: ResourceClient<DashboardV2Spec>;
 
   constructor() {
@@ -22,7 +22,10 @@ export class K8sDashboardV2APIStub implements DashboardAPI<DashboardWithAccessIn
   }
 
   async getDashboardDTO(uid: string, params?: UrlQueryMap) {
-    return await this.client.subresource<DashboardWithAccessInfo<DashboardV2Spec>>(uid, 'dto');
+    const dashboard = await this.client.subresource<DashboardWithAccessInfo<DashboardV2Spec>>(uid, 'dto');
+
+    // For dev purposes only now, the conversion should happen in the API. This is just to stub v2 api responses.
+    return ResponseTransformers.transformV1ToV2(dashboard);
   }
 
   deleteDashboard(uid: string, showSuccessAlert: boolean): Promise<DeleteDashboardResponse> {


### PR DESCRIPTION
Built on top of https://github.com/grafana/grafana/pull/96666

Adds a simple, yet incomplete transformers that would transform v1 to v2 and v2 to v1 dashboard schema objects. 

This will allow us to start using v2 API without waiting for the backend conversions, so that we can start interacting with v2 schema in dashboards.