### PR TITLE
Fix out of sync openapi specs

### DIFF
--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -8606,6 +8606,32 @@
         }
       }
     },
+    "/scim/users/": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Creates user.",
+        "operationId": "createUser",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/responses/forbiddenError"
+          },
+          "409": {
+            "$ref": "#/responses/conflictError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
+      }
+    },
     "/search": {
       "get": {
         "tags": [

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -22483,6 +22483,32 @@
         ]
       }
     },
+    "/scim/users/": {
+      "post": {
+        "operationId": "createUser",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorisedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbiddenError"
+          },
+          "409": {
+            "$ref": "#/components/responses/conflictError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Creates user.",
+        "tags": [
+          "users"
+        ]
+      }
+    },
     "/search": {
       "get": {
         "operationId": "search",


### PR DESCRIPTION
The swagger/openapi specs got out of date from https://github.com/grafana/grafana/pull/97220, probably due to a faulty merge.

