### PR TITLE
Alerting: Fix updating condition when refId changes

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -269,10 +269,10 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange }: P
 
       // update condition too if refId was updated
       if (condition === oldRefId) {
-        handleSetCondition(newRefId);
+        setValue('condition', newRefId);
       }
     },
-    [condition, queries, handleSetCondition]
+    [condition, queries, setValue]
   );
 
   const updateExpressionAndDatasource = useSetExpressionAndDataSource();


### PR DESCRIPTION
**What is this feature?**

This PR fixes and error thrown when editing the condition refId in an alert rule.

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

All alerting users.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

I believe the right approach is only setting the condition instead of `runningQueries` (is what `runQueriesPreview` does)

Before the fix:


https://github.com/user-attachments/assets/b4f4b220-b10a-455d-b66c-024f27dc1bdd



After the fix: 

https://github.com/user-attachments/assets/20218b8f-0fd9-45f4-9ba0-4fb47e6f683c




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
