### PR TITLE
CI: Commit package.json changes in e2e/test-plugins when bumping versions

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Add package.json changes
         run: |
-          git add package.json lerna.json yarn.lock packages public
+          git add package.json lerna.json yarn.lock packages public e2e/test-plugins
           git commit -m "Update version to ${{ inputs.version }}"
 
       - name: Git push


### PR DESCRIPTION
In a previous [release PR](https://github.com/grafana/grafana/pull/97437) after the ["Update package.json versions"](https://github.com/grafana/grafana/actions/runs/12167311834/job/33935572720) step is run the changes in `e2e/test-plugins/grafana-extensionstest-app/package.json` don't get committed and we have to manually update it.

You can checkout the `v11.3.x` branch and run `go run ./pkg/build/actions/bump-version/main.go -version=patch` to see it correctly bump the version in `e2e/test-plugins/grafana-extensionstest-app/package.json`.

~This just needs to be backported to the v11.3.x branch because versions before that don't have `e2e/test-plugins`.~ Actually I don't think this needs a backport, looks like it's the main grafana [release-pr.yml workflow](https://github.com/grafana/grafana/actions/runs/12167311834/workflow) that gets run.