### PR TITLE
feedback/llm: refactor LLM client simplify init and return errors

### DIFF
--- a/apps/feedback/pkg/llmclient/model.go
+++ b/apps/feedback/pkg/llmclient/model.go
@@ -1,18 +1,17 @@
 package llmclient
 
-import "github.com/grafana/grafana/pkg/setting"
-
-const (
-	TEAM_RESPONSIBILITIES_FILE = "apps/feedback/pkg/llmclient/team_responsibilities.csv"
-	TEAM_PROMPT_TEMPLATE       = "apps/feedback/pkg/llmclient/template_team_prompt.txt"
-	ISSUE_NAME_PROMPT_TEMPLATE = "apps/feedback/pkg/llmclient/template_issue_name_prompt.txt"
+import (
+	"net/http"
+	"text/template"
 )
 
 type LLMClient struct {
 	URL                  string
 	ChatOptions          ChatOptions
 	TeamResponsibilities map[string]string
-	cfg                  *setting.Cfg
+	httpClient           *http.Client
+	tmplTeamPrompt       *template.Template
+	tmplIssueNamePrompt  *template.Template
 }
 
 type ChatOptions struct {


### PR DESCRIPTION
- Uses go embed and templates for the prompt files and the team responsibilities
- Return error on method instead of logging
- General code tidying style

Tested and working https://github.com/grafana/hackathon-feedback-button/issues/69