### PR TITLE
Dashboard Changed Modal: Fix spelling

### DIFF
--- a/public/app/features/live/dashboard/DashboardChangedModal.tsx
+++ b/public/app/features/live/dashboard/DashboardChangedModal.tsx
@@ -35,7 +35,7 @@ export function DashboardChangedModal({ onDismiss, event }: Props) {
       className={styles.modal}
     >
       <div className={styles.description}>
-        The dashboad has been updated by another session. Do you want to continue editing or discard your local changes?
+        The dashboard has been updated by another session. Do you want to continue editing or discard your local changes?
       </div>
       <Modal.ButtonRow>
         <Button onClick={onDismiss} variant="secondary" fill="outline">

--- a/public/app/features/live/dashboard/DashboardChangedModal.tsx
+++ b/public/app/features/live/dashboard/DashboardChangedModal.tsx
@@ -35,7 +35,8 @@ export function DashboardChangedModal({ onDismiss, event }: Props) {
       className={styles.modal}
     >
       <div className={styles.description}>
-        The dashboard has been updated by another session. Do you want to continue editing or discard your local changes?
+        The dashboard has been updated by another session. Do you want to continue editing or discard your local
+        changes?
       </div>
       <Modal.ButtonRow>
         <Button onClick={onDismiss} variant="secondary" fill="outline">


### PR DESCRIPTION
Saw this and just wanted to fix it quick.. Auto merge enabled.

Line break is required by prettier and does not affect output

<img width="680" alt="Screenshot 2024-11-29 at 10 37 31 AM" src="https://github.com/user-attachments/assets/cad99599-662c-4f2e-8aec-176dd2f0c699">
