### PR TITLE
SQL: Set errors as downstream based on underlying errorsource

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -235,6 +235,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		emptyFrame.SetMeta(&data.FrameMeta{
 			ExecutedQueryString: query,
 		})
+		if backend.IsDownstreamError(err) {
+			source = backend.ErrorSourceDownstream
+		}
 		queryResult.dataResponse.Error = fmt.Errorf("%s: %w", frameErr, err)
 		queryResult.dataResponse.ErrorSource = source
 		queryResult.dataResponse.Frames = data.Frames{&emptyFrame}

--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -240,6 +240,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		emptyFrame.SetMeta(&data.FrameMeta{
 			ExecutedQueryString: query,
 		})
+		if backend.IsDownstreamError(err) {
+			source = backend.ErrorSourceDownstream
+		}
 		queryResult.dataResponse.Error = fmt.Errorf("%s: %w", frameErr, err)
 		queryResult.dataResponse.ErrorSource = source
 		queryResult.dataResponse.Frames = data.Frames{&emptyFrame}

--- a/pkg/tsdb/mysql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mysql/sqleng/sql_engine.go
@@ -231,6 +231,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		emptyFrame.SetMeta(&data.FrameMeta{
 			ExecutedQueryString: query,
 		})
+		if backend.IsDownstreamError(err) {
+			source = backend.ErrorSourceDownstream
+		}
 		queryResult.dataResponse.Error = fmt.Errorf("%s: %w", frameErr, err)
 		queryResult.dataResponse.ErrorSource = source
 		queryResult.dataResponse.Frames = data.Frames{&emptyFrame}


### PR DESCRIPTION
This PR depends on the outcome of grafana/grafana-plugin-sdk-go#1159.

At the moment we set the source of many SQL errors within the plugin. However, the source of some of these errors should be determined at a lower level and respected at the plugin level. 

This PR adds support for validating if an error has an already existing source of downstream. If it does then that source will be used. Otherwise, the source passed into the `errAppendDebug` function will be used.

Will fix grafana/data-sources#219 on merge (alongside the SDK PR).
Will fix grafana/data-sources#176 on merge (alongside the SDK PR).