### PR TITLE
Explore Metrics: URL sync previews of metric graphs

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -7,8 +7,8 @@ import {
   GrafanaTheme2,
   MetricFindValue,
   RawTimeRange,
-  VariableHide,
   urlUtil,
+  VariableHide,
 } from '@grafana/data';
 import { PromQuery } from '@grafana/prometheus';
 import { locationService, useChromeHeaderHeight } from '@grafana/runtime';
@@ -25,6 +25,7 @@ import {
   SceneObjectState,
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
+  SceneObjectWithUrlSync,
   SceneQueryRunner,
   SceneRefreshPicker,
   SceneTimePicker,
@@ -50,11 +51,11 @@ import { reportChangeInLabelFilters } from './interactions';
 import { getDeploymentEnvironments, TARGET_INFO_FILTER, totalOtelResources } from './otel/api';
 import { OtelResourcesObject, OtelTargetType } from './otel/types';
 import {
-  sortResources,
   getOtelJoinQuery,
   getOtelResourcesObject,
-  updateOtelJoinWithGroupLeft,
   getProdOrDefaultOption,
+  sortResources,
+  updateOtelJoinWithGroupLeft,
 } from './otel/util';
 import { getOtelExperienceToggleState } from './services/store';
 import {
@@ -98,8 +99,8 @@ export interface DataTrailState extends SceneObjectState {
   metricSearch?: string;
 }
 
-export class DataTrail extends SceneObjectBase<DataTrailState> {
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['metric', 'metricSearch'] });
+export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneObjectWithUrlSync {
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['metric', 'metricSearch', 'showPreviews'] });
 
   public constructor(state: Partial<DataTrailState>) {
     super({
@@ -122,7 +123,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
       useOtelExperience: state.useOtelExperience ?? false,
       // preserve the otel join query
       otelJoinQuery: state.otelJoinQuery ?? '',
-      showPreviews: true,
+      showPreviews: state.showPreviews ?? true,
       ...state,
     });
 
@@ -283,9 +284,14 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     return stateUpdate;
   }
 
-  getUrlState() {
-    const { metric, metricSearch } = this.state;
-    return { metric, metricSearch };
+  getUrlState(): SceneObjectUrlValues {
+    const { metric, metricSearch, showPreviews } = this.state;
+    console.log('getUrlState', { showPreviews });
+    return {
+      metric,
+      metricSearch,
+      ...(showPreviews === false ? { showPreviews: 'false' } : { showPreviews: null }),
+    };
   }
 
   updateFromUrl(values: SceneObjectUrlValues) {
@@ -305,6 +311,14 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
     } else if (values.metric == null) {
       stateUpdate.metricSearch = undefined;
     }
+
+    if (typeof values.showPreviews === 'string') {
+      stateUpdate.showPreviews = values.showPreviews !== 'false';
+    } else {
+      console.log('somehow it is not a string');
+    }
+
+    console.log('updateFromUrl', { showPreviews: values.showPreviews });
 
     this.setState(stateUpdate);
   }

--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -286,11 +286,10 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
 
   getUrlState(): SceneObjectUrlValues {
     const { metric, metricSearch, showPreviews } = this.state;
-    console.log('getUrlState', { showPreviews });
     return {
       metric,
       metricSearch,
-      ...(showPreviews === false ? { showPreviews: 'false' } : { showPreviews: null }),
+      ...{ showPreviews: showPreviews === false ? 'false' : null },
     };
   }
 
@@ -314,11 +313,7 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
 
     if (typeof values.showPreviews === 'string') {
       stateUpdate.showPreviews = values.showPreviews !== 'false';
-    } else {
-      console.log('somehow it is not a string');
     }
-
-    console.log('updateFromUrl', { showPreviews: values.showPreviews });
 
     this.setState(stateUpdate);
   }


### PR DESCRIPTION
**What is this feature?**

Metric previews are enabled by default but we can disable it too. It wasn't reflected in the URL so when you share the URL with somebody, they will always see the previews. This PR makes sure the preview option will be synced in the URL. When it's disabled `^showPreviews=false` will be added to the URL. 

**Why do we need this feature?**

Better URL sharing in Explore Metrics

**Who is this feature for?**

Explore metrics users

