### PR TITLE
hackathon: Resolve prom-style queries in a way that matches prometheus

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -378,9 +378,9 @@ func (alertRule *AlertRule) GetLabels(opts ...LabelOption) map[string]string {
 	return labels
 }
 
-func (alertRule *AlertRule) IsPromStyle() bool {
+func (alertRule *AlertRule) GetEvalSemantics() EvaluationSemantics {
 	if len(alertRule.Data) != 1 {
-		return false
+		return EvaluationSemanticsGrafana
 	}
 
 	type datasource struct {
@@ -395,13 +395,13 @@ func (alertRule *AlertRule) IsPromStyle() bool {
 	err := json.Unmarshal(alertRule.Data[0].Model, &node)
 	if err != nil {
 		// Invalid model.
-		return false
+		return EvaluationSemanticsGrafana
 	}
 
 	if node.Datasource.Type == "prometheus" {
-		return true
+		return EvaluationSemanticsPrometheus
 	}
-	return false
+	return EvaluationSemanticsGrafana
 }
 
 func (alertRule *AlertRule) GetEvalCondition() Condition {
@@ -411,10 +411,7 @@ func (alertRule *AlertRule) GetEvalCondition() Condition {
 		"Type":    string(alertRule.Type()),
 		"Version": strconv.FormatInt(alertRule.Version, 10),
 	}
-	semantics := EvaluationSemanticsGrafana
-	if alertRule.IsPromStyle() {
-		semantics = EvaluationSemanticsPrometheus
-	}
+	semantics := alertRule.GetEvalSemantics()
 	if alertRule.Type() == RuleTypeRecording {
 		return Condition{
 			Metadata:  meta,

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -378,6 +378,32 @@ func (alertRule *AlertRule) GetLabels(opts ...LabelOption) map[string]string {
 	return labels
 }
 
+func (alertRule *AlertRule) IsPromStyle() bool {
+	if len(alertRule.Data) != 1 {
+		return false
+	}
+
+	type datasource struct {
+		Type string `json:"type"`
+		UID  string `json:"uid"`
+	}
+	type queryModel struct {
+		Datasource datasource `json:"datasource"`
+	}
+
+	var node queryModel
+	err := json.Unmarshal(alertRule.Data[0].Model, &node)
+	if err != nil {
+		// Invalid model.
+		return false
+	}
+
+	if node.Datasource.Type == "prometheus" {
+		return true
+	}
+	return false
+}
+
 func (alertRule *AlertRule) GetEvalCondition() Condition {
 	meta := map[string]string{
 		"Name":    alertRule.Title,
@@ -385,18 +411,22 @@ func (alertRule *AlertRule) GetEvalCondition() Condition {
 		"Type":    string(alertRule.Type()),
 		"Version": strconv.FormatInt(alertRule.Version, 10),
 	}
+	semantics := EvaluationSemanticsGrafana
+	if alertRule.IsPromStyle() {
+		semantics = EvaluationSemanticsPrometheus
+	}
 	if alertRule.Type() == RuleTypeRecording {
 		return Condition{
 			Metadata:  meta,
 			Condition: alertRule.Record.From,
-			Semantics: EvaluationSemanticsGrafana,
+			Semantics: semantics,
 			Data:      alertRule.Data,
 		}
 	}
 	return Condition{
 		Metadata:  meta,
 		Condition: alertRule.Condition,
-		Semantics: EvaluationSemanticsGrafana,
+		Semantics: semantics,
 		Data:      alertRule.Data,
 	}
 }


### PR DESCRIPTION
instead of the stale thing based on time, resolve a series instantly if that labelset disappears from the query.
don't do it with (MissingSeries), use a normal resolve.