### PR TITLE
Kat/hackathon UI

### DIFF
--- a/public/app/features/trails/wingman/WingmanScene.tsx
+++ b/public/app/features/trails/wingman/WingmanScene.tsx
@@ -84,28 +84,26 @@ export class WingmanScene extends SceneObjectBase<WingmanSceneState> implements 
 export function getStyles(theme: GrafanaTheme2) {
   return {
     verticalLine: css({
-      marginLeft: '16px', // not currently working
       borderRight: `1px solid var(--border-Weak, rgba(204, 204, 220, 0.12))`,
       height: '540px',
+      paddingRight: '16px',
     }),
     title: css({
       overflow: 'hidden',
       color: '#FFF',
       textOverflow: 'ellipsis',
-      fontSize: '14px', // should be 12px but making 14px to match the label font size
+      fontSize: '14px',
       fontWeight: 500,
-      lineHeight: '18px' /* 150% */,
+      lineHeight: '18px',
       letterSpacing: '0.018px',
     }),
     label: css({
-      fontSize: '12px', // not being properly applied, currently is 14px
       color: 'theme.colors.text.primary',
       fontWeight: 400,
-      // lineHeight: '18px',
       letterSpacing: '0.018px',
     }),
     horizontalLine: css({
-      width: '154px',
+      width: '200px',
       height: '1px',
       background: theme.colors.border.weak,
       marginTop: '8px',

--- a/public/app/features/trails/wingman/WingmanScene.tsx
+++ b/public/app/features/trails/wingman/WingmanScene.tsx
@@ -1,3 +1,6 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
 import {
   SceneComponentProps,
   SceneObjectBase,
@@ -6,7 +9,7 @@ import {
   SceneObjectUrlValues,
   SceneObjectWithUrlSync,
 } from '@grafana/scenes';
-import { RadioButtonList } from '@grafana/ui';
+import { RadioButtonList, useStyles2 } from '@grafana/ui';
 
 import { isWingmanGroupKey, useWingmanOptionGroup, WingmanGroupKeyType } from './wingman';
 
@@ -51,25 +54,61 @@ export class WingmanScene extends SceneObjectBase<WingmanSceneState> implements 
   };
 
   public static Component = ({ model }: SceneComponentProps<WingmanScene>) => {
+    const styles = useStyles2(getStyles);
     const state = model.useState();
     const { onWingmanOptionChanged } = model;
     const initialData = useWingmanOptionGroup();
     return (
-      <div>
-        <div>11241 Metrics</div>
+      <div className={styles.vertialLine}>
+        <div className={styles.title}>11241 Metrics</div>
         {initialData.map((group, groupIdx) => (
           <div key={group.title}>
-            <h2>{group.title}</h2>
-            <RadioButtonList<string>
-              name={group.title + '---name'}
-              value={state[group.id]}
-              disabledOptions={group.options.filter((opt) => !opt.available).map((op) => op.id)}
-              options={group.options.map((opt) => ({ label: opt.label, value: opt.id }))}
-              onChange={(val) => onWingmanOptionChanged(group.id, val)}
-            />
+            <div className={styles.horizontalLine} />
+            <h2 className={styles.title}>{group.title}</h2>
+            <div className={styles.label}>
+              <RadioButtonList<string>
+                name={group.title + '---name'}
+                value={state[group.id]}
+                disabledOptions={group.options.filter((opt) => !opt.available).map((op) => op.id)}
+                options={group.options.map((opt) => ({ label: opt.label, value: opt.id }))}
+                onChange={(val) => onWingmanOptionChanged(group.id, val)}
+              />
+            </div>
           </div>
         ))}
       </div>
     );
+  };
+}
+
+export function getStyles(theme: GrafanaTheme2) {
+  return {
+    vertialLine: css({
+      borderRight: `1px solid var(--border-Weak, rgba(204, 204, 220, 0.12))`,
+      height: '540px',
+    }),
+    title: css({
+      overflow: 'hidden',
+      color: '#FFF',
+      textOverflow: 'ellipsis',
+      fontSize: '14px', // should be 12px but making 14px to match the label font size
+      fontWeight: 500,
+      lineHeight: '18px' /* 150% */,
+      letterSpacing: '0.018px',
+    }),
+    label: css({
+      fontSize: '12px', // not being properly applied, currently is 14px
+      color: 'theme.colors.text.primary',
+      fontWeight: 400,
+      // lineHeight: '18px',
+      letterSpacing: '0.018px',
+    }),
+    horizontalLine: css({
+      width: '154px',
+      height: '1px',
+      background: theme.colors.border.weak,
+      marginTop: '8px',
+      marginBottom: '8px',
+    }),
   };
 }

--- a/public/app/features/trails/wingman/WingmanScene.tsx
+++ b/public/app/features/trails/wingman/WingmanScene.tsx
@@ -59,7 +59,7 @@ export class WingmanScene extends SceneObjectBase<WingmanSceneState> implements 
     const { onWingmanOptionChanged } = model;
     const initialData = useWingmanOptionGroup();
     return (
-      <div className={styles.vertialLine}>
+      <div className={styles.verticalLine}>
         <div className={styles.title}>11241 Metrics</div>
         {initialData.map((group, groupIdx) => (
           <div key={group.title}>
@@ -83,7 +83,8 @@ export class WingmanScene extends SceneObjectBase<WingmanSceneState> implements 
 
 export function getStyles(theme: GrafanaTheme2) {
   return {
-    vertialLine: css({
+    verticalLine: css({
+      marginLeft: '16px', // not currently working
       borderRight: `1px solid var(--border-Weak, rgba(204, 204, 220, 0.12))`,
       height: '540px',
     }),


### PR DESCRIPTION
make sidebar style match @catherineymgui's [figma designs](https://www.figma.com/design/8Inkl2uIeiHXPWCmtvyKMs/Explore-Metrics---Hackathon-Dec-2024?node-id=49-9928&node-type=canvas&m=dev)

note: buttons are not functional atm (they don't change the page view)

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/af6a5a52-1b6f-474a-9555-7ae770c0685f">

ref https://github.com/grafana/observability-metrics-squad/issues/146
