### PR TITLE
Chore: Attempt to reduce flakiness in integration tests

### DIFF
--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -110,7 +110,8 @@ func sqLite3TestDB() (*TestDB, error) {
 
 	ret.ConnStr = "file:" + sqliteDb + "?cache=private&mode=rwc"
 	if os.Getenv("SQLITE_JOURNAL_MODE") != "false" {
-		ret.ConnStr += "&_journal_mode=WAL"
+		// For tests, set sync=OFF for faster commits. Reference: https://www.sqlite.org/pragma.html#pragma_synchronous.
+		ret.ConnStr += "&_journal_mode=WAL&_synchronous=OFF"
 	}
 	ret.Path = sqliteDb
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -461,9 +461,14 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 			}
 		}
 	}
-	logSection, err := getOrCreateSection("database")
+
+	dbSection, err := getOrCreateSection("database")
 	require.NoError(t, err)
-	_, err = logSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
+	_, err = dbSection.NewKey("query_retries", fmt.Sprintf("%d", queryRetries))
+	require.NoError(t, err)
+	_, err = dbSection.NewKey("max_open_conn", "2")
+	require.NoError(t, err)
+	_, err = dbSection.NewKey("max_idle_conn", "2")
 	require.NoError(t, err)
 
 	cfgPath := filepath.Join(cfgDir, "test.ini")


### PR DESCRIPTION
## **What is this feature?**

### 1. In integration tests, set `sync=OFF` if `_journal_mode=WAL` is set.

**Why?** From the [SQLite docs](https://www.sqlite.org/pragma.html#pragma_synchronous):
> With synchronous OFF (0), SQLite continues without syncing as soon as it has handed data off to the operating system. If the application running SQLite crashes, the data will be safe, but the database [might become corrupted](https://www.sqlite.org/howtocorrupt.html#cfgerr) if the operating system crashes or the computer loses power before that data has been written to the disk surface. On the other hand, **commits can be orders of magnitude faster with synchronous OFF**.
  
Even though it might corrupt the database in case of OS crashes, since these are supposed to be ephemeral databases, these characteristics are not needed. The default is `FULL (2)`.

### 2. Limit `max_open_conn` and `max_idle_conn` to `2`. This matches the settings used in E2E tests.

**Why?**
- Based on previous work from https://github.com/grafana/grafana/pull/76659
- As well as the following issue https://github.com/mattn/go-sqlite3/issues/274

It seems that limiting the max connections (especially `open`) improves the locking errors.

We were previously not setting the `max_open_conn` at all. This might make some tests slower, but I need to compare them closely.

## **Why do we need this feature?**

This is an attempt to reduce flakiness in integration tests that are failing with `database is locked` errors.

## **Who is this feature for?**

Contributors.

## **Which issue(s) does this PR fix?**:

N/A
