### PR TITLE
[POC] Transformations: Extract to fields can't handle multiple matches

### DIFF
--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -155,7 +155,7 @@ describe('Extract fields from text', () => {
   it('splits by regexp with multiple groups', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.RegExp);
     const opts: ExtractFieldsOptions = {
-      regExp: '/(?<Metrics>Metrics)?(?<Logs>Logs)?(?<Traces>Traces)?(?<Profiles>Profiles)/',
+      regExp: '/(?<Metrics>Metrics)?(?<Logs>Logs)?(?<Profiles>Profiles)/',
     };
     const parse = extractor.getParser(opts);
     const out = parse('Metrics, Logs, Traces, Profiles');

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -151,4 +151,21 @@ describe('Extract fields from text', () => {
       }
     `);
   });
+
+  it('splits by regexp with multiple groups', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.RegExp);
+    const opts: ExtractFieldsOptions = {
+      regExp: '/(?<Metrics>Metrics)?(?<Logs>Logs)?(?<Traces>Traces)?(?<Profiles>Profiles)/',
+    };
+    const parse = extractor.getParser(opts);
+    const out = parse('Metrics, Logs, Traces, Profiles');
+
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "Metrics": "Metrics",
+        "Logs": "Logs",
+        "Profiles": "Profiles",
+      }
+    `);
+  });
 });

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -152,10 +152,27 @@ describe('Extract fields from text', () => {
     `);
   });
 
-  it('splits by regexp with multiple groups', async () => {
+  it('splits by regexp with multiple groups with seperate matches', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.RegExp);
     const opts: ExtractFieldsOptions = {
       regExp: '/(?<Metrics>Metrics)?(?<Logs>Logs)?(?<Profiles>Profiles)/',
+    };
+    const parse = extractor.getParser(opts);
+    const out = parse('Metrics, Logs, Traces, Profiles');
+
+    expect(out).toMatchInlineSnapshot(`
+      {
+        "Metrics": "Metrics",
+        "Logs": "Logs",
+        "Profiles": "Profiles",
+      }
+    `);
+  });
+
+  it('splits by regexp with multiple groups in a single match', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.RegExp);
+    const opts: ExtractFieldsOptions = {
+      regExp: '/(?:(?<Metrics>Metrics))?(?:(?<Logs>Logs))?(?:(?<Profiles>Profiles))/', // (?: ... ) makes each capture group optional
     };
     const parse = extractor.getParser(opts);
     const out = parse('Metrics, Logs, Traces, Profiles');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

Maybe add support for multiple matches? If not, documentation on how to write regexes that provide multiple named capture groups in a single match. Notifying the user when groups are undefined would be good too.

**Use case**
Multiple choice questions in Google Forms produce a comma separated list of values, which wuld be nice to have as fields.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
