### PR TITLE
Logs: update panel state when clearing displayed fields

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -625,8 +625,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   );
 
   const clearDetectedFields = useCallback(() => {
+    updatePanelState({
+      ...panelState?.logs,
+      displayedFields: [],
+    });
     setDisplayedFields([]);
-  }, []);
+  }, [panelState?.logs, updatePanelState]);
 
   const onCloseCallbackRef = useRef<() => void>(() => {});
 


### PR DESCRIPTION
Missing update of panel state after clearing displayed fields. Without this change, the last displayed fields are sticky when the user refreshes after clicking "show original line".