### PR TITLE
Dashboard: Schema V2 - remove code in sharing export   

### DIFF
--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2937,8 +2937,7 @@
       "loading": "Loading...",
       "save-button": "Save to file",
       "share-externally-label": "Export for sharing externally",
-      "view-button": "View JSON",
-      "view-button-schemav2": "View JSON SchemaV2"
+      "view-button": "View JSON"
     },
     "library": {
       "info": "Create library panel."

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -2937,8 +2937,7 @@
       "loading": "Ŀőäđįŉģ...",
       "save-button": "Ŝävę ŧő ƒįľę",
       "share-externally-label": "Ēχpőřŧ ƒőř şĥäřįŉģ ęχŧęřŉäľľy",
-      "view-button": "Vįęŵ ĴŜØŃ",
-      "view-button-schemav2": "Vįęŵ ĴŜØŃ ŜčĥęmäV2"
+      "view-button": "Vįęŵ ĴŜØŃ"
     },
     "library": {
       "info": "Cřęäŧę ľįþřäřy päŉęľ."


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/95546/, we added the option "View JSON SchemaV2." This work was part of the POC and is no longer needed. 

In this PR, I am removing the unnecessary code.
