### PR TITLE
UsageInsights: Include panelId and panelName in events when available

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -557,6 +557,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
+  panelName?: string;
   panelPluginId?: string;
   dashboardUID?: string;
   headers?: Record<string, string>;

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -652,6 +652,7 @@ describe('DashboardScene', () => {
           app: CoreApp.Dashboard,
           dashboardUID: 'dash-1',
           panelId: 1,
+          panelName: 'Panel A',
           panelPluginId: 'table',
         });
       });
@@ -667,6 +668,7 @@ describe('DashboardScene', () => {
           app: CoreApp.Dashboard,
           dashboardUID: 'dash-1',
           panelId: 1,
+          panelName: 'Panel A',
           panelPluginId: 'table',
         });
       });

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -622,6 +622,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> {
       app: CoreApp.Dashboard,
       dashboardUID: this.state.uid,
       panelId,
+      panelName: panel?.state?.title,
       panelPluginId: panel?.state.pluginId,
       scopes: this._scopesFacade?.value,
     };

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -380,6 +380,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       datasource: this.datasource,
       queries: this.targets,
       panelId: this.id,
+      panelName: this.title,
       panelPluginId: this.type,
       dashboardUID: dashboardUID,
       timezone: dashboardTimezone,

--- a/public/app/features/query/state/PanelQueryRunner.test.ts
+++ b/public/app/features/query/state/PanelQueryRunner.test.ts
@@ -160,6 +160,7 @@ function describeQueryRunnerScenario(
           raw: { from: '1d', to: 'now' },
         },
         panelId: 1,
+        panelName: 'PanelName',
         queries: [{ refId: 'A' }],
       } as QueryRunnerOptions;
 
@@ -197,6 +198,11 @@ describe('PanelQueryRunner', () => {
       expect(ctx.queryCalledWith?.scopedVars.server!.text).toBe('Server1');
       expect(ctx.queryCalledWith?.scopedVars.__interval!.text).toBe('5m');
       expect(ctx.queryCalledWith?.scopedVars.__interval_ms!.text).toBe('300000');
+    });
+
+    it('should pass the panel id and name', async () => {
+      expect(ctx.queryCalledWith?.panelId).toBe(1);
+      expect(ctx.queryCalledWith?.panelName).toBe('PanelName');
     });
   });
 

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -50,6 +50,7 @@ export interface QueryRunnerOptions<
   datasource: DataSourceRef | DataSourceApi<TQuery, TOptions> | null;
   queries: TQuery[];
   panelId?: number;
+  panelName?: string;
   panelPluginId?: string;
   dashboardUID?: string;
   timezone: TimeZone;
@@ -258,6 +259,7 @@ export class PanelQueryRunner {
       timezone,
       datasource,
       panelId,
+      panelName,
       panelPluginId,
       dashboardUID,
       timeRange,
@@ -283,6 +285,7 @@ export class PanelQueryRunner {
       requestId: getNextRequestId(),
       timezone,
       panelId,
+      panelName,
       panelPluginId,
       dashboardUID,
       range: timeRange,
@@ -327,6 +330,9 @@ export class PanelQueryRunner {
       request.interval = norm.interval;
       request.intervalMs = norm.intervalMs;
       request.filters = this.templateSrv.getAdhocFilters(ds.name, true);
+
+      request.panelId = panelId;
+      request.panelName = panelName;
 
       this.lastRequest = request;
 

--- a/public/app/features/query/state/queryAnalytics.test.ts
+++ b/public/app/features/query/state/queryAnalytics.test.ts
@@ -118,6 +118,7 @@ describe('emitDataRequestEvent', () => {
     it('Should report meta analytics', () => {
       const data = getTestData({
         panelId: 2,
+        panelName: 'Panel Name2',
       });
       emitDataRequestEvent(datasource)(data);
 
@@ -130,6 +131,7 @@ describe('emitDataRequestEvent', () => {
           datasourceType: datasource.type,
           source: CoreApp.Dashboard,
           panelId: 2,
+          panelName: 'Panel Name2',
           dashboardUid: 'test', // from dashboard srv
           dataSize: 0,
           duration: 1,
@@ -144,6 +146,7 @@ describe('emitDataRequestEvent', () => {
       const data = getTestData(
         {
           panelId: 2,
+          panelName: 'Panel Name2',
         },
         partiallyCachedSeries
       );
@@ -158,6 +161,7 @@ describe('emitDataRequestEvent', () => {
           datasourceType: datasource.type,
           source: CoreApp.Dashboard,
           panelId: 2,
+          panelName: 'Panel Name2',
           dashboardUid: 'test',
           dataSize: 2,
           duration: 1,
@@ -172,6 +176,7 @@ describe('emitDataRequestEvent', () => {
       const data = getTestData(
         {
           panelId: 2,
+          panelName: 'Panel Name2',
         },
         multipleDataframesWithSameRefId
       );
@@ -186,6 +191,7 @@ describe('emitDataRequestEvent', () => {
           datasourceType: datasource.type,
           source: CoreApp.Dashboard,
           panelId: 2,
+          panelName: 'Panel Name2',
           dashboardUid: 'test', // from dashboard srv
           dataSize: 2,
           duration: 1,

--- a/public/app/features/query/state/queryAnalytics.ts
+++ b/public/app/features/query/state/queryAnalytics.ts
@@ -31,6 +31,8 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
       panelId: 0,
       panelPluginId: data.request?.panelPluginId,
       duration: data.request.endTime! - data.request.startTime,
+      ...(data?.request?.panelId && Number.isInteger(data.request.panelId) && { panelId: data.request.panelId }),
+      ...(data?.request?.panelName && { panelName: data.request.panelName }),
     };
 
     enrichWithInfo(eventData, data);
@@ -62,9 +64,6 @@ export function emitDataRequestEvent(datasource: DataSourceApi) {
 
     eventData.totalQueries = Object.keys(queryCacheStatus).length;
     eventData.cachedQueries = Object.values(queryCacheStatus).filter((val) => val === true).length;
-    if (data.request && Number.isInteger(data.request.panelId)) {
-      eventData.panelId = data.request.panelId;
-    }
 
     const dashboard = getDashboardSrv().getCurrent();
     if (dashboard) {


### PR DESCRIPTION
**What is this feature?**

When the event name is `data-request`, we were not passing the `panelId` or `panelName` when available to the usage insights API.

Tested with the `dashboardScene` feature toggle both enabled and disabled.

Enabled:
```
INFO [12-10|11:53:11] Usage insights event                     logger=usageinsights.events eventName=data-request folderName=General dashboardName=NEW_DASHBOARD1 dashboardId=1 dashboardUid=fe6hku3wpdqf4f orgId=1 orgName="Main Org." timestamp=2024-12-10T10:53:11.595778Z tokenId=1 username=admin userId=1 totalQueries=1 cachedQueries=0 datasourceName="-- Grafana --" datasourceId=-1 datasourceUid=grafana datasourceType=datasource panelId=2 panelName=PANEL_TITLE2 duration=13 source=dashboard
INFO [12-10|11:53:11] Usage insights event                     logger=usageinsights.events eventName=data-request folderName=General dashboardName=NEW_DASHBOARD1 dashboardId=1 dashboardUid=fe6hku3wpdqf4f orgId=1 orgName="Main Org." timestamp=2024-12-10T10:53:11.595778Z tokenId=1 username=admin userId=1 totalQueries=1 cachedQueries=0 datasourceName="-- Grafana --" datasourceId=-1 datasourceUid=grafana datasourceType=datasource panelId=1 panelName=PANEL_TITLE duration=11 source=dashboard
```

Disabled:
```
INFO [12-10|11:49:52] Usage insights event                     logger=usageinsights.events eventName=data-request folderName=General dashboardName=NEW_DASHBOARD1 dashboardId=1 dashboardUid=fe6hku3wpdqf4f orgId=1 orgName="Main Org." timestamp=2024-12-10T10:49:52.520018Z tokenId=1 username=admin userId=1 totalQueries=1 cachedQueries=0 datasourceName="-- Grafana --" datasourceId=-1 datasourceUid=grafana datasourceType=datasource panelId=2 panelName=PANEL_TITLE2 duration=8 source=dashboard
INFO [12-10|11:49:52] Usage insights event                     logger=usageinsights.events eventName=data-request folderName=General dashboardName=NEW_DASHBOARD1 dashboardId=1 dashboardUid=fe6hku3wpdqf4f orgId=1 orgName="Main Org." timestamp=2024-12-10T10:49:52.520019Z tokenId=1 username=admin userId=1 totalQueries=1 cachedQueries=0 datasourceName="-- Grafana --" datasourceId=-1 datasourceUid=grafana datasourceType=datasource panelId=1 panelName=PANEL_TITLE duration=14 source=dashboard
```

Also tested in cloud with an ephemeral instance:
![Screenshot 2024-12-10 at 12 46 02](https://github.com/user-attachments/assets/1a01d9eb-c874-44ff-a5bd-5a4069d88a50)


**Why do we need this feature?**

Improves usage insights data making it more granular by fixing an issue since the panel data should have been included.

**Who is this feature for?**

Usage Insights users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/13518

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
