### PR TITLE
Unified Storage: Use tls preferred when grafana db using ssl

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbEngine.go
@@ -25,6 +25,10 @@ func getEngineMySQL(getter confGetter) (*xorm.Engine, error) {
 		// See: https://dev.mysql.com/doc/refman/en/sql-mode.html
 		"@@SESSION.sql_mode": "ANSI",
 	}
+	sslMode := getter.String("ssl_mode")
+	if sslMode == "true" || sslMode == "skip-verify" {
+		config.Params["tls"] = "preferred"
+	}
 	tls := getter.String("tls")
 	if tls != "" {
 		config.Params["tls"] = tls


### PR DESCRIPTION
When unified storage is using the grafana db (default case for on-prem) if the db is using ssl then set tls=preferred. This fixes an on-prem bug in 11.3.1.

