### PR TITLE
Loki: Fix a bug when reading frames without values but warnings

### DIFF
--- a/pkg/tsdb/loki/frame.go
+++ b/pkg/tsdb/loki/frame.go
@@ -10,19 +10,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-// we adjust the dataframes to be the way frontend & alerting
-// wants them.
 func adjustFrame(frame *data.Frame, query *lokiQuery, setMetricFrameName bool, logsDataplane bool) error {
-	fields := frame.Fields
-
-	if len(fields) < 2 {
-		return fmt.Errorf("missing fields in frame")
-	}
-
 	// metric-fields have "timefield, valuefield"
 	// logs-fields have "labelsfield, timefield, ..."
-
-	secondField := fields[1]
+	secondField := frame.Fields[1]
 
 	if secondField.Type() == data.FieldTypeFloat64 {
 		return adjustMetricFrame(frame, query, setMetricFrameName)

--- a/pkg/tsdb/loki/framing_test.go
+++ b/pkg/tsdb/loki/framing_test.go
@@ -54,6 +54,8 @@ func TestSuccessResponse(t *testing.T) {
 
 		{name: "parse structured metadata", filepath: "streams_structured_metadata", query: streamsQuery},
 		{name: "parse structured metadata different labels each log line", filepath: "streams_structured_metadata_2", query: streamsQuery},
+
+		{name: "parse warnings", filepath: "warning", query: streamsQuery},
 	}
 
 	runTest := func(folder string, path string, query lokiQuery, responseOpts ResponseOpts) {

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -290,7 +290,7 @@ func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts 
 
 	for _, frame := range res.Frames {
 		// Skip frames without fields
-		if len(frame.Fields) == 0 {
+		if len(frame.Fields) < 2 {
 			continue
 		}
 

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -289,8 +289,12 @@ func runQuery(ctx context.Context, api *LokiAPI, query *lokiQuery, responseOpts 
 	}
 
 	for _, frame := range res.Frames {
-		err = adjustFrame(frame, query, false, responseOpts.logsDataplane)
+		// Skip frames without fields
+		if len(frame.Fields) == 0 {
+			continue
+		}
 
+		err = adjustFrame(frame, query, false, responseOpts.logsDataplane)
 		if err != nil {
 			plog.Error("Error adjusting frame", "error", err)
 			return res, err

--- a/pkg/tsdb/loki/test_non_dataplane/warning.golden.jsonc
+++ b/pkg/tsdb/loki/test_non_dataplane/warning.golden.jsonc
@@ -1,0 +1,47 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "notices": [
+//          {
+//              "severity": "warning",
+//              "text": "Some logs may have been dropped by Adaptive Logs sampling"
+//          }
+//      ]
+//  }
+//  Name: Warnings
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Warnings",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "notices": [
+            {
+              "severity": "warning",
+              "text": "Some logs may have been dropped by Adaptive Logs sampling"
+            }
+          ]
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/loki/test_non_dataplane/warning.json
+++ b/pkg/tsdb/loki/test_non_dataplane/warning.json
@@ -1,0 +1,4 @@
+{
+  "status": "success",
+  "warnings": ["Some logs may have been dropped by Adaptive Logs sampling"]
+}

--- a/pkg/tsdb/loki/testdata_dataplane/warning.golden.jsonc
+++ b/pkg/tsdb/loki/testdata_dataplane/warning.golden.jsonc
@@ -1,0 +1,47 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "typeVersion": [
+//          0,
+//          0
+//      ],
+//      "notices": [
+//          {
+//              "severity": "warning",
+//              "text": "Some logs may have been dropped by Adaptive Logs sampling"
+//          }
+//      ]
+//  }
+//  Name: Warnings
+//  Dimensions: 0 Fields by 0 Rows
+//  +
+//  +
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "Warnings",
+        "meta": {
+          "typeVersion": [
+            0,
+            0
+          ],
+          "notices": [
+            {
+              "severity": "warning",
+              "text": "Some logs may have been dropped by Adaptive Logs sampling"
+            }
+          ]
+        },
+        "fields": []
+      },
+      "data": {
+        "values": []
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/loki/testdata_dataplane/warning.json
+++ b/pkg/tsdb/loki/testdata_dataplane/warning.json
@@ -1,0 +1,4 @@
+{
+  "status": "success",
+  "warnings": ["Some logs may have been dropped by Adaptive Logs sampling"]
+}


### PR DESCRIPTION
**What is this feature?**

Loki may return warnings, e.g. when adaptive logs is applied, but not return any values. That resulted in errors thrown, because the backend created dataframes without fields.

This PR removes throwing errors when dataframes have less than 2 fields.