### PR TITLE
CloudMigrations: Obtain gcom plugins to enable plugins migration

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/gcomstub.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/gcomstub.go
@@ -23,3 +23,24 @@ func (client *gcomStub) GetInstanceByID(_ context.Context, _ string, instanceID 
 		ClusterSlug: "fake-cluser",
 	}, nil
 }
+
+func (client *gcomStub) GetPlugins(ctx context.Context, requestID string) (map[string]gcom.Plugin, error) {
+	plugins := map[string]gcom.Plugin{
+		"plugin-external-valid-grafana": {
+			Slug:          "plugin-external-valid-grafana",
+			Status:        "active",
+			SignatureType: "grafana",
+		},
+		"plugin-external-valid-commercial": {
+			Slug:          "plugin-external-valid-commercial",
+			Status:        "active",
+			SignatureType: "commercial",
+		},
+		"plugin-external-valid-community": {
+			Slug:          "active-plugin",
+			Status:        "active",
+			SignatureType: "community",
+		},
+	}
+	return plugins, nil
+}

--- a/pkg/services/gcom/gcom.go
+++ b/pkg/services/gcom/gcom.go
@@ -131,7 +131,7 @@ func (client *GcomClient) GetPlugins(ctx context.Context, requestID string) (map
 	}
 
 	// Return only active or enterprise plugins
-	resPlugins := make(map[string]Plugin)
+	resPlugins := make(map[string]Plugin, len(body.Items))
 	for _, plugin := range body.Items {
 		if plugin.Status == "active" || plugin.Status == "enterprise" {
 			resPlugins[plugin.Slug] = plugin

--- a/pkg/services/gcom/gcom.go
+++ b/pkg/services/gcom/gcom.go
@@ -18,6 +18,7 @@ var ErrTokenNotFound = errors.New("gcom: token not found")
 
 type Service interface {
 	GetInstanceByID(ctx context.Context, requestID string, instanceID string) (Instance, error)
+	GetPlugins(ctx context.Context, requestID string) (map[string]Plugin, error)
 }
 
 type Instance struct {
@@ -26,6 +27,15 @@ type Instance struct {
 	RegionSlug  string `json:"regionSlug"`
 	ClusterSlug string `json:"clusterSlug"`
 	OrgId       int    `json:"orgId"`
+}
+
+type Plugin struct {
+	Slug          string `json:"slug"`
+	Status        string `json:"status"`
+	SignatureType string `json:"signatureType"`
+}
+type listPluginsResponse struct {
+	Items []Plugin `json:"items"`
 }
 
 type GcomClient struct {
@@ -84,4 +94,48 @@ func (client *GcomClient) GetInstanceByID(ctx context.Context, requestID string,
 	}
 
 	return instance, nil
+}
+
+func (client *GcomClient) GetPlugins(ctx context.Context, requestID string) (map[string]Plugin, error) {
+	endpoint, err := url.JoinPath(client.cfg.ApiURL, "/plugins")
+	if err != nil {
+		return nil, fmt.Errorf("building gcom instance url: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating http request: %w", err)
+	}
+
+	request.Header.Set("x-request-id", requestID)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := client.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("sending http request to get plugins: %w", err)
+	}
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			client.log.Error("closing http response body", "err", err.Error())
+		}
+	}()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		return nil, fmt.Errorf("unexpected response when obtaining plugins: code=%d body=%s", response.StatusCode, body)
+	}
+
+	var body listPluginsResponse
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("unmarshaling response body: %w", err)
+	}
+
+	// Return only active or enterprise plugins
+	resPlugins := make(map[string]Plugin)
+	for _, plugin := range body.Items {
+		if plugin.Status == "active" || plugin.Status == "enterprise" {
+			resPlugins[plugin.Slug] = plugin
+		}
+	}
+	return resPlugins, nil
 }


### PR DESCRIPTION
**What is this feature?**

To enable plugins migration, there needs to be a check that the plugins to be migrated can be added to the instance. This will be used to compare local plugins with list of available plugins from gcom.

**Why do we need this feature?**

To enable plugins migration.

**Who is this feature for?**

Cloud migration assistant users.

**Which issue(s) does this PR fix?**:


Fixes #https://github.com/grafana/grafana-operator-experience-squad/issues/1129

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
