### PR TITLE
Plugins: Set migration handler to definne its own PanelMigrationModel and add tests

### DIFF
--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -135,11 +135,28 @@ export interface PanelEditorProps<T = any> {
 }
 
 /**
+ * This type mirrors the required properties from PanelModel<TOptions> needed for migration handlers.
+ *
+ * By maintaining a separate type definition, we ensure that changes to PanelModel
+ * that would break third-party migration handlers are caught at compile time,
+ * rather than failing silently when third-party code attempts to use an incompatible panel.
+ */
+export interface PanelMigrationModel<TOptions = any> {
+  id: number;
+  type: string;
+  title?: string;
+  options: TOptions;
+  fieldConfig: PanelModel<TOptions>['fieldConfig'];
+  pluginVersion?: string;
+  targets?: PanelModel<TOptions>['targets'];
+}
+
+/**
  * Called when a panel is first loaded with current panel model to migrate panel options if needed.
  * Can return panel options, or a Promise that resolves to panel options for async migrations
  */
 export type PanelMigrationHandler<TOptions = any> = (
-  panel: PanelModel<TOptions>
+  panel: PanelMigrationModel<TOptions>
 ) => Partial<TOptions> | Promise<Partial<TOptions>>;
 
 /**

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -140,7 +140,10 @@ export interface PanelEditorProps<T = any> {
  * By maintaining a separate type definition, we ensure that changes to PanelModel
  * that would break third-party migration handlers are caught at compile time,
  * rather than failing silently when third-party code attempts to use an incompatible panel.
+ *
+ * TOptions must be any to follow the same pattern as PanelModel<TOptions>
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface PanelMigrationModel<TOptions = any> {
   id: number;
   type: string;


### PR DESCRIPTION
**What is this feature?**

Creates a separate type definition for `setMigrationHandler` inside the PanelPlugin that mirrors PanelModel's required properties.

**Why do we need this feature?**

Third-party code uses migration handlers but isn't validated against PanelModel changes. By creating a distinct type definition, we ensure breaking changes to PanelModel are caught at compile time when they affect migration handlers, rather than causing runtime failures in third-party code.

**Who is this feature for?**

All plugin code running in Grafana

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
