### PR TITLE
WIP extend admission validate for delete use case

### DIFF
--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -316,7 +316,7 @@ func TestFolderAPIBuilder_Validate(t *testing.T) {
 				tt.input.name,
 				v0alpha1.SchemeGroupVersion.WithResource("folders"),
 				"",
-				"create",
+				"CREATE",
 				nil,
 				true,
 				&user.SignedInUser{},


### PR DESCRIPTION
**What is this feature?**

Using searcher from https://github.com/grafana/grafana/pull/97534 to validate if there are dashboards and folders inside a folder marked for deletion.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
