### PR TITLE
POC/Provisioning: Export: Only write dashboards in-tree of the repo

### DIFF
--- a/pkg/registry/apis/provisioning/export.go
+++ b/pkg/registry/apis/provisioning/export.go
@@ -174,9 +174,15 @@ func (t *folderTree) In(folder string) bool {
 	return ok
 }
 
+// DirPath creates the path to the directory with slashes.
+// The repository folder is not included in the path.
+// If In(folder) is false, this will panic, because it would be undefined behaviour.
 func (t *folderTree) DirPath(folder string) string {
 	if folder == t.repoFolder {
 		return ""
+	}
+	if !t.In(folder) {
+		panic("undefined behaviour")
 	}
 
 	dirPath := folder

--- a/pkg/registry/apis/provisioning/export.go
+++ b/pkg/registry/apis/provisioning/export.go
@@ -183,6 +183,7 @@ func (t *folderTree) DirPath(folder string) string {
 	parent := t.tree[folder]
 	for parent != "" && parent != t.repoFolder {
 		dirPath = path.Join(parent, dirPath)
+		parent = t.tree[parent]
 	}
 	// Not using Clean here is intentional. We don't want `.` or similar.
 	return dirPath

--- a/pkg/registry/apis/provisioning/export.go
+++ b/pkg/registry/apis/provisioning/export.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"path"
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
@@ -14,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/dynamic"
 
@@ -95,7 +95,7 @@ func (c *exportConnector) Connect(
 		})
 
 		// TODO: handle pagination
-		folders, err := c.fetchFolderInfo(ctx, folderIface)
+		folders, err := c.fetchRepoFolderTree(ctx, folderIface, repo.Config().Spec.Folder)
 		if err != nil {
 			responder.Error(apierrors.NewInternalError(fmt.Errorf("failed to list folders: %w", err)))
 			return
@@ -115,26 +115,25 @@ func (c *exportConnector) Connect(
 				return
 			}
 
-			logger.InfoContext(ctx, "got item in dashboard list",
-				"name", item.GetName(),
-				"namespace", item.GetNamespace())
+			logger := logger.With("name", item.GetName(), "namespace", item.GetNamespace())
+			logger.DebugContext(ctx, "got item in dashboard list")
 			name := item.GetName()
 			if namespace := item.GetNamespace(); namespace != ns {
 				logger.DebugContext(ctx, "skipping dashboard in export due to mismatched namespace",
-					"name", name,
-					"namespace", map[string]string{"expected": ns, "actual": namespace})
+					"expected", ns)
 				continue
 			}
 
-			folder := folders[item.GetAnnotations()[apiutils.AnnoKeyFolder]]
+			folder := item.GetAnnotations()[apiutils.AnnoKeyFolder]
+			if !folders.In(folder) {
+				logger.DebugContext(ctx, "skipping dashboard in export due to folder being out-of-tree of repository")
+				continue
+			}
 
 			delete(item.Object, "metadata")
 			marshalledBody, baseFileName, err := c.marshalPreferredFormat(item.Object, name, repo)
 			if err != nil {
-				logger.ErrorContext(ctx, "failed to marshal dashboard into preferred format",
-					"err", err,
-					"dashboard", name,
-					"namespace", ns)
+				logger.ErrorContext(ctx, "failed to marshal dashboard into preferred format", "err", err)
 				responder.Error(apierrors.NewInternalError(fmt.Errorf("failed to marshal dashboard %s: %w", name, err)))
 				return
 			}
@@ -144,7 +143,7 @@ func (c *exportConnector) Connect(
 				ref = repo.Config().Spec.GitHub.Branch
 			}
 
-			fileName := filepath.Join(folder.CreatePath(), baseFileName)
+			fileName := filepath.Join(folders.DirPath(folder), baseFileName)
 			_, err = repo.Read(ctx, logger, fileName, ref)
 			if err != nil && !(errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err)) {
 				responder.Error(apierrors.NewInternalError(fmt.Errorf("failed to check if file exists before writing: %w", err)))
@@ -155,11 +154,7 @@ func (c *exportConnector) Connect(
 				err = repo.Update(ctx, logger, fileName, ref, marshalledBody, "export of dashboard "+name+" in namespace "+ns)
 			}
 			if err != nil {
-				logger.ErrorContext(ctx, "failed to write dashboard model to repository",
-					"err", err,
-					"repository", repo.Config().GetName(),
-					"dashboard", name,
-					"namespace", ns)
+				logger.ErrorContext(ctx, "failed to write dashboard model to repository", "err", err)
 				responder.Error(apierrors.NewInternalError(fmt.Errorf("failed to write file in repo: %w", err)))
 				return
 			}
@@ -169,69 +164,76 @@ func (c *exportConnector) Connect(
 	}), nil
 }
 
-type folderExport struct {
-	Name string
-	UID  apitypes.UID
-	// Parent is a pointer to a parent folder. Nil if none.
-	Parent *folderExport
+type folderTree struct {
+	tree       map[string]string
+	repoFolder string
 }
 
-func (e *folderExport) CreatePath() string {
-	if e == nil {
+func (t *folderTree) In(folder string) bool {
+	_, ok := t.tree[folder]
+	return ok
+}
+
+func (t *folderTree) DirPath(folder string) string {
+	if folder == t.repoFolder {
 		return ""
 	}
 
-	if e.Parent == nil {
-		return e.Name
-	} else {
-		return filepath.Join(e.Parent.CreatePath(), e.Name)
+	dirPath := folder
+	parent := t.tree[folder]
+	for parent != "" && parent != t.repoFolder {
+		dirPath = path.Join(parent, dirPath)
 	}
+	// Not using Clean here is intentional. We don't want `.` or similar.
+	return dirPath
 }
 
-func (c *exportConnector) fetchFolderInfo(
+func (c *exportConnector) fetchRepoFolderTree(
 	ctx context.Context,
 	iface dynamic.ResourceInterface,
-) (map[string]*folderExport, error) {
-	folders := make(map[string]*folderExport)
-
+	repoFolder string,
+) (*folderTree, error) {
 	// TODO: handle pagination
 	rawFolders, err := iface.List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 
+	folders := make(map[string]string, len(rawFolders.Items))
 	for _, rf := range rawFolders.Items {
 		name := rf.GetName()
-		uid := rf.GetUID()
-		folders[name] = &folderExport{
-			Name: name,
-			UID:  uid,
-		}
+		// TODO: Can I use MetaAccessor here?
+		parent := rf.GetAnnotations()[apiutils.AnnoKeyFolder]
+		folders[name] = parent
 	}
 
-	// Double iteration is not great but whatever... probably not too many folders anyhow...
-	for _, folder := range folders {
-		parents, err := iface.Get(ctx, folder.Name, metav1.GetOptions{}, "parents")
-		if err != nil {
-			return nil, err
-		}
-
-		// FIXME: use "items" here when we undo that hack
-		uncastItems := parents.Object["infoItems"]
-		if uncastItems == nil { // avoid interface conversion panic
-			continue
-		}
-		items := uncastItems.([]any)
-		if len(items) == 0 {
+	// folders now includes a map[folder name]parent name
+	// The top-most folder has a parent of "". Any folders below have parent refs.
+	// We want to find only folders which are or start in repoFolder.
+	for folder, parent := range folders {
+		if folder == repoFolder {
 			continue
 		}
 
-		// the UID in the returned value is actually the metadata.name!
-		parentUid := items[0].(map[string]interface{})["uid"].(string)
-		folder.Parent = folders[parentUid]
+		hasRepoRoot := false
+		for parent != "" {
+			if parent == repoFolder {
+				hasRepoRoot = true
+				break
+			}
+			parent = folders[parent]
+		}
+		if !hasRepoRoot {
+			delete(folders, folder)
+		}
 	}
 
-	return folders, nil
+	// folders now only includes the tree of the repoFolder.
+
+	return &folderTree{
+		tree:       folders,
+		repoFolder: repoFolder,
+	}, nil
 }
 
 func (c *exportConnector) marshalPreferredFormat(obj any, name string, repo repository.Repository) (body []byte, fileName string, err error) {

--- a/pkg/registry/apis/provisioning/export_test.go
+++ b/pkg/registry/apis/provisioning/export_test.go
@@ -1,0 +1,34 @@
+package provisioning
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFolderTree(t *testing.T) {
+	t.Run("empty tree", func(t *testing.T) {
+		tree := &folderTree{
+			tree:       map[string]string{"x": ""},
+			repoFolder: "x",
+		}
+
+		assert.True(t, tree.In("x"))
+		assert.False(t, tree.In("z"))
+		assert.Empty(t, tree.DirPath("x"))
+	})
+
+	t.Run("simple tree", func(t *testing.T) {
+		tree := &folderTree{
+			tree:       map[string]string{"a": "b", "b": "c", "c": "x", "x": ""},
+			repoFolder: "x",
+		}
+
+		assert.True(t, tree.In("x"))
+		assert.True(t, tree.In("a"))
+		assert.False(t, tree.In("z"))
+		assert.Empty(t, tree.DirPath("x"))
+		assert.Equal(t, "c", tree.DirPath("c"))
+		assert.Equal(t, "c/b/a", tree.DirPath("a"))
+	})
+}

--- a/pkg/registry/apis/provisioning/export_test.go
+++ b/pkg/registry/apis/provisioning/export_test.go
@@ -16,6 +16,7 @@ func TestFolderTree(t *testing.T) {
 		assert.True(t, tree.In("x"))
 		assert.False(t, tree.In("z"))
 		assert.Empty(t, tree.DirPath("x"))
+		assert.PanicsWithValue(t, "undefined behaviour", func() { tree.DirPath("z") }, "unknown folders cannot have a DirPath result")
 	})
 
 	t.Run("simple tree", func(t *testing.T) {


### PR DESCRIPTION
We'll only export the in-tree dashboards of the repository.

This means exporting (for example) `local-devenv` will only output files that were in the tree of `local-devenv`, along with its nested folder structure. The repo folder itself is no longer output.