### PR TITLE
Alerting: Improve performance ash page

### DIFF
--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -241,12 +241,15 @@ export function ClearFilterButtonObjectRenderer({ model }: SceneComponentProps<C
   }
 
   const onClearFilter = () => {
+    // eslint-disable-next-line
     const labelsFiltersVariable = sceneGraph.lookupVariable(LABELS_FILTER, model) as TextBoxVariable;
     labelsFiltersVariable.setValue('');
 
+    // eslint-disable-next-line
     const stateToFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_TO, model) as CustomVariable;
     stateToFilterVariable.changeValueTo(StateFilterValues.all);
 
+    // eslint-disable-next-line
     const stateFromFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_FROM, model) as CustomVariable;
     stateFromFilterVariable.changeValueTo(StateFilterValues.all);
   };

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -171,26 +171,23 @@ function getEventsSceneObject(
   transitionsToFilterVariable: CustomVariable,
   transitionsFromFilterVariable: CustomVariable
 ) {
-  return new EmbeddedScene({
-    controls: [],
-    body: new SceneFlexLayout({
-      direction: 'column',
-      children: [
-        new SceneFlexItem({
-          ySizing: 'content',
-          body: new SceneFlexLayout({
-            children: [
-              getEventsScenesFlexItem(
-                alertStateHistoryDataSource,
-                labelsFilterVariable,
-                transitionsToFilterVariable,
-                transitionsFromFilterVariable
-              ),
-            ],
-          }),
+  return new SceneFlexLayout({
+    direction: 'column',
+    children: [
+      new SceneFlexItem({
+        ySizing: 'content',
+        body: new SceneFlexLayout({
+          children: [
+            getEventsScenesFlexItem(
+              alertStateHistoryDataSource,
+              labelsFilterVariable,
+              transitionsToFilterVariable,
+              transitionsFromFilterVariable
+            ),
+          ],
         }),
-      ],
-    }),
+      }),
+    ],
   });
 }
 
@@ -322,13 +319,6 @@ export function EventsPanelScenesObjectRenderer({
   EventsPanelScenesObject & { datasource: DataSourceInformation; body: VizPanel<Options, FieldConfig> }
 >) {
   const { body } = model.useState();
-
-  // we need to call this to sync the url with the scene state
-  const isUrlSyncInitialized = useUrlSync(model.getRoot());
-
-  if (!isUrlSyncInitialized) {
-    return null;
-  }
 
   if (body) {
     return <body.Component model={body} />;

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -154,14 +154,7 @@ export const CentralAlertHistoryScene = () => {
 function getEventsSceneObject() {
   return new SceneFlexLayout({
     direction: 'column',
-    children: [
-      new SceneFlexItem({
-        ySizing: 'content',
-        body: new SceneFlexLayout({
-          children: [getEventsScenesFlexItem()],
-        }),
-      }),
-    ],
+    children: [getEventsScenesFlexItem()],
   });
 }
 

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
 import { useEffect, useMemo } from 'react';
-import { Options } from 'uplot';
 
-import { FieldConfig, GrafanaTheme2, VariableHide } from '@grafana/data';
+import { GrafanaTheme2, VariableHide } from '@grafana/data';
 import {
   CustomVariable,
   EmbeddedScene,
@@ -21,7 +20,6 @@ import {
   TextBoxVariable,
   VariableDependencyConfig,
   VariableValueSelectors,
-  VizPanel,
   sceneGraph,
   useUrlSync,
 } from '@grafana/scenes';
@@ -184,31 +182,29 @@ function getQueryRunnerForAlertHistoryDataSource() {
 export function getEventsScenesFlexItem() {
   return new SceneFlexItem({
     minHeight: 300,
-    body:
-      // eslint-disable-next-line
-      PanelBuilders.timeseries()
-        .setTitle('Alert Events')
-        .setDescription(
-          'Each alert event represents an alert instance that changed its state at a particular point in time. The history of the data is displayed over a period of time.'
-        )
-        .setData(getQueryRunnerForAlertHistoryDataSource())
-        .setColor({ mode: 'continuous-BlPu' })
-        .setCustomFieldConfig('fillOpacity', 100)
-        .setCustomFieldConfig('drawStyle', GraphDrawStyle.Bars)
-        .setCustomFieldConfig('lineInterpolation', LineInterpolation.Linear)
-        .setCustomFieldConfig('lineWidth', 1)
-        .setCustomFieldConfig('barAlignment', 0)
-        .setCustomFieldConfig('spanNulls', false)
-        .setCustomFieldConfig('insertNulls', false)
-        .setCustomFieldConfig('showPoints', VisibilityMode.Auto)
-        .setCustomFieldConfig('pointSize', 5)
-        .setCustomFieldConfig('stacking', { mode: StackingMode.None, group: 'A' })
-        .setCustomFieldConfig('gradientMode', GraphGradientMode.Hue)
-        .setCustomFieldConfig('scaleDistribution', { type: ScaleDistribution.Linear })
-        .setOption('legend', { showLegend: false, displayMode: LegendDisplayMode.Hidden })
-        .setOption('tooltip', { mode: TooltipDisplayMode.Single })
-        .setNoValue('No events found')
-        .build() as VizPanel<Options, FieldConfig>,
+    body: PanelBuilders.timeseries()
+      .setTitle('Alert Events')
+      .setDescription(
+        'Each alert event represents an alert instance that changed its state at a particular point in time. The history of the data is displayed over a period of time.'
+      )
+      .setData(getQueryRunnerForAlertHistoryDataSource())
+      .setColor({ mode: 'continuous-BlPu' })
+      .setCustomFieldConfig('fillOpacity', 100)
+      .setCustomFieldConfig('drawStyle', GraphDrawStyle.Bars)
+      .setCustomFieldConfig('lineInterpolation', LineInterpolation.Linear)
+      .setCustomFieldConfig('lineWidth', 1)
+      .setCustomFieldConfig('barAlignment', 0)
+      .setCustomFieldConfig('spanNulls', false)
+      .setCustomFieldConfig('insertNulls', false)
+      .setCustomFieldConfig('showPoints', VisibilityMode.Auto)
+      .setCustomFieldConfig('pointSize', 5)
+      .setCustomFieldConfig('stacking', { mode: StackingMode.None, group: 'A' })
+      .setCustomFieldConfig('gradientMode', GraphGradientMode.Hue)
+      .setCustomFieldConfig('scaleDistribution', { type: ScaleDistribution.Linear })
+      .setOption('legend', { showLegend: false, displayMode: LegendDisplayMode.Hidden })
+      .setOption('tooltip', { mode: TooltipDisplayMode.Single })
+      .setNoValue('No events found')
+      .build(),
   });
 }
 
@@ -234,17 +230,20 @@ export function ClearFilterButtonObjectRenderer({ model }: SceneComponentProps<C
   }
 
   const onClearFilter = () => {
-    // eslint-disable-next-line
-    const labelsFiltersVariable = sceneGraph.lookupVariable(LABELS_FILTER, model) as TextBoxVariable;
-    labelsFiltersVariable.setValue('');
+    const labelsFiltersVariable = sceneGraph.lookupVariable(LABELS_FILTER, model);
+    if (labelsFiltersVariable instanceof TextBoxVariable) {
+      labelsFiltersVariable.setValue('');
+    }
 
-    // eslint-disable-next-line
-    const stateToFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_TO, model) as CustomVariable;
-    stateToFilterVariable.changeValueTo(StateFilterValues.all);
+    const stateToFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_TO, model);
+    if (stateToFilterVariable instanceof CustomVariable) {
+      stateToFilterVariable.changeValueTo(StateFilterValues.all);
+    }
 
-    // eslint-disable-next-line
-    const stateFromFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_FROM, model) as CustomVariable;
-    stateFromFilterVariable.changeValueTo(StateFilterValues.all);
+    const stateFromFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_FROM, model);
+    if (stateFromFilterVariable instanceof CustomVariable) {
+      stateFromFilterVariable.changeValueTo(StateFilterValues.all);
+    }
   };
 
   return (

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
@@ -1,6 +1,8 @@
+import { template } from 'lodash';
 import { useEffect, useMemo } from 'react';
 
 import { DataQuery, DataQueryRequest, DataQueryResponse, TestDataSourceResponse } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { RuntimeDataSource, sceneUtils } from '@grafana/scenes';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { dispatch } from 'app/store/store';
@@ -31,6 +33,12 @@ export function useRegisterHistoryRuntimeDataSource() {
   }, [ds]);
 }
 
+interface HistoryAPIQuery extends DataQuery {
+  labels?: string;
+  stateFrom?: string;
+  stateTo?: string;
+}
+
 /**
  * This class is a runtime datasource that fetches the events from the history api.
  * The events are grouped by alert instance and then converted to a DataFrame list.
@@ -38,23 +46,29 @@ export function useRegisterHistoryRuntimeDataSource() {
  * This allows us to filter the events by labels.
  * The result is a timeseries panel that shows the events for the selected time range and filtered by labels.
  */
-class HistoryAPIDatasource extends RuntimeDataSource {
+class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
   constructor(pluginId: string, uid: string) {
     super(uid, pluginId);
   }
 
-  async query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> {
+  async query(request: DataQueryRequest<HistoryAPIQuery>): Promise<DataQueryResponse> {
     const from = request.range.from.unix();
     const to = request.range.to.unix();
 
     // Get the labels and states filters from the URL
-    const stateTo = getStateFilterToInQueryParams();
-    const stateFrom = getStateFilterFromInQueryParams();
+    const query = request.targets[0]!;
+
+    const templateSrv = getTemplateSrv();
+
+    // where is the labels filter used??
+    const labels = templateSrv.replace(query.labels ?? '', request.scopedVars);
+    const stateTo = templateSrv.replace(query.stateTo ?? '', request.scopedVars);
+    const stateFrom = templateSrv.replace(query.stateFrom ?? '', request.scopedVars);
 
     const historyResult = await getHistory(from, to);
 
     return {
-      data: historyResultToDataFrame(historyResult, { stateTo, stateFrom }),
+      data: historyResultToDataFrame(historyResult, { stateTo, stateFrom, labels }),
     };
   }
 

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
@@ -53,13 +53,12 @@ class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
   async query(request: DataQueryRequest<HistoryAPIQuery>): Promise<DataQueryResponse> {
     const from = request.range.from.unix();
     const to = request.range.to.unix();
-
-    // Get the labels and states filters from the URL
+    // get the query from the request
     const query = request.targets[0]!;
 
     const templateSrv = getTemplateSrv();
 
-    // where is the labels filter used??
+    // we get the labels, stateTo and stateFrom from the query variables
     const labels = templateSrv.replace(query.labels ?? '', request.scopedVars);
     const stateTo = templateSrv.replace(query.stateTo ?? '', request.scopedVars);
     const stateFrom = templateSrv.replace(query.stateFrom ?? '', request.scopedVars);

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
@@ -1,4 +1,3 @@
-import { template } from 'lodash';
 import { useEffect, useMemo } from 'react';
 
 import { DataQuery, DataQueryRequest, DataQueryResponse, TestDataSourceResponse } from '@grafana/data';
@@ -11,7 +10,7 @@ import { stateHistoryApi } from '../../../api/stateHistoryApi';
 import { DataSourceInformation } from '../../../home/Insights';
 
 import { LIMIT_EVENTS } from './EventListSceneObject';
-import { getStateFilterFromInQueryParams, getStateFilterToInQueryParams, historyResultToDataFrame } from './utils';
+import { historyResultToDataFrame } from './utils';
 
 const historyDataSourceUid = '__history_api_ds_uid__';
 const historyDataSourcePluginId = '__history_api_ds_pluginId__';

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -510,35 +510,40 @@ export function HistoryEventsListObjectRenderer({ model }: SceneComponentProps<H
 
   const { value: timeRange } = sceneGraph.getTimeRange(model).useState(); // get time range from scene graph
 
-  // eslint-disable-next-line
-  const labelsFiltersVariable = sceneGraph.lookupVariable(LABELS_FILTER, model)! as TextBoxVariable;
-  // eslint-disable-next-line
-  const stateToFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_TO, model)! as CustomVariable;
-  // eslint-disable-next-line
-  const stateFromFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_FROM, model)! as CustomVariable;
+  const labelsFiltersVariable = sceneGraph.lookupVariable(LABELS_FILTER, model);
+  const stateToFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_TO, model);
+  const stateFromFilterVariable = sceneGraph.lookupVariable(STATE_FILTER_FROM, model);
 
   const addFilter = (key: string, value: string, type: FilterType) => {
     const newFilterToAdd = `${key}=${value}`;
     trackUseCentralHistoryFilterByClicking({ type, key, value });
-    if (type === 'stateTo') {
+    if (type === 'stateTo' && stateToFilterVariable instanceof CustomVariable) {
       stateToFilterVariable.changeValueTo(value);
     }
-    if (type === 'stateFrom') {
+    if (type === 'stateFrom' && stateFromFilterVariable instanceof CustomVariable) {
       stateFromFilterVariable.changeValueTo(value);
     }
-    const finalFilter = combineMatcherStrings(labelsFiltersVariable.state.value.toString(), newFilterToAdd);
-    if (type === 'label') {
+    if (type === 'label' && labelsFiltersVariable instanceof TextBoxVariable) {
+      const finalFilter = combineMatcherStrings(labelsFiltersVariable.state.value.toString(), newFilterToAdd);
       labelsFiltersVariable.setValue(finalFilter);
     }
   };
 
-  return (
-    <HistoryEventsList
-      timeRange={timeRange}
-      valueInLabelFilter={labelsFiltersVariable.state.value}
-      addFilter={addFilter}
-      valueInStateToFilter={stateToFilterVariable.state.value}
-      valueInStateFromFilter={stateFromFilterVariable.state.value}
-    />
-  );
+  if (
+    stateToFilterVariable instanceof CustomVariable &&
+    stateFromFilterVariable instanceof CustomVariable &&
+    labelsFiltersVariable instanceof TextBoxVariable
+  ) {
+    return (
+      <HistoryEventsList
+        timeRange={timeRange}
+        valueInLabelFilter={labelsFiltersVariable.state.value}
+        addFilter={addFilter}
+        valueInStateToFilter={stateToFilterVariable.state.value}
+        valueInStateFromFilter={stateFromFilterVariable.state.value}
+      />
+    );
+  } else {
+    return null;
+  }
 }

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -8,7 +8,6 @@ import {
   CustomVariable,
   SceneComponentProps,
   SceneObjectBase,
-  SceneObjectState,
   TextBoxVariable,
   VariableDependencyConfig,
   VariableValue,

--- a/public/app/features/alerting/unified/components/rules/central-state-history/__snapshots__/utils.test.ts.snap
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/__snapshots__/utils.test.ts.snap
@@ -39,7 +39,7 @@ exports[`historyResultToDataFrame should decode 1`] = `
 ]
 `;
 
-exports[`historyResultToDataFrame should decode and filter 1`] = `
+exports[`historyResultToDataFrame should decode and filter example1 1`] = `
 [
   {
     "fields": [
@@ -62,6 +62,37 @@ exports[`historyResultToDataFrame should decode and filter 1`] = `
         "type": "number",
         "values": [
           1,
+        ],
+      },
+    ],
+    "length": 1,
+  },
+]
+`;
+
+exports[`historyResultToDataFrame should decode and filter example2 1`] = `
+[
+  {
+    "fields": [
+      {
+        "config": {
+          "custom": {
+            "fillOpacity": 100,
+          },
+          "displayName": "Time",
+        },
+        "name": "time",
+        "type": "time",
+        "values": [
+          1727189670000,
+        ],
+      },
+      {
+        "config": {},
+        "name": "value",
+        "type": "number",
+        "values": [
+          8,
         ],
       },
     ],

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.test.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.test.ts
@@ -7,6 +7,8 @@ describe('historyResultToDataFrame', () => {
   });
 
   it('should decode and filter', () => {
-    expect(historyResultToDataFrame(fixtureData, { stateFrom: 'Pending', stateTo: 'Alerting' })).toMatchSnapshot();
+    expect(
+      historyResultToDataFrame(fixtureData, { stateFrom: 'Pending', stateTo: 'Alerting', labels: '' })
+    ).toMatchSnapshot();
   });
 });

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.test.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.test.ts
@@ -6,9 +6,18 @@ describe('historyResultToDataFrame', () => {
     expect(historyResultToDataFrame(fixtureData)).toMatchSnapshot();
   });
 
-  it('should decode and filter', () => {
+  it('should decode and filter example1', () => {
     expect(
-      historyResultToDataFrame(fixtureData, { stateFrom: 'Pending', stateTo: 'Alerting', labels: '' })
+      historyResultToDataFrame(fixtureData, {
+        stateFrom: 'Pending',
+        stateTo: 'Alerting',
+        labels: "alertname: 'XSS attack vector'",
+      })
+    ).toMatchSnapshot();
+  });
+  it('should decode and filter example2', () => {
+    expect(
+      historyResultToDataFrame(fixtureData, { stateFrom: 'Normal', stateTo: 'NoData', labels: 'region: EMEA' })
     ).toMatchSnapshot();
   });
 });

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -105,7 +105,7 @@ export function getStateFilterFromInQueryParams() {
  * This function groups the data frames by time and filters them by labels.
  * The interval is set to 10 seconds.
  * */
-function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[], filters: HistoryFilters): DataFrame[] {
+export function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[], filters: HistoryFilters): DataFrame[] {
   // Filter data frames by labels. This is used to filter out the data frames that do not match the query.
   const labelsFilterValue = filters.labels;
   const dataframesFiltered = dataFrames.filter((frame) => {

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -24,9 +24,16 @@ import { LABELS_FILTER, STATE_FILTER_FROM, STATE_FILTER_TO, StateFilterValues } 
 const GROUPING_INTERVAL = 10 * 1000; // 10 seconds
 const QUERY_PARAM_PREFIX = 'var-'; // Prefix used by Grafana to sync variables in the URL
 
-const emptyFilters = {
+interface HistoryFilters {
+  stateTo: string;
+  stateFrom: string;
+  labels: string;
+}
+
+const emptyFilters: HistoryFilters = {
   stateTo: 'all',
   stateFrom: 'all',
+  labels: '',
 };
 
 /*
@@ -75,7 +82,7 @@ export function historyResultToDataFrame({ data }: DataFrameJSON, filters = empt
   });
 
   // Group DataFrames by time and filter by labels
-  return groupDataFramesByTimeAndFilterByLabels(dataFrames);
+  return groupDataFramesByTimeAndFilterByLabels(dataFrames, filters);
 }
 
 // Scenes sync variables in the URL adding a prefix to the variable name.
@@ -98,9 +105,9 @@ export function getStateFilterFromInQueryParams() {
  * This function groups the data frames by time and filters them by labels.
  * The interval is set to 10 seconds.
  * */
-function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[]): DataFrame[] {
+function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[], filters: HistoryFilters): DataFrame[] {
   // Filter data frames by labels. This is used to filter out the data frames that do not match the query.
-  const labelsFilterValue = getLabelsFilterInQueryParams();
+  const labelsFilterValue = filters.labels;
   const dataframesFiltered = dataFrames.filter((frame) => {
     const labels = JSON.parse(frame.name ?? ''); // in name we store the labels stringified
 


### PR DESCRIPTION
**What is this feature?**

This PR improves the performance in the central alert state history page. So far, the scene is mounted and unmounted any time any filter changes.

**Why do we need this feature?**


**Who is this feature for?**

All alerting users.

**Which issue(s) does this PR fix?**:



Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
