### PR TITLE
GCM: Correctly mark errors as downstream

### DIFF
--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -443,7 +443,7 @@ func (s *Service) buildQueryExecutors(logger log.Logger, req *backend.QueryDataR
 			}
 			queryInterface = cmp
 		default:
-			return nil, fmt.Errorf("unrecognized query type %q", query.QueryType)
+			return nil, backend.DownstreamError(fmt.Errorf("unrecognized query type %q", query.QueryType))
 		}
 
 		cloudMonitoringQueryExecutors = append(cloudMonitoringQueryExecutors, queryInterface)

--- a/pkg/tsdb/cloud-monitoring/converter/converter.go
+++ b/pkg/tsdb/cloud-monitoring/converter/converter.go
@@ -24,7 +24,7 @@ type Options struct {
 }
 
 func rspErr(e error) backend.DataResponse {
-	return backend.DataResponse{Error: e}
+	return backend.DataResponse{Error: e, ErrorSource: backend.ErrorSourceDownstream}
 }
 
 // ReadPrometheusStyleResult will read results from a prometheus or loki server and return data frames
@@ -50,7 +50,7 @@ l1Fields:
 		case "data":
 			rsp = readPrometheusData(iter, opt)
 			if rsp.Error != nil {
-				return rsp
+				return rspErr(err)
 			}
 
 		case "error":
@@ -86,7 +86,8 @@ l1Fields:
 
 	if status == "error" {
 		return backend.DataResponse{
-			Error: fmt.Errorf("%s: %s", errorType, promErrString),
+			Error:       fmt.Errorf("%s: %s", errorType, promErrString),
+			ErrorSource: backend.ErrorSourceDownstream,
 		}
 	}
 


### PR DESCRIPTION
Update query type error as downstream.

Mark Prom response parsing errors and general response errors as downstream.

Fixes grafana/data-sources#162
Fixes grafana/data-sources#164