### PR TITLE
fix: mark bucketAgg parse errors as downstream

### DIFF
--- a/pkg/tsdb/elasticsearch/parse_query.go
+++ b/pkg/tsdb/elasticsearch/parse_query.go
@@ -1,6 +1,8 @@
 package elasticsearch
 
 import (
+	"fmt"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
@@ -22,7 +24,7 @@ func parseQuery(tsdbQuery []backend.DataQuery, logger log.Logger) ([]*Query, err
 		bucketAggs, err := parseBucketAggs(model)
 		if err != nil {
 			logger.Error("Failed to parse bucket aggs in query", "error", err, "model", string(q.JSON))
-			return nil, err
+			return nil, backend.DownstreamError(err)
 		}
 		metrics, err := parseMetrics(model)
 		if err != nil {
@@ -59,12 +61,12 @@ func parseBucketAggs(model *simplejson.Json) ([]*BucketAgg, error) {
 
 		agg.Type, err = aggJSON.Get("type").String()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse bucket aggs type: %w", err)
 		}
 
 		agg.ID, err = aggJSON.Get("id").String()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse bucket aggs id: %w", err)
 		}
 
 		agg.Field = aggJSON.Get("field").MustString()


### PR DESCRIPTION
**What is this feature?**
This marks certain errors in ElasticSearch query parsing as Downstream errors.

**Why do we need this feature?**
Some customer alerts have been provisioned with incorrectly structured ElasticSearch queries, which is causing an error that's currently not corrrectly identified by the system, leading to SLO burn and misleading alerts for our datasources operations.

**Who is this feature for?**
It's mostly for us to correctly identify these errors as not something we need to urgently act on.
[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/data-sources/issues/223
