### PR TITLE
CI: ignore failure in github_app_generate_token step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -193,6 +193,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -276,6 +277,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -383,6 +385,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -521,6 +524,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -618,6 +622,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -1062,6 +1067,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -1414,6 +1420,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -1538,6 +1545,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -2095,6 +2103,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -3791,6 +3800,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -4822,6 +4832,7 @@ steps:
       from_secret: github-app-installation-id
     GITHUB_APP_PRIVATE_KEY:
       from_secret: github-app-private-key
+  failure: ignore
   image: us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/github-app-secret-writer:2024-11-05-v11688112090.1-83920c59
   name: github-app-generate-token
   volumes:
@@ -5740,6 +5751,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: e97f7a0c3923b506dad6bf861bb1ea440a8f072ee3744742eec35e7278c3581c
+hmac: 04ba0c9b8e69705a28a24ba03de14ece0b15c4b44f6262fcbc6a9ee874b5a9db
 
 ...

--- a/scripts/drone/steps/github.star
+++ b/scripts/drone/steps/github.star
@@ -37,4 +37,6 @@ def github_app_generate_token_step():
             "echo $(/usr/bin/github-app-external-token) > /github-app/token",
         ],
         "volumes": github_app_step_volumes(),
+        # forks or those without access would cause it to fail, but we can safely ignore it since there'll be no token.
+        "failure": "ignore",
     }


### PR DESCRIPTION
**What is this feature?**

Ignores cases where the `github_app_generate_token_step` would fail and lets the CI continue.

**Why do we need this feature?**

External PRs do not have access to pull the private image that this step uses, and anyway won't be able to clone private repos, so we can ignore failures that happen in that step.

**Who is this feature for?**

External contributors.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

I don't think we need to backport it because those are usually either run by the Bot or by someone with access in the repo.