### PR TITLE
Chore: Update tests and remove `MockDataSourceSrv`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2865,10 +2865,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/alerting/unified/plugins/PluginOriginBadge.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -1,28 +1,19 @@
 import { produce } from 'immer';
 import { isEmpty, pick } from 'lodash';
-import { Observable } from 'rxjs';
 
 import {
-  DataQuery,
-  DataQueryRequest,
-  DataQueryResponse,
-  DataSourceApi,
   DataSourceInstanceSettings,
   DataSourceJsonData,
   DataSourcePluginMeta,
-  DataSourceRef,
   PluginExtensionLink,
   PluginExtensionTypes,
   ReducerID,
-  ScopedVars,
-  TestDataSourceResponse,
 } from '@grafana/data';
-import { DataSourceSrv, GetDataSourceListFilters, RuntimeDataSourceRegistration, config } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { defaultDashboard } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { MOCK_GRAFANA_ALERT_RULE_TITLE } from 'app/features/alerting/unified/mocks/server/handlers/grafanaRuler';
 import { ExpressionQuery, ExpressionQueryType, ReducerMode } from 'app/features/expressions/types';
-import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import {
   AlertManagerCortexConfig,
   AlertState,
@@ -399,82 +390,6 @@ export const mockReceiversState = (partial: Partial<ReceiversState> = {}): Recei
     ...partial,
   };
 };
-
-class MockDataSourceApi extends DataSourceApi {
-  constructor(instanceSettings: DataSourceInstanceSettings<DataSourceJsonData>) {
-    super(instanceSettings);
-  }
-
-  query(request: DataQueryRequest<DataQuery>): Promise<DataQueryResponse> | Observable<DataQueryResponse> {
-    throw new Error('Method not implemented.');
-  }
-  testDatasource(): Promise<TestDataSourceResponse> {
-    throw new Error('Method not implemented.');
-  }
-}
-
-/** @deprecated use `setupDatasources` instead */
-export class MockDataSourceSrv implements DataSourceSrv {
-  datasources: Record<string, DataSourceApi> = {};
-  // @ts-ignore
-  private settingsMapByName: Record<string, DataSourceInstanceSettings> = {};
-  private settingsMapByUid: Record<string, DataSourceInstanceSettings> = {};
-  private settingsMapById: Record<string, DataSourceInstanceSettings> = {};
-  // @ts-ignore
-  private templateSrv = {
-    getVariables: () => [],
-    replace: (name: any) => name,
-  };
-
-  defaultName = '';
-
-  constructor(datasources: Record<string, DataSourceInstanceSettings>) {
-    this.datasources = {};
-    this.settingsMapByName = Object.values(datasources).reduce<Record<string, DataSourceInstanceSettings>>(
-      (acc, ds) => {
-        acc[ds.name] = ds;
-        return acc;
-      },
-      {}
-    );
-
-    for (const dsSettings of Object.values(this.settingsMapByName)) {
-      this.settingsMapByUid[dsSettings.uid] = dsSettings;
-      this.settingsMapById[dsSettings.id] = dsSettings;
-      if (dsSettings.isDefault) {
-        this.defaultName = dsSettings.name;
-      }
-      this.datasources[dsSettings.uid] = new MockDataSourceApi(dsSettings);
-    }
-  }
-
-  registerRuntimeDataSource(entry: RuntimeDataSourceRegistration): void {}
-
-  get(name?: string | null | DataSourceRef, scopedVars?: ScopedVars): Promise<DataSourceApi> {
-    return DatasourceSrv.prototype.get.call(this, name, scopedVars);
-    //return Promise.reject(new Error('not implemented'));
-  }
-
-  /**
-   * Get a list of data sources
-   */
-  getList(filters?: GetDataSourceListFilters): DataSourceInstanceSettings[] {
-    return DatasourceSrv.prototype.getList.call(this, filters);
-  }
-
-  /**
-   * Get settings and plugin metadata by name or uid
-   */
-  getInstanceSettings(nameOrUid: string | null | undefined): DataSourceInstanceSettings | undefined {
-    return DatasourceSrv.prototype.getInstanceSettings.call(this, nameOrUid);
-  }
-
-  async loadDatasource(name: string): Promise<DataSourceApi<any, any>> {
-    return DatasourceSrv.prototype.loadDatasource.call(this, name);
-  }
-
-  reload() {}
-}
 
 export const mockGrafanaReceiver = (
   type: string,

--- a/public/app/features/alerting/unified/mocks/server/db.ts
+++ b/public/app/features/alerting/unified/mocks/server/db.ts
@@ -14,7 +14,7 @@ import {
   RulerRuleGroupDTO,
 } from 'app/types/unified-alerting-dto';
 
-import { MockDataSourceSrv } from '../../mocks';
+import { setupDataSources } from '../../testSetup/datasources';
 import { DataSourceType } from '../../utils/datasource';
 
 const prometheusRuleFactory = Factory.define<PromAlertingRuleDTO>(({ sequence }) => ({
@@ -62,7 +62,7 @@ const prometheusRuleGroupFactory = Factory.define<PromRuleGroupDTO>(({ sequence 
 const dataSourceFactory = Factory.define<DataSourceInstanceSettings>(({ sequence, params, afterBuild }) => {
   afterBuild((dataSource) => {
     config.datasources[dataSource.name] = dataSource;
-    setDataSourceSrv(new MockDataSourceSrv(config.datasources));
+    setupDataSources(...Object.values(config.datasources));
   });
 
   const uid = params.uid ?? `mock-ds-${sequence}`;

--- a/public/app/features/alerting/unified/mocks/server/db.ts
+++ b/public/app/features/alerting/unified/mocks/server/db.ts
@@ -2,7 +2,7 @@ import { Factory } from 'fishery';
 import { uniqueId } from 'lodash';
 
 import { DataSourceInstanceSettings, PluginType } from '@grafana/data';
-import { config, setDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { FolderDTO } from 'app/types';
 import {
   PromAlertingRuleDTO,

--- a/public/app/features/correlations/Forms/QueryEditorField.test.tsx
+++ b/public/app/features/correlations/Forms/QueryEditorField.test.tsx
@@ -4,7 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';
 
 import { setDataSourceSrv } from '@grafana/runtime';
-import { MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
 import { QueryEditorField } from './QueryEditorField';
 
@@ -25,7 +25,7 @@ const renderWithContext = (
   children: ReactNode,
   getHandler: (name: string) => Promise<MockDataSourceApi> = defaultGetHandler
 ) => {
-  const dsServer = new MockDataSourceSrv({});
+  const dsServer = setupDataSources();
   dsServer.get = getHandler;
 
   setDataSourceSrv(dsServer);

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataAlertingTab.test.tsx
@@ -2,16 +2,14 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 import { byTestId } from 'testing-library-selector';
 
-import { DataSourceApi } from '@grafana/data';
-import { PromOptions, PrometheusDatasource } from '@grafana/prometheus';
-import { config, locationService, setDataSourceSrv, setPluginLinksHook } from '@grafana/runtime';
+import { PromOptions } from '@grafana/prometheus';
+import { config, locationService, setPluginLinksHook } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import * as ruler from 'app/features/alerting/unified/api/ruler';
 import * as ruleActionButtons from 'app/features/alerting/unified/components/rules/RuleActionsButtons';
 import * as alertingAbilities from 'app/features/alerting/unified/hooks/useAbilities';
 import { mockAlertRuleApi, setupMswServer } from 'app/features/alerting/unified/mockApi';
 import {
-  MockDataSourceSrv,
   grantUserPermissions,
   mockDataSource,
   mockFolder,
@@ -20,13 +18,12 @@ import {
   mockRulerAlertingRule,
   mockRulerRuleGroup,
 } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
-import * as configDS from 'app/features/alerting/unified/utils/config';
 import { Annotation } from 'app/features/alerting/unified/utils/constants';
 import { DataSourceType, GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction, DashboardDataDTO } from 'app/types';
 import { AlertQuery, PromRulesResponse } from 'app/types/unified-alerting-dto';
@@ -44,7 +41,6 @@ import { PanelDataAlertingTab, PanelDataAlertingTabRendered } from './PanelDataA
 jest.mock('app/features/alerting/unified/api/prometheus');
 jest.mock('app/features/alerting/unified/api/ruler');
 
-jest.spyOn(configDS, 'getAllDataSources');
 jest.spyOn(ruleActionButtons, 'matchesWidth').mockReturnValue(false);
 jest.spyOn(ruler, 'rulerUrlBuilder');
 jest.spyOn(alertingAbilities, 'useAlertRuleAbility');
@@ -55,22 +51,34 @@ setPluginLinksHook(() => ({
 }));
 
 const dataSources = {
-  prometheus: mockDataSource<PromOptions>({
-    name: 'Prometheus',
-    type: DataSourceType.Prometheus,
-    isDefault: false,
-  }),
-  default: mockDataSource<PromOptions>({
-    name: 'Default',
-    type: DataSourceType.Prometheus,
-    isDefault: true,
-  }),
+  prometheus: mockDataSource<PromOptions>(
+    {
+      name: 'Prometheus',
+      type: DataSourceType.Prometheus,
+      isDefault: false,
+    },
+    { alerting: true, module: 'core:plugin/prometheus' }
+  ),
+  default: mockDataSource<PromOptions>(
+    {
+      name: 'Default',
+      type: DataSourceType.Prometheus,
+      isDefault: true,
+    },
+    { alerting: true, module: 'core:plugin/prometheus' }
+  ),
+  prometheusMinInterval: mockDataSource<PromOptions>(
+    {
+      name: 'Prometheus Min Interval',
+      type: DataSourceType.Prometheus,
+      isDefault: false,
+      jsonData: { manageAlerts: true, timeInterval: '7m' },
+    },
+    { alerting: true, module: 'core:plugin/prometheus' }
+  ),
 };
-dataSources.prometheus.meta.alerting = true;
-dataSources.default.meta.alerting = true;
 
 const mocks = {
-  getAllDataSources: jest.mocked(configDS.getAllDataSources),
   useAlertRuleAbilityMock: jest.mocked(alertingAbilities.useAlertRuleAbility),
   rulerBuilderMock: jest.mocked(ruler.rulerUrlBuilder),
 };
@@ -182,14 +190,8 @@ describe('PanelAlertTabContent', () => {
     ]);
 
     jest.spyOn(backendSrv, 'getFolderByUid').mockResolvedValue(mockFolder());
+    setupDataSources(...Object.values(dataSources));
 
-    mocks.getAllDataSources.mockReturnValue(Object.values(dataSources));
-    const dsService = new MockDataSourceSrv(dataSources);
-    dsService.datasources[dataSources.prometheus.uid] = new PrometheusDatasource(
-      dataSources.prometheus
-    ) as DataSourceApi;
-    dsService.datasources[dataSources.default.uid] = new PrometheusDatasource(dataSources.default) as DataSourceApi;
-    setDataSourceSrv(dsService);
     mocks.rulerBuilderMock.mockReturnValue({
       rules: () => ({ path: `api/ruler/${GRAFANA_RULES_SOURCE_NAME}/api/v1/rules` }),
       namespace: () => ({ path: 'ruler' }),
@@ -281,11 +283,13 @@ describe('PanelAlertTabContent', () => {
   });
 
   it('Will take into account datasource minInterval', async () => {
-    (getDatasourceSrv() as unknown as MockDataSourceSrv).datasources[dataSources.prometheus.uid].interval = '7m';
-
     dashboard.panels = [
       new PanelModel({
         ...panel,
+        datasource: {
+          type: 'prometheus',
+          uid: dataSources.prometheusMinInterval.uid,
+        },
         maxDataPoints: 100,
       }),
     ];
@@ -298,7 +302,7 @@ describe('PanelAlertTabContent', () => {
       refId: 'A',
       datasource: {
         type: 'prometheus',
-        uid: 'mock-ds-2',
+        uid: 'mock-ds-4',
       },
       interval: '',
       intervalMs: 420000,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -2,7 +2,6 @@ import { of } from 'rxjs';
 
 import { DataQueryRequest, DataSourceApi, LoadingState, PanelPlugin } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
-import { setDataSourceSrv } from '@grafana/runtime';
 import {
   CancelActivationHandler,
   CustomVariable,
@@ -14,7 +13,8 @@ import {
   SceneVariableSet,
   VizPanel,
 } from '@grafana/scenes';
-import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 import * as libAPI from 'app/features/library-panels/state/api';
 
@@ -61,13 +61,16 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 const dataSources = {
-  ds1: mockDataSource({
-    uid: 'ds1',
-    type: DataSourceType.Prometheus,
-  }),
+  ds1: mockDataSource(
+    {
+      uid: 'ds1',
+      type: DataSourceType.Prometheus,
+    },
+    { module: 'core:plugin/prometheus' }
+  ),
 };
 
-setDataSourceSrv(new MockDataSourceSrv(dataSources));
+setupDataSources(...Object.values(dataSources));
 
 let deactivate: CancelActivationHandler | undefined;
 

--- a/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
@@ -1,9 +1,8 @@
-import { render, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TestProvider } from 'test/helpers/TestProvider';
+import { render, screen, within } from 'test/test-utils';
 
-import { locationService, setAngularLoader, setDataSourceSrv } from '@grafana/runtime';
-import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { locationService, setAngularLoader } from '@grafana/runtime';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
 import { DashboardModel } from '../../state/DashboardModel';
 import { createDashboardModelFixture } from '../../state/__fixtures__/dashboardFixtures';
@@ -18,11 +17,7 @@ function setup(dashboard: DashboardModel, editIndex?: number) {
     },
   };
 
-  return render(
-    <TestProvider>
-      <AnnotationsSettings sectionNav={sectionNav} dashboard={dashboard} editIndex={editIndex} />
-    </TestProvider>
-  );
+  return render(<AnnotationsSettings sectionNav={sectionNav} dashboard={dashboard} editIndex={editIndex} />);
 }
 
 describe('AnnotationsSettings', () => {
@@ -56,7 +51,7 @@ describe('AnnotationsSettings', () => {
     ),
   };
 
-  setDataSourceSrv(new MockDataSourceSrv(dataSources));
+  setupDataSources(...Object.values(dataSources));
 
   const getTableBody = () => screen.getAllByRole('rowgroup')[1];
   const getTableBodyRows = () => within(getTableBody()).getAllByRole('row');
@@ -149,7 +144,7 @@ describe('AnnotationsSettings', () => {
       },
     ];
 
-    setup(dashboard);
+    const { user } = setup(dashboard);
 
     // Check that we have sorting buttons
     expect(within(getTableBodyRows()[0]).queryByRole('button', { name: 'Move up' })).not.toBeInTheDocument();
@@ -166,9 +161,9 @@ describe('AnnotationsSettings', () => {
     expect(within(getTableBodyRows()[1]).queryByText(/annotation 2/i)).toBeInTheDocument();
     expect(within(getTableBodyRows()[2]).queryByText(/annotation 3/i)).toBeInTheDocument();
 
-    await userEvent.click(within(getTableBody()).getAllByRole('button', { name: 'Move down' })[0]);
-    await userEvent.click(within(getTableBody()).getAllByRole('button', { name: 'Move down' })[1]);
-    await userEvent.click(within(getTableBody()).getAllByRole('button', { name: 'Move up' })[0]);
+    await user.click(within(getTableBody()).getAllByRole('button', { name: 'Move down' })[0]);
+    await user.click(within(getTableBody()).getAllByRole('button', { name: 'Move down' })[1]);
+    await user.click(within(getTableBody()).getAllByRole('button', { name: 'Move up' })[0]);
 
     // Checking if it has changed the sorting accordingly
     expect(within(getTableBodyRows()[0]).queryByText(/annotation 3/i)).toBeInTheDocument();
@@ -177,9 +172,9 @@ describe('AnnotationsSettings', () => {
   });
 
   test('Adding a new annotation', async () => {
-    setup(dashboard);
+    const { user } = setup(dashboard);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add annotation query' }));
+    await user.click(screen.getByRole('button', { name: 'Add annotation query' }));
 
     expect(locationService.getSearchObject().editIndex).toBe('1');
     expect(dashboard.annotations.list.length).toBe(2);
@@ -193,18 +188,18 @@ describe('AnnotationsSettings', () => {
       enable: true,
     });
 
-    setup(dashboard, 1);
+    const { user } = setup(dashboard, 1);
 
     const nameInput = screen.getByRole('textbox', { name: /name/i });
-    await userEvent.clear(nameInput);
-    await userEvent.type(nameInput, 'My Prometheus Annotation');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Prometheus Annotation');
 
-    await userEvent.click(screen.getByPlaceholderText(/testdata/i));
+    await user.click(screen.getByPlaceholderText(/testdata/i));
 
     expect(await screen.findByText(/Prometheus/i)).toBeVisible();
     expect(screen.queryAllByText(/testdata/i)).toHaveLength(1);
 
-    await userEvent.click(screen.getByText(/prometheus/i));
+    await user.click(screen.getByText(/prometheus/i));
 
     expect(screen.getByRole('checkbox', { name: /hidden/i })).not.toBeChecked();
   });
@@ -222,9 +217,9 @@ describe('AnnotationsSettings', () => {
         type: 'dashboard',
       },
     ];
-    setup(dashboard, 1); // Edit the not built-in annotations
+    const { user } = setup(dashboard, 1); // Edit the not built-in annotations
 
-    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
 
     expect(locationService.getSearchObject().editIndex).toBe(undefined);
     expect(dashboard.annotations.list.length).toBe(1); // started with two

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -2,11 +2,11 @@ import { each, map } from 'lodash';
 
 import { DataLinkBuiltInVars, MappingType, VariableHide } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
-import { setDataSourceSrv } from '@grafana/runtime';
 import { FieldConfigSource } from '@grafana/schema';
 import { config } from 'app/core/config';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN } from 'app/core/constants';
-import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { DashboardModel } from '../state/DashboardModel';
@@ -41,7 +41,7 @@ const dataSources = {
   }),
 };
 
-setDataSourceSrv(new MockDataSourceSrv(dataSources));
+setupDataSources(...Object.values(dataSources));
 
 describe('DashboardModel', () => {
   describe('when creating dashboard with old schema', () => {

--- a/public/app/features/templating/template_srv.test.ts
+++ b/public/app/features/templating/template_srv.test.ts
@@ -1,5 +1,5 @@
 import { dateTime, QueryVariableModel, TimeRange, TypedVariableModel } from '@grafana/data';
-import { setDataSourceSrv, VariableInterpolation } from '@grafana/runtime';
+import { VariableInterpolation } from '@grafana/runtime';
 import {
   ConstantVariable,
   CustomVariable,
@@ -13,10 +13,11 @@ import {
   TestVariable,
 } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
 import { silenceConsoleOutput } from '../../../test/core/utils/silenceConsoleOutput';
 import { initTemplateSrv } from '../../../test/helpers/initTemplateSrv';
-import { mockDataSource, MockDataSourceSrv } from '../alerting/unified/mocks';
+import { mockDataSource } from '../alerting/unified/mocks';
 import { VariableAdapter, variableAdapters } from '../variables/adapters';
 import { createAdHocVariableAdapter } from '../variables/adhoc/adapter';
 import { createQueryVariableAdapter } from '../variables/query/adapter';
@@ -218,16 +219,14 @@ describe('templateSrv', () => {
         { type: 'adhoc', name: 'test', datasource: { uid: 'oogle' }, filters: [1] },
         { type: 'adhoc', name: 'test2', datasource: { uid: '$ds' }, filters: [2] },
       ]);
-      setDataSourceSrv(
-        new MockDataSourceSrv({
-          oogle: mockDataSource({
-            name: 'oogle',
-            uid: 'oogle',
-          }),
-          logstash: mockDataSource({
-            name: 'logstash',
-            uid: 'logstash-id',
-          }),
+      setupDataSources(
+        mockDataSource({
+          name: 'oogle',
+          uid: 'oogle',
+        }),
+        mockDataSource({
+          name: 'logstash',
+          uid: 'logstash-id',
         })
       );
     });

--- a/public/app/features/trails/DataTrail.test.tsx
+++ b/public/app/features/trails/DataTrail.test.tsx
@@ -1,9 +1,10 @@
 import { VariableHide } from '@grafana/data';
-import { locationService, setDataSourceSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { AdHocFiltersVariable, ConstantVariable, sceneGraph } from '@grafana/scenes';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 
-import { MockDataSourceSrv, mockDataSource } from '../alerting/unified/mocks';
+import { mockDataSource } from '../alerting/unified/mocks';
 import { activateFullSceneTree } from '../dashboard-scene/utils/test-utils';
 
 import { DataTrail } from './DataTrail';
@@ -26,12 +27,11 @@ jest.mock('./otel/api', () => ({
 describe('DataTrail', () => {
   beforeAll(() => {
     jest.spyOn(DataTrail.prototype, 'checkDataSourceForOTelResources').mockImplementation(() => Promise.resolve());
-    setDataSourceSrv(
-      new MockDataSourceSrv({
-        prom: mockDataSource({
-          name: 'Prometheus',
-          type: DataSourceType.Prometheus,
-        }),
+
+    setupDataSources(
+      mockDataSource({
+        name: 'Prometheus',
+        type: DataSourceType.Prometheus,
       })
     );
   });

--- a/public/app/features/trails/TrailStore/TrailStore.test.ts
+++ b/public/app/features/trails/TrailStore/TrailStore.test.ts
@@ -1,8 +1,9 @@
-import { locationService, setDataSourceSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { AdHocFiltersVariable, sceneGraph, sceneUtils } from '@grafana/scenes';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 
-import { MockDataSourceSrv, mockDataSource } from '../../alerting/unified/mocks';
+import { mockDataSource } from '../../alerting/unified/mocks';
 import { DataTrail } from '../DataTrail';
 import { TRAIL_BOOKMARKS_KEY, RECENT_TRAILS_KEY, VAR_FILTERS } from '../shared';
 
@@ -31,13 +32,10 @@ describe('TrailStore', () => {
     jest.useFakeTimers();
 
     // Having the mock service set up is required for activating the loaded trails
-    setDataSourceSrv(
-      new MockDataSourceSrv({
-        prom: mockDataSource({
-          name: 'Prometheus',
-          type: DataSourceType.Prometheus,
-          uid: 'ds',
-        }),
+    setupDataSources(
+      mockDataSource({
+        name: 'Prometheus',
+        type: DataSourceType.Prometheus,
       })
     );
   });

--- a/public/app/features/trails/otel/utils.test.ts
+++ b/public/app/features/trails/otel/utils.test.ts
@@ -2,6 +2,7 @@ import { AdHocVariableFilter, MetricFindValue } from '@grafana/data';
 import { locationService, setDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariable, ConstantVariable, sceneGraph } from '@grafana/scenes';
 import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 import { activateFullSceneTree } from 'app/features/dashboard-scene/utils/test-utils';
 
@@ -332,6 +333,12 @@ describe('util functions that rely on trail and variable setup', () => {
       useOtelExperience: true,
       nonPromotedOtelResources,
     });
+    setupDataSources(
+      mockDataSource({
+        name: 'Prometheus',
+        type: DataSourceType.Prometheus,
+      })
+    );
     locationService.push(preTrailUrl);
     activateFullSceneTree(trail);
     getOtelGroupLeftVar(trail).setState({ value: 'attribute1,attribute2' });

--- a/public/app/features/trails/otel/utils.test.ts
+++ b/public/app/features/trails/otel/utils.test.ts
@@ -1,7 +1,7 @@
 import { AdHocVariableFilter, MetricFindValue } from '@grafana/data';
-import { locationService, setDataSourceSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { AdHocFiltersVariable, ConstantVariable, sceneGraph } from '@grafana/scenes';
-import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 import { activateFullSceneTree } from 'app/features/dashboard-scene/utils/test-utils';
@@ -206,12 +206,10 @@ describe('updateOtelJoinWithGroupLeft', () => {
 
   beforeEach(() => {
     jest.spyOn(DataTrail.prototype, 'checkDataSourceForOTelResources').mockImplementation(() => Promise.resolve());
-    setDataSourceSrv(
-      new MockDataSourceSrv({
-        prom: mockDataSource({
-          name: 'Prometheus',
-          type: DataSourceType.Prometheus,
-        }),
+    setupDataSources(
+      mockDataSource({
+        name: 'Prometheus',
+        type: DataSourceType.Prometheus,
       })
     );
     trail = new DataTrail({
@@ -275,12 +273,11 @@ describe('getProdOrDefaultEnv', () => {
 describe('util functions that rely on trail and variable setup', () => {
   beforeAll(() => {
     jest.spyOn(DataTrail.prototype, 'checkDataSourceForOTelResources').mockImplementation(() => Promise.resolve());
-    setDataSourceSrv(
-      new MockDataSourceSrv({
-        prom: mockDataSource({
-          name: 'Prometheus',
-          type: DataSourceType.Prometheus,
-        }),
+
+    setupDataSources(
+      mockDataSource({
+        name: 'Prometheus',
+        type: DataSourceType.Prometheus,
       })
     );
   });

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { getDefaultTimeRange, LoadingState } from '@grafana/data';
-import { setDataSourceSrv } from '@grafana/runtime';
-import { mockDataSource, MockDataSourceSrv } from 'app/features/alerting/unified/mocks';
+import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 
@@ -30,11 +30,7 @@ jest.mock('app/core/config', () => ({
   },
 }));
 
-setDataSourceSrv(
-  new MockDataSourceSrv({
-    test: mockDataSource({ isDefault: true }),
-  })
-);
+setupDataSources(mockDataSource({ isDefault: true }));
 
 describe('DashboardQueryEditor', () => {
   const mockOnChange = jest.fn();


### PR DESCRIPTION
**What is this feature?**
Removes the use of `MockDataSourceSrv` from all other tests, and deletes it altogether 🎉 

**Why do we need this feature?**
`MockDataSourceSrv` is marked as deprecated, and the same functionality can be achieved with the `setupDataSources` method. This is important for us to not have to maintain the mock service along with changes to the real one, and allows us to test more accurately with fewer mocks in general.

Instead, `setupDataSources` in the alerting folder can be used (and this can eventually move to a more general utils file anyway)
