### PR TITLE
chore: Pin `send-slack-message` action

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Send Slack Message via Payload
         id: slack
         if: steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 && github.repository == 'grafana/grafana'
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
         with:
           channel-id: "C031SLFH6G0"
           payload:  |


### PR DESCRIPTION
**What is this feature?**

`send-slack-message` upstream action has a lot of breaking changes ([see here](https://github.com/grafana/shared-workflows/pull/534)). We need to make sure that all usages of our shared-workflow are pinned to avoid breakages.

**Why do we need this feature?**

Because all the new change in main for the workflow will break existing behavior.

**Who is this feature for?**

Every levitate pipeline.