### PR TITLE
Explore Metrics: Remove filter resetting when changing the datasource 

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -176,11 +176,6 @@ export class DataTrail extends SceneObjectBase<DataTrailState> {
 
         // fresh check for otel experience
         this.checkDataSourceForOTelResources();
-        // clear filters on resetting the data source
-        const adhocVariable = sceneGraph.lookupVariable(VAR_FILTERS, this);
-        if (adhocVariable instanceof AdHocFiltersVariable) {
-          adhocVariable.setState({ filters: [] });
-        }
       }
 
       // update otel variables when changed


### PR DESCRIPTION
**What is this feature?**

Make sure we preserve the filters

**Who is this feature for?**

Explore metrics users.
