### PR TITLE
Refactoring central alert history scene 

### DIFF
--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralHistoryRuntimeDataSource.ts
@@ -1,6 +1,8 @@
+import { template } from 'lodash';
 import { useEffect, useMemo } from 'react';
 
 import { DataQuery, DataQueryRequest, DataQueryResponse, TestDataSourceResponse } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { RuntimeDataSource, sceneUtils } from '@grafana/scenes';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { dispatch } from 'app/store/store';
@@ -31,6 +33,12 @@ export function useRegisterHistoryRuntimeDataSource() {
   }, [ds]);
 }
 
+interface HistoryAPIQuery extends DataQuery {
+  labels?: string;
+  stateFrom?: string;
+  stateTo?: string;
+}
+
 /**
  * This class is a runtime datasource that fetches the events from the history api.
  * The events are grouped by alert instance and then converted to a DataFrame list.
@@ -38,23 +46,29 @@ export function useRegisterHistoryRuntimeDataSource() {
  * This allows us to filter the events by labels.
  * The result is a timeseries panel that shows the events for the selected time range and filtered by labels.
  */
-class HistoryAPIDatasource extends RuntimeDataSource {
+class HistoryAPIDatasource extends RuntimeDataSource<HistoryAPIQuery> {
   constructor(pluginId: string, uid: string) {
     super(uid, pluginId);
   }
 
-  async query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> {
+  async query(request: DataQueryRequest<HistoryAPIQuery>): Promise<DataQueryResponse> {
     const from = request.range.from.unix();
     const to = request.range.to.unix();
 
     // Get the labels and states filters from the URL
-    const stateTo = getStateFilterToInQueryParams();
-    const stateFrom = getStateFilterFromInQueryParams();
+    const query = request.targets[0]!;
+
+    const templateSrv = getTemplateSrv();
+
+    // where is the labels filter used??
+    const labels = templateSrv.replace(query.labels ?? '', request.scopedVars);
+    const stateTo = templateSrv.replace(query.stateTo ?? '', request.scopedVars);
+    const stateFrom = templateSrv.replace(query.stateFrom ?? '', request.scopedVars);
 
     const historyResult = await getHistory(from, to);
 
     return {
-      data: historyResultToDataFrame(historyResult, { stateTo, stateFrom }),
+      data: historyResultToDataFrame(historyResult, { stateTo, stateFrom, labels }),
     };
   }
 

--- a/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/utils.ts
@@ -24,9 +24,16 @@ import { LABELS_FILTER, STATE_FILTER_FROM, STATE_FILTER_TO, StateFilterValues } 
 const GROUPING_INTERVAL = 10 * 1000; // 10 seconds
 const QUERY_PARAM_PREFIX = 'var-'; // Prefix used by Grafana to sync variables in the URL
 
-const emptyFilters = {
+interface HistoryFilters {
+  stateTo: string;
+  stateFrom: string;
+  labels: string;
+}
+
+const emptyFilters: HistoryFilters = {
   stateTo: 'all',
   stateFrom: 'all',
+  labels: '',
 };
 
 /*
@@ -75,7 +82,7 @@ export function historyResultToDataFrame({ data }: DataFrameJSON, filters = empt
   });
 
   // Group DataFrames by time and filter by labels
-  return groupDataFramesByTimeAndFilterByLabels(dataFrames);
+  return groupDataFramesByTimeAndFilterByLabels(dataFrames, filters);
 }
 
 // Scenes sync variables in the URL adding a prefix to the variable name.
@@ -98,9 +105,9 @@ export function getStateFilterFromInQueryParams() {
  * This function groups the data frames by time and filters them by labels.
  * The interval is set to 10 seconds.
  * */
-function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[]): DataFrame[] {
+function groupDataFramesByTimeAndFilterByLabels(dataFrames: DataFrame[], filters: HistoryFilters): DataFrame[] {
   // Filter data frames by labels. This is used to filter out the data frames that do not match the query.
-  const labelsFilterValue = getLabelsFilterInQueryParams();
+  const labelsFilterValue = filters.labels;
   const dataframesFiltered = dataFrames.filter((frame) => {
     const labels = JSON.parse(frame.name ?? ''); // in name we store the labels stringified
 


### PR DESCRIPTION
Refactors https://github.com/grafana/grafana/pull/97619  

* Move variables to query model to take advantage of automatic requery 
* Use filters from query model instead of URL in the data source 
* simplify the clear filters scene object 
* simplify the events list 