### PR TITLE
Alerting: Improve performance in hashQuery function

### DIFF
--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -289,7 +289,7 @@ function getPromRuleFingerprint(rule: Rule) {
 }
 
 // there can be slight differences in how prom & ruler render a query, this will hash them accounting for the differences
-export function hashQuery(query: string) {
+export function oldhashQuery(query: string) {
   // one of them might be wrapped in parens
   if (query.length > 1 && query[0] === '(' && query[query.length - 1] === ')') {
     query = query.slice(1, -1);
@@ -298,6 +298,30 @@ export function hashQuery(query: string) {
   query = query.replace(/\s|\n/g, '');
   // labels matchers can be reordered, so sort the enitre string, esentially comparing just the character counts
   return query.split('').sort().join('');
+}
+export function hashQuery(query: string): string {
+  // one of them might be wrapped in parens
+  if (query.length > 1 && query[0] === '(' && query[query.length - 1] === ')') {
+    query = query.slice(1, -1);
+  }
+  // whitespace could be added or removed
+  query = query.replace(/\s|\n/g, '');
+
+  // Use a counting sort approach to sort characters
+  const charCount = new Array(256).fill(0); // Assuming ASCII characters
+
+  for (let i = 0; i < query.length; i++) {
+    charCount[query.charCodeAt(i)]++;
+  }
+
+  let sortedQuery = '';
+  for (let i = 0; i < charCount.length; i++) {
+    if (charCount[i] > 0) {
+      sortedQuery += String.fromCharCode(i).repeat(charCount[i]);
+    }
+  }
+
+  return sortedQuery;
 }
 
 export function hashLabelsOrAnnotations(item: Labels | Annotations | undefined): string {

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -308,7 +308,11 @@ export function hashQuery(query: string): string {
   query = query.replace(/\s|\n/g, '');
 
   // Use a counting sort approach to sort characters
-  const charCount = new Array(256).fill(0); // Assuming ASCII characters
+  const charCount = new Array(256).fill(0);
+  // Assuming ASCII characters, this is correct because the sort uses the UTF-16 charset order
+  // The default sort order(used in the oldHasQuery) in JavaScript is based on the UTF-16 code units, not UTF-8.
+  // This means that the sorting behavior is based on the UTF-16 encoding of the characters. However, for ASCII characters (0-127),
+  // the UTF-16 and UTF-8 encodings are the same, so the approach using an array of length 256 is still valid for ASCII characters.
 
   for (let i = 0; i < query.length; i++) {
     charCount[query.charCodeAt(i)]++;

--- a/public/app/features/alerting/unified/utils/rules.test.ts
+++ b/public/app/features/alerting/unified/utils/rules.test.ts
@@ -135,7 +135,7 @@ describe('hashQuery Performance Comparison', () => {
         refId: `A${i}`,
         queryType: '',
         relativeTimeRange: { from: 600 + i * 10, to: i }, // Slightly varying time ranges
-        datasourceUid: `DSUID${i}`, // Unique datasource UID
+        datasourceUid: `DSU€ID${i}`, // Unique datasource UID
         model: {
           dimensions: {},
           expression: '',
@@ -146,7 +146,7 @@ describe('hashQuery Performance Comparison', () => {
           metricEditorMode: 0,
           metricName: `Metric${i}`, // Unique metric name
           metricQueryType: i % 3, // Rotating through query types
-          namespace: `AWS/Service${i % 5}`, // Rotating namespaces
+          namespace: `AWS/Serv€ice${i % 5}`, // Rotating namespaces
           queryMode: 'Metrics',
           refId: `A${i}`,
           region: i % 2 === 0 ? 'us-east-1' : 'us-west-1', // Alternating regions
@@ -212,6 +212,7 @@ describe('hashQuery Performance Comparison', () => {
       totalOptimizedTime += optimizedTime;
     }
 
+    // uncomment to see time comparison
     // console.log(`  Original Time: ${totalOriginalTime.toFixed(3)} ms`);
     // console.log(`  Optimized Time: ${totalOptimizedTime.toFixed(3)} ms`);
     // console.log(`  Speedup: ${(totalOriginalTime / totalOptimizedTime).toFixed(2)}x`);

--- a/public/app/features/alerting/unified/utils/rules.test.ts
+++ b/public/app/features/alerting/unified/utils/rules.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../mocks';
 
 import { GRAFANA_ORIGIN_LABEL } from './labels';
+import { hashQuery, oldhashQuery } from './rule-id';
 import {
   getRuleGroupLocationFromCombinedRule,
   getRuleGroupLocationFromRuleWithLocation,
@@ -120,5 +121,116 @@ describe('ruleGroupLocation', () => {
       namespaceName: 'abc123',
       groupName: 'group-1',
     });
+  });
+});
+
+describe('hashQuery Performance Comparison', () => {
+  const repetitions = 4;
+  const length = 200;
+
+  function generateLargeNumberOfQueries(count: number) {
+    const queries = [];
+    for (let i = 0; i < count; i++) {
+      queries.push({
+        refId: `A${i}`,
+        queryType: '',
+        relativeTimeRange: { from: 600 + i * 10, to: i }, // Slightly varying time ranges
+        datasourceUid: `DSUID${i}`, // Unique datasource UID
+        model: {
+          dimensions: {},
+          expression: '',
+          hide: i % 2 === 0, // Alternating hide values
+          intervalMs: 1000 + (i % 5) * 500, // Varying intervals
+          matchExact: i % 2 === 0,
+          maxDataPoints: 43200 - (i % 100), // Adjusting maxDataPoints
+          metricEditorMode: 0,
+          metricName: `Metric${i}`, // Unique metric name
+          metricQueryType: i % 3, // Rotating through query types
+          namespace: `AWS/Service${i % 5}`, // Rotating namespaces
+          queryMode: 'Metrics',
+          refId: `A${i}`,
+          region: i % 2 === 0 ? 'us-east-1' : 'us-west-1', // Alternating regions
+          statistic: i % 2 === 0 ? 'Maximum' : 'Average', // Alternating statistics
+        },
+      });
+      queries.push({
+        refId: `B${i}`,
+        queryType: '',
+        relativeTimeRange: { from: i * 10, to: i },
+        datasourceUid: `-10${i}`,
+        model: {
+          conditions: [
+            {
+              evaluator: { params: [i, i + 1], type: i % 2 === 0 ? 'gt' : 'lt' },
+              operator: { type: i % 2 === 0 ? 'and' : 'or' },
+              query: { params: [] },
+              reducer: { params: [], type: i % 2 === 0 ? 'last' : 'max' },
+              type: 'query',
+            },
+          ],
+          datasource: { name: 'Expression', type: '__expr__', uid: '__expr__' },
+          hide: i % 3 === 0,
+          intervalMs: 1000 + (i % 10) * 100,
+          maxDataPoints: 43200 - (i % 50),
+          refId: `B${i}`,
+          type: 'classic_conditions',
+        },
+      });
+    }
+    return queries;
+  }
+
+  const largeQueries = generateLargeNumberOfQueries(1000);
+  const queries = largeQueries;
+  it(`Compare performance for query length ${length}`, () => {
+    let totalOriginalTime = 0;
+    let totalOptimizedTime = 0;
+    // for each rule
+    for (let i = 0; i < queries.length; i++) {
+      const query = JSON.stringify(queries[i]);
+      // original function
+      let originalTime = 0;
+      for (let i = 0; i < repetitions; i++) {
+        // we repeat the test to get a more accurate average time
+        const start = performance.now();
+        oldhashQuery(query);
+        const end = performance.now();
+        originalTime += end - start;
+      }
+      originalTime /= repetitions;
+      totalOriginalTime += originalTime;
+
+      // optimized function
+      let optimizedTime = 0;
+      for (let i = 0; i < repetitions; i++) {
+        const start = performance.now();
+        hashQuery(query);
+        const end = performance.now();
+        optimizedTime += end - start;
+      }
+      optimizedTime /= repetitions;
+      totalOptimizedTime += optimizedTime;
+    }
+
+    // console.log(`  Original Time: ${totalOriginalTime.toFixed(3)} ms`);
+    // console.log(`  Optimized Time: ${totalOptimizedTime.toFixed(3)} ms`);
+    // console.log(`  Speedup: ${(totalOriginalTime / totalOptimizedTime).toFixed(2)}x`);
+
+    // Expect the optimized function to be faster or equivalent
+    expect(totalOptimizedTime).toBeLessThanOrEqual(totalOriginalTime);
+  });
+  it(`Same results for optimized and original functions for query length ${length}`, () => {
+    let result1 = '';
+    let result2 = '';
+    // for each rule
+    for (let i = 0; i < queries.length; i++) {
+      const query = JSON.stringify(queries[i]);
+      // original function
+      result1 = oldhashQuery(query);
+      // optimized function
+      result2 = hashQuery(query);
+      // Expect the optimized function to get the same result
+      expect(result1).toBe(result2);
+    }
   });
 });


### PR DESCRIPTION
**What is this feature?**

This PR aims to improve the performance of the `hashQuery` function. This function is called multiple times from the AlertListPanel, causing a UI freeze when we have a long list of alert rules.

With this change the test reflects a `2.25x` speed 

Issue context https://raintank-corp.slack.com/archives/C028MCV4R7C/p1733322547140629 

Context of the issue in a dashboard with an alert list panel:

https://github.com/user-attachments/assets/f445be09-90b5-42a3-9b8b-a0b6ae1b3d84


**Special notes for your reviewer:**

Added 2 tests, one for comparing the performance of the new/old function, and another for checking if they return the same results.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
