### PR TITLE
[v11.2.x] Azure Monitor: Add a feature flag to toggle user auth for Azure Monitor only

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -68,6 +68,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `cloudWatchNewLabelParsing`            | Updates CloudWatch label parsing to be more accurate                                                                                                                                                                         | Yes                |
 | `pluginProxyPreserveTrailingSlash`     | Preserve plugin proxy trailing slash.                                                                                                                                                                                        |                    |
 | `cloudWatchRoundUpEndTime`             | Round up end time for metric queries to the next minute to avoid missing data                                                                                                                                                | Yes                |
+| `azureMonitorEnableUserAuth`           | Enables user auth for Azure Monitor datasource only                                                                                                                                                                          | Yes                |
 
 ## Public preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -200,4 +200,5 @@ export interface FeatureToggles {
   cloudwatchMetricInsightsCrossAccount?: boolean;
   prometheusAzureOverrideAudience?: boolean;
   dataplaneAggregator?: boolean;
+  azureMonitorEnableUserAuth?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1379,6 +1379,13 @@ var (
 			Owner:           grafanaAppPlatformSquad,
 			RequiresRestart: true,
 		},
+		{
+			Name:        "azureMonitorEnableUserAuth",
+			Description: "Enables user auth for Azure Monitor datasource only",
+			Stage:       FeatureStageGeneralAvailability,
+			Owner:       grafanaPartnerPluginsSquad,
+			Expression:  "true", // Enabled by default for now
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -181,3 +181,4 @@ bodyScrolling,preview,@grafana/grafana-frontend-platform,false,false,true
 cloudwatchMetricInsightsCrossAccount,preview,@grafana/aws-datasources,false,false,true
 prometheusAzureOverrideAudience,deprecated,@grafana/partner-datasources,false,false,false
 dataplaneAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
+azureMonitorEnableUserAuth,GA,@grafana/partner-datasources,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -734,4 +734,8 @@ const (
 	// FlagDataplaneAggregator
 	// Enable grafana dataplane aggregator
 	FlagDataplaneAggregator = "dataplaneAggregator"
+
+	// FlagAzureMonitorEnableUserAuth
+	// Enables user auth for Azure Monitor datasource only
+	FlagAzureMonitorEnableUserAuth = "azureMonitorEnableUserAuth"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -504,6 +504,19 @@
     },
     {
       "metadata": {
+        "name": "azureMonitorEnableUserAuth",
+        "resourceVersion": "1733495779155",
+        "creationTimestamp": "2024-12-06T14:36:19Z"
+      },
+      "spec": {
+        "description": "Enables user auth for Azure Monitor datasource only",
+        "stage": "GA",
+        "codeowner": "@grafana/partner-datasources",
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "azureMonitorPrometheusExemplars",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2024-06-06T16:53:17Z"

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -114,6 +115,10 @@ func NewInstanceSettings(clientProvider *httpclient.Provider, executors map[stri
 		routesForModel, err := getAzureMonitorRoutes(azureSettings, credentials, settings.JSONData)
 		if err != nil {
 			return nil, err
+		}
+
+		if credentials.AzureAuthType() == azcredentials.AzureAuthCurrentUserIdentity && !backend.GrafanaConfigFromContext(ctx).FeatureToggles().IsEnabled("azureMonitorEnableUserAuth") {
+			return nil, backend.DownstreamError(errors.New("current user authentication is not enabled for azure monitor"))
 		}
 
 		model := types.DatasourceInfo{

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
 
@@ -58,9 +59,29 @@ func TestNewInstanceSettings(t *testing.T) {
 	tests := []struct {
 		name          string
 		settings      backend.DataSourceInstanceSettings
-		expectedModel types.DatasourceInfo
+		expectedModel *types.DatasourceInfo
 		Err           require.ErrorAssertionFunc
+		setupContext  func(ctx context.Context) context.Context
 	}{
+		{
+			name: "current user authentication disabled by feature toggle",
+			settings: backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"azureAuthType":"currentuser"}`),
+				DecryptedSecureJSONData: map[string]string{},
+				ID:                      60,
+			},
+			expectedModel: nil,
+			Err: func(t require.TestingT, err error, _ ...interface{}) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "current user authentication is not enabled for azure monitor")
+			},
+			setupContext: func(ctx context.Context) context.Context {
+				featureToggles := backend.NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures: "", // No enabled features
+				})
+				return backend.WithGrafanaConfig(ctx, featureToggles)
+			},
+		},
 		{
 			name: "creates an instance",
 			settings: backend.DataSourceInstanceSettings{
@@ -68,7 +89,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				DecryptedSecureJSONData: map[string]string{"key": "value"},
 				ID:                      40,
 			},
-			expectedModel: types.DatasourceInfo{
+			expectedModel: &types.DatasourceInfo{
 				Credentials:             &azcredentials.AzureManagedIdentityCredentials{},
 				Settings:                types.AzureMonitorSettings{},
 				Routes:                  testRoutes,
@@ -86,7 +107,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
 				ID:                      50,
 			},
-			expectedModel: types.DatasourceInfo{
+			expectedModel: &types.DatasourceInfo{
 				Credentials: &azcredentials.AzureClientSecretCredentials{
 					AzureCloud:   "AzureCustomizedCloud",
 					ClientSecret: "secret",
@@ -116,11 +137,23 @@ func TestNewInstanceSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.setupContext != nil {
+				ctx = tt.setupContext(ctx)
+			}
+
 			factory := NewInstanceSettings(&httpclient.Provider{}, map[string]azDatasourceExecutor{}, log.DefaultLogger)
-			instance, err := factory(context.Background(), tt.settings)
+			instance, err := factory(ctx, tt.settings)
+
 			tt.Err(t, err)
-			if !cmp.Equal(instance, tt.expectedModel) {
-				t.Errorf("Unexpected instance: %v", cmp.Diff(instance, tt.expectedModel))
+
+			if tt.expectedModel == nil {
+				require.Nil(t, instance, "Expected instance to be nil")
+			} else {
+				require.NotNil(t, instance, "Expected instance to be created")
+				if !cmp.Equal(instance, *tt.expectedModel) {
+					t.Errorf("Unexpected instance: %v", cmp.Diff(instance, *tt.expectedModel))
+				}
 			}
 		})
 	}

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -74,17 +74,27 @@ export const AzureCredentialsForm = (props: Props) => {
   }, [managedIdentityEnabled, workloadIdentityEnabled, userIdentityEnabled]);
 
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
-    const defaultAuthType = managedIdentityEnabled
-      ? 'msi'
-      : workloadIdentityEnabled
-        ? 'workloadidentity'
-        : userIdentityEnabled
-          ? 'currentuser'
-          : 'clientsecret';
+    const defaultAuthType = (() => {
+      if (managedIdentityEnabled) {
+        return 'msi';
+      }
+
+      if (workloadIdentityEnabled) {
+        return 'workloadidentity';
+      }
+
+      if (userIdentityEnabled) {
+        return 'currentuser';
+      }
+
+      return 'clientsecret';
+    })();
+
     const updated: AzureCredentials = {
       ...credentials,
       authType: selected.value || defaultAuthType,
     };
+
     onCredentialsChange(updated);
   };
 
@@ -123,7 +133,6 @@ export const AzureCredentialsForm = (props: Props) => {
           disabled={disabled}
           managedIdentityEnabled={managedIdentityEnabled}
           workloadIdentityEnabled={workloadIdentityEnabled}
-          userIdentityEnabled={userIdentityEnabled}
         />
       )}
     </ConfigSection>

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.test.tsx
@@ -10,7 +10,6 @@ const setup = (propsFunc?: (props: Props) => Props) => {
   let props: Props = {
     managedIdentityEnabled: true,
     workloadIdentityEnabled: true,
-    userIdentityEnabled: true,
     credentials: { authType: 'currentuser' },
     azureCloudOptions: [
       { value: 'AzureCloud', label: 'Azure' },

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
@@ -14,7 +14,6 @@ import { AppRegistrationCredentials } from './AppRegistrationCredentials';
 export interface Props {
   managedIdentityEnabled: boolean;
   workloadIdentityEnabled: boolean;
-  userIdentityEnabled: boolean;
   credentials: AadCurrentUserCredentials;
   azureCloudOptions?: SelectableValue[];
   onCredentialsChange: (updatedCredentials: AzureCredentials) => void;

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/re
 import { config } from '@grafana/runtime';
 
 import { createMockDatasourceSettings } from '../../__mocks__/datasourceSettings';
+import { AzureCloud } from '../../types';
 
 import { MonitorConfig, Props } from './MonitorConfig';
 

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.test.tsx
@@ -60,6 +60,7 @@ describe('MonitorConfig', () => {
   it('should render with user identity enabled when feature toggle is true', async () => {
     config.azure.userIdentityEnabled = true;
     config.featureToggles.azureMonitorEnableUserAuth = true;
+    config.azure.cloud = AzureCloud.Public;
 
     const optionsWithUserAuth = createMockDatasourceSettings({
       jsonData: { azureAuthType: 'currentuser' },

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx
@@ -52,7 +52,7 @@ export const MonitorConfig = (props: Props) => {
       <AzureCredentialsForm
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
         workloadIdentityEnabled={config.azure.workloadIdentityEnabled}
-        userIdentityEnabled={config.azure.userIdentityEnabled}
+        userIdentityEnabled={config.azure.userIdentityEnabled && !!config.featureToggles.azureMonitorEnableUserAuth}
         credentials={credentials}
         azureCloudOptions={getAzureCloudOptions()}
         onCredentialsChange={onCredentialsChange}


### PR DESCRIPTION
Backport b898a4540d986eb7ccf3127924f47eec3c0e1542 from #96858

---

**What is this feature?**

This PR allows Grafana operators to enable or disable Azure Monitor user-based authentication independently from other Azure data sources. 

A new feature toggle `azureMonitorEnableUserAuth` has been introduced within the `config.featureToggles` object. 

The feature toggle is checked alongside the existing configuration options (`config.azure.userIdentityEnabled`) to determine if user-based authentication for Azure Monitor is available.

**Which issue(s) does this PR fix?**:

Fixes #96650.
