### PR TITLE
Drone: Stop moving the modified tag package json has changes" 

### DIFF
--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -46,7 +46,8 @@ for file in ./npm-artifacts/*.tgz; do
 done
 
 # Check if any files in packages/grafana-e2e-selectors were changed. If so, add a 'modified' tag to the package
-CHANGES_COUNT=$(git diff HEAD~1..HEAD --name-only -- packages/grafana-e2e-selectors | awk 'END{print NR}')
+# Ignore changes to the package.json file to prevent modified tag from being pointed to patch releases
+CHANGES_COUNT=$(git diff HEAD~1..HEAD --name-only -- packages/grafana-e2e-selectors | awk '!/packages\/grafana-e2e-selectors\/package.json/' | awk 'END{print NR}')
 if (( $CHANGES_COUNT > 0 )); then
     # Wait a little bit to allow the package to be published to the registry
     sleep 5s


### PR DESCRIPTION
**What is this feature?**

We want the `modified` tag to be repointed whenever the selectors change. However, before the change in this PR the `modified` tag was moved whenever any of the files in the e2e-selectors workspace changed. When the package.json file is changed, this usually means there's a new release of Grafana (major, minor or patch). There's no need to move the dist that when that happens, so I'm now ignoring changes to this file. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
