### PR TITLE
Logs Panel: Add infinite scrolling support for Dashboards and Apps

### DIFF
--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -15,6 +15,7 @@ export const pluginVersion = "11.4.0-pre";
 export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
   displayedFields?: Array<string>;
+  enableInfiniteScrolling: boolean;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
   logRowMenuIconsAfter?: unknown;

--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -15,7 +15,7 @@ export const pluginVersion = "11.4.0-pre";
 export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
   displayedFields?: Array<string>;
-  enableInfiniteScrolling: boolean;
+  enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
   logRowMenuIconsAfter?: unknown;
@@ -29,6 +29,7 @@ export interface Options {
   onClickFilterString?: unknown;
   onClickHideField?: unknown;
   onClickShowField?: unknown;
+  onNewLogsReceived?: unknown;
   prettifyLogMessage: boolean;
   showCommonLabels: boolean;
   showLabels: boolean;

--- a/public/app/core/utils/shortLinks.test.ts
+++ b/public/app/core/utils/shortLinks.test.ts
@@ -1,4 +1,8 @@
-import { createShortLink, createAndCopyShortLink } from './shortLinks';
+import { LogRowModel } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { createLogRow } from 'app/features/logs/components/__mocks__/logRow';
+
+import { createShortLink, createAndCopyShortLink, getLogsPermalinkRange } from './shortLinks';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -9,6 +13,7 @@ jest.mock('@grafana/runtime', () => ({
       },
     };
   },
+  config: jest.requireActual('@grafana/runtime').config,
 }));
 
 describe('createShortLink', () => {
@@ -23,5 +28,59 @@ describe('createAndCopyShortLink', () => {
     document.execCommand = jest.fn();
     await createAndCopyShortLink('www.verylonglinkwehavehere.com');
     expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+});
+
+describe('getLogsPermalinkRange', () => {
+  let row: LogRowModel, rows: LogRowModel[];
+  beforeEach(() => {
+    config.featureToggles.logsInfiniteScrolling = true;
+    row = createLogRow({
+      timeEpochMs: 1111112222222,
+    });
+    rows = [
+      createLogRow({
+        timeEpochMs: 1111113333333,
+      }),
+      row,
+    ];
+  });
+  afterAll(() => {
+    config.featureToggles.logsInfiniteScrolling = false;
+  });
+
+  it('returns the original range if infinite scrolling is not enabled', () => {
+    config.featureToggles.logsInfiniteScrolling = false;
+    const range = {
+      from: 1111111111111,
+      to: 1111112222222,
+    };
+    const expectedRange = {
+      from: new Date(1111111111111).toISOString(),
+      to: new Date(1111112222222).toISOString(),
+    };
+    expect(getLogsPermalinkRange(row, [row], range)).toEqual(expectedRange);
+  });
+
+  it('returns the range relative to the previous log line', () => {
+    const range = {
+      from: 1111111111111,
+      to: 1111114444444,
+    };
+    expect(getLogsPermalinkRange(row, rows, range)).toEqual({
+      from: '2005-03-18T01:58:31.111Z',
+      to: '2005-03-18T02:35:33.333Z',
+    });
+  });
+
+  it('returns the range relative to the previous log line', () => {
+    const range = {
+      from: 1111111111110,
+      to: 1111111111111,
+    };
+    expect(getLogsPermalinkRange(row, [row], range)).toEqual({
+      from: '2005-03-18T01:58:31.110Z',
+      to: '2005-03-18T02:17:02.223Z',
+    });
   });
 });

--- a/public/app/core/utils/shortLinks.test.ts
+++ b/public/app/core/utils/shortLinks.test.ts
@@ -13,7 +13,6 @@ jest.mock('@grafana/runtime', () => ({
       },
     };
   },
-  config: jest.requireActual('@grafana/runtime').config,
 }));
 
 describe('createShortLink', () => {

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -1,6 +1,6 @@
 import memoizeOne from 'memoize-one';
 
-import { UrlQueryMap } from '@grafana/data';
+import { AbsoluteTimeRange, LogRowModel, UrlQueryMap } from '@grafana/data';
 import { getBackendSrv, config, locationService } from '@grafana/runtime';
 import { sceneGraph, SceneTimeRangeLike, VizPanel } from '@grafana/scenes';
 import { notifyApp } from 'app/core/actions';
@@ -96,3 +96,43 @@ export const getShareUrlParams = (
 
   return urlParamsUpdate;
 };
+
+function getPreviousLog(row: LogRowModel, allLogs: LogRowModel[]): LogRowModel | null {
+  for (let i = allLogs.indexOf(row) - 1; i >= 0; i--) {
+    if (allLogs[i].timeEpochMs > row.timeEpochMs) {
+      return allLogs[i];
+    }
+  }
+
+  return null;
+}
+
+export function getLogsPermalinkRange(row: LogRowModel, rows: LogRowModel[], absoluteRange: AbsoluteTimeRange) {
+  const range = {
+    from: new Date(absoluteRange.from).toISOString(),
+    to: new Date(absoluteRange.to).toISOString(),
+  };
+  if (!config.featureToggles.logsInfiniteScrolling) {
+    return range;
+  }
+
+  // With infinite scrolling, the time range of the log line can be after the absolute range or beyond the request line limit, so we need to adjust
+  // Look for the previous sibling log, and use its timestamp
+  const allLogs = rows.filter((logRow) => logRow.dataFrame.refId === row.dataFrame.refId);
+  const prevLog = getPreviousLog(row, allLogs);
+
+  if (row.timeEpochMs > absoluteRange.to && !prevLog) {
+    // Because there's no sibling and the current `to` is oldest than the log, we have no reference we can use for the interval
+    // This only happens when you scroll into the future and you want to share the first log of the list
+    return {
+      from: new Date(absoluteRange.from).toISOString(),
+      // Slide 1ms otherwise it's very likely to be omitted in the results
+      to: new Date(row.timeEpochMs + 1).toISOString(),
+    };
+  }
+
+  return {
+    from: new Date(absoluteRange.from).toISOString(),
+    to: new Date(prevLog ? prevLog.timeEpochMs : absoluteRange.to).toISOString(),
+  };
+}

--- a/public/app/plugins/panel/logs/LogsPanel.test.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.test.tsx
@@ -12,6 +12,7 @@ import {
   getDefaultTimeRange,
   LogsDedupStrategy,
   EventBusSrv,
+  DataFrameType,
 } from '@grafana/data';
 import * as grafanaUI from '@grafana/ui';
 import * as styles from 'app/features/logs/components/getLogRowStyles';
@@ -108,23 +109,36 @@ describe('LogsPanel', () => {
       createDataFrame({
         fields: [
           {
-            name: 'time',
+            name: 'timestamp',
             type: FieldType.time,
             values: ['2019-04-26T09:28:11.352440161Z', '2019-04-26T14:42:50.991981292Z'],
           },
           {
-            name: 'message',
+            name: 'body',
             type: FieldType.string,
             values: [
               't=2019-04-26T11:05:28+0200 lvl=info msg="Initializing DatasourceCacheService" logger=server',
               't=2019-04-26T16:42:50+0200 lvl=eror msg="new token…t unhashed token=56d9fdc5c8b7400bd51b060eea8ca9d7',
             ],
-            labels: {
-              app: 'common_app',
-              job: 'common_job',
-            },
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              {
+                app: 'common_app',
+                job: 'common_job',
+              },
+              {
+                app: 'common_app',
+                job: 'common_job',
+              },
+            ],
           },
         ],
+        meta: {
+          type: DataFrameType.LogLines,
+        },
       }),
     ];
 
@@ -172,12 +186,12 @@ describe('LogsPanel', () => {
       createDataFrame({
         fields: [
           {
-            name: 'time',
+            name: 'timestamp',
             type: FieldType.time,
             values: ['2019-04-26T09:28:11.352440161Z', '2019-04-26T14:42:50.991981292Z'],
           },
           {
-            name: 'message',
+            name: 'body',
             type: FieldType.string,
             values: [
               't=2019-04-26T11:05:28+0200 lvl=info msg="Initializing DatasourceCacheService" logger=server',
@@ -185,6 +199,9 @@ describe('LogsPanel', () => {
             ],
           },
         ],
+        meta: {
+          type: DataFrameType.LogLines,
+        },
       }),
     ];
     it('shows (no common labels) when showCommonLabels is set to true', async () => {
@@ -214,20 +231,33 @@ describe('LogsPanel', () => {
         refId: 'A',
         fields: [
           {
-            name: 'time',
+            name: 'timestamp',
             type: FieldType.time,
             values: ['2019-04-26T09:28:11.352440161Z', '2019-04-26T14:42:50.991981292Z'],
           },
           {
-            name: 'message',
+            name: 'body',
             type: FieldType.string,
-            values: ['logline text'],
-            labels: {
-              app: 'common_app',
-              job: 'common_job',
-            },
+            values: ['logline text', 'more text'],
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              {
+                app: 'common_app',
+                job: 'common_job',
+              },
+              {
+                app: 'common_app',
+                job: 'common_job',
+              },
+            ],
           },
         ],
+        meta: {
+          type: DataFrameType.LogLines,
+        },
       }),
     ];
 
@@ -367,20 +397,29 @@ describe('LogsPanel', () => {
         refId: 'A',
         fields: [
           {
-            name: 'time',
+            name: 'timestamp',
             type: FieldType.time,
             values: ['2019-04-26T09:28:11.352440161Z'],
           },
           {
-            name: 'message',
+            name: 'body',
             type: FieldType.string,
             values: ['logline text'],
-            labels: {
-              app: 'common_app',
-              job: 'common_job',
-            },
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              {
+                app: 'common_app',
+                job: 'common_job',
+              },
+            ],
           },
         ],
+        meta: {
+          type: DataFrameType.LogLines,
+        },
       }),
     ];
 
@@ -431,19 +470,28 @@ describe('LogsPanel', () => {
         refId: 'A',
         fields: [
           {
-            name: 'time',
+            name: 'timestamp',
             type: FieldType.time,
             values: ['2019-04-26T09:28:11.352440161Z'],
           },
           {
-            name: 'message',
+            name: 'body',
             type: FieldType.string,
             values: ['logline text'],
-            labels: {
-              app: 'common_app',
-            },
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              {
+                app: 'common_app',
+              },
+            ],
           },
         ],
+        meta: {
+          type: DataFrameType.LogLines,
+        },
       }),
     ];
 
@@ -544,19 +592,28 @@ describe('LogsPanel', () => {
         refId: 'A',
         fields: [
           {
-            name: 'time',
+            name: 'timestamp',
             type: FieldType.time,
             values: ['2019-04-26T09:28:11.352440161Z'],
           },
           {
-            name: 'message',
+            name: 'body',
             type: FieldType.string,
             values: ['logline text'],
-            labels: {
-              app: 'common_app',
-            },
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              {
+                app: 'common_app',
+              },
+            ],
           },
         ],
+        meta: {
+          type: DataFrameType.LogLines,
+        },
       }),
     ];
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -535,8 +535,8 @@ async function copyDashboardUrl(row: LogRowModel, rows: LogRowModel[], timeRange
     from: toUtc(timeRange.from).valueOf(),
     to: toUtc(timeRange.to).valueOf(),
   });
-  currentURL.searchParams.set('from', range.from.toString(10));
-  currentURL.searchParams.set('to', range.to.toString(10));
+  currentURL.searchParams.set('from', range.from.toString());
+  currentURL.searchParams.set('to', range.to.toString());
 
   await createAndCopyShortLink(currentURL.toString());
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -88,6 +88,9 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Passed to the LogRowMenuCell component to be rendered after the default actions in the menu.
    * logRowMenuIconsAfter?: ReactNode[];
+   *
+   * Callback to be invoked when enableInfiniteScrolling and new logs have been received after an scroll event.
+   * onNewLogsReceived?: (allLogs: DataFrame[], newLogs: DataFrame[]) => void;
    */
 }
 interface LogsPermalinkUrlState {
@@ -255,12 +258,7 @@ export const LogsPanel = ({
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
   const [logRows, deduplicatedRows, commonLabels] = useMemo(() => {
     const logs = panelData
-      ? dataFrameToLogsModel(
-          panelData.series,
-          data.request?.intervalMs,
-          undefined,
-          data.request?.targets,
-        )
+      ? dataFrameToLogsModel(panelData.series, data.request?.intervalMs, undefined, data.request?.targets)
       : null;
     const logRows = logs?.rows || [];
     const commonLabels = logs?.meta?.find((m) => m.label === COMMON_LABELS);
@@ -583,7 +581,7 @@ async function requestMoreLogs(
   let updatedSeries = panelData.series;
   for (const response of responses) {
     const newData = isObservable(response) ? await lastValueFrom(response) : response;
-    
+
     updatedSeries = combineResponses(
       {
         data: updatedSeries,

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -43,6 +43,12 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
         description: '',
         defaultValue: true,
       })
+      .addBooleanSwitch({
+        path: 'enableInfiniteScrolling',
+        name: 'Enable infinite scrolling',
+        description: 'Experimental. Request more results by scrolling to the bottom of the logs list.',
+        defaultValue: false,
+      })
       .addRadio({
         path: 'dedupStrategy',
         name: 'Deduplication',

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -26,13 +26,14 @@ composableKinds: PanelCfg: {
 			version: [0, 0]
 			schema: {
 				Options: {
-					showLabels:           bool
-					showCommonLabels:     bool
-					showTime:             bool
-					showLogContextToggle: bool
-					wrapLogMessage:       bool
-					prettifyLogMessage:   bool
-					enableLogDetails:     bool
+					showLabels:              bool
+					showCommonLabels:        bool
+					showTime:                bool
+					showLogContextToggle:    bool
+					wrapLogMessage:          bool
+					prettifyLogMessage:      bool
+					enableLogDetails:        bool
+					enableInfiniteScrolling: bool
 					sortOrder:            common.LogsSortOrder
 					dedupStrategy:        common.LogsDedupStrategy
 					// TODO: figure out how to define callbacks

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -33,9 +33,9 @@ composableKinds: PanelCfg: {
 					wrapLogMessage:          bool
 					prettifyLogMessage:      bool
 					enableLogDetails:        bool
-					enableInfiniteScrolling: bool
 					sortOrder:            common.LogsSortOrder
 					dedupStrategy:        common.LogsDedupStrategy
+					enableInfiniteScrolling?: bool
 					// TODO: figure out how to define callbacks
 					onClickFilterLabel?:     _
 					onClickFilterOutLabel?:  _
@@ -46,6 +46,7 @@ composableKinds: PanelCfg: {
 					onClickHideField?:       _
 					logRowMenuIconsBefore?:  _
 					logRowMenuIconsAfter?:   _
+					onNewLogsReceived?:      _
 					displayedFields?: [...string]
 				} @cuetsy(kind="interface")
 			}

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -13,6 +13,7 @@ import * as common from '@grafana/schema';
 export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
   displayedFields?: Array<string>;
+  enableInfiniteScrolling: boolean;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
   logRowMenuIconsAfter?: unknown;

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -13,7 +13,7 @@ import * as common from '@grafana/schema';
 export interface Options {
   dedupStrategy: common.LogsDedupStrategy;
   displayedFields?: Array<string>;
-  enableInfiniteScrolling: boolean;
+  enableInfiniteScrolling?: boolean;
   enableLogDetails: boolean;
   isFilterLabelActive?: unknown;
   logRowMenuIconsAfter?: unknown;
@@ -27,6 +27,7 @@ export interface Options {
   onClickFilterString?: unknown;
   onClickHideField?: unknown;
   onClickShowField?: unknown;
+  onNewLogsReceived?: unknown;
   prettifyLogMessage: boolean;
   showCommonLabels: boolean;
   showLabels: boolean;

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -13,7 +13,6 @@ type isOnClickShowFieldType = (value: string) => void;
 type isOnClickHideFieldType = (value: string) => void;
 export type onNewLogsReceivedType = (allLogs: DataFrame[], newLogs: DataFrame[]) => void;
 
-
 export function isOnClickFilterLabel(callback: unknown): callback is onClickFilterLabelType {
   return typeof callback === 'function';
 }

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -11,6 +11,8 @@ type onClickFilterOutStringType = (value: string, refId?: string) => void;
 type isFilterLabelActiveType = (key: string, value: string, refId?: string) => Promise<boolean>;
 type isOnClickShowFieldType = (value: string) => void;
 type isOnClickHideFieldType = (value: string) => void;
+export type onNewLogsReceivedType = (allLogs: DataFrame[], newLogs: DataFrame[]) => void;
+
 
 export function isOnClickFilterLabel(callback: unknown): callback is onClickFilterLabelType {
   return typeof callback === 'function';
@@ -37,6 +39,10 @@ export function isOnClickShowField(callback: unknown): callback is isOnClickShow
 }
 
 export function isOnClickHideField(callback: unknown): callback is isOnClickHideFieldType {
+  return typeof callback === 'function';
+}
+
+export function isOnNewLogsReceivedType(callback: unknown): callback is onNewLogsReceivedType {
   return typeof callback === 'function';
 }
 


### PR DESCRIPTION
This PR introduces infinite scrolling to Logs Panel users in Dashboards and App plugins.

For Dashboards, it's exposed as an option in the panel editor:

![editor](https://github.com/user-attachments/assets/4138c13e-72f0-4c85-b7b6-bdd91dc69f44)

For App developers it's exposed through a boolean option that enables the feature called `enableInfiniteScrolling`. Additionally, another prop, under the name `onNewLogsReceived`,  can be passed to be called when new logs are received and displayed.

Since the panel is agnostic to data sources and data source instances, the approach is based on how [Log Context](https://github.com/grafana/grafana/blob/main/public/app/features/explore/Logs/LogsContainer.tsx#L160) queries for more logs before and after the source row.

As a side note, the feature can be completely disabled (everywhere) using the feature flag `logsInfiniteScrolling`, which is currently enabled by default. 

Additionally, the logspanel.test.tsx test file has been updated to use Dataplane log format for data frames.

**Which issue(s) does this PR fix?**:

Part of #71728
Part of https://github.com/grafana/explore-logs/issues/919
Related with https://github.com/grafana/explore-logs/pull/925

**Special notes for your reviewer:**

Dashboard demo:

https://github.com/user-attachments/assets/1758bcb9-a5a8-4261-a65a-7ae490ed22fe

App demo:

https://github.com/user-attachments/assets/714cfd28-76aa-45c8-8c15-7345729ea49f


