### PR TITLE
hackathon: Change p2g marker label key

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -157,7 +157,7 @@ const (
 
 	// PrometheusStyleRuleLabel indicates that this rule is imported from Prometheus and should be treated as such.
 	// For example, different evaluation semantics is used, etc.
-	PrometheusStyleRuleLabel = "__grafana_prometheus_style_rule__"
+	PrometheusStyleRuleLabel = "grafana_prometheus_style_rule"
 )
 
 const (


### PR DESCRIPTION
there's a chunk of logic somewhere that filters certain magic label spellings when sending alerts to the AM