### PR TITLE
Table Panel: Allow fields to configure additional cell actions

### DIFF
--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import * as React from 'react';
 
-import { IconSize } from '../../types/icon';
+import { IconName, IconSize } from '../../types/icon';
 import { IconButton } from '../IconButton/IconButton';
 import { Stack } from '../Layout/Stack/Stack';
 import { TooltipPlacement } from '../Tooltip';
@@ -20,11 +20,19 @@ interface CommonButtonProps {
   tooltipPlacement: TooltipPlacement;
 }
 
+interface ActionButtonProps {
+  icon: IconName;
+  tooltip: string;
+  onClick: () => void;
+}
+
 export function CellActions({ field, cell, previewMode, showFilters, onCellFilterAdded }: CellActionProps) {
   const [isInspecting, setIsInspecting] = useState(false);
 
   const isRightAligned = getTextAlign(field) === 'flex-end';
   const inspectEnabled = Boolean(field.config.custom?.inspect);
+  const extraActions = field.config.custom?.actions as (ActionButtonProps[] | undefined);
+
   const commonButtonProps: CommonButtonProps = {
     size: 'sm',
     tooltipPlacement: 'top',
@@ -67,6 +75,15 @@ export function CellActions({ field, cell, previewMode, showFilters, onCellFilte
           {showFilters && (
             <IconButton name={'search-minus'} onClick={onFilterOut} tooltip="Filter out value" {...commonButtonProps} />
           )}
+          {extraActions?.map((action, i) => (
+            <IconButton
+              key={i}
+              name={action.icon}
+              tooltip={action.tooltip}
+              onClick={action.onClick}
+              {...commonButtonProps}
+            />
+          ))}
         </Stack>
       </div>
 


### PR DESCRIPTION
**What is this feature?**

Allows passing a new `actions` field to `FieldConfig.custom` to add additional action buttons to table cells.

**Why do we need this feature?**

Datasource developers may want to add cell actions to their cells to trigger various functionality. At the moment we need to use a custom cell renderer and try to match the styling of the builtin cell actions. This is error prone because the cell actions may conflict and the layout does not match up. It makes more sense to expose it here.

In my use case, I have an `EditableTableCell` that allows me to push updates to a backend.

**Who is this feature for?**

Datasource plugin developers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
