### PR TITLE
Zanzana: Handle renderer service authorization requests

### DIFF
--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -68,6 +68,8 @@ var FolderRelations = append(
 	RelationFolderResourcePermissionsWrite,
 )
 
+const RenderUser string = "render:0"
+
 func FolderResourceRelation(relation string) string {
 	return fmt.Sprintf("%s_%s", TypeResource, relation)
 }
@@ -245,4 +247,19 @@ func ToOpenFGATuples(tuples []*authzextv1.Tuple) []*openfgav1.Tuple {
 		result = append(result, ToOpenFGATuple(t))
 	}
 	return result
+}
+
+func AddRenderContext(req *openfgav1.CheckRequest) {
+	if req.ContextualTuples == nil {
+		req.ContextualTuples = &openfgav1.ContextualTupleKeys{}
+	}
+	if req.ContextualTuples.TupleKeys == nil {
+		req.ContextualTuples.TupleKeys = make([]*openfgav1.TupleKey, 0)
+	}
+
+	req.ContextualTuples.TupleKeys = append(req.ContextualTuples.TupleKeys, &openfgav1.TupleKey{
+		User:     RenderUser,
+		Relation: "view",
+		Object:   NewNamespaceResourceIdent("dashboard.grafana.app", "dashboards"),
+	})
 }

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -259,7 +259,7 @@ func AddRenderContext(req *openfgav1.CheckRequest) {
 	}
 
 	req.ContextualTuples.TupleKeys = append(req.ContextualTuples.TupleKeys, &openfgav1.TupleKey{
-		User:     RenderUser,
+		User:     req.TupleKey.User,
 		Relation: "view",
 		Object: NewNamespaceResourceIdent(
 			dashboardalpha1.DashboardResourceInfo.GroupResource().Group,

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -12,6 +12,7 @@ import (
 const (
 	TypeUser           string = "user"
 	TypeServiceAccount string = "service-account"
+	TypeRenderService  string = "render"
 	TypeTeam           string = "team"
 	TypeRole           string = "role"
 	TypeFolder         string = "folder"

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -69,7 +69,7 @@ var FolderRelations = append(
 	RelationFolderResourcePermissionsWrite,
 )
 
-const RenderUser string = "render:0"
+const RenderUserType string = "render"
 
 func FolderResourceRelation(relation string) string {
 	return fmt.Sprintf("%s_%s", TypeResource, relation)

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -6,6 +6,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	dashboardalpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 )
 
@@ -260,6 +261,9 @@ func AddRenderContext(req *openfgav1.CheckRequest) {
 	req.ContextualTuples.TupleKeys = append(req.ContextualTuples.TupleKeys, &openfgav1.TupleKey{
 		User:     RenderUser,
 		Relation: "view",
-		Object:   NewNamespaceResourceIdent("dashboard.grafana.app", "dashboards"),
+		Object: NewNamespaceResourceIdent(
+			dashboardalpha1.DashboardResourceInfo.GroupResource().Group,
+			dashboardalpha1.DashboardResourceInfo.GroupResource().Resource,
+		),
 	})
 }

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -69,8 +69,6 @@ var FolderRelations = append(
 	RelationFolderResourcePermissionsWrite,
 )
 
-const RenderUserType string = "render"
-
 func FolderResourceRelation(relation string) string {
 	return fmt.Sprintf("%s_%s", TypeResource, relation)
 }

--- a/pkg/services/authz/zanzana/schema/schema_core.fga
+++ b/pkg/services/authz/zanzana/schema/schema_core.fga
@@ -1,21 +1,23 @@
 module core
 
+type user
+
+type service-account
+
+type render
+
 type namespace
   relations
-    define view: [user, service-account, team#member, role#assignee] or edit
+    define view: [user, service-account, render, team#member, role#assignee] or edit
     define edit: [user, service-account, team#member, role#assignee] or admin
     define admin: [user, service-account, team#member, role#assignee]
 
-    define read: [user, service-account, team#member, role#assignee] or view
+    define read: [user, service-account, render, team#member, role#assignee] or view
     define create: [user, service-account, team#member, role#assignee] or edit
     define write: [user, service-account, team#member, role#assignee] or edit
     define delete: [user, service-account, team#member, role#assignee] or edit
     define permissions_read: [user, service-account, team#member, role#assignee] or admin
     define permissions_write: [user, service-account, team#member, role#assignee] or admin
-
-type user
-
-type service-account
 
 type role
   relations

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -49,7 +51,7 @@ func (s *Server) checkNamespace(ctx context.Context, subject, relation, group, r
 			Object:   common.NewNamespaceResourceIdent(group, resource),
 		},
 	}
-	if subject == common.RenderUser {
+	if strings.HasPrefix(subject, fmt.Sprintf("%s:", common.RenderUserType)) {
 		common.AddRenderContext(req)
 	}
 

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -51,7 +51,7 @@ func (s *Server) checkNamespace(ctx context.Context, subject, relation, group, r
 			Object:   common.NewNamespaceResourceIdent(group, resource),
 		},
 	}
-	if strings.HasPrefix(subject, fmt.Sprintf("%s:", common.RenderUserType)) {
+	if strings.HasPrefix(subject, fmt.Sprintf("%s:", common.TypeRenderService)) {
 		common.AddRenderContext(req)
 	}
 

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -48,16 +48,11 @@ func (s *Server) checkNamespace(ctx context.Context, subject, relation, group, r
 			Relation: relation,
 			Object:   common.NewNamespaceResourceIdent(group, resource),
 		},
-		ContextualTuples: &openfgav1.ContextualTupleKeys{
-			TupleKeys: []*openfgav1.TupleKey{
-				{
-					User:     "render:0",
-					Relation: "view",
-					Object:   common.NewNamespaceResourceIdent("dashboard.grafana.app", "dashboards"),
-				},
-			},
-		},
 	}
+	if subject == common.RenderUser {
+		common.AddRenderContext(req)
+	}
+
 	res, err := s.openfga.Check(ctx, req)
 	if err != nil {
 		return nil, err

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -13,6 +13,7 @@ import (
 const (
 	TypeUser           = common.TypeUser
 	TypeServiceAccount = common.TypeServiceAccount
+	TypeRenderService  = common.TypeRenderService
 	TypeTeam           = common.TypeTeam
 	TypeRole           = common.TypeRole
 	TypeFolder         = common.TypeFolder


### PR DESCRIPTION
**What is this feature?**

Add `render` type to schema and handle it with a contextual tuple. Idea is that render service should be able to read all the dashboards. Currently it's implemented by [setting org role to `Admin`](https://github.com/grafana/grafana/blob/99395b62d4885fdc0d3cf5a4ecc948c67c8878e5/pkg/services/screenshot/screenshot.go#L114) for the render user, but it seems too much, we can limit it to read only access.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/1046

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
