### PR TITLE
SQL: close rows to release connection

### DIFF
--- a/pkg/services/accesscontrol/database/policies.go
+++ b/pkg/services/accesscontrol/database/policies.go
@@ -42,6 +42,9 @@ func GetAccessPolicies(ctx context.Context, orgID int64, sql *session.SessionDB,
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	created := time.Now()
 	updated := time.Now()

--- a/pkg/services/playlist/playlistimpl/xorm_store.go
+++ b/pkg/services/playlist/playlistimpl/xorm_store.go
@@ -222,6 +222,11 @@ func (s *sqlStore) ListAll(ctx context.Context, orgId int64) ([]playlist.Playlis
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() {
+		_ = rows.Close()
+	}()
+
 	for rows.Next() {
 		err = rows.Scan(&playlistId, &itemType, &itemValue)
 		if err != nil {

--- a/pkg/storage/unified/search/document.go
+++ b/pkg/storage/unified/search/document.go
@@ -29,6 +29,11 @@ func (s *StandardDocumentBuilders) GetDocumentBuilders() ([]resource.DocumentBui
 			if err != nil {
 				return nil, err
 			}
+
+			defer func() {
+				_ = rows.Close()
+			}()
+
 			for rows.Next() {
 				info := &dashboard.DatasourceQueryResult{}
 				err = rows.Scan(&info.UID, &info.Type, &info.Name, &info.IsDefault)

--- a/pkg/storage/unified/sql/dbutil/dbutil.go
+++ b/pkg/storage/unified/sql/dbutil/dbutil.go
@@ -165,6 +165,10 @@ func Query[T any](ctx context.Context, x db.ContextExecer, tmpl *template.Templa
 		return nil, err
 	}
 
+	defer func() {
+		_ = rows.Close()
+	}()
+
 	var ret []T
 	for rows.Next() {
 		v, err := scanRow(rows, req)

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -101,7 +101,7 @@ func (r *sqlResourceHistoryPollRequest) Validate() error {
 func (r *sqlResourceHistoryPollRequest) Results() (*historyPollResponse, error) {
 	prevRV := r.Response.PreviousRV
 	if prevRV == nil {
-		*prevRV = int64(0)
+		prevRV = new(int64)
 	}
 	return &historyPollResponse{
 		Key: resource.ResourceKey{


### PR DESCRIPTION
**What is this feature?**

Adding some `rows.Close()` (with `defer`) whenever we return `rows`.

**Why do we need this feature?**

It is a good practice to clean up resources and release the connection back to the DB pool.

Moreover I've been seeing some intermittent integration tests failing with `database is locked` (all coming from `testinfra.CreateUser`) and I wonder if these could be playing a contributing factor.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

N/A
