### PR TITLE
enure there is always an identity in the context

### DIFF
--- a/pkg/apiserver/rest/dualwriter_syncer.go
+++ b/pkg/apiserver/rest/dualwriter_syncer.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
 
+	"github.com/grafana/authlib/claims"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
@@ -104,7 +106,12 @@ func legacyToUnifiedStorageDataSyncer(ctx context.Context, mode DualWriterMode, 
 		log.Info("starting legacyToUnifiedStorageDataSyncer")
 		startSync := time.Now()
 
+		orgId := int64(1)
+
 		ctx = klog.NewContext(ctx, log)
+		ctx = identity.WithRequester(ctx, getSyncRequester(orgId))
+		ctx = request.WithNamespace(ctx, requestInfo.Namespace)
+		ctx = request.WithRequestInfo(ctx, requestInfo)
 
 		storageList, err := getList(ctx, storage, &metainternalversion.ListOptions{
 			Limit: maxRecordsSync,
@@ -244,4 +251,21 @@ func getList(ctx context.Context, obj rest.Lister, listOptions *metainternalvers
 	}
 
 	return meta.ExtractList(ll)
+}
+
+func getSyncRequester(orgId int64) *identity.StaticRequester {
+	return &identity.StaticRequester{
+		Type:           claims.TypeServiceAccount, // system:apiserver
+		UserID:         1,
+		OrgID:          orgId,
+		Name:           "admin",
+		Login:          "admin",
+		OrgRole:        identity.RoleAdmin,
+		IsGrafanaAdmin: true,
+		Permissions: map[int64]map[string][]string{
+			orgId: {
+				"*": {"*"}, // all resources, all scopes
+			},
+		},
+	}
 }

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -159,7 +159,8 @@ func idTokenExtractorCloud(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("no claims found")
 	}
 
-	// This is a workaround to allow background job to use internal token.
+	// This is a mechanism to allow background job to use the underlying access_token permissions.
+	// Those must add a StaticRequester of type service account with IsGrafanaAdmin set to true.
 	if staticRequester, ok := authInfo.(*identity.StaticRequester); ok {
 		if staticRequester.Type != claims.TypeServiceAccount {
 			return "", fmt.Errorf("unexpected identity type: %s", staticRequester.Type)

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -159,18 +159,6 @@ func idTokenExtractorCloud(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("no claims found")
 	}
 
-	// This is a mechanism to allow background job to use the underlying access_token permissions.
-	// Those must add a StaticRequester of type service account with IsGrafanaAdmin set to true.
-	if staticRequester, ok := authInfo.(*identity.StaticRequester); ok {
-		if staticRequester.Type != claims.TypeServiceAccount {
-			return "", fmt.Errorf("unexpected identity type: %s", staticRequester.Type)
-		}
-		if staticRequester.IsGrafanaAdmin == false {
-			return "", fmt.Errorf("unexpected Grafana admin status: %t", staticRequester.IsGrafanaAdmin)
-		}
-		return "", nil
-	}
-
 	extra := authInfo.GetExtra()
 	if token, exists := extra["id-token"]; exists && len(token) != 0 && token[0] != "" {
 		return token[0], nil

--- a/pkg/storage/unified/resource/client_test.go
+++ b/pkg/storage/unified/resource/client_test.go
@@ -10,22 +10,17 @@ import (
 )
 
 func TestIDTokenExtractorInternal(t *testing.T) {
-	t.Run("should return empty when no claims found", func(t *testing.T) {
+	t.Run("should return an error when no claims found", func(t *testing.T) {
 		ctx := context.Background()
 		token, err := idTokenExtractorInternal(ctx)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 		assert.Empty(t, token)
 	})
 
 	t.Run("should create internal token for StaticRequester", func(t *testing.T) {
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Type:           claims.TypeServiceAccount,
-			UserID:         1,
-			OrgID:          1,
-			Name:           "foo",
-			Login:          "foo",
-			OrgRole:        identity.RoleAdmin,
-			IsGrafanaAdmin: false,
+			IsGrafanaAdmin: true,
 		})
 		token, err := idTokenExtractorInternal(ctx)
 		assert.NoError(t, err)
@@ -34,22 +29,18 @@ func TestIDTokenExtractorInternal(t *testing.T) {
 }
 
 func TestIDTokenExtractorCloud(t *testing.T) {
-	t.Run("should return an empty string when no claims found", func(t *testing.T) {
+	t.Run("should return an error when no claims found", func(t *testing.T) {
 		token, err := idTokenExtractorCloud(context.Background())
-		assert.NoError(t, err)
+		assert.Error(t, err)
 		assert.Empty(t, token)
 	})
-	t.Run("should return an error for StaticRequester", func(t *testing.T) {
+	t.Run("should return an empty token for static requester of type service account as grafana admin ", func(t *testing.T) {
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
 			Type:           claims.TypeServiceAccount,
-			UserID:         1,
-			OrgID:          1,
-			Name:           "foo",
-			Login:          "foo",
-			OrgRole:        identity.RoleAdmin,
-			IsGrafanaAdmin: false,
+			IsGrafanaAdmin: true,
 		})
-		_, err := idTokenExtractorCloud(ctx)
-		assert.Error(t, err)
+		token, err := idTokenExtractorCloud(ctx)
+		assert.NoError(t, err)
+		assert.Empty(t, token)
 	})
 }


### PR DESCRIPTION
enure there is always an identity in the context