### PR TITLE
SBOM Report: reference sbom in shared workflow

### DIFF
--- a/.github/workflows/sbom-report.yml
+++ b/.github/workflows/sbom-report.yml
@@ -10,6 +10,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Anchore SBOM Action
-      uses: grafana/shared-workflows/actions@syft-sbom-v0.0.1
+      uses: grafana/shared-workflows/actions/syft-sbom-report/syft-sbom-report.yml@main
       with:
         artifact-name: ${{ github.event.repository.name }}-spdx.json


### PR DESCRIPTION
This uses the SBOM action in the shared-workflows repo to generate SBOMs for `grafana/grafana` on new releases.