### PR TITLE
[Prototyping] Comment with preview links in pull requests

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"path/filepath"
 	"slices"
 
@@ -207,7 +208,12 @@ func (b *ProvisioningAPIBuilder) asRepository(ctx context.Context, obj runtime.O
 	case provisioning.LocalRepositoryType:
 		return repository.NewLocal(r, b.localFileResolver), nil
 	case provisioning.GitHubRepositoryType:
-		return repository.NewGitHub(ctx, r, b.ghFactory), nil
+		baseURL, err := url.Parse(b.urlProvider(r.GetNamespace()))
+		if err != nil {
+			return nil, fmt.Errorf("invalid base URL: %w", err)
+		}
+
+		return repository.NewGitHub(ctx, r, b.ghFactory, baseURL), nil
 	case provisioning.S3RepositoryType:
 		return repository.NewS3(r), nil
 	default:

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -493,7 +493,7 @@ Grafana spotted some changes for your resources in this pull request:
 | {{.Filename}} | {{.Type}} | {{.Path}} | {{.Action}} | {{if .Original}}[Original]({{.Original}}){{end}}{{if .Current}}, [Current]({{.Current}}){{end}}{{if .Preview}}, [Preview]({{.Preview}}){{end}}|
 {{- end}}
 
-Take a look and judge yourself! 🚀`
+Click the preview links above to view how your changes will look and compare them with the original and current versions.`
 
 type commentFile struct {
 	Filename string

--- a/pkg/registry/apis/provisioning/repository/repository.go
+++ b/pkg/registry/apis/provisioning/repository/repository.go
@@ -100,6 +100,7 @@ type Repository interface {
 
 // FileReplicator is an interface for replicating files
 type FileReplicator interface {
+	Validate(ctx context.Context, fileInfo *FileInfo) (bool, error)
 	Replicate(ctx context.Context, fileInfo *FileInfo) error
 	Delete(ctx context.Context, fileInfo *FileInfo) error
 }

--- a/pkg/registry/apis/provisioning/resources/replicator.go
+++ b/pkg/registry/apis/provisioning/resources/replicator.go
@@ -171,9 +171,18 @@ func (r *replicator) Delete(ctx context.Context, fileInfo *repository.FileInfo) 
 	return nil
 }
 
+func (r *replicator) Validate(ctx context.Context, fileInfo *repository.FileInfo) (bool, error) {
+	if _, err := r.parseResource(ctx, fileInfo); err != nil {
+		if errors.Is(err, ErrUnableToReadResourceBytes) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (r *replicator) parseResource(ctx context.Context, fileInfo *repository.FileInfo) (*ParsedFile, error) {
-	// NOTE: We're validating here to make sure we want the folders to be created.
-	//  If the file isn't valid, its folders aren't relevant, either.
 	file, err := r.parser.Parse(ctx, r.logger, fileInfo, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse file %s: %w", fileInfo.Path, err)


### PR DESCRIPTION
The comments will now include links to preview the changes, the original and the current state of a dashboard depending on the change: 

The urls contain a query param called `pull_request_url` with the link to the original PR which can be used by the frontend to redirect users to the PR again after editing. 


https://github.com/grafana/git-ui-sync-demo/pull/7#issuecomment-2506454384

![image](https://github.com/user-attachments/assets/7d37abed-6a8f-45d6-afdd-80176d5ffac3)
