### PR TITLE
Chore: Add `no-duplicate-case` eslint rule and fix violations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,6 +85,7 @@ module.exports = [
     },
 
     rules: {
+      'no-duplicate-case': 'error',
       '@grafana/no-border-radius-literal': 'error',
       '@grafana/no-unreduced-motion': 'error',
       'react/prop-types': 'off',

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -153,8 +153,6 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.slo.title', 'SLO');
     case 'plugin-page-k6-app':
       return t('nav.k6.title', 'Performance');
-    case 'monitoring':
-      return t('nav.observability.title', 'Observability');
     case 'plugin-page-grafana-k8s-app':
       return t('nav.kubernetes.title', 'Kubernetes');
     case 'plugin-page-grafana-dbo11y-app':

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -44,6 +44,7 @@ function useExpressionsCache() {
       // We want to use the same value for Reduce, Resample and Threshold
       case ExpressionQueryType.reduce:
       case ExpressionQueryType.resample:
+      case ExpressionQueryType.threshold:
         expressionCache.current.reduce = value;
         expressionCache.current.resample = value;
         expressionCache.current.threshold = value;

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -44,7 +44,6 @@ function useExpressionsCache() {
       // We want to use the same value for Reduce, Resample and Threshold
       case ExpressionQueryType.reduce:
       case ExpressionQueryType.resample:
-      case ExpressionQueryType.resample:
         expressionCache.current.reduce = value;
         expressionCache.current.resample = value;
         expressionCache.current.threshold = value;

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -82,7 +82,6 @@ function parseKeyValuePairs(raw: string): Record<string, string> {
       case `'`:
       // whitespace
       case ` `:
-      case `\n`:
       case `\t`:
       case `\r`:
       case `\n`:

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2201,9 +2201,6 @@
     "new-folder": {
       "title": "New folder"
     },
-    "observability": {
-      "title": "Observability"
-    },
     "oncall": {
       "title": "OnCall"
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -2201,9 +2201,6 @@
     "new-folder": {
       "title": "Ńęŵ ƒőľđęř"
     },
-    "observability": {
-      "title": "Øþşęřväþįľįŧy"
-    },
     "oncall": {
       "title": "ØŉCäľľ"
     },


### PR DESCRIPTION
**What is this feature?**
Adds `no-duplicate-case` rule and fixes problems

**Why do we need this feature?**
In Vite investigation (https://github.com/grafana/grafana/pull/80664), the build warns about duplicated switch cases. This is something we should fix, and can sort separately to the Vite migration anyway

**Who is this feature for?**
UI devs
