### PR TITLE
Loki: Hide internal labels

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -441,6 +441,14 @@ describe('Language completion provider', () => {
         start: 1560153109000,
       });
     });
+
+    it('should filter internal labels', async () => {
+      const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
+
+      const instance = new LanguageProvider(datasourceWithLabels);
+      const labels = await instance.fetchLabels();
+      expect(labels).toEqual(['bar', 'foo']);
+    });
   });
 });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -176,7 +176,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       const labels = res
         .slice()
         .sort()
-        .filter((label) => label !== '__name__');
+        .filter((label: string) => label.startsWith('__') === false);
       this.labelKeys = labels;
       return this.labelKeys;
     }


### PR DESCRIPTION
**What is this feature?**

Loki indicates internal labels with two underscores (`__`). These labels do not bring a lot of value to users and rather cause confusion. This PR hides all labels from the label browser, query builder and autocomplete.