### PR TITLE
Loki: Default to `/labels` API with `query` param instead of `/series` API

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -84,6 +84,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `zipkinBackendMigration`               | Enables querying Zipkin data source without the proxy                                                                                                              | Yes                |
 | `alertingUIOptimizeReducer`            | Enables removing the reducer from the alerting UI when creating a new alert rule and using instant query                                                           | Yes                |
 | `azureMonitorEnableUserAuth`           | Enables user auth for Azure Monitor datasource only                                                                                                                | Yes                |
+| `lokiLabelNamesQueryApi`               | Defaults to using the Loki `/labels` API instead of `/series`                                                                                                      | Yes                |
 
 ## Public preview feature toggles
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -244,4 +244,5 @@ export interface FeatureToggles {
   feedbackButton?: boolean;
   elasticsearchCrossClusterSearch?: boolean;
   unifiedHistory?: boolean;
+  lokiLabelNamesQueryApi?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1689,6 +1689,13 @@ var (
 			Owner:        grafanaFrontendPlatformSquad,
 			FrontendOnly: true,
 		},
+		{
+			Name:        "lokiLabelNamesQueryApi",
+			Description: "Defaults to using the Loki `/labels` API instead of `/series`",
+			Stage:       FeatureStageGeneralAvailability,
+			Owner:       grafanaObservabilityLogsSquad,
+			Expression:  "true",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -225,3 +225,4 @@ alertingNotificationsStepMode,experimental,@grafana/alerting-squad,false,false,t
 feedbackButton,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 elasticsearchCrossClusterSearch,preview,@grafana/aws-datasources,false,false,false
 unifiedHistory,experimental,@grafana/grafana-frontend-platform,false,false,true
+lokiLabelNamesQueryApi,GA,@grafana/observability-logs,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -910,4 +910,8 @@ const (
 	// FlagUnifiedHistory
 	// Displays the navigation history so the user can navigate back to previous pages
 	FlagUnifiedHistory = "unifiedHistory"
+
+	// FlagLokiLabelNamesQueryApi
+	// Defaults to using the Loki `/labels` API instead of `/series`
+	FlagLokiLabelNamesQueryApi = "lokiLabelNamesQueryApi"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2097,6 +2097,19 @@
     },
     {
       "metadata": {
+        "name": "lokiLabelNamesQueryApi",
+        "resourceVersion": "1734096677730",
+        "creationTimestamp": "2024-12-13T13:31:17Z"
+      },
+      "spec": {
+        "description": "Defaults to using the Loki `/labels` API instead of `/series`",
+        "stage": "GA",
+        "codeowner": "@grafana/observability-logs",
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "lokiLogsDataplane",
         "resourceVersion": "1718727528075",
         "creationTimestamp": "2023-07-13T07:58:00Z"

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -428,17 +428,51 @@ describe('Language completion provider', () => {
       expect(instance.request).toHaveBeenCalledWith('labels', datasourceWithLabels.getTimeRangeParams(mockTimeRange));
     });
 
-    it('should use series endpoint for request with stream selector', async () => {
-      const datasourceWithLabels = setup({});
-      datasourceWithLabels.languageProvider.request = jest.fn();
+    describe('without labelNames feature toggle', () => {
+      const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
+      beforeAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = false;
+      });
+      afterAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
+      });
 
-      const instance = new LanguageProvider(datasourceWithLabels);
-      instance.request = jest.fn();
-      await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
-      expect(instance.request).toHaveBeenCalledWith('series', {
-        end: 1560163909000,
-        'match[]': '{foo="bar"}',
-        start: 1560153109000,
+      it('should use series endpoint for request with stream selector', async () => {
+        const datasourceWithLabels = setup({});
+        datasourceWithLabels.languageProvider.request = jest.fn();
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        instance.request = jest.fn();
+        await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
+        expect(instance.request).toHaveBeenCalledWith('series', {
+          end: 1560163909000,
+          'match[]': '{foo="bar"}',
+          start: 1560153109000,
+        });
+      });
+    });
+
+    describe('with labelNames feature toggle', () => {
+      const lokiLabelNamesQueryApi = config.featureToggles.lokiLabelNamesQueryApi;
+      beforeAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = true;
+      });
+      afterAll(() => {
+        config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
+      });
+
+      it('should use series endpoint for request with stream selector', async () => {
+        const datasourceWithLabels = setup({});
+        datasourceWithLabels.languageProvider.request = jest.fn();
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        instance.request = jest.fn();
+        await instance.fetchLabels({ streamSelector: '{foo="bar"}' });
+        expect(instance.request).toHaveBeenCalledWith('labels', {
+          end: 1560163909000,
+          query: '{foo="bar"}',
+          start: 1560153109000,
+        });
       });
     });
 


### PR DESCRIPTION
**What is this feature?**

Loki's `/series` API was used to get label names for existing stream selector combinations in Loki's query builder and code editor. Loki introduced a `query` parameter to the `/labels` API, which this PR defaults to now. `/labels` API is far more performant than using the `/series` API.

NB: this will cause false label suggestions using a Loki database with a version lower than 3.1.0. In order to make use of this change either upgrade the Loki database, or toggle the `lokiLabelNamesQueryApi` feature flag, that was introduced in this PR.

**Which issue(s) does this PR fix?**:

Fixes #90613

# Release notice breaking change

This will break UX when using the query builder and code editor targeting Loki data sources that are before version 3.1.0. In those cases the query builder and code editor might suggest labels, that can not be used together with previously selected labels.