### PR TITLE
Alerting: Fix lost initial values when changing receiver type and back

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -53,7 +53,7 @@ export function ChannelSubForm<R extends ChannelValues>({
 
   const fieldName = useCallback((fieldName: string) => `${pathPrefix}${fieldName}`, [pathPrefix]);
 
-  const { control, watch, register, trigger, formState, setValue } = useFormContext();
+  const { control, watch, register, trigger, formState, setValue, getValues } = useFormContext();
   const selectedType = watch(fieldName('type')) ?? defaultValues.type; // nope, setting "default" does not work at all.
   const parse_mode = watch(fieldName('settings.parse_mode'));
   const { loading: testingReceiver } = useUnifiedAlertingSelector((state) => state.testReceivers);
@@ -73,22 +73,14 @@ export function ChannelSubForm<R extends ChannelValues>({
   useEffect(() => {
     // Restore values when switching back from a changed integration to the default one
     const subscription = watch((v, { name, type }) => {
-      const value = name ? v[name] : '';
+      const value = name ? getValues(name) : '';
       if (initialValues && name === fieldName('type') && value === initialValues.type && type === 'change') {
         setValue(fieldName('settings'), initialValues.settings);
-      }
-      // Restore initial value of an existing oncall integration
-      if (
-        initialValues &&
-        name === fieldName('settings.integration_type') &&
-        value === OnCallIntegrationType.ExistingIntegration
-      ) {
-        setValue(fieldName('settings.url'), initialValues.settings.url);
       }
     });
 
     return () => subscription.unsubscribe();
-  }, [selectedType, initialValues, setValue, fieldName, watch]);
+  }, [selectedType, initialValues, setValue, getValues, fieldName, watch]);
 
   const [_secureFields, setSecureFields] = useState<Record<string, boolean | ''>>(secureFields ?? {});
 


### PR DESCRIPTION
**What is this feature?**

Ensures initial values are not lost during update of an existing receiver when changing integration type to something else and going back to the original.

**Why do we need this feature?**

Initial values should not be lost when returning to the original integration type. 

**Special notes for your reviewer:**

Bug:

[Peek 2024-12-05 13-41.webm](https://github.com/user-attachments/assets/b71d5292-640b-464f-bb6a-304fa52c1c4d)

Fix:

[Peek 2024-12-05 13-47.webm](https://github.com/user-attachments/assets/c705234f-0950-4dda-95ce-f590eb2a2aef)



Please check that:
- [x] It works as expected from a user's perspective.