### PR TITLE
Cloudwatch: Change deprecated errorsource references

### DIFF
--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -58,7 +58,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(ctx context.Context, pluginC
 
 	cli, err := e.getCWClient(ctx, pluginCtx, region)
 	if err != nil {
-		result = errorsource.AddDownstreamErrorToResponse(query.RefID, result, fmt.Errorf("%v: %w", "failed to get client", err))
+		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(fmt.Errorf("%v: %w", "failed to get client", err))
 		return result, nil
 	}
 

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -23,7 +23,7 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 
 	instance, err := e.getInstance(ctx, req.PluginContext)
 	if err != nil {
-		errorsource.AddErrorToResponse(req.Queries[0].RefID, resp, err)
+		resp.Responses[req.Queries[0].RefID] = backend.ErrorResponseWithErrorSource(err)
 		return resp, nil
 	}
 

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -34,7 +34,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 
 	instance, err := e.getInstance(ctx, req.PluginContext)
 	if err != nil {
-		errorsource.AddErrorToResponse(req.Queries[0].RefID, resp, err)
+		resp.Responses[req.Queries[0].RefID] = backend.ErrorResponseWithErrorSource(err)
 		return resp, nil
 	}
 


### PR DESCRIPTION
This has been failing to compile, bringing down a _lot_ of tests along with it (notably the entire pkg/tests dir).

The PR fixes these compilations. The `experimental/errorsource` package was deprecated, so the recommended replacement was used.

Another PR has also targetted this (#97363), but seems like these few references were left behind (maybe they were added after the base of that PR?).

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
