### PR TITLE
feedback/app: add basic validation for spec

### DIFF
--- a/apps/feedback/pkg/app/app.go
+++ b/apps/feedback/pkg/app/app.go
@@ -63,7 +63,21 @@ func New(cfg app.Config) (app.App, error) {
 				},
 				Validator: &simple.Validator{
 					ValidateFunc: func(ctx context.Context, req *app.AdmissionRequest) error {
-						// do something here if needed
+						feedback, ok := req.Object.(*feedbackv0alpha1.Feedback)
+						if !ok {
+							logging.FromContext(ctx).Error("received admission request for validator that is not of feedback type")
+
+							return nil
+						}
+
+						if feedback.Spec.Message == "" {
+							return fmt.Errorf("message cannot be empty")
+						}
+
+						if feedback.Spec.ScreenshotUrl != nil && *feedback.Spec.ScreenshotUrl != "" && len(feedback.Spec.Screenshot) > 0 {
+							return fmt.Errorf("screenshot and screenshot url cannot be both filled in at the same time")
+						}
+
 						return nil
 					},
 				},


### PR DESCRIPTION
Adds some basic validation in the admission controller, to not have an empty message, or both screenshot + screenshot url at the same time.

We could also use the mutator to truncate the message length if we want.

![Screenshot 2024-12-05 at 15 20 22](https://github.com/user-attachments/assets/bd1b94e8-45d6-4066-bf15-19a6f34cfc9e)
