### PR TITLE
Docs: Add Dynatrace to unsupported data sources

### DIFF
--- a/docs/sources/dashboards/share-dashboards-panels/shared-dashboards/index.md
+++ b/docs/sources/dashboards/share-dashboards-panels/shared-dashboards/index.md
@@ -239,6 +239,7 @@ guaranteed because plugin developers can override this functionality. The follow
 ### Unsupported
 
 - Graphite
+- Dynatrace
 
 ### Unconfirmed
 
@@ -258,7 +259,6 @@ guaranteed because plugin developers can override this functionality. The follow
 - Datadog
 - Dataset
 - Druid
-- Dynatrace
 - GitHub
 - Google BigQuery
 - Grafana for YNAB


### PR DESCRIPTION
**What is this feature?**

Move Dynatrace to the list of unsupported data sources in shared dashboards.

Fixes https://github.com/grafana/support-escalations/issues/13838

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
