### PR TITLE
Rendering: Add logs

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -271,6 +271,16 @@ func (rs *RenderingService) Render(ctx context.Context, renderType RenderType, o
 }
 
 func (rs *RenderingService) render(ctx context.Context, renderType RenderType, opts Opts, renderKeyProvider renderKeyProvider) (*RenderResult, error) {
+	if !rs.IsAvailable(ctx) {
+		rs.log.Warn("Could not render image, no image renderer found/installed. " +
+			"For image rendering support please install the grafana-image-renderer plugin. " +
+			"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
+		if opts.ErrorRenderUnavailable {
+			return nil, ErrRenderUnavailable
+		}
+		return rs.renderUnavailableImage(), nil
+	}
+
 	if int(atomic.LoadInt32(&rs.inProgressCount)) > opts.ConcurrentLimit {
 		rs.log.Warn("Could not render image, hit the currency limit", "concurrencyLimit", opts.ConcurrentLimit, "path", opts.Path)
 		if opts.ErrorConcurrentLimitReached {
@@ -287,15 +297,10 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 		}, nil
 	}
 
-	if !rs.IsAvailable(ctx) {
-		rs.log.Warn("Could not render image, no image renderer found/installed. " +
-			"For image rendering support please install the grafana-image-renderer plugin. " +
-			"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
-		if opts.ErrorRenderUnavailable {
-			return nil, ErrRenderUnavailable
-		}
-		return rs.renderUnavailableImage(), nil
-	}
+	defer func() {
+		metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, -1)))
+	}()
+	metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, 1)))
 
 	if renderType == RenderPDF {
 		if !rs.features.IsEnabled(ctx, featuremgmt.FlagNewPDFRendering) {
@@ -318,12 +323,14 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 
 	defer renderKeyProvider.afterRequest(ctx, opts.AuthOpts, renderKey)
 
-	defer func() {
-		metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, -1)))
-	}()
-
-	metrics.MRenderingQueue.Set(float64(atomic.AddInt32(&rs.inProgressCount, 1)))
-	return rs.renderAction(ctx, renderType, renderKey, opts)
+	res, err := rs.renderAction(ctx, renderType, renderKey, opts)
+	if err != nil {
+		rs.log.Error("Failed to render image", "path", opts.Path, "error", err)
+		return nil, err
+	}
+	rs.log.Debug("Successfully rendered image", "path", opts.Path)
+	
+	return res, nil
 }
 
 func (rs *RenderingService) RenderCSV(ctx context.Context, opts CSVOpts, session Session) (*RenderCSVResult, error) {

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -329,7 +329,7 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 		return nil, err
 	}
 	rs.log.Debug("Successfully rendered image", "path", opts.Path)
-	
+
 	return res, nil
 }
 

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -121,7 +121,8 @@ func TestRenderLimitImage(t *testing.T) {
 
 	rs := RenderingService{
 		Cfg: &setting.Cfg{
-			HomePath: path,
+			HomePath:    path,
+			RendererUrl: "http://localhost:8081/render",
 		},
 		inProgressCount: 2,
 		log:             log.New("test"),
@@ -161,7 +162,9 @@ func TestRenderLimitImage(t *testing.T) {
 
 func TestRenderLimitImageError(t *testing.T) {
 	rs := RenderingService{
-		Cfg:             &setting.Cfg{},
+		Cfg: &setting.Cfg{
+			RendererUrl: "http://localhost:8081/render",
+		},
 		inProgressCount: 2,
 		log:             log.New("test"),
 	}


### PR DESCRIPTION
**What is this feature?**
This PR contains 2 things:
- Move the `inProgressCount` update closer to the check to ensure that we don't go over the concurrency limit
- Add logs so we can see the error (if this function is called by a remote alert manager, the error is swallowed and we don't have access to it) and see when a request ends. 

**Why do we need this feature?**
Help with investigation with the image renderer