### PR TITLE
[v11.3.x] Alerting: AlertingQueryRunner should skip descendant nodes of invalid queries

### DIFF
--- a/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/alerting.spec.ts
+++ b/e2e/plugin-e2e/plugin-e2e-api-tests/as-admin-user/alerting.spec.ts
@@ -1,19 +1,6 @@
 import * as e2e from '@grafana/e2e-selectors';
 import { expect, test } from '@grafana/plugin-e2e';
 
-test('should evaluate to false if entire request returns 500', async ({ page, alertRuleEditPage, selectors }) => {
-  await alertRuleEditPage.alertRuleNameField.fill('Test Alert Rule');
-
-  // remove the default query
-  const queryA = alertRuleEditPage.getAlertRuleQueryRow('A');
-  await alertRuleEditPage
-    .getByGrafanaSelector(selectors.components.QueryEditorRow.actionButton('Remove query'), {
-      root: queryA.locator,
-    })
-    .click();
-  await expect(alertRuleEditPage.evaluate()).not.toBeOK();
-});
-
 test('should evaluate to false if entire request returns 200 but partial query result is invalid', async ({
   page,
   alertRuleEditPage,

--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -2,11 +2,12 @@ import { Graph } from 'app/core/utils/dag';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {
-  _getOriginsOfRefId,
-  parseRefsFromMathExpression,
   _createDagFromQueries,
+  _getDescendants,
+  _getOriginsOfRefId,
   fingerprintGraph,
   fingerPrintQueries,
+  parseRefsFromMathExpression,
 } from './dag';
 
 describe('working with dag', () => {
@@ -81,6 +82,20 @@ describe('getOriginsOfRefId', () => {
 
     expect(_getOriginsOfRefId('C', graph)).toEqual(['A']);
     expect(_getOriginsOfRefId('D', graph)).toEqual(['A']);
+  });
+});
+
+describe('getDescendants', () => {
+  test('with multiple generations', () => {
+    const graph = new Graph();
+    graph.createNodes(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
+    graph.link('A', 'B');
+    graph.link('B', 'G');
+    graph.link('A', 'C');
+    graph.link('C', 'D');
+    graph.link('E', 'F');
+
+    expect(_getDescendants('A', graph)).toEqual(['B', 'G', 'C', 'D']);
   });
 });
 

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -216,10 +216,10 @@ describe('AlertingQueryRunner', () => {
     });
   });
 
-  it('should skip hidden queries', async () => {
+  it('should skip hidden queries and descendant nodes', async () => {
     const results = createFetchResponse<AlertingQueryResponse>({
       results: {
-        B: { frames: [createDataFrameJSON([1, 2, 3])] },
+        C: { frames: [createDataFrameJSON([1, 2, 3])] },
       },
     });
 
@@ -239,7 +239,17 @@ describe('AlertingQueryRunner', () => {
             hide: true,
           },
         }),
-        createQuery('B'),
+        createQuery('B', {
+          model: {
+            expression: 'A', // depends on A
+            refId: 'B',
+          },
+        }),
+        createQuery('C', {
+          model: {
+            refId: 'C',
+          },
+        }),
       ],
       'B'
     );
@@ -248,7 +258,8 @@ describe('AlertingQueryRunner', () => {
       const [loading, _data] = values;
 
       expect(loading.A).toBeUndefined();
-      expect(loading.B.state).toEqual(LoadingState.Done);
+      expect(loading.B).toBeUndefined();
+      expect(loading.C.state).toEqual(LoadingState.Done);
     });
   });
 });

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -21,6 +21,7 @@ import { cancelNetworkRequestsOnUnsubscribe } from 'app/features/query/state/pro
 import { setStructureRevision } from 'app/features/query/state/processing/revision';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
+import { createDagFromQueries, getDescendants } from '../components/rule-editor/dag';
 import { getTimeRangeForExpression } from '../utils/timeRange';
 
 export interface AlertingQueryResult {
@@ -51,29 +52,7 @@ export class AlertingQueryRunner {
 
   async run(queries: AlertQuery[], condition: string) {
     const empty = initialState(queries, LoadingState.Done);
-    const queriesToExclude: string[] = [];
-
-    // do not execute if one more of the queries are not runnable,
-    // for example not completely configured
-    for (const query of queries) {
-      const refId = query.model.refId;
-
-      if (isExpressionQuery(query.model)) {
-        continue;
-      }
-
-      const dataSourceInstance = await this.dataSourceSrv.get(query.datasourceUid);
-      const skipRunningQuery =
-        dataSourceInstance instanceof DataSourceWithBackend &&
-        dataSourceInstance.filterQuery &&
-        !dataSourceInstance.filterQuery(query.model);
-
-      if (skipRunningQuery) {
-        queriesToExclude.push(refId);
-      }
-    }
-
-    const queriesToRun = reject(queries, (q) => queriesToExclude.includes(q.model.refId));
+    const queriesToRun = await this.prepareQueries(queries);
 
     if (queriesToRun.length === 0) {
       return this.subject.next(empty);
@@ -96,6 +75,38 @@ export class AlertingQueryRunner {
         this.subject.next(this.lastResult);
       },
     });
+  }
+
+  // this function will omit any invalid queries and all of its descendants from the list of queries
+  // to do this we will convert the list of queries into a DAG and walk the invalid node's output edges recursively
+  async prepareQueries(queries: AlertQuery[]) {
+    const queriesToExclude: string[] = [];
+
+    // convert our list of queries to a graph
+    const queriesGraph = createDagFromQueries(queries);
+
+    // find all invalid nodes and omit those and their child nodes from the final queries array
+    // ⚠️ also make sure all dependent nodes are omitted, otherwise we will be evaluating a broken graph with missing references
+    for (const query of queries) {
+      const refId = query.model.refId;
+
+      if (isExpressionQuery(query.model)) {
+        continue;
+      }
+
+      const dataSourceInstance = await this.dataSourceSrv.get(query.datasourceUid);
+      const skipRunningQuery =
+        dataSourceInstance instanceof DataSourceWithBackend &&
+        dataSourceInstance.filterQuery &&
+        !dataSourceInstance.filterQuery(query.model);
+
+      if (skipRunningQuery) {
+        const descendants = getDescendants(refId, queriesGraph);
+        queriesToExclude.push(refId, ...descendants);
+      }
+    }
+
+    return reject(queries, (q) => queriesToExclude.includes(q.model.refId));
   }
 
   cancel() {


### PR DESCRIPTION
Backport 9c396b74f934434ab9ccd01dde58f438e1e7039c from #97528

---

**What is this feature?**

This PR will make sure that we are also omitting descendant nodes of invalid queries in the entire rule definition.

This is done by constructing the queries into a DAG and recursively walking all output edges / nodes and also omitting those refIds from the final list of queries to send to the query runner / preview endpoint.

This prevents invalid graphs from being sent to the back-end and stop the annoying `Failed to build evaluator for queries and expressions: unable to find dependent node '<refId>'` warning from being shown in the front-end.

**Special notes for your reviewer:**

