### PR TITLE
Fix: Do not fetch Orgs if the user is authenticated by apikey/sa or render key

### DIFF
--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -28,7 +28,10 @@ export function OrganizationSwitcher() {
     }
   };
   useEffect(() => {
-    if (contextSrv.isSignedIn && !(contextSrv.user.authenticatedBy === 'apikey' || contextSrv.user.authenticatedBy === 'render')) {
+    if (
+      contextSrv.isSignedIn &&
+      !(contextSrv.user.authenticatedBy === 'apikey' || contextSrv.user.authenticatedBy === 'render')
+    ) {
       dispatch(getUserOrganizations());
     }
   }, [dispatch]);

--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -28,7 +28,7 @@ export function OrganizationSwitcher() {
     }
   };
   useEffect(() => {
-    if (contextSrv.isSignedIn) {
+    if (contextSrv.isSignedIn && !(contextSrv.user.authenticatedBy === 'apikey' || contextSrv.user.authenticatedBy === 'render')) {
       dispatch(getUserOrganizations());
     }
   }, [dispatch]);


### PR DESCRIPTION
**What is this feature?**
It prevents fetching the current user's organization list if the current user is authenticated by an apikey/sa or a render key (used by the Grafana Image Renderer). 

**Why do we need this feature?**
Currently, if Grafana is opened through grafana-kiosk (using service account) or a dashboard is rendered using the Image Renderer then Grafana shows a warning banner with `Endpoint only available for users` message.

**Who is this feature for?**
Users who use Grafana in kiosk mode and/or grafana-image-renderer.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-kiosk/issues/146
Fixes #94649

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
