### PR TITLE
TableNG: Improve sort performance

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -335,7 +335,7 @@ export function TableNG(props: TableNGProps) {
 
       for (const { columnKey } of sortColumns) {
         const compare = comparators[sortIndex];
-        const result = sortDirs[sortIndex] * compare(a[columnKey], b[columnKey]);
+        result = sortDirs[sortIndex] * compare(a[columnKey], b[columnKey]);
 
         if (result !== 0) {
           break;

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -322,15 +322,17 @@ export function TableNG(props: TableNGProps) {
 
   // Sort rows
   const sortedRows = useMemo(() => {
+    const comparators = sortColumns.map((sort) => getComparator(columnTypes[sort.columnKey]));
     if (sortColumns.length === 0) {
       return rows;
     }
 
     return [...rows].sort((a, b) => {
+      let sortIndex = 0;
       for (const sort of sortColumns) {
         const { columnKey, direction } = sort;
-        const comparator = getComparator(columnTypes[columnKey]);
-        const compResult = comparator(a[columnKey], b[columnKey]);
+        const compResult = comparators[sortIndex](a[columnKey], b[columnKey]);
+        sortIndex += 1;
         if (compResult !== 0) {
           return direction === 'ASC' ? compResult : -compResult;
         }
@@ -481,6 +483,7 @@ function myRowRenderer(key: React.Key, props: RenderRowProps<TableRow>): React.R
 type Comparator = (a: any, b: any) => number;
 
 function getComparator(sortColumnType: string): Comparator {
+  const collator = new Intl.Collator('en', { sensitivity: 'base' });
   switch (sortColumnType) {
     case FieldType.time:
     case FieldType.number:
@@ -489,7 +492,7 @@ function getComparator(sortColumnType: string): Comparator {
     case FieldType.string:
     case FieldType.enum:
     default:
-      return (a, b) => String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+      return (a, b) => collator.compare(String(a), String(b));
   }
 }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -322,8 +322,8 @@ export function TableNG(props: TableNGProps) {
 
   // Sort rows
   const sortedRows = useMemo(() => {
-    const comparators = sortColumns.map((sort) => getComparator(columnTypes[sort.columnKey]));
-    const sortDirs = sortColumns.map((sort) => (sort.direction === 'ASC' ? 1 : -1));
+    const comparators = sortColumns.map(({ columnKey }) => getComparator(columnTypes[columnKey]));
+    const sortDirs = sortColumns.map(({ direction }) => (direction === 'ASC' ? 1 : -1));
 
     if (sortColumns.length === 0) {
       return rows;


### PR DESCRIPTION
Improves table sort performance by replacing localeCompare with collator.compare.

For a representative dataset to sort column actors:
[filmtv_movies.csv](https://github.com/user-attachments/files/18084984/filmtv_movies.csv)

Table OG, ~6s: 
![Screenshot 2024-12-10 at 11 34 11 AM](https://github.com/user-attachments/assets/c89b485c-d7db-4aca-8bea-997289c71fd0)

Table NG Before, ~2s:
![Screenshot 2024-12-10 at 11 31 47 AM](https://github.com/user-attachments/assets/694c6900-9b80-4ded-bf0d-27a626bbc21f)

Table NG After, ~200ms:
![Screenshot 2024-12-10 at 11 29 18 AM](https://github.com/user-attachments/assets/104ac5e4-25c1-4a2f-892e-ba57e216e63f)

A part of https://github.com/grafana/grafana/issues/95195
