### PR TITLE
POC: Schemav2 api unify resources

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -465,18 +465,17 @@ export const defaultVizConfigKind = (): VizConfigKind => ({
 export interface AnnotationQuerySpec {
 	datasource?: DataSourceRef;
 	query: DataQueryKind;
-	builtIn?: boolean;
 	enable: boolean;
-	filter: AnnotationPanelFilter;
 	hide: boolean;
 	iconColor: string;
 	name: string;
+	builtIn?: boolean;
+	filter?: AnnotationPanelFilter;
 }
 
 export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
 	query: defaultDataQueryKind(),
 	enable: false,
-	filter: defaultAnnotationPanelFilter(),
 	hide: false,
 	iconColor: "",
 	name: "",

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -958,7 +958,6 @@ export interface DatasourceVariableSpec {
 	refresh: VariableRefresh;
 	regex: string;
 	current: VariableOption;
-	defaultOptionEnabled: boolean;
 	options: VariableOption[];
 	multi: boolean;
 	includeAll: boolean;
@@ -975,7 +974,6 @@ export const defaultDatasourceVariableSpec = (): DatasourceVariableSpec => ({
 	refresh: "never",
 	regex: "",
 	current: { text: "", value: "", },
-	defaultOptionEnabled: false,
 	options: [],
 	multi: false,
 	includeAll: false,

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -364,12 +364,12 @@ VizConfigKind: {
 AnnotationQuerySpec: {
   datasource?: DataSourceRef
   query: DataQueryKind
-  builtIn?: bool
   enable: bool
-  filter: AnnotationPanelFilter
   hide: bool
   iconColor: string
   name: string
+  builtIn?: bool
+  filter?: AnnotationPanelFilter
 }
 
 AnnotationQueryKind: {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -663,7 +663,6 @@ DatasourceVariableSpec: {
     text: ""
     value: ""
   }
-  defaultOptionEnabled: bool | *false
   options: [...VariableOption] | *[]
   multi: bool | *false
   includeAll: bool | *false

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
@@ -281,7 +281,6 @@ export const handyTestingSchema: DashboardV2Spec = {
           text: 'text1',
           value: 'value1',
         },
-        defaultOptionEnabled: true,
         description: 'A datasource variable',
         hide: 'dontHide',
         includeAll: false,

--- a/public/app/core/components/Select/DashboardPicker.tsx
+++ b/public/app/core/components/Select/DashboardPicker.tsx
@@ -6,7 +6,6 @@ import { AsyncSelectProps, AsyncSelect } from '@grafana/ui';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { AnnoKeyFolder, AnnoKeyFolderTitle } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
-import { isDashboardResource } from 'app/features/dashboard/api/utils';
 import { DashboardSearchItem } from 'app/features/search/types';
 import { DashboardDTO } from 'app/types';
 
@@ -59,30 +58,15 @@ export const DashboardPicker = ({
       // We need to fetch dashboard information.
       const res = await getDashboardAPI().getDashboardDTO(value);
 
-
-      if (isDashboardResource(res)) {
-        setCurrent({
-          value: {
-            uid: res.metadata.name,
-            title: res.spec.title,
-            folderTitle: res.metadata.annotations?.[AnnoKeyFolderTitle],
-            folderUid: res.metadata.annotations?.[AnnoKeyFolder],
-          },
-          label: formatLabel(res.metadata.annotations?.[AnnoKeyFolder], res.spec.title),
-        });
-      } else {
-        if (res.dashboard) {
-          setCurrent({
-            value: {
-              uid: res.dashboard.uid,
-              title: res.dashboard.title,
-              folderTitle: res.meta.folderTitle,
-              folderUid: res.meta.folderUid,
-            },
-            label: formatLabel(res.meta?.folderTitle, res.dashboard.title),
-          });
-        }
-      }
+      setCurrent({
+        value: {
+          uid: res.metadata.name,
+          title: res.spec.title,
+          folderTitle: res.metadata.annotations?.[AnnoKeyFolderTitle],
+          folderUid: res.metadata.annotations?.[AnnoKeyFolder],
+        },
+        label: formatLabel(res.metadata.annotations?.[AnnoKeyFolderTitle], res.spec.title),
+      });
     })();
     // we don't need to rerun this effect every time `current` changes
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -519,7 +519,7 @@ export class BackendSrv implements BackendService {
     const dashboard = await getDashboardAPI().getDashboardDTO(uid);
 
     // Since we have a deprecated method here, let's transoform the response to the format that the consumers are using (v1 schema)
-    return ResponseTransformers.transformV2ToV1(dashboard);
+    return ResponseTransformers.transformDashboardWithAccessInfoToDashboardDTO(dashboard);
   }
 
   validateDashboard(dashboard: DashboardModel): Promise<ValidateDashboardResponse> {

--- a/public/app/core/services/impression_srv.ts
+++ b/public/app/core/services/impression_srv.ts
@@ -4,21 +4,21 @@ import { getBackendSrv } from '@grafana/runtime';
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
 import config from 'app/core/config';
 import store from 'app/core/store';
+import { AnnoKeyDashboardNotFound } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
-import { isDashboardResource } from 'app/features/dashboard/api/utils';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO } from 'app/types';
 
 export class ImpressionSrv {
   constructor() {}
 
-  addDashboardImpression(dashboard: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>) {
-    const shouldAddImpression = isDashboardResource(dashboard) || dashboard.meta.dashboardNotFound !== true;
+  addDashboardImpression(dashboard:  DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>) {
+    const shouldAddImpression =  dashboard.metadata.annotations?.[AnnoKeyDashboardNotFound] !== true;
 
     if (!shouldAddImpression) {
       return;
     }
 
-    const dashboardUID = isDashboardResource(dashboard) ? dashboard.metadata.name : dashboard.dashboard.uid;
+    const dashboardUID = dashboard.metadata.name;
 
     const impressionsKey = this.impressionKey();
     let impressions: string[] = [];

--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -38,6 +38,7 @@ export const AnnoKeyFolderId = 'grafana.app/folderId';
 export const AnnoKeyFolderUrl = 'grafana.app/folderUrl';
 export const AnnoKeyMessage = 'grafana.app/message';
 export const AnnoKeySlug = 'grafana.app/slug';
+export const AnnoKeyRedirectUri = 'grafana.app/redirectUri'; // TODO add to the response
 
 // Identify where values came from
 export const AnnoKeyRepoName = 'grafana.app/repoName';
@@ -46,6 +47,10 @@ export const AnnoKeyRepoHash = 'grafana.app/repoHash';
 export const AnnoKeyRepoTimestamp = 'grafana.app/repoTimestamp';
 
 export const AnnoKeySavedFromUI = 'grafana.app/saved-from-ui';
+export const AnnoKeyIsFolder = 'grafana.app/isFolder';
+export const AnnoKeyIsSnapshot = 'grafana.app/isSnapshot';
+export const AnnoKeyDashboardNotFound = 'grafana.app/dashboardNotFound';
+export const AnnoKeyIsEmbedded = 'grafana.app/isEmbedded';
 
 // Annotations provided by the API
 type GrafanaAnnotations = {
@@ -54,6 +59,7 @@ type GrafanaAnnotations = {
   [AnnoKeyUpdatedBy]?: string;
   [AnnoKeyFolder]?: string;
   [AnnoKeySlug]?: string;
+  [AnnoKeyRedirectUri]?: string;
 
   [AnnoKeyRepoName]?: string;
   [AnnoKeyRepoPath]?: string;
@@ -64,11 +70,15 @@ type GrafanaAnnotations = {
 // Annotations provided by the front-end client
 type GrafanaClientAnnotations = {
   [AnnoKeyMessage]?: string;
+  [AnnoKeyIsFolder]?: boolean;
   [AnnoKeyFolderTitle]?: string;
   [AnnoKeyFolderUrl]?: string;
   [AnnoKeyFolderId]?: number;
   [AnnoKeyFolderId]?: number;
   [AnnoKeySavedFromUI]?: string;
+  [AnnoKeyIsSnapshot]?: boolean;
+  [AnnoKeyDashboardNotFound]?: boolean;
+  [AnnoKeyIsEmbedded]?: boolean;
 };
 
 export interface Resource<T = object, K = string> extends TypeMeta<K> {

--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -50,14 +50,16 @@ export const AnnoKeySavedFromUI = 'grafana.app/saved-from-ui';
 export const AnnoKeyIsFolder = 'grafana.app/isFolder';
 export const AnnoKeyIsSnapshot = 'grafana.app/isSnapshot';
 export const AnnoKeyDashboardNotFound = 'grafana.app/dashboardNotFound';
+export const AnnoKeyPublicDashboardEnabled = 'grafana.app/publicDashboardEnabled';
 export const AnnoKeyIsEmbedded = 'grafana.app/isEmbedded';
+export const AnnoKeyFromScript = 'grafana.app/fromScript';
 
 // Annotations provided by the API
 type GrafanaAnnotations = {
   [AnnoKeyCreatedBy]?: string;
   [AnnoKeyUpdatedTimestamp]?: string;
   [AnnoKeyUpdatedBy]?: string;
-  [AnnoKeyFolder]?: string;
+  [AnnoKeyFolder]?: string; 
   [AnnoKeySlug]?: string;
   [AnnoKeyRedirectUri]?: string;
 
@@ -78,7 +80,9 @@ type GrafanaClientAnnotations = {
   [AnnoKeySavedFromUI]?: string;
   [AnnoKeyIsSnapshot]?: boolean;
   [AnnoKeyDashboardNotFound]?: boolean;
+  [AnnoKeyPublicDashboardEnabled]?: boolean;
   [AnnoKeyIsEmbedded]?: boolean;
+  [AnnoKeyFromScript]?: boolean;
 };
 
 export interface Resource<T = object, K = string> extends TypeMeta<K> {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -25,6 +25,7 @@ import { refetchChildren, refreshParents } from '../state';
 import { DashboardTreeSelection } from '../types';
 
 import { PAGE_SIZE } from './services';
+import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 
 interface RequestOptions extends BackendSrvRequest {
   manageError?: (err: unknown) => { error: unknown };
@@ -263,12 +264,17 @@ export const browseDashboardsAPI = createApi({
         for (const dashboardUID of selectedDashboards) {
           const dashDto = await getDashboardAPI().getDashboardDTO(dashboardUID);
 
+          // TODO[schema v2]: save commmand should accept either v1 or v2 
+          if(isDashboardV2Spec(dashDto.spec)) {
+            throw new Error('schema v2 not supported');
+          }
+
           const options: SaveDashboardCommand = {
             folderUid: destinationUID,
             overwrite: false,
             message: '',
             // TODO[schema v2]: save commmand should accept either v1 or v2
-            dashboard: ResponseTransformers.transformV2ToV1(dashDto).dashboard,
+            dashboard: ResponseTransformers.transformDashboardWithAccessInfoToDashboardDTO(dashDto).dashboard,
           };
 
           await getDashboardAPI().saveDashboard(options);

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -77,7 +77,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
     let scene: SceneObject | undefined = undefined;
     if (snapshot) {
       try {
-        const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
+        const dash = transformSaveModelToScene(snapshot, { isEmbedded: true } );
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
         console.log('Error creating scene:', ex);

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -16,7 +16,16 @@ describe('DashboardScenePageStateManager', () => {
 
   describe('when fetching/loading a dashboard', () => {
     it('should call loader from server if the dashboard is not cached', async () => {
-      const loadDashboardMock = setupLoadDashboardMock({ dashboard: { uid: 'fake-dash', editable: true }, meta: {} });
+      // { dashboard: { uid: 'fake-dash', editable: true }, meta: {} }
+      const loadDashboardMock = setupLoadDashboardMock({
+        metadata: {
+          name: 'fake-dash',
+        },
+        spec: {
+          editable: true,
+        },
+        access: {},
+      });
 
       const loader = new DashboardScenePageStateManager({});
       await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
@@ -29,7 +38,7 @@ describe('DashboardScenePageStateManager', () => {
     });
 
     it("should error when the dashboard doesn't exist", async () => {
-      setupLoadDashboardMock({ dashboard: undefined, meta: {} });
+      setupLoadDashboardMock(undefined);
 
       const loader = new DashboardScenePageStateManager({});
       await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
@@ -40,14 +49,32 @@ describe('DashboardScenePageStateManager', () => {
     });
 
     it('should clear current dashboard while loading next', async () => {
-      setupLoadDashboardMock({ dashboard: { uid: 'fake-dash', editable: true }, meta: {} });
+      setupLoadDashboardMock({
+        metadata: {
+          name: 'fake-dash',
+        },
+        spec: {
+          editable: true,
+          panels: [],
+        },
+        access: {},
+      });
 
       const loader = new DashboardScenePageStateManager({});
       await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
 
       expect(loader.state.dashboard).toBeDefined();
 
-      setupLoadDashboardMock({ dashboard: { uid: 'fake-dash2', editable: true }, meta: {} });
+      setupLoadDashboardMock({
+        metadata: {
+          name: 'fake-dash-2',
+        },
+        spec: {
+          editable: true,
+          panels: [],
+        },
+        access: {},
+      });
 
       loader.loadDashboard({ uid: 'fake-dash2', route: DashboardRoutes.Normal });
 
@@ -56,7 +83,16 @@ describe('DashboardScenePageStateManager', () => {
     });
 
     it('should initialize the dashboard scene with the loaded dashboard', async () => {
-      setupLoadDashboardMock({ dashboard: { uid: 'fake-dash' }, meta: {} });
+      setupLoadDashboardMock({
+        metadata: {
+          name: 'fake-dash',
+        },
+        spec: {
+          editable: true,
+          panels: [],
+        },
+        access: {},
+      });
 
       const loader = new DashboardScenePageStateManager({});
       await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
@@ -67,7 +103,17 @@ describe('DashboardScenePageStateManager', () => {
     });
 
     it('should use DashboardScene creator to initialize the scene', async () => {
-      setupLoadDashboardMock({ dashboard: { uid: 'fake-dash' }, meta: {} });
+      setupLoadDashboardMock({
+        metadata: {
+          name: 'fake-dash',
+        },
+        spec: {
+          editable: true,
+          panels: [],
+        },
+        access: {},
+      });
+
 
       const loader = new DashboardScenePageStateManager({});
       await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
@@ -77,7 +123,17 @@ describe('DashboardScenePageStateManager', () => {
     });
 
     it('should use DashboardScene creator to initialize the snapshot scene', async () => {
-      setupLoadDashboardMock({ dashboard: { uid: 'fake-dash' }, meta: {} });
+      setupLoadDashboardMock({
+        metadata: {
+          name: 'fake-dash',
+        },
+        spec: {
+          editable: true,
+          panels: [],
+        },
+        access: {},
+      });
+
 
       const loader = new DashboardScenePageStateManager({});
       await loader.loadSnapshot('fake-slug');
@@ -137,8 +193,18 @@ describe('DashboardScenePageStateManager', () => {
     });
 
     describe('caching', () => {
-      it('should take scene from cache if it exists', async () => {
-        setupLoadDashboardMock({ dashboard: { uid: 'fake-dash', version: 10 }, meta: {} });
+      it.only('should take scene from cache if it exists', async () => {
+        setupLoadDashboardMock({
+          metadata: {
+            name: 'fake-dash',
+            resourceVersion:'10'
+          },
+          spec: {
+            editable: true,
+            panels: [],
+          },
+          access: {},
+        });
 
         const loader = new DashboardScenePageStateManager({});
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -18,6 +18,7 @@ import { DashboardDTO, DashboardRoutes } from 'app/types';
 import { PanelEditor } from '../panel-edit/PanelEditor';
 import { DashboardScene } from '../scene/DashboardScene';
 import { buildNewDashboardSaveModel } from '../serialization/buildNewDashboardSaveModel';
+import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
@@ -118,6 +119,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
                 ...params.variables,
               }
             : undefined;
+
           rsp = await dashboardLoaderSrv.loadDashboard('db', '', uid, queryParams);
 
           if (route === DashboardRoutes.Embedded) {
@@ -280,8 +282,13 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
         return fromCache;
       }
 
-      // TODO[schema]: handle v2
-      throw new Error('v2 schema handling not implemented');
+      // TODO[schema v2]: handle v2 redirect url
+
+      const scene = transformSaveModelSchemaV2ToScene(rsp);
+      if (options.uid) {
+        this.setSceneCache(options.uid, scene);
+      }
+      return scene;
     } else {
       if (fromCache && fromCache.state.version === rsp?.dashboard.version) {
         return fromCache;

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -184,7 +184,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
       // TODO[schema]: handle v2
     } else {
       if (rsp?.dashboard) {
-        const scene = transformSaveModelToScene(rsp);
+        const scene = transformSaveModelToScene(rsp.dashboard, rsp.meta);
         return scene;
       }
     }
@@ -260,7 +260,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
           this.setState({ isLoading: false, loadError: 'Dashboard not found' });
           return;
         }
-        const scene = transformSaveModelToScene(rsp);
+        const scene = transformSaveModelToScene(rsp.dashboard, rsp.meta);
         this.setSceneCache(options.uid, scene);
         this.setState({ dashboard: scene, isLoading: false, options });
       }
@@ -295,7 +295,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
       }
 
       if (rsp?.dashboard) {
-        const scene = transformSaveModelToScene(rsp);
+        const scene = transformSaveModelToScene(rsp.dashboard, rsp.meta);
 
         // Cache scene only if not coming from Explore, we don't want to cache temporary dashboard
         if (options.uid) {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -40,7 +40,7 @@ const LOAD_SCENE_MEASUREMENT = 'loadDashboardScene';
 export const HOME_DASHBOARD_CACHE_KEY = '__grafana_home_uid__';
 
 interface DashboardCacheEntry {
-  dashboard: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>;
+  dashboard: DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>;
   ts: number;
   cacheKey: string;
 }
@@ -340,7 +340,7 @@ export class DashboardScenePageStateManager extends StateManagerBase<DashboardSc
     });
   }
 
-  public setDashboardCache(cacheKey: string, dashboard: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>) {
+  public setDashboardCache(cacheKey: string, dashboard: DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>) {
     this.dashboardCache = { dashboard, ts: Date.now(), cacheKey };
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -725,7 +725,7 @@ describe('PanelDataQueriesTab', () => {
 });
 
 async function setupScene(panelId: string) {
-  const dashboard = transformSaveModelToScene({ dashboard: testDashboard as unknown as DashboardDataDTO, meta: {} });
+  const dashboard = transformSaveModelToScene(testDashboard as unknown as DashboardDataDTO, {});
   const panel = findVizPanelByKey(dashboard, panelId)!;
 
   const panelEditor = buildPanelEditScene(panel);

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
@@ -168,7 +168,7 @@ describe('PanelDataTransformationsTab', () => {
 });
 
 function setupTabScene(panelId: string) {
-  const scene = transformSaveModelToScene({ dashboard: testDashboard as unknown as DashboardDataDTO, meta: {} });
+  const scene = transformSaveModelToScene(testDashboard as unknown as DashboardDataDTO, {});
   const panel = findVizPanelByKey(scene, panelId)!;
 
   const transformsTab = new PanelDataTransformationsTab({ panelRef: panel.getRef() });

--- a/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelOptionsPane.test.tsx
@@ -88,7 +88,7 @@ describe('PanelOptionsPane', () => {
 });
 
 function setupTest(panelId: string) {
-  const scene = transformSaveModelToScene({ dashboard: testDashboard, meta: {} });
+  const scene = transformSaveModelToScene(testDashboard, {});
   const panel = findVizPanelByKey(scene, panelId)!;
 
   const optionsPane = new PanelOptionsPane({ panelRef: panel.getRef(), listMode: OptionFilter.All, searchQuery: '' });

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -200,16 +200,16 @@ function mockSaveDashboard(options: Partial<MockBackendApiOptions> = {}) {
 let cleanUp = () => {};
 
 function setup() {
-  const dashboard = transformSaveModelToScene({
-    dashboard: {
+  const dashboard = transformSaveModelToScene(
+    {
       title: 'hello',
       uid: 'my-uid',
       schemaVersion: 30,
       panels: [],
       version: 10,
     },
-    meta: {},
-  });
+    {}
+  );
 
   // Clear any data layers
   dashboard.setState({ $data: undefined });

--- a/public/app/features/dashboard-scene/saving/getDashboardChangesFromScene.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChangesFromScene.test.ts
@@ -119,8 +119,8 @@ describe('getDashboardChangesFromScene', () => {
       });
 
       it('Can detect group by static options change', () => {
-        const dashboard = transformSaveModelToScene({
-          dashboard: {
+        const dashboard = transformSaveModelToScene(
+          {
             title: 'hello',
             uid: 'my-uid',
             schemaVersion: 30,
@@ -155,8 +155,8 @@ describe('getDashboardChangesFromScene', () => {
               ],
             },
           },
-          meta: {},
-        });
+          {}
+        );
         const initialSaveModel = transformSceneToSaveModel(dashboard);
         dashboard.setInitialSaveModel(initialSaveModel);
 
@@ -194,8 +194,8 @@ describe('getDashboardChangesFromScene', () => {
           ],
         } as VariableModel;
 
-        const dashboard = transformSaveModelToScene({
-          dashboard: {
+        const dashboard = transformSaveModelToScene(
+          {
             title: 'hello',
             uid: 'my-uid',
             schemaVersion: 30,
@@ -211,8 +211,8 @@ describe('getDashboardChangesFromScene', () => {
               list: [adhocVar],
             },
           },
-          meta: {},
-        });
+          {}
+        );
 
         const initialSaveModel = transformSceneToSaveModel(dashboard);
         dashboard.setInitialSaveModel(initialSaveModel);
@@ -251,8 +251,8 @@ interface ScenarioOptions {
 }
 
 function setup(options: ScenarioOptions = {}) {
-  const dashboard = transformSaveModelToScene({
-    dashboard: {
+  const dashboard = transformSaveModelToScene(
+    {
       title: 'hello',
       uid: 'my-uid',
       schemaVersion: 30,
@@ -277,8 +277,8 @@ function setup(options: ScenarioOptions = {}) {
         ],
       },
     },
-    meta: {},
-  });
+    {}
+  );
 
   const initialSaveModel = transformSceneToSaveModel(dashboard);
   dashboard.setInitialSaveModel(initialSaveModel);

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -374,7 +374,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       dashboard: new DashboardModel(version.data),
       meta: this.state.meta,
     };
-    const dashScene = transformSaveModelToScene(dashboardDTO);
+    const dashScene = transformSaveModelToScene(dashboardDTO.dashboard, dashboardDTO.meta);
     const newState = sceneUtils.cloneSceneObjectState(dashScene.state);
     newState.version = versionRsp.version;
 

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.test.tsx
@@ -35,17 +35,8 @@ jest.mock('@grafana/runtime', () => ({
 
 describe('DashboardSceneRenderer', () => {
   it('should render Not Found notice when dashboard is not found', async () => {
-    const scene = transformSaveModelToScene({
-      meta: {
-        isSnapshot: true,
-        dashboardNotFound: true,
-        canStar: false,
-        canDelete: false,
-        canSave: false,
-        canEdit: false,
-        canShare: false,
-      },
-      dashboard: {
+    const scene = transformSaveModelToScene(
+      {
         title: 'Not found',
         uid: 'uid',
         schemaVersion: 0,
@@ -67,7 +58,16 @@ describe('DashboardSceneRenderer', () => {
           ],
         },
       },
-    });
+      {
+        isSnapshot: true,
+        dashboardNotFound: true,
+        canStar: false,
+        canDelete: false,
+        canSave: false,
+        canEdit: false,
+        canShare: false,
+      }
+    );
 
     render(<scene.Component model={scene} />);
 
@@ -78,9 +78,8 @@ describe('DashboardSceneRenderer', () => {
     const noticeText = /This dashboard depends on Angular/i;
     //enable feature flag angularDeprecationUI
     config.featureToggles.angularDeprecationUI = true;
-    const scene = transformSaveModelToScene({
-      meta: {},
-      dashboard: {
+    const scene = transformSaveModelToScene(
+      {
         title: 'Angular dashboard',
         uid: 'uid',
         schemaVersion: 0,
@@ -117,7 +116,8 @@ describe('DashboardSceneRenderer', () => {
           },
         ],
       },
-    });
+      {}
+    );
 
     render(<scene.Component model={scene} />);
 

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -55,6 +55,7 @@ NavToolbarActions.displayName = 'NavToolbarActions';
  */
 export function ToolbarActions({ dashboard }: Props) {
   const { isEditing, viewPanelScene, isDirty, uid, meta, editview, editPanel, editable } = dashboard.useState();
+
   const { isPlaying } = playlistSrv.useState();
   const [isAddPanelMenuOpen, setIsAddPanelMenuOpen] = useState(false);
 

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -167,8 +167,8 @@ interface SceneOptions {
 }
 
 function buildTestScene(options: SceneOptions) {
-  const scene = transformSaveModelToScene({
-    dashboard: {
+  const scene = transformSaveModelToScene(
+    {
       title: 'hello',
       uid: 'dash-1',
       schemaVersion: 38,
@@ -209,7 +209,7 @@ function buildTestScene(options: SceneOptions) {
           : [],
       },
     },
-    meta: {
+    {
       canEdit: options.dashboardCanEdit,
       annotationsPermissions: {
         dashboard: {
@@ -223,8 +223,8 @@ function buildTestScene(options: SceneOptions) {
           canDelete: options.canDelete ?? false,
         },
       },
-    },
-  });
+    }
+  );
 
   const vizPanel = findVizPanelByKey(scene, 'panel-4')!;
   const context: PanelContext = {

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.test.ts
@@ -60,7 +60,7 @@ jest.mock('@grafana/runtime', () => ({
 describe('buildNewDashboardSaveModelV1', () => {
   it('should not have template variables defined by default', async () => {
     const result = await buildNewDashboardSaveModelV1();
-    expect(result.dashboard.templating).toBeUndefined();
+    expect(result.spec.templating).toBeUndefined();
   });
 
   describe('when featureToggles.newDashboardWithFiltersAndGroupBy is true', () => {
@@ -73,14 +73,14 @@ describe('buildNewDashboardSaveModelV1', () => {
 
     it('should add filter and group by variables if the datasource supports it and is set as default', async () => {
       const result = await buildNewDashboardSaveModelV1();
-      expect(result.dashboard.templating?.list).toHaveLength(2);
-      expect(result.dashboard.templating?.list?.[0].type).toBe('adhoc');
-      expect(result.dashboard.templating?.list?.[1].type).toBe('groupby');
+      expect(result.spec.templating?.list).toHaveLength(2);
+      expect(result.spec.templating?.list?.[0].type).toBe('adhoc');
+      expect(result.spec.templating?.list?.[1].type).toBe('groupby');
     });
 
     it("should set the new dashboard's timezone to the user's timezone", async () => {
       const result = await buildNewDashboardSaveModelV1();
-      expect(result.dashboard.timezone).toEqual('Africa/Abidjan');
+      expect(result.spec.timezone).toEqual('Africa/Abidjan');
     });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -10,13 +10,14 @@ import {
   GroupByVariableKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
+import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
 export async function buildNewDashboardSaveModel(
   urlFolderUid?: string
-): Promise<DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>> {
+): Promise<DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>> {
   if (config.featureToggles.useV2DashboardsAPI) {
     return buildNewDashboardSaveModelV2(urlFolderUid);
   }
@@ -24,7 +25,7 @@ export async function buildNewDashboardSaveModel(
   return buildNewDashboardSaveModelV1(urlFolderUid);
 }
 
-export async function buildNewDashboardSaveModelV1(urlFolderUid?: string): Promise<DashboardDTO> {
+export async function buildNewDashboardSaveModelV1(urlFolderUid?: string) {
   let variablesList = defaultDashboard.templating?.list;
 
   if (config.featureToggles.newDashboardWithFiltersAndGroupBy) {
@@ -81,7 +82,7 @@ export async function buildNewDashboardSaveModelV1(urlFolderUid?: string): Promi
     data.meta.folderUid = urlFolderUid;
   }
 
-  return data;
+  return ResponseTransformers.transformDashboardDTOToDashboardWithAccessInfo(data);
 }
 
 export async function buildNewDashboardSaveModelV2(

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -145,9 +145,7 @@ export async function buildNewDashboardSaveModelV2(
     },
   };
 
-  if (variablesList) {
-    data.spec.variables = variablesList;
-  }
+  data.spec.variables = variablesList;
 
   if (urlFolderUid && data.metadata.annotations) {
     data.metadata.annotations[AnnoKeyFolder] = urlFolderUid;

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -62,6 +62,7 @@ export async function buildNewDashboardSaveModelV1(urlFolderUid?: string) {
       canDelete: false,
       isNew: true,
       folderUid: '',
+      created: '',
     },
     dashboard: {
       ...defaultDashboard,

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -326,7 +326,6 @@ export function sceneVariablesSetToSchemaV2Variables(
           regex: variable.state.regex,
           refresh: 'onDashboardLoad',
           pluginId: variable.state.pluginId,
-          defaultOptionEnabled: !!variable.state.defaultOptionEnabled,
           multi: variable.state.isMulti || false,
           allValue: variable.state.allValue,
           includeAll: variable.state.includeAll || false,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -44,10 +44,19 @@ const defaultDashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
     namespace: 'default',
     labels: {},
     resourceVersion: '',
-    creationTimestamp: '',
+    creationTimestamp: 'creationTs',
+    annotations: {
+      'grafana.app/createdBy': 'user:createBy',
+      'grafana.app/folder': 'folder-uid',
+      'grafana.app/updatedBy': 'user:updatedBy',
+      'grafana.app/updatedTimestamp': 'updatedTs',
+    },
   },
   spec: handyTestingSchema,
-  access: {},
+  access: {
+    url: '/d/abc',
+    slug: 'what-a-dashboard',
+  },
   apiVersion: 'v2',
 };
 
@@ -289,5 +298,121 @@ describe('transformSaveModelSchemaV2ToScene', () => {
     expect(vizPanels.length).toBe(1);
     expect(getQueryRunnerFor(vizPanels[0])?.state.datasource?.type).toBe('mixed');
     expect(getQueryRunnerFor(vizPanels[0])?.state.datasource?.uid).toBe(MIXED_DATASOURCE_NAME);
+  });
+
+  describe('meta', () => {
+    describe('initializes meta based on k8s resource', () => {
+      it('handles undefined access values', () => {
+        const scene = transformSaveModelSchemaV2ToScene(defaultDashboard);
+        // when access metadata undefined
+        expect(scene.state.meta.canShare).toBe(true);
+        expect(scene.state.meta.canSave).toBe(true);
+        expect(scene.state.meta.canStar).toBe(true);
+        expect(scene.state.meta.canEdit).toBe(true);
+        expect(scene.state.meta.canDelete).toBe(true);
+        expect(scene.state.meta.canAdmin).toBe(true);
+        expect(scene.state.meta.annotationsPermissions).toBe(undefined);
+
+        expect(scene.state.meta.url).toBe('/d/abc');
+        expect(scene.state.meta.slug).toBe('what-a-dashboard');
+        expect(scene.state.meta.created).toBe('creationTs');
+        expect(scene.state.meta.createdBy).toBe('user:createBy');
+        expect(scene.state.meta.updated).toBe('updatedTs');
+        expect(scene.state.meta.updatedBy).toBe('user:updatedBy');
+        expect(scene.state.meta.folderUid).toBe('folder-uid');
+      });
+
+      it('handles access metadata values', () => {
+        const dashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
+          ...defaultDashboard,
+          access: {
+            canSave: false,
+            canEdit: false,
+            canDelete: false,
+            canShare: false,
+            canStar: false,
+            canAdmin: false,
+            annotationsPermissions: {
+              dashboard: {
+                canAdd: false,
+                canEdit: false,
+                canDelete: false,
+              },
+              organization: {
+                canAdd: false,
+                canEdit: false,
+                canDelete: false,
+              },
+            },
+          },
+        };
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+
+        expect(scene.state.meta.canShare).toBe(false);
+        expect(scene.state.meta.canSave).toBe(false);
+        expect(scene.state.meta.canStar).toBe(false);
+        expect(scene.state.meta.canEdit).toBe(false);
+        expect(scene.state.meta.canDelete).toBe(false);
+        expect(scene.state.meta.canAdmin).toBe(false);
+        expect(scene.state.meta.annotationsPermissions).toEqual(dashboard.access.annotationsPermissions);
+      });
+    });
+
+    describe('Editable false dashboard', () => {
+      let dashboard: DashboardWithAccessInfo<DashboardV2Spec>;
+
+      beforeEach(() => {
+        dashboard = {
+          ...cloneDeep(defaultDashboard),
+          spec: {
+            ...defaultDashboard.spec,
+            editable: false,
+          },
+        };
+      });
+      it('Should set meta canEdit and canSave to false', () => {
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+        expect(scene.state.meta.canMakeEditable).toBe(true);
+
+        expect(scene.state.meta.canSave).toBe(false);
+        expect(scene.state.meta.canEdit).toBe(false);
+        expect(scene.state.meta.canDelete).toBe(false);
+      });
+
+      describe('when does not have save permissions', () => {
+        it('Should set meta correct meta', () => {
+          dashboard.access.canSave = false;
+          const scene = transformSaveModelSchemaV2ToScene(dashboard);
+          expect(scene.state.meta.canMakeEditable).toBe(false);
+
+          expect(scene.state.meta.canSave).toBe(false);
+          expect(scene.state.meta.canEdit).toBe(false);
+          expect(scene.state.meta.canDelete).toBe(false);
+        });
+      });
+    });
+
+    describe('Editable true dashboard', () => {
+      let dashboard: DashboardWithAccessInfo<DashboardV2Spec>;
+
+      beforeEach(() => {
+        dashboard = {
+          ...cloneDeep(defaultDashboard),
+          spec: {
+            ...defaultDashboard.spec,
+            editable: true,
+          },
+        };
+      });
+      it('Should set meta canEdit and canSave to false', () => {
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+
+        expect(scene.state.meta.canMakeEditable).toBe(false);
+
+        expect(scene.state.meta.canSave).toBe(true);
+        expect(scene.state.meta.canEdit).toBe(true);
+        expect(scene.state.meta.canDelete).toBe(true);
+      });
+    });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -36,6 +36,7 @@ import { validateVariable, validateVizPanel } from '../v2schema/test-helpers';
 
 import { transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
 import { transformCursorSynctoEnum } from './transformToV2TypesUtils';
+import { buildNewDashboardSaveModelV2 } from './buildNewDashboardSaveModel';
 
 const defaultDashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
   kind: 'DashboardWithAccessInfo',
@@ -413,6 +414,15 @@ describe('transformSaveModelSchemaV2ToScene', () => {
         expect(scene.state.meta.canEdit).toBe(true);
         expect(scene.state.meta.canDelete).toBe(true);
       });
+    });
+  });
+
+  describe('When creating a new dashboard', () => {
+    it('should initialize the DashboardScene in edit mode and dirty', async () => {
+      const rsp = await buildNewDashboardSaveModelV2();
+      const scene = transformSaveModelSchemaV2ToScene(rsp);
+      expect(scene.state.isEditing).toBe(undefined);
+      expect(scene.state.isDirty).toBe(false);
     });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -141,6 +141,7 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
     showSettings: Boolean(dto.access.canEdit),
     canMakeEditable: canSave && !isDashboardEditable,
     hasUnsavedFolderChange: false,
+    isNew: dto.access.isNew,
   };
 
   // Ref: DashboardModel.initMeta

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -51,8 +51,15 @@ import {
   QueryVariableKind,
   TextVariableKind,
 } from '@grafana/schema/src/schema/dashboard/v2alpha0/dashboard.gen';
+import {
+  AnnoKeyCreatedBy,
+  AnnoKeyFolder,
+  AnnoKeyUpdatedBy,
+  AnnoKeyUpdatedTimestamp,
+} from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
+import { DashboardMeta } from 'app/types';
 
 import { addPanelsOnLoadBehavior } from '../addToDashboard/addPanelsOnLoadBehavior';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
@@ -111,6 +118,38 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
     });
   });
 
+  const isDashboardEditable = Boolean(dashboard.editable);
+  const canSave = dto.access.canSave !== false;
+
+  const meta: DashboardMeta = {
+    canShare: dto.access.canShare !== false,
+    canSave,
+    canStar: dto.access.canStar !== false,
+    canEdit: dto.access.canEdit !== false,
+    canDelete: dto.access.canDelete !== false,
+    canAdmin: dto.access.canAdmin !== false,
+    url: dto.access.url,
+    slug: dto.access.slug,
+    annotationsPermissions: dto.access.annotationsPermissions,
+    created: metadata.creationTimestamp,
+    createdBy: metadata.annotations?.[AnnoKeyCreatedBy],
+    updated: metadata.annotations?.[AnnoKeyUpdatedTimestamp],
+    updatedBy: metadata.annotations?.[AnnoKeyUpdatedBy],
+    folderUid: metadata.annotations?.[AnnoKeyFolder],
+
+    // UI-only metadata, ref: DashboardModel.initMeta
+    showSettings: Boolean(dto.access.canEdit),
+    canMakeEditable: canSave && !isDashboardEditable,
+    hasUnsavedFolderChange: false,
+  };
+
+  // Ref: DashboardModel.initMeta
+  if (!isDashboardEditable) {
+    meta.canEdit = false;
+    meta.canDelete = false;
+    meta.canSave = false;
+  }
+
   const dashboardScene = new DashboardScene({
     description: dashboard.description,
     editable: dashboard.editable,
@@ -119,7 +158,7 @@ export function transformSaveModelSchemaV2ToScene(dto: DashboardWithAccessInfo<D
     isDirty: false,
     links: dashboard.links,
     // TODO: Combine access and metadata to compose the V1 meta object
-    meta: {},
+    meta,
     tags: dashboard.tags,
     title: dashboard.title,
     uid: metadata.name,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -20,6 +20,7 @@ import {
   RowPanel,
   VariableType,
 } from '@grafana/schema';
+import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { createPanelSaveModel } from 'app/features/dashboard/state/__fixtures__/dashboardFixtures';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard';
@@ -173,7 +174,8 @@ describe('transformSaveModelToScene', () => {
   describe('When creating a new dashboard', () => {
     it('should initialize the DashboardScene in edit mode and dirty', async () => {
       const rsp = await buildNewDashboardSaveModelV1();
-      const scene = transformSaveModelToScene(rsp.dashboard, rsp.meta);
+
+      const scene = transformSaveModelToScene(rsp.spec, ResponseTransformers.getDashboardMeta(rsp));
       expect(scene.state.isEditing).toBe(undefined);
       expect(scene.state.isDirty).toBe(false);
     });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -173,7 +173,7 @@ describe('transformSaveModelToScene', () => {
   describe('When creating a new dashboard', () => {
     it('should initialize the DashboardScene in edit mode and dirty', async () => {
       const rsp = await buildNewDashboardSaveModelV1();
-      const scene = transformSaveModelToScene(rsp);
+      const scene = transformSaveModelToScene(rsp.dashboard, rsp.meta);
       expect(scene.state.isEditing).toBe(undefined);
       expect(scene.state.isDirty).toBe(false);
     });
@@ -782,10 +782,7 @@ describe('transformSaveModelToScene', () => {
 
   describe('Repeating rows', () => {
     it('Should build correct scene model', () => {
-      const scene = transformSaveModelToScene({
-        dashboard: repeatingRowsAndPanelsDashboardJson as DashboardDataDTO,
-        meta: {},
-      });
+      const scene = transformSaveModelToScene(repeatingRowsAndPanelsDashboardJson as DashboardDataDTO, {});
 
       const layout = scene.state.body as DefaultGridLayoutManager;
       const body = layout.state.grid;
@@ -803,7 +800,7 @@ describe('transformSaveModelToScene', () => {
 
   describe('Annotation queries', () => {
     it('Should build correct scene model', () => {
-      const scene = transformSaveModelToScene({ dashboard: dashboard_to_load1 as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboard_to_load1 as DashboardDataDTO, {});
 
       expect(scene.state.$data).toBeInstanceOf(DashboardDataLayerSet);
       expect(scene.state.controls!.state.variableControls[1]).toBeInstanceOf(SceneDataLayerControls);
@@ -831,7 +828,7 @@ describe('transformSaveModelToScene', () => {
   describe('Alerting data layer', () => {
     it('Should add alert states data layer if unified alerting enabled', () => {
       config.unifiedAlertingEnabled = true;
-      const scene = transformSaveModelToScene({ dashboard: dashboard_to_load1 as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboard_to_load1 as DashboardDataDTO, {});
 
       expect(scene.state.$data).toBeInstanceOf(DashboardDataLayerSet);
       expect(scene.state.controls!.state.variableControls[1]).toBeInstanceOf(SceneDataLayerControls);
@@ -844,7 +841,7 @@ describe('transformSaveModelToScene', () => {
       config.unifiedAlertingEnabled = false;
       const dashboard = { ...dashboard_to_load1 } as unknown as DashboardDataDTO;
       dashboard.panels![0].alert = {};
-      const scene = transformSaveModelToScene({ dashboard: dashboard_to_load1 as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboard_to_load1 as DashboardDataDTO, {});
 
       expect(scene.state.$data).toBeInstanceOf(DashboardDataLayerSet);
       expect(scene.state.controls!.state.variableControls[1]).toBeInstanceOf(SceneDataLayerControls);

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -21,7 +21,7 @@ import {
   UserActionEvent,
 } from '@grafana/scenes';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
-import { DashboardDTO, DashboardDataDTO } from 'app/types';
+import {  DashboardDataDTO, DashboardMeta } from 'app/types';
 
 import { addPanelsOnLoadBehavior } from '../addToDashboard/addPanelsOnLoadBehavior';
 import { AlertStatesDataLayer } from '../scene/AlertStatesDataLayer';
@@ -62,13 +62,13 @@ export interface SaveModelToSceneOptions {
   isEmbedded?: boolean;
 }
 
-export function transformSaveModelToScene(rsp: DashboardDTO): DashboardScene {
+export function transformSaveModelToScene(dashboard: DashboardDataDTO, meta: DashboardMeta): DashboardScene {
   // Just to have migrations run
-  const oldModel = new DashboardModel(rsp.dashboard, rsp.meta);
+  const oldModel = new DashboardModel(dashboard, meta);
 
-  const scene = createDashboardSceneFromDashboardModel(oldModel, rsp.dashboard);
+  const scene = createDashboardSceneFromDashboardModel(oldModel, dashboard);
   // TODO: refactor createDashboardSceneFromDashboardModel to work on Dashboard schema model
-  scene.setInitialSaveModel(rsp.dashboard);
+  scene.setInitialSaveModel(dashboard);
 
   return scene;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts
@@ -185,7 +185,7 @@ describe('transformSceneToSaveModel', () => {
         },
         links: [{ ...NEW_LINK, title: 'Link 1' }],
       };
-      const scene = transformSaveModelToScene({ dashboard: dashboardWithCustomSettings as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboardWithCustomSettings as DashboardDataDTO, {});
       const saveModel = transformSceneToSaveModel(scene);
 
       expect(saveModel).toMatchSnapshot();
@@ -194,7 +194,7 @@ describe('transformSceneToSaveModel', () => {
 
   describe('Given a simple scene with variables', () => {
     it('Should transform back to persisted model', () => {
-      const scene = transformSaveModelToScene({ dashboard: dashboard_to_load1 as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboard_to_load1 as DashboardDataDTO, {});
       const saveModel = transformSceneToSaveModel(scene);
 
       expect(saveModel).toMatchSnapshot();
@@ -203,10 +203,7 @@ describe('transformSceneToSaveModel', () => {
 
   describe('Given a scene with rows', () => {
     it('Should transform back to persisted model', () => {
-      const scene = transformSaveModelToScene({
-        dashboard: repeatingRowsAndPanelsDashboardJson as DashboardDataDTO,
-        meta: {},
-      });
+      const scene = transformSaveModelToScene(repeatingRowsAndPanelsDashboardJson as DashboardDataDTO, {});
 
       const saveModel = transformSceneToSaveModel(scene);
 
@@ -218,10 +215,7 @@ describe('transformSceneToSaveModel', () => {
     });
 
     it('Should remove repeated rows in save model', () => {
-      const scene = transformSaveModelToScene({
-        dashboard: repeatingRowsAndPanelsDashboardJson as DashboardDataDTO,
-        meta: {},
-      });
+      const scene = transformSaveModelToScene(repeatingRowsAndPanelsDashboardJson as DashboardDataDTO, {});
 
       const variable = scene.state.$variables?.state.variables[0] as MultiValueVariable;
       variable.changeValueTo(['a', 'b', 'c']);
@@ -427,7 +421,7 @@ describe('transformSceneToSaveModel', () => {
 
   describe('Annotations', () => {
     it('should transform annotations to save model', () => {
-      const scene = transformSaveModelToScene({ dashboard: dashboard_to_load1 as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboard_to_load1 as DashboardDataDTO, {});
       const saveModel = transformSceneToSaveModel(scene);
 
       expect(saveModel.annotations?.list?.length).toBe(4);
@@ -435,7 +429,7 @@ describe('transformSceneToSaveModel', () => {
     });
 
     it('should transform annotations to save model after state changes', () => {
-      const scene = transformSaveModelToScene({ dashboard: dashboard_to_load1 as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(dashboard_to_load1 as DashboardDataDTO, {});
 
       const layers = (scene.state.$data as DashboardDataLayerSet)?.state.annotationLayers;
       const enabledLayer = layers[1];
@@ -678,7 +672,7 @@ describe('transformSceneToSaveModel', () => {
     });
 
     it('attaches snapshot data to panels using Grafana snapshot query', async () => {
-      const scene = transformSaveModelToScene({ dashboard: snapshotableDashboardJson as DashboardDataDTO, meta: {} });
+      const scene = transformSaveModelToScene(snapshotableDashboardJson as DashboardDataDTO, {});
 
       activateFullSceneTree(scene);
 
@@ -733,10 +727,7 @@ describe('transformSceneToSaveModel', () => {
     });
 
     it('handles basic rows', async () => {
-      const scene = transformSaveModelToScene({
-        dashboard: snapshotableWithRowsDashboardJson as DashboardDataDTO,
-        meta: {},
-      });
+      const scene = transformSaveModelToScene(snapshotableWithRowsDashboardJson as DashboardDataDTO, {});
 
       activateFullSceneTree(scene);
 
@@ -943,7 +934,7 @@ describe('transformSceneToSaveModel', () => {
       let snapshot: Dashboard = {} as Dashboard;
 
       beforeEach(() => {
-        const scene = transformSaveModelToScene({ dashboard: snapshotableDashboardJson as DashboardDataDTO, meta: {} });
+        const scene = transformSaveModelToScene(snapshotableDashboardJson as DashboardDataDTO, {});
         activateFullSceneTree(scene);
         snapshot = transformSceneToSaveModel(scene, true);
       });
@@ -1007,7 +998,7 @@ describe('transformSceneToSaveModel', () => {
       });
 
       it('should remove links', async () => {
-        const scene = transformSaveModelToScene({ dashboard: snapshotableDashboardJson as DashboardDataDTO, meta: {} });
+        const scene = transformSaveModelToScene(snapshotableDashboardJson as DashboardDataDTO, {});
         activateFullSceneTree(scene);
         const snapshot = transformSceneToSaveModel(scene, true);
         expect(snapshot.links?.length).toBe(1);
@@ -1019,10 +1010,7 @@ describe('transformSceneToSaveModel', () => {
 
   describe('Given a scene with repeated panels and non-repeated panels', () => {
     it('should save repeated panels itemHeight as height', () => {
-      const scene = transformSaveModelToScene({
-        dashboard: repeatingRowsAndPanelsDashboardJson as DashboardDataDTO,
-        meta: {},
-      });
+      const scene = transformSaveModelToScene(repeatingRowsAndPanelsDashboardJson as DashboardDataDTO, {});
       const gridItem = sceneGraph.findByKey(scene, 'grid-item-2') as DashboardGridItem;
       expect(gridItem).toBeInstanceOf(DashboardGridItem);
       expect(gridItem.state.height).toBe(10);
@@ -1035,10 +1023,7 @@ describe('transformSceneToSaveModel', () => {
     });
 
     it('should not save non-repeated panels itemHeight as height', () => {
-      const scene = transformSaveModelToScene({
-        dashboard: repeatingRowsAndPanelsDashboardJson as DashboardDataDTO,
-        meta: {},
-      });
+      const scene = transformSaveModelToScene(repeatingRowsAndPanelsDashboardJson as DashboardDataDTO, {});
       const gridItem = sceneGraph.findByKey(scene, 'grid-item-15') as DashboardGridItem;
       expect(gridItem).toBeInstanceOf(DashboardGridItem);
       expect(gridItem.state.height).toBe(2);

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -36,7 +36,6 @@ import {
   GroupByVariableKind,
   AdhocVariableKind,
   AnnotationQueryKind,
-  defaultAnnotationPanelFilter,
   defaultAnnotationQuerySpec,
 } from '../../../../../packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
@@ -405,7 +404,7 @@ function getAnnotations(state: DashboardSceneState): AnnotationQueryKind[] {
         },
         enable: Boolean(layer.state.isEnabled),
         hide: Boolean(layer.state.isHidden),
-        filter: layer.state.query.filter ?? defaultAnnotationPanelFilter(),
+        filter: layer.state.query.filter,
         iconColor: layer.state.query.iconColor,
         builtIn:
           layer.state.query.builtIn === undefined

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -3,7 +3,9 @@ import {
   VariableRefresh as VariableRefreshV1,
   VariableSort as VariableSortV1,
   DashboardCursorSync as DashboardCursorSyncV1,
+  DataTopic,
 } from '@grafana/schema';
+import { DataTransformerConfig } from '@grafana/schema/dist/esm/raw/dashboard/x/dashboard_types.gen';
 import {
   DashboardCursorSync,
   defaultDashboardV2Spec,
@@ -66,5 +68,18 @@ export function transformSortVariableToEnum(sort?: VariableSortV1): VariableSort
       return 'numericalDesc';
     default:
       return defaultVariableSort();
+  }
+}
+
+export function transformDataTopic(topic: DataTransformerConfig['topic']): DataTopic | undefined {
+  switch (topic) {
+    case 'annotations':
+      return DataTopic.Annotations;
+    case 'alertStates':
+      return DataTopic.AlertStates;
+    case 'series':
+      return DataTopic.Series;
+    default:
+      return undefined;
   }
 }

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -69,7 +69,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
       dashboard: jsonModel,
       meta: dashboard.state.meta,
     };
-    const newDashboardScene = transformSaveModelToScene(rsp);
+    const newDashboardScene = transformSaveModelToScene(rsp.dashboard, rsp.meta);
     const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state);
 
     dashboard.pauseTrackingChanges();

--- a/public/app/features/dashboard-scene/solo/useSoloPanel.test.tsx
+++ b/public/app/features/dashboard-scene/solo/useSoloPanel.test.tsx
@@ -63,7 +63,7 @@ describe('useSoloPanel', () => {
 });
 
 const setup = () => {
-  const dashboard = transformSaveModelToScene({ dashboard: TEST_DASHBOARD, meta: {} });
+  const dashboard = transformSaveModelToScene(TEST_DASHBOARD, {} );
 
   return { dashboard };
 };

--- a/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardSessionState.test.ts
@@ -120,7 +120,7 @@ function buildTestScene() {
     weekStart: '',
   };
 
-  const scene = transformSaveModelToScene({ dashboard: testDashboard, meta: {} });
+  const scene = transformSaveModelToScene(testDashboard, {} );
 
   // Removing data layers to avoid mocking built-in Grafana data source
   scene.setState({ $data: undefined });

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -11,16 +11,18 @@ import {
   TestVariable,
   VizPanel,
 } from '@grafana/scenes';
+import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
+import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { DashboardLoaderSrv, setDashboardLoaderSrv } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO } from 'app/types';
 
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { RowRepeaterBehavior } from '../scene/RowRepeaterBehavior';
 import { DashboardGridItem, RepeatDirection } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 
-export function setupLoadDashboardMock(rsp: DeepPartial<DashboardDTO>, spy?: jest.Mock) {
+export function setupLoadDashboardMock(rsp: DeepPartial<DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>>, spy?: jest.Mock) {
   const loadDashboardMock = (spy || jest.fn()).mockResolvedValue(rsp);
   // disabling type checks since this is a test util
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1,5 +1,5 @@
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
 import { ResponseTransformers } from './ResponseTransformers';
 import { DashboardWithAccessInfo } from './types';
@@ -7,13 +7,37 @@ import { DashboardWithAccessInfo } from './types';
 describe('ResponseTransformers', () => {
   describe('v1 transformation', () => {
     it('should transform DashboardDTO to DashboardWithAccessInfo<DashboardV2Spec>', () => {
-      const dashboardDTO: DashboardDTO = {
-        meta: {
-          created: '2023-01-01T00:00:00Z',
-          createdBy: 'user1',
-          updated: '2023-01-02T00:00:00Z',
-          updatedBy: 'user2',
-          folderUid: 'folder1',
+      const dashboardV1: DashboardDataDTO = {
+        uid: 'dashboard1',
+        title: 'Dashboard Title',
+        description: 'Dashboard Description',
+        tags: ['tag1', 'tag2'],
+        schemaVersion: 1,
+        graphTooltip: 0,
+        preload: true,
+        liveNow: false,
+        editable: true,
+        time: { from: 'now-6h', to: 'now' },
+        timezone: 'browser',
+        refresh: '5m',
+        timepicker: {
+          refresh_intervals: ['5s', '10s', '30s'],
+          hidden: false,
+          time_options: ['5m', '15m', '1h'],
+          nowDelay: '1m',
+        },
+        fiscalYearStartMonth: 1,
+        weekStart: 'monday',
+        version: 1,
+        links: [],
+        annotations: {
+          list: [],
+        },
+      };
+
+      const dto: DashboardWithAccessInfo<DashboardDataDTO> = {
+        spec: dashboardV1,
+        access: {
           slug: 'dashboard-slug',
           url: '/d/dashboard-slug',
           canAdmin: true,
@@ -27,67 +51,47 @@ describe('ResponseTransformers', () => {
             organization: { canAdd: true, canEdit: true, canDelete: true },
           },
         },
-        dashboard: {
-          uid: 'dashboard1',
-          title: 'Dashboard Title',
-          description: 'Dashboard Description',
-          tags: ['tag1', 'tag2'],
-          schemaVersion: 1,
-          graphTooltip: 0,
-          preload: true,
-          liveNow: false,
-          editable: true,
-          time: { from: 'now-6h', to: 'now' },
-          timezone: 'browser',
-          refresh: '5m',
-          timepicker: {
-            refresh_intervals: ['5s', '10s', '30s'],
-            hidden: false,
-            time_options: ['5m', '15m', '1h'],
-            nowDelay: '1m',
-          },
-          fiscalYearStartMonth: 1,
-          weekStart: 'monday',
-          version: 1,
-          links: [],
+        apiVersion: 'v1',
+        kind: 'DashboardWithAccessInfo',
+        metadata: {
+          name: 'dashboard-uid',
+          resourceVersion: '1',
+
+          creationTimestamp: '2023-01-01T00:00:00Z',
           annotations: {
-            list: [],
+            'grafana.app/createdBy': 'user1',
+            'grafana.app/updatedBy': 'user2',
+            'grafana.app/updatedTimestamp': '2023-01-02T00:00:00Z',
+            'grafana.app/folder': 'folder1',
           },
         },
       };
 
-      const transformed = ResponseTransformers.transformV1ToV2(dashboardDTO);
+      const transformed = ResponseTransformers.transformV1ToV2(dto);
 
-      expect(transformed.apiVersion).toBe('v2alpha1');
+      expect(transformed.apiVersion).toBe('v1');
       expect(transformed.kind).toBe('DashboardWithAccessInfo');
-      expect(transformed.metadata.creationTimestamp).toBe(dashboardDTO.meta.created);
-      expect(transformed.metadata.name).toBe(dashboardDTO.dashboard.uid);
-      expect(transformed.metadata.resourceVersion).toBe(dashboardDTO.dashboard.version?.toString());
-      expect(transformed.metadata.annotations?.['grafana.app/createdBy']).toBe(dashboardDTO.meta.createdBy);
-      expect(transformed.metadata.annotations?.['grafana.app/updatedBy']).toBe(dashboardDTO.meta.updatedBy);
-      expect(transformed.metadata.annotations?.['grafana.app/updatedTimestamp']).toBe(dashboardDTO.meta.updated);
-      expect(transformed.metadata.annotations?.['grafana.app/folder']).toBe(dashboardDTO.meta.folderUid);
-      expect(transformed.metadata.annotations?.['grafana.app/slug']).toBe(dashboardDTO.meta.slug);
+      expect(transformed.metadata).toEqual(dto.metadata);
 
       const spec = transformed.spec;
-      expect(spec.title).toBe(dashboardDTO.dashboard.title);
-      expect(spec.description).toBe(dashboardDTO.dashboard.description);
-      expect(spec.tags).toEqual(dashboardDTO.dashboard.tags);
-      expect(spec.schemaVersion).toBe(dashboardDTO.dashboard.schemaVersion);
+      expect(spec.title).toBe(dashboardV1.title);
+      expect(spec.description).toBe(dashboardV1.description);
+      expect(spec.tags).toEqual(dashboardV1.tags);
+      expect(spec.schemaVersion).toBe(dashboardV1.schemaVersion);
       expect(spec.cursorSync).toBe('Off'); // Assuming transformCursorSynctoEnum(0) returns 'Off'
-      expect(spec.preload).toBe(dashboardDTO.dashboard.preload);
-      expect(spec.liveNow).toBe(dashboardDTO.dashboard.liveNow);
-      expect(spec.editable).toBe(dashboardDTO.dashboard.editable);
-      expect(spec.timeSettings.from).toBe(dashboardDTO.dashboard.time?.from);
-      expect(spec.timeSettings.to).toBe(dashboardDTO.dashboard.time?.to);
-      expect(spec.timeSettings.timezone).toBe(dashboardDTO.dashboard.timezone);
-      expect(spec.timeSettings.autoRefresh).toBe(dashboardDTO.dashboard.refresh);
-      expect(spec.timeSettings.autoRefreshIntervals).toEqual(dashboardDTO.dashboard.timepicker?.refresh_intervals);
-      expect(spec.timeSettings.hideTimepicker).toBe(dashboardDTO.dashboard.timepicker?.hidden);
-      expect(spec.timeSettings.quickRanges).toEqual(dashboardDTO.dashboard.timepicker?.time_options);
-      expect(spec.timeSettings.nowDelay).toBe(dashboardDTO.dashboard.timepicker?.nowDelay);
-      expect(spec.timeSettings.fiscalYearStartMonth).toBe(dashboardDTO.dashboard.fiscalYearStartMonth);
-      expect(spec.timeSettings.weekStart).toBe(dashboardDTO.dashboard.weekStart);
+      expect(spec.preload).toBe(dashboardV1.preload);
+      expect(spec.liveNow).toBe(dashboardV1.liveNow);
+      expect(spec.editable).toBe(dashboardV1.editable);
+      expect(spec.timeSettings.from).toBe(dashboardV1.time?.from);
+      expect(spec.timeSettings.to).toBe(dashboardV1.time?.to);
+      expect(spec.timeSettings.timezone).toBe(dashboardV1.timezone);
+      expect(spec.timeSettings.autoRefresh).toBe(dashboardV1.refresh);
+      expect(spec.timeSettings.autoRefreshIntervals).toEqual(dashboardV1.timepicker?.refresh_intervals);
+      expect(spec.timeSettings.hideTimepicker).toBe(dashboardV1.timepicker?.hidden);
+      expect(spec.timeSettings.quickRanges).toEqual(dashboardV1.timepicker?.time_options);
+      expect(spec.timeSettings.nowDelay).toBe(dashboardV1.timepicker?.nowDelay);
+      expect(spec.timeSettings.fiscalYearStartMonth).toBe(dashboardV1.fiscalYearStartMonth);
+      expect(spec.timeSettings.weekStart).toBe(dashboardV1.weekStart);
       expect(spec.links).toEqual([]); // Assuming transformDashboardLinksToEnums([]) returns []
       expect(spec.annotations).toEqual([]);
     });

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -137,6 +137,18 @@ export function transformV2ToV1(dashboard: DashboardWithAccessInfo<DashboardV2Sp
       links: spec.links,
       // TODO[schema v2]: handle annotations
       annotations: { list: [] },
+      // TODO[schema v2]: handle panels
+      panels: [],
+      // TODO[schema v2]: handle variables
+      templating: {
+        list: [],
+      },
+      // TODO[schema v2]: handle id
+      // id: 0,
+      // TODO[schema v2]: handle revision
+      // revision: 0,
+      // TODO[schema v2]: handle variables
+      // gnetId
     },
   };
 }

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,5 +1,5 @@
 import { config } from '@grafana/runtime';
-import { AnnotationQuery, DataQuery, DataTransformerConfig, Panel, VariableModel } from '@grafana/schema';
+import { AnnotationQuery, DataQuery, Panel, VariableModel } from '@grafana/schema';
 import {
   AnnotationQueryKind,
   DashboardV2Spec,
@@ -10,6 +10,7 @@ import {
   QueryVariableKind,
   TransformationKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
+import { DataTransformerConfig } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
 import {
   AnnoKeyCreatedBy,
   AnnoKeyFolder,
@@ -17,9 +18,13 @@ import {
   AnnoKeyUpdatedBy,
   AnnoKeyUpdatedTimestamp,
 } from 'app/features/apiserver/types';
+import { transformCursorSyncV2ToV1 } from 'app/features/dashboard-scene/serialization/transformToV1TypesUtils';
 import {
   transformCursorSynctoEnum,
+  transformDataTopic,
+  transformSortVariableToEnum,
   transformVariableHideToEnum,
+  transformVariableRefreshToEnum,
 } from 'app/features/dashboard-scene/serialization/transformToV2TypesUtils';
 import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
@@ -68,7 +73,7 @@ export function transformV1ToV2(
       nowDelay: spec.timepicker?.nowDelay || timeSettingsDefaults.nowDelay,
     },
     links: spec.links || [],
-    annotations, // TODO
+    annotations,
     variables,
     elements,
     layout,
@@ -110,8 +115,7 @@ export function transformV2ToV1(dashboard: DashboardWithAccessInfo<DashboardV2Sp
       description: spec.description,
       tags: spec.tags,
       schemaVersion: spec.schemaVersion,
-      // @ts-ignore TODO: Use transformers for these enums
-      //   graphTooltip: spec.cursorSync, // Assuming transformCursorSynctoEnum is reversible
+      graphTooltip: transformCursorSyncV2ToV1(spec.cursorSync),
       preload: spec.preload,
       liveNow: spec.liveNow,
       editable: spec.editable,
@@ -130,8 +134,9 @@ export function transformV2ToV1(dashboard: DashboardWithAccessInfo<DashboardV2Sp
       fiscalYearStartMonth: spec.timeSettings.fiscalYearStartMonth,
       weekStart: spec.timeSettings.weekStart,
       version: parseInt(dashboard.metadata.resourceVersion, 10),
-      links: spec.links, // Assuming transformDashboardLinksToEnums is reversible
-      annotations: { list: [] }, // TODO
+      links: spec.links,
+      // TODO[schema v2]: handle annotations
+      annotations: { list: [] },
     },
   };
 }
@@ -250,6 +255,7 @@ function getPanelTransformations(transformations: DataTransformerConfig[]): Tran
       kind: t.id,
       spec: {
         ...t,
+        topic: transformDataTopic(t.topic),
       },
     };
   });
@@ -260,6 +266,13 @@ function getVariables(vars: VariableModel[]): DashboardV2Spec['variables'] {
   for (const v of vars) {
     switch (v.type) {
       case 'query':
+        let query = v.query || {};
+
+        if (typeof query === 'string') {
+          console.error('Query variable query is a string. It needs to extend DataQuery.');
+          query = {};
+        }
+
         const qv: QueryVariableKind = {
           kind: 'QueryVariable',
           spec: {
@@ -270,16 +283,16 @@ function getVariables(vars: VariableModel[]): DashboardV2Spec['variables'] {
             multi: Boolean(v.multi),
             includeAll: Boolean(v.includeAll),
             allValue: v.allValue,
-            current: v.current, // TODO[schema v2]: handle current
+            current: v.current || { text: '', value: '' },
             options: v.options || [],
-            refresh: 'onDashboardLoad', // TODO[schema v2]: handle refresh
+            refresh: transformVariableRefreshToEnum(v.refresh),
             datasource: v.datasource ?? undefined,
             regex: v.regex || '',
-            sort: 'alphabeticalAsc', // TODO[schema v2]: handle sort
+            sort: transformSortVariableToEnum(v.sort),
             query: {
               kind: v.datasource?.type || getDefaultDatasourceType(),
               spec: {
-                ...v.query, // TODO[schema v2]: handle query
+                ...query,
               },
             },
           },
@@ -287,21 +300,26 @@ function getVariables(vars: VariableModel[]): DashboardV2Spec['variables'] {
         variables.push(qv);
         break;
       case 'datasource':
+        let pluginId = getDefaultDatasourceType();
+
+        if (v.query && typeof v.query === 'string') {
+          pluginId = v.query;
+        }
+
         const dv: DatasourceVariableKind = {
           kind: 'DatasourceVariable',
           spec: {
             name: v.name,
             label: v.label,
-            hide: 'dontHide', // TODO[schema v2]: handle hide
+            hide: transformVariableHideToEnum(v.hide),
             skipUrlSync: Boolean(v.skipUrlSync),
             multi: Boolean(v.multi),
             includeAll: Boolean(v.includeAll),
             allValue: v.allValue,
-            current: v.current, // TODO[schema v2]: handle current
+            current: v.current || { text: '', value: '' },
             options: v.options || [],
-            refresh: 'onDashboardLoad', // TODO[schema v2]: handle refresh
-            pluginId: v.query || getDefaultDatasourceType(),
-            // defaultOptionEnabled: Boolean(v.defaultOptionEnabled), // TODO[schema v2]: handle defaultOptionEnabled
+            refresh: transformVariableRefreshToEnum(v.refresh),
+            pluginId,
             regex: v.regex || '',
             description: v.description || '',
           },

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -330,7 +330,7 @@ function getAnnotations(annotations: AnnotationQuery[]): DashboardV2Spec['annota
             ...a.target,
           },
         },
-        filter: a.filter, // TODO[schema v2]: handle filter
+        filter: a.filter,
       },
     };
     return aq;

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,85 +1,82 @@
+import { config } from '@grafana/runtime';
+import { AnnotationQuery, DataQuery, DataTransformerConfig, Panel, VariableModel } from '@grafana/schema';
 import {
+  AnnotationQueryKind,
   DashboardV2Spec,
+  DatasourceVariableKind,
   defaultDashboardV2Spec,
   defaultTimeSettingsSpec,
+  PanelQueryKind,
+  QueryVariableKind,
+  TransformationKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
-import { transformCursorSynctoEnum } from 'app/features/dashboard-scene/serialization/transformToV2TypesUtils';
-import { DashboardDTO } from 'app/types';
+import {
+  AnnoKeyCreatedBy,
+  AnnoKeyFolder,
+  AnnoKeySlug,
+  AnnoKeyUpdatedBy,
+  AnnoKeyUpdatedTimestamp,
+} from 'app/features/apiserver/types';
+import {
+  transformCursorSynctoEnum,
+  transformVariableHideToEnum,
+} from 'app/features/dashboard-scene/serialization/transformToV2TypesUtils';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
 import { DashboardWithAccessInfo } from './types';
-import { isDashboardResource } from './utils';
+import { isDashboardResource, isDashboardV2Spec } from './utils';
 
 export function transformV1ToV2(
-  dto: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>
+  dto: DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>
 ): DashboardWithAccessInfo<DashboardV2Spec> {
-  if (isDashboardResource(dto)) {
+  const spec = dto.spec;
+
+  if (!isDashboardResource(dto)) {
+    throw new Error('Invalid dashboard resource');
+  }
+
+  // return as is if already v2
+  if (isDashboardV2Spec(spec)) {
     return dto;
   }
 
   const timeSettingsDefaults = defaultTimeSettingsSpec();
   const dashboardDefaults = defaultDashboardV2Spec();
+  const [elements, layout] = getElementsFromPanels(spec.panels || []);
+  const variables = getVariables(spec.templating?.list || []);
+  const annotations = getAnnotations(spec.annotations?.list || []);
 
-  const spec: DashboardV2Spec = {
-    title: dto.dashboard.title,
-    description: dto.dashboard.description,
-    tags: dto.dashboard.tags,
-    schemaVersion: dto.dashboard.schemaVersion,
-    cursorSync: transformCursorSynctoEnum(dto.dashboard.graphTooltip),
-    preload: dto.dashboard.preload || dashboardDefaults.preload,
-    liveNow: dto.dashboard.liveNow,
-    editable: dto.dashboard.editable,
+  const result: DashboardV2Spec = {
+    title: spec.title,
+    description: spec.description,
+    tags: spec.tags,
+    schemaVersion: spec.schemaVersion,
+    cursorSync: transformCursorSynctoEnum(spec.graphTooltip),
+    preload: spec.preload || dashboardDefaults.preload,
+    liveNow: spec.liveNow,
+    editable: spec.editable,
     timeSettings: {
-      from: dto.dashboard.time?.from || timeSettingsDefaults.from,
-      to: dto.dashboard.time?.to || timeSettingsDefaults.to,
-      timezone: dto.dashboard.timezone || timeSettingsDefaults.timezone,
-      autoRefresh: dto.dashboard.refresh || timeSettingsDefaults.autoRefresh,
-      autoRefreshIntervals: dto.dashboard.timepicker?.refresh_intervals || timeSettingsDefaults.autoRefreshIntervals,
-      fiscalYearStartMonth: dto.dashboard.fiscalYearStartMonth || timeSettingsDefaults.fiscalYearStartMonth,
-      hideTimepicker: dto.dashboard.timepicker?.hidden || timeSettingsDefaults.hideTimepicker,
-      quickRanges: dto.dashboard.timepicker?.time_options || timeSettingsDefaults.quickRanges,
-      weekStart: dto.dashboard.weekStart || timeSettingsDefaults.weekStart,
-      nowDelay: dto.dashboard.timepicker?.nowDelay || timeSettingsDefaults.nowDelay,
+      from: spec.time?.from || timeSettingsDefaults.from,
+      to: spec.time?.to || timeSettingsDefaults.to,
+      timezone: spec.timezone || timeSettingsDefaults.timezone,
+      autoRefresh: spec.refresh || timeSettingsDefaults.autoRefresh,
+      autoRefreshIntervals: spec.timepicker?.refresh_intervals || timeSettingsDefaults.autoRefreshIntervals,
+      fiscalYearStartMonth: spec.fiscalYearStartMonth || timeSettingsDefaults.fiscalYearStartMonth,
+      hideTimepicker: spec.timepicker?.hidden || timeSettingsDefaults.hideTimepicker,
+      quickRanges: spec.timepicker?.time_options || timeSettingsDefaults.quickRanges,
+      weekStart: spec.weekStart || timeSettingsDefaults.weekStart,
+      nowDelay: spec.timepicker?.nowDelay || timeSettingsDefaults.nowDelay,
     },
-    links: dto.dashboard.links || [],
-    annotations: [], // TODO
-    variables: [], // todo
-    elements: {}, // todo
-    layout: {
-      // todo
-      kind: 'GridLayout',
-      spec: {
-        items: [],
-      },
-    },
+    links: spec.links || [],
+    annotations, // TODO
+    variables,
+    elements,
+    layout,
   };
 
   return {
-    apiVersion: 'v2alpha1',
-    kind: 'DashboardWithAccessInfo',
-    metadata: {
-      creationTimestamp: dto.meta.created || '', // TODO verify this empty string is valid
-      name: dto.dashboard.uid,
-      resourceVersion: dto.dashboard.version?.toString() || '0',
-      annotations: {
-        'grafana.app/createdBy': dto.meta.createdBy,
-        'grafana.app/updatedBy': dto.meta.updatedBy,
-        'grafana.app/updatedTimestamp': dto.meta.updated,
-        'grafana.app/folder': dto.meta.folderUid,
-        'grafana.app/slug': dto.meta.slug,
-      },
-    },
-    spec,
-    access: {
-      url: dto.meta.url || '',
-      canAdmin: dto.meta.canAdmin,
-      canDelete: dto.meta.canDelete,
-      canEdit: dto.meta.canEdit,
-      canSave: dto.meta.canSave,
-      canShare: dto.meta.canShare,
-      canStar: dto.meta.canStar,
-      slug: dto.meta.slug,
-      annotationsPermissions: dto.meta.annotationsPermissions,
-    },
+    ...dto,
+    spec: result,
   };
 }
 
@@ -93,11 +90,11 @@ export function transformV2ToV1(dashboard: DashboardWithAccessInfo<DashboardV2Sp
   return {
     meta: {
       created: dashboard.metadata.creationTimestamp,
-      createdBy: dashboard.metadata.annotations?.['grafana.app/createdBy'] ?? '',
-      updated: dashboard.metadata.annotations?.['grafana.app/updatedTimestamp'],
-      updatedBy: dashboard.metadata.annotations?.['grafana.app/updatedBy'],
-      folderUid: dashboard.metadata.annotations?.['grafana.app/folder'],
-      slug: dashboard.metadata.annotations?.['grafana.app/slug'],
+      createdBy: dashboard.metadata.annotations?.[AnnoKeyCreatedBy] ?? '',
+      updated: dashboard.metadata.annotations?.[AnnoKeyUpdatedTimestamp],
+      updatedBy: dashboard.metadata.annotations?.[AnnoKeyUpdatedBy],
+      folderUid: dashboard.metadata.annotations?.[AnnoKeyFolder],
+      slug: dashboard.metadata.annotations?.[AnnoKeySlug],
       url: dashboard.access.url,
       canAdmin: dashboard.access.canAdmin,
       canDelete: dashboard.access.canDelete,
@@ -143,3 +140,199 @@ export const ResponseTransformers = {
   transformV1ToV2,
   transformV2ToV1,
 };
+
+// TODO[schema v2]: handle rows
+function getElementsFromPanels(panels: Panel[]): [DashboardV2Spec['elements'], DashboardV2Spec['layout']] {
+  const elements: DashboardV2Spec['elements'] = {};
+  const layout: DashboardV2Spec['layout'] = {
+    kind: 'GridLayout',
+    spec: {
+      items: [],
+    },
+  };
+
+  if (!panels) {
+    return [elements, layout];
+  }
+
+  // iterate over panels
+  for (const p of panels) {
+    const queries = getPanelQueries(
+      (p.targets as unknown as DataQuery[]) || [],
+      p.datasource?.type || getDefaultDatasourceType()
+    );
+
+    const transformations = getPanelTransformations(p.transformations || []);
+
+    elements[p.id!] = {
+      kind: 'Panel',
+      spec: {
+        title: p.title || '',
+        description: p.description || '',
+        vizConfig: {
+          kind: p.type,
+          spec: {
+            fieldConfig: p.fieldConfig as any,
+            options: p.options as any,
+            pluginVersion: p.pluginVersion!,
+          },
+        },
+        links: p.links || [],
+        uid: p.id!.toString(), // TODO[schema v2]: handle undefined id?!!?!?
+        data: {
+          kind: 'QueryGroup',
+          spec: {
+            queries,
+            transformations, // TODO[schema v2]: handle transformations
+            queryOptions: {
+              cacheTimeout: p.cacheTimeout,
+              maxDataPoints: p.maxDataPoints,
+              interval: p.interval,
+              hideTimeOverride: p.hideTimeOverride,
+              queryCachingTTL: p.queryCachingTTL,
+              timeFrom: p.timeFrom,
+              timeShift: p.timeShift,
+            },
+          },
+        },
+      },
+    };
+
+    layout.spec.items.push({
+      kind: 'GridLayoutItem',
+      spec: {
+        x: p.gridPos!.x,
+        y: p.gridPos!.y,
+        width: p.gridPos!.w,
+        height: p.gridPos!.h,
+        element: {
+          kind: 'ElementReference',
+          name: p.id!.toString(),
+        },
+      },
+    });
+  }
+
+  return [elements, layout];
+}
+
+function getDefaultDatasourceType() {
+  const datasources = config.datasources;
+  // find default datasource in datasources
+  return Object.values(datasources).find((ds) => ds.isDefault)!.type;
+}
+
+function getPanelQueries(targets: DataQuery[], panelDatasourceType: string): PanelQueryKind[] {
+  return targets.map((t) => {
+    const { refId, hide, datasource, ...query } = t;
+    const q: PanelQueryKind = {
+      kind: 'PanelQuery',
+      spec: {
+        refId: t.refId,
+        hidden: t.hide ?? false,
+        // TODO[schema v2]: ds coming from panel ?!?!!?! AAAAAAAAAAAAA! Send help!
+        datasource: t.datasource ? t.datasource : undefined,
+        query: {
+          kind: t.datasource?.type || panelDatasourceType,
+          spec: {
+            ...query,
+          },
+        },
+      },
+    };
+    return q;
+  });
+}
+
+function getPanelTransformations(transformations: DataTransformerConfig[]): TransformationKind[] {
+  return transformations.map((t) => {
+    return {
+      kind: t.id,
+      spec: {
+        ...t,
+      },
+    };
+  });
+}
+
+function getVariables(vars: VariableModel[]): DashboardV2Spec['variables'] {
+  const variables: DashboardV2Spec['variables'] = [];
+  for (const v of vars) {
+    switch (v.type) {
+      case 'query':
+        const qv: QueryVariableKind = {
+          kind: 'QueryVariable',
+          spec: {
+            name: v.name,
+            label: v.label,
+            hide: transformVariableHideToEnum(v.hide),
+            skipUrlSync: Boolean(v.skipUrlSync),
+            multi: Boolean(v.multi),
+            includeAll: Boolean(v.includeAll),
+            allValue: v.allValue,
+            current: v.current, // TODO[schema v2]: handle current
+            options: v.options || [],
+            refresh: 'onDashboardLoad', // TODO[schema v2]: handle refresh
+            datasource: v.datasource ?? undefined,
+            regex: v.regex || '',
+            sort: 'alphabeticalAsc', // TODO[schema v2]: handle sort
+            query: {
+              kind: v.datasource?.type || getDefaultDatasourceType(),
+              spec: {
+                ...v.query, // TODO[schema v2]: handle query
+              },
+            },
+          },
+        };
+        variables.push(qv);
+        break;
+      case 'datasource':
+        const dv: DatasourceVariableKind = {
+          kind: 'DatasourceVariable',
+          spec: {
+            name: v.name,
+            label: v.label,
+            hide: 'dontHide', // TODO[schema v2]: handle hide
+            skipUrlSync: Boolean(v.skipUrlSync),
+            multi: Boolean(v.multi),
+            includeAll: Boolean(v.includeAll),
+            allValue: v.allValue,
+            current: v.current, // TODO[schema v2]: handle current
+            options: v.options || [],
+            refresh: 'onDashboardLoad', // TODO[schema v2]: handle refresh
+            pluginId: v.query || getDefaultDatasourceType(),
+            // defaultOptionEnabled: Boolean(v.defaultOptionEnabled), // TODO[schema v2]: handle defaultOptionEnabled
+            regex: v.regex || '',
+            description: v.description || '',
+          },
+        };
+        variables.push(dv);
+        break;
+    }
+  }
+  return variables;
+}
+
+function getAnnotations(annotations: AnnotationQuery[]): DashboardV2Spec['annotations'] {
+  return annotations.map((a) => {
+    const aq: AnnotationQueryKind = {
+      kind: 'AnnotationQuery',
+      spec: {
+        name: a.name,
+        datasource: a.datasource ?? undefined,
+        enable: a.enable,
+        hide: Boolean(a.hide),
+        iconColor: a.iconColor,
+        builtIn: Boolean(a.builtIn),
+        query: {
+          kind: a.datasource?.type || getDefaultDatasourceType(),
+          spec: {
+            ...a.target,
+          },
+        },
+        filter: a.filter, // TODO[schema v2]: handle filter
+      },
+    };
+    return aq;
+  });
+}

--- a/public/app/features/dashboard/api/dashboard_api.ts
+++ b/public/app/features/dashboard/api/dashboard_api.ts
@@ -1,23 +1,23 @@
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO } from 'app/types';
 
 import { LegacyDashboardAPI } from './legacy';
-import { DashboardAPI, DashboardWithAccessInfo } from './types';
+import { DashboardAPI } from './types';
 import { getDashboardsApiVersion } from './utils';
 import { K8sDashboardAPI } from './v0';
 import { K8sDashboardV2APIStub } from './v2';
 
 // Describes the dashboard DTO types per API version
 export interface ApiVersionDTO {
-  legacy: DashboardDTO;
-  v0: DashboardDTO;
+  legacy: DashboardDataDTO;
+  v0: DashboardDataDTO;
   // v1: DashboardDTO; TODO[schema]: enable v1 when available
-  v2: DashboardWithAccessInfo<DashboardV2Spec>;
+  v2: DashboardV2Spec;
 }
 
 type DashboardAPIClients = Record<
   keyof ApiVersionDTO,
-  DashboardAPI<DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>>
+  DashboardAPI<DashboardDataDTO | DashboardV2Spec>
 >;
 
 let clients: Partial<DashboardAPIClients> | undefined;
@@ -29,7 +29,7 @@ export function setDashboardAPI(override: Partial<DashboardAPIClients> | undefin
   clients = override;
 }
 
-export function getDashboardAPI(): DashboardAPI<DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>> {
+export function getDashboardAPI(): DashboardAPI<DashboardDataDTO | DashboardV2Spec> {
   if (!clients) {
     clients = {
       legacy: new LegacyDashboardAPI(),

--- a/public/app/features/dashboard/api/legacy.test.ts
+++ b/public/app/features/dashboard/api/legacy.test.ts
@@ -1,3 +1,4 @@
+import { AnnoKeyCreatedBy, AnnoKeyFolder, AnnoKeyFolderId, AnnoKeyFolderTitle, AnnoKeyFolderUrl, AnnoKeySlug, AnnoKeyUpdatedBy, AnnoKeyUpdatedTimestamp } from 'app/features/apiserver/types';
 import { DashboardDTO } from 'app/types';
 
 import { LegacyDashboardAPI } from './legacy';
@@ -5,10 +6,38 @@ import { LegacyDashboardAPI } from './legacy';
 const mockDashboardDto: DashboardDTO = {
   meta: {
     isFolder: false,
+    createdBy: 'testCreatedBy',
+    updatedBy: 'testCreatedBy',
+    created: 'testCreated',
+    updated: 'testUpdated',
+    slug: 'testSlug',
+    url: 'testUrl',
+    folderId: 1,
+    folderTitle: 'testFolderTitle',
+    folderUid: 'testFolderUid',
+    folderUrl: 'testFolderUrl',
+    canAdmin: true,
+    canDelete: true,
+    canEdit: true,
+    canSave: true,
+    canShare: true,
+    canStar: true,
+    annotationsPermissions: {
+      dashboard: {
+        canAdd: true,
+        canDelete: true,
+        canEdit: true,
+      },
+      organization: {
+        canAdd: true,
+        canDelete: true,
+        canEdit: true,
+      },
+    }
   },
   dashboard: {
     title: 'test',
-    uid: 'test',
+    uid: 'validUid',
     schemaVersion: 0,
   },
 };
@@ -42,6 +71,44 @@ describe('Legacy dashboard API', () => {
   it('should return a valid dashboard', async () => {
     const api = new LegacyDashboardAPI();
     const result = await api.getDashboardDTO('validUid');
-    expect(result).toEqual(mockDashboardDto);
+
+    expect(result).toEqual({
+      kind: 'DashboardWithAccessInfo',
+      apiVersion: 'legacy',
+      metadata: {
+        creationTimestamp: 'testCreated',
+        name: 'validUid',
+        resourceVersion: '0',
+        annotations: {
+          [AnnoKeyFolder]: 'testFolderUid',
+          [AnnoKeyFolderTitle]: 'testFolderTitle',
+          [AnnoKeyFolderUrl]: 'testFolderUrl',
+          [AnnoKeyFolderId]: 1,
+          [AnnoKeyCreatedBy]: 'testCreatedBy',
+          [AnnoKeyUpdatedTimestamp]: 'testUpdated',
+          [AnnoKeyUpdatedBy]: 'testCreatedBy',
+          [AnnoKeySlug]: 'testSlug',
+        },
+      },
+      spec: {
+        title: 'test',
+        uid: 'validUid',
+        schemaVersion: 0,
+      },
+      access: {
+        slug: 'testSlug',
+        url: 'testUrl',
+        canSave: true,
+        canEdit: true,
+        canDelete: true,
+        canShare: true,
+        canStar: true,
+        canAdmin: true,
+        annotationsPermissions: {
+          dashboard: { canAdd: true, canEdit: true, canDelete: true },
+          organization: { canAdd: true, canEdit: true, canDelete: true },
+        },
+      },
+    });
   });
 });

--- a/public/app/features/dashboard/api/legacy.ts
+++ b/public/app/features/dashboard/api/legacy.ts
@@ -53,7 +53,10 @@ export class LegacyDashboardAPI implements DashboardAPI<DashboardDataDTO> {
          [AnnoKeyFolderTitle]: result.meta.folderTitle,
          [AnnoKeyFolderUrl]: result.meta.folderUrl,
          [AnnoKeyFolderId]: result.meta.folderId,
+         [AnnoKeyRedirectUri]: result.redirectUri,
         },
+        // Adding legacy metadata for legacy API backwards compatibility
+        _legacyMetadata: result.meta
       },
       spec: result.dashboard,
       access: {

--- a/public/app/features/dashboard/api/types.ts
+++ b/public/app/features/dashboard/api/types.ts
@@ -1,7 +1,7 @@
 import { UrlQueryMap } from '@grafana/data';
-import { Resource } from 'app/features/apiserver/types';
+import { ObjectMeta, Resource } from 'app/features/apiserver/types';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
-import { AnnotationsPermissions, SaveDashboardResponseDTO } from 'app/types';
+import { AnnotationsPermissions, DashboardMeta, SaveDashboardResponseDTO } from 'app/types';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
@@ -16,6 +16,9 @@ export interface DashboardAPI<G> {
 
 // Implemented using /api/dashboards/*
 export interface DashboardWithAccessInfo<T> extends Resource<T, 'DashboardWithAccessInfo'> {
+  metadata: ObjectMeta & {
+    _legacyMetadata?: DashboardMeta
+  };
   access: {
     url?: string;
     slug?: string;
@@ -25,6 +28,7 @@ export interface DashboardWithAccessInfo<T> extends Resource<T, 'DashboardWithAc
     canShare?: boolean;
     canStar?: boolean;
     canAdmin?: boolean;
+    canMakeEditable?: boolean;
     annotationsPermissions?: AnnotationsPermissions;
     isNew?: boolean;
   }; // TODO...

--- a/public/app/features/dashboard/api/types.ts
+++ b/public/app/features/dashboard/api/types.ts
@@ -7,7 +7,7 @@ import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
 export interface DashboardAPI<G> {
   /** Get a dashboard with the access control metadata */
-  getDashboardDTO(uid: string, params?: UrlQueryMap): Promise<G>;
+  getDashboardDTO(uid: string, params?: UrlQueryMap): Promise<DashboardWithAccessInfo<G>>;
   /** Save dashboard */
   saveDashboard(options: SaveDashboardCommand): Promise<SaveDashboardResponseDTO>;
   /** Delete a dashboard */

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,12 +1,14 @@
-import { config } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
-import { DashboardDTO } from 'app/types';
+import { DashboardDataDTO, DashboardDTO } from 'app/types';
 
 import { DashboardWithAccessInfo } from './types';
 
 export function getDashboardsApiVersion() {
+  const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
+
   // if dashboard scene is disabled, use legacy API response for the old architecture
-  if (!config.featureToggles.dashboardScene) {
+  if (!config.featureToggles.dashboardScene || forcingOldDashboardArch) {
     // for old architecture, use v0 API for k8s dashboards
     if (config.featureToggles.kubernetesDashboards) {
       return 'v0';
@@ -27,7 +29,7 @@ export function getDashboardsApiVersion() {
 }
 
 export function isDashboardResource(
-  obj?: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | null
+  obj?: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO> | null
 ): obj is DashboardWithAccessInfo<DashboardV2Spec> {
   if (!obj) {
     return false;
@@ -36,6 +38,6 @@ export function isDashboardResource(
   return 'kind' in obj && obj.kind === 'DashboardWithAccessInfo';
 }
 
-export function isDashboardV2Spec(obj: object): obj is DashboardV2Spec {
+export function isDashboardV2Spec(obj: DashboardDataDTO | DashboardV2Spec): obj is DashboardV2Spec {
   return 'elements' in obj;
 }

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -41,3 +41,16 @@ export function isDashboardResource(
 export function isDashboardV2Spec(obj: DashboardDataDTO | DashboardV2Spec): obj is DashboardV2Spec {
   return 'elements' in obj;
 }
+
+export function isDashboardV1Spec(obj: DashboardDataDTO | DashboardV2Spec): obj is DashboardDataDTO {
+  return 'panels' in obj;
+}
+
+export function isDashboardV2Response(obj: DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>): obj is DashboardWithAccessInfo<DashboardV2Spec> {
+  return obj != null && isDashboardV2Spec(obj.spec);
+}
+
+export function isDashboardV1Response(obj: DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>): obj is DashboardWithAccessInfo<DashboardDataDTO> {
+  return obj != null && isDashboardV1Spec(obj.spec);
+}
+

--- a/public/app/features/dashboard/api/v0.test.ts
+++ b/public/app/features/dashboard/api/v0.test.ts
@@ -1,5 +1,5 @@
 import { backendSrv } from 'app/core/services/backend_srv';
-import { AnnoKeyFolder } from 'app/features/apiserver/types';
+import { AnnoKeyFolder, AnnoKeyFolderId, AnnoKeyFolderTitle, AnnoKeyFolderUrl, AnnoKeyIsFolder } from 'app/features/apiserver/types';
 import { DashboardDataDTO } from 'app/types';
 
 import { DashboardWithAccessInfo } from './types';
@@ -56,10 +56,10 @@ describe('v0 dashboard API', () => {
 
     const api = new K8sDashboardAPI();
     const result = await api.getDashboardDTO('test');
-    expect(result.meta.isFolder).toBe(false);
-    expect(result.meta.folderId).toBe(1);
-    expect(result.meta.folderTitle).toBe('New Folder');
-    expect(result.meta.folderUrl).toBe('/folder/url');
-    expect(result.meta.folderUid).toBe('new-folder');
+    expect(result.metadata.annotations?.[AnnoKeyIsFolder]).toBe(false);
+    expect(result.metadata.annotations?.[AnnoKeyFolderId]).toBe(1);
+    expect(result.metadata.annotations?.[AnnoKeyFolderTitle]).toBe('New Folder');
+    expect(result.metadata.annotations?.[AnnoKeyFolderUrl]).toBe('/folder/url');
+    expect(result.metadata.annotations?.[AnnoKeyFolder]).toBe('new-folder');
   });
 });

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -17,7 +17,7 @@ import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 import { ResponseTransformers } from './ResponseTransformers';
 import { DashboardAPI, DashboardWithAccessInfo } from './types';
 
-export class K8sDashboardV2APIStub implements DashboardAPI<DashboardWithAccessInfo<DashboardV2Spec>> {
+export class K8sDashboardV2APIStub implements DashboardAPI<DashboardV2Spec> {
   private client: ResourceClient<DashboardV2Spec>;
 
   constructor() {

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -33,7 +33,7 @@ export class K8sDashboardV2APIStub implements DashboardAPI<DashboardWithAccessIn
 
     // For dev purposes only, the conversion should and will happen in the API. This is just to stub v2 api responses.
     const result = ResponseTransformers.transformV1ToV2(dashboard);
-
+    
     if (result.metadata.annotations && result.metadata.annotations[AnnoKeyFolder]) {
       try {
         const folder = await backendSrv.getFolderByUid(result.metadata.annotations[AnnoKeyFolder]);

--- a/public/app/features/dashboard/containers/DashboardPageProxy.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.test.tsx
@@ -8,12 +8,21 @@ import {
   HOME_DASHBOARD_CACHE_KEY,
   getDashboardScenePageStateManager,
 } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
-import { DashboardDTO, DashboardRoutes } from 'app/types';
+import { DashboardDataDTO, DashboardRoutes } from 'app/types';
+
+import { DashboardWithAccessInfo } from '../api/types';
 
 import DashboardPageProxy, { DashboardPageProxyProps } from './DashboardPageProxy';
 
-const dashMock: DashboardDTO = {
-  dashboard: {
+const dashMock: DashboardWithAccessInfo<DashboardDataDTO> = {
+  apiVersion: 'legacy',
+  kind: 'DashboardWithAccessInfo',
+  metadata: {
+    name: 'uid',
+    resourceVersion: '1',
+    creationTimestamp: '1',  
+  },
+  spec: {
     id: 1,
     annotations: {
       list: [],
@@ -24,32 +33,32 @@ const dashMock: DashboardDTO = {
     version: 1,
     schemaVersion: 1,
   },
-  meta: {
+  access: {
     canEdit: false,
   },
 };
 
-const homeMock = {
+const homeMock: DashboardWithAccessInfo<DashboardDataDTO>  = {
   ...dashMock,
-  dashboard: {
-    ...dashMock.dashboard,
+  spec: {
+    ...dashMock.spec,
     uid: '',
     title: 'Home',
   },
 };
 
-const homeMockEditable = {
+const homeMockEditable: DashboardWithAccessInfo<DashboardDataDTO>  = {
   ...homeMock,
-  meta: {
-    ...homeMock.meta,
+  access: {
+    ...homeMock.access,
     canEdit: true,
   },
 };
 
-const dashMockEditable = {
+const dashMockEditable: DashboardWithAccessInfo<DashboardDataDTO>  = {
   ...dashMock,
-  meta: {
-    ...dashMock.meta,
+  access: {
+    ...dashMock.access,
     canEdit: true,
   },
 };

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -7,7 +7,6 @@ import DashboardScenePage from 'app/features/dashboard-scene/pages/DashboardScen
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
 import { DashboardRoutes } from 'app/types';
 
-import { isDashboardResource } from '../api/utils';
 
 import DashboardPage, { DashboardPageParams } from './DashboardPage';
 import { DashboardPageRouteParams, DashboardPageRouteSearchParams } from './types';
@@ -54,32 +53,34 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
   if (dashboard.loading) {
     return null;
   }
-  if (isDashboardResource(dashboard.value)) {
-    // TODO[schema]: handle v2
-    throw new Error('v2 schema handling not implemented');
-  } else {
-    if (dashboard?.value?.dashboard?.uid !== params.uid && dashboard.value?.meta?.isNew !== true) {
+
+
+  // if (isDashboardResource(dashboard.value)) {
+  //   // TODO[schema]: handle v2
+  //   throw new Error('v2 schema handling not implemented');
+  // } else {
+    if (dashboard?.value?.metadata?.name !== params.uid && dashboard.value?.access?.isNew !== true) {
       return null;
     }
-  }
+  // }
 
   if (!config.featureToggles.dashboardSceneForViewers) {
     return <DashboardPage {...props} params={params} location={location} />;
   }
 
-  if (isDashboardResource(dashboard.value)) {
-    throw new Error('v2 schema handling not implemented');
-  } else {
+  // if (isDashboardResource(dashboard.value)) {
+  //   throw new Error('v2 schema handling not implemented');
+  // } else { 
     if (
       dashboard.value &&
-      !(dashboard.value.meta?.canEdit || dashboard.value.meta?.canMakeEditable) &&
+      !(dashboard.value.access?.canEdit || dashboard.value.access?.canMakeEditable) &&
       isScenesSupportedRoute
     ) {
       return <DashboardScenePage {...props} />;
     } else {
       return <DashboardPage {...props} params={params} location={location} />;
     }
-  }
+  // }
 }
 
 export default DashboardPageProxy;

--- a/public/app/features/dashboard/containers/DashboardPageProxy.tsx
+++ b/public/app/features/dashboard/containers/DashboardPageProxy.tsx
@@ -25,6 +25,12 @@ function DashboardPageProxy(props: DashboardPageProxyProps) {
   const params = useParams<DashboardPageParams>();
   const location = useLocation();
 
+  // Force scenes if v2 api and scenes are enabled
+  if (config.featureToggles.useV2DashboardsAPI && config.featureToggles.dashboardScene && !forceOld) {
+    console.log('DashboardPageProxy: forcing scenes because of v2 api');
+    return <DashboardScenePage {...props} />;
+  }
+
   if (forceScenes || (config.featureToggles.dashboardScene && !forceOld)) {
     return <DashboardScenePage {...props} />;
   }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -129,6 +129,7 @@ export class DashboardModel implements TimeModel {
       getVariablesFromState?: GetVariables;
     }
   ) {
+    
     this.getVariablesFromState = options?.getVariablesFromState ?? getVariablesByKey;
     this.events = new EventBusSrv();
     this.id = data.id || null;

--- a/public/app/features/manage-dashboards/utils/validation.ts
+++ b/public/app/features/manage-dashboards/utils/validation.ts
@@ -2,7 +2,6 @@ import { t } from 'i18next';
 
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
-import { isDashboardResource } from 'app/features/dashboard/api/utils';
 
 import { validationSrv } from '../services/ValidationSrv';
 
@@ -52,11 +51,7 @@ export const validateUid = (value: string) => {
   return getDashboardAPI()
     .getDashboardDTO(value)
     .then((existingDashboard) => {
-      if (isDashboardResource(existingDashboard)) {
-        // TODO[schema v2]: Update to use correct annotation with title when it's added
-        return `Dashboard named '${existingDashboard?.spec.title}' in folder '${existingDashboard?.metadata.annotations?.[AnnoKeyFolder]}' has the same UID`;
-      }
-      return `Dashboard named '${existingDashboard?.dashboard.title}' in folder '${existingDashboard?.meta.folderTitle}' has the same UID`;
+      return `Dashboard named '${existingDashboard?.spec.title}' in folder '${existingDashboard?.metadata.annotations?.[AnnoKeyFolder]}' has the same UID`;
     })
     .catch((error) => {
       error.isHandled = true;

--- a/public/app/features/scopes/tests/utils/render.tsx
+++ b/public/app/features/scopes/tests/utils/render.tsx
@@ -186,7 +186,7 @@ export function renderDashboard(
   initializeScopes();
 
   const dto: DashboardDTO = getDashboardDTO(overrideDashboard, overrideMeta);
-  const scene = transformSaveModelToScene(dto);
+  const scene = transformSaveModelToScene(dto.dashboard, dto.meta);
 
   render(
     <KBarProvider>

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -150,7 +150,7 @@ describe('Graph Migrations', () => {
 
       dashboard.panels.push(new PanelModelState(panel));
 
-      const scene = transformSaveModelToScene({ dashboard, meta: {} });
+      const scene = transformSaveModelToScene(dashboard, {});
       window.__grafanaSceneContext = scene;
 
       panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);


### PR DESCRIPTION
Based on top of https://github.com/grafana/grafana/pull/97338

POC of unifying dashboard API client response type to be k8s resource. Instead of using union of `DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>` this changes the response to be `DashboardWithAccessInfo<DashboardV2Spec | DashboardDataDTO>`.  dashboard.meta in the response is now represented ash resource's `metadata` and `access` properties.

For now opening just to demonstrate  the impact of the change.