### PR TITLE
Explore Profiles: Preinstall for onprem Grafana instances

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -30,6 +30,7 @@ var (
 	defaultPreinstallPlugins = map[string]InstallPlugin{
 		// Default preinstalled plugins
 		"grafana-lokiexplore-app": {"grafana-lokiexplore-app", "", ""},
+		"grafana-pyroscope-app": {"grafana-pyroscope-app", "", ""},
 	}
 )
 

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -30,7 +30,7 @@ var (
 	defaultPreinstallPlugins = map[string]InstallPlugin{
 		// Default preinstalled plugins
 		"grafana-lokiexplore-app": {"grafana-lokiexplore-app", "", ""},
-		"grafana-pyroscope-app": {"grafana-pyroscope-app", "", ""},
+		"grafana-pyroscope-app":   {"grafana-pyroscope-app", "", ""},
 	}
 )
 


### PR DESCRIPTION
Fixes [#274](https://github.com/grafana/explore-profiles/issues/274)

Similar to https://github.com/grafana/grafana/pull/94221, this is to make Explore Profiles app bundled with Grafana.

### How to test it?

You should see Explore Profiles installed automatically when you run the server:

<img width="301" alt="Screenshot 2024-12-10 at 22 23 54" src="https://github.com/user-attachments/assets/c025b75f-6420-4e09-870a-c2788d5928a0">

It should load the latest released version of the plugin available in the catalog https://grafana.com/grafana/plugins/grafana-pyroscope-app/:

<img width="457" alt="Screenshot 2024-12-10 at 22 20 03" src="https://github.com/user-attachments/assets/dcbbc80b-e7ed-477b-9fe2-9ba3c02b629d">
