### PR TITLE
[Prototyping] Update last sync commit on webhook processing

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -258,8 +258,15 @@ func (b *ProvisioningAPIBuilder) AsRepository(ctx context.Context, r *provisioni
 			r.Spec.GitHub.WebhookURL = strings.ReplaceAll(r.Spec.GitHub.WebhookURL, resourceNamePlaceholder, r.GetName())
 		}
 
+		// TODO: why do we have to create a client everywhere?
+		dynamicClient, _, err := b.client.New(r.GetNamespace())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+		}
+
+		ifce := dynamicClient.Resource(provisioning.RepositoryResourceInfo.GroupVersionResource())
 		linterFactory := lint.NewDashboardLinterFactory()
-		return repository.NewGitHub(ctx, r, b.ghFactory, baseURL, linterFactory, b.renderer), nil
+		return repository.NewGitHub(ctx, r, b.ghFactory, baseURL, linterFactory, b.renderer, ifce), nil
 	case provisioning.S3RepositoryType:
 		return repository.NewS3(r), nil
 	default:
@@ -516,7 +523,7 @@ func (b *ProvisioningAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.
 		sub.Post.RequestBody = &spec3.RequestBody{
 			RequestBodyProps: spec3.RequestBodyProps{
 				Content: map[string]*spec3.MediaType{
-					"application/json": &spec3.MediaType{
+					"application/json": {
 						MediaTypeProps: spec3.MediaTypeProps{
 							Schema: &repoSchema,
 						},

--- a/pkg/registry/apis/provisioning/repository/github.go
+++ b/pkg/registry/apis/provisioning/repository/github.go
@@ -662,10 +662,14 @@ func (r *githubRepository) Process(ctx context.Context, logger *slog.Logger, wra
 		}
 
 		unstructuredResource := resource.DeepCopy()
-		unstructured.SetNestedField(unstructuredResource.Object, commit.SHA1, "status", "currentGitCommit")
+		if err := unstructured.SetNestedField(unstructuredResource.Object, commit.SHA1, "status", "currentGitCommit"); err != nil {
+			logger.ErrorContext(ctx, "failed to set current git commit status", "error", err)
+			continue
+		}
 
 		if _, err := r.iface.UpdateStatus(ctx, unstructuredResource, metav1.UpdateOptions{}); err != nil {
 			logger.ErrorContext(ctx, "failed to update repository status", "error", err)
+			continue
 		}
 
 		logger.InfoContext(ctx, "repository status updated", "commit", commit.SHA1)


### PR DESCRIPTION
This is still a draft to record the last synced commit in the repository status.

It already works but I am not too sure if the way I updated the status is orthodox or not.

Some thoughts:

- I used a dynamic client for the update. Do I need to use a different client? or is the right one?
- I had to fetch again the object because it must be an `unstructured.Unstructured` for the update. Is there a way to avoid this?
- I added new lines to create the client again, but probably I could use one of the existing clients. I didn't have much time to check this. I will check this tomorrow.
- I don't like the fact we are using kubernetes clients within the Github repository in the `Process` method. I would prefer k8s to stay away from `repository` package. I guess I could define an interface in the middle but it's again one of those situations in which I don't like the `Process` logic to live in that `repository` package. I will look at this tomorrow.

`$ kubectl --kubeconfig grafana.kubeconfig -n default get repository github-ui-sync-demo -o yaml`

```yaml
apiVersion: provisioning.grafana.app/v0alpha1
kind: Repository
metadata:
// ...
spec:
// ...
status:
  currentGitCommit: ebfde81c1cbabec0a8db0a3570325ecaaaaa0614

```
