### PR TITLE
[Prototyping] validate branch name in backend

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidGitBranchName(t *testing.T) {
+	tests := []struct {
+		name     string
+		branch   string
+		expected bool
+	}{
+		{"Valid branch name", "feature/add-tests", true},
+		{"Starts with /", "/feature", false},
+		{"Ends with /", "feature/", false},
+		{"Ends with .", "feature.", false},
+		{"Ends with space", "feature ", false},
+		{"Contains consecutive slashes", "feature//branch", false},
+		{"Contains consecutive dots", "feature..branch", false},
+		{"Contains @{", "feature@{branch", false},
+		{"Contains invalid character ~", "feature~branch", false},
+		{"Contains invalid character ^", "feature^branch", false},
+		{"Contains invalid character :", "feature:branch", false},
+		{"Contains invalid character ?", "feature?branch", false},
+		{"Contains invalid character *", "feature*branch", false},
+		{"Contains invalid character [", "feature[branch", false},
+		{"Contains invalid character ]", "feature]branch", false},
+		{"Contains invalid character \\", "feature\\branch", false},
+		{"Empty branch name", "", false},
+		{"Only whitespace", " ", false},
+		{"Single valid character", "a", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isValidGitBranchName(tt.branch))
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -36,6 +36,7 @@ func TestIsValidGitBranchName(t *testing.T) {
 		{"Empty branch name", "", false},
 		{"Only whitespace", " ", false},
 		{"Single valid character", "a", true},
+		{"Ends with .lock", "feature.lock", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -13,6 +13,11 @@ func TestIsValidGitBranchName(t *testing.T) {
 		expected bool
 	}{
 		{"Valid branch name", "feature/add-tests", true},
+		{"Valid branch name with numbers", "feature/123-add-tests", true},
+		{"Valid branch name with dots", "feature.add.tests", true},
+		{"Valid branch name with hyphens", "feature-add-tests", true},
+		{"Valid branch name with underscores", "feature_add_tests", true},
+		{"Valid branch name with mixed characters", "feature/add_tests-123", true},
 		{"Starts with /", "/feature", false},
 		{"Ends with /", "feature/", false},
 		{"Ends with .", "feature.", false},


### PR DESCRIPTION
Manually validate that we satisfy what the frontend regex does as Go does not support positive lookahead:

https://github.com/grafana/grafana/pull/97034/files#diff-3b1f1ed6b0a1b84c685a9144a93a39186282037fc18752e6e5a0bda8623ecb65R10-R23

