### PR TITLE
Table: RowsList passing incorrect index to onRowHover

### DIFF
--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -124,14 +124,15 @@ export const RowsList = (props: RowsListProps) => {
 
   const onRowHover = useCallback(
     (idx: number, frame: DataFrame) => {
-      if (!panelContext || !enableSharedCrosshair || !hasTimeField(frame)) {
+      if (!panelContext || !enableSharedCrosshair) {
         return;
       }
 
-      // HERE
-
       const timeField: Field = frame!.fields.find((f) => f.type === FieldType.time)!;
-      console.log('onrowHover', timeField.values[idx], timeField, frame, idx);
+
+      if (!timeField) {
+        return;
+      }
 
       panelContext.eventBus.publish(
         new DataHoverEvent({

--- a/packages/grafana-ui/src/components/Table/RowsList.tsx
+++ b/packages/grafana-ui/src/components/Table/RowsList.tsx
@@ -128,7 +128,10 @@ export const RowsList = (props: RowsListProps) => {
         return;
       }
 
+      // HERE
+
       const timeField: Field = frame!.fields.find((f) => f.type === FieldType.time)!;
+      console.log('onrowHover', timeField.values[idx], timeField, frame, idx);
 
       panelContext.eventBus.publish(
         new DataHoverEvent({
@@ -311,7 +314,7 @@ export const RowsList = (props: RowsListProps) => {
           key={key}
           {...rowProps}
           className={cx(tableStyles.row, expandedRowStyle)}
-          onMouseEnter={() => onRowHover(index, data)}
+          onMouseEnter={() => onRowHover(row.index, data)}
           onMouseLeave={onRowLeave}
         >
           {/*add the nested data to the DOM first to prevent a 1px border CSS issue on the last cell of the row*/}


### PR DESCRIPTION
**What is this fix?**
The DataHoverEvent currently being emitted from RowsList in the table is using the index of the row in the table, not the index of the value in the dataframe.

**Why do we need this fix?**
So sorted tables emit the correct `DataHoverEvent` required for shared crosshairs in dashboards and apps.

**Who is this feature for?**
Users of the table panel

**Special notes for your reviewer:**
Looks like the bug was released in https://github.com/grafana/grafana/pull/78392 in 10.3
~Not sure how far back we should backport it, I'll let dataviz decide~
Requires `tableSharedCrosshair` experimental feature flag to reproduce in dashboards.

I can repro the bug and the fix locally, but in ops I don't see shared crosshairs working at all: https://ops.grafana-ops.net/d/ee64u5gtj1ptsc/shared-tooltip-bug-copy?orgId=1&from=now-3h&to=now&timezone=utc

But if you debug RowsList in ops, you'll see that the DataHoverEvent is being emitted, just with the wrong index

So there might be another bug

Localhost showing bug:

https://github.com/user-attachments/assets/9c368726-feeb-4a93-9357-f840731c9407

Localhost showing fix:

https://github.com/user-attachments/assets/f2411f96-a2fc-4d95-8a5e-519fec7b21ad

Ops showing a different bug?:

https://github.com/user-attachments/assets/1e58156d-e269-49be-9dbe-0583183589e3

Also you can see another bug with the tooltip showing up in a panel you are not hovering over, I reported that here: https://github.com/grafana/grafana/issues/97600

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
