### PR TITLE
Chore: Update codeowners for gdev dashboards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,7 +187,52 @@
 /devenv/datasources.yaml @grafana/grafana-backend-group
 /devenv/datasources_docker.yaml @grafana/grafana-backend-group
 /devenv/dev-dashboards-without-uid/ @grafana/dashboards-squad
-/devenv/dev-dashboards/ @grafana/dashboards-squad
+
+/devenv/dev-dashboards/annotations @grafana/dataviz-squad
+/devenv/dev-dashboards/migrations @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-barchart @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-bargauge @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-candlestick @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-canvas @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-datagrid @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-gauge @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-geomap @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-graph @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-heatmap @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-histogram @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-library @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-piechart @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-stat @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-table @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-timeline @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-timeseries @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-trend @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-xychart @grafana/dataviz-squad
+/devenv/dev-dashboards/transforms @grafana/dataviz-squad
+/devenv/dev-dashboards/panel-datagrid @grafana/dataviz-squad
+
+/devenv/dev-dashboards/datasource-elasticsearch/ @grafana/aws-datasources
+/devenv/dev-dashboards/datasource-opentsdb/ @grafana/partner-datasources
+/devenv/dev-dashboards/datasource-influxdb/ @grafana/partner-datasources
+/devenv/dev-dashboards/datasource-mssql/ @grafana/partner-datasources
+/devenv/dev-dashboards/datasource-loki/ @grafana/plugins-platform-frontend
+/devenv/dev-dashboards/datasource-testdata/ @grafana/plugins-platform-frontend
+/devenv/dev-dashboards/datasource-mysql/ @grafana/oss-big-tent
+/devenv/dev-dashboards/datasource-postgres/ @grafana/oss-big-tent
+
+/devenv/dev-dashboards/e2e-repeats/ @grafana/grafana-frontend-platform
+/devenv/dev-dashboards/panel-text @grafana/grafana-frontend-platform
+/devenv/dev-dashboards/scenarios @grafana/grafana-frontend-platform
+
+/devenv/dev-dashboards/feature-templating/ @grafana/dashboards-squad
+/devenv/dev-dashboards/panel-common @grafana/dashboards-squad
+/devenv/dev-dashboards/panel-dashlist @grafana/dashboards-squad
+/devenv/dev-dashboards/live @grafana/dashboards-squad
+
+/devenv/dev-dashboards/panel-framegraph @grafana/observability-traces-and-profiling
+/devenv/dev-dashboards/panel-polystat @grafana/plugins-platform-frontend
+/devenv/dev-dashboards/extensions/ @grafana/plugins-platform-frontend
+
 /devenv/docker/blocks/alert_webhook_listener/ @grafana/alerting-backend
 /devenv/docker/blocks/caddy_tls/ @grafana/alerting-backend
 /devenv/docker/blocks/clickhouse/ @grafana/partner-datasources


### PR DESCRIPTION
This PR updates the codeowners for our gdev dashboards, previously owned by Dashboards.

Fixes https://github.com/grafana/grafana/issues/96644

**Special notes for your reviewer:**
- `/devenv/dev-dashboards/datasource-*` list needs to be re-checked
- is `/devenv/dev-dashboards/panel-datagrid` still used?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
