### PR TITLE
Graphite: Set `maxDataPoints` based on user value in alerting

### DIFF
--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -109,7 +109,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		"from":          []string{from},
 		"until":         []string{until},
 		"format":        []string{"json"},
-		"maxDataPoints": []string{"500"},
+		"maxDataPoints": []string{fmt.Sprintf("%d", q.MaxDataPoints)},
 		"target":        []string{},
 	}
 


### PR DESCRIPTION
There seems to have been an oversight in the Graphite data source that hardcoded the max data points value for alerting to 500. This PR lifts this limit and appropriately uses the value configured by the user.

Fixes #96934