### PR TITLE
LBAC for datasources: Update the docs to point to UID instead of ID

### DIFF
--- a/docs/sources/developers/http_api/datasource_lbac_rules.md
+++ b/docs/sources/developers/http_api/datasource_lbac_rules.md
@@ -57,13 +57,13 @@ Content-Length: 131
 {
   "rules": [
     {
-      "teamId": "1",
+      "teamUId": "fdnd1pf4m9sxvc",
       "rules": [
         "{ service_name=\"bigquery-sync-mysql\" }"
       ]
     },
     {
-      "teamId": "2",
+      "teamUid": "dfed1p2m9sxvfc",
       "rules": [
         "{ service_name=\"api\" }"
       ]
@@ -99,13 +99,13 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 {
   "rules": [
     {
-      "teamId": "1",
+      "teamUId": "fdnd1pf4m9sxvc",
       "rules": [
         "{ service_name=\"bigquery-sync-mysql\" }"
       ]
     },
     {
-      "teamId": "2",
+      "teamUid": "dfed1p2m9sxvfc",
       "rules": [
         "{ service_name=\"api\" }"
       ]
@@ -127,13 +127,13 @@ Content-Length: 35
   "name": "loki",
   "rules": [
     {
-      "teamId": "1",
+      "teamUId": "fdnd1pf4m9sxvc",
       "rules": [
         "{ service_name=\"bigquery-sync-mysql\" }"
       ]
     },
     {
-      "teamId": "2",
+      "teamUid": "dfed1p2m9sxvfc",
       "rules": [
         "{ service_name=\"api\" }"
       ]


### PR DESCRIPTION
Now that we have UID as an endpoint we should update the docs.

https://github.com/grafana/grafana-enterprise/pull/7469