### PR TITLE
Docs: Fix URL in loki live tail nginx proxy example

### DIFF
--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -212,7 +212,7 @@ If you use reverse proxies, configure them accordingly to use live tailing:
 **Using Apache2 for proxying between the browser and the Grafana server:**
 
 ```
-ProxyPassMatch "^/(api/datasources/proxy/uid/\d+/loki/api/v1/tail)" "ws://127.0.0.1:3000/$1"
+ProxyPassMatch "^/(api/datasources/proxy/uid/[a-zA-Z0-9_-]+/loki/api/v1/tail)" "ws://127.0.0.1:3000/$1"
 ```
 
 **Using NGINX:**
@@ -233,7 +233,7 @@ In the `http` section of NGINX configuration, add the following map definition:
 In your `server` section, add the following configuration:
 
 ```
-  location ~ /(api/datasources/proxy/uid/\d+/loki/api/v1/tail) {
+  location ~ /(api/datasources/proxy/uid/[a-zA-Z0-9_-]+/loki/api/v1/tail) {
       proxy_pass          http://localhost:3000$request_uri;
       proxy_set_header    Host              $host;
       proxy_set_header    X-Real-IP         $remote_addr;

--- a/docs/sources/datasources/loki/query-editor/index.md
+++ b/docs/sources/datasources/loki/query-editor/index.md
@@ -212,7 +212,7 @@ If you use reverse proxies, configure them accordingly to use live tailing:
 **Using Apache2 for proxying between the browser and the Grafana server:**
 
 ```
-ProxyPassMatch "^/(api/datasources/proxy/\d+/loki/api/v1/tail)" "ws://127.0.0.1:3000/$1"
+ProxyPassMatch "^/(api/datasources/proxy/uid/\d+/loki/api/v1/tail)" "ws://127.0.0.1:3000/$1"
 ```
 
 **Using NGINX:**
@@ -233,7 +233,7 @@ In the `http` section of NGINX configuration, add the following map definition:
 In your `server` section, add the following configuration:
 
 ```
-  location ~ /(api/datasources/proxy/\d+/loki/api/v1/tail) {
+  location ~ /(api/datasources/proxy/uid/\d+/loki/api/v1/tail) {
       proxy_pass          http://localhost:3000$request_uri;
       proxy_set_header    Host              $host;
       proxy_set_header    X-Real-IP         $remote_addr;


### PR DESCRIPTION
Makes https://github.com/grafana/grafana/pull/27998 correct again.

The change that broke this is probably what's documented in

https://github.com/grafana/grafana/commit/060af782df7957445a8666b4d4e38f9a1b293790#diff-a17c68ce20226f9b776cf4c8882169e9a56c7b6bcda73a58a61ce5e1988fa99fR699

but I couldn't find the non-docs commit where the new URI was introduced.