### PR TITLE
TableNG: Support groupToNestedTableTransform

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/RowExpander.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/RowExpander.tsx
@@ -1,0 +1,36 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../../../themes';
+import { Icon } from '../../../Icon/Icon';
+import { RowExpanderNGProps } from '../types';
+
+export function RowExpander({ height, onCellExpand, isExpanded }: RowExpanderNGProps) {
+  const styles = useStyles2(getStyles, height);
+  function handleKeyDown(e: React.KeyboardEvent<HTMLSpanElement>) {
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      onCellExpand();
+    }
+  }
+  return (
+    <div className={styles.expanderCell} onClick={onCellExpand} onKeyDown={handleKeyDown}>
+      <Icon
+        aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
+        name={isExpanded ? 'angle-down' : 'angle-right'}
+        size="lg"
+      />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2, rowHeight: number) => ({
+  expanderCell: css({
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    height: `${rowHeight}px`,
+    cursor: 'pointer',
+  }),
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -314,6 +314,12 @@ export function TableNG(props: TableNGProps) {
       }
       const key = field.name;
 
+      // get column width from overrides
+      const override = fieldConfig?.overrides?.find(
+        (o) => o.matcher.id === 'byName' && o.matcher.options === field.name
+      );
+      const width = override?.properties?.find((p) => p.id === 'width')?.value || field.config?.custom?.width;
+
       const justifyColumnContent = getTextAlign(field);
       const footerStyles = getFooterStyles(justifyColumnContent);
 
@@ -370,7 +376,7 @@ export function TableNG(props: TableNGProps) {
           />
         ),
         // TODO these anys are making me sad
-        width: field.config?.custom?.width ?? columnWidth,
+        width: width ?? columnWidth,
         minWidth: field.config?.custom?.minWidth ?? columnMinWidth,
       });
     });

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -360,7 +360,14 @@ export function TableNG(props: TableNGProps) {
           let expandedRecords: Array<Record<string, string>> = [];
           expandedColumns = mapFrameToDataGrid(row.data, calcsRef, true);
           expandedRecords = frameToRecords(row.data);
-          return <DataGrid rows={expandedRecords} columns={expandedColumns} rowHeight={defaultRowHeight} />;
+          return (
+            <DataGrid
+              rows={expandedRecords}
+              columns={expandedColumns}
+              rowHeight={defaultRowHeight}
+              style={{ height: '100%', overflow: 'visible' }}
+            />
+          );
         },
         width: EXPANDER_WIDTH,
         minWidth: EXPANDER_WIDTH,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -291,11 +291,11 @@ export function TableNG(props: TableNGProps) {
       const values = frame.fields.map(f => f.values);
       let rowCount = 0;
       for (let i = 0; i < frame.length; i++) {
-        rows[rowCount] = {____type: 'parent', index: i, ${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
+        rows[rowCount] = {__depth: 0, __index: i, ${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
         rowCount += 1;
         if (rows[rowCount-1]['Nested frames']){
           const childFrame = rows[rowCount-1]['Nested frames'];
-          rows[rowCount] = {____type: 'child', index: i, data: childFrame[0]}
+          rows[rowCount] = {__depth: 1, __index: i, data: childFrame[0]}
           rowCount += 1;
         }
       }
@@ -329,12 +329,12 @@ export function TableNG(props: TableNGProps) {
         field: expanderField,
         cellClass: styles.cell,
         colSpan(args) {
-          return args.type === 'ROW' && args.row.____type === 'child' ? main.fields.length : 1;
+          return args.type === 'ROW' && Number(args.row.__depth) === 1 ? main.fields.length : 1;
         },
         renderCell: ({ row }) => {
-          // TODO add TableRow type extension to include row type enum and optional data
-          if (row.____type === 'parent') {
-            const rowIdx = Number(row.index);
+          // TODO add TableRow type extension to include row depth and optional data
+          if (Number(row.__depth) === 0) {
+            const rowIdx = Number(row.__index);
             return (
               <RowExpander
                 height={defaultRowHeight}
@@ -458,7 +458,7 @@ export function TableNG(props: TableNGProps) {
     // i.e. we can look at row styles and such here
     const { row } = props;
     // Don't render non expanded child rows
-    if (row.____type === 'child' && !expandedRows.includes(Number(row.index))) {
+    if (Number(row.__depth) === 1 && !expandedRows.includes(Number(row.__index))) {
       return null;
     }
     return <Row key={key} {...props} />;
@@ -603,9 +603,9 @@ export function TableNG(props: TableNGProps) {
           resizable: true,
         }}
         rowHeight={(row) => {
-          if (row.____type === 'child' && !expandedRows.includes(Number(row.index))) {
+          if (Number(row.__depth) === 1 && !expandedRows.includes(Number(row.__index))) {
             return 0;
-          } else if (row.____type === 'child' && expandedRows.includes(Number(row.index))) {
+          } else if (Number(row.__depth) === 1 && expandedRows.includes(Number(row.__index))) {
             return defaultRowHeight * (row.data.length + 1); // TODO this probably isn't very robust
           }
           return getRowHeight(

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -360,12 +360,14 @@ export function TableNG(props: TableNGProps) {
           let expandedRecords: Array<Record<string, string>> = [];
           expandedColumns = mapFrameToDataGrid(row.data, calcsRef, true);
           expandedRecords = frameToRecords(row.data);
+          // TODO add renderHeaderCell HeaderCell's here and handle all features
           return (
             <DataGrid
               rows={expandedRecords}
               columns={expandedColumns}
               rowHeight={defaultRowHeight}
               style={{ height: '100%', overflow: 'visible' }}
+              headerRowHeight={row.data.meta?.custom?.noHeader ? 0 : undefined}
             />
           );
         },
@@ -613,7 +615,8 @@ export function TableNG(props: TableNGProps) {
           if (Number(row.__depth) === 1 && !expandedRows.includes(Number(row.__index))) {
             return 0;
           } else if (Number(row.__depth) === 1 && expandedRows.includes(Number(row.__index))) {
-            return defaultRowHeight * (row.data.length + 1); // TODO this probably isn't very robust
+            const headerCount = row.data.meta?.custom?.noHeader ? 0 : 1;
+            return defaultRowHeight * (row.data.length + headerCount); // TODO this probably isn't very robust
           }
           return getRowHeight(
             row,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -137,6 +137,9 @@ export function TableNG(props: TableNGProps) {
   }, [isContextMenuOpen]);
 
   const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
+  // TODO: this ref using to persist sortColumns between renders;
+  // setSortColumns is still used to trigger re-render
+  const sortColumnsRef = useRef(sortColumns);
   const [expandedRows, setExpandedRows] = useState<number[]>([]);
 
   function getDefaultRowHeight(): number {
@@ -245,7 +248,7 @@ export function TableNG(props: TableNGProps) {
     return records;
   }, []);
   const calcsRef = useRef<string[]>([]);
-  const mapFrameToDataGrid = (main: DataFrame, subTable?: boolean) => {
+  const mapFrameToDataGrid = (main: DataFrame, calcsRef: React.MutableRefObject<string[]>, subTable?: boolean) => {
     const columns: TableColumn[] = [];
 
     // Check for nestedFrames
@@ -295,7 +298,7 @@ export function TableNG(props: TableNGProps) {
           // If it's a child, render entire DataGrid at first column position
           let expandedColumns: TableColumn[] = [];
           let expandedRecords: Array<Record<string, string>> = [];
-          expandedColumns = mapFrameToDataGrid(row.data, true);
+          expandedColumns = mapFrameToDataGrid(row.data, calcsRef, true);
           expandedRecords = frameToRecords(row.data);
           return <DataGrid rows={expandedRecords} columns={expandedColumns} rowHeight={defaultRowHeight} />;
         },
@@ -453,7 +456,7 @@ export function TableNG(props: TableNGProps) {
     });
   }, [filteredRows, props.data.fields, footerOptions, isCountRowsSet]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const columns = useMemo(() => mapFrameToDataGrid(props.data), [props.data, calcsRef, expandedRows]); // eslint-disable-line react-hooks/exhaustive-deps
+  const columns = useMemo(() => mapFrameToDataGrid(props.data, calcsRef), [props.data, calcsRef, filter, expandedRows]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // This effect needed to set header cells refs before row height calculation
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -161,8 +161,8 @@ export function TableNG(props: TableNGProps) {
     const headerRef = useRef(null);
 
     let isColumnFilterable = filterable;
-    if (field.config.custom.filterable !== filterable) {
-      isColumnFilterable = field.config.custom.filterable || false;
+    if (field.config.custom?.filterable !== filterable) {
+      isColumnFilterable = field.config.custom?.filterable || false;
     }
     // we have to remove/reset the filter if the column is not filterable
     if (!isColumnFilterable && filter[field.name]) {
@@ -228,7 +228,6 @@ export function TableNG(props: TableNGProps) {
       const values = frame.fields.map(f => f.values);
       let rowCount = 0;
       for (let i = 0; i < frame.length; i++) {
-        rows[i] = {index: i, ${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
         rows[rowCount] = {____type: 'parent', index: i, ${frame.fields.map((field, fieldIdx) => `${JSON.stringify(field.name)}: values[${fieldIdx}][i]`).join(',')}};
         rowCount += 1;
         if (rows[rowCount-1]['Nested frames']){
@@ -243,11 +242,10 @@ export function TableNG(props: TableNGProps) {
     const convert = new Function('frame', fnBody);
 
     const records = convert(frame);
-
     return records;
   }, []);
-
-  const mapFrameToDataGrid = (main: DataFrame, calcsRef: React.MutableRefObject<string[]>, subTable?: boolean) => {
+  const calcsRef = useRef<string[]>([]);
+  const mapFrameToDataGrid = (main: DataFrame, subTable?: boolean) => {
     const columns: TableColumn[] = [];
 
     // Check for nestedFrames
@@ -440,7 +438,6 @@ export function TableNG(props: TableNGProps) {
     });
   }, [rows, filter, sortedRows, props.data.fields]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const calcsRef = useRef<string[]>([]);
   useMemo(() => {
     calcsRef.current = props.data.fields.map((field, index) => {
       if (field.state?.calcs) {
@@ -456,7 +453,7 @@ export function TableNG(props: TableNGProps) {
     });
   }, [filteredRows, props.data.fields, footerOptions, isCountRowsSet]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const columns = useMemo(() => mapFrameToDataGrid(props.data, calcsRef), [props.data, calcsRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  const columns = useMemo(() => mapFrameToDataGrid(props.data), [props.data, calcsRef]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // This effect needed to set header cells refs before row height calculation
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -246,7 +246,6 @@ export function TableNG(props: TableNGProps) {
   }, []);
   const calcsRef = useRef<string[]>([]);
   const mapFrameToDataGrid = (main: DataFrame, subTable?: boolean) => {
-    console.log('called');
     const columns: TableColumn[] = [];
 
     // Check for nestedFrames

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -246,6 +246,7 @@ export function TableNG(props: TableNGProps) {
   }, []);
   const calcsRef = useRef<string[]>([]);
   const mapFrameToDataGrid = (main: DataFrame, subTable?: boolean) => {
+    console.log('called');
     const columns: TableColumn[] = [];
 
     // Check for nestedFrames
@@ -453,7 +454,7 @@ export function TableNG(props: TableNGProps) {
     });
   }, [filteredRows, props.data.fields, footerOptions, isCountRowsSet]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const columns = useMemo(() => mapFrameToDataGrid(props.data), [props.data, calcsRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  const columns = useMemo(() => mapFrameToDataGrid(props.data), [props.data, calcsRef, expandedRows]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // This effect needed to set header cells refs before row height calculation
   useLayoutEffect(() => {

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -12,6 +12,12 @@ export interface CellNGProps {
   shouldTextOverflow?: () => boolean;
 }
 
+export interface RowExpanderNGProps {
+  height: number;
+  onCellExpand: () => void;
+  isExpanded?: boolean;
+}
+
 export interface BarGaugeCellProps extends CellNGProps {
   height: number;
   timeRange: TimeRange;


### PR DESCRIPTION
Support [groupToNestedTableTransformation](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v10-4/#create-subtables-in-table-visualizations-with-group-to-nested-tables) feature toggle.

- [x] Type clean-up to help avoid clashes with field names
- [x] `Show field names in nested tables` toggle
- [ ] ~~Inherited outer styling from parent - background color for example~~ https://github.com/grafana/grafana/issues/99030

![Nov-19-2024 19-45-44](https://github.com/user-attachments/assets/322a9969-e926-450c-b559-2acb3911acee)

Closes #94776