### PR TITLE
Search: Build index from resource stats

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -132,7 +132,7 @@ type rowsWrapper struct {
 	err error
 }
 
-func (a *dashboardSqlAccess) GetResourceStats(ctx context.Context, minCount int64) ([]resource.ResourceStats, error) {
+func (a *dashboardSqlAccess) GetResourceStats(ctx context.Context, minCount int) ([]resource.ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -132,7 +132,7 @@ type rowsWrapper struct {
 	err error
 }
 
-func (a *dashboardSqlAccess) Namespaces(ctx context.Context) ([]string, error) {
+func (a *dashboardSqlAccess) GetResourceStats(ctx context.Context, minCount int64) ([]resource.ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -109,7 +109,7 @@ func (s *cdkBackend) getPath(key *ResourceKey, rv int64) string {
 }
 
 // GetResourceStats implements Backend.
-func (s *cdkBackend) GetResourceStats(ctx context.Context, minCount int64) ([]ResourceStats, error) {
+func (s *cdkBackend) GetResourceStats(ctx context.Context, minCount int) ([]ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -108,7 +108,8 @@ func (s *cdkBackend) getPath(key *ResourceKey, rv int64) string {
 	return buffer.String()
 }
 
-func (s *cdkBackend) Namespaces(ctx context.Context) ([]string, error) {
+// GetResourceStats implements Backend.
+func (s *cdkBackend) GetResourceStats(ctx context.Context, minCount int64) ([]ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -164,40 +164,22 @@ func (s *searchSupport) init(ctx context.Context) error {
 	_, span := s.tracer.Start(ctx, tracingPrexfixSearch+"Init")
 	defer span.End()
 
-	// TODO, replace namespaces with a query that gets top values
-	namespaces, err := s.storage.Namespaces(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Hardcoded for now... should come from the query
-	kinds := []schema.GroupResource{
-		{Group: "dashboard.grafana.app", Resource: "dashboards"},
-		{Group: "playlist.grafana.app", Resource: "playlists"},
-	}
-
 	totalBatchesIndexed := 0
 	group := errgroup.Group{}
 	group.SetLimit(s.initWorkers)
 
-	// Prepare all the (large) indexes
-	// TODO, threading and query real information:
-	// SELECT namespace,"group",resource,COUNT(*),resource_version FROM resource
-	//   GROUP BY "group", "resource", "namespace"
-	//   ORDER BY resource_version desc;
-	for _, ns := range namespaces {
-		for _, gr := range kinds {
-			group.Go(func() error {
-				s.log.Debug("initializing search index", "namespace", ns, "gr", gr)
-				totalBatchesIndexed++
-				_, _, err = s.build(ctx, NamespacedResource{
-					Group:     gr.Group,
-					Resource:  gr.Resource,
-					Namespace: ns,
-				}, 10, 0) // TODO, approximate size
-				return err
-			})
-		}
+	stats, err := s.storage.GetResourceStats(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	for _, info := range stats {
+		group.Go(func() error {
+			s.log.Debug("initializing search index", "namespace", info.Namespace, "group", info.Group, "resource", info.Resource)
+			totalBatchesIndexed++
+			_, _, err = s.build(ctx, info.NamespacedResource, info.Count, info.ResourceVersion) // TODO, approximate size
+			return err
+		})
 	}
 
 	err = group.Wait()

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -95,7 +95,14 @@ type StorageBackend interface {
 	// For HA setups, this will be more events than the local WriteEvent above!
 	WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent, error)
 
-	Namespaces(ctx context.Context) ([]string, error)
+	GetResourceStats(ctx context.Context, minCount int64) ([]ResourceStats, error)
+}
+
+type ResourceStats struct {
+	NamespacedResource
+
+	Count           int64
+	ResourceVersion int64
 }
 
 // This interface is not exposed to end users directly

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -95,7 +95,7 @@ type StorageBackend interface {
 	// For HA setups, this will be more events than the local WriteEvent above!
 	WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent, error)
 
-	GetResourceStats(ctx context.Context, minCount int64) ([]ResourceStats, error)
+	GetResourceStats(ctx context.Context, minCount int) ([]ResourceStats, error)
 }
 
 type ResourceStats struct {
@@ -140,6 +140,9 @@ type SearchOptions struct {
 
 	// How many threads should build indexes
 	WorkerThreads int
+
+	// Skip building index on startup for small indexes
+	InitMinCount int
 }
 
 type ResourceServerOptions struct {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -122,7 +122,7 @@ func (b *backend) Stop(_ context.Context) error {
 }
 
 // GetResourceStats implements Backend.
-func (b *backend) GetResourceStats(ctx context.Context, minCount int64) ([]resource.ResourceStats, error) {
+func (b *backend) GetResourceStats(ctx context.Context, minCount int) ([]resource.ResourceStats, error) {
 	_, span := b.tracer.Start(ctx, tracePrefix+".GetResourceStats")
 	defer span.End()
 
@@ -143,7 +143,7 @@ func (b *backend) GetResourceStats(ctx context.Context, minCount int64) ([]resou
 			if err != nil {
 				return err
 			}
-			if row.Count > minCount {
+			if row.Count > int64(minCount) {
 				res = append(res, row)
 			}
 		}

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -121,6 +121,38 @@ func (b *backend) Stop(_ context.Context) error {
 	return nil
 }
 
+// GetResourceStats implements Backend.
+func (b *backend) GetResourceStats(ctx context.Context, minCount int64) ([]resource.ResourceStats, error) {
+	_, span := b.tracer.Start(ctx, tracePrefix+".GetResourceStats")
+	defer span.End()
+
+	req := &sqlStatsRequest{
+		SQLTemplate: sqltemplate.New(b.dialect),
+		MinCount:    minCount, // not used in query... yet?
+	}
+
+	res := make([]resource.ResourceStats, 0, 100)
+	err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
+		rows, err := dbutil.QueryRows(ctx, tx, sqlResourceStats, req)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			row := resource.ResourceStats{}
+			err = rows.Scan(&row.Namespace, &row.Group, &row.Resource, &row.Count, &row.ResourceVersion)
+			if err != nil {
+				return err
+			}
+			if row.Count > minCount {
+				res = append(res, row)
+			}
+		}
+		return err
+	})
+
+	return res, err
+}
+
 func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (int64, error) {
 	_, span := b.tracer.Start(ctx, tracePrefix+"WriteEvent")
 	defer span.End()
@@ -135,35 +167,6 @@ func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (in
 	default:
 		return 0, fmt.Errorf("unsupported event type")
 	}
-}
-
-// Namespaces returns the list of unique namespaces in storage.
-func (b *backend) Namespaces(ctx context.Context) ([]string, error) {
-	var namespaces []string
-
-	err := b.db.WithTx(ctx, RepeatableRead, func(ctx context.Context, tx db.Tx) error {
-		rows, err := tx.QueryContext(ctx, "SELECT DISTINCT(namespace) FROM resource ORDER BY namespace;")
-		if err != nil {
-			return err
-		}
-
-		defer func() {
-			_ = rows.Close()
-		}()
-
-		for rows.Next() {
-			var ns string
-			err = rows.Scan(&ns)
-			if err != nil {
-				return err
-			}
-			namespaces = append(namespaces, ns)
-		}
-
-		return nil
-	})
-
-	return namespaces, err
 }
 
 func (b *backend) create(ctx context.Context, event resource.WriteEvent) (int64, error) {

--- a/pkg/storage/unified/sql/data/resource_stats.sql
+++ b/pkg/storage/unified/sql/data/resource_stats.sql
@@ -3,12 +3,10 @@ SELECT
   {{ .Ident "group"     }},
   {{ .Ident "resource"  }},
   COUNT(*),
-  {{ .Ident "resource_version" }}
+  MAX({{ .Ident "resource_version" }})
 FROM {{ .Ident "resource" }}
 GROUP BY 
   {{ .Ident "namespace" }},
   {{ .Ident "group"     }},
   {{ .Ident "resource"  }}
-ORDER BY
-  {{ .Ident "resource_version" }} desc
 ;

--- a/pkg/storage/unified/sql/data/resource_stats.sql
+++ b/pkg/storage/unified/sql/data/resource_stats.sql
@@ -1,0 +1,14 @@
+SELECT
+  {{ .Ident "namespace" }},
+  {{ .Ident "group"     }},
+  {{ .Ident "resource"  }},
+  COUNT(*),
+  {{ .Ident "resource_version" }}
+FROM {{ .Ident "resource" }}
+GROUP BY 
+  {{ .Ident "namespace" }},
+  {{ .Ident "group"     }},
+  {{ .Ident "resource"  }}
+ORDER BY
+  {{ .Ident "resource_version" }} desc
+;

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -31,6 +31,7 @@ var (
 	sqlResourceInsert          = mustTemplate("resource_insert.sql")
 	sqlResourceUpdate          = mustTemplate("resource_update.sql")
 	sqlResourceRead            = mustTemplate("resource_read.sql")
+	sqlResourceStats           = mustTemplate("resource_stats.sql")
 	sqlResourceList            = mustTemplate("resource_list.sql")
 	sqlResourceHistoryList     = mustTemplate("resource_history_list.sql")
 	sqlResourceUpdateRV        = mustTemplate("resource_update_rv.sql")
@@ -68,6 +69,15 @@ type sqlResourceRequest struct {
 }
 
 func (r sqlResourceRequest) Validate() error {
+	return nil // TODO
+}
+
+type sqlStatsRequest struct {
+	sqltemplate.SQLTemplate
+	MinCount int64
+}
+
+func (r sqlStatsRequest) Validate() error {
 	return nil // TODO
 }
 

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -74,7 +74,7 @@ func (r sqlResourceRequest) Validate() error {
 
 type sqlStatsRequest struct {
 	sqltemplate.SQLTemplate
-	MinCount int64
+	MinCount int
 }
 
 func (r sqlStatsRequest) Validate() error {

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -219,5 +219,15 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					},
 				},
 			},
+
+			sqlResourceStats: {
+				{
+					Name: "query",
+					Data: &sqlStatsRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						MinCount:    int64(10), // Not yet used in query (only response filter)
+					},
+				},
+			},
 		}})
 }

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -225,7 +225,7 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					Name: "query",
 					Data: &sqlStatsRequest{
 						SQLTemplate: mocks.NewTestingSQLTemplate(),
-						MinCount:    int64(10), // Not yet used in query (only response filter)
+						MinCount:    10, // Not yet used in query (only response filter)
 					},
 				},
 			},

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -65,6 +65,7 @@ func NewResourceServer(ctx context.Context, db infraDB.DB, cfg *setting.Cfg,
 			}, tracer, reg),
 			Resources:     docs,
 			WorkerThreads: 5, // from cfg?
+			InitMinCount:  1,
 		}
 	}
 

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -101,7 +101,8 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 		stats, err := backend.GetResourceStats(ctx, 0)
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
-		require.Equal(t, 3, stats[0].Count)
+		require.Equal(t, int64(3), stats[0].Count)
+		require.Equal(t, rv3, stats[0].ResourceVersion)
 	})
 
 	t.Run("Update item2", func(t *testing.T) {

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/grafana/authlib/claims"
 	"github.com/grafana/dskit/services"
-
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
@@ -98,6 +97,11 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 		rv3, err = writeEvent(ctx, backend, "item3", resource.WatchEvent_ADDED)
 		require.NoError(t, err)
 		require.Greater(t, rv3, rv2)
+
+		stats, err := backend.GetResourceStats(ctx, 0)
+		require.NoError(t, err)
+		require.Len(t, stats, 1)
+		require.Equal(t, 3, stats[0].Count)
 	})
 
 	t.Run("Update item2", func(t *testing.T) {

--- a/pkg/storage/unified/sql/testdata/mysql--resource_stats-query.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_stats-query.sql
@@ -1,0 +1,14 @@
+SELECT
+  `namespace`,
+  `group`,
+  `resource`,
+  COUNT(*),
+  `resource_version`
+FROM `resource`
+GROUP BY 
+  `namespace`,
+  `group`,
+  `resource`
+ORDER BY
+  `resource_version` desc
+;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_stats-query.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_stats-query.sql
@@ -3,12 +3,10 @@ SELECT
   `group`,
   `resource`,
   COUNT(*),
-  `resource_version`
+  MAX(`resource_version`)
 FROM `resource`
 GROUP BY 
   `namespace`,
   `group`,
   `resource`
-ORDER BY
-  `resource_version` desc
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_stats-query.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_stats-query.sql
@@ -1,0 +1,14 @@
+SELECT
+  "namespace",
+  "group",
+  "resource",
+  COUNT(*),
+  "resource_version"
+FROM "resource"
+GROUP BY 
+  "namespace",
+  "group",
+  "resource"
+ORDER BY
+  "resource_version" desc
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_stats-query.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_stats-query.sql
@@ -3,12 +3,10 @@ SELECT
   "group",
   "resource",
   COUNT(*),
-  "resource_version"
+  MAX("resource_version")
 FROM "resource"
 GROUP BY 
   "namespace",
   "group",
   "resource"
-ORDER BY
-  "resource_version" desc
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_stats-query.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_stats-query.sql
@@ -1,0 +1,14 @@
+SELECT
+  "namespace",
+  "group",
+  "resource",
+  COUNT(*),
+  "resource_version"
+FROM "resource"
+GROUP BY 
+  "namespace",
+  "group",
+  "resource"
+ORDER BY
+  "resource_version" desc
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_stats-query.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_stats-query.sql
@@ -3,12 +3,10 @@ SELECT
   "group",
   "resource",
   COUNT(*),
-  "resource_version"
+  MAX("resource_version")
 FROM "resource"
 GROUP BY 
   "namespace",
   "group",
   "resource"
-ORDER BY
-  "resource_version" desc
 ;


### PR DESCRIPTION
This PR updates the initialization logic to build indexes based on the real size + rv

This will let us skip pre-building indexes that can be build very quickly