### PR TITLE
API key: Fix API key migration to service account

### DIFF
--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -324,26 +324,85 @@ func TestIntegrationStore_MigrateApiKeys(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 	cases := []struct {
-		desc        string
-		key         tests.TestApiKey
-		expectedErr error
+		desc            string
+		serviceAccounts []user.CreateUserCommand
+		key             tests.TestApiKey
+		expectedLogin   string
+		expectedErr     error
 	}{
 		{
-			desc:        "api key should be migrated to service account token",
-			key:         tests.TestApiKey{Name: "Test1", Role: org.RoleEditor, OrgId: 1},
-			expectedErr: nil,
+			desc:            "api key should be migrated to service account token",
+			serviceAccounts: []user.CreateUserCommand{},
+			key:             tests.TestApiKey{Name: "test1", Role: org.RoleEditor, OrgId: 1},
+			expectedLogin:   "sa-autogen-1-test1",
+			expectedErr:     nil,
+		},
+		{
+			desc: "api key should be migrated to service account token on second attempt",
+			serviceAccounts: []user.CreateUserCommand{
+				{Login: "sa-autogen-1-test2"},
+			},
+			key:           tests.TestApiKey{Name: "test2", Role: org.RoleEditor, OrgId: 1},
+			expectedLogin: "sa-autogen-1-test2-001",
+			expectedErr:   nil,
+		},
+		{
+			desc: "api key should be migrated to service account token on last attempt (the 10th)",
+			serviceAccounts: []user.CreateUserCommand{
+				{Login: "sa-autogen-1-test3"},
+				{Login: "sa-autogen-1-test3-001"},
+				{Login: "sa-autogen-1-test3-002"},
+				{Login: "sa-autogen-1-test3-003"},
+				{Login: "sa-autogen-1-test3-004"},
+				{Login: "sa-autogen-1-test3-005"},
+				{Login: "sa-autogen-1-test3-006"},
+				{Login: "sa-autogen-1-test3-007"},
+				{Login: "sa-autogen-1-test3-008"},
+				{Login: "sa-autogen-1-test3-009"},
+			},
+			key:           tests.TestApiKey{Name: "test3", Role: org.RoleEditor, OrgId: 1},
+			expectedLogin: "sa-autogen-1-test3-010",
+			expectedErr:   nil,
+		},
+		{
+			desc: "api key should not be migrated to service account token because all attempts failed",
+			serviceAccounts: []user.CreateUserCommand{
+				{Login: "sa-autogen-1-test4"},
+				{Login: "sa-autogen-1-test4-001"},
+				{Login: "sa-autogen-1-test4-002"},
+				{Login: "sa-autogen-1-test4-003"},
+				{Login: "sa-autogen-1-test4-004"},
+				{Login: "sa-autogen-1-test4-005"},
+				{Login: "sa-autogen-1-test4-006"},
+				{Login: "sa-autogen-1-test4-007"},
+				{Login: "sa-autogen-1-test4-008"},
+				{Login: "sa-autogen-1-test4-009"},
+				{Login: "sa-autogen-1-test4-010"},
+			},
+			key:         tests.TestApiKey{Name: "test4", Role: org.RoleEditor, OrgId: 1},
+			expectedErr: serviceaccounts.ErrServiceAccountAlreadyExists,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			db, store := setupTestDatabase(t)
+
 			store.cfg.AutoAssignOrg = true
 			store.cfg.AutoAssignOrgId = 1
 			store.cfg.AutoAssignOrgRole = "Viewer"
 			_, err := store.orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "main"})
 			require.NoError(t, err)
+
 			key := tests.SetupApiKey(t, db, store.cfg, c.key)
+
+			for _, sa := range c.serviceAccounts {
+				sa.IsServiceAccount = true
+				sa.OrgID = key.OrgID
+				_, err := store.userService.CreateServiceAccount(context.Background(), &sa)
+				require.NoError(t, err)
+			}
+
 			err = store.MigrateApiKey(context.Background(), key.OrgID, key.ID)
 			if c.expectedErr != nil {
 				require.ErrorIs(t, err, c.expectedErr)
@@ -352,7 +411,7 @@ func TestIntegrationStore_MigrateApiKeys(t *testing.T) {
 
 				q := serviceaccounts.SearchOrgServiceAccountsQuery{
 					OrgID: key.OrgID,
-					Query: "",
+					Query: c.expectedLogin,
 					Page:  1,
 					Limit: 50,
 					SignedInUser: &user.SignedInUser{
@@ -370,6 +429,7 @@ func TestIntegrationStore_MigrateApiKeys(t *testing.T) {
 				require.Equal(t, int64(1), serviceAccounts.TotalCount)
 				saMigrated := serviceAccounts.ServiceAccounts[0]
 				require.Equal(t, string(key.Role), saMigrated.Role)
+				require.Equal(t, c.expectedLogin, saMigrated.Login)
 
 				tokens, err := store.ListTokens(context.Background(), &serviceaccounts.GetSATokensQuery{
 					OrgID:            &key.OrgID,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes the migration of an API key to a service account when a service account with the same login name already exists.

**Why do we need this feature?**

To migrate all API keys without errors. Previously the migration failed if a service account cannot be created due to a login name collision.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
