### PR TITLE
Annotations: Fix `min step` parameter interpolation in Prometheus annotations query

### DIFF
--- a/packages/grafana-prometheus/src/datasource.test.ts
+++ b/packages/grafana-prometheus/src/datasource.test.ts
@@ -1051,9 +1051,13 @@ describe('PrometheusDatasource2', () => {
         },
       } as unknown as AnnotationQueryRequest;
 
-      async function runAnnotationQuery(data: number[][]) {
+      async function runAnnotationQuery(data: number[][], overrideStep?: string) {
         let response = createAnnotationResponse();
         response.data.results['X'].frames[0].data.values = data;
+        if ( overrideStep ) {
+          const meta = response.data.results['X'].frames[0].schema.meta;
+          meta.executedQueryString = meta.executedQueryString.replace('1m0s', overrideStep);
+        }
 
         options.annotation.useValueForTime = false;
         fetchMock.mockImplementation(() => of(response));
@@ -1092,6 +1096,18 @@ describe('PrometheusDatasource2', () => {
       it('should handle single active value', async () => {
         const results = await runAnnotationQuery([[2 * 60000], [1]]);
         expect(results.map((result) => [result.time, result.timeEnd])).toEqual([[120000, 120000]]);
+      });
+
+      it('should handle non-default step in executedQuery', async () => {
+        const results = await runAnnotationQuery([
+          [1 * 120000, 2 * 120000, 3 * 120000, 4 * 120000, 5 * 120000, 6 * 120000],
+          [1, 1, 0, 0, 1, 1],
+        ], '2m0s');
+
+        expect(results.map((result) => [result.time, result.timeEnd])).toEqual([
+          [120000, 240000],
+          [600000, 720000],
+        ]);
       });
     });
 

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -537,7 +537,15 @@ export class PrometheusDatasource
     const annotation = options.annotation;
     const { tagKeys = '', titleFormat = '', textFormat = '' } = annotation;
 
-    const step = rangeUtil.intervalToSeconds(annotation.step || ANNOTATION_QUERY_STEP_DEFAULT) * 1000;
+    const scopedVars = {
+      ...this.getIntervalVars(),
+      ...this.getRangeScopedVars(options?.range ?? getDefaultTimeRange()),
+    };
+
+    const step = rangeUtil.intervalToSeconds(
+      this.interpolateString(annotation.step || ANNOTATION_QUERY_STEP_DEFAULT, scopedVars)
+    ) * 1000;
+
     const tagKeysArray = tagKeys.split(',');
 
     const eventList: AnnotationEvent[] = [];

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -537,15 +537,11 @@ export class PrometheusDatasource
     const annotation = options.annotation;
     const { tagKeys = '', titleFormat = '', textFormat = '' } = annotation;
 
-    const scopedVars = {
-      ...this.getIntervalVars(),
-      ...this.getRangeScopedVars(options?.range ?? getDefaultTimeRange()),
-    };
-
-    const step = rangeUtil.intervalToSeconds(
-      this.interpolateString(annotation.step || ANNOTATION_QUERY_STEP_DEFAULT, scopedVars)
-    ) * 1000;
-
+    const input = frames[0].meta?.executedQueryString || '';
+    const regex = /Step:\s*([\d\w]+)/;
+    const match = input.match(regex);
+    const stepValue = match ? match[1] : null;
+    const step = rangeUtil.intervalToSeconds(stepValue || ANNOTATION_QUERY_STEP_DEFAULT) * 1000;
     const tagKeysArray = tagKeys.split(',');
 
     const eventList: AnnotationEvent[] = [];

--- a/packages/grafana-prometheus/src/test/__mocks__/datasource.ts
+++ b/packages/grafana-prometheus/src/test/__mocks__/datasource.ts
@@ -110,7 +110,7 @@ export function createAnnotationResponse() {
                 refId: 'X',
                 meta: {
                   typeVersion: [0, 0],
-                  executedQueryString: 'Expr: ALERTS{}\nStep: 1m0s'
+                  executedQueryString: 'Expr: ALERTS{}\nStep: 1m0s',
                 },
                 fields: [
                   {

--- a/packages/grafana-prometheus/src/test/__mocks__/datasource.ts
+++ b/packages/grafana-prometheus/src/test/__mocks__/datasource.ts
@@ -108,6 +108,10 @@ export function createAnnotationResponse() {
               schema: {
                 name: 'bar',
                 refId: 'X',
+                meta: {
+                  typeVersion: [0, 0],
+                  executedQueryString: 'Expr: ALERTS{}\nStep: 1m0s'
+                },
                 fields: [
                   {
                     name: 'Time',


### PR DESCRIPTION
**Additional work:** This is a bug fix for Prometheus annotations, where when the range is extended, annotations displayed in a range (not individual) were broken apart. This fixes it by using the calculated step in the algorithm used to decide whether to show annotations over a range or as individual.

Fixes #63687

Historical info:

**What is this feature?**

Looks like the step is interpolated in annotationQuery, but not interpolated in processAnnotationResponse. Fixing that.

It doesn't fix the 'Annotation query ranges break apart when zooming' issue completely, but at least it makes possible using variables in the `min step` field.

**Why do we need this feature?**

Fixes errors in console when using variables (f.e. $__interval) in the `min step` field:

```
Error: Invalid interval string, has to be either unit-less or end with one of the following units: "y, M, w, d, h, m, s, ms"
```

Also, with some tweaking in variables/annotations query it can be almost usable on some zoom ranges. 

**Who is this feature for?**

Everyone who tries to visualize alerts from the prometheus data source on Grafana dashboards.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->



**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
