### PR TITLE
Logs: fix canKeepDisplayedFields with possibly undefined queries

### DIFF
--- a/public/app/features/explore/Logs/utils/logs.test.ts
+++ b/public/app/features/explore/Logs/utils/logs.test.ts
@@ -1,0 +1,27 @@
+import { DataQuery } from '@grafana/data';
+
+import { canKeepDisplayedFields } from './logs';
+
+describe('canKeepDisplayedFields', () => {
+  test('Returns false when passing no queries', () => {
+    expect(canKeepDisplayedFields(undefined, [])).toBe(false);
+  });
+
+  test('Returns false when some prev queries are undefined', () => {
+    const logQueries: DataQuery[] = [{ refId: 'A' }, { refId: 'B' }];
+    const prevLogQueries = [{ refId: 'C' }];
+    expect(canKeepDisplayedFields(logQueries, prevLogQueries)).toBe(false);
+  });
+
+  test('Returns false when some new queries are undefined', () => {
+    const logQueries: DataQuery[] = [{ refId: 'A' }];
+    const prevLogQueries = [{ refId: 'C' }, { refId: 'B' }];
+    expect(canKeepDisplayedFields(logQueries, prevLogQueries)).toBe(false);
+  });
+
+  test('Returns true when the queries exactly match', () => {
+    const logQueries: DataQuery[] = [{ refId: 'C' }, { refId: 'B' }];
+    const prevLogQueries = [{ refId: 'C' }, { refId: 'B' }];
+    expect(canKeepDisplayedFields(logQueries, prevLogQueries)).toBe(true);
+  });
+});

--- a/public/app/features/explore/Logs/utils/logs.ts
+++ b/public/app/features/explore/Logs/utils/logs.ts
@@ -17,7 +17,7 @@ export const canKeepDisplayedFields = (logsQueries: DataQuery[] | undefined, pre
     return false;
   }
   for (let i = 0; i < logsQueries.length; i++) {
-    if (!shallowCompare(logsQueries[i], prevLogsQueries[i])) {
+    if (!logsQueries[i] || !prevLogsQueries[i] || !shallowCompare(logsQueries[i], prevLogsQueries[i])) {
       return false;
     }
   }


### PR DESCRIPTION
Fixes cases where the arrays have a different size and we attempt to compare an object with undefined.

![imagen](https://github.com/user-attachments/assets/7f955ddb-7e1e-43b0-833b-ccfceace81fe)
