### PR TITLE
[Prototyping] Use linter config in files endpoints

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -101,6 +101,9 @@ type RepositorySpec struct {
 	// The repository type.  When selected oneOf the values below should be non-nil
 	Type RepositoryType `json:"type"`
 
+	// Linting enables linting for this repository
+	Linting bool `json:"linting,omitempty"`
+
 	// The repository on the local file system.
 	// Mutually exclusive with s3 and github.
 	Local *LocalRepositoryConfig `json:"local,omitempty"`

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -721,6 +721,13 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositorySpec(ref common.ReferenceCa
 							Enum:        []interface{}{"github", "local", "s3"},
 						},
 					},
+					"linting": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Linting enables linting for this repository",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"local": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The repository on the local file system. Mutually exclusive with s3 and github.",

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -147,7 +147,7 @@ func (s *filesConnector) Connect(ctx context.Context, name string, opts runtime.
 	}), nil
 }
 
-func (s *filesConnector) getParser(repo repository.Repository) (*resources.FileParser, error) {
+func (s *filesConnector) getParser(repo repository.Repository) (*resources.Parser, error) {
 	ns := repo.Config().Namespace
 	client, kinds, err := s.client.New(ns) // As system user
 	if err != nil {

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -157,8 +157,7 @@ func (s *filesConnector) getParser(ctx context.Context, repo repository.Reposito
 	}
 
 	parser := resources.NewParser(repo.Config(), client, kinds)
-	// FIXME: make linting an global option and not specific to PRs
-	if repo.Config().Spec.GitHub.PullRequestLinter {
+	if repo.Config().Spec.Linting {
 		linterFactory := lint.NewDashboardLinterFactory()
 		// TODO: which logger?
 		cfg, err := repo.Read(ctx, s.logger, linterFactory.ConfigPath(), repo.Config().Spec.GitHub.Branch)

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -16,7 +16,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/lint"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository/github"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
@@ -147,13 +149,36 @@ func (s *filesConnector) Connect(ctx context.Context, name string, opts runtime.
 	}), nil
 }
 
-func (s *filesConnector) getParser(repo repository.Repository) (*resources.Parser, error) {
+func (s *filesConnector) getParser(ctx context.Context, repo repository.Repository) (*resources.Parser, error) {
 	ns := repo.Config().Namespace
 	client, kinds, err := s.client.New(ns) // As system user
 	if err != nil {
 		return nil, err
 	}
-	return resources.NewParser(repo.Config(), client, kinds), nil
+
+	parser := resources.NewParser(repo.Config(), client, kinds)
+	// FIXME: make linting an global option and not specific to PRs
+	if repo.Config().Spec.GitHub.PullRequestLinter {
+		linterFactory := lint.NewDashboardLinterFactory()
+		// TODO: which logger?
+		cfg, err := repo.Read(ctx, s.logger, linterFactory.ConfigPath(), repo.Config().Spec.GitHub.Branch)
+		switch {
+		case err == nil:
+			s.logger.InfoContext(ctx, "linter config found", "config", string(cfg.Data))
+		case errors.Is(err, github.ErrResourceNotFound):
+			s.logger.InfoContext(ctx, "no linter config found")
+		default:
+			return nil, fmt.Errorf("failed to read linter config: %w", err)
+		}
+
+		linter, err := linterFactory.NewFromConfig(cfg.Data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create linter: %w", err)
+		}
+		parser.SetLinter(linter)
+	}
+
+	return parser, nil
 }
 
 func (s *filesConnector) doRead(ctx context.Context, logger *slog.Logger, repo repository.Repository, path string, ref string) (int, *provisioning.ResourceWrapper, error) {
@@ -162,7 +187,7 @@ func (s *filesConnector) doRead(ctx context.Context, logger *slog.Logger, repo r
 		return 0, nil, err
 	}
 
-	parser, err := s.getParser(repo)
+	parser, err := s.getParser(ctx, repo)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -209,7 +234,7 @@ func (s *filesConnector) doWrite(ctx context.Context, logger *slog.Logger, updat
 		Ref:  ref,
 	}
 
-	parser, err := s.getParser(repo)
+	parser, err := s.getParser(ctx, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -153,7 +153,7 @@ func (s *filesConnector) getParser(repo repository.Repository) (*resources.Parse
 	if err != nil {
 		return nil, err
 	}
-	return resources.NewParser(repo, client, kinds), nil
+	return resources.NewParser(repo.Config(), client, kinds), nil
 }
 
 func (s *filesConnector) doRead(ctx context.Context, logger *slog.Logger, repo repository.Repository, path string, ref string) (int, *provisioning.ResourceWrapper, error) {

--- a/pkg/registry/apis/provisioning/lint/dashboard.go
+++ b/pkg/registry/apis/provisioning/lint/dashboard.go
@@ -17,8 +17,8 @@ func NewDashboardLinterFactory() *DashboardLinterFactory {
 	return &DashboardLinterFactory{}
 }
 
-func (f *DashboardLinterFactory) New() (Linter, error) {
-	return &DashboardLinter{rules: lint.NewRuleSet()}, nil
+func (f *DashboardLinterFactory) New() Linter {
+	return &DashboardLinter{rules: lint.NewRuleSet()}
 }
 
 func (f *DashboardLinterFactory) NewFromConfig(cfg []byte) (Linter, error) {

--- a/pkg/registry/apis/provisioning/lint/lint.go
+++ b/pkg/registry/apis/provisioning/lint/lint.go
@@ -13,5 +13,5 @@ type Linter interface {
 type LinterFactory interface {
 	ConfigPath() string
 	NewFromConfig(cfg []byte) (Linter, error)
-	New() (Linter, error)
+	New() Linter
 }

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -504,7 +504,7 @@ func (r *githubRepository) parsePullRequestEvent(event *github.PullRequestEvent)
 		return nil, fmt.Errorf("missing github config")
 	}
 
-	if !cfg.PullRequestLinter && !cfg.GenerateDashboardPreviews {
+	if !r.shouldLintPullRequest() && !cfg.GenerateDashboardPreviews {
 		return &provisioning.WebhookResponse{
 			Code:    http.StatusOK, // Nothing needed
 			Message: "no action required on pull request event",
@@ -715,6 +715,10 @@ type changedResource struct {
 	Data                 []byte
 }
 
+func (r *githubRepository) shouldLintPullRequest() bool {
+	return r.config.Spec.GitHub.PullRequestLinter && r.config.Spec.Linting
+}
+
 var lintDashboardIssuesTemplate = `Hey there! 👋
 Grafana found some linting issues in this dashboard you may want to check:
 {{ range .}}
@@ -726,7 +730,7 @@ Grafana found some linting issues in this dashboard you may want to check:
 // The linter is disabled if the configuration does not have PullRequestLinter enabled.
 // The only supported type of file to lint is a dashboard.
 func (r *githubRepository) lintPullRequest(ctx context.Context, logger *slog.Logger, prNumber int, ref string, resources []changedResource) error {
-	if !r.Config().Spec.GitHub.PullRequestLinter {
+	if !r.shouldLintPullRequest() {
 		return nil
 	}
 

--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -83,19 +83,20 @@ func TestParseWebhooks(t *testing.T) {
 			Jobs: []provisioning.Job{
 				{
 					Action: provisioning.JobActionMergeBranch,
+					Ref:    "5c816f9812e391c62b0c5555d0b473b296d9179c",
 					Added: []provisioning.FileRef{
 						{
-							Ref:  "",
+							Ref:  "5c816f9812e391c62b0c5555d0b473b296d9179c",
 							Path: "nested-1/dash-1.json",
 						},
 						{
-							Ref:  "",
+							Ref:  "5c816f9812e391c62b0c5555d0b473b296d9179c",
 							Path: "nested-1/nested-2/dash-2.json",
 						},
 					},
 					Modified: []provisioning.FileRef{
 						{
-							Ref:  "72096e3adc646c5a5b8a91744f962b12bac06045",
+							Ref:  "5c816f9812e391c62b0c5555d0b473b296d9179c",
 							Path: "first-dashboard.json",
 						},
 					},

--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -83,20 +83,19 @@ func TestParseWebhooks(t *testing.T) {
 			Jobs: []provisioning.Job{
 				{
 					Action: provisioning.JobActionMergeBranch,
-					Ref:    "5c816f9812e391c62b0c5555d0b473b296d9179c",
 					Added: []provisioning.FileRef{
 						{
-							Ref:  "5c816f9812e391c62b0c5555d0b473b296d9179c",
+							Ref:  "",
 							Path: "nested-1/dash-1.json",
 						},
 						{
-							Ref:  "5c816f9812e391c62b0c5555d0b473b296d9179c",
+							Ref:  "",
 							Path: "nested-1/nested-2/dash-2.json",
 						},
 					},
 					Modified: []provisioning.FileRef{
 						{
-							Ref:  "5c816f9812e391c62b0c5555d0b473b296d9179c",
+							Ref:  "72096e3adc646c5a5b8a91744f962b12bac06045",
 							Path: "first-dashboard.json",
 						},
 					},

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -77,7 +77,8 @@ spec:
 			"schemaVersion": 7,
 			"panels": [],
 			"tags": []
-		}`)})
+		}`),
+		})
 
 		require.NoError(t, err)
 		require.Equal(t, provisioning.ClassicDashboard, classic)
@@ -97,11 +98,11 @@ spec:
 		info.Data, err = os.ReadFile(filepath.Join("../../../../..", info.Path))
 		require.NoError(t, err)
 
-		parser := NewParser(repository.NewUnknown(&provisioning.Repository{
+		parser := NewParser(&provisioning.Repository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 			},
-		}), &DynamicClient{}, &StaticKindsLookup{})
+		}, &DynamicClient{}, &StaticKindsLookup{})
 
 		// try to validate (and lint)
 		validate := true
@@ -119,7 +120,7 @@ spec:
 
 		jj, err := json.MarshalIndent(parsed.Lint, "", "  ")
 		require.NoError(t, err)
-		//fmt.Printf("%s\n", string(jj))
+		// fmt.Printf("%s\n", string(jj))
 		require.JSONEq(t, `[
 			{
 				"severity": "error",

--- a/pkg/registry/apis/provisioning/resources/fileformat_test.go
+++ b/pkg/registry/apis/provisioning/resources/fileformat_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	provisioning "github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/lint"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/repository"
 )
 
@@ -106,6 +107,7 @@ spec:
 
 		// try to validate (and lint)
 		validate := true
+		parser.SetLinter(lint.NewDashboardLinter())
 
 		// Support dashboard conversion
 		parsed, err := parser.Parse(context.Background(), slog.Default(), info, validate)

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -27,14 +27,14 @@ var ErrNamespaceMismatch = errors.New("the file namespace does not match target 
 
 type Parser struct {
 	// The target repository
-	repo repository.Repository
+	repo *provisioning.Repository
 
 	// client helper (for this namespace?)
 	client *DynamicClient
 	kinds  KindsLookup
 }
 
-func NewParser(repo repository.Repository, client *DynamicClient, kinds KindsLookup) *Parser {
+func NewParser(repo *provisioning.Repository, client *DynamicClient, kinds KindsLookup) *Parser {
 	return &Parser{
 		repo:   repo,
 		client: client,
@@ -98,7 +98,7 @@ func (r *Parser) Parse(ctx context.Context, logger *slog.Logger, info *repositor
 		return nil, err
 	}
 	obj := parsed.Obj
-	cfg := r.repo.Config()
+	cfg := r.repo
 
 	// Validate the namespace
 	if obj.GetNamespace() != "" && obj.GetNamespace() != cfg.GetNamespace() {

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -25,7 +25,7 @@ import (
 
 var ErrNamespaceMismatch = errors.New("the file namespace does not match target namespace")
 
-type FileParser struct {
+type Parser struct {
 	// The target repository
 	repo repository.Repository
 
@@ -34,8 +34,8 @@ type FileParser struct {
 	kinds  KindsLookup
 }
 
-func NewParser(repo repository.Repository, client *DynamicClient, kinds KindsLookup) *FileParser {
-	return &FileParser{
+func NewParser(repo repository.Repository, client *DynamicClient, kinds KindsLookup) *Parser {
+	return &Parser{
 		repo:   repo,
 		client: client,
 		kinds:  kinds,
@@ -78,7 +78,7 @@ type ParsedResource struct {
 	Errors []error
 }
 
-func (r *FileParser) Parse(ctx context.Context, logger *slog.Logger, info *repository.FileInfo, validate bool) (parsed *ParsedResource, err error) {
+func (r *Parser) Parse(ctx context.Context, logger *slog.Logger, info *repository.FileInfo, validate bool) (parsed *ParsedResource, err error) {
 	parsed = &ParsedResource{
 		Info: info,
 	}

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -42,7 +42,7 @@ func NewParser(repo repository.Repository, client *DynamicClient, kinds KindsLoo
 	}
 }
 
-type ParsedFile struct {
+type ParsedResource struct {
 	// Original file Info
 	Info *repository.FileInfo
 
@@ -78,8 +78,8 @@ type ParsedFile struct {
 	Errors []error
 }
 
-func (r *FileParser) Parse(ctx context.Context, logger *slog.Logger, info *repository.FileInfo, validate bool) (parsed *ParsedFile, err error) {
-	parsed = &ParsedFile{
+func (r *FileParser) Parse(ctx context.Context, logger *slog.Logger, info *repository.FileInfo, validate bool) (parsed *ParsedResource, err error) {
+	parsed = &ParsedResource{
 		Info: info,
 	}
 
@@ -179,7 +179,7 @@ func (r *FileParser) Parse(ctx context.Context, logger *slog.Logger, info *repos
 	return parsed, nil
 }
 
-func (f *ParsedFile) ToSaveBytes() ([]byte, error) {
+func (f *ParsedResource) ToSaveBytes() ([]byte, error) {
 	// TODO... should use the validated one?
 	obj := f.Obj.Object
 	delete(obj, "metadata")
@@ -198,7 +198,7 @@ func (f *ParsedFile) ToSaveBytes() ([]byte, error) {
 	}
 }
 
-func (f *ParsedFile) AsResourceWrapper() *provisioning.ResourceWrapper {
+func (f *ParsedResource) AsResourceWrapper() *provisioning.ResourceWrapper {
 	info := f.Info
 	res := provisioning.ResourceObjects{
 		Type: provisioning.ResourceType{

--- a/pkg/registry/apis/provisioning/resources/replicator.go
+++ b/pkg/registry/apis/provisioning/resources/replicator.go
@@ -56,7 +56,7 @@ func (f *ReplicatorFactory) New() (repository.FileReplicator, error) {
 type replicator struct {
 	logger     *slog.Logger
 	client     *DynamicClient
-	parser     *FileParser
+	parser     *Parser
 	folders    dynamic.ResourceInterface
 	repository repository.Repository
 }

--- a/pkg/registry/apis/provisioning/resources/replicator.go
+++ b/pkg/registry/apis/provisioning/resources/replicator.go
@@ -37,7 +37,7 @@ func (f *ReplicatorFactory) New() (repository.FileReplicator, error) {
 		return nil, fmt.Errorf("failed to get client for namespace %s: %w", f.namespace, err)
 	}
 
-	parser := NewParser(f.repo, dynamicClient, kinds)
+	parser := NewParser(f.repo.Config(), dynamicClient, kinds)
 	folders := dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    "folder.grafana.app",
 		Version:  "v0alpha1",

--- a/pkg/registry/apis/provisioning/resources/replicator.go
+++ b/pkg/registry/apis/provisioning/resources/replicator.go
@@ -37,6 +37,7 @@ func (f *ReplicatorFactory) New() (repository.FileReplicator, error) {
 		return nil, fmt.Errorf("failed to get client for namespace %s: %w", f.namespace, err)
 	}
 
+	// The replicator does not need a linter
 	parser := NewParser(f.repo.Config(), dynamicClient, kinds)
 	folders := dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    "folder.grafana.app",

--- a/pkg/registry/apis/provisioning/resources/replicator.go
+++ b/pkg/registry/apis/provisioning/resources/replicator.go
@@ -181,7 +181,7 @@ func (r *replicator) Validate(ctx context.Context, fileInfo *repository.FileInfo
 	return true, nil
 }
 
-func (r *replicator) parseResource(ctx context.Context, fileInfo *repository.FileInfo) (*ParsedFile, error) {
+func (r *replicator) parseResource(ctx context.Context, fileInfo *repository.FileInfo) (*ParsedResource, error) {
 	file, err := r.parser.Parse(ctx, r.logger, fileInfo, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse file %s: %w", fileInfo.Path, err)


### PR DESCRIPTION
- Rename ParsedFile to ParsedResource (seems more suitable as it's about parsing a resource).
- Rename FileParser to Parser (I think it's clear enough with Parser only).
- Use repository config in parse. 
- Use linter config in files endpoints to match the linting errors in the PRs. 
- Add spec option to enable repository linting as linting is not only in the PR anymore as it's also displayed in the UI. 



Without config:
![Screenshot 2024-12-09 at 15 52 47](https://github.com/user-attachments/assets/c886b17b-f982-4790-a34e-cfbbc3eb375e)
 config: 


With config: 
![Screenshot 2024-12-09 at 15 55 42](https://github.com/user-attachments/assets/897da6f9-6fee-43e7-b7bc-1085c4987ece)



