### PR TITLE
Chore: Fix `yarn generate-apis` command

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,12 @@
       "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"]
     }
   },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "ESNext",
+      "moduleResolution": "Node"
+    }
+  },
   "extends": "@grafana/tsconfig/base.json",
   "include": [
     "public/app/**/*.ts*",


### PR DESCRIPTION
**What is this feature?**
Fixes the `yarn generate-apis` command - https://github.com/grafana/grafana/pull/96450 introduce a change that broke it. The fix is taken from https://github.com/reduxjs/redux-toolkit/issues/4470