### PR TITLE
Docs: Added clarification to Azure monitor config doc

### DIFF
--- a/docs/sources/datasources/azure-monitor/_index.md
+++ b/docs/sources/datasources/azure-monitor/_index.md
@@ -211,6 +211,10 @@ The public cloud name is `AzureCloud`, the Chinese national cloud name is `Azure
 
 ### Configure Managed Identity
 
+{{< admonition type="note" >}}
+Managed Identity is available only in [Azure Managed Grafana](https://azure.microsoft.com/en-us/products/managed-grafana) or Grafana Enterprise when deployed in Azure. It is not available in Grafana Cloud.
+{{< /admonition >}}
+
 You can use managed identity to configure Azure Monitor in Grafana if you host Grafana in Azure (such as an App Service or with Azure Virtual Machines) and have managed identity enabled on your VM.
 This lets you securely authenticate data sources without manually configuring credentials via Azure AD App Registrations.
 For details on Azure managed identities, refer to the [Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview).


### PR DESCRIPTION
Updated Configure Managed Identity section to note that this is available only in Azure managed Grafana or Grafana Enterprise when deployed in Azure.

Addresses:
https://github.com/grafana/grafana/issues/97794

