### PR TITLE
AppLinks: Fix showing navitems for manually disabled plugins

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -26,9 +26,6 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 	}
 
 	isPluginEnabled := func(plugin pluginstore.Plugin) bool {
-		if plugin.AutoEnabled {
-			return true
-		}
 		for _, ps := range pss {
 			if ps.PluginID == plugin.ID {
 				return ps.Enabled


### PR DESCRIPTION
**What is this feature?**

Plugins would render a NavTree if they are autoenabled, but manually disabled. This PR removes this check, since auto enabled plugins are also enabled in the pluginsettings (`pss`).


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #97157

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
