### PR TITLE
PanelSearchLayout: Fix issue where variable changes didn't cause refresh

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -64,7 +64,17 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
     }
 
     if (panelSearch || panelsPerRow) {
-      return <PanelSearchLayout panelSearch={panelSearch} panelsPerRow={panelsPerRow} dashboard={model} />;
+      // By keeping the bodyToRender.Component hidden but still rendered,
+      // the associated scene object tree stays activated, and so changes to
+      // variables will still cause a refresh
+      return (
+        <>
+          <PanelSearchLayout panelSearch={panelSearch} panelsPerRow={panelsPerRow} dashboard={model} />
+          <div style={{ visibility: 'hidden' }}>
+            <bodyToRender.Component model={bodyToRender} />
+          </div>
+        </>
+      );
     }
 
     return (


### PR DESCRIPTION
Fixes an issue where the dashboard wouldn't refresh when changing template variables if you have a repeat panel and are using the special `systemPanelFilterVar` or `systemDynamicRowSizeVar` variables.
Hacky solution, but hopefully it'll do in a pinch.