### PR TITLE
Variable: correctly show when variable is empty string 

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -287,7 +287,7 @@ export const SelectMenuOptions = ({
       {icon && <Icon name={icon} className={styles.optionIcon} />}
       {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} alt={data.label || String(data.value)} />}
       <div className={styles.optionBody}>
-        <span>{renderOptionLabel ? renderOptionLabel(data) : children}</span>
+        <span>{renderOptionLabel ? renderOptionLabel(data) : children === "" ? "\u200B" : children}</span>
         {data.description && <div className={styles.optionDescription}>{data.description}</div>}
         {data.component && <data.component />}
       </div>


### PR DESCRIPTION
Fixes #96950
![image](https://github.com/user-attachments/assets/fe6e1993-a6d7-4340-a49c-985670649c23)
use `\u200B` to make span have height