### PR TITLE
POC/Provisioning: Gosec: Fix/ignore gosec violations

### DIFF
--- a/pkg/registry/apis/provisioning/repository/github/real.go
+++ b/pkg/registry/apis/provisioning/repository/github/real.go
@@ -67,7 +67,7 @@ func (r *realImpl) GetTree(ctx context.Context, owner, repository, ref string, r
 		return nil, false, err
 	}
 
-	var entries []RepositoryContent
+	entries := make([]RepositoryContent, 0, len(tree.Entries))
 	for _, te := range tree.Entries {
 		rrc := &realRepositoryContent{
 			real: &github.RepositoryContent{


### PR DESCRIPTION
This should make `golangci-lint` pass again.