### PR TITLE
Dashboard: Fixes issue with compatability of old DashboardModel.annotations

### DIFF
--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.test.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.test.ts
@@ -1,24 +1,17 @@
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
-import {
-  behaviors,
-  SceneQueryRunner,
-  SceneTimeRange,
-  VizPanel,
-  SceneDataTransformer,
-  SceneDataLayerSet,
-} from '@grafana/scenes';
+import { behaviors, SceneQueryRunner, SceneTimeRange, VizPanel, SceneDataTransformer } from '@grafana/scenes';
 import { DashboardCursorSync } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard';
 
 import { AlertStatesDataLayer } from '../scene/AlertStatesDataLayer';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { DashboardControls } from '../scene/DashboardControls';
+import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { NEW_LINK } from '../settings/links/utils';
 
 import { DashboardModelCompatibilityWrapper } from './DashboardModelCompatibilityWrapper';
-import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 
 describe('DashboardModelCompatibilityWrapper', () => {
   it('Provide basic prop and function of compatability', () => {

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.test.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.test.ts
@@ -18,6 +18,7 @@ import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLay
 import { NEW_LINK } from '../settings/links/utils';
 
 import { DashboardModelCompatibilityWrapper } from './DashboardModelCompatibilityWrapper';
+import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 
 describe('DashboardModelCompatibilityWrapper', () => {
   it('Provide basic prop and function of compatability', () => {
@@ -150,8 +151,8 @@ function setup() {
       weekStart: 'friday',
       timeZone: 'America/New_York',
     }),
-    $data: new SceneDataLayerSet({
-      layers: [
+    $data: new DashboardDataLayerSet({
+      annotationLayers: [
         new DashboardAnnotationsDataLayer({
           key: `annotations-test`,
           query: {

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -9,6 +9,7 @@ import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotation
 
 import { PanelModelCompatibilityWrapper } from './PanelModelCompatibilityWrapper';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from './utils';
+import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 
 /**
  * Will move this to make it the main way we remain somewhat compatible with getDashboardSrv().getCurrent
@@ -104,8 +105,8 @@ export class DashboardModelCompatibilityWrapper {
   public get annotations(): { list: AnnotationQuery[] } {
     const annotations: { list: AnnotationQuery[] } = { list: [] };
 
-    if (this._scene.state.$data instanceof SceneDataLayerSet) {
-      annotations.list = dataLayersToAnnotations(this._scene.state.$data.state.layers);
+    if (this._scene.state.$data instanceof DashboardDataLayerSet) {      
+      annotations.list = dataLayersToAnnotations(this._scene.state.$data.state.annotationLayers);
     }
 
     return annotations;

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -2,14 +2,14 @@ import { Subscription } from 'rxjs';
 
 import { AnnotationQuery, DashboardCursorSync, dateTimeFormat, DateTimeInput, EventBusSrv } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
-import { behaviors, SceneDataLayerSet, sceneGraph, SceneObject, VizPanel } from '@grafana/scenes';
+import { behaviors, sceneGraph, SceneObject, VizPanel } from '@grafana/scenes';
 
+import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotations';
 
 import { PanelModelCompatibilityWrapper } from './PanelModelCompatibilityWrapper';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from './utils';
-import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 
 /**
  * Will move this to make it the main way we remain somewhat compatible with getDashboardSrv().getCurrent
@@ -105,7 +105,7 @@ export class DashboardModelCompatibilityWrapper {
   public get annotations(): { list: AnnotationQuery[] } {
     const annotations: { list: AnnotationQuery[] } = { list: [] };
 
-    if (this._scene.state.$data instanceof DashboardDataLayerSet) {      
+    if (this._scene.state.$data instanceof DashboardDataLayerSet) {
       annotations.list = dataLayersToAnnotations(this._scene.state.$data.state.annotationLayers);
     }
 


### PR DESCRIPTION
Was pointed out to me that this compatibility function is not working, checks the wrong data provider type (And the test was using the wrong type as well)

https://github.com/grafana/grafana/pull/85322#issuecomment-2505215979