### PR TITLE
Scopes: Merge scope filters with OR condition in case their keys overlap. 

### DIFF
--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -73,7 +73,7 @@ func ApplyFiltersAndGroupBy(rawExpr string, scopeFilters, adHocFilters []ScopeFi
 func FiltersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matcher, error) {
 	filterMap := make(map[string]*labels.Matcher)
 
-	// scopes filters
+	// scope filters are applied first
 	for _, filter := range scopeFilters {
 		matcher, err := filterToMatcher(filter)
 		if err != nil {

--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -88,7 +88,6 @@ func FiltersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matc
 		} else {
 			filterMap[filter.Key] = matcher
 		}
-
 	}
 
 	// ad hoc filters are applied after scope filters

--- a/pkg/promlib/models/scope.go
+++ b/pkg/promlib/models/scope.go
@@ -73,11 +73,32 @@ func ApplyFiltersAndGroupBy(rawExpr string, scopeFilters, adHocFilters []ScopeFi
 func FiltersToMatchers(scopeFilters, adhocFilters []ScopeFilter) ([]*labels.Matcher, error) {
 	filterMap := make(map[string]*labels.Matcher)
 
-	for _, filter := range append(scopeFilters, adhocFilters...) {
+	// scopes filters
+	for _, filter := range scopeFilters {
 		matcher, err := filterToMatcher(filter)
 		if err != nil {
 			return nil, err
 		}
+
+		// when scopes have the same key, both values should be matched
+		// in prometheus that means using an regex with both values
+		if _, ok := filterMap[filter.Key]; ok {
+			filterMap[filter.Key].Value = filterMap[filter.Key].Value + "|" + matcher.Value
+			filterMap[filter.Key].Type = labels.MatchRegexp
+		} else {
+			filterMap[filter.Key] = matcher
+		}
+
+	}
+
+	// ad hoc filters are applied after scope filters
+	for _, filter := range adhocFilters {
+		matcher, err := filterToMatcher(filter)
+		if err != nil {
+			return nil, err
+		}
+
+		// when ad hoc filters have the same key, the last one should be used
 		filterMap[filter.Key] = matcher
 	}
 

--- a/pkg/promlib/models/scope_test.go
+++ b/pkg/promlib/models/scope_test.go
@@ -107,13 +107,26 @@ func TestApplyQueryFiltersAndGroupBy_Filters(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:  "merge label matchers from if multiple scopes are passed",
+			name:  "merge scopes filters into using OR if they share filter key",
 			query: `http_requests_total{}`,
 			scopeFilters: []ScopeFilter{
 				{Key: "namespace", Value: "default", Operator: FilterOperatorEquals},
 				{Key: "namespace", Value: "kube-system", Operator: FilterOperatorEquals},
 			},
 			expected:  `http_requests_total{namespace=~"default|kube-system"}`,
+			expectErr: false,
+		},
+		{
+			name:  "adhoc filters win over scope filters if they share filter key",
+			query: `http_requests_total{}`,
+			scopeFilters: []ScopeFilter{
+				{Key: "namespace", Value: "default", Operator: FilterOperatorEquals},
+				{Key: "namespace", Value: "kube-system", Operator: FilterOperatorEquals},
+			},
+			adhocFilters: []ScopeFilter{
+				{Key: "namespace", Value: "adhoc-wins", Operator: FilterOperatorEquals},
+			},
+			expected:  `http_requests_total{namespace="adhoc-wins"}`,
 			expectErr: false,
 		},
 	}

--- a/pkg/promlib/models/scope_test.go
+++ b/pkg/promlib/models/scope_test.go
@@ -106,6 +106,16 @@ func TestApplyQueryFiltersAndGroupBy_Filters(t *testing.T) {
 			expected:  `{__name__="http_requests_total",namespace="istio"}`,
 			expectErr: false,
 		},
+		{
+			name:  "merge label matchers from if multiple scopes are passed",
+			query: `http_requests_total{}`,
+			scopeFilters: []ScopeFilter{
+				{Key: "namespace", Value: "default", Operator: FilterOperatorEquals},
+				{Key: "namespace", Value: "kube-system", Operator: FilterOperatorEquals},
+			},
+			expected:  `http_requests_total{namespace=~"default|kube-system"}`,
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,7 +126,7 @@ func TestApplyQueryFiltersAndGroupBy_Filters(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, expr)
+				require.Equal(t, tt.expected, expr, tt.name)
 			}
 		})
 	}


### PR DESCRIPTION
I think scopes should be merged using OR logic. Any use-case for selecting multiple scopes with competing filter key, I want to see metrics from both. 

There _might_ be an argument about using AND instead of OR but the current implementation just take the latest which is definitely not what we want. so lets go with OR for now. 