### PR TITLE
LoginAttempt: Add setting to control max number of attempts before user login gets locked

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -351,6 +351,9 @@ data_source_proxy_whitelist =
 # disable protection against brute force login attempts
 disable_brute_force_login_protection = false
 
+# Max number of failed login attempts before user gets locked
+brute_force_login_protection_max_attempts = 5
+
 # set to true if you host Grafana behind HTTPS. default is false.
 cookie_secure = false
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -351,7 +351,7 @@ data_source_proxy_whitelist =
 # disable protection against brute force login attempts
 disable_brute_force_login_protection = false
 
-# Max number of failed login attempts before user gets locked
+# max number of failed login attempts before user gets locked
 brute_force_login_protection_max_attempts = 5
 
 # set to true if you host Grafana behind HTTPS. default is false.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -350,6 +350,9 @@
 # disable protection against brute force login attempts
 ;disable_brute_force_login_protection = false
 
+# Max number of failed login attempts before user gets locked
+;brute_force_login_protection_max_attempts = 5
+
 # set to true if you host Grafana behind HTTPS. default is false.
 ;cookie_secure = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -350,7 +350,7 @@
 # disable protection against brute force login attempts
 ;disable_brute_force_login_protection = false
 
-# Max number of failed login attempts before user gets locked
+# max number of failed login attempts before user gets locked
 ;brute_force_login_protection_max_attempts = 5
 
 # set to true if you host Grafana behind HTTPS. default is false.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -630,7 +630,11 @@ Define a whitelist of allowed IP addresses or domains, with ports, to be used in
 
 ### disable_brute_force_login_protection
 
-Set to `true` to disable [brute force login protection](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-lockout). Default is `false`. An existing user's account will be locked after 5 attempts in 5 minutes.
+Set to `true` to disable [brute force login protection](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-lockout). Default is `false`. An existing user's account will be locked for 5 minutes if all attempts are spent within a 5 minute window.
+
+### brute_force_login_protection_max_attempts
+
+Configure how many login attempts a user have within a 5 minute window before the account will be locked. Default is `5`.
 
 ### cookie_secure
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -630,7 +630,7 @@ Define a whitelist of allowed IP addresses or domains, with ports, to be used in
 
 ### disable_brute_force_login_protection
 
-Set to `true` to disable [brute force login protection](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-lockout). Default is `false`. An existing user's account will be locked for 5 minutes if all attempts are spent within a 5 minute window.
+Set to `true` to disable [brute force login protection](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#account-lockout). Default is `false`. An existing user's account will be unable to login for 5 minutes if all login attempts are spent within a 5 minute window.
 
 ### brute_force_login_protection_max_attempts
 

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt.go
@@ -11,10 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-const (
-	maxInvalidLoginAttempts int64 = 5
-	loginAttemptsWindow           = time.Minute * 5
-)
+const loginAttemptsWindow = time.Minute * 5
 
 func ProvideService(db db.DB, cfg *setting.Cfg, lock *serverlock.ServerLockService) *Service {
 	return &Service{
@@ -80,7 +77,7 @@ func (s *Service) Validate(ctx context.Context, username string) (bool, error) {
 		return false, err
 	}
 
-	if count >= maxInvalidLoginAttempts {
+	if count >= s.cfg.BruteForceLoginProtectionMaxAttempts {
 		return false, nil
 	}
 

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestService_Validate(t *testing.T) {
+	const maxInvalidLoginAttempts = 5
+
 	testCases := []struct {
 		name          string
 		loginAttempts int64
@@ -64,6 +66,7 @@ func TestService_Validate(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := setting.NewCfg()
+			cfg.BruteForceLoginProtectionMaxAttempts = maxInvalidLoginAttempts
 			cfg.DisableBruteForceLoginProtection = tt.disabled
 			service := &Service{
 				store: fakeStore{
@@ -84,6 +87,7 @@ func TestLoginAttempts(t *testing.T) {
 	ctx := context.Background()
 	cfg := setting.NewCfg()
 	cfg.DisableBruteForceLoginProtection = false
+	cfg.BruteForceLoginProtectionMaxAttempts = 5
 	db := db.InitTestDB(t)
 	service := ProvideService(db, cfg, nil)
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -154,18 +154,19 @@ type Cfg struct {
 	RendererDefaultImageScale      float64
 
 	// Security
-	DisableInitAdminCreation          bool
-	DisableBruteForceLoginProtection  bool
-	CookieSecure                      bool
-	CookieSameSiteDisabled            bool
-	CookieSameSiteMode                http.SameSite
-	AllowEmbedding                    bool
-	XSSProtectionHeader               bool
-	ContentTypeProtectionHeader       bool
-	StrictTransportSecurity           bool
-	StrictTransportSecurityMaxAge     int
-	StrictTransportSecurityPreload    bool
-	StrictTransportSecuritySubDomains bool
+	DisableInitAdminCreation             bool
+	DisableBruteForceLoginProtection     bool
+	BruteForceLoginProtectionMaxAttempts int64
+	CookieSecure                         bool
+	CookieSameSiteDisabled               bool
+	CookieSameSiteMode                   http.SameSite
+	AllowEmbedding                       bool
+	XSSProtectionHeader                  bool
+	ContentTypeProtectionHeader          bool
+	StrictTransportSecurity              bool
+	StrictTransportSecurityMaxAge        int
+	StrictTransportSecurityPreload       bool
+	StrictTransportSecuritySubDomains    bool
 	// CSPEnabled toggles Content Security Policy support.
 	CSPEnabled bool
 	// CSPTemplate contains the Content Security Policy template.
@@ -1498,7 +1499,9 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	security := iniFile.Section("security")
 	cfg.SecretKey = valueAsString(security, "secret_key", "")
 	cfg.DisableGravatar = security.Key("disable_gravatar").MustBool(true)
+
 	cfg.DisableBruteForceLoginProtection = security.Key("disable_brute_force_login_protection").MustBool(false)
+	cfg.BruteForceLoginProtectionMaxAttempts = security.Key("brute_force_login_protection_max_attempts").MustInt64(5)
 
 	CookieSecure = security.Key("cookie_secure").MustBool(false)
 	cfg.CookieSecure = CookieSecure

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1503,6 +1503,11 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableBruteForceLoginProtection = security.Key("disable_brute_force_login_protection").MustBool(false)
 	cfg.BruteForceLoginProtectionMaxAttempts = security.Key("brute_force_login_protection_max_attempts").MustInt64(5)
 
+	// Ensure at least one login attempt can be performed.
+	if cfg.BruteForceLoginProtectionMaxAttempts <= 0 {
+		cfg.BruteForceLoginProtectionMaxAttempts = 1
+	}
+
 	CookieSecure = security.Key("cookie_secure").MustBool(false)
 	cfg.CookieSecure = CookieSecure
 


### PR DESCRIPTION
Currently max number of login attempts are hard coded to 5. This pr adds a setting so it can be changed.

`disable_brute_force_login_protection` is placed under the security section so I placed the new setting there as well. I am not a big fan of the name and would rather create a new section for these settings, something like 

```
[login_attempts]
enabled = true
max_attemtps = 5
```

But that would require us to deprecate old setting and still read it for a while, not sure if it is worth the effort