### PR TITLE
Alerting: Fix alert rules unpausing after moving rule to different folder

### DIFF
--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -628,6 +628,7 @@ func CopyRule(r *AlertRule, mutators ...AlertRuleMutator) *AlertRule {
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,
 		Record:          r.Record,
+		IsPaused:        r.IsPaused,
 	}
 
 	if r.DashboardUID != nil {


### PR DESCRIPTION
When moving an alert rule from folder `A` to folder `B`, paused alerts in folder `A` can be unpaused.

https://github.com/user-attachments/assets/d213f651-d7f2-49b0-8cb6-b16e817682c9

When deep-copying the alert rules in the group, we forget to add the `IsPaused` field. This PR fixes that bug.