### PR TITLE
OAuth: Add configurable login lookup for existing users

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -614,6 +614,9 @@ azure_auth_enabled = false
 # Use email lookup in addition to the unique ID provided by the IdP
 oauth_allow_insecure_email_lookup = false
 
+# Use login lookup in addition to the unique ID provided by the IdP
+oauth_allow_insecure_login_lookup = false
+
 # Set to true to include id of identity as a response header
 id_response_header_enabled = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -618,6 +618,9 @@
 # Use email lookup in addition to the unique ID provided by the IdP
 ;oauth_allow_insecure_email_lookup = false
 
+# Use login lookup in addition to the unique ID provided by the IdP
+;oauth_allow_insecure_login_lookup = false
+
 # Set to true to include id of identity as a response header
 ;id_response_header_enabled = false
 

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -174,6 +174,10 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 	if allowInsecureEmailLookup {
 		lookupParams.Email = &userInfo.Email
 	}
+	allowInsecureLoginLookup := c.settingsProviderSvc.KeyValue("auth", "oauth_allow_insecure_login_lookup").MustBool(false)
+	if allowInsecureLoginLookup {
+		lookupParams.Login = &userInfo.Login
+	}
 
 	return &authn.Identity{
 		Login:           userInfo.Login,


### PR DESCRIPTION
# OAuth: Add configurable login lookup for existing users

## What is this feature?
This PR adds support for looking up existing users by their login attribute during OAuth authentication, similar to LDAP's functionality. It introduces a new configuration option `oauth_allow_insecure_login_lookup` that enables finding pre-created users by their login identifier during OAuth authentication.

## Why do we need this feature?
Currently, OAuth authentication only supports looking up existing users by email (via `oauth_allow_insecure_email_lookup`), while LDAP supports both email and login attributes. This limitation creates problems in environments where:

1. Users are pre-created through automation before their first login
2. Login (username) is used as the primary unique identifier across the platform
3. User data needs to be synced when they authenticate via OAuth

The current behavior leads to conflicts when:
- A user is pre-created in Grafana
- The user attempts OAuth login
- OAuth tries to create a new user instead of finding and updating the existing one
- The operation fails due to username conflicts

## Who is this feature for?
This feature is for organizations that:
- Are migrating from LDAP to OAuth authentication
- Use automation to pre-create Grafana users
- Require login/username as their primary unique identifier
- Need to maintain user identity consistency across their platform

## Which issue(s) does this PR fix?
<!-- Add issue number when available -->
Fixes #

## Special notes for your reviewer
Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

The implementation follows the same pattern as the existing `oauth_allow_insecure_email_lookup` option to maintain consistency and make it familiar for administrators.