### PR TITLE
Loki shard splitting: enable for supported metric queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -361,11 +361,7 @@ export class LokiDatasource
       return this.runLiveQueryThroughBackend(fixedRequest);
     }
 
-    if (
-      config.featureToggles.lokiShardSplitting &&
-      requestSupportsSharding(fixedRequest.targets) &&
-      fixedRequest.app === CoreApp.Explore
-    ) {
+    if (config.featureToggles.lokiShardSplitting && requestSupportsSharding(fixedRequest.targets)) {
       return runShardSplitQuery(this, fixedRequest);
     } else if (config.featureToggles.lokiQuerySplitting && requestSupportsSplitting(fixedRequest.targets)) {
       return runSplitQuery(this, fixedRequest);

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -609,6 +609,9 @@ describe('requestSupportsSharding', () => {
     'count_over_time({place="luna"}[1m])',
     'sum_over_time({place="luna"}[1m])',
     'sum by (level) (count_over_time({place="luna"}[1m]))',
+    'sum by (level) (rate({place="luna"}[1m]))',
+    'sum(sum by (level) (avg_over_time({place="luna"}[1m])))',
+    'sum(rate({place="luna"}[1m]))',
   ])('allows supported metric queries', (expr: string) => {
     expect(requestSupportsSharding([{ refId: 'A', expr }])).toBe(true);
   });
@@ -616,8 +619,10 @@ describe('requestSupportsSharding', () => {
   it.each([
     'avg_over_time({place="luna"}[1m])',
     'avg(sum_over_time({place="luna"}[1m]))',
-    'sum by (level) (rate({place="luna"}[1m]))',
+    'avg(rate({place="luna"}[1m]))',
     'count_over_time({place="luna"}[1m]) / count_over_time({place="luna"}[1m])',
+    'avg(sum by (level) (avg_over_time({place="luna"}[1m])))',
+    'sum(rate({place="luna"}[1m])) / sum(rate({place="luna"}[1m]))',
   ])('declines supported metric queries', (expr: string) => {
     expect(requestSupportsSharding([{ refId: 'A', expr }])).toBe(false);
   });

--- a/public/app/plugins/datasource/loki/queryUtils.test.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.test.ts
@@ -18,8 +18,9 @@ import {
   getNodePositionsFromQuery,
   getLogQueryFromMetricsQueryAtPosition,
   interpolateShardingSelector,
+  requestSupportsSharding,
 } from './queryUtils';
-import { LokiQuery, LokiQueryType } from './types';
+import { LokiQuery, LokiQueryDirection, LokiQueryType } from './types';
 
 describe('getHighlighterExpressionsFromQuery', () => {
   it('returns no expressions for empty query', () => {
@@ -588,5 +589,36 @@ describe('interpolateShardingSelector', () => {
         },
       ]);
     });
+  });
+});
+
+describe('requestSupportsSharding', () => {
+  it('supports log queries with Scan direction', () => {
+    expect(requestSupportsSharding([{ refId: 'A', expr: '{place="luna"}', direction: LokiQueryDirection.Scan }])).toBe(
+      true
+    );
+  });
+
+  it('declines log queries without Scan direction', () => {
+    expect(
+      requestSupportsSharding([{ refId: 'A', expr: '{place="luna"}', direction: LokiQueryDirection.Backward }])
+    ).toBe(false);
+  });
+
+  it.each([
+    'count_over_time({place="luna"}[1m])',
+    'sum_over_time({place="luna"}[1m])',
+    'sum by (level) (count_over_time({place="luna"}[1m]))',
+  ])('allows supported metric queries', (expr: string) => {
+    expect(requestSupportsSharding([{ refId: 'A', expr }])).toBe(true);
+  });
+
+  it.each([
+    'avg_over_time({place="luna"}[1m])',
+    'avg(sum_over_time({place="luna"}[1m]))',
+    'sum by (level) (rate({place="luna"}[1m]))',
+    'count_over_time({place="luna"}[1m]) / count_over_time({place="luna"}[1m])',
+  ])('declines supported metric queries', (expr: string) => {
+    expect(requestSupportsSharding([{ refId: 'A', expr }])).toBe(false);
   });
 });

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -348,9 +348,11 @@ function metricSupportsSharding(query: string) {
    * Allowed: sum(sum by (level) (avg_over_time({place="luna"}[1m])))
    */
   const vectorOps = getNodesFromQuery(query, [VectorOp]);
-  const supportedVectorOps = vectorOps.filter(node => getNodeString(query, node) === 'sum');
-  const unsupportedVectorOps = vectorOps.filter(node => getNodeString(query, node) !== 'sum');
-  const supportedWrappingVectorOpps = supportedVectorOps.filter(supportedOp => unsupportedVectorOps.every(unsupportedOp => supportedOp.from < unsupportedOp.from));
+  const supportedVectorOps = vectorOps.filter((node) => getNodeString(query, node) === 'sum');
+  const unsupportedVectorOps = vectorOps.filter((node) => getNodeString(query, node) !== 'sum');
+  const supportedWrappingVectorOpps = supportedVectorOps.filter((supportedOp) =>
+    unsupportedVectorOps.every((unsupportedOp) => supportedOp.from < unsupportedOp.from)
+  );
   if (unsupportedVectorOps.length > 0) {
     return supportedWrappingVectorOpps.length > 0;
   }


### PR DESCRIPTION
Queries wrapped with `sum()`, or only containing `sum_over_time()`, and `count_over_time()`, and `bytes_over_time()`, will be executed with shard splitting if the feature flag is enabled.

Additionally, we're removing the app limitation from the condition.

Otherwise, time splitting will be used.