### PR TITLE
K8s: Make it possible to register several kinds for a GroupVersion

### DIFF
--- a/apps/playlist/pkg/app/app.go
+++ b/apps/playlist/pkg/app/app.go
@@ -76,12 +76,12 @@ func New(cfg app.Config) (app.App, error) {
 	return a, nil
 }
 
-func GetKinds() map[schema.GroupVersion]resource.Kind {
+func GetKinds() map[schema.GroupVersion][]resource.Kind {
 	gv := schema.GroupVersion{
 		Group:   playlistv0alpha1.PlaylistKind().Group(),
 		Version: playlistv0alpha1.PlaylistKind().Version(),
 	}
-	return map[schema.GroupVersion]resource.Kind{
-		gv: playlistv0alpha1.PlaylistKind(),
+	return map[schema.GroupVersion][]resource.Kind{
+		gv: {playlistv0alpha1.PlaylistKind()},
 	}
 }

--- a/pkg/services/apiserver/builder/runner/builder.go
+++ b/pkg/services/apiserver/builder/runner/builder.go
@@ -24,7 +24,7 @@ type AppBuilderConfig struct {
 	Authorizer          authorizer.Authorizer
 	LegacyStorageGetter LegacyStorageGetter
 	OpenAPIDefGetter    common.GetOpenAPIDefinitions
-	ManagedKinds        map[schema.GroupVersion]resource.Kind
+	ManagedKinds        map[schema.GroupVersion][]resource.Kind
 	CustomConfig        any
 
 	groupVersion schema.GroupVersion
@@ -60,26 +60,31 @@ func (b *appBuilder) GetGroupVersion() schema.GroupVersion {
 // InstallSchema implements APIGroupBuilder.InstallSchema
 func (b *appBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	gv := b.GetGroupVersion()
-	for _, kind := range b.config.ManagedKinds {
-		scheme.AddKnownTypeWithName(gv.WithKind(kind.Kind()), kind.ZeroValue())
-		scheme.AddKnownTypeWithName(gv.WithKind(kind.Kind()+"List"), kind.ZeroListValue())
+	for _, kinds := range b.config.ManagedKinds {
+		for _, kind := range kinds {
+			scheme.AddKnownTypeWithName(gv.WithKind(kind.Kind()), kind.ZeroValue())
+			scheme.AddKnownTypeWithName(gv.WithKind(kind.Kind()+"List"), kind.ZeroListValue())
+		}
 	}
 	return scheme.SetVersionPriority(gv)
 }
 
 // UpdateAPIGroupInfo implements APIGroupBuilder.UpdateAPIGroupInfo
 func (b *appBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
-	for _, kind := range b.config.ManagedKinds {
-		version := kind.GroupVersionKind().Version
-		if _, ok := apiGroupInfo.VersionedResourcesStorageMap[version]; !ok {
-			apiGroupInfo.VersionedResourcesStorageMap[version] = make(map[string]rest.Storage)
+	for _, kinds := range b.config.ManagedKinds {
+		for _, kind := range kinds {
+			version := kind.GroupVersionKind().Version
+			if _, ok := apiGroupInfo.VersionedResourcesStorageMap[version]; !ok {
+				apiGroupInfo.VersionedResourcesStorageMap[version] = make(map[string]rest.Storage)
+			}
+			resourceInfo := KindToResourceInfo(kind)
+			store, err := b.getStorage(resourceInfo, opts)
+			if err != nil {
+				return err
+			}
+			apiGroupInfo.VersionedResourcesStorageMap[version][resourceInfo.StoragePath()] = store
+
 		}
-		resourceInfo := KindToResourceInfo(kind)
-		store, err := b.getStorage(resourceInfo, opts)
-		if err != nil {
-			return err
-		}
-		apiGroupInfo.VersionedResourcesStorageMap[version][resourceInfo.StoragePath()] = store
 	}
 	return nil
 }

--- a/pkg/services/apiserver/builder/runner/builder.go
+++ b/pkg/services/apiserver/builder/runner/builder.go
@@ -83,7 +83,6 @@ func (b *appBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 				return err
 			}
 			apiGroupInfo.VersionedResourcesStorageMap[version][resourceInfo.StoragePath()] = store
-
 		}
 	}
 	return nil

--- a/pkg/services/apiserver/builder/runner/runner.go
+++ b/pkg/services/apiserver/builder/runner/runner.go
@@ -101,7 +101,7 @@ func newAppBuilderGroup(cfg RunnerConfig, provider app.Provider) (appBuilderGrou
 
 	for gv, kinds := range appBuilderConfig.ManagedKinds {
 		confCopy := *appBuilderConfig
-		confCopy.ManagedKinds = map[schema.GroupVersion]resource.Kind{
+		confCopy.ManagedKinds = map[schema.GroupVersion][]resource.Kind{
 			gv: kinds,
 		}
 		confCopy.groupVersion = gv


### PR DESCRIPTION
While writing a POC using grafana-app-sdk and new structures to setup an app I noticed that it was not possible to register several kinds under the same `GroupVersion`.

