### PR TITLE
Schema v2: Read API integration 

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -476,18 +476,17 @@ export const defaultVizConfigKind = (): VizConfigKind => ({
 export interface AnnotationQuerySpec {
 	datasource?: DataSourceRef;
 	query: DataQueryKind;
-	builtIn?: boolean;
 	enable: boolean;
-	filter: AnnotationPanelFilter;
 	hide: boolean;
 	iconColor: string;
 	name: string;
+	builtIn?: boolean;
+	filter?: AnnotationPanelFilter;
 }
 
 export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
 	query: defaultDataQueryKind(),
 	enable: false,
-	filter: defaultAnnotationPanelFilter(),
 	hide: false,
 	iconColor: "",
 	name: "",

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -969,7 +969,6 @@ export interface DatasourceVariableSpec {
 	refresh: VariableRefresh;
 	regex: string;
 	current: VariableOption;
-	defaultOptionEnabled: boolean;
 	options: VariableOption[];
 	multi: boolean;
 	includeAll: boolean;
@@ -986,7 +985,6 @@ export const defaultDatasourceVariableSpec = (): DatasourceVariableSpec => ({
 	refresh: "never",
 	regex: "",
 	current: { text: "", value: "", },
-	defaultOptionEnabled: false,
 	options: [],
 	multi: false,
 	includeAll: false,

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -370,12 +370,12 @@ VizConfigKind: {
 AnnotationQuerySpec: {
   datasource?: DataSourceRef
   query: DataQueryKind
-  builtIn?: bool
   enable: bool
-  filter: AnnotationPanelFilter
   hide: bool
   iconColor: string
   name: string
+  builtIn?: bool
+  filter?: AnnotationPanelFilter
 }
 
 AnnotationQueryKind: {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -669,7 +669,6 @@ DatasourceVariableSpec: {
     text: ""
     value: ""
   }
-  defaultOptionEnabled: bool | *false
   options: [...VariableOption] | *[]
   multi: bool | *false
   includeAll: bool | *false

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
@@ -284,7 +284,6 @@ export const handyTestingSchema: DashboardV2Spec = {
           text: 'text1',
           value: 'value1',
         },
-        defaultOptionEnabled: true,
         description: 'A datasource variable',
         hide: 'dontHide',
         includeAll: false,

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -18,6 +18,7 @@ import { DashboardDTO, DashboardRoutes } from 'app/types';
 import { PanelEditor } from '../panel-edit/PanelEditor';
 import { DashboardScene } from '../scene/DashboardScene';
 import { buildNewDashboardSaveModel } from '../serialization/buildNewDashboardSaveModel';
+import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
@@ -118,6 +119,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
                 ...params.variables,
               }
             : undefined;
+
           rsp = await dashboardLoaderSrv.loadDashboard('db', '', uid, queryParams);
 
           if (route === DashboardRoutes.Embedded) {
@@ -280,8 +282,13 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
         return fromCache;
       }
 
-      // TODO[schema]: handle v2
-      throw new Error('v2 schema handling not implemented');
+      // TODO[schema v2]: handle v2 redirect url
+
+      const scene = transformSaveModelSchemaV2ToScene(rsp);
+      if (options.uid) {
+        this.setSceneCache(options.uid, scene);
+      }
+      return scene;
     } else {
       if (fromCache && fromCache.state.version === rsp?.dashboard.version) {
         return fromCache;

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -55,6 +55,7 @@ NavToolbarActions.displayName = 'NavToolbarActions';
  */
 export function ToolbarActions({ dashboard }: Props) {
   const { isEditing, viewPanelScene, isDirty, uid, meta, editview, editPanel, editable } = dashboard.useState();
+
   const { isPlaying } = playlistSrv.useState();
   const [isAddPanelMenuOpen, setIsAddPanelMenuOpen] = useState(false);
 

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -145,9 +145,7 @@ export async function buildNewDashboardSaveModelV2(
     },
   };
 
-  if (variablesList) {
-    data.spec.variables = variablesList;
-  }
+  data.spec.variables = variablesList;
 
   if (urlFolderUid && data.metadata.annotations) {
     data.metadata.annotations[AnnoKeyFolder] = urlFolderUid;

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -326,7 +326,6 @@ export function sceneVariablesSetToSchemaV2Variables(
           regex: variable.state.regex,
           refresh: 'onDashboardLoad',
           pluginId: variable.state.pluginId,
-          defaultOptionEnabled: !!variable.state.defaultOptionEnabled,
           multi: variable.state.isMulti || false,
           allValue: variable.state.allValue,
           includeAll: variable.state.includeAll || false,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -44,10 +44,19 @@ const defaultDashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
     namespace: 'default',
     labels: {},
     resourceVersion: '',
-    creationTimestamp: '',
+    creationTimestamp: 'creationTs',
+    annotations: {
+      'grafana.app/createdBy': 'user:createBy',
+      'grafana.app/folder': 'folder-uid',
+      'grafana.app/updatedBy': 'user:updatedBy',
+      'grafana.app/updatedTimestamp': 'updatedTs',
+    },
   },
   spec: handyTestingSchema,
-  access: {},
+  access: {
+    url: '/d/abc',
+    slug: 'what-a-dashboard',
+  },
   apiVersion: 'v2',
 };
 
@@ -289,5 +298,121 @@ describe('transformSaveModelSchemaV2ToScene', () => {
     expect(vizPanels.length).toBe(1);
     expect(getQueryRunnerFor(vizPanels[0])?.state.datasource?.type).toBe('mixed');
     expect(getQueryRunnerFor(vizPanels[0])?.state.datasource?.uid).toBe(MIXED_DATASOURCE_NAME);
+  });
+
+  describe('meta', () => {
+    describe('initializes meta based on k8s resource', () => {
+      it('handles undefined access values', () => {
+        const scene = transformSaveModelSchemaV2ToScene(defaultDashboard);
+        // when access metadata undefined
+        expect(scene.state.meta.canShare).toBe(true);
+        expect(scene.state.meta.canSave).toBe(true);
+        expect(scene.state.meta.canStar).toBe(true);
+        expect(scene.state.meta.canEdit).toBe(true);
+        expect(scene.state.meta.canDelete).toBe(true);
+        expect(scene.state.meta.canAdmin).toBe(true);
+        expect(scene.state.meta.annotationsPermissions).toBe(undefined);
+
+        expect(scene.state.meta.url).toBe('/d/abc');
+        expect(scene.state.meta.slug).toBe('what-a-dashboard');
+        expect(scene.state.meta.created).toBe('creationTs');
+        expect(scene.state.meta.createdBy).toBe('user:createBy');
+        expect(scene.state.meta.updated).toBe('updatedTs');
+        expect(scene.state.meta.updatedBy).toBe('user:updatedBy');
+        expect(scene.state.meta.folderUid).toBe('folder-uid');
+      });
+
+      it('handles access metadata values', () => {
+        const dashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
+          ...defaultDashboard,
+          access: {
+            canSave: false,
+            canEdit: false,
+            canDelete: false,
+            canShare: false,
+            canStar: false,
+            canAdmin: false,
+            annotationsPermissions: {
+              dashboard: {
+                canAdd: false,
+                canEdit: false,
+                canDelete: false,
+              },
+              organization: {
+                canAdd: false,
+                canEdit: false,
+                canDelete: false,
+              },
+            },
+          },
+        };
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+
+        expect(scene.state.meta.canShare).toBe(false);
+        expect(scene.state.meta.canSave).toBe(false);
+        expect(scene.state.meta.canStar).toBe(false);
+        expect(scene.state.meta.canEdit).toBe(false);
+        expect(scene.state.meta.canDelete).toBe(false);
+        expect(scene.state.meta.canAdmin).toBe(false);
+        expect(scene.state.meta.annotationsPermissions).toEqual(dashboard.access.annotationsPermissions);
+      });
+    });
+
+    describe('Editable false dashboard', () => {
+      let dashboard: DashboardWithAccessInfo<DashboardV2Spec>;
+
+      beforeEach(() => {
+        dashboard = {
+          ...cloneDeep(defaultDashboard),
+          spec: {
+            ...defaultDashboard.spec,
+            editable: false,
+          },
+        };
+      });
+      it('Should set meta canEdit and canSave to false', () => {
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+        expect(scene.state.meta.canMakeEditable).toBe(true);
+
+        expect(scene.state.meta.canSave).toBe(false);
+        expect(scene.state.meta.canEdit).toBe(false);
+        expect(scene.state.meta.canDelete).toBe(false);
+      });
+
+      describe('when does not have save permissions', () => {
+        it('Should set meta correct meta', () => {
+          dashboard.access.canSave = false;
+          const scene = transformSaveModelSchemaV2ToScene(dashboard);
+          expect(scene.state.meta.canMakeEditable).toBe(false);
+
+          expect(scene.state.meta.canSave).toBe(false);
+          expect(scene.state.meta.canEdit).toBe(false);
+          expect(scene.state.meta.canDelete).toBe(false);
+        });
+      });
+    });
+
+    describe('Editable true dashboard', () => {
+      let dashboard: DashboardWithAccessInfo<DashboardV2Spec>;
+
+      beforeEach(() => {
+        dashboard = {
+          ...cloneDeep(defaultDashboard),
+          spec: {
+            ...defaultDashboard.spec,
+            editable: true,
+          },
+        };
+      });
+      it('Should set meta canEdit and canSave to false', () => {
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+
+        expect(scene.state.meta.canMakeEditable).toBe(false);
+
+        expect(scene.state.meta.canSave).toBe(true);
+        expect(scene.state.meta.canEdit).toBe(true);
+        expect(scene.state.meta.canDelete).toBe(true);
+      });
+    });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -36,6 +36,7 @@ import { validateVariable, validateVizPanel } from '../v2schema/test-helpers';
 
 import { transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
 import { transformCursorSynctoEnum } from './transformToV2TypesUtils';
+import { buildNewDashboardSaveModelV2 } from './buildNewDashboardSaveModel';
 
 const defaultDashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
   kind: 'DashboardWithAccessInfo',
@@ -413,6 +414,15 @@ describe('transformSaveModelSchemaV2ToScene', () => {
         expect(scene.state.meta.canEdit).toBe(true);
         expect(scene.state.meta.canDelete).toBe(true);
       });
+    });
+  });
+
+  describe('When creating a new dashboard', () => {
+    it('should initialize the DashboardScene in edit mode and dirty', async () => {
+      const rsp = await buildNewDashboardSaveModelV2();
+      const scene = transformSaveModelSchemaV2ToScene(rsp);
+      expect(scene.state.isEditing).toBe(undefined);
+      expect(scene.state.isDirty).toBe(false);
     });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -142,6 +142,7 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
     showSettings: Boolean(dto.access.canEdit),
     canMakeEditable: canSave && !isDashboardEditable,
     hasUnsavedFolderChange: false,
+    isNew: dto.access.isNew,
   };
 
   // Ref: DashboardModel.initMeta

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -35,7 +35,6 @@ import {
   GroupByVariableKind,
   AdhocVariableKind,
   AnnotationQueryKind,
-  defaultAnnotationPanelFilter,
   defaultAnnotationQuerySpec,
   DataLink,
 } from '../../../../../packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen';
@@ -405,7 +404,7 @@ function getAnnotations(state: DashboardSceneState): AnnotationQueryKind[] {
         },
         enable: Boolean(layer.state.isEnabled),
         hide: Boolean(layer.state.isHidden),
-        filter: layer.state.query.filter ?? defaultAnnotationPanelFilter(),
+        filter: layer.state.query.filter,
         iconColor: layer.state.query.iconColor,
         builtIn:
           layer.state.query.builtIn === undefined

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -3,7 +3,9 @@ import {
   VariableRefresh as VariableRefreshV1,
   VariableSort as VariableSortV1,
   DashboardCursorSync as DashboardCursorSyncV1,
+  DataTopic,
 } from '@grafana/schema';
+import { DataTransformerConfig } from '@grafana/schema/dist/esm/raw/dashboard/x/dashboard_types.gen';
 import {
   DashboardCursorSync,
   defaultDashboardV2Spec,
@@ -66,5 +68,18 @@ export function transformSortVariableToEnum(sort?: VariableSortV1): VariableSort
       return 'numericalDesc';
     default:
       return defaultVariableSort();
+  }
+}
+
+export function transformDataTopic(topic: DataTransformerConfig['topic']): DataTopic | undefined {
+  switch (topic) {
+    case 'annotations':
+      return DataTopic.Annotations;
+    case 'alertStates':
+      return DataTopic.AlertStates;
+    case 'series':
+      return DataTopic.Series;
+    default:
+      return undefined;
   }
 }

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1,5 +1,5 @@
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
 import { ResponseTransformers } from './ResponseTransformers';
 import { DashboardWithAccessInfo } from './types';
@@ -7,13 +7,37 @@ import { DashboardWithAccessInfo } from './types';
 describe('ResponseTransformers', () => {
   describe('v1 transformation', () => {
     it('should transform DashboardDTO to DashboardWithAccessInfo<DashboardV2Spec>', () => {
-      const dashboardDTO: DashboardDTO = {
-        meta: {
-          created: '2023-01-01T00:00:00Z',
-          createdBy: 'user1',
-          updated: '2023-01-02T00:00:00Z',
-          updatedBy: 'user2',
-          folderUid: 'folder1',
+      const dashboardV1: DashboardDataDTO = {
+        uid: 'dashboard1',
+        title: 'Dashboard Title',
+        description: 'Dashboard Description',
+        tags: ['tag1', 'tag2'],
+        schemaVersion: 1,
+        graphTooltip: 0,
+        preload: true,
+        liveNow: false,
+        editable: true,
+        time: { from: 'now-6h', to: 'now' },
+        timezone: 'browser',
+        refresh: '5m',
+        timepicker: {
+          refresh_intervals: ['5s', '10s', '30s'],
+          hidden: false,
+          time_options: ['5m', '15m', '1h'],
+          nowDelay: '1m',
+        },
+        fiscalYearStartMonth: 1,
+        weekStart: 'monday',
+        version: 1,
+        links: [],
+        annotations: {
+          list: [],
+        },
+      };
+
+      const dto: DashboardWithAccessInfo<DashboardDataDTO> = {
+        spec: dashboardV1,
+        access: {
           slug: 'dashboard-slug',
           url: '/d/dashboard-slug',
           canAdmin: true,
@@ -27,67 +51,47 @@ describe('ResponseTransformers', () => {
             organization: { canAdd: true, canEdit: true, canDelete: true },
           },
         },
-        dashboard: {
-          uid: 'dashboard1',
-          title: 'Dashboard Title',
-          description: 'Dashboard Description',
-          tags: ['tag1', 'tag2'],
-          schemaVersion: 1,
-          graphTooltip: 0,
-          preload: true,
-          liveNow: false,
-          editable: true,
-          time: { from: 'now-6h', to: 'now' },
-          timezone: 'browser',
-          refresh: '5m',
-          timepicker: {
-            refresh_intervals: ['5s', '10s', '30s'],
-            hidden: false,
-            time_options: ['5m', '15m', '1h'],
-            nowDelay: '1m',
-          },
-          fiscalYearStartMonth: 1,
-          weekStart: 'monday',
-          version: 1,
-          links: [],
+        apiVersion: 'v1',
+        kind: 'DashboardWithAccessInfo',
+        metadata: {
+          name: 'dashboard-uid',
+          resourceVersion: '1',
+
+          creationTimestamp: '2023-01-01T00:00:00Z',
           annotations: {
-            list: [],
+            'grafana.app/createdBy': 'user1',
+            'grafana.app/updatedBy': 'user2',
+            'grafana.app/updatedTimestamp': '2023-01-02T00:00:00Z',
+            'grafana.app/folder': 'folder1',
           },
         },
       };
 
-      const transformed = ResponseTransformers.ensureV2Response(dashboardDTO);
+      const transformed = ResponseTransformers.ensureV2Response(dto);
 
-      expect(transformed.apiVersion).toBe('v2alpha1');
+      expect(transformed.apiVersion).toBe('v1');
       expect(transformed.kind).toBe('DashboardWithAccessInfo');
-      expect(transformed.metadata.creationTimestamp).toBe(dashboardDTO.meta.created);
-      expect(transformed.metadata.name).toBe(dashboardDTO.dashboard.uid);
-      expect(transformed.metadata.resourceVersion).toBe(dashboardDTO.dashboard.version?.toString());
-      expect(transformed.metadata.annotations?.['grafana.app/createdBy']).toBe(dashboardDTO.meta.createdBy);
-      expect(transformed.metadata.annotations?.['grafana.app/updatedBy']).toBe(dashboardDTO.meta.updatedBy);
-      expect(transformed.metadata.annotations?.['grafana.app/updatedTimestamp']).toBe(dashboardDTO.meta.updated);
-      expect(transformed.metadata.annotations?.['grafana.app/folder']).toBe(dashboardDTO.meta.folderUid);
-      expect(transformed.metadata.annotations?.['grafana.app/slug']).toBe(dashboardDTO.meta.slug);
+      expect(transformed.metadata).toEqual(dto.metadata);
 
       const spec = transformed.spec;
-      expect(spec.title).toBe(dashboardDTO.dashboard.title);
-      expect(spec.description).toBe(dashboardDTO.dashboard.description);
-      expect(spec.tags).toEqual(dashboardDTO.dashboard.tags);
-      expect(spec.schemaVersion).toBe(dashboardDTO.dashboard.schemaVersion);
+      expect(spec.title).toBe(dashboardV1.title);
+      expect(spec.description).toBe(dashboardV1.description);
+      expect(spec.tags).toEqual(dashboardV1.tags);
+      expect(spec.schemaVersion).toBe(dashboardV1.schemaVersion);
       expect(spec.cursorSync).toBe('Off'); // Assuming transformCursorSynctoEnum(0) returns 'Off'
-      expect(spec.preload).toBe(dashboardDTO.dashboard.preload);
-      expect(spec.liveNow).toBe(dashboardDTO.dashboard.liveNow);
-      expect(spec.editable).toBe(dashboardDTO.dashboard.editable);
-      expect(spec.timeSettings.from).toBe(dashboardDTO.dashboard.time?.from);
-      expect(spec.timeSettings.to).toBe(dashboardDTO.dashboard.time?.to);
-      expect(spec.timeSettings.timezone).toBe(dashboardDTO.dashboard.timezone);
-      expect(spec.timeSettings.autoRefresh).toBe(dashboardDTO.dashboard.refresh);
-      expect(spec.timeSettings.autoRefreshIntervals).toEqual(dashboardDTO.dashboard.timepicker?.refresh_intervals);
-      expect(spec.timeSettings.hideTimepicker).toBe(dashboardDTO.dashboard.timepicker?.hidden);
-      expect(spec.timeSettings.quickRanges).toEqual(dashboardDTO.dashboard.timepicker?.time_options);
-      expect(spec.timeSettings.nowDelay).toBe(dashboardDTO.dashboard.timepicker?.nowDelay);
-      expect(spec.timeSettings.fiscalYearStartMonth).toBe(dashboardDTO.dashboard.fiscalYearStartMonth);
-      expect(spec.timeSettings.weekStart).toBe(dashboardDTO.dashboard.weekStart);
+      expect(spec.preload).toBe(dashboardV1.preload);
+      expect(spec.liveNow).toBe(dashboardV1.liveNow);
+      expect(spec.editable).toBe(dashboardV1.editable);
+      expect(spec.timeSettings.from).toBe(dashboardV1.time?.from);
+      expect(spec.timeSettings.to).toBe(dashboardV1.time?.to);
+      expect(spec.timeSettings.timezone).toBe(dashboardV1.timezone);
+      expect(spec.timeSettings.autoRefresh).toBe(dashboardV1.refresh);
+      expect(spec.timeSettings.autoRefreshIntervals).toEqual(dashboardV1.timepicker?.refresh_intervals);
+      expect(spec.timeSettings.hideTimepicker).toBe(dashboardV1.timepicker?.hidden);
+      expect(spec.timeSettings.quickRanges).toEqual(dashboardV1.timepicker?.time_options);
+      expect(spec.timeSettings.nowDelay).toBe(dashboardV1.timepicker?.nowDelay);
+      expect(spec.timeSettings.fiscalYearStartMonth).toBe(dashboardV1.fiscalYearStartMonth);
+      expect(spec.timeSettings.weekStart).toBe(dashboardV1.weekStart);
       expect(spec.links).toEqual([]); // Assuming transformDashboardLinksToEnums([]) returns []
       expect(spec.annotations).toEqual([]);
     });

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -27,7 +27,7 @@ import { DashboardWithAccessInfo } from './types';
 import { isDashboardResource, isDashboardV2Spec } from './utils';
 
 export function ensureV2Response(
-  dto: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>
+  dto: DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>
 ): DashboardWithAccessInfo<DashboardV2Spec> {
   const spec = dto.spec;
 

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -137,6 +137,18 @@ export function ensureV1Response(dashboard: DashboardWithAccessInfo<DashboardV2S
       links: spec.links,
       // TODO[schema v2]: handle annotations
       annotations: { list: [] },
+      // TODO[schema v2]: handle panels
+      panels: [],
+      // TODO[schema v2]: handle variables
+      templating: {
+        list: [],
+      },
+      // TODO[schema v2]: handle id
+      // id: 0,
+      // TODO[schema v2]: handle revision
+      // revision: 0,
+      // TODO[schema v2]: handle variables
+      // gnetId
     },
   };
 }

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -330,7 +330,7 @@ function getAnnotations(annotations: AnnotationQuery[]): DashboardV2Spec['annota
             ...a.target,
           },
         },
-        filter: a.filter, // TODO[schema v2]: handle filter
+        filter: a.filter,
       },
     };
     return aq;

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,12 +1,14 @@
-import { config } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
 import { DashboardWithAccessInfo } from './types';
 
 export function getDashboardsApiVersion() {
+  const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
+
   // if dashboard scene is disabled, use legacy API response for the old architecture
-  if (!config.featureToggles.dashboardScene) {
+  if (!config.featureToggles.dashboardScene || forcingOldDashboardArch) {
     // for old architecture, use v0 API for k8s dashboards
     if (config.featureToggles.kubernetesDashboards) {
       return 'v0';
@@ -27,7 +29,7 @@ export function getDashboardsApiVersion() {
 }
 
 export function isDashboardResource(
-  obj?: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | null
+  obj?: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO> | null
 ): obj is DashboardWithAccessInfo<DashboardV2Spec> {
   if (!obj) {
     return false;
@@ -36,6 +38,6 @@ export function isDashboardResource(
   return 'kind' in obj && obj.kind === 'DashboardWithAccessInfo';
 }
 
-export function isDashboardV2Spec(obj: object): obj is DashboardV2Spec {
+export function isDashboardV2Spec(obj: DashboardDataDTO | DashboardV2Spec): obj is DashboardV2Spec {
   return 'elements' in obj;
 }

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -25,6 +25,12 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
   const params = useParams<DashboardPageParams>();
   const location = useLocation();
 
+  // Force scenes if v2 api and scenes are enabled
+  if (config.featureToggles.useV2DashboardsAPI && config.featureToggles.dashboardScene && !forceOld) {
+    console.log('DashboardPageProxy: forcing scenes because of v2 api');
+    return <DashboardScenePage {...props} />;
+  }
+
   if (forceScenes || (config.featureToggles.dashboardScene && !forceOld)) {
     return <DashboardScenePage {...props} />;
   }


### PR DESCRIPTION
Builds on top of https://github.com/grafana/grafana/pull/96666

_To test enable `useV2DashboardsAPI` feature toggle. This feature toggle is going to replace `dashboardSchemaV2` toggle._

This adds schema v1->v2 and v2->v1 transformers. v2 API will now transform v1 responses to v2 so that we can move forward with integrating v2 schema into dashboard scene. 

Remaining transformations:
- [ ] **v1->v2** Remaining variables 
- [ ] **v1->v2** Dashboard id
- [ ] **v2->v1** Annotations
- [ ] **v2->v1** Panels
- [ ] **v2->v1** Variables
- [ ] Rows and repeats
- [ ] Library panels
- [ ] `gnetId` and `revision`
