### PR TITLE
Chore: Prevent layout shift with DropdownIndicator

### DIFF
--- a/packages/grafana-ui/src/components/Select/DropdownIndicator.tsx
+++ b/packages/grafana-ui/src/components/Select/DropdownIndicator.tsx
@@ -5,6 +5,5 @@ import { Icon } from '../Icon/Icon';
 export function DropdownIndicator({ selectProps }: DropdownIndicatorProps) {
   const isOpen = selectProps.menuIsOpen;
   const icon = isOpen ? 'search' : 'angle-down';
-  const size = isOpen ? 'sm' : 'md';
-  return <Icon name={icon} size={size} />;
+  return <Icon name={icon} size="sm" />;
 }

--- a/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
@@ -93,10 +93,10 @@ exports[`VariableQueryEditor renders correctly 1`] = `
             <svg
               aria-hidden={true}
               className="css-1d3xu67-Icon"
-              height={16}
+              height={14}
               id="public/img/icons/unicons/angle-down.svg"
               title=""
-              width={16}
+              width={14}
             />
           </div>
         </div>


### PR DESCRIPTION
The dropdown icon is a bit smaller, but I think getting rid of the layout shift is a better tradeoff.

Old:


https://github.com/user-attachments/assets/3a5f09d3-0e0a-4623-8aea-60046f388123

New:


https://github.com/user-attachments/assets/91fb97f7-b0cf-4ae5-b8a7-6753e40dba55

