### PR TITLE
Transformations: Relax regexp format in refIdMatcher

### DIFF
--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -1,4 +1,4 @@
-import { stringStartsAsRegEx, stringToJsRegex } from '../../text/string';
+import { escapeStringForRegex, stringStartsAsRegEx, stringToJsRegex } from '../../text/string';
 import { DataFrame } from '../../types/dataFrame';
 import { FrameMatcherInfo } from '../../types/transformations';
 
@@ -22,6 +22,12 @@ const refIdMatcher: FrameMatcherInfo<string> = {
           console.warn(error.message);
         }
       }
+    }
+    // old format that was simply unescaped pipe-joined strings -> regexp
+    else if (pattern.includes('|')) {
+      // convert A|B -> /^(?:A|B)$/, regexp-escaping all chars between pipes
+      const escapedUnion = pattern.split('|').map(escapeStringForRegex).join('|');
+      regex = new RegExp(`^(?:${escapedUnion})$`);
     }
 
     return (frame: DataFrame) => {

--- a/packages/grafana-data/src/transformations/transformers/filterByRefId.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByRefId.test.ts
@@ -37,8 +37,22 @@ describe('filterByRefId transformer', () => {
     });
   });
 
-  describe('respects', () => {
-    it('inclusion', async () => {
+  describe('respects inclusion', () => {
+    it('pipe delimited literals', async () => {
+      const cfg = {
+        id: DataTransformerID.filterByRefId,
+        options: {
+          include: 'A|B',
+        },
+      };
+
+      await expect(transformDataFrame([cfg], allSeries)).toEmitValuesWith((received) => {
+        const filtered = received[0];
+        expect(filtered.map((f) => f.refId)).toEqual(['A', 'B']);
+      });
+    });
+
+    it('explicit regexp', async () => {
       const cfg = {
         id: DataTransformerID.filterByRefId,
         options: {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/13690

turns out we have an existing transformation UI/editor for matching multiple frame refIds, and that editor currently assembles `A|B` style strings that end up in the saved JSON model.

<details><summary>filter-data-by-refids.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 410,
  "links": [],
  "panels": [
    {
      "datasource": {
        "default": true,
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 6,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "maxDataPoints": 10,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 1,
          "spread": 100
        },
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "B",
          "scenarioId": "random_walk",
          "seriesCount": 1,
          "spread": 100
        },
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "C",
          "scenarioId": "random_walk",
          "seriesCount": 1,
          "spread": 100
        }
      ],
      "title": "Original",
      "type": "timeseries"
    },
    {
      "datasource": {
        "default": false,
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 6,
        "x": 6,
        "y": 0
      },
      "id": 2,
      "maxDataPoints": 10,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 1,
          "refId": "A"
        }
      ],
      "title": "Empty transform",
      "transformations": [
        {
          "id": "filterByRefId",
          "options": {
            "include": ""
          }
        }
      ],
      "type": "timeseries"
    },
    {
      "datasource": {
        "default": false,
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 6,
        "x": 0,
        "y": 14
      },
      "id": 4,
      "maxDataPoints": 10,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 1,
          "refId": "A"
        }
      ],
      "title": "C",
      "transformations": [
        {
          "id": "filterByRefId",
          "options": {
            "include": "C"
          }
        }
      ],
      "type": "timeseries"
    },
    {
      "datasource": {
        "default": false,
        "type": "datasource",
        "uid": "-- Dashboard --"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 14,
        "w": 6,
        "x": 6,
        "y": 14
      },
      "id": 3,
      "maxDataPoints": 10,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "datasource",
            "uid": "-- Dashboard --"
          },
          "panelId": 1,
          "refId": "A"
        }
      ],
      "title": "A|B",
      "transformations": [
        {
          "id": "filterByRefId",
          "options": {
            "include": "A|B"
          }
        }
      ],
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "schemaVersion": 40,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "filter-data-by-refids",
  "uid": "fe5fvhj638jk0d",
  "version": 2,
  "weekStart": ""
}
```
</details>

![image](https://github.com/user-attachments/assets/f9842b09-430d-4859-acda-a06dfd9c563e)

one improvement to this is to replace the existing pill editor with the new one that we use in transformation filters (see https://github.com/grafana/grafana/pull/97212), but that still leaves the problem of existing save models potentially containing `A|B` rather than `/^(?:A|B)$/` (with A and B regexp-escaped and treated as literals).

this PR relaxes the handling of the byRefId option (it was made more strict in https://github.com/grafana/grafana/pull/96358). we now treat `A|B` as pipe-delimited literals rather than a partial regexp as it was originally, and escape everything between the pipes, constructing a safe regexp in the process.