### PR TITLE
Docs: Reword variables limitation

### DIFF
--- a/docs/sources/dashboards/share-dashboards-panels/shared-dashboards/index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/shared-dashboards/index.md
@@ -292,7 +292,7 @@ guaranteed because plugin developers can override this functionality. The follow
 ## Limitations
 
 - Panels that use frontend data sources will fail to fetch data.
-- Template variables are not supported.
+- Variables and queries including variables are not supported.
 - Exemplars will be omitted from the panel.
 - Only annotations that query the `-- Grafana --` data source are supported.
 - Organization annotations are not supported.


### PR DESCRIPTION
Reworded variables limitation to remove the term "template" and replace it with its meaning.

Once this PR is approved, open a new PR to update the docs [11.3 Public dashboards docs](https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/#limitations) as well.
