### PR TITLE
Team: front end cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // @grafana/partner-datasources
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0 // @grafana/observability-metrics
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
-	github.com/jmespath/go-jmespath v0.4.0 // indirect; @grafana/grafana-backend-group
+	github.com/jmespath/go-jmespath v0.4.0 // @grafana/grafana-backend-group
 	github.com/jmoiron/sqlx v1.3.5 // @grafana/grafana-backend-group
 	github.com/json-iterator/go v1.1.12 // @grafana/grafana-backend-group
 	github.com/lib/pq v1.10.9 // @grafana/grafana-backend-group

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // @grafana/partner-datasources
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0 // @grafana/observability-metrics
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
-	github.com/jmespath/go-jmespath v0.4.0 // @grafana/grafana-backend-group
+	github.com/jmespath/go-jmespath v0.4.0 // indirect; @grafana/grafana-backend-group
 	github.com/jmoiron/sqlx v1.3.5 // @grafana/grafana-backend-group
 	github.com/json-iterator/go v1.1.12 // @grafana/grafana-backend-group
 	github.com/lib/pq v1.10.9 // @grafana/grafana-backend-group

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -8,7 +8,6 @@ import * as useQueryParams from 'app/core/hooks/useQueryParams';
 
 import { TestProvider } from '../../../test/helpers/TestProvider';
 import { backendSrv } from '../../core/services/backend_srv';
-import { TeamPermissionLevel } from '../../types';
 import { getMockTeam } from '../teams/__mocks__/teamMocks';
 
 import { Props, UserProfileEditPage } from './UserProfileEditPage';
@@ -45,7 +44,6 @@ const defaultProps: Props = {
       email: 'team.one@test.com',
       avatarUrl: '/avatar/07d881f402480a2a511a9a15b5fa82c0',
       memberCount: 2000,
-      permission: TeamPermissionLevel.Admin,
     }),
   ],
   orgs: [

--- a/public/app/features/profile/state/reducers.test.ts
+++ b/public/app/features/profile/state/reducers.test.ts
@@ -1,5 +1,5 @@
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
-import { OrgRole, TeamPermissionLevel } from '../../../types';
+import { OrgRole } from '../../../types';
 import { getMockTeam } from '../../teams/__mocks__/teamMocks';
 
 import {
@@ -92,13 +92,13 @@ describe('userReducer', () => {
         .givenReducer(userReducer, { ...initialUserState, teamsAreLoading: true })
         .whenActionIsDispatched(
           teamsLoaded({
-            teams: [getMockTeam(1, 'aaaaaa', { permission: TeamPermissionLevel.Admin })],
+            teams: [getMockTeam(1, 'aaaaaa')],
           })
         )
         .thenStateShouldEqual({
           ...initialUserState,
           teamsAreLoading: false,
-          teams: [getMockTeam(1, 'aaaaaa', { permission: TeamPermissionLevel.Admin })],
+          teams: [getMockTeam(1, 'aaaaaa')],
         });
     });
   });

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -23,13 +23,13 @@ import { Page } from 'app/core/components/Page/Page';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { Trans, t } from 'app/core/internationalization';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction, Role, StoreState, Team } from 'app/types';
+import { AccessControlAction, Role, StoreState, TeamWithRoles } from 'app/types';
 
 import { TeamRolePicker } from '../../core/components/RolePicker/TeamRolePicker';
 
 import { deleteTeam, loadTeams, changePage, changeQuery, changeSort } from './state/actions';
 
-type Cell<T extends keyof Team = keyof Team> = CellProps<Team, Team[T]>;
+type Cell<T extends keyof TeamWithRoles = keyof TeamWithRoles> = CellProps<TeamWithRoles, TeamWithRoles[T]>;
 export interface OwnProps {}
 
 export interface State {
@@ -37,13 +37,12 @@ export interface State {
 }
 
 // this is dummy data to pass to the table while the real data is loading
-const skeletonData: Team[] = new Array(3).fill(null).map((_, index) => ({
+const skeletonData: TeamWithRoles[] = new Array(3).fill(null).map((_, index) => ({
   id: index,
   uid: '',
   memberCount: 0,
   name: '',
   orgId: 0,
-  permission: 0,
 }));
 
 export const TeamList = ({
@@ -76,7 +75,7 @@ export const TeamList = ({
   const canCreate = contextSrv.hasPermission(AccessControlAction.ActionTeamsCreate);
   const displayRolePicker = shouldDisplayRolePicker();
 
-  const columns: Array<Column<Team>> = useMemo(
+  const columns: Array<Column<TeamWithRoles>> = useMemo(
     () => [
       {
         id: 'avatarUrl',

--- a/public/app/features/teams/__mocks__/teamMocks.ts
+++ b/public/app/features/teams/__mocks__/teamMocks.ts
@@ -24,7 +24,6 @@ export const getMockTeam = (i = 1, uid = 'aaaaaa', overrides = {}): Team => {
     avatarUrl: 'some/url/',
     email: `test-${uid}@test.com`,
     memberCount: i,
-    permission: TeamPermissionLevel.Member,
     accessControl: { isEditor: false },
     orgId: 0,
     ...overrides,

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -5,7 +5,7 @@ import { FetchDataArgs } from '@grafana/ui';
 import { updateNavIndex } from 'app/core/actions';
 import { contextSrv } from 'app/core/core';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
-import { AccessControlAction, Team, TeamMember, ThunkResult } from 'app/types';
+import { AccessControlAction, TeamWithRoles, TeamMember, ThunkResult, Team } from 'app/types';
 
 import { buildNavModel } from './navModel';
 import {
@@ -46,9 +46,9 @@ export function loadTeams(initial = false): ThunkResult<void> {
       contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList)
     ) {
       dispatch(rolesFetchBegin());
-      const teamIds = response?.teams.map((t: Team) => t.id);
+      const teamIds = response?.teams.map((t: TeamWithRoles) => t.id);
       const roles = await getBackendSrv().post(`/api/access-control/teams/roles/search`, { teamIds });
-      response.teams.forEach((t: Team) => {
+      response.teams.forEach((t: TeamWithRoles) => {
         t.roles = roles ? roles[t.id] || [] : [];
       });
       dispatch(rolesFetchEnd());

--- a/public/app/types/acl.ts
+++ b/public/app/types/acl.ts
@@ -2,9 +2,7 @@ import { OrgRole } from '@grafana/data';
 
 export enum TeamPermissionLevel {
   Admin = 4,
-  Editor = 2,
   Member = 0,
-  Viewer = 1,
 }
 
 export { OrgRole as OrgRole };

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -16,12 +16,12 @@ export interface TeamDTO {
 // This is the team resource with permissions and metadata expanded
 export interface Team extends WithAccessControlMetadata {
   /**
-   * internal id of team
+   * Internal id of team
    * @deprecated use uid instead
    */
-  id: number; // TODO switch to UUID
+  id: number;
   /**
-   * AvatarUrl is the team's avatar URL.
+   * A unique identifier for the team.
    */
   uid: string; // Prefer UUID
   /**

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -1,5 +1,4 @@
 import { Role } from './accessControl';
-import { TeamPermissionLevel } from './acl';
 
 export interface TeamDTO {
   /**
@@ -41,10 +40,6 @@ export interface Team {
    * OrgId is the ID of an organisation the team belongs to.
    */
   orgId: number;
-  /**
-   * TODO - it seems it's a team_member.permission, unlikely it should belong to the team kind
-   */
-  permission: TeamPermissionLevel;
   /**
    * RBAC roles assigned to the team.
    */

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -1,3 +1,5 @@
+import { WithAccessControlMetadata } from '@grafana/data';
+
 import { Role } from './accessControl';
 
 export interface TeamDTO {
@@ -12,14 +14,10 @@ export interface TeamDTO {
 }
 
 // This is the team resource with permissions and metadata expanded
-export interface Team {
+export interface Team extends WithAccessControlMetadata {
   id: number; // TODO switch to UUID
   uid: string; // Prefer UUID
 
-  /**
-   * AccessControl metadata associated with a given resource.
-   */
-  accessControl?: Record<string, boolean>;
   /**
    * AvatarUrl is the team's avatar URL.
    */

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -15,9 +15,15 @@ export interface TeamDTO {
 
 // This is the team resource with permissions and metadata expanded
 export interface Team extends WithAccessControlMetadata {
+  /**
+   * internal id of team
+   * @deprecated use uid instead
+   */
   id: number; // TODO switch to UUID
+  /**
+   * AvatarUrl is the team's avatar URL.
+   */
   uid: string; // Prefer UUID
-
   /**
    * AvatarUrl is the team's avatar URL.
    */

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -38,6 +38,9 @@ export interface Team extends WithAccessControlMetadata {
    * OrgId is the ID of an organisation the team belongs to.
    */
   orgId: number;
+}
+
+export interface TeamWithRoles extends Team {
   /**
    * RBAC roles assigned to the team.
    */


### PR DESCRIPTION
We have a pr to move TeamPicker to `grafana/runtime` and with that we also need to move the interfaces for team to `grafana/data` https://github.com/grafana/grafana/pull/97558.

With that we will expose these internal structures so I wanted do do a bit of cleanup:

1. Remove `Editor` and `Viewer` from `TeamPermissionLevel`. [They are invalid values](https://github.com/grafana/grafana/blob/6d21eddf1319b7ecd493f2a0ce49bc59f01ba6c7/pkg/services/team/model.go#L105-L108)
2. Remove permission from team interface, this was not used.
3. Remove `Role` from team interface and move it to `TeamWithRoles`. They are not part of the team structure when making a request and we only need it in one place 

With this we no longer have to move `Role` and `TeamPermissionLevel`. I will look into getting rid of `id` and only expose uid, our apis support both. But I will do that in another pr

**Which issue(s) does this PR fix?**:
Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
