### PR TITLE
K8s/Folders: Add test for folder creation and fix version setting

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -787,6 +787,7 @@ func (fk8s *folderK8sHandler) getFolder(c *contextmodel.ReqContext) {
 				"spec": map[string]interface{}{
 					"title":       folder.RootFolder.Title,
 					"description": folder.RootFolder.Description,
+					"version":     int64(0),
 				},
 			},
 		}

--- a/pkg/apis/folder/v0alpha1/types.go
+++ b/pkg/apis/folder/v0alpha1/types.go
@@ -20,6 +20,7 @@ type Spec struct {
 
 	// Describe the feature toggle
 	Description string `json:"description,omitempty"`
+	Version     int    `json:"version,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/folder/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/folder/v0alpha1/zz_generated.openapi.go
@@ -372,6 +372,12 @@ func schema_pkg_apis_folder_v0alpha1_Spec(ref common.ReferenceCallback) common.O
 							Format:      "",
 						},
 					},
+					"version": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 				Required: []string{"title"},
 			},

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -76,6 +76,10 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) (*f
 	spec := item.Object["spec"].(map[string]any)
 	uid := item.GetName()
 	title := spec["title"].(string)
+	version, ok := spec["version"].(int64)
+	if !ok {
+		return nil, ""
+	}
 
 	meta, err := utils.MetaAccessor(&item)
 	if err != nil {
@@ -130,6 +134,7 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) (*f
 		// it can't be saved in the resource metadata because then everything must cascade
 		// nolint:staticcheck
 		FullpathUIDs: meta.GetFullPathUIDs(),
+		Version:      int(version),
 	}
 	// CreatedBy needs to be returned separately because it's the user UID (string) but
 	// folder.Folder expects user ID (int64).
@@ -153,6 +158,7 @@ func convertToK8sResource(v *folder.Folder, namespacer request.NamespaceMapper) 
 		Spec: v0alpha1.Spec{
 			Title:       v.Title,
 			Description: v.Description,
+			Version:     v.Version,
 		},
 	}
 

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api"
 	"github.com/grafana/grafana/pkg/api/dtos"
-	fdtos "github.com/grafana/grafana/pkg/api/dtos"
 	folderv0alpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
@@ -1328,7 +1327,7 @@ func TestK8sFolderCreateFullResponse(t *testing.T) {
 				User: helper.Org1.Editor,
 				GVR:  gvr,
 			})
-			var f fdtos.Folder
+			var f dtos.Folder
 			create := apis.DoRequest(helper, apis.RequestParams{
 				User:   client.Args.User,
 				Method: http.MethodPost,
@@ -1339,7 +1338,7 @@ func TestK8sFolderCreateFullResponse(t *testing.T) {
 			require.Equal(t, http.StatusOK, create.Response.StatusCode)
 
 			var newDate time.Time
-			expectedRes := fdtos.Folder{
+			expectedRes := dtos.Folder{
 				ID:        1,
 				UID:       "uid",
 				OrgID:     0,

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -405,7 +405,8 @@ func doFolderTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelper
 			  "uid": "${uid}"
 			},
 			"spec": {
-			  "title": "Test"
+			  "title": "Test",
+			  "version": 1
 			}
 		  }`
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

* Fix setting version when creating folders.
* Add test for folder creation response.

**Why do we need this feature?**

This ensures the response when dual writing in different modes matches the response expected when creating folders using legacy storage.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/150

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
