### PR TITLE
POC/Provisioning: Allow specific local path prefixes

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -26,6 +26,13 @@ plugins = data/plugins
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 provisioning = conf/provisioning
 
+# Directories that are permitted to contain local repositories.
+# This is a list. Each entry is delimited by a pipe (|). No leading or trailing spaces are supported.
+# These do not need to be absolute paths, in which case they'll be relative to the path where you are running Grafana.
+# Empty entries will return an error, unless the string is just a single pipe.
+# Example: permitted_provisioning_paths = /tmp|/etc/grafana/repositories|conf/provisioning
+permitted_provisioning_paths = devenv/dev-dashboards|conf/provisioning
+
 #################################### Server ##############################
 [server]
 # Protocol (http, https, h2, socket)

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -26,6 +26,13 @@
 # folder that contains provisioning config files that grafana will apply on startup and while running.
 ;provisioning = conf/provisioning
 
+# Directories that are permitted to contain local repositories.
+# This is a list. Each entry is delimited by a pipe (|). No leading or trailing spaces are supported.
+# These do not need to be absolute paths, in which case they'll be relative to the path where you are running Grafana.
+# Empty entries will return an error, unless the string is just a single pipe.
+# Example: permitted_provisioning_paths = /tmp|/etc/grafana/repositories|conf/provisioning
+;permitted_provisioning_paths = devenv/dev-dashboards|conf/provisioning
+
 #################################### Server ####################################
 [server]
 # Protocol (http, https, h2, socket)

--- a/pkg/registry/apis/provisioning/repository/local.go
+++ b/pkg/registry/apis/provisioning/repository/local.go
@@ -27,35 +27,55 @@ import (
 )
 
 type LocalFolderResolver struct {
-	// Local path to data directory
-	ProvisioningPath string
-
-	// Path to development environment
-	DevenvPath string
+	PermittedPrefixes []string
+	HomePath          string
 }
 
-var ErrInvalidLocalFolder = apierrors.NewBadRequest("the path given is invalid")
+type InvalidLocalFolderError struct {
+	Path           string
+	AdditionalInfo string
+}
+
+var (
+	_ error               = (*InvalidLocalFolderError)(nil)
+	_ apierrors.APIStatus = (*InvalidLocalFolderError)(nil)
+)
+
+func (e *InvalidLocalFolderError) Error() string {
+	return fmt.Sprintf("the path given ('%s') is invalid for a local repository (%s)", e.Path, e.AdditionalInfo)
+}
+
+func (e *InvalidLocalFolderError) Status() metav1.Status {
+	return metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusBadRequest,
+		Reason:  metav1.StatusReasonBadRequest,
+		Message: e.Error(),
+	}
+}
 
 func (r *LocalFolderResolver) LocalPath(p string) (string, error) {
-	parts := strings.SplitN(p, "/", 2)
-	if len(parts) != 2 {
-		return "", ErrInvalidLocalFolder
+	if len(r.PermittedPrefixes) == 0 {
+		return "", &InvalidLocalFolderError{p, "no permitted prefixes were configured"}
 	}
 
-	switch parts[0] {
-	case "provisioning":
-		if r.ProvisioningPath == "" {
-			return "", ErrInvalidLocalFolder
+	originalPath := p
+	if !path.IsAbs(p) {
+		var err error
+		p, err = safepath.Join(r.HomePath, p)
+		if err != nil {
+			return "", &InvalidLocalFolderError{originalPath, "the path could not be safely resolved"}
 		}
-		return safepath.Join(r.ProvisioningPath, parts[1])
-
-	case "devenv":
-		if r.DevenvPath == "" {
-			return "", ErrInvalidLocalFolder
-		}
-		return safepath.Join(r.DevenvPath, parts[1])
+	} else {
+		p = safepath.Clean(p)
 	}
-	return "", ErrInvalidLocalFolder
+
+	for _, permitted := range r.PermittedPrefixes {
+		if strings.HasPrefix(p, safepath.Clean(permitted)) {
+			return p, nil
+		}
+	}
+	return "", &InvalidLocalFolderError{originalPath, "the path matches no permitted prefix"}
 }
 
 var _ Repository = (*localRepository)(nil)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -129,13 +129,14 @@ type Cfg struct {
 	Packaging string
 
 	// Paths
-	HomePath              string
-	ProvisioningPath      string
-	DataPath              string
-	LogsPath              string
-	PluginsPath           string
-	BundledPluginsPath    string
-	EnterpriseLicensePath string
+	HomePath                   string
+	ProvisioningPath           string
+	PermittedProvisioningPaths []string
+	DataPath                   string
+	LogsPath                   string
+	PluginsPath                string
+	BundledPluginsPath         string
+	EnterpriseLicensePath      string
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -1095,8 +1096,6 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	plugins := valueAsString(iniFile.Section("paths"), "plugins", "")
 	cfg.PluginsPath = makeAbsolute(plugins, cfg.HomePath)
 	cfg.BundledPluginsPath = makeAbsolute("plugins-bundled", cfg.HomePath)
-	provisioning := valueAsString(iniFile.Section("paths"), "provisioning", "")
-	cfg.ProvisioningPath = makeAbsolute(provisioning, cfg.HomePath)
 
 	if err := cfg.readServerSettings(iniFile); err != nil {
 		return err
@@ -1115,6 +1114,10 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	}
 
 	if err := readGRPCServerSettings(cfg, iniFile); err != nil {
+		return err
+	}
+
+	if err := cfg.readProvisioningSettings(iniFile); err != nil {
 		return err
 	}
 
@@ -1990,6 +1993,24 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	}
 
 	cfg.LiveAllowedOrigins = originPatterns
+	return nil
+}
+
+func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
+	provisioning := valueAsString(iniFile.Section("paths"), "provisioning", "")
+	cfg.ProvisioningPath = makeAbsolute(provisioning, cfg.HomePath)
+
+	provisioningPaths := valueAsString(iniFile.Section("paths"), "permitted_provisioning_paths", "")
+	if strings.TrimSpace(provisioningPaths) != "|" {
+		cfg.PermittedProvisioningPaths = strings.Split(provisioningPaths, "|")
+		for i, s := range cfg.PermittedProvisioningPaths {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				return fmt.Errorf("a provisioning path is empty in '%s' (at index %d)", provisioningPaths, i)
+			}
+			cfg.PermittedProvisioningPaths[i] = makeAbsolute(s, cfg.HomePath)
+		}
+	}
 	return nil
 }
 

--- a/pkg/tests/apis/provisioning/testdata/local-devenv.yaml
+++ b/pkg/tests/apis/provisioning/testdata/local-devenv.yaml
@@ -10,6 +10,6 @@ spec:
     create: true
     update: true
     delete: true
-  type: local 
+  type: local
   local:
     path: devenv/dev-dashboards


### PR DESCRIPTION
This allows us to specify local path prefixes that are permitted.
The same logic as previously should be mostly upheld.

I'm not too sure about the configuration syntax, but it seems the most sensible.
Semicolons wouldn't work, as the INI implementation reads them as comments (even if not at the start of the line, which AFAIK is against the spec...).

The defaults were chosen as they are the same as the old code used.
I intentionally did not want to add `/tmp` or any standard Docker directory as it may contain sockets to other services running on the host.