### PR TITLE
Update index.md to add a note about provisioned data source

### DIFF
--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/index.md
@@ -13,7 +13,7 @@ weight: 250
 
 # Configure LBAC for data sources for Loki data source on Grafana Cloud
 
-LBAC for data sources is available in private preview on Grafana Cloud for Loki created with basic authentication. Loki data sources for LBAC for data sources can only be created, provisioning is currently not available. 
+LBAC for data sources is available in private preview on Grafana Cloud for Loki created with basic authentication. Loki data sources for LBAC for data sources can only be created, provisioning is currently not available.
 
 You cannot configure LBAC rules for Grafana-provisioned data sources from the UI. Alternatively, you can replicate the setting of the provisioned data source in a new data source as described in [LBAC Configuration for New Loki Data Source](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/#task-1-lbac-configuration-for-new-loki-data-source) and then add the LBAC configuration to the new data source.
 

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/index.md
@@ -13,7 +13,8 @@ weight: 250
 
 # Configure LBAC for data sources for Loki data source on Grafana Cloud
 
-LBAC for data sources is available in private preview on Grafana Cloud for Loki created with basic authentication. Loki data sources for LBAC for data sources can only be created, provisioning is currently not available.
+LBAC for data sources is available in private preview on Grafana Cloud for Loki created with basic authentication. Loki data sources for LBAC for data sources can only be created, provisioning is currently not available. 
+You cannot configure LBAC rules for Grafana-provisioned data sources from the UI. You can alternatively replicate the setting of the provisioned data source in a new data source as described in [LBAC Configuration for New Loki Data Source](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/#task-1-lbac-configuration-for-new-loki-data-source) and then add the LBAC configuration to the new data source.
 
 ## Before you begin
 

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/index.md
@@ -14,7 +14,8 @@ weight: 250
 # Configure LBAC for data sources for Loki data source on Grafana Cloud
 
 LBAC for data sources is available in private preview on Grafana Cloud for Loki created with basic authentication. Loki data sources for LBAC for data sources can only be created, provisioning is currently not available. 
-You cannot configure LBAC rules for Grafana-provisioned data sources from the UI. You can alternatively replicate the setting of the provisioned data source in a new data source as described in [LBAC Configuration for New Loki Data Source](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/#task-1-lbac-configuration-for-new-loki-data-source) and then add the LBAC configuration to the new data source.
+
+You cannot configure LBAC rules for Grafana-provisioned data sources from the UI. Alternatively, you can replicate the setting of the provisioned data source in a new data source as described in [LBAC Configuration for New Loki Data Source](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/#task-1-lbac-configuration-for-new-loki-data-source) and then add the LBAC configuration to the new data source.
 
 ## Before you begin
 


### PR DESCRIPTION
The document needs a NOTE above saying that one can't add LBAC permissions configurations on the PROVISIONED Loki data source and that you need to replicate the data source and then add LBAC permissions configurations to this new data source.

Zendesk: https://grafana.zendesk.com/agent/tickets/162563
Issue: https://github.com/grafana/support-escalations/issues/13682