### PR TITLE
Alerting: Fix using stacks- prefix instead of stack- for checking the namespace in boot data

### DIFF
--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -95,7 +95,7 @@ export const PANEL_STYLES = { minHeight: 300 };
 
 const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });
 
-const namespace = config.bootData.settings.namespace;
+const namespace = config.namespace;
 
 export const INSTANCE_ID = namespace.includes('stacks-') ? namespace.replace('stacks-', '') : undefined;
 

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -97,7 +97,7 @@ const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });
 
 const namespace = config.bootData.settings.namespace;
 
-export const INSTANCE_ID = namespace.includes('stack-') ? namespace.replace('stack-', '') : undefined;
+export const INSTANCE_ID = namespace.includes('stacks-') ? namespace.replace('stacks-', '') : undefined;
 
 const getInsightsDataSources = () => {
   const dataSourceSrv = getDataSourceSrv();


### PR DESCRIPTION

**What is this feature?**

This PR fixes the Insights page not filtering by stack correctly.

**Why do we need this feature?**

The page was showing all the stacks data instead of the one in boot data namespace.

**Who is this feature for?**

Alerting cloud users.

**Which issue(s) does this PR fix?**:
 see context here https://raintank-corp.slack.com/archives/C01LJ5F8NRX/p1733413020312829 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
