### PR TITLE
Chore: Remove @eslint/compat and don't run all eslint rules in betterer

### DIFF
--- a/.betterer.eslint.config.js
+++ b/.betterer.eslint.config.js
@@ -1,8 +1,77 @@
 // @ts-check
+const emotionPlugin = require('@emotion/eslint-plugin');
+const importPlugin = require('eslint-plugin-import');
+const jestPlugin = require('eslint-plugin-jest');
+const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
+const lodashPlugin = require('eslint-plugin-lodash');
+const barrelPlugin = require('eslint-plugin-no-barrel-files');
+const reactPlugin = require('eslint-plugin-react');
+const testingLibraryPlugin = require('eslint-plugin-testing-library');
+
+const grafanaConfig = require('@grafana/eslint-config/flat');
+const grafanaPlugin = require('@grafana/eslint-plugin');
+
+// Include the Grafana config and remove the rules,
+// as we just want to pull in all of the necessary configuration but not run the rules
+// (this should only be concerned with checking rules that we want to improve,
+// so there's no need to try and run the rules that will be linted properly anyway)
+const { rules, ...baseConfig } = grafanaConfig;
+
 /**
  * @type {Array<import('eslint').Linter.Config>}
  */
 module.exports = [
+  {
+    name: 'grafana/betterer-ignores',
+    ignores: [
+      '.github',
+      '.yarn',
+      '**/.*',
+      '**/*.gen.ts',
+      '**/build/',
+      '**/compiled/',
+      '**/dist/',
+      'data/',
+      'deployment_tools_config.json',
+      'devenv',
+      'e2e/test-plugins',
+      'e2e/tmp',
+      'packages/grafana-ui/src/components/Icon/iconBundle.ts',
+      'pkg',
+      'playwright-report',
+      'public/lib/monaco/',
+      'public/locales/_build',
+      'public/locales/**/*.js',
+      'public/vendor/',
+      'scripts/grafana-server/tmp',
+      '!.betterer.eslint.config.js',
+    ],
+  },
+  {
+    name: 'react/jsx-runtime',
+    // @ts-ignore - not sure why but flat config is typed as a maybe?
+    ...reactPlugin.configs.flat['jsx-runtime'],
+  },
+  {
+    files: ['**/*.{ts,tsx,js}'],
+    ...baseConfig,
+    plugins: {
+      ...baseConfig.plugins,
+      '@emotion': emotionPlugin,
+      lodash: lodashPlugin,
+      jest: jestPlugin,
+      import: importPlugin,
+      'jsx-a11y': jsxA11yPlugin,
+      'no-barrel-files': barrelPlugin,
+      '@grafana': grafanaPlugin,
+      'testing-library': testingLibraryPlugin,
+    },
+    linterOptions: {
+      // This reports unused disable directives that we can clean up but
+      // it also conflicts with the betterer eslint rules so disabled
+      reportUnusedDisableDirectives: false,
+    },
+  },
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     rules: {

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -2,8 +2,6 @@ import { BettererFileTest } from '@betterer/betterer';
 import { ESLint } from 'eslint';
 import { promises as fs } from 'fs';
 
-import config from './.betterer.eslint.config';
-
 // Why are we ignoring these?
 // They're all deprecated/being removed so doesn't make sense to fix types
 const eslintPathsToIgnore = [
@@ -11,7 +9,6 @@ const eslintPathsToIgnore = [
   'public/app/angular', // will be removed in Grafana 12
   'public/app/plugins/panel/graph', // will be removed alongside angular in Grafana 12
   'public/app/plugins/panel/table-old', // will be removed alongside angular in Grafana 12
-  'e2e/test-plugins',
 ];
 
 // Avoid using functions that report the position of the issues, as this causes a lot of merge conflicts
@@ -75,17 +72,14 @@ function regexp(pattern: RegExp, issueMessage: string) {
 }
 
 function countEslintErrors() {
-  return new BettererFileTest(async (filePaths, fileTestResult, resolver) => {
+  return new BettererFileTest(async (filePaths, fileTestResult) => {
     // Just bail early if there's no files to test. Prevents trying to get the base config from failing
     if (filePaths.length === 0) {
       return;
     }
 
-    const { baseDirectory } = resolver;
-
     const runner = new ESLint({
-      overrideConfig: config,
-      cwd: baseDirectory,
+      overrideConfigFile: './.betterer.eslint.config.js',
       warnIgnored: false,
     });
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,5 @@
 // @ts-check
 const emotionPlugin = require('@emotion/eslint-plugin');
-const { fixupPluginRules } = require('@eslint/compat');
 const importPlugin = require('eslint-plugin-import');
 const jestPlugin = require('eslint-plugin-jest');
 const jestDomPlugin = require('eslint-plugin-jest-dom');
@@ -260,7 +259,7 @@ module.exports = [
   {
     name: 'grafana/alerting-test-overrides',
     plugins: {
-      'testing-library': fixupPluginRules({ rules: testingLibraryPlugin.rules }),
+      'testing-library': testingLibraryPlugin,
       'jest-dom': jestDomPlugin,
     },
     files: [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,7 @@ module.exports = [
       'public/locales/**/*.js',
       'public/vendor/',
       'scripts/grafana-server/tmp',
+      '!.betterer.eslint.config.js',
     ],
   },
   // Conditionally run the betterer rules if enabled in dev's config

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@betterer/eslint": "5.4.0",
     "@cypress/webpack-preprocessor": "6.0.2",
     "@emotion/eslint-plugin": "11.12.0",
-    "@eslint/compat": "^1.2.0",
     "@grafana/eslint-config": "8.0.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
     "@grafana/plugin-e2e": "^1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,18 +2513,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:^1.2.0":
-  version: 1.2.3
-  resolution: "@eslint/compat@npm:1.2.3"
-  peerDependencies:
-    eslint: ^9.10.0
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: 10/5a8fc6ecb127a1ce757c2b94e4a71fd72939c3e9007eb80c0a819618e1c7cc98ffe3e5229a504c52e6f5b5dc0f6be3b899fa6a3dedb220cb4a02c8d5d0c333df
-  languageName: node
-  linkType: hard
-
 "@eslint/config-array@npm:^0.18.0":
   version: 0.18.0
   resolution: "@eslint/config-array@npm:0.18.0"
@@ -17182,7 +17170,6 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@emotion/eslint-plugin": "npm:11.12.0"
     "@emotion/react": "npm:11.13.5"
-    "@eslint/compat": "npm:^1.2.0"
     "@fingerprintjs/fingerprintjs": "npm:^3.4.2"
     "@floating-ui/react": "npm:0.26.28"
     "@formatjs/intl-durationformat": "npm:^0.6.0"


### PR DESCRIPTION
**What is this feature?**
Ensures that betterer doesn't run eslint rules that are checked anyway in separate linting steps

**Why do we need this feature?**
Brings betterer check time back to what it used to be, ~1min (rather than ~1:30).
Also means that the betterer step will only fail for betterer issues, rather than linting issues that would be caught in the eslint step anyway

Locally, I've seen it roughly halve the time for running `yarn betterer -u` against all files

**Who is this feature for?**
UI devs
