### PR TITLE
Alerting: Consistently order member imports in alerting code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -251,6 +251,7 @@ module.exports = [
     },
     files: ['public/app/features/alerting/**/*.{ts,tsx,js,jsx}'],
     rules: {
+      'sort-imports': ['error', { ignoreDeclarationSort: true }],
       'dot-notation': 'error',
       'prefer-const': 'error',
       'react/no-unused-prop-types': 'error',

--- a/public/app/features/alerting/state/ThresholdMapper.test.ts
+++ b/public/app/features/alerting/state/ThresholdMapper.test.ts
@@ -1,6 +1,6 @@
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 
-import { hiddenReducerTypes, ThresholdMapper } from './ThresholdMapper';
+import { ThresholdMapper, hiddenReducerTypes } from './ThresholdMapper';
 import alertDef from './alertDef';
 
 const visibleReducerTypes = alertDef.reducerTypes

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -1,7 +1,7 @@
 import { isArray, reduce } from 'lodash';
 
 import { IconName } from '@grafana/ui';
-import { QueryPartDef, QueryPart } from 'app/features/alerting/state/query_part';
+import { QueryPart, QueryPartDef } from 'app/features/alerting/state/query_part';
 
 const alertQueryDef = new QueryPartDef({
   type: 'query',

--- a/public/app/features/alerting/state/reducers.test.ts
+++ b/public/app/features/alerting/state/reducers.test.ts
@@ -9,9 +9,9 @@ import {
   initialState,
   loadAlertRules,
   loadedAlertRules,
+  notificationChannelLoaded,
   notificationChannelReducer,
   setSearchQuery,
-  notificationChannelLoaded,
 } from './reducers';
 
 describe('Alert rules', () => {

--- a/public/app/features/alerting/state/reducers.ts
+++ b/public/app/features/alerting/state/reducers.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { dateTime } from '@grafana/data';
 import {

--- a/public/app/features/alerting/state/selectors.test.ts
+++ b/public/app/features/alerting/state/selectors.test.ts
@@ -1,6 +1,6 @@
 import { AlertRulesState, StoreState } from 'app/types';
 
-import { getSearchQuery, getAlertRuleItems } from './selectors';
+import { getAlertRuleItems, getSearchQuery } from './selectors';
 
 describe('Get search query', () => {
   it('should get search query', () => {

--- a/public/app/features/alerting/unified/AlertGroups.test.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.test.tsx
@@ -8,11 +8,11 @@ import { AccessControlAction } from 'app/types';
 import AlertGroups from './AlertGroups';
 import { fetchAlertGroups } from './api/alertmanager';
 import {
+  MockDataSourceSrv,
   grantUserPermissions,
   mockAlertGroup,
   mockAlertmanagerAlert,
   mockDataSource,
-  MockDataSourceSrv,
 } from './mocks';
 import { AlertmanagerProvider } from './state/AlertmanagerContext';
 import { DataSourceType } from './utils/datasource';

--- a/public/app/features/alerting/unified/AlertGroups.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect } from 'react';
 
-import { Alert, LoadingPlaceholder, Text, Box } from '@grafana/ui';
+import { Alert, Box, LoadingPlaceholder, Text } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { useDispatch } from 'app/types';
 

--- a/public/app/features/alerting/unified/AlertsFolderView.tsx
+++ b/public/app/features/alerting/unified/AlertsFolderView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useDebounce } from 'react-use';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Card, FilterInput, Icon, Pagination, Select, TagList, useStyles2, Stack } from '@grafana/ui';
+import { Card, FilterInput, Icon, Pagination, Select, Stack, TagList, useStyles2 } from '@grafana/ui';
 import { DEFAULT_PER_PAGE_PAGINATION } from 'app/core/constants';
 import { getQueryParamValue } from 'app/core/utils/query';
 import { FolderState, useDispatch } from 'app/types';

--- a/public/app/features/alerting/unified/Analytics.test.ts
+++ b/public/app/features/alerting/unified/Analytics.test.ts
@@ -1,7 +1,7 @@
 import { dateTime } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
-import { isNewUser, USER_CREATION_MIN_DAYS } from './Analytics';
+import { USER_CREATION_MIN_DAYS, isNewUser } from './Analytics';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -9,7 +9,7 @@ import { RuleNamespace } from '../../../types/unified-alerting';
 import { RulerRulesConfigDTO } from '../../../types/unified-alerting-dto';
 
 import { FilterType } from './components/rules/central-state-history/EventListSceneObject';
-import { getSearchFilterFromQuery, RulesFilter } from './search/rulesSearchParser';
+import { RulesFilter, getSearchFilterFromQuery } from './search/rulesSearchParser';
 import { RuleFormType } from './types/rule-form';
 
 export const USER_CREATION_MIN_DAYS = 7;

--- a/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/CloneRuleEditor.test.tsx
@@ -14,13 +14,13 @@ import {
   RulerRuleDTO,
 } from '../../../types/unified-alerting-dto';
 
-import { cloneRuleDefinition, CloneRuleEditor } from './CloneRuleEditor';
+import { CloneRuleEditor, cloneRuleDefinition } from './CloneRuleEditor';
 import { ExpressionEditorProps } from './components/rule-editor/ExpressionEditor';
 import { mockFeatureDiscoveryApi, setupMswServer } from './mockApi';
 import {
+  MockDataSourceSrv,
   grantUserPermissions,
   mockDataSource,
-  MockDataSourceSrv,
   mockRulerAlertingRule,
   mockRulerGrafanaRule,
   mockRulerRuleGroup,

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.test.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 
 import { DataSourceRef } from '@grafana/schema';
 import { AlertQuery } from 'app/types/unified-alerting-dto';

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -12,10 +12,10 @@ import { CombinedRule } from 'app/types/unified-alerting';
 import { AlertDataQuery, AlertQuery } from '../../../types/unified-alerting-dto';
 import { isExpressionQuery } from '../../expressions/guards';
 import {
-  downsamplingTypes,
   ExpressionQuery,
   ExpressionQueryType,
   ReducerMode,
+  downsamplingTypes,
   reducerModes,
   reducerTypes,
   thresholdFunctions,
@@ -26,7 +26,7 @@ import alertDef, { EvalFunction } from '../state/alertDef';
 import { Spacer } from './components/Spacer';
 import { WithReturnButton } from './components/WithReturnButton';
 import { ExpressionResult } from './components/expressions/Expression';
-import { getThresholdsForQueries, ThresholdDefinition } from './components/rule-editor/util';
+import { ThresholdDefinition, getThresholdsForQueries } from './components/rule-editor/util';
 import { RuleViewerVisualization } from './components/rule-viewer/RuleViewerVisualization';
 import { DatasourceModelPreview } from './components/rule-viewer/tabs/Query/DataSourceModelPreview';
 import { AlertRuleAction, useAlertRuleAbility } from './hooks/useAbilities';

--- a/public/app/features/alerting/unified/MuteTimings.test.tsx
+++ b/public/app/features/alerting/unified/MuteTimings.test.tsx
@@ -1,7 +1,7 @@
 import { InitialEntry } from 'history';
 import { last } from 'lodash';
 import { Route, Routes } from 'react-router-dom-v5-compat';
-import { render, within, userEvent, screen } from 'test/test-utils';
+import { render, screen, userEvent, within } from 'test/test-utils';
 import { byTestId } from 'testing-library-selector';
 
 import { config } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
-import { render, screen, waitFor, userEvent } from 'test/test-utils';
+import { render, screen, userEvent, waitFor } from 'test/test-utils';
 
 import {
   PROVISIONED_MIMIR_ALERTMANAGER_UID,

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 
 import { config } from '@grafana/runtime';
 

--- a/public/app/features/alerting/unified/Templates.tsx
+++ b/public/app/features/alerting/unified/Templates.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 
 import { withErrorBoundary } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -18,11 +18,11 @@ import {
 
 import { ExportFormats } from '../components/export/providers';
 import { Folder } from '../types/rule-form';
-import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME, isGrafanaRulesSource } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid, isGrafanaRulesSource } from '../utils/datasource';
 import { arrayKeyValuesToObject } from '../utils/labels';
 import { isCloudRuleIdentifier, isGrafanaRulerRule, isPrometheusRuleIdentifier } from '../utils/rules';
 
-import { alertingApi, WithNotificationOptions } from './alertingApi';
+import { WithNotificationOptions, alertingApi } from './alertingApi';
 import {
   FetchPromRulesFilter,
   getRulesFilterSearchParams,

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -12,7 +12,7 @@ import {
   TestReceiversResult,
 } from 'app/plugins/datasource/alertmanager/types';
 
-import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from '../utils/datasource';
 
 // "grafana" for grafana-managed, otherwise a datasource name
 export async function fetchAlertManagerConfig(alertManagerSourceName: string): Promise<AlertManagerCortexConfig> {

--- a/public/app/features/alerting/unified/api/buildInfo.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.ts
@@ -9,7 +9,7 @@ import {
 } from 'app/types/unified-alerting-dto';
 
 import { RULER_NOT_SUPPORTED_MSG } from '../utils/constants';
-import { getDataSourceByName, getRulesDataSourceByUID, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDataSourceByName, getRulesDataSourceByUID } from '../utils/datasource';
 
 import { fetchRules } from './prometheus';
 import { fetchTestRulerRulesGroup } from './ruler';

--- a/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
+++ b/public/app/features/alerting/unified/api/featureDiscoveryApi.ts
@@ -6,9 +6,9 @@ import {
   RulesSourceApplication,
 } from '../../../../types/unified-alerting-dto';
 import {
+  GRAFANA_RULES_SOURCE_NAME,
   getDataSourceUID,
   getRulesDataSourceByUID,
-  GRAFANA_RULES_SOURCE_NAME,
   isGrafanaRulesSource,
 } from '../utils/datasource';
 

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -1,7 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv } from '@grafana/runtime';
-import { ContactPointsState, ReceiversStateDTO, ReceiverState } from 'app/types';
+import { ContactPointsState, ReceiverState, ReceiversStateDTO } from 'app/types';
 
 import { getDatasourceAPIUid } from '../utils/datasource';
 

--- a/public/app/features/alerting/unified/api/preview.ts
+++ b/public/app/features/alerting/unified/api/preview.ts
@@ -2,20 +2,20 @@ import { Observable, of } from 'rxjs';
 import { catchError, map, share } from 'rxjs/operators';
 
 import {
-  dataFrameFromJSON,
   DataFrameJSON,
-  getDefaultTimeRange,
   LoadingState,
   PanelData,
+  dataFrameFromJSON,
+  getDefaultTimeRange,
   withLoadingIndicator,
 } from '@grafana/data';
 import { getBackendSrv, toDataQueryError } from '@grafana/runtime';
 
 import {
-  isCloudPreviewRequest,
-  isGrafanaPreviewRequest,
   PreviewRuleRequest,
   PreviewRuleResponse,
+  isCloudPreviewRequest,
+  isGrafanaPreviewRequest,
 } from '../types/preview';
 import { RuleFormType } from '../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';

--- a/public/app/features/alerting/unified/api/prometheus.ts
+++ b/public/app/features/alerting/unified/api/prometheus.ts
@@ -7,11 +7,11 @@ import { RuleGroup, RuleIdentifier, RuleNamespace } from 'app/types/unified-aler
 import {
   PromAlertingRuleState,
   PromRuleGroupDTO,
-  PromRulesResponse,
   PromRuleType,
+  PromRulesResponse,
 } from 'app/types/unified-alerting-dto';
 
-import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from '../utils/datasource';
 import { isCloudRuleIdentifier, isPrometheusRuleIdentifier } from '../utils/rules';
 
 export interface FetchPromRulesFilter {

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -7,7 +7,7 @@ import { RulerRuleGroupDTO, RulerRulesConfigDTO } from 'app/types/unified-alerti
 
 import { containsPathSeparator } from '../components/rule-editor/util';
 import { RULER_NOT_SUPPORTED_MSG } from '../utils/constants';
-import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from '../utils/datasource';
 
 import { getRulesFilterSearchParams } from './prometheus';
 

--- a/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
+++ b/public/app/features/alerting/unified/components/AlertLabelDropdown.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
-import { forwardRef, FC } from 'react';
-import { createFilter, GroupBase, OptionsOrGroups } from 'react-select';
+import { FC, forwardRef } from 'react';
+import { GroupBase, OptionsOrGroups, createFilter } from 'react-select';
 
 import { SelectableValue } from '@grafana/data';
 import { Field, Select, useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/AlertLabels.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertLabels.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { AlertLabels } from './AlertLabels';

--- a/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
+++ b/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useMemo, ComponentProps } from 'react';
+import { ComponentProps, useMemo } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { InlineField, Select, SelectMenuOptions, useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes } from 'react';
 
-import { IconSize, Button } from '@grafana/ui';
+import { Button, IconSize } from '@grafana/ui';
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   isCollapsed: boolean;

--- a/public/app/features/alerting/unified/components/ConditionalWrap.tsx
+++ b/public/app/features/alerting/unified/components/ConditionalWrap.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, forwardRef, Ref } from 'react';
+import { Ref, cloneElement, forwardRef } from 'react';
 
 interface ConditionalWrapProps {
   shouldWrap: boolean;

--- a/public/app/features/alerting/unified/components/Expression.tsx
+++ b/public/app/features/alerting/unified/components/Expression.tsx
@@ -5,7 +5,7 @@ import { Editor } from 'slate-react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { promqlGrammar } from '@grafana/prometheus';
-import { makeValue, SlatePrism, useStyles2 } from '@grafana/ui';
+import { SlatePrism, makeValue, useStyles2 } from '@grafana/ui';
 import LogqlSyntax from 'app/plugins/datasource/loki/syntax';
 import { RulesSource } from 'app/types/unified-alerting';
 

--- a/public/app/features/alerting/unified/components/HoverCard.tsx
+++ b/public/app/features/alerting/unified/components/HoverCard.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
 import { Placement } from '@popperjs/core';
 import classnames from 'classnames';
-import { cloneElement, ReactElement, ReactNode, useRef } from 'react';
+import { ReactElement, ReactNode, cloneElement, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Popover as GrafanaPopover, PopoverController, useStyles2, Stack } from '@grafana/ui';
+import { Popover as GrafanaPopover, PopoverController, Stack, useStyles2 } from '@grafana/ui';
 
 export interface PopupCardProps {
   children: ReactElement;

--- a/public/app/features/alerting/unified/components/MetaText.tsx
+++ b/public/app/features/alerting/unified/components/MetaText.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { ComponentProps, HTMLAttributes } from 'react';
 
-import { Icon, IconName, useStyles2, Text, Stack } from '@grafana/ui';
+import { Icon, IconName, Stack, Text, useStyles2 } from '@grafana/ui';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   icon?: IconName;

--- a/public/app/features/alerting/unified/components/MoreButton.tsx
+++ b/public/app/features/alerting/unified/components/MoreButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Ref } from 'react';
+import { Ref, forwardRef } from 'react';
 
 import { Button, ButtonProps, Icon, Stack } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/components/PluginBridge.test.tsx
+++ b/public/app/features/alerting/unified/components/PluginBridge.test.tsx
@@ -1,10 +1,10 @@
-import { screen, render } from 'test/test-utils';
+import { render, screen } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
 import { SupportedPlugin } from '../types/pluginBridges';
 
-import { createBridgeURL, PluginBridge } from './PluginBridge';
+import { PluginBridge, createBridgeURL } from './PluginBridge';
 const NON_EXISTING_PLUGIN = '__does_not_exist__';
 setupMswServer();
 

--- a/public/app/features/alerting/unified/components/Tokenize.tsx
+++ b/public/app/features/alerting/unified/components/Tokenize.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Badge, useStyles2 } from '@grafana/ui';
 
 import { PopupCard } from './HoverCard';
-import { keywords as KEYWORDS, builtinFunctions as FUNCTIONS } from './receivers/editor/language';
+import { builtinFunctions as FUNCTIONS, keywords as KEYWORDS } from './receivers/editor/language';
 
 const VARIABLES = ['$', '.', '"'];
 

--- a/public/app/features/alerting/unified/components/Well.tsx
+++ b/public/app/features/alerting/unified/components/Well.tsx
@@ -1,4 +1,4 @@
-import { cx, css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/alerting/unified/components/alert-groups/AlertDetails.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertDetails.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { LinkButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AlertmanagerAlert, AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { AlertState, AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction } from 'app/types';
 
 import { AlertmanagerAction } from '../../hooks/useAbilities';

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroup.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, Stack, TextLink } from '@grafana/ui';
+import { Stack, TextLink, useStyles2 } from '@grafana/ui';
 import { AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
 
 import { createContactPointSearchLink } from '../../utils/misc';

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroupFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroupFilter.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
-import { AlertmanagerGroup, AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { AlertState, AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
 
 import { getFiltersFromUrlParams } from '../../utils/misc';
 

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroupHeader.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroupHeader.tsx
@@ -1,7 +1,7 @@
 import pluralize from 'pluralize';
 
 import { useStyles2 } from '@grafana/ui';
-import { AlertmanagerGroup, AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { AlertState, AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
 
 import { getNotificationsTextColors } from '../../styles/notifications';
 

--- a/public/app/features/alerting/unified/components/alert-groups/AlertStateFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertStateFilter.tsx
@@ -1,5 +1,5 @@
 import { SelectableValue } from '@grafana/data';
-import { RadioButtonGroup, Label, Tooltip, Icon } from '@grafana/ui';
+import { Icon, Label, RadioButtonGroup, Tooltip } from '@grafana/ui';
 import { AlertState } from 'app/plugins/datasource/alertmanager/types';
 
 interface Props {

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -5,7 +5,7 @@ import { useDebounce } from 'react-use';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Icon, Input, Label, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { logInfo, LogMessages } from '../../Analytics';
+import { LogMessages, logInfo } from '../../Analytics';
 import { parsePromQLStyleMatcherLoose } from '../../utils/matchers';
 
 interface Props {

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoint.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoint.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { groupBy, size, upperFirst } from 'lodash';
 import { Fragment, ReactNode } from 'react';
 
-import { dateTime, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, dateTime } from '@grafana/data';
 import { Icon, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 import { PrimaryText } from 'app/features/alerting/unified/components/common/TextVariants';
@@ -19,7 +19,7 @@ import { ReceiverMetadataBadge } from '../receivers/grafanaAppReceivers/Receiver
 import { ReceiverPluginMetadata } from '../receivers/grafanaAppReceivers/useReceiversMetadata';
 
 import { RECEIVER_META_KEY, RECEIVER_PLUGIN_META_KEY, RECEIVER_STATUS_KEY } from './constants';
-import { ContactPointWithMetadata, getReceiverDescription, ReceiverConfigWithMetadata } from './utils';
+import { ContactPointWithMetadata, ReceiverConfigWithMetadata, getReceiverDescription } from './utils';
 
 interface ContactPointProps {
   contactPoint: ContactPointWithMetadata;

--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
@@ -3,7 +3,7 @@ import { Fragment, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Dropdown, LinkButton, Menu, Stack, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import ConditionalWrap from 'app/features/alerting/unified/components/ConditionalWrap';
 import { useExportContactPoint } from 'app/features/alerting/unified/components/contact-points/useExportContactPoint';
 import { ManagePermissionsDrawer } from 'app/features/alerting/unified/components/permissions/ManagePermissions';

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -15,7 +15,7 @@ import {
   withErrorBoundary,
 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import { shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
 import { makeAMLink, stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
 import { AccessControlAction } from 'app/types';

--- a/public/app/features/alerting/unified/components/contact-points/EditContactPoint.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/EditContactPoint.test.tsx
@@ -1,5 +1,5 @@
 import 'core-js/stable/structured-clone';
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { render, screen } from 'test/test-utils';
 

--- a/public/app/features/alerting/unified/components/contact-points/__mocks__/mimirFlavoredServer.ts
+++ b/public/app/features/alerting/unified/components/contact-points/__mocks__/mimirFlavoredServer.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';

--- a/public/app/features/alerting/unified/components/contact-points/__mocks__/vanillaAlertmanagerServer.ts
+++ b/public/app/features/alerting/unified/components/contact-points/__mocks__/vanillaAlertmanagerServer.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 
 import { AlertmanagerStatus } from 'app/plugins/datasource/alertmanager/types';

--- a/public/app/features/alerting/unified/components/contact-points/utils.ts
+++ b/public/app/features/alerting/unified/components/contact-points/utils.ts
@@ -17,7 +17,7 @@ import { OnCallIntegrationDTO } from '../../api/onCallApi';
 import { computeInheritedTree } from '../../utils/notification-policies';
 import { extractReceivers } from '../../utils/receivers';
 import { ReceiverTypes } from '../receivers/grafanaAppReceivers/onCall/onCall';
-import { getOnCallMetadata, ReceiverPluginMetadata } from '../receivers/grafanaAppReceivers/useReceiversMetadata';
+import { ReceiverPluginMetadata, getOnCallMetadata } from '../receivers/grafanaAppReceivers/useReceiversMetadata';
 
 import { RECEIVER_META_KEY, RECEIVER_PLUGIN_META_KEY, RECEIVER_STATUS_KEY } from './constants';
 

--- a/public/app/features/alerting/unified/components/export/FileExportPreview.tsx
+++ b/public/app/features/alerting/unified/components/export/FileExportPreview.tsx
@@ -7,7 +7,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, ClipboardButton, CodeEditor, TextLink, useStyles2 } from '@grafana/ui';
 
-import { allGrafanaExportProviders, ExportFormats, ExportProvider, ProvisioningType } from './providers';
+import { ExportFormats, ExportProvider, ProvisioningType, allGrafanaExportProviders } from './providers';
 
 interface FileExportPreviewProps {
   format: ExportFormats;

--- a/public/app/features/alerting/unified/components/export/GrafanaModifyExport.test.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaModifyExport.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { Props } from 'react-virtualized-auto-sizer';
-import { render, waitFor, waitForElementToBeRemoved, userEvent } from 'test/test-utils';
+import { render, userEvent, waitFor, waitForElementToBeRemoved } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { mockExportApi, setupMswServer } from '../../mockApi';

--- a/public/app/features/alerting/unified/components/export/GrafanaMuteTimingsExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaMuteTimingsExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 interface MuteTimingsExporterPreviewProps {
   exportFormat: ExportFormats;
   onClose: () => void;

--- a/public/app/features/alerting/unified/components/export/GrafanaPoliciesExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaPoliciesExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 interface GrafanaPoliciesPreviewProps {
   exportFormat: ExportFormats;
   onClose: () => void;

--- a/public/app/features/alerting/unified/components/export/GrafanaReceiverExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaReceiverExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 
 interface GrafanaReceiverExportPreviewProps {
   exportFormat: ExportFormats;

--- a/public/app/features/alerting/unified/components/export/GrafanaReceiversExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaReceiversExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 
 interface GrafanaReceiversExportPreviewProps {
   exportFormat: ExportFormats;

--- a/public/app/features/alerting/unified/components/export/GrafanaRuleExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaRuleExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 
 interface GrafanaRuleExportPreviewProps {
   alertUid: string;

--- a/public/app/features/alerting/unified/components/export/GrafanaRuleFolderExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaRuleFolderExporter.tsx
@@ -7,7 +7,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 
 interface GrafanaRuleFolderExporterProps {
   folder: FolderDTO;

--- a/public/app/features/alerting/unified/components/export/GrafanaRuleGroupExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaRuleGroupExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 
 interface GrafanaRuleGroupExporterProps {
   folderUid: string;

--- a/public/app/features/alerting/unified/components/export/GrafanaRulesExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaRulesExporter.tsx
@@ -6,7 +6,7 @@ import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';
 import { GrafanaExportDrawer } from './GrafanaExportDrawer';
-import { allGrafanaExportProviders, ExportFormats } from './providers';
+import { ExportFormats, allGrafanaExportProviders } from './providers';
 
 interface GrafanaRulesExporterProps {
   onClose: () => void;

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -3,8 +3,8 @@ import { uniqueId } from 'lodash';
 import { FC, useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { DataFrame, dateTimeFormat, GrafanaTheme2, isTimeSeriesFrames, LoadingState, PanelData } from '@grafana/data';
-import { Alert, AutoSizeInput, Button, clearButtonStyles, IconButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { DataFrame, GrafanaTheme2, LoadingState, PanelData, dateTimeFormat, isTimeSeriesFrames } from '@grafana/data';
+import { Alert, AutoSizeInput, Button, IconButton, Stack, Text, clearButtonStyles, useStyles2 } from '@grafana/ui';
 import { ClassicConditions } from 'app/features/expressions/components/ClassicConditions';
 import { Math } from 'app/features/expressions/components/Math';
 import { Reduce } from 'app/features/expressions/components/Reduce';

--- a/public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeInterval.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeInterval.tsx
@@ -8,7 +8,7 @@ import { Button, Field, FieldSet, Icon, InlineSwitch, Input, Stack, useStyles2 }
 
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { MuteTimingFields } from '../../types/mute-timing-form';
-import { DAYS_OF_THE_WEEK, defaultTimeInterval, MONTHS, validateArrayField } from '../../utils/mute-timings';
+import { DAYS_OF_THE_WEEK, MONTHS, defaultTimeInterval, validateArrayField } from '../../utils/mute-timings';
 
 import { MuteTimingTimeRange } from './MuteTimingTimeRange';
 import { TimezoneSelect } from './timezones';

--- a/public/app/features/alerting/unified/components/notification-policies/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/ContactPointSelector.tsx
@@ -2,7 +2,7 @@ import { css, cx, keyframes } from '@emotion/css';
 import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Select, SelectCommonProps, Stack, Alert, IconButton, Text, useStyles2 } from '@grafana/ui';
+import { Alert, IconButton, Select, SelectCommonProps, Stack, Text, useStyles2 } from '@grafana/ui';
 import { ContactPointReceiverSummary } from 'app/features/alerting/unified/components/contact-points/ContactPoint';
 import { useAlertmanager } from 'app/features/alerting/unified/state/AlertmanagerContext';
 

--- a/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditDefaultPolicyForm.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useState } from 'react';
-import { useForm, Controller } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 
 import { Collapse, Field, Link, MultiSelect, useStyles2 } from '@grafana/ui';
 import { ContactPointSelector } from 'app/features/alerting/unified/components/notification-policies/ContactPointSelector';
@@ -13,8 +13,8 @@ import {
   mapMultiSelectValueToStrings,
   promDurationValidator,
   repeatIntervalValidator,
-  stringsToSelectableValues,
   stringToSelectableValue,
+  stringsToSelectableValues,
 } from '../../utils/amroutes';
 import { makeAMLink } from '../../utils/misc';
 

--- a/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { ReactNode, useState } from 'react';
-import { useForm, Controller, useFieldArray } from 'react-hook-form';
+import { Controller, useFieldArray, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import {

--- a/public/app/features/alerting/unified/components/notification-policies/Matchers.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Matchers.tsx
@@ -3,7 +3,7 @@ import { take, takeRight, uniqueId } from 'lodash';
 import { FC } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { getTagColorsFromName, useStyles2, Stack } from '@grafana/ui';
+import { Stack, getTagColorsFromName, useStyles2 } from '@grafana/ui';
 import { ObjectMatcher } from 'app/plugins/datasource/alertmanager/types';
 
 import { MatcherFormatter, matcherFormatter } from '../../utils/matchers';

--- a/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
@@ -3,7 +3,7 @@ import { FC, useCallback, useMemo, useState } from 'react';
 
 import { Button, Icon, Modal, ModalProps, Spinner, Stack } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
-import { AlertmanagerGroup, AlertState, ObjectMatcher, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
+import { AlertState, AlertmanagerGroup, ObjectMatcher, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 
 import { FormAmRoute } from '../../types/amroutes';
 import { MatcherFormatter } from '../../utils/matchers';

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { first, noop } from 'lodash';
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/components/notification-policies/PolicyUpdateErrorAlert.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/PolicyUpdateErrorAlert.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 
 import { stringifyErrorLike } from '../../utils/misc';
 

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx
@@ -7,7 +7,7 @@ import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { useSelector } from 'app/types';
 
-import { logInfo, LogMessages } from '../../Analytics';
+import { LogMessages, logInfo } from '../../Analytics';
 import { panelToRuleFormValues } from '../../utils/rule-form';
 
 interface Props {

--- a/public/app/features/alerting/unified/components/permissions/ManagePermissions.tsx
+++ b/public/app/features/alerting/unified/components/permissions/ManagePermissions.tsx
@@ -1,8 +1,8 @@
-import { useState, ComponentProps } from 'react';
+import { ComponentProps, useState } from 'react';
 
 import { Button, Drawer } from '@grafana/ui';
 import { Permissions } from 'app/core/components/AccessControl';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 
 type ButtonProps = { onClick: () => void };
 

--- a/public/app/features/alerting/unified/components/receivers/AlertInstanceModalSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/AlertInstanceModalSelector.tsx
@@ -6,14 +6,14 @@ import { FixedSizeList } from 'react-window';
 import { GrafanaTheme2 } from '@grafana/data';
 import {
   Button,
-  clearButtonStyles,
   FilterInput,
+  Icon,
   LoadingPlaceholder,
   Modal,
-  Tooltip,
-  useStyles2,
-  Icon,
   Tag,
+  Tooltip,
+  clearButtonStyles,
+  useStyles2,
 } from '@grafana/ui';
 import { AlertmanagerAlert, TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 

--- a/public/app/features/alerting/unified/components/receivers/GlobalConfigForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/GlobalConfigForm.tsx
@@ -1,6 +1,6 @@
-import { useForm, FormProvider } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 
-import { Alert, Button, Stack, LinkButton } from '@grafana/ui';
+import { Alert, Button, LinkButton, Stack } from '@grafana/ui';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { useDispatch } from 'app/types';

--- a/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render, screen } from 'test/test-utils';
 import { byLabelText, byPlaceholderText, byRole, byTestId } from 'testing-library-selector';
 

--- a/public/app/features/alerting/unified/components/receivers/ReceiversSection.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversSection.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Dropdown, Icon, Menu, MenuItem, useStyles2, Stack } from '@grafana/ui';
+import { Button, Dropdown, Icon, Menu, MenuItem, Stack, useStyles2 } from '@grafana/ui';
 
 import { GrafanaReceiversExporter } from '../export/GrafanaReceiversExporter';
 

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, Stack } from '@grafana/ui';
+import { Stack, useStyles2 } from '@grafana/ui';
 
 import { PopupCard } from '../HoverCard';
 

--- a/public/app/features/alerting/unified/components/receivers/TemplateEditor.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateEditor.tsx
@@ -3,7 +3,7 @@
  *
  * It includes auto-complete for template data and syntax highlighting
  */
-import { editor, IDisposable } from 'monaco-editor';
+import { IDisposable, editor } from 'monaco-editor';
 import { useEffect, useRef } from 'react';
 
 import { CodeEditor } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -26,7 +26,7 @@ import {
 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { useCleanup } from 'app/core/hooks/useCleanup';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import { ActiveTab as ContactPointsActiveTabs } from 'app/features/alerting/unified/components/contact-points/ContactPoints';
 import { TestTemplateAlert } from 'app/plugins/datasource/alertmanager/types';
 

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -1,7 +1,7 @@
 import { default as React } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Provider } from 'react-redux';
-import { screen, render, waitFor } from 'test/test-utils';
+import { render, screen, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { Components } from '@grafana/e2e-selectors';
@@ -10,12 +10,12 @@ import { configureStore } from 'app/store/configureStore';
 
 import { TemplatePreviewResponse } from '../../api/templateApi';
 import {
+  REJECTED_PREVIEW_RESPONSE,
   mockPreviewTemplateResponse,
   mockPreviewTemplateResponseRejected,
-  REJECTED_PREVIEW_RESPONSE,
 } from '../../mocks/templatesApi';
 
-import { defaults, TemplateFormValues } from './TemplateForm';
+import { TemplateFormValues, defaults } from './TemplateForm';
 import { TemplatePreview } from './TemplatePreview';
 
 jest.mock(

--- a/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatesTable.tsx
@@ -3,7 +3,7 @@ import { Fragment, useState } from 'react';
 import { logError } from '@grafana/runtime';
 import { Badge, ConfirmModal, Tooltip, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import { CodeText } from 'app/features/alerting/unified/components/common/TextVariants';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 

--- a/public/app/features/alerting/unified/components/receivers/editor/autocomplete.ts
+++ b/public/app/features/alerting/unified/components/receivers/editor/autocomplete.ts
@@ -1,13 +1,13 @@
 import { concat } from 'lodash';
-import type { languages, editor, Position, IRange, IDisposable } from 'monaco-editor/esm/vs/editor/editor.api';
+import type { IDisposable, IRange, Position, editor, languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
 import type { Monaco } from '@grafana/ui';
 
 import { getAlertManagerSuggestions } from './alertManagerSuggestions';
 import { SuggestionDefinition } from './suggestionDefinition';
 import {
-  getAlertsSuggestions,
   getAlertSuggestions,
+  getAlertsSuggestions,
   getGlobalSuggestions,
   getKeyValueSuggestions,
   getSnippetsSuggestions,

--- a/public/app/features/alerting/unified/components/receivers/form/fields/SubformArrayField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/SubformArrayField.tsx
@@ -1,4 +1,4 @@
-import { FieldError, DeepMap, useFormContext } from 'react-hook-form';
+import { DeepMap, FieldError, useFormContext } from 'react-hook-form';
 
 import { Button, useStyles2 } from '@grafana/ui';
 import { useControlledFieldArray } from 'app/features/alerting/unified/hooks/useControlledFieldArray';

--- a/public/app/features/alerting/unified/components/receivers/form/fields/SubformField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/SubformField.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FieldError, DeepMap, useFormContext } from 'react-hook-form';
+import { DeepMap, FieldError, useFormContext } from 'react-hook-form';
 
 import { Button, useStyles2 } from '@grafana/ui';
 import { NotificationChannelOption, NotificationChannelSecureFields } from 'app/types';

--- a/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.test.tsx
@@ -12,7 +12,7 @@ import { PROVENANCE_NONE } from 'app/features/alerting/unified/utils/k8s/constan
 import { DEFAULT_TEMPLATES } from 'app/features/alerting/unified/utils/template-constants';
 import { AccessControlAction, NotificationChannelOption } from 'app/types';
 
-import { getTemplateOptions, TemplatesPicker } from './TemplateSelector';
+import { TemplatesPicker, getTemplateOptions } from './TemplateSelector';
 import { parseTemplates } from './utils';
 
 const alertmanagerConfigMock = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/ReceiverMetadataBadge.tsx
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/ReceiverMetadataBadge.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, LinkButton, Tooltip, useStyles2, Stack } from '@grafana/ui';
+import { Icon, LinkButton, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { ReceiverPluginMetadata } from './useReceiversMetadata';
 

--- a/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
+++ b/public/app/features/alerting/unified/components/receivers/grafanaAppReceivers/onCall/useOnCallIntegration.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor, getWrapper } from 'test/test-utils';
+import { getWrapper, renderHook, waitFor } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { disablePlugin } from 'app/features/alerting/unified/mocks/server/configure';

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationHeaderField.tsx
@@ -1,6 +1,6 @@
-import { FieldArrayWithId, useFormContext, Controller } from 'react-hook-form';
+import { Controller, FieldArrayWithId, useFormContext } from 'react-hook-form';
 
-import { Text, Stack } from '@grafana/ui';
+import { Stack, Text } from '@grafana/ui';
 
 import { RuleFormValues } from '../../types/rule-form';
 import { Annotation, annotationDescriptions, annotationLabels } from '../../utils/constants';

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { FormProvider, useForm } from 'react-hook-form';
-import { screen, render, within } from 'test/test-utils';
+import { render, screen, within } from 'test/test-utils';
 import { byRole, byTestId } from 'testing-library-selector';
 
 import { DashboardSearchItemType } from '../../../../search/types';

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.tsx
@@ -6,7 +6,7 @@ import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Field, Input, Stack, Text, TextArea, useStyles2 } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 
 import { DashboardModel } from '../../../../dashboard/state/DashboardModel';
 import { RuleFormValues } from '../../types/rule-form';
@@ -15,7 +15,7 @@ import { isGrafanaManagedRuleByType } from '../../utils/rules';
 
 import AnnotationHeaderField from './AnnotationHeaderField';
 import DashboardAnnotationField from './DashboardAnnotationField';
-import { DashboardPicker, getVisualPanels, PanelDTO } from './DashboardPicker';
+import { DashboardPicker, PanelDTO, getVisualPanels } from './DashboardPicker';
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
 import { useDashboardQuery } from './useDashboardQuery';

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -9,12 +9,12 @@ import { GrafanaTheme2 } from '@grafana/data/src';
 import {
   Alert,
   Button,
-  clearButtonStyles,
   FilterInput,
   Icon,
   LoadingPlaceholder,
   Modal,
   Tooltip,
+  clearButtonStyles,
   useStyles2,
 } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/components/rule-editor/EvaluationGroupQuickPick.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/EvaluationGroupQuickPick.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, userEvent } from 'test/test-utils';
 
-import { getEvaluationGroupOptions, EvaluationGroupQuickPick } from './EvaluationGroupQuickPick';
+import { EvaluationGroupQuickPick, getEvaluationGroupOptions } from './EvaluationGroupQuickPick';
 
 describe('EvaluationGroupQuickPick', () => {
   it('should render the correct default preset, set active element and allow selecting another option', async () => {

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -21,11 +21,11 @@ import {
   Tooltip,
   useStyles2,
 } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 import { RulerRuleGroupDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
-import { logInfo, LogMessages } from '../../Analytics';
+import { LogMessages, logInfo } from '../../Analytics';
 import { alertRuleApi } from '../../api/alertRuleApi';
 import { GRAFANA_RULER_CONFIG } from '../../api/featureDiscoveryApi';
 import { useCombinedRuleNamespaces } from '../../hooks/useCombinedRuleNamespaces';

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaFolderAndLabelsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaFolderAndLabelsStep.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Stack, Text } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 
 import { KBObjectArray, RuleFormValues } from '../../types/rule-form';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';

--- a/public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GroupAndNamespaceFields.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
-import { useFormContext, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { Field, useStyles2, VirtualizedSelect } from '@grafana/ui';
+import { Field, VirtualizedSelect, useStyles2 } from '@grafana/ui';
 
 import { RuleFormValues } from '../../types/rule-form';
 

--- a/public/app/features/alerting/unified/components/rule-editor/NeedHelpInfo.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NeedHelpInfo.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, Text, Toggletip, useStyles2, Stack } from '@grafana/ui';
+import { Icon, Stack, Text, Toggletip, useStyles2 } from '@grafana/ui';
 
 interface NeedHelpInfoProps {
   contentText: string | JSX.Element;

--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from 'react-hook-form';
 import { useMountedState } from 'react-use';
 import { takeWhile } from 'rxjs/operators';
 
-import { dateTimeFormatISO, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { GrafanaTheme2, LoadingState, dateTimeFormatISO } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { Alert, Button, Stack, useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { dateTime, getDefaultRelativeTimeRange, GrafanaTheme2, RelativeTimeRange } from '@grafana/data';
+import { GrafanaTheme2, RelativeTimeRange, dateTime, getDefaultRelativeTimeRange } from '@grafana/data';
 import { relativeToTimeRange } from '@grafana/data/src/datetime/rangeutil';
-import { clearButtonStyles, Icon, InlineField, RelativeTimeRangePicker, Toggletip, useStyles2 } from '@grafana/ui';
+import { Icon, InlineField, RelativeTimeRangePicker, Toggletip, clearButtonStyles, useStyles2 } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { AlertQueryOptions, MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -1,15 +1,15 @@
-import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
+import { DragDropContext, DropResult, Droppable } from '@hello-pangea/dnd';
 import { omit } from 'lodash';
 import { PureComponent, useState } from 'react';
 
 import {
   DataQuery,
   DataSourceInstanceSettings,
-  getDataSourceRef,
   LoadingState,
   PanelData,
-  rangeUtil,
   RelativeTimeRange,
+  getDataSourceRef,
+  rangeUtil,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { Button, Card, Icon, Stack } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { FC, useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { PanelData, CoreApp, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { CoreApp, GrafanaTheme2, LoadingState, PanelData } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rule-editor/RuleInspector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleInspector.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from 'react-hook-form';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, CodeEditor, Drawer, Icon, Tab, TabsBar, useStyles2, Tooltip } from '@grafana/ui';
+import { Button, CodeEditor, Drawer, Icon, Tab, TabsBar, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { RulerRuleDTO } from '../../../../../types/unified-alerting-dto';
 import { RuleFormValues } from '../../types/rule-form';

--- a/public/app/features/alerting/unified/components/rule-editor/VizWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/VizWrapper.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { GrafanaTheme2, isTimeSeriesFrames, PanelData, ThresholdsConfig } from '@grafana/data';
+import { GrafanaTheme2, PanelData, ThresholdsConfig, isTimeSeriesFrames } from '@grafana/data';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { useEffect, useMemo, useState } from 'react';
-import { FormProvider, SubmitErrorHandler, useForm, UseFormWatch } from 'react-hook-form';
+import { FormProvider, SubmitErrorHandler, UseFormWatch, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -26,8 +26,8 @@ import { RuleGroupIdentifier, RuleIdentifier, RuleWithLocation } from 'app/types
 import { PostableRuleGrafanaRuleDTO, RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
 import {
-  logInfo,
   LogMessages,
+  logInfo,
   trackAlertRuleFormCancelled,
   trackAlertRuleFormError,
   trackAlertRuleFormSaved,
@@ -44,15 +44,15 @@ import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
 import { DataSourceType } from '../../../utils/datasource';
 import {
   DEFAULT_GROUP_EVALUATION_INTERVAL,
+  MANUAL_ROUTING_KEY,
+  SIMPLIFIED_QUERY_EDITOR_KEY,
   formValuesFromExistingRule,
   formValuesToRulerGrafanaRuleDTO,
   formValuesToRulerRuleDTO,
   getDefaultFormValues,
   getDefaultQueries,
   ignoreHiddenQueries,
-  MANUAL_ROUTING_KEY,
   normalizeDefaultAnnotations,
-  SIMPLIFIED_QUERY_EDITOR_KEY,
 } from '../../../utils/rule-form';
 import * as ruleId from '../../../utils/rule-id';
 import { fromRulerRule, fromRulerRuleAndRuleGroupIdentifier, stringifyIdentifier } from '../../../utils/rule-id';
@@ -68,9 +68,9 @@ import { NotificationsStep } from '../NotificationsStep';
 import { RecordingRulesNameSpaceAndGroupStep } from '../RecordingRulesNameSpaceAndGroupStep';
 import { RuleInspector } from '../RuleInspector';
 import {
+  QueryAndExpressionsStep,
   areQueriesTransformableToSimpleCondition,
   isExpressionQueryInAlert,
-  QueryAndExpressionsStep,
 } from '../query-and-alert-condition/QueryAndExpressionsStep';
 import { translateRouteParamToRuleType } from '../util';
 

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/SimplifiedRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/SimplifiedRuleEditor.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Route, Routes } from 'react-router-dom-v5-compat';
 import { ui } from 'test/helpers/alertingRuleEditor';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { render, screen, userEvent } from 'test/test-utils';

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/MuteTimingFields.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/MuteTimingFields.tsx
@@ -1,4 +1,4 @@
-import { useFormContext, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { Field } from '@grafana/ui';
 import MuteTimingsSelector from 'app/features/alerting/unified/components/alertmanager-entities/MuteTimingsSelector';

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import * as React from 'react';
-import { useFormContext, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { Field, FieldValidationMessage, InlineField, MultiSelect, Stack, Switch, Text, useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -2,11 +2,11 @@ import { Graph } from 'app/core/utils/dag';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {
-  _getOriginsOfRefId,
-  parseRefsFromMathExpression,
   _createDagFromQueries,
-  fingerprintGraph,
+  _getOriginsOfRefId,
   fingerPrintQueries,
+  fingerprintGraph,
+  parseRefsFromMathExpression,
 } from './dag';
 
 describe('working with dag', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPolicyMatchers.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPolicyMatchers.tsx
@@ -6,7 +6,7 @@ import { useStyles2 } from '@grafana/ui';
 import { MatcherFormatter } from '../../../utils/matchers';
 import { Matchers } from '../../notification-policies/Matchers';
 
-import { hasEmptyMatchers, isDefaultPolicy, RouteWithPath } from './route';
+import { RouteWithPath, hasEmptyMatchers, isDefaultPolicy } from './route';
 
 interface Props {
   route: RouteWithPath;

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -1,5 +1,5 @@
 import { compact } from 'lodash';
-import { lazy, Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 
 import { Button, LoadingPlaceholder, Stack, Text } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreviewByAlertManager.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, LoadingPlaceholder, useStyles2, withErrorBoundary } from '@grafana/ui';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
 
 import { Stack } from '../../../../../../plugins/datasource/parca/QueryEditor/Stack';

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRoute.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, getTagColorIndexFromName, TagList, useStyles2 } from '@grafana/ui';
+import { Button, TagList, getTagColorIndexFromName, useStyles2 } from '@grafana/ui';
 
 import { Receiver } from '../../../../../../plugins/datasource/alertmanager/types';
 import { Stack } from '../../../../../../plugins/datasource/parca/QueryEditor/Stack';

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationRouteDetailsModal.tsx
@@ -13,7 +13,7 @@ import { createContactPointSearchLink } from '../../../utils/misc';
 import { Authorize } from '../../Authorize';
 import { Matchers } from '../../notification-policies/Matchers';
 
-import { hasEmptyMatchers, isDefaultPolicy, RouteWithPath } from './route';
+import { RouteWithPath, hasEmptyMatchers, isDefaultPolicy } from './route';
 
 interface Props {
   routesByIdMap: Map<string, RouteWithPath>;

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts
@@ -11,7 +11,7 @@ import { addUniqueIdentifierToRoute } from '../../../utils/amroutes';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
 import { AlertInstanceMatch, computeInheritedTree, normalizeRoute } from '../../../utils/notification-policies';
 
-import { getRoutesByIdMap, RouteWithPath } from './route';
+import { RouteWithPath, getRoutesByIdMap } from './route';
 
 export const useAlertmanagerNotificationRoutingPreview = (alertmanager: string, potentialInstances: Labels[]) => {
   const {

--- a/public/app/features/alerting/unified/components/rule-editor/preview.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/preview.ts
@@ -1,6 +1,6 @@
 import { DataFrame } from '@grafana/data';
 
-import { GrafanaAlertState, isGrafanaAlertState, Labels } from '../../../../../types/unified-alerting-dto';
+import { GrafanaAlertState, Labels, isGrafanaAlertState } from '../../../../../types/unified-alerting-dto';
 
 interface AlertPreviewInstance {
   state: GrafanaAlertState;

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/CloudDataSourceSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/CloudDataSourceSelector.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useFormContext, Controller } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 
 import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { Field, useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -3,7 +3,7 @@ import { cloneDeep } from 'lodash';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { getDefaultRelativeTimeRange, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, getDefaultRelativeTimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
@@ -20,21 +20,21 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { Text } from '@grafana/ui/src/components/Text/Text';
-import { t, Trans } from 'app/core/internationalization';
+import { Trans, t } from 'app/core/internationalization';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import {
   ExpressionDatasourceUID,
   ExpressionQuery,
   ExpressionQueryType,
-  expressionTypes,
   ReducerMode,
+  expressionTypes,
 } from 'app/features/expressions/types';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { useRulesSourcesWithRuler } from '../../../hooks/useRuleSourcesWithRuler';
 import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
 import { getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
-import { isPromOrLokiQuery, PromOrLokiQuery } from '../../../utils/rule-form';
+import { PromOrLokiQuery, isPromOrLokiQuery } from '../../../utils/rule-form';
 import {
   isCloudAlertingRuleByType,
   isCloudRecordingRuleByType,
@@ -51,7 +51,7 @@ import { RuleEditorSection } from '../RuleEditorSection';
 import { errorFromCurrentCondition, errorFromPreviewData, findRenamedDataQueryReferences, refIdExists } from '../util';
 
 import { CloudDataSourceSelector } from './CloudDataSourceSelector';
-import { getSimpleConditionFromExpressions, SimpleConditionEditor, SimpleConditionIdentifier } from './SimpleCondition';
+import { SimpleConditionEditor, SimpleConditionIdentifier, getSimpleConditionFromExpressions } from './SimpleCondition';
 import { SmartAlertTypeDetector } from './SmartAlertTypeDetector';
 import { DESCRIPTIONS } from './descriptions';
 import {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,4 +1,4 @@
-import { getDefaultRelativeTimeRange, RelativeTimeRange } from '@grafana/data';
+import { RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime/src/services/__mocks__/dataSourceSrv';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import {
@@ -12,12 +12,12 @@ import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { SimpleConditionIdentifier } from './SimpleCondition';
 import {
+  QueriesAndExpressionsState,
   addNewDataQuery,
   addNewExpression,
   duplicateQuery,
   optimizeReduceExpression,
   queriesAndExpressionsReducer,
-  QueriesAndExpressionsState,
   removeExpression,
   rewireExpressions,
   setDataQueries,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -2,12 +2,12 @@ import { createAction, createReducer, original } from '@reduxjs/toolkit';
 
 import {
   DataQuery,
+  ReducerID,
+  RelativeTimeRange,
   getDataSourceRef,
   getDefaultRelativeTimeRange,
   getNextRefId,
   rangeUtil,
-  ReducerID,
-  RelativeTimeRange,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
@@ -6,7 +6,7 @@ import { ExpressionQuery } from 'app/features/expressions/types';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { areQueriesTransformableToSimpleCondition } from './QueryAndExpressionsStep';
-import { getSimpleConditionFromExpressions, SimpleCondition } from './SimpleCondition';
+import { SimpleCondition, getSimpleConditionFromExpressions } from './SimpleCondition';
 
 function initializeSimpleCondition(
   isGrafanaAlertingType: boolean,

--- a/public/app/features/alerting/unified/components/rule-editor/rule-types/RuleTypePicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/rule-types/RuleTypePicker.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { isEmpty } from 'lodash';
 
 import { GrafanaTheme2 } from '@grafana/data/src';
-import { useStyles2, Stack } from '@grafana/ui';
+import { Stack, useStyles2 } from '@grafana/ui';
 
 import { useRulesSourcesWithRuler } from '../../../hooks/useRuleSourcesWithRuler';
 import { RuleFormType } from '../../../types/rule-form';

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -2,11 +2,11 @@ import { xor } from 'lodash';
 
 import {
   DataFrame,
-  isTimeSeriesFrames,
   LoadingState,
   PanelData,
   ThresholdsConfig,
   ThresholdsMode,
+  isTimeSeriesFrames,
 } from '@grafana/data';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
 import { config } from 'app/core/config';

--- a/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { locationService } from '@grafana/runtime';
 import { ConfirmModal } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.test.tsx
@@ -1,6 +1,6 @@
 import { within } from '@testing-library/react';
-import { render, waitFor, screen, userEvent } from 'test/test-utils';
-import { byText, byRole } from 'testing-library-selector';
+import { render, screen, userEvent, waitFor } from 'test/test-utils';
+import { byRole, byText } from 'testing-library-selector';
 
 import { setPluginLinksHook } from '@grafana/runtime';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -5,7 +5,7 @@ import { useMeasure } from 'react-use';
 
 import { NavModelItem, UrlQueryValue } from '@grafana/data';
 import { Alert, LinkButton, LoadingBar, Stack, TabContent, Text, TextLink, useStyles2 } from '@grafana/ui';
-import { t, Trans } from '@grafana/ui/src/utils/i18n';
+import { Trans, t } from '@grafana/ui/src/utils/i18n';
 import { PageInfoItem } from 'app/core/components/Page/types';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import InfoPausedRule from 'app/features/alerting/unified/components/InfoPausedRule';
@@ -21,6 +21,7 @@ import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { Annotation } from '../../utils/constants';
 import { makeDashboardLink, makePanelLink, stringifyErrorLike } from '../../utils/misc';
 import {
+  RulePluginOrigin,
   getRulePluginOrigin,
   isAlertingRule,
   isFederatedRuleGroup,
@@ -28,7 +29,6 @@ import {
   isGrafanaRulerRule,
   isGrafanaRulerRulePaused,
   isRecordingRule,
-  RulePluginOrigin,
 } from '../../utils/rules';
 import { createRelativeUrl } from '../../utils/url';
 import { AlertLabels } from '../AlertLabels';

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/History.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/History.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 
 import { config } from '@grafana/runtime';
 import { RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/DataSourceModelPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/Query/DataSourceModelPreview.tsx
@@ -7,7 +7,7 @@ import { AlertDataQuery } from 'app/types/unified-alerting-dto';
 import { DataSourceType } from '../../../../utils/datasource';
 import { isPromOrLokiQuery } from '../../../../utils/rule-form';
 
-import { isSQLLikeQuery, SQLQueryPreview } from './SQLQueryPreview';
+import { SQLQueryPreview, isSQLLikeQuery } from './SQLQueryPreview';
 
 const PrometheusQueryPreview = React.lazy(() => import('./PrometheusQueryPreview'));
 const LokiQueryPreview = React.lazy(() => import('./LokiQueryPreview'));

--- a/public/app/features/alerting/unified/components/rules/ActionIcon.tsx
+++ b/public/app/features/alerting/unified/components/rules/ActionIcon.tsx
@@ -1,4 +1,4 @@
-import { IconName, Tooltip, LinkButton, Button } from '@grafana/ui';
+import { Button, IconName, LinkButton, Tooltip } from '@grafana/ui';
 import { PopoverContent, TooltipPlacement } from '@grafana/ui/src/components/Tooltip';
 
 interface Props {

--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
@@ -3,14 +3,14 @@ import { PopValueActionMeta, RemoveValueActionMeta } from 'react-select';
 
 import {
   DataSourceInstanceSettings,
+  SelectableValue,
   getDataSourceUID,
   isUnsignedPluginSignature,
-  SelectableValue,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { getDataSourceSrv, DataSourcePickerState, DataSourcePickerProps } from '@grafana/runtime';
+import { DataSourcePickerProps, DataSourcePickerState, getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
-import { ActionMeta, Stack, PluginSignatureBadge, MultiSelect } from '@grafana/ui';
+import { ActionMeta, MultiSelect, PluginSignatureBadge, Stack } from '@grafana/ui';
 
 import { isDataSourceManagingAlerts } from '../../utils/datasource';
 

--- a/public/app/features/alerting/unified/components/rules/ReorderRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/ReorderRuleGroupModal.tsx
@@ -3,9 +3,9 @@ import {
   DragDropContext,
   Draggable,
   DraggableProvided,
+  DropResult,
   Droppable,
   DroppableProvided,
-  DropResult,
 } from '@hello-pangea/dnd';
 import cx from 'classnames';
 import { produce } from 'immer';
@@ -27,7 +27,7 @@ import { RulerRuleDTO } from 'app/types/unified-alerting-dto';
 import { alertRuleApi } from '../../api/alertRuleApi';
 import { useReorderRuleForRuleGroup } from '../../hooks/ruleGroup/useUpdateRuleGroup';
 import { isLoading } from '../../hooks/useAsync';
-import { swapItems, SwapOperation } from '../../reducers/ruler/ruleGroups';
+import { SwapOperation, swapItems } from '../../reducers/ruler/ruleGroups';
 import { fetchRulerRulesAction } from '../../state/actions';
 import { isCloudRulesSource } from '../../utils/datasource';
 import { hashRulerRule } from '../../utils/rule-id';

--- a/public/app/features/alerting/unified/components/rules/RuleActionsButtons.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleActionsButtons.test.tsx
@@ -1,4 +1,4 @@
-import { userEvent, screen, render } from 'test/test-utils';
+import { render, screen, userEvent } from 'test/test-utils';
 import { byLabelText, byRole } from 'testing-library-selector';
 
 import { config, locationService, setPluginLinksHook } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -1,14 +1,14 @@
 import { css } from '@emotion/css';
 import { SerializedError } from '@reduxjs/toolkit';
 import pluralize from 'pluralize';
-import { useMemo, ReactElement, useState, FC } from 'react';
+import { FC, ReactElement, useMemo, useState } from 'react';
 import { useLocalStorage } from 'react-use';
 
 import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
-import { getRulesDataSources, GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesDataSources } from '../../utils/datasource';
 import { makeDataSourceLink } from '../../utils/misc';
 import { isRulerNotSupportedResponse } from '../../utils/rules';
 

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -10,7 +10,7 @@ import { usePagination } from '../../hooks/usePagination';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { AlertRuleListItem } from '../../rule-list/components/AlertRuleListItem';
 import { ListSection } from '../../rule-list/components/ListSection';
-import { getRulesDataSources, GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesDataSources } from '../../utils/datasource';
 import { createViewLink } from '../../utils/misc';
 import { isAsyncRequestStatePending } from '../../utils/redux';
 import { hashRule } from '../../utils/rule-id';

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -7,13 +7,13 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Badge, ConfirmModal, Icon, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { CombinedRuleGroup, CombinedRuleNamespace, RuleGroupIdentifier, RulesSource } from 'app/types/unified-alerting';
 
-import { logInfo, LogMessages } from '../../Analytics';
+import { LogMessages, logInfo } from '../../Analytics';
 import { featureDiscoveryApi } from '../../api/featureDiscoveryApi';
 import { useDeleteRuleGroup } from '../../hooks/ruleGroup/useDeleteRuleGroup';
 import { useFolder } from '../../hooks/useFolder';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { useRulesAccess } from '../../utils/accessControlHooks';
-import { getRulesSourceName, GRAFANA_RULES_SOURCE_NAME, isCloudRulesSource } from '../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesSourceName, isCloudRulesSource } from '../../utils/datasource';
 import { makeFolderLink, makeFolderSettingsLink } from '../../utils/misc';
 import { isFederatedRuleGroup, isGrafanaRulerRule } from '../../utils/rules';
 import { CollapseToggle } from '../CollapseToggle';

--- a/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, userEvent, screen, waitFor } from 'test/test-utils';
+import { render, screen, userEvent, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { setPluginLinksHook } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -17,7 +17,7 @@ import { usePagination } from '../../hooks/usePagination';
 import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { calculateNextEvaluationEstimate } from '../../rule-list/components/util';
 import { Annotation } from '../../utils/constants';
-import { getRulesSourceName, GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesSourceName } from '../../utils/datasource';
 import { getRulePluginOrigin, isGrafanaRulerRule, isGrafanaRulerRulePaused } from '../../utils/rules';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { DynamicTableWithGuidelines } from '../DynamicTableWithGuidelines';

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { byRole } from 'testing-library-selector';
 
 import { LogRecordViewerByTimestamp } from './LogRecordViewer';

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { groupBy, uniqueId } from 'lodash';
-import { memo, Fragment, useEffect } from 'react';
+import { Fragment, memo, useEffect } from 'react';
 
-import { dateTimeFormat, GrafanaTheme2 } from '@grafana/data';
-import { Icon, TagList, useStyles2, Stack } from '@grafana/ui';
+import { GrafanaTheme2, dateTimeFormat } from '@grafana/data';
+import { Icon, Stack, TagList, useStyles2 } from '@grafana/ui';
 
 import { Label } from '../../Label';
 import { AlertStateTag } from '../AlertStateTag';

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.test.tsx
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { Props } from 'react-virtualized-auto-sizer';
 import { render, waitFor } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';

--- a/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LokiStateHistory.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { DataFrame, dateTime, GrafanaTheme2, TimeRange } from '@grafana/data';
+import { DataFrame, GrafanaTheme2, TimeRange, dateTime } from '@grafana/data';
 import { Alert, Button, Field, Icon, Input, Label, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { stateHistoryApi } from '../../../api/stateHistoryApi';

--- a/public/app/features/alerting/unified/components/rules/state-history/StateHistory.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/StateHistory.tsx
@@ -3,8 +3,8 @@ import { groupBy } from 'lodash';
 import { FormEvent, useCallback, useState } from 'react';
 import * as React from 'react';
 
-import { AlertState, dateTimeFormat, GrafanaTheme2 } from '@grafana/data';
-import { Alert, Field, Icon, Input, Label, LoadingPlaceholder, Tooltip, useStyles2, Stack } from '@grafana/ui';
+import { AlertState, GrafanaTheme2, dateTimeFormat } from '@grafana/data';
+import { Alert, Field, Icon, Input, Label, LoadingPlaceholder, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { StateHistoryItem, StateHistoryItemData } from 'app/types/unified-alerting';
 import { GrafanaAlertStateWithReason, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/components/rules/state-history/common.test.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/common.test.ts
@@ -1,4 +1,4 @@
-import { extractCommonLabels, Label, omitLabels } from './common';
+import { Label, extractCommonLabels, omitLabels } from './common';
 
 test('extractCommonLabels', () => {
   const labels: Label[][] = [

--- a/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.test.tsx
@@ -1,4 +1,4 @@
-import { createTheme, FieldType } from '@grafana/data';
+import { FieldType, createTheme } from '@grafana/data';
 
 import { LogRecord } from './common';
 import { logRecordsToDataFrame } from './useRuleHistoryRecords';

--- a/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx
@@ -6,8 +6,8 @@ import {
   Field as DataFrameField,
   DataFrameJSON,
   FieldType,
-  getDisplayProcessor,
   GrafanaTheme2,
+  getDisplayProcessor,
 } from '@grafana/data';
 import { fieldIndexComparer } from '@grafana/data/src/field/fieldComparers';
 import { MappingType, ThresholdsMode } from '@grafana/schema';
@@ -16,7 +16,7 @@ import { useTheme2 } from '@grafana/ui';
 import { labelsMatchMatchers } from '../../../utils/alertmanager';
 import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 
-import { extractCommonLabels, Line, LogRecord, omitLabels } from './common';
+import { Line, LogRecord, extractCommonLabels, omitLabels } from './common';
 
 export function useRuleHistoryRecords(stateHistory?: DataFrameJSON, filter?: string) {
   const theme = useTheme2();

--- a/public/app/features/alerting/unified/components/settings/SettingsContext.tsx
+++ b/public/app/features/alerting/unified/components/settings/SettingsContext.tsx
@@ -1,5 +1,5 @@
 import { debounce, union, without } from 'lodash';
-import { createContext, useContext, PropsWithChildren, useEffect, useRef } from 'react';
+import { PropsWithChildren, createContext, useContext, useEffect, useRef } from 'react';
 
 import { AppEvents } from '@grafana/data';
 import { config, getAppEvents } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
+++ b/public/app/features/alerting/unified/components/settings/__mocks__/server.ts
@@ -1,4 +1,4 @@
-import { delay, http, HttpResponse } from 'msw';
+import { HttpResponse, delay, http } from 'msw';
 import { SetupServerApi } from 'msw/node';
 
 import { setDataSourceSrv } from '@grafana/runtime';
@@ -10,7 +10,7 @@ import {
   Receiver,
 } from 'app/plugins/datasource/alertmanager/types';
 
-import { mockDataSource, MockDataSourceSrv } from '../../../mocks';
+import { MockDataSourceSrv, mockDataSource } from '../../../mocks';
 import * as config from '../../../utils/config';
 import { DataSourceType } from '../../../utils/datasource';
 

--- a/public/app/features/alerting/unified/components/silences/MatchersField.tsx
+++ b/public/app/features/alerting/unified/components/silences/MatchersField.tsx
@@ -1,9 +1,9 @@
 import { css, cx } from '@emotion/css';
 import { useEffect } from 'react';
-import { useFormContext, useFieldArray, Controller } from 'react-hook-form';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Field, Input, IconButton, useStyles2, Select, Divider } from '@grafana/ui';
+import { Button, Divider, Field, IconButton, Input, Select, useStyles2 } from '@grafana/ui';
 import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 

--- a/public/app/features/alerting/unified/components/silences/SilenceDetails.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilenceDetails.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { dateMath, GrafanaTheme2, intervalToAbbreviatedDurationString } from '@grafana/data';
+import { GrafanaTheme2, dateMath, intervalToAbbreviatedDurationString } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
 import SilencedAlertsTable from './SilencedAlertsTable';

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useDebounce, useDeepCompareEffect } from 'react-use';
 
-import { dateTime, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, dateTime } from '@grafana/data';
 import { Alert, Badge, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { MatcherFieldValue } from 'app/features/alerting/unified/types/silence-form';
 import { matcherFieldToMatcher } from 'app/features/alerting/unified/utils/alertmanager';

--- a/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesEditor.tsx
@@ -6,9 +6,9 @@ import { useParams } from 'react-router-dom-v5-compat';
 import { useDebounce } from 'react-use';
 
 import {
+  GrafanaTheme2,
   addDurationToDate,
   dateTime,
-  GrafanaTheme2,
   intervalToAbbreviatedDurationString,
   isValidDate,
   parseDuration,
@@ -27,9 +27,9 @@ import {
   useStyles2,
   withErrorBoundary,
 } from '@grafana/ui';
-import { alertSilencesApi, SilenceCreatedResponse } from 'app/features/alerting/unified/api/alertSilencesApi';
+import { SilenceCreatedResponse, alertSilencesApi } from 'app/features/alerting/unified/api/alertSilencesApi';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
-import { getDatasourceAPIUid, GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDatasourceAPIUid } from 'app/features/alerting/unified/utils/datasource';
 import { MatcherOperator, SilenceCreatePayload } from 'app/plugins/datasource/alertmanager/types';
 
 import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -3,7 +3,7 @@ import { debounce, uniqueId } from 'lodash';
 import { FormEvent, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Field, Icon, Input, Label, Tooltip, useStyles2, Stack } from '@grafana/ui';
+import { Button, Field, Icon, Input, Label, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
 import { parsePromQLStyleMatcherLoose } from '../../utils/matchers';

--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import SVG from 'react-inlinesvg';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, useTheme2, Stack, Text, TextLink } from '@grafana/ui';
+import { Stack, Text, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
 
 export default function GettingStarted() {
   const theme = useTheme2();

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useDeleteRuleFromGroup.test.tsx
@@ -7,15 +7,15 @@ import { CombinedRule } from 'app/types/unified-alerting';
 
 import server, { setupMswServer } from '../../mockApi';
 import {
+  grantUserPermissions,
   mockCombinedRule,
   mockGrafanaRulerRule,
-  mockRulerRuleGroup,
   mockRulerAlertingRule,
   mockRulerRecordingRule,
-  grantUserPermissions,
+  mockRulerRuleGroup,
 } from '../../mocks';
 import { grafanaRulerRule } from '../../mocks/grafanaRulerApi';
-import { setUpdateRulerRuleNamespaceHandler, setRulerRuleGroupHandler } from '../../mocks/server/configure';
+import { setRulerRuleGroupHandler, setUpdateRulerRuleNamespaceHandler } from '../../mocks/server/configure';
 import { captureRequests, serializeRequests } from '../../mocks/server/events';
 import { rulerRuleGroupHandler, updateRulerRuleNamespaceHandler } from '../../mocks/server/handlers/mimirRuler';
 import { fromRulerRuleAndRuleGroupIdentifier } from '../../utils/rule-id';

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useMoveRuleFromRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useMoveRuleFromRuleGroup.test.tsx
@@ -14,7 +14,7 @@ import {
   grafanaRulerNamespace,
   grafanaRulerRule,
 } from '../../mocks/grafanaRulerApi';
-import { group1, GROUP_3, NAMESPACE_1, NAMESPACE_2 } from '../../mocks/mimirRulerApi';
+import { GROUP_3, NAMESPACE_1, NAMESPACE_2, group1 } from '../../mocks/mimirRulerApi';
 import { mimirDataSource } from '../../mocks/server/configure';
 import { MIMIR_DATASOURCE_UID } from '../../mocks/server/constants';
 import { captureRequests, serializeRequests } from '../../mocks/server/events';

--- a/public/app/features/alerting/unified/hooks/ruleGroup/usePauseAlertRule.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/usePauseAlertRule.test.tsx
@@ -1,14 +1,14 @@
 import userEvent from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 import { render } from 'test/test-utils';
-import { byText, byRole } from 'testing-library-selector';
+import { byRole, byText } from 'testing-library-selector';
 
 import { AccessControlAction } from 'app/types';
 import { RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { setupMswServer } from '../../mockApi';
-import { mockGrafanaRulerRule, mockCombinedRule, mockCombinedRuleGroup, grantUserPermissions } from '../../mocks';
-import { grafanaRulerNamespace, grafanaRulerRule, grafanaRulerGroupName } from '../../mocks/grafanaRulerApi';
+import { grantUserPermissions, mockCombinedRule, mockCombinedRuleGroup, mockGrafanaRulerRule } from '../../mocks';
+import { grafanaRulerGroupName, grafanaRulerNamespace, grafanaRulerRule } from '../../mocks/grafanaRulerApi';
 import { setUpdateRulerRuleNamespaceHandler } from '../../mocks/server/configure';
 import { captureRequests, serializeRequests } from '../../mocks/server/events';
 import { getRuleGroupLocationFromCombinedRule } from '../../utils/rules';

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleGroup.test.tsx
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleGroup.test.tsx
@@ -6,8 +6,8 @@ import { RuleGroupIdentifier } from 'app/types/unified-alerting';
 
 import { setupMswServer } from '../../mockApi';
 import { grantUserPermissions } from '../../mocks';
-import { grafanaRulerGroupName2, grafanaRulerGroupName, grafanaRulerNamespace } from '../../mocks/grafanaRulerApi';
-import { NAMESPACE_2, namespace2, GROUP_1, NAMESPACE_1 } from '../../mocks/mimirRulerApi';
+import { grafanaRulerGroupName, grafanaRulerGroupName2, grafanaRulerNamespace } from '../../mocks/grafanaRulerApi';
+import { GROUP_1, NAMESPACE_1, NAMESPACE_2, namespace2 } from '../../mocks/mimirRulerApi';
 import { mimirDataSource } from '../../mocks/server/configure';
 import { MIMIR_DATASOURCE_UID } from '../../mocks/server/constants';
 import { captureRequests, serializeRequests } from '../../mocks/server/events';

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleGroup.ts
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useUpdateRuleGroup.ts
@@ -4,10 +4,10 @@ import { RuleGroupIdentifier } from 'app/types/unified-alerting';
 import { alertRuleApi } from '../../api/alertRuleApi';
 import { notFoundToNullOrThrow } from '../../api/util';
 import {
-  updateRuleGroupAction,
   moveRuleGroupAction,
   renameRuleGroupAction,
   reorderRulesInRuleGroupAction,
+  updateRuleGroupAction,
 } from '../../reducers/ruler/ruleGroups';
 import { isGrafanaRulesSource } from '../../utils/datasource';
 import { useAsync } from '../useAsync';

--- a/public/app/features/alerting/unified/hooks/ruleGroup/useUpsertRuleFromRuleGroup.ts
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/useUpsertRuleFromRuleGroup.ts
@@ -2,7 +2,7 @@ import { produce } from 'immer';
 import { isEqual } from 'lodash';
 
 import { t } from 'app/core/internationalization';
-import { RuleGroupIdentifier, EditableRuleIdentifier } from 'app/types/unified-alerting';
+import { EditableRuleIdentifier, RuleGroupIdentifier } from 'app/types/unified-alerting';
 import { PostableRuleDTO } from 'app/types/unified-alerting-dto';
 
 import { alertRuleApi } from '../../api/alertRuleApi';

--- a/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useAbilities.test.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react';
-import { render, screen, renderHook, waitFor, getWrapper } from 'test/test-utils';
+import { getWrapper, render, renderHook, screen, waitFor } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { setFolderAccessControl } from 'app/features/alerting/unified/mocks/server/configure';

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { isGrafanaRulesSource } from 'app/features/alerting/unified/utils/datasource';
-import { CombinedRule, RuleIdentifier, RulesSource, RuleWithLocation } from 'app/types/unified-alerting';
+import { CombinedRule, RuleIdentifier, RuleWithLocation, RulesSource } from 'app/types/unified-alerting';
 import { RulerRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
 import { alertRuleApi } from '../api/alertRuleApi';

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.test.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.test.ts
@@ -1,6 +1,6 @@
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 
-import { sortRulesByName, flattenGrafanaManagedRules } from './useCombinedRuleNamespaces';
+import { flattenGrafanaManagedRules, sortRulesByName } from './useCombinedRuleNamespaces';
 
 describe('flattenGrafanaManagedRules', () => {
   it('should properly transform grafana managed namespaces', () => {

--- a/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts
@@ -3,9 +3,9 @@ import { useMemo, useRef } from 'react';
 
 import {
   AlertGroupTotals,
-  AlertingRule,
-  AlertInstanceTotals,
   AlertInstanceTotalState,
+  AlertInstanceTotals,
+  AlertingRule,
   CombinedRule,
   CombinedRuleGroup,
   CombinedRuleNamespace,
@@ -25,9 +25,9 @@ import { alertRuleApi } from '../api/alertRuleApi';
 import { GRAFANA_RULER_CONFIG } from '../api/featureDiscoveryApi';
 import { RULE_LIST_POLL_INTERVAL_MS } from '../utils/constants';
 import {
+  GRAFANA_RULES_SOURCE_NAME,
   getAllRulesSources,
   getRulesSourceByName,
-  GRAFANA_RULES_SOURCE_NAME,
   isCloudRulesSource,
   isGrafanaRulesSource,
 } from '../utils/datasource';

--- a/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 import { getWrapper } from 'test/test-utils';
 

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -2,6 +2,7 @@ import { setDataSourceSrv } from '@grafana/runtime';
 
 import { PromAlertingRuleState } from '../../../../types/unified-alerting-dto';
 import {
+  MockDataSourceSrv,
   getCloudRule,
   mockAlertQuery,
   mockCombinedCloudRuleNamespace,
@@ -9,7 +10,6 @@ import {
   mockCombinedRuleGroup,
   mockCombinedRuleNamespace,
   mockDataSource,
-  MockDataSourceSrv,
   mockPromAlert,
   mockPromAlertingRule,
   mockRulerGrafanaRule,

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -6,10 +6,10 @@ import { useCallback, useDeferredValue, useEffect, useMemo } from 'react';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { Matcher } from 'app/plugins/datasource/alertmanager/types';
 import { CombinedRuleGroup, CombinedRuleNamespace, Rule } from 'app/types/unified-alerting';
-import { isPromAlertingRuleState, PromRuleType, RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
+import { PromRuleType, RulerGrafanaRuleDTO, isPromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import { logError } from '../Analytics';
-import { applySearchFilterToQuery, getSearchFilterFromQuery, RulesFilter } from '../search/rulesSearchParser';
+import { RulesFilter, applySearchFilterToQuery, getSearchFilterFromQuery } from '../search/rulesSearchParser';
 import { labelsMatchMatchers, matcherToMatcherField } from '../utils/alertmanager';
 import { Annotation } from '../utils/constants';
 import { isCloudRulesSource } from '../utils/datasource';

--- a/public/app/features/alerting/unified/hooks/usePagination.ts
+++ b/public/app/features/alerting/unified/hooks/usePagination.ts
@@ -1,5 +1,5 @@
 import { chunk, clamp } from 'lodash';
-import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export function usePagination<T>(items: T[], initialPage = 1, itemsPerPage: number) {
   const [page, setPage] = useState(initialPage);

--- a/public/app/features/alerting/unified/hooks/useStateHistoryModal.tsx
+++ b/public/app/features/alerting/unified/hooks/useStateHistoryModal.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
+import { Suspense, lazy, useCallback, useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/initAlerting.tsx
+++ b/public/app/features/alerting/unified/initAlerting.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/alerting/unified/insights/InsightsMenuButton.tsx
+++ b/public/app/features/alerting/unified/insights/InsightsMenuButton.tsx
@@ -1,14 +1,14 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { ExploreUrlState, serializeStateToUrlParam, toURLRange, GrafanaTheme2 } from '@grafana/data';
+import { ExploreUrlState, GrafanaTheme2, serializeStateToUrlParam, toURLRange } from '@grafana/data';
 import {
   SceneComponentProps,
-  sceneGraph,
   SceneObjectBase,
   SceneObjectState,
   SceneTimeRangeState,
   SceneVariableSetState,
+  sceneGraph,
 } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
 import { Button, Dropdown, Icon, IconButton, Menu, Modal, useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/AlertsByStateScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneDataTransformer, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getGrafanaInstancesByStateScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalDurationScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 
 export function getGrafanaEvalDurationScene(datasource: DataSourceRef, panelTitle: string) {
   const query = new SceneQueryRunner({

--- a/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getGrafanaEvalSuccessVsFailuresScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluation.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getGrafanaRulesByEvaluationScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/RulesByEvaluationPercentage.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getGrafanaRulesByEvaluationPercentageScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/AlertsByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getAlertsByStateScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/alertmanager/NotificationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getGrafanaAlertmanagerNotificationsScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/AlertsByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getAlertsByStateScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/Notifications.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getNotificationsScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/perGroup/RuleGroupEvaluationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getRuleGroupEvaluationsScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/EvalSuccessVsFailuresScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getEvalSuccessVsFailuresScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getInstancesByStateScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/InstancesPercentageByState.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getInstancesPercentageByStateScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/mimir/rules/MissedIterationsScene.tsx
@@ -1,7 +1,7 @@
 import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
-import { INSTANCE_ID, overrideToFixedColor, PANEL_STYLES } from '../../../home/Insights';
+import { INSTANCE_ID, PANEL_STYLES, overrideToFixedColor } from '../../../home/Insights';
 import { InsightsMenuButton } from '../../InsightsMenuButton';
 
 export function getMissedIterationsScene(datasource: DataSourceRef, panelTitle: string) {

--- a/public/app/features/alerting/unified/integration/AlertRulesDrawer.tsx
+++ b/public/app/features/alerting/unified/integration/AlertRulesDrawer.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 
 import { Drawer, LoadingPlaceholder, Stack, TextLink } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -1,5 +1,5 @@
-import { http, HttpResponse } from 'msw';
-import { setupServer, SetupServer } from 'msw/node';
+import { HttpResponse, http } from 'msw';
+import { SetupServer, setupServer } from 'msw/node';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { setBackendSrv } from '@grafana/runtime';
@@ -21,8 +21,8 @@ import {
 
 import { backendSrv } from '../../../core/services/backend_srv';
 import {
-  AlertmanagerConfig,
   AlertManagerCortexConfig,
+  AlertmanagerConfig,
   AlertmanagerReceiver,
   EmailConfig,
   GrafanaManagedReceiverConfig,

--- a/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/mocks/alertmanagerApi.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 
 import { grafanaAlertingConfigurationStatusHandler } from 'app/features/alerting/unified/mocks/server/handlers/alertmanagers';

--- a/public/app/features/alerting/unified/mocks/grafanaRulerApi.ts
+++ b/public/app/features/alerting/unified/mocks/grafanaRulerApi.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 
 import { FieldType } from '@grafana/data';
@@ -9,7 +9,7 @@ import {
   RulerRuleGroupDTO,
 } from 'app/types/unified-alerting-dto';
 
-import { PREVIEW_URL, PreviewResponse, PROM_RULES_URL } from '../api/alertRuleApi';
+import { PREVIEW_URL, PROM_RULES_URL, PreviewResponse } from '../api/alertRuleApi';
 import { Annotation } from '../utils/constants';
 
 export function mockPreviewApiResponse(server: SetupServer, result: PreviewResponse) {

--- a/public/app/features/alerting/unified/mocks/rulerApi.ts
+++ b/public/app/features/alerting/unified/mocks/rulerApi.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 
 import { RulerRuleGroupDTO, RulerRulesConfigDTO } from '../../../../types/unified-alerting-dto';

--- a/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse, JsonBodyType, StrictResponse } from 'msw';
+import { HttpResponse, JsonBodyType, StrictResponse, http } from 'msw';
 
 import { TemplatesTestPayload } from 'app/features/alerting/unified/api/templateApi';
 import receiversMock from 'app/features/alerting/unified/components/contact-points/__mocks__/receivers.mock.json';

--- a/public/app/features/alerting/unified/mocks/server/handlers/datasources.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/datasources.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 
 import { buildInfoResponse } from 'app/features/alerting/unified/testSetup/featureDiscovery';
 

--- a/public/app/features/alerting/unified/mocks/server/handlers/grafanaRuler.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/grafanaRuler.ts
@@ -1,4 +1,4 @@
-import { delay, http, HttpResponse } from 'msw';
+import { HttpResponse, delay, http } from 'msw';
 
 export const MOCK_GRAFANA_ALERT_RULE_TITLE = 'Test alert';
 

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/receivers.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/receivers.k8s.ts
@@ -5,7 +5,7 @@ import { getAlertmanagerConfig } from 'app/features/alerting/unified/mocks/serve
 import { ALERTING_API_SERVER_BASE_URL, getK8sResponse } from 'app/features/alerting/unified/mocks/server/utils';
 import { ComGithubGrafanaGrafanaPkgApisAlertingNotificationsV0Alpha1Receiver } from 'app/features/alerting/unified/openapi/receiversApi.gen';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
-import { PROVENANCE_NONE, K8sAnnotations } from 'app/features/alerting/unified/utils/k8s/constants';
+import { K8sAnnotations, PROVENANCE_NONE } from 'app/features/alerting/unified/utils/k8s/constants';
 
 const getReceiversList = () => {
   const config = getAlertmanagerConfig(GRAFANA_RULES_SOURCE_NAME);

--- a/public/app/features/alerting/unified/mocks/server/handlers/mimirRuler.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/mimirRuler.ts
@@ -1,4 +1,4 @@
-import { delay, http, HttpResponse } from 'msw';
+import { HttpResponse, delay, http } from 'msw';
 
 import {
   PromRulesResponse,

--- a/public/app/features/alerting/unified/mocks/server/handlers/plugins.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/plugins.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 
 import { PluginLoadingStrategy, PluginMeta } from '@grafana/data';
 import { config } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/mocks/server/handlers/plugins/configure-plugins.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/plugins/configure-plugins.ts
@@ -1,8 +1,8 @@
 import { OnCallIntegrationDTO } from 'app/features/alerting/unified/api/onCallApi';
 import server from 'app/features/alerting/unified/mockApi';
 import {
-  getOnCallIntegrationsHandler,
   getFeaturesHandler,
+  getOnCallIntegrationsHandler,
 } from 'app/features/alerting/unified/mocks/server/handlers/plugins/grafana-oncall';
 
 export const setOnCallFeatures = (features: string[]) => {

--- a/public/app/features/alerting/unified/mocks/templatesApi.ts
+++ b/public/app/features/alerting/unified/mocks/templatesApi.ts
@@ -1,7 +1,7 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { SetupServer } from 'msw/node';
 
-import { previewTemplateUrl, TemplatePreviewResponse } from '../api/templateApi';
+import { TemplatePreviewResponse, previewTemplateUrl } from '../api/templateApi';
 
 export function mockPreviewTemplateResponse(server: SetupServer, response: TemplatePreviewResponse) {
   server.use(http.post(previewTemplateUrl, () => HttpResponse.json(response)));

--- a/public/app/features/alerting/unified/reducers/ruler/ruleGroups.test.ts
+++ b/public/app/features/alerting/unified/reducers/ruler/ruleGroups.test.ts
@@ -8,6 +8,7 @@ import { mockGrafanaRulerRule, mockRulerAlertingRule, mockRulerGrafanaRule, mock
 import { fromRulerRule } from '../../utils/rule-id';
 
 import {
+  SwapOperation,
   addRuleAction,
   deleteRuleAction,
   moveRuleGroupAction,
@@ -17,7 +18,6 @@ import {
   reorderRulesInRuleGroupAction,
   ruleGroupReducer,
   swapItems,
-  SwapOperation,
   updateRuleAction,
   updateRuleGroupAction,
 } from './ruleGroups';

--- a/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v1.tsx
@@ -26,7 +26,7 @@ import { useFilteredRules, useRulesFilter } from '../hooks/useFilteredRules';
 import { useUnifiedAlertingSelector } from '../hooks/useUnifiedAlertingSelector';
 import { fetchAllPromAndRulerRulesAction, fetchAllPromRulesAction, fetchRulerRulesAction } from '../state/actions';
 import { RULE_LIST_POLL_INTERVAL_MS } from '../utils/constants';
-import { getAllRulesSourceNames, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getAllRulesSourceNames } from '../utils/datasource';
 import { createRelativeUrl } from '../utils/url';
 
 const VIEWS = {

--- a/public/app/features/alerting/unified/rule-list/components/RuleListIcon.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/RuleListIcon.tsx
@@ -1,6 +1,6 @@
 import type { RequireAtLeastOne } from 'type-fest';
 
-import { Icon, Text, Tooltip, type IconName } from '@grafana/ui';
+import { Icon, type IconName, Text, Tooltip } from '@grafana/ui';
 import type { TextProps } from '@grafana/ui/src/components/Text/Text';
 import type { RuleHealth } from 'app/types/unified-alerting';
 import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';

--- a/public/app/features/alerting/unified/search/rulesSearchParser.test.ts
+++ b/public/app/features/alerting/unified/search/rulesSearchParser.test.ts
@@ -1,7 +1,7 @@
 import { PromAlertingRuleState, PromRuleType } from '../../../../types/unified-alerting-dto';
 import { getFilter } from '../utils/search';
 
-import { applySearchFilterToQuery, getSearchFilterFromQuery, RuleHealth } from './rulesSearchParser';
+import { RuleHealth, applySearchFilterToQuery, getSearchFilterFromQuery } from './rulesSearchParser';
 
 describe('Alert rules searchParser', () => {
   describe('getSearchFilterFromQuery', () => {

--- a/public/app/features/alerting/unified/search/rulesSearchParser.ts
+++ b/public/app/features/alerting/unified/search/rulesSearchParser.ts
@@ -1,13 +1,13 @@
-import { isPromAlertingRuleState, PromAlertingRuleState, PromRuleType } from '../../../../types/unified-alerting-dto';
+import { PromAlertingRuleState, PromRuleType, isPromAlertingRuleState } from '../../../../types/unified-alerting-dto';
 import { getRuleHealth, isPromRuleType } from '../utils/rules';
 
 import * as terms from './search.terms';
 import {
-  applyFiltersToQuery,
   FilterExpr,
   FilterSupportedTerm,
-  parseQueryToFilter,
   QueryFilterMapper,
+  applyFiltersToQuery,
+  parseQueryToFilter,
 } from './searchParser';
 
 export interface RulesFilter {

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -1,17 +1,17 @@
 import { reject } from 'lodash';
-import { Observable, of, OperatorFunction, ReplaySubject, Unsubscribable } from 'rxjs';
+import { Observable, OperatorFunction, ReplaySubject, Unsubscribable, of } from 'rxjs';
 import { catchError, map, share } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  dataFrameFromJSON,
   DataFrameJSON,
-  getDefaultTimeRange,
   LoadingState,
   PanelData,
+  TimeRange,
+  dataFrameFromJSON,
+  getDefaultTimeRange,
   preProcessPanelData,
   rangeUtil,
-  TimeRange,
   withLoadingIndicator,
 } from '@grafana/data';
 import { DataSourceWithBackend, FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/utils/messageFromError.test.ts
+++ b/public/app/features/alerting/unified/utils/messageFromError.test.ts
@@ -1,6 +1,6 @@
 import { FetchError } from '@grafana/runtime';
 
-import { messageFromError, UNKNOW_ERROR } from './redux';
+import { UNKNOW_ERROR, messageFromError } from './redux';
 
 describe('messageFromError method', () => {
   it('should return UNKNOW_ERROR message when error is an object and not having neither in the e.data.message and nor in e.message', () => {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -23,13 +23,13 @@ import {
 } from 'app/types/unified-alerting';
 import {
   GrafanaAlertState,
-  mapStateWithReasonToBaseState,
   PromAlertingRuleState,
+  mapStateWithReasonToBaseState,
 } from 'app/types/unified-alerting-dto';
 
 import { ALERTMANAGER_NAME_QUERY_KEY } from './constants';
 import { getRulesSourceName } from './datasource';
-import { getErrorMessageFromCode, isApiMachineryError, SupportedErrors } from './k8s/errors';
+import { SupportedErrors, getErrorMessageFromCode, isApiMachineryError } from './k8s/errors';
 import { getMatcherQueryParams } from './matchers';
 import * as ruleId from './rule-id';
 import { createAbsoluteUrl, createRelativeUrl } from './url';

--- a/public/app/features/alerting/unified/utils/notification-policies.ts
+++ b/public/app/features/alerting/unified/utils/notification-policies.ts
@@ -3,7 +3,7 @@ import { isArray, pick, reduce } from 'lodash';
 import { AlertmanagerGroup, ObjectMatcher, Route, RouteWithID } from 'app/plugins/datasource/alertmanager/types';
 import { Labels } from 'app/types/unified-alerting-dto';
 
-import { isLabelMatch, Label, matchLabelsSet, normalizeMatchers, unquoteWithUnescape } from './matchers';
+import { Label, isLabelMatch, matchLabelsSet, normalizeMatchers, unquoteWithUnescape } from './matchers';
 
 // If a policy has no matchers it still can be a match, hence matchers can be empty and match can be true
 // So we cannot use null as an indicator of no match

--- a/public/app/features/alerting/unified/utils/receiver-form.test.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.test.ts
@@ -5,12 +5,12 @@ import { grafanaAlertNotifiers, grafanaAlertNotifiersMock } from '../mockGrafana
 import { CloudChannelValues, GrafanaChannelValues, ReceiverFormValues } from '../types/receiver-form';
 
 import {
-  formValuesToGrafanaReceiver,
-  omitEmptyValues,
-  omitEmptyUnlessExisting,
-  omitTemporaryIdentifiers,
   formValuesToCloudReceiver,
+  formValuesToGrafanaReceiver,
   grafanaReceiverToFormValues,
+  omitEmptyUnlessExisting,
+  omitEmptyValues,
+  omitTemporaryIdentifiers,
 } from './receiver-form';
 
 describe('Receiver form utils', () => {

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -1,10 +1,10 @@
-import { AsyncThunk, createSlice, Draft, isAsyncThunkAction, PayloadAction, SerializedError } from '@reduxjs/toolkit';
+import { AsyncThunk, Draft, PayloadAction, SerializedError, createSlice, isAsyncThunkAction } from '@reduxjs/toolkit';
 
 import { AppEvents } from '@grafana/data';
 import { FetchError, isFetchError } from '@grafana/runtime';
 import { appEvents } from 'app/core/core';
 
-import { logInfo, LogMessages } from '../Analytics';
+import { LogMessages, logInfo } from '../Analytics';
 
 import { isErrorLike } from './misc';
 

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -4,18 +4,18 @@ import {
   DataQuery,
   DataSourceInstanceSettings,
   DataSourceRef,
-  getDefaultRelativeTimeRange,
-  getNextRefId,
   IntervalValues,
-  rangeUtil,
   RelativeTimeRange,
   ScopedVars,
   TimeRange,
+  getDefaultRelativeTimeRange,
+  getNextRefId,
+  rangeUtil,
 } from '@grafana/data';
 import { PromQuery } from '@grafana/prometheus';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
-import { sceneGraph, VizPanel } from '@grafana/scenes';
+import { VizPanel, sceneGraph } from '@grafana/scenes';
 import { DataSourceJsonData } from '@grafana/schema';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -55,8 +55,8 @@ import { getRulesAccess } from './access-control';
 import { Annotation, defaultAnnotations } from './constants';
 import {
   DataSourceType,
-  getDefaultOrFirstCompatibleDataSource,
   GRAFANA_RULES_SOURCE_NAME,
+  getDefaultOrFirstCompatibleDataSource,
   isGrafanaRulesSource,
 } from './datasource';
 import { arrayToRecord, recordToArray } from './misc';


### PR DESCRIPTION
**What is this feature?**
Makes sure import members are consistently ordered (within the alerting code)

**Why do we need this feature?**
Consistency - I've seen reorders happen in various PRs along the way, but perhaps its best to just get them all consistent in one go.

The first commit is adding the rule, the second is 100% autofixes
