### PR TITLE
Flag: Add a new flag to switch the AuthZ Client to use the AuthZ Service

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -228,6 +228,7 @@ Experimental features might be changed or removed without prior notice.
 | `crashDetection`                              | Enables browser crash detection reporting to Faro.                                                                                                                                                                                                                                |
 | `jaegerBackendMigration`                      | Enables querying the Jaeger data source without the proxy                                                                                                                                                                                                                         |
 | `alertingNotificationsStepMode`               | Enables simplified step mode in the notifications section                                                                                                                                                                                                                         |
+| `switchToRbacAuthZService`                    | Switch the AuthZ Client to use the RBAC AuthZ Service.                                                                                                                                                                                                                            |
 
 ## Development feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -243,4 +243,5 @@ export interface FeatureToggles {
   alertingUIOptimizeReducer?: boolean;
   azureMonitorEnableUserAuth?: boolean;
   alertingNotificationsStepMode?: boolean;
+  switchToRbacAuthZService?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1680,6 +1680,12 @@ var (
 			Owner:        grafanaAlertingSquad,
 			FrontendOnly: true,
 		},
+		{
+			Name:        "switchToRbacAuthZService",
+			Description: "Switch the AuthZ Client to use the RBAC AuthZ Service.",
+			Stage:       FeatureStageExperimental,
+			Owner:       identityAccessTeam,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -224,3 +224,4 @@ reportingUseRawTimeRange,preview,@grafana/sharing-squad,false,false,false
 alertingUIOptimizeReducer,GA,@grafana/alerting-squad,false,false,true
 azureMonitorEnableUserAuth,GA,@grafana/partner-datasources,false,false,false
 alertingNotificationsStepMode,experimental,@grafana/alerting-squad,false,false,true
+switchToRbacAuthZService,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -906,4 +906,8 @@ const (
 	// FlagAlertingNotificationsStepMode
 	// Enables simplified step mode in the notifications section
 	FlagAlertingNotificationsStepMode = "alertingNotificationsStepMode"
+
+	// FlagSwitchToRbacAuthZService
+	// Switch the AuthZ Client to use the RBAC AuthZ Service.
+	FlagSwitchToRbacAuthZService = "switchToRbacAuthZService"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3318,6 +3318,18 @@
     },
     {
       "metadata": {
+        "name": "switchToRbacAuthZService",
+        "resourceVersion": "1732807756937",
+        "creationTimestamp": "2024-11-28T15:29:16Z"
+      },
+      "spec": {
+        "description": "Switch the AuthZ Client to use the RBAC AuthZ Service.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team"
+      }
+    },
+    {
+      "metadata": {
         "name": "tableSharedCrosshair",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2023-12-13T09:33:14Z"


### PR DESCRIPTION
Add a new feature flag to be able to switch the client to use the newer version of the AuthZ Service.

On second thought, I think we don't need this flag :thinking: 