### PR TITLE
POC/Provisioning: Import: Apply folder nesting properly

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -89,7 +89,8 @@ func RegisterAPIService(
 	ghFactory github.ClientFactory,
 ) *ProvisioningAPIBuilder {
 	if !(features.IsEnabledGlobally(featuremgmt.FlagProvisioning) ||
-		features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs)) {
+		features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) ||
+		features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerTestingWithExperimentalAPIs)) {
 		return nil // skip registration unless opting into experimental apis OR the feature specifically
 	}
 	builder := NewProvisioningAPIBuilder(&repository.LocalFolderResolver{
@@ -278,11 +279,6 @@ func (b *ProvisioningAPIBuilder) beginUpdate(ctx context.Context, obj, old runti
 }
 
 func (b *ProvisioningAPIBuilder) ensureRepositoryFolderExists(ctx context.Context, cfg *provisioning.Repository) error {
-	if !b.features.IsEnabledGlobally(featuremgmt.FlagKubernetesFolders) && !b.features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerTestingWithExperimentalAPIs) {
-		// Nothing to do: we can't use the folders API.
-		return nil
-	}
-
 	if cfg.Spec.Folder == "" {
 		// The root folder can't not exist, so we don't have to do anything.
 		return nil
@@ -292,6 +288,7 @@ func (b *ProvisioningAPIBuilder) ensureRepositoryFolderExists(ctx context.Contex
 	if err != nil {
 		return err
 	}
+	// FIXME: make sure folders are actually enabled in the apiserver.
 	folderIface := client.Resource(schema.GroupVersionResource{
 		Group:    "folder.grafana.app",
 		Version:  "v0alpha1",


### PR DESCRIPTION
Dashboards without a parent folder are now put in the root of the repository folder.
Dashboards in a folder are now put in a nested folder under the repository folder.

![image](https://github.com/user-attachments/assets/c9dbc76b-2314-489e-b047-b5331aa2a547)
