### PR TITLE
Browse dashboards: Use dashboard DashboardAPI

### DIFF
--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -263,19 +263,14 @@ export const browseDashboardsAPI = createApi({
         for (const dashboardUID of selectedDashboards) {
           const fullDash: DashboardDTO = await getDashboardAPI().getDashboardDTO(dashboardUID);
 
-          const options = {
+          await getDashboardAPI().saveDashboard({
             dashboard: fullDash.dashboard,
             folderUid: destinationUID,
             overwrite: false,
             message: '',
-          };
-
-          await baseQuery({
-            url: `/dashboards/db`,
-            method: 'POST',
-            data: options,
           });
         }
+
         return { data: undefined };
       },
       onQueryStarted: ({ destinationUID, selectedItems }, { queryFulfilled, dispatch }) => {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -309,11 +309,8 @@ export const browseDashboardsAPI = createApi({
         // Delete all the dashboards sequentially
         // TODO error handling here
         for (const dashboardUID of selectedDashboards) {
-          const response = await baseQuery({
-            url: `/dashboards/uid/${dashboardUID}`,
-            method: 'DELETE',
-            showSuccessAlert: false,
-          });
+          const response = getDashboardAPI().deleteDashboard(dashboardUID, false);
+
           // @ts-expect-error
           const name = response?.data?.title;
 

--- a/public/app/features/manage-dashboards/utils/validation.ts
+++ b/public/app/features/manage-dashboards/utils/validation.ts
@@ -1,6 +1,6 @@
 import { t } from 'i18next';
 
-import { getBackendSrv } from '@grafana/runtime';
+import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 
 import { validationSrv } from '../services/ValidationSrv';
 
@@ -47,8 +47,8 @@ export const validateTitle = (newTitle: string, folderUid: string) => {
 };
 
 export const validateUid = (value: string) => {
-  return getBackendSrv()
-    .get(`/api/dashboards/uid/${value}`)
+  return getDashboardAPI()
+    .getDashboardDTO(value)
     .then((existingDashboard) => {
       return `Dashboard named '${existingDashboard?.dashboard.title}' in folder '${existingDashboard?.meta.folderTitle}' has the same UID`;
     })


### PR DESCRIPTION
Instead of using /api/dashboards* endpoint directly for CRUD operations, use DashboardAPI interface when moving/deleting items in browse dashboards.
