### PR TITLE
K8s: Make GetAPIRoutes an optional interface

### DIFF
--- a/pkg/registry/apis/alerting/notifications/register.go
+++ b/pkg/registry/apis/alerting/notifications/register.go
@@ -108,10 +108,6 @@ func (t *NotificationsAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefin
 	return notificationsModels.GetOpenAPIDefinitions
 }
 
-func (t *NotificationsAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil
-}
-
 // PostProcessOpenAPI is a hook to alter OpenAPI3 specification of the API server.
 func (t *NotificationsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	// The plugin description

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -74,7 +74,3 @@ func (b *DashboardsAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefiniti
 func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	return oas, nil
 }
-
-func (b *DashboardsAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil // no custom API routes
-}

--- a/pkg/registry/apis/dashboard/v1alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v1alpha1/register.go
@@ -197,7 +197,3 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 	}
 	return oas, nil
 }
-
-func (b *DashboardsAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil // no custom API routes
-}

--- a/pkg/registry/apis/dashboard/v2alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v2alpha1/register.go
@@ -197,7 +197,3 @@ func (b *DashboardsAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 	}
 	return oas, nil
 }
-
-func (b *DashboardsAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil // no custom API routes
-}

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -281,8 +281,3 @@ func (b *DataSourceAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 	}
 	return oas, err
 }
-
-// Register additional routes with the server
-func (b *DataSourceAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil
-}

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -146,10 +146,6 @@ func (b *FolderAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions 
 	return v0alpha1.GetOpenAPIDefinitions
 }
 
-func (b *FolderAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil // no custom API routes
-}
-
 func (b *FolderAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	// The plugin description
 	oas.Info.Description = "Grafana folders"

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -125,11 +125,6 @@ func (b *IdentityAccessManagementAPIBuilder) GetOpenAPIDefinitions() common.GetO
 	return iamv0.GetOpenAPIDefinitions
 }
 
-func (b *IdentityAccessManagementAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	// no custom API routes
-	return nil
-}
-
 func (b *IdentityAccessManagementAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return b.authorizer
 }

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -165,11 +165,6 @@ func (b *QueryAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 	return query.GetOpenAPIDefinitions
 }
 
-// Register additional routes with the server
-func (b *QueryAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil
-}
-
 func (b *QueryAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return nil // default is OK
 }

--- a/pkg/registry/apis/scope/register.go
+++ b/pkg/registry/apis/scope/register.go
@@ -157,11 +157,6 @@ func (b *ScopeAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 	return scope.GetOpenAPIDefinitions
 }
 
-// Register additional routes with the server
-func (b *ScopeAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil
-}
-
 func (b *ScopeAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	// The plugin description
 	oas.Info.Description = "Grafana scopes"

--- a/pkg/registry/apis/service/register.go
+++ b/pkg/registry/apis/service/register.go
@@ -88,8 +88,3 @@ func (b *ServiceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.AP
 func (b *ServiceAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 	return service.GetOpenAPIDefinitions
 }
-
-// Register additional routes with the server
-func (b *ServiceAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil
-}

--- a/pkg/registry/apis/userstorage/register.go
+++ b/pkg/registry/apis/userstorage/register.go
@@ -11,9 +11,10 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	userstorage "github.com/grafana/grafana/pkg/apis/userstorage/v0alpha1"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -76,10 +77,6 @@ func (b *UserStorageAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserve
 
 func (b *UserStorageAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 	return userstorage.GetOpenAPIDefinitions
-}
-
-func (b *UserStorageAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
-	return nil
 }
 
 func (b *UserStorageAPIBuilder) GetAuthorizer() authorizer.Authorizer {

--- a/pkg/registry/apis/userstorage/register.go
+++ b/pkg/registry/apis/userstorage/register.go
@@ -3,6 +3,7 @@ package userstorage
 import (
 	"context"
 
+	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -11,11 +12,8 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	userstorage "github.com/grafana/grafana/pkg/apis/userstorage/v0alpha1"
-
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )

--- a/pkg/services/apiserver/builder/common.go
+++ b/pkg/services/apiserver/builder/common.go
@@ -39,9 +39,6 @@ type APIGroupBuilder interface {
 	// Get OpenAPI definitions
 	GetOpenAPIDefinitions() common.GetOpenAPIDefinitions
 
-	// Get the API routes for each version
-	GetAPIRoutes() *APIRoutes
-
 	// Optionally add an authorization hook
 	// Standard namespace checking will happen before this is called, specifically
 	// the namespace must matches an org|stack that the user belongs to
@@ -58,6 +55,11 @@ type APIGroupValidation interface {
 	// Validate makes an admission decision based on the request attributes.  It is NOT allowed to mutate
 	// Context is used only for timeout/deadline/cancellation and tracing information.
 	Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) (err error)
+}
+
+type APIGroupRouteProvider interface {
+	// Support direct HTTP routes from an APIGroup
+	GetAPIRoutes() *APIRoutes
 }
 
 type APIGroupOptions struct {

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -9,7 +9,6 @@ import (
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
 
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
-
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 )
 

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -4,10 +4,11 @@ import (
 	"maps"
 	"strings"
 
-	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 	common "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 	spec "k8s.io/kube-openapi/pkg/validation/spec"
+
+	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
 
 	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 )
@@ -48,7 +49,6 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 			return s, nil
 		}
 		for _, b := range builders {
-			routes := b.GetAPIRoutes()
 			gv := b.GetGroupVersion()
 			prefix := "/apis/" + gv.String() + "/"
 			if s.Paths.Paths[prefix] != nil {
@@ -66,19 +66,22 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 					Paths:        s.Paths,
 				}
 
-				if routes == nil {
-					routes = &APIRoutes{}
-				}
+				// Optionally include raw http handlers
+				provider, ok := b.(APIGroupRouteProvider)
+				if ok && provider != nil {
+					routes := provider.GetAPIRoutes()
+					if routes != nil {
+						for _, route := range routes.Root {
+							copy.Paths.Paths[prefix+route.Path] = &spec3.Path{
+								PathProps: *route.Spec,
+							}
+						}
 
-				for _, route := range routes.Root {
-					copy.Paths.Paths[prefix+route.Path] = &spec3.Path{
-						PathProps: *route.Spec,
-					}
-				}
-
-				for _, route := range routes.Namespace {
-					copy.Paths.Paths[prefix+"namespaces/{namespace}/"+route.Path] = &spec3.Path{
-						PathProps: *route.Spec,
+						for _, route := range routes.Namespace {
+							copy.Paths.Paths[prefix+"namespaces/{namespace}/"+route.Path] = &spec3.Path{
+								PathProps: *route.Spec,
+							}
+						}
 					}
 				}
 

--- a/pkg/services/apiserver/builder/request_handler.go
+++ b/pkg/services/apiserver/builder/request_handler.go
@@ -18,7 +18,12 @@ func GetCustomRoutesHandler(delegateHandler http.Handler, restConfig *restclient
 	router := mux.NewRouter()
 
 	for _, builder := range builders {
-		routes := builder.GetAPIRoutes()
+		provider, ok := builder.(APIGroupRouteProvider)
+		if !ok || provider == nil {
+			continue
+		}
+
+		routes := provider.GetAPIRoutes()
 		if routes == nil {
 			continue
 		}

--- a/pkg/services/apiserver/builder/runner/builder.go
+++ b/pkg/services/apiserver/builder/runner/builder.go
@@ -1,8 +1,6 @@
 package runner
 
 import (
-	"github.com/grafana/grafana-app-sdk/app"
-	"github.com/grafana/grafana-app-sdk/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -10,6 +8,8 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kube-openapi/pkg/common"
 
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -114,12 +114,6 @@ func (b *appBuilder) getStorage(resourceInfo utils.ResourceInfo, opts builder.AP
 // GetOpenAPIDefinitions implements APIGroupBuilder.GetOpenAPIDefinitions
 func (b *appBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions {
 	return b.config.OpenAPIDefGetter
-}
-
-// GetAPIRoutes implements APIGroupBuilder.GetAPIRoutes
-func (b *appBuilder) GetAPIRoutes() *builder.APIRoutes {
-	// TODO: The API routes are not yet exposed by the app.App interface.
-	return nil
 }
 
 // GetAuthorizer implements APIGroupBuilder.GetAuthorizer


### PR DESCRIPTION
This PR removes:
```
GetAPIRoutes() *APIRoutes
```
from the root builder interface and lets builders optionally implement them (should be rare!)