### PR TITLE
Alerting: Use the stepNo to make sure the ID of the switch is unique

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -37,7 +37,7 @@ export const RuleEditorSection = ({
             {switchMode && (
               <Text variant="bodySmall">
                 <InlineSwitch
-                  id="query-and-expressions-advanced-switch"
+                  id={`advanced-switch-${stepNo}`}
                   data-testid={
                     switchMode.isAdvancedMode
                       ? 'query-and-expressions-advanced-options'


### PR DESCRIPTION
if it's not unique then all switches would be controlling only the first one.

Applying the `no-changelog` since this only impacts users with particular feature toggles turned on.