### PR TITLE
Transformations: GroupToMatrix add 0 as special value

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -105,11 +105,18 @@ describe('Grouping to Matrix', () => {
     });
   });
 
-  it('generates Matrix with empty entries', async () => {
+  it.only.each([
+    [undefined, ''],
+    [SpecialValue.Null, null],
+    [SpecialValue.False, false],
+    [SpecialValue.True, true],
+    [SpecialValue.Empty, ''],
+    [SpecialValue.Zero, 0],
+  ])('generates Matrix with empty entries', async (emptyValue, expectedValue) => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,
       options: {
-        emptyValue: SpecialValue.Null,
+        emptyValue: emptyValue,
       },
     };
 
@@ -133,13 +140,13 @@ describe('Grouping to Matrix', () => {
         {
           name: '1000',
           type: FieldType.number,
-          values: [1, null],
+          values: [1, expectedValue],
           config: {},
         },
         {
           name: '1001',
           type: FieldType.number,
-          values: [null, 2],
+          values: [expectedValue, 2],
           config: {},
         },
       ];

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -105,7 +105,7 @@ describe('Grouping to Matrix', () => {
     });
   });
 
-  it.only.each([
+  it.each([
     [undefined, ''],
     [SpecialValue.Null, null],
     [SpecialValue.False, false],

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -183,6 +183,8 @@ function getSpecialValue(specialValue: SpecialValue) {
       return true;
     case SpecialValue.Null:
       return null;
+    case SpecialValue.Zero:
+      return 0;
     case SpecialValue.Empty:
     default:
       return '';

--- a/packages/grafana-data/src/types/transformations.ts
+++ b/packages/grafana-data/src/types/transformations.ts
@@ -115,4 +115,5 @@ export enum SpecialValue {
   False = 'false',
   Null = 'null',
   Empty = 'empty',
+  Zero = 'zero',
 }

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -62,6 +62,7 @@ export const GroupingToMatrixTransformerEditor = ({
     { label: 'Null', value: SpecialValue.Null, description: 'Null value' },
     { label: 'True', value: SpecialValue.True, description: 'Boolean true value' },
     { label: 'False', value: SpecialValue.False, description: 'Boolean false value' },
+    { label: 'Zero', value: SpecialValue.Zero, description: 'Number 0 value' },
     { label: 'Empty', value: SpecialValue.Empty, description: 'Empty string' },
   ];
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds 0 as an empty value option.

**Why do we need this feature?**

In case we need all values to be numbers.

**Who is this feature for?**

Editors, and me :) Quite valuable when working with Google Forms data.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #97632

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
