### PR TITLE
SCIM: DELETE /scim/Users/:id endpoint swagger documentation

### DIFF
--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -8657,6 +8657,30 @@
             "$ref": "#/responses/internalServerError"
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Deletes user.",
+        "operationId": "deleteUser",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/responses/badRequestError"
+          },
+          "401": {
+            "$ref": "#/responses/unauthorisedError"
+          },
+          "404": {
+            "$ref": "#/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/responses/internalServerError"
+          }
+        }
       }
     },
     "/search": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -22618,6 +22618,30 @@
       }
     },
     "/scim/users/": {
+      "delete": {
+        "operationId": "deleteUser",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/okResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/badRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorisedError"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/internalServerError"
+          }
+        },
+        "summary": "Deletes user.",
+        "tags": [
+          "user"
+        ]
+      },
       "get": {
         "operationId": "getUsers",
         "responses": {


### PR DESCRIPTION
**What is this feature?**

This PR adds the swagger documentation for the DELETE /scim/Users/:id endpoint.

**Why do we need this feature?**

Part of the development for the SCIM feature.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

https://github.com/grafana/identity-access-team/issues/1029

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
