### PR TITLE
Alerting/chore: Deprecate MockDataSourceSrv and remove from Alerting tests

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1663,14 +1663,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
     ],
-    "public/app/features/alerting/unified/components/settings/__mocks__/server.ts:5381": [
-      [0, 0, 0, "Do not re-export imported variable (\`DataSourcesResponse\`)", "0"],
-      [0, 0, 0, "Do not re-export imported variable (\`AdminConfigResponse\`)", "1"],
-      [0, 0, 0, "Do not re-export imported variable (\`AlertmanagersResponse\`)", "2"],
-      [0, 0, 0, "Do not re-export imported variable (\`InternalAlertmanagerConfiguration\`)", "3"],
-      [0, 0, 0, "Do not re-export imported variable (\`VanillaAlertmanagerConfiguration\`)", "4"],
-      [0, 0, 0, "Do not re-export imported variable (\`alertmanagerConfigurationHistory\`)", "5"]
-    ],
     "public/app/features/alerting/unified/components/silences/MatchersField.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]

--- a/public/app/features/alerting/unified/AlertGroups.test.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.test.tsx
@@ -2,18 +2,12 @@ import { render, waitFor, waitForElementToBeRemoved } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { setDataSourceSrv } from '@grafana/runtime';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { AccessControlAction } from 'app/types';
 
 import AlertGroups from './AlertGroups';
 import { fetchAlertGroups } from './api/alertmanager';
-import {
-  MockDataSourceSrv,
-  grantUserPermissions,
-  mockAlertGroup,
-  mockAlertmanagerAlert,
-  mockDataSource,
-} from './mocks';
+import { grantUserPermissions, mockAlertGroup, mockAlertmanagerAlert, mockDataSource } from './mocks';
 import { AlertmanagerProvider } from './state/AlertmanagerContext';
 import { DataSourceType } from './utils/datasource';
 
@@ -63,7 +57,7 @@ describe('AlertGroups', () => {
   });
 
   beforeEach(() => {
-    setDataSourceSrv(new MockDataSourceSrv(dataSources));
+    setupDataSources(dataSources.am);
   });
 
   afterEach(() => {

--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -3,7 +3,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { getWrapper, render, waitFor, waitForElementToBeRemoved, within } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
-import { setDataSourceSrv } from '@grafana/runtime';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 
 import { AccessControlAction } from '../../../types';
@@ -74,7 +73,7 @@ describe('CloneRuleEditor', function () {
 
   describe('Grafana-managed rules', function () {
     it('should populate form values from the existing alert rule', async function () {
-      setDataSourceSrv(new MockDataSourceSrv({}));
+      setupDataSources();
 
       render(
         <CloneRuleEditor sourceRuleId={{ uid: grafanaRulerRule.grafana_alert.uid, ruleSourceName: 'grafana' }} />,

--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -17,7 +17,6 @@ import { CloneRuleEditor, cloneRuleDefinition } from './CloneRuleEditor';
 import { ExpressionEditorProps } from './components/rule-editor/ExpressionEditor';
 import { mockFeatureDiscoveryApi, setupMswServer } from './mockApi';
 import {
-  MockDataSourceSrv,
   grantUserPermissions,
   mockDataSource,
   mockRulerAlertingRule,

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -1,13 +1,11 @@
 import { render } from 'test/test-utils';
 import { byTestId, byText } from 'testing-library-selector';
 
-import { DataSourceApi } from '@grafana/data';
-import { PromOptions, PrometheusDatasource } from '@grafana/prometheus';
-import { setDataSourceSrv, setPluginLinksHook } from '@grafana/runtime';
-import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
+import { PromOptions } from '@grafana/prometheus';
+import { setPluginLinksHook } from '@grafana/runtime';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { AccessControlAction } from 'app/types';
 import { AlertQuery, PromRulesResponse } from 'app/types/unified-alerting-dto';
 
@@ -16,7 +14,6 @@ import * as apiRuler from './api/ruler';
 import * as alertingAbilities from './hooks/useAbilities';
 import { mockAlertRuleApi, setupMswServer } from './mockApi';
 import {
-  MockDataSourceSrv,
   grantUserPermissions,
   mockDataSource,
   mockPromAlert,
@@ -26,42 +23,51 @@ import {
 } from './mocks';
 import { captureRequests } from './mocks/server/events';
 import { RuleFormValues } from './types/rule-form';
-import * as config from './utils/config';
 import { Annotation } from './utils/constants';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
-jest.mock('./api/prometheus');
 jest.mock('./api/ruler');
-jest.mock('../../../core/hooks/useMediaQueryChange');
-
-jest.spyOn(config, 'getAllDataSources');
-jest.spyOn(ruleActionButtons, 'matchesWidth').mockReturnValue(false);
-jest.spyOn(apiRuler, 'rulerUrlBuilder');
 jest.spyOn(alertingAbilities, 'useAlertRuleAbility');
+
+const prometheusModuleSettings = { alerting: true, module: 'core:plugin/prometheus' };
+
 const dataSources = {
-  prometheus: mockDataSource<PromOptions>({
-    name: 'Prometheus',
-    type: DataSourceType.Prometheus,
-    isDefault: false,
-  }),
-  default: mockDataSource<PromOptions>({
-    name: 'Default',
-    type: DataSourceType.Prometheus,
-    isDefault: true,
-  }),
+  prometheus: mockDataSource<PromOptions>(
+    {
+      name: 'Prometheus',
+      type: DataSourceType.Prometheus,
+      isDefault: false,
+      jsonData: { manageAlerts: true },
+    },
+    prometheusModuleSettings
+  ),
+  default: mockDataSource<PromOptions>(
+    {
+      name: 'Default',
+      type: DataSourceType.Prometheus,
+      isDefault: true,
+      jsonData: { manageAlerts: true },
+    },
+    prometheusModuleSettings
+  ),
+  prometheusMinInterval: mockDataSource<PromOptions>(
+    {
+      name: 'Prometheus Min Interval',
+      type: DataSourceType.Prometheus,
+      isDefault: false,
+      jsonData: { manageAlerts: true, timeInterval: '7m' },
+    },
+    prometheusModuleSettings
+  ),
 };
-dataSources.prometheus.meta.alerting = true;
-dataSources.default.meta.alerting = true;
 
 const mocks = {
-  getAllDataSources: jest.mocked(config.getAllDataSources),
   useAlertRuleAbilityMock: jest.mocked(alertingAbilities.useAlertRuleAbility),
   rulerBuilderMock: jest.mocked(apiRuler.rulerUrlBuilder),
 };
 
-const renderAlertTabContent = (dashboard: DashboardModel, panel: PanelModel) => {
+const renderAlertTabContent = (dashboard: DashboardModel, panel: PanelModel) =>
   render(<PanelAlertTabContent dashboard={dashboard} panel={panel} />);
-};
 
 const promResponse: PromRulesResponse = {
   status: 'success',
@@ -190,19 +196,13 @@ describe('PanelAlertTabContent', () => {
       AccessControlAction.AlertingRuleExternalRead,
       AccessControlAction.AlertingRuleExternalWrite,
     ]);
+    setupDataSources(...Object.values(dataSources));
 
     setPluginLinksHook(() => ({
       links: [],
       isLoading: false,
     }));
 
-    mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
-    const dsService = new MockDataSourceSrv(dataSources);
-    dsService.datasources[dataSources.prometheus.uid] = new PrometheusDatasource(
-      dataSources.prometheus
-    ) as DataSourceApi;
-    dsService.datasources[dataSources.default.uid] = new PrometheusDatasource(dataSources.default) as DataSourceApi;
-    setDataSourceSrv(dsService);
     mocks.rulerBuilderMock.mockReturnValue({
       rules: () => ({ path: `api/ruler/${GRAFANA_RULES_SOURCE_NAME}/api/v1/rules` }),
       namespace: () => ({ path: 'ruler' }),
@@ -297,13 +297,15 @@ describe('PanelAlertTabContent', () => {
   });
 
   it('Will take into account datasource minInterval', async () => {
-    (getDatasourceSrv() as unknown as MockDataSourceSrv).datasources[dataSources.prometheus.uid].interval = '7m';
-
     renderAlertTabContent(
       dashboard,
       new PanelModel({
         ...panel,
         maxDataPoints: 100,
+        datasource: {
+          type: 'prometheus',
+          uid: dataSources.prometheusMinInterval.uid,
+        },
       })
     );
 
@@ -318,7 +320,7 @@ describe('PanelAlertTabContent', () => {
       refId: 'A',
       datasource: {
         type: 'prometheus',
-        uid: 'mock-ds-2',
+        uid: 'mock-ds-4',
       },
       interval: '',
       intervalMs: 420000,

--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -4,11 +4,8 @@ import { render } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import SettingsPage from './Settings';
-import {
-  DataSourcesResponse,
-  setupGrafanaManagedServer,
-  withExternalOnlySetting,
-} from './components/settings/__mocks__/server';
+import DataSourcesResponse from './components/settings/__mocks__/api/datasources.json';
+import { setupGrafanaManagedServer, withExternalOnlySetting } from './components/settings/__mocks__/server';
 import { setupMswServer } from './mockApi';
 import { grantUserRole } from './mocks';
 

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from 'test/test-utils';
 import { byLabelText, byRole } from 'testing-library-selector';
 
-import { locationService, setDataSourceSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
 import * as analytics from '../../Analytics';
-import { MockDataSourceSrv } from '../../mocks';
 import { setupPluginsExtensionsHook } from '../../testSetup/plugins';
 
 import RulesFilter from './Filter/RulesFilter';
@@ -20,8 +19,6 @@ jest.mock('./MultipleDataSourcePicker', () => {
     MultipleDataSourcePicker: () => <></>,
   };
 });
-
-setDataSourceSrv(new MockDataSourceSrv({}));
 
 setupPluginsExtensionsHook();
 

--- a/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { AccessControlAction } from 'app/types';
 
 import { setupMswServer } from '../../mockApi';
@@ -12,6 +13,7 @@ import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
 import AlertmanagerConfig from './AlertmanagerConfig';
 import {
   EXTERNAL_VANILLA_ALERTMANAGER_UID,
+  mockDataSources,
   PROVISIONED_MIMIR_ALERTMANAGER_UID,
   setupVanillaAlertmanagerServer,
 } from './__mocks__/server';
@@ -75,6 +77,7 @@ describe('vanilla Alertmanager', () => {
 
   beforeEach(() => {
     setupVanillaAlertmanagerServer(server);
+    setupDataSources(...Object.values(mockDataSources));
     grantUserPermissions([AccessControlAction.AlertingNotificationsRead, AccessControlAction.AlertingInstanceRead]);
   });
 

--- a/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.test.tsx
@@ -13,8 +13,8 @@ import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
 import AlertmanagerConfig from './AlertmanagerConfig';
 import {
   EXTERNAL_VANILLA_ALERTMANAGER_UID,
-  mockDataSources,
   PROVISIONED_MIMIR_ALERTMANAGER_UID,
+  mockDataSources,
   setupVanillaAlertmanagerServer,
 } from './__mocks__/server';
 

--- a/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
+++ b/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
@@ -1,7 +1,6 @@
 import { HttpResponse, delay, http } from 'msw';
 import { SetupServerApi } from 'msw/node';
 
-import { setDataSourceSrv } from '@grafana/runtime';
 import {
   AlertManagerCortexConfig,
   AlertManagerDataSourceJsonData,
@@ -10,7 +9,7 @@ import {
   Receiver,
 } from 'app/plugins/datasource/alertmanager/types';
 
-import { MockDataSourceSrv, mockDataSource } from '../../../mocks';
+import { mockDataSource } from '../../../mocks';
 import * as config from '../../../utils/config';
 import { DataSourceType } from '../../../utils/datasource';
 
@@ -34,29 +33,31 @@ export const PROVISIONED_MIMIR_ALERTMANAGER_UID = 'provisioned-alertmanager';
 
 jest.spyOn(config, 'getAllDataSources');
 
-const mocks = {
-  getAllDataSources: jest.mocked(config.getAllDataSources),
-};
-
 export const mockDataSources = {
-  [EXTERNAL_VANILLA_ALERTMANAGER_UID]: mockDataSource<AlertManagerDataSourceJsonData>({
-    uid: EXTERNAL_VANILLA_ALERTMANAGER_UID,
-    name: EXTERNAL_VANILLA_ALERTMANAGER_UID,
-    type: DataSourceType.Alertmanager,
-    jsonData: {
-      implementation: AlertManagerImplementation.prometheus,
+  [EXTERNAL_VANILLA_ALERTMANAGER_UID]: mockDataSource<AlertManagerDataSourceJsonData>(
+    {
+      uid: EXTERNAL_VANILLA_ALERTMANAGER_UID,
+      name: EXTERNAL_VANILLA_ALERTMANAGER_UID,
+      type: DataSourceType.Alertmanager,
+      jsonData: {
+        implementation: AlertManagerImplementation.prometheus,
+      },
     },
-  }),
-  [PROVISIONED_MIMIR_ALERTMANAGER_UID]: mockDataSource<AlertManagerDataSourceJsonData>({
-    uid: PROVISIONED_MIMIR_ALERTMANAGER_UID,
-    name: PROVISIONED_MIMIR_ALERTMANAGER_UID,
-    type: DataSourceType.Alertmanager,
-    jsonData: {
-      // this is a mutable data source type but we're making it readOnly
-      implementation: AlertManagerImplementation.mimir,
+    { module: 'core:plugin/alertmanager' }
+  ),
+  [PROVISIONED_MIMIR_ALERTMANAGER_UID]: mockDataSource<AlertManagerDataSourceJsonData>(
+    {
+      uid: PROVISIONED_MIMIR_ALERTMANAGER_UID,
+      name: PROVISIONED_MIMIR_ALERTMANAGER_UID,
+      type: DataSourceType.Alertmanager,
+      jsonData: {
+        // this is a mutable data source type but we're making it readOnly
+        implementation: AlertManagerImplementation.mimir,
+      },
+      readOnly: true,
     },
-    readOnly: true,
-  }),
+    { module: 'core:plugin/alertmanager' }
+  ),
 };
 
 export function setupGrafanaManagedServer(server: SetupServerApi) {
@@ -72,9 +73,6 @@ export function setupGrafanaManagedServer(server: SetupServerApi) {
 }
 
 export function setupVanillaAlertmanagerServer(server: SetupServerApi) {
-  mocks.getAllDataSources.mockReturnValue(Object.values(mockDataSources));
-  setDataSourceSrv(new MockDataSourceSrv(mockDataSources));
-
   server.use(
     createVanillaAlertmanagerConfigurationHandler(EXTERNAL_VANILLA_ALERTMANAGER_UID),
     ...createAlertmanagerConfigurationHandlers()

--- a/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
+++ b/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
@@ -20,13 +20,6 @@ import datasources from './api/datasources.json';
 import admin_config from './api/v1/ngalert/admin_config.json';
 import alertmanagers from './api/v1/ngalert/alertmanagers.json';
 
-export { datasources as DataSourcesResponse };
-export { admin_config as AdminConfigResponse };
-export { alertmanagers as AlertmanagersResponse };
-export { internalAlertmanagerConfig as InternalAlertmanagerConfiguration };
-export { vanillaAlertmanagerConfig as VanillaAlertmanagerConfiguration };
-export { history as alertmanagerConfigurationHistory };
-
 export const EXTERNAL_VANILLA_ALERTMANAGER_UID = 'vanilla-alertmanager';
 export const PROVISIONED_MIMIR_ALERTMANAGER_UID = 'provisioned-alertmanager';
 

--- a/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
+++ b/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
@@ -10,7 +10,6 @@ import {
 } from 'app/plugins/datasource/alertmanager/types';
 
 import { mockDataSource } from '../../../mocks';
-import * as config from '../../../utils/config';
 import { DataSourceType } from '../../../utils/datasource';
 
 import internalAlertmanagerConfig from './api/alertmanager/grafana/config/api/v1/alerts.json';
@@ -30,8 +29,6 @@ export { history as alertmanagerConfigurationHistory };
 
 export const EXTERNAL_VANILLA_ALERTMANAGER_UID = 'vanilla-alertmanager';
 export const PROVISIONED_MIMIR_ALERTMANAGER_UID = 'provisioned-alertmanager';
-
-jest.spyOn(config, 'getAllDataSources');
 
 export const mockDataSources = {
   [EXTERNAL_VANILLA_ALERTMANAGER_UID]: mockDataSource<AlertManagerDataSourceJsonData>(

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -2,7 +2,6 @@ import { setupDataSources } from 'app/features/alerting/unified/testSetup/dataso
 
 import { PromAlertingRuleState } from '../../../../types/unified-alerting-dto';
 import {
-  MockDataSourceSrv,
   getCloudRule,
   mockAlertQuery,
   mockCombinedCloudRuleNamespace,

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -1,4 +1,4 @@
-import { setDataSourceSrv } from '@grafana/runtime';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
 import { PromAlertingRuleState } from '../../../../types/unified-alerting-dto';
 import {
@@ -25,7 +25,7 @@ const dataSources = {
   loki: mockDataSource({ uid: 'loki-1', name: 'loki' }),
 };
 beforeAll(() => {
-  setDataSourceSrv(new MockDataSourceSrv(dataSources));
+  setupDataSources(...Object.values(dataSources));
 });
 
 describe('filterRules', function () {

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -416,7 +416,7 @@ class MockDataSourceApi extends DataSourceApi {
   }
 }
 
-// TODO This should be eventually moved to public/app/features/alerting/unified/testSetup/datasources.ts
+/** @deprecated use `setupDatasources` instead */
 export class MockDataSourceSrv implements DataSourceSrv {
   datasources: Record<string, DataSourceApi> = {};
   // @ts-ignore

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -104,7 +104,7 @@ export function mimirDataSource() {
         manageAlerts: true,
       },
     },
-    { alerting: true }
+    { alerting: true, module: 'core:plugin/alertmanager' }
   );
 
   setupDataSources(dataSource);

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -102,7 +102,7 @@ export function mimirDataSource() {
       url: 'https://mimir.local:9000',
       jsonData: {
         manageAlerts: true,
-        // implementation: 'mimir',
+        implementation: 'mimir',
       },
     },
     { alerting: true, module: 'core:plugin/prometheus' }

--- a/public/app/features/alerting/unified/mocks/server/configure.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure.ts
@@ -102,9 +102,10 @@ export function mimirDataSource() {
       url: 'https://mimir.local:9000',
       jsonData: {
         manageAlerts: true,
+        // implementation: 'mimir',
       },
     },
-    { alerting: true, module: 'core:plugin/alertmanager' }
+    { alerting: true, module: 'core:plugin/prometheus' }
   );
 
   setupDataSources(dataSource);

--- a/public/app/features/alerting/unified/mocks/server/handlers/datasources.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/datasources.ts
@@ -28,5 +28,28 @@ export const datasourceBuildInfoHandler = () =>
     }
   );
 
-const datasourcesHandlers = [datasourceBuildInfoHandler()];
+// TODO: Add more accurate endpoint responses as tests require
+const labelValuesHandler = () =>
+  http.get('/api/datasources/uid/:datasourceUid/resources/api/v1/label/__name__/values', ({ params }) => {
+    return HttpResponse.json({ status: 'sucess', data: [] });
+  });
+
+// TODO: Add more accurate endpoint responses as tests require
+const resourcesLabelsHandler = () =>
+  http.get('/api/datasources/uid/:datasourceUid/resources/api/v1/labels', () =>
+    HttpResponse.json({ status: 'success', data: [] })
+  );
+
+// TODO: Add more accurate endpoint responses as tests require
+const resourcesMetadataHandler = () =>
+  http.get('/api/datasources/uid/:datasourceUid/resources/api/v1/metadata', () =>
+    HttpResponse.json({ status: 'success', data: {} })
+  );
+
+const datasourcesHandlers = [
+  datasourceBuildInfoHandler(),
+  labelValuesHandler(),
+  resourcesLabelsHandler(),
+  resourcesMetadataHandler(),
+];
 export default datasourcesHandlers;

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -16,9 +16,17 @@ import {
 import { DataSourceSrv, DataSourceWithBackend, FetchResponse } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { BackendSrv } from 'app/core/services/backend_srv';
+import {
+  EXTERNAL_VANILLA_ALERTMANAGER_UID,
+  mockDataSources,
+} from 'app/features/alerting/unified/components/settings/__mocks__/server';
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { AlertingQueryResponse, AlertingQueryRunner } from './AlertingQueryRunner';
+
+setupMswServer();
 
 describe('AlertingQueryRunner', () => {
   it('should successfully map response and return panel data by refId', async () => {
@@ -28,12 +36,12 @@ describe('AlertingQueryRunner', () => {
         B: { frames: [createDataFrameJSON([5, 6])] },
       },
     });
+    setupDataSources(...Object.values(mockDataSources));
 
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => of(response),
-      }),
-      mockDataSourceSrv()
+      })
     );
 
     const data = runner.get();
@@ -121,8 +129,7 @@ describe('AlertingQueryRunner', () => {
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => of(response).pipe(delay(210)),
-      }),
-      mockDataSourceSrv()
+      })
     );
 
     const data = runner.get();
@@ -176,8 +183,7 @@ describe('AlertingQueryRunner', () => {
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => throwError(error),
-      }),
-      mockDataSourceSrv()
+      })
     );
 
     const data = runner.get();
@@ -332,7 +338,7 @@ const createQuery = (refId: string, options?: Partial<AlertQuery>): AlertQuery =
   return defaultsDeep(options, {
     refId,
     queryType: '',
-    datasourceUid: '',
+    datasourceUid: EXTERNAL_VANILLA_ALERTMANAGER_UID,
     model: { refId },
     relativeTimeRange: getDefaultRelativeTimeRange(),
   });

--- a/public/app/features/alerting/unified/testSetup/datasources.ts
+++ b/public/app/features/alerting/unified/testSetup/datasources.ts
@@ -2,8 +2,7 @@ import { keyBy } from 'lodash';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { config, setDataSourceSrv } from '@grafana/runtime';
-
-import { MockDataSourceSrv } from '../mocks';
+import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 /**
  * Sets up the data sources for the tests.
@@ -11,6 +10,13 @@ import { MockDataSourceSrv } from '../mocks';
  * @param configs data source instance settings. Use **mockDataSource** to create mock settings
  */
 export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
-  config.datasources = keyBy(configs, (c) => c.name);
-  setDataSourceSrv(new MockDataSourceSrv(config.datasources));
+  const dataSourceSrv = new DatasourceSrv();
+  const datasourceSettings = keyBy(configs, (c) => c.name);
+
+  const defaultDatasource = configs.find((c) => c.isDefault);
+  config.datasources = datasourceSettings;
+  dataSourceSrv.init(config.datasources, defaultDatasource?.name || config.defaultDatasource);
+  setDataSourceSrv(dataSourceSrv);
+
+  return dataSourceSrv;
 }


### PR DESCRIPTION
**What is this feature?**
Marks the `MockDataSourceSrv` as deprecated, and tweaks our existing `setupDataSources` method to be more accurate with how it sets up datasources for tests. This, combined with removing the plugin_loader mock allows us to unit test datasource behaviour more accurately. We also don't have to worry as much about keeping the mock datasource srv in line with the real service (which I've seen having to happen recently)

**Why do we need this feature?**
This is a step along the way to having a common set of datasources that we use in our alerting tests

**Who is this feature for?**
Alerting UI devs
