### PR TITLE
Scopes: Add ScopesContext to `@grafana/runtime`

### DIFF
--- a/packages/grafana-runtime/src/services/ScopesContext.ts
+++ b/packages/grafana-runtime/src/services/ScopesContext.ts
@@ -4,28 +4,47 @@ import { Observable } from 'rxjs';
 
 import { Scope } from '@grafana/data';
 
+export interface ScopesContextValueState {
+  drawerOpened: boolean;
+  enabled: boolean;
+  loading: boolean;
+  readOnly: boolean;
+  value: Scope[];
+}
+
 export interface ScopesContextValue {
-  state: {
-    isDrawerOpened: boolean;
-    isEnabled: boolean;
-    isLoading: boolean;
-    isReadOnly: boolean;
-    value: Scope[];
-  };
+  /**
+   * Current state.
+   */
+  state: ScopesContextValueState;
+
+  /**
+   * Observable that emits the current state.
+   */
   stateObservable: Observable<ScopesContextValue['state']>;
-  changeScopes: (scopeNames: string[]) => void;
-  enterReadOnly: () => void;
-  exitReadOnly: () => void;
-  toggleDrawer: () => void;
-  openDrawer: () => void;
-  closeDrawer: () => void;
-  enable: () => void;
-  disable: () => void;
+
+  /**
+   * Change the selected scopes. The service takes care about loading them and propagating the changes.
+   * @param scopeNames
+   */
+  changeScopes(scopeNames: string[]): void;
+
+  /**
+   * Set read-only mode.
+   * If `readOnly` is `true`, the selector will be set to read-only and the dashboards panel will be closed.
+   */
+  setReadOnly(readOnly: boolean): void;
+
+  /**
+   * Enable or disable the usage of scopes.
+   * This will hide the selector and the dashboards panel, and it will stop propagating the scopes to the query object.
+   */
+  setEnabled(enabled: boolean): void;
 }
 
 export const ScopesContext = createContext<ScopesContextValue | undefined>(undefined);
 
-export function useScopes() {
+export function useScopes(): ScopesContextValue | undefined {
   const context = useContext(ScopesContext);
 
   useObservable(context?.stateObservable ?? new Observable(), context?.state);
@@ -35,13 +54,8 @@ export function useScopes() {
         state: context.state,
         stateObservable: context.stateObservable,
         changeScopes: context.changeScopes,
-        enterReadOnly: context.enterReadOnly,
-        exitReadOnly: context.exitReadOnly,
-        toggleDrawer: context.toggleDrawer,
-        openDrawer: context.openDrawer,
-        closeDrawer: context.closeDrawer,
-        enable: context.enable,
-        disable: context.disable,
+        setReadOnly: context.setReadOnly,
+        setEnabled: context.setEnabled,
       }
     : undefined;
 }

--- a/packages/grafana-runtime/src/services/ScopesContext.ts
+++ b/packages/grafana-runtime/src/services/ScopesContext.ts
@@ -1,0 +1,47 @@
+import { createContext, useContext } from 'react';
+import { useObservable } from 'react-use';
+import { Observable } from 'rxjs';
+
+import { Scope } from '@grafana/data';
+
+export interface ScopesContextValue {
+  state: {
+    isDrawerOpened: boolean;
+    isEnabled: boolean;
+    isLoading: boolean;
+    isReadOnly: boolean;
+    value: Scope[];
+  };
+  stateObservable: Observable<ScopesContextValue['state']>;
+  changeScopes: (scopeNames: string[]) => void;
+  enterReadOnly: () => void;
+  exitReadOnly: () => void;
+  toggleDrawer: () => void;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+  enable: () => void;
+  disable: () => void;
+}
+
+export const ScopesContext = createContext<ScopesContextValue | undefined>(undefined);
+
+export function useScopes() {
+  const context = useContext(ScopesContext);
+
+  useObservable(context?.stateObservable ?? new Observable(), context?.state);
+
+  return context
+    ? {
+        state: context.state,
+        stateObservable: context.stateObservable,
+        changeScopes: context.changeScopes,
+        enterReadOnly: context.enterReadOnly,
+        exitReadOnly: context.exitReadOnly,
+        toggleDrawer: context.toggleDrawer,
+        openDrawer: context.openDrawer,
+        closeDrawer: context.closeDrawer,
+        enable: context.enable,
+        disable: context.disable,
+      }
+    : undefined;
+}

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -36,3 +36,5 @@ export { setPluginLinksHook, usePluginLinks } from './pluginExtensions/usePlugin
 
 export { isPluginExtensionLink, isPluginExtensionComponent } from './pluginExtensions/utils';
 export { setCurrentUser } from './user';
+
+export { ScopesContext, type ScopesContextValue, useScopes } from './ScopesContext';

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -37,4 +37,4 @@ export { setPluginLinksHook, usePluginLinks } from './pluginExtensions/usePlugin
 export { isPluginExtensionLink, isPluginExtensionComponent } from './pluginExtensions/utils';
 export { setCurrentUser } from './user';
 
-export { ScopesContext, type ScopesContextValue, useScopes } from './ScopesContext';
+export { ScopesContext, type ScopesContextValueState, type ScopesContextValue, useScopes } from './ScopesContext';


### PR DESCRIPTION
**What is this feature?**

Add `ScopesContext` to `@grafana/runtime` so it can be consumed by `@grafana/scenes'

**Why do we need this feature?**

First step of:
- https://github.com/grafana/scenes/pull/990
- https://github.com/grafana/grafana/pull/97176

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
