### PR TITLE
Plugins Admin: Avoid disabling auto-enabled apps

### DIFF
--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -86,6 +86,7 @@ export interface PluginMeta<T extends KeyValue = {}> {
   secureJsonData?: KeyValue;
   secureJsonFields?: KeyValue<boolean>;
   enabled?: boolean;
+  autoEnabled?: boolean;
   defaultNavUrl?: string;
   hasUpdate?: boolean;
   enterprise?: boolean;

--- a/pkg/api/dtos/plugins.go
+++ b/pkg/api/dtos/plugins.go
@@ -12,6 +12,7 @@ type PluginSetting struct {
 	Id               string               `json:"id"`
 	Enabled          bool                 `json:"enabled"`
 	Pinned           bool                 `json:"pinned"`
+	AutoEnabled      bool                 `json:"autoEnabled"`
 	Module           string               `json:"module"`
 	BaseUrl          string               `json:"baseUrl"`
 	Info             plugins.Info         `json:"info"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -721,6 +721,7 @@ func (hs *HTTPServer) pluginSettings(ctx context.Context, orgID int64) (map[stri
 			OrgID:         orgID,
 			Enabled:       plugin.AutoEnabled,
 			Pinned:        plugin.AutoEnabled,
+			AutoEnabled:   plugin.AutoEnabled,
 			PluginVersion: plugin.Info.Version,
 		}
 

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -216,6 +216,7 @@ func (hs *HTTPServer) GetPluginSettingByID(c *contextmodel.ReqContext) response.
 	if plugin.IsApp() {
 		dto.Enabled = plugin.AutoEnabled
 		dto.Pinned = plugin.AutoEnabled
+		dto.AutoEnabled = plugin.AutoEnabled
 	}
 
 	ps, err := hs.PluginSettings.GetPluginSettingByPluginID(c.Req.Context(), &pluginsettings.GetByPluginIDArgs{
@@ -256,6 +257,14 @@ func (hs *HTTPServer) UpdatePluginSetting(c *contextmodel.ReqContext) response.R
 
 	if _, exists := hs.pluginStore.Plugin(c.Req.Context(), pluginID); !exists {
 		return response.Error(http.StatusNotFound, "Plugin not installed", nil)
+	}
+
+	p, found := hs.pluginStore.Plugin(c.Req.Context(), pluginID)
+	if !found {
+		return response.Error(http.StatusNotFound, "Plugin not found", nil)
+	}
+	if p.AutoEnabled && !cmd.Enabled {
+		return response.Error(http.StatusBadRequest, "Cannot disable auto-enabled plugin", nil)
 	}
 
 	cmd.OrgId = c.SignedInUser.GetOrgID()

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -255,13 +255,9 @@ func (hs *HTTPServer) UpdatePluginSetting(c *contextmodel.ReqContext) response.R
 	}
 	pluginID := web.Params(c.Req)[":pluginId"]
 
-	if _, exists := hs.pluginStore.Plugin(c.Req.Context(), pluginID); !exists {
+	p, exists := hs.pluginStore.Plugin(c.Req.Context(), pluginID)
+	if !exists {
 		return response.Error(http.StatusNotFound, "Plugin not installed", nil)
-	}
-
-	p, found := hs.pluginStore.Plugin(c.Req.Context(), pluginID)
-	if !found {
-		return response.Error(http.StatusNotFound, "Plugin not found", nil)
 	}
 	if p.AutoEnabled && !cmd.Enabled {
 		return response.Error(http.StatusBadRequest, "Cannot disable auto-enabled plugin", nil)

--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -871,3 +871,43 @@ func Test_PluginsSettings(t *testing.T) {
 		})
 	}
 }
+
+func Test_UpdatePluginSetting(t *testing.T) {
+	pID := "test-app"
+	p1 := createPlugin(plugins.JSONData{
+		ID: pID, Type: "app", Name: pID,
+		Info: plugins.Info{
+			Version: "1.0.0",
+		},
+		AutoEnabled: true,
+	}, plugins.ClassExternal, plugins.NewFakeFS(),
+	)
+	pluginRegistry := &fakes.FakePluginRegistry{
+		Store: map[string]*plugins.Plugin{
+			p1.ID: p1,
+		},
+	}
+
+	pluginSettings := pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{
+		pID: {ID: 0, OrgID: 1, PluginID: pID, PluginVersion: "1.0.0", Enabled: true},
+	}}
+
+	t.Run("should return an error when trying to disable an auto-enabled plugin", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Cfg = setting.NewCfg()
+			hs.PluginSettings = &pluginSettings
+			hs.pluginStore = pluginstore.New(pluginRegistry, &fakes.FakeLoader{})
+			hs.pluginFileStore = filestore.ProvideService(pluginRegistry)
+			hs.managedPluginsService = managedplugins.NewNoop()
+			hs.log = log.NewNopLogger()
+		})
+
+		input := strings.NewReader(`{"enabled": false}`)
+		endpoint := fmt.Sprintf("/api/plugins/%s/settings", pID)
+		req := webtest.RequestWithSignedInUser(server.NewPostRequest(endpoint, input), userWithPermissions(1, []ac.Permission{{Action: pluginaccesscontrol.ActionWrite, Scope: "plugins:id:test-app"}}))
+		res, err := server.SendJSON(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+}

--- a/pkg/services/pluginsintegration/pluginsettings/models.go
+++ b/pkg/services/pluginsintegration/pluginsettings/models.go
@@ -27,6 +27,7 @@ type InfoDTO struct {
 	Enabled       bool
 	Pinned        bool
 	PluginVersion string
+	AutoEnabled   bool
 }
 
 type UpdateArgs struct {

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.test.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+
+import { PluginSignatureStatus } from '@grafana/data';
+import { contextSrv } from 'app/core/core';
+
+import { usePluginConfig } from '../../hooks/usePluginConfig';
+import { CatalogPlugin } from '../../types';
+
+import { GetStartedWithApp } from './GetStartedWithApp';
+
+jest.mock('app/core/core', () => ({
+  contextSrv: {
+    hasPermission: jest.fn(),
+  },
+}));
+
+jest.mock('../../api', () => ({
+  updatePluginSettings: jest.fn(),
+}));
+
+jest.mock('../../hooks/usePluginConfig', () => ({
+  usePluginConfig: jest.fn(),
+}));
+
+const mockPlugin: CatalogPlugin = {
+  id: 'test-plugin',
+  name: 'Test Plugin',
+  description: 'Test Plugin Description',
+  downloads: 0,
+  hasUpdate: false,
+  info: {
+    logos: {
+      large: 'https://grafana.com/assets/img/brand/grafana_icon.svg',
+      small: 'https://grafana.com/assets/img/brand/grafana_icon.svg',
+    },
+    keywords: [],
+  },
+  isDev: false,
+  isCore: false,
+  isEnterprise: false,
+  isInstalled: false,
+  isDisabled: false,
+  isDeprecated: false,
+  isManaged: false,
+  isPreinstalled: { found: false, withVersion: false },
+  isPublished: false,
+  orgName: 'Test Org',
+  signature: PluginSignatureStatus.valid,
+  popularity: 0,
+  publishedAt: '2021-01-01',
+  updatedAt: '2021-01-01',
+};
+
+describe('GetStartedWithApp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders null if pluginConfig is not available', () => {
+    (usePluginConfig as jest.Mock).mockReturnValue({ value: null });
+    (contextSrv.hasPermission as jest.Mock).mockReturnValue(true);
+
+    const { container } = render(<GetStartedWithApp plugin={mockPlugin} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders null if user does not have permission', () => {
+    (usePluginConfig as jest.Mock).mockReturnValue({ value: { meta: {} } });
+    (contextSrv.hasPermission as jest.Mock).mockReturnValue(false);
+
+    const { container } = render(<GetStartedWithApp plugin={mockPlugin} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders enable button if plugin is not enabled', () => {
+    (usePluginConfig as jest.Mock).mockReturnValue({ value: { meta: { enabled: false } } });
+    (contextSrv.hasPermission as jest.Mock).mockReturnValue(true);
+
+    render(<GetStartedWithApp plugin={mockPlugin} />);
+    expect(screen.getByText('Enable')).toBeInTheDocument();
+  });
+
+  it('renders disable button if plugin is enabled and not autoEnabled', () => {
+    (usePluginConfig as jest.Mock).mockReturnValue({ value: { meta: { enabled: true, autoEnabled: false } } });
+    (contextSrv.hasPermission as jest.Mock).mockReturnValue(true);
+
+    render(<GetStartedWithApp plugin={mockPlugin} />);
+    expect(screen.getByText('Disable')).toBeInTheDocument();
+  });
+
+  it('does not render disable button if plugin is enabled and autoEnabled', () => {
+    (usePluginConfig as jest.Mock).mockReturnValue({ value: { meta: { enabled: true, autoEnabled: true } } });
+    (contextSrv.hasPermission as jest.Mock).mockReturnValue(true);
+
+    render(<GetStartedWithApp plugin={mockPlugin} />);
+    expect(screen.queryByText('Disable')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -25,7 +25,7 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
     return null;
   }
 
-  const { enabled, jsonData } = pluginConfig?.meta;
+  const { enabled, autoEnabled, jsonData } = pluginConfig?.meta;
 
   const enable = () => {
     reportInteraction('plugins_detail_enable_clicked', {
@@ -63,7 +63,7 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
         </Button>
       )}
 
-      {enabled && (
+      {enabled && !autoEnabled && (
         <Button variant="destructive" onClick={disable}>
           Disable
         </Button>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently, the UI allows users to disable auto-enabled apps, that end up in a broken state. This PR prevents that:
 - The UI button to disable these apps is not rendered if the app is auto-enabled.
 - The HTTP and provision APIs now return an error when trying to disable an auto-enabled app.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/97157

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
