### PR TITLE
Storage: Query stats within a namespace

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -132,7 +132,7 @@ type rowsWrapper struct {
 	err error
 }
 
-func (a *dashboardSqlAccess) GetResourceStats(ctx context.Context, minCount int) ([]resource.ResourceStats, error) {
+func (a *dashboardSqlAccess) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]resource.ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -109,7 +109,7 @@ func (s *cdkBackend) getPath(key *ResourceKey, rv int64) string {
 }
 
 // GetResourceStats implements Backend.
-func (s *cdkBackend) GetResourceStats(ctx context.Context, minCount int) ([]ResourceStats, error) {
+func (s *cdkBackend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -170,7 +170,7 @@ func (s *searchSupport) init(ctx context.Context) error {
 	group := errgroup.Group{}
 	group.SetLimit(s.initWorkers)
 
-	stats, err := s.storage.GetResourceStats(ctx, s.initMinSize)
+	stats, err := s.storage.GetResourceStats(ctx, "", s.initMinSize)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -95,7 +95,8 @@ type StorageBackend interface {
 	// For HA setups, this will be more events than the local WriteEvent above!
 	WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent, error)
 
-	GetResourceStats(ctx context.Context, minCount int) ([]ResourceStats, error)
+	// Get resource stats within the storage backend.  When namespace is empty, it will apply to all
+	GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error)
 }
 
 type ResourceStats struct {

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -122,12 +122,13 @@ func (b *backend) Stop(_ context.Context) error {
 }
 
 // GetResourceStats implements Backend.
-func (b *backend) GetResourceStats(ctx context.Context, minCount int) ([]resource.ResourceStats, error) {
+func (b *backend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]resource.ResourceStats, error) {
 	_, span := b.tracer.Start(ctx, tracePrefix+".GetResourceStats")
 	defer span.End()
 
 	req := &sqlStatsRequest{
 		SQLTemplate: sqltemplate.New(b.dialect),
+		Namespace:   namespace,
 		MinCount:    minCount, // not used in query... yet?
 	}
 

--- a/pkg/storage/unified/sql/data/resource_stats.sql
+++ b/pkg/storage/unified/sql/data/resource_stats.sql
@@ -5,6 +5,10 @@ SELECT
   COUNT(*),
   MAX({{ .Ident "resource_version" }})
 FROM {{ .Ident "resource" }}
+{{ if .Namespace }}
+WHERE 1 = 1
+  AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+{{ end}}
 GROUP BY 
   {{ .Ident "namespace" }},
   {{ .Ident "group"     }},

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -74,7 +74,8 @@ func (r sqlResourceRequest) Validate() error {
 
 type sqlStatsRequest struct {
 	sqltemplate.SQLTemplate
-	MinCount int
+	Namespace string
+	MinCount  int
 }
 
 func (r sqlStatsRequest) Validate() error {

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -228,6 +228,14 @@ func TestUnifiedStorageQueries(t *testing.T) {
 						MinCount:    10, // Not yet used in query (only response filter)
 					},
 				},
+				{
+					Name: "query-namespace",
+					Data: &sqlStatsRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "default",
+						MinCount:    10, // Not yet used in query (only response filter)
+					},
+				},
 			},
 		}})
 }

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -98,7 +98,7 @@ func TestIntegrationBackendHappyPath(t *testing.T) {
 		require.NoError(t, err)
 		require.Greater(t, rv3, rv2)
 
-		stats, err := backend.GetResourceStats(ctx, 0)
+		stats, err := backend.GetResourceStats(ctx, "", 0)
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		require.Equal(t, int64(3), stats[0].Count)

--- a/pkg/storage/unified/sql/testdata/mysql--resource_stats-query-namespace.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_stats-query-namespace.sql
@@ -1,0 +1,14 @@
+SELECT
+  `namespace`,
+  `group`,
+  `resource`,
+  COUNT(*),
+  MAX(`resource_version`)
+FROM `resource`
+WHERE 1 = 1
+  AND `namespace` = 'default'
+GROUP BY 
+  `namespace`,
+  `group`,
+  `resource`
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_stats-query-namespace.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_stats-query-namespace.sql
@@ -1,0 +1,14 @@
+SELECT
+  "namespace",
+  "group",
+  "resource",
+  COUNT(*),
+  MAX("resource_version")
+FROM "resource"
+WHERE 1 = 1
+  AND "namespace" = 'default'
+GROUP BY 
+  "namespace",
+  "group",
+  "resource"
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_stats-query-namespace.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_stats-query-namespace.sql
@@ -1,0 +1,14 @@
+SELECT
+  "namespace",
+  "group",
+  "resource",
+  COUNT(*),
+  MAX("resource_version")
+FROM "resource"
+WHERE 1 = 1
+  AND "namespace" = 'default'
+GROUP BY 
+  "namespace",
+  "group",
+  "resource"
+;


### PR DESCRIPTION
We need a quick way to know all resources within a namespace handled by a storage server -- this adds the option to StorageBackend.

In SQL, it would not be _hard_ to include folder as an option... but then things won't work with a more object store approach 😢 