### PR TITLE
MSSQL: Redact sensitive info from logs in the mssql plugin

### DIFF
--- a/pkg/tsdb/mssql/kerberos/kerberos.go
+++ b/pkg/tsdb/mssql/kerberos/kerberos.go
@@ -73,8 +73,6 @@ func Krb5ParseAuthCredentials(host string, port string, db string, user string, 
 		krb5DriverParams += "krb5-dnslookupkdc=" + kerberosAuth.EnableDNSLookupKDC + ";"
 	}
 
-	logger.Info(fmt.Sprintf("final krb connstr: %s", krb5DriverParams))
-
 	return krb5DriverParams
 }
 


### PR DESCRIPTION
<!--


Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
Hello Team,


These changes fix the compliance violation and an issue where we were printing the database connection string with the username and especially the unhidden password directly into the logs (see the logs below). Printing passwords in the logs is insecure and has already been fixed in other part of the code, e.g: da13f88862e60297127b2e6a9a5f038dc99fa701

```
2024-11-05T07:11:13.228934+0000 proton-grafana-dv-2 service-grafana: final krb connstr: authenticator=krb1;krb5-configfile=;server=10.1.204.61\ARC_DV;database=ArchiveDataCatalogue_DX;user id=SVC-GMT-DX-PP@muzetx.intra;password=PublicPass;logger=tsdb.mssql t=2024-11-05T07:11:13.228934Z level=error msg="Query error" err="unable to open tcp connection with host '10.1.204.61:1433': dial tcp 10.1.204.61: connect: connection refused"
2024-11-05T07:11:10.548330+0000 proton-grafana-dv-2 service-grafana: final krb connstr: authenticator=krb1;krb5-configfile=;server=10.1.204.61\ARC_DV;database=ArchiveDataCatalogue_DX;user id=SVC-GMT-DX-PP@muzetx.intra;password=PublicPass;logger=tsdb.mssql t=2024-11-05T07:11:10.548330Z level=error msg="Query error" err="unable to open tcp connection with host '10.1.204.61:1433': dial tcp 10.1.204.61:1433: connect: connection refused"
```

The problem was introduced here - [MSSQL: Add Windows AD/Kerberos auth](https://github.com/grafana/grafana/pull/84742) and I see the following possible options how we can fix the issue:
- do not log the creds at all
- hide the password from the line we're logging

The PR includes the changes for the latter case, based on the assumption that we need explicit logging for these credentials. However, I think the simplest solution is simply to remove the log line altogether. 

@asimpson as an author of the original patch, could you take a look at the changes and say which of the options best suits the project?

---

**What is this feature?**

Fix the problem with the security compliance violations

**Why do we need this feature?**

To resolve the security violations. 

**Who is this feature for?**

Fix the security problem.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
