### PR TITLE
Chore: Remove canAdmin from folder typescript types

### DIFF
--- a/public/app/features/browse-dashboards/fixtures/folder.fixture.ts
+++ b/public/app/features/browse-dashboards/fixtures/folder.fixture.ts
@@ -6,7 +6,6 @@ export function mockFolderDTO(seed = 1, partial?: Partial<FolderDTO>): FolderDTO
   const random = Chance(seed);
   const uid = random.guid();
   return {
-    canAdmin: true,
     canDelete: true,
     canEdit: true,
     canSave: true,

--- a/public/app/features/dashboard-scene/pages/utils.test.ts
+++ b/public/app/features/dashboard-scene/pages/utils.test.ts
@@ -12,7 +12,6 @@ describe('utils', () => {
       uid: 'new-folder',
       title: 'NewFolder',
       url: '',
-      canAdmin: true,
       canDelete: true,
       canEdit: true,
       canSave: true,

--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -73,7 +73,6 @@ export function getLoadingNav(tabIndex: number): NavModel {
     url: 'url',
     canSave: true,
     canEdit: true,
-    canAdmin: true,
     canDelete: true,
     version: 0,
   });

--- a/public/app/features/folders/state/reducers.test.ts
+++ b/public/app/features/folders/state/reducers.test.ts
@@ -12,7 +12,6 @@ function getTestFolder(): FolderDTO {
     url: 'url',
     canSave: true,
     canEdit: true,
-    canAdmin: true,
     canDelete: true,
     version: 0,
     created: '',

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -8,7 +8,6 @@ export interface FolderListItemDTO {
 export type FolderParent = Pick<FolderDTO, 'title' | 'uid' | 'url'>;
 
 export interface FolderDTO extends WithAccessControlMetadata {
-  canAdmin: boolean;
   canDelete: boolean;
   canEdit: boolean;
   canSave: boolean;


### PR DESCRIPTION
As we move to the k8s style authorizer, the standard verbs are easy to handle -- it looks like folder.canAdmin is not used anywhere, so can we remove/hide it?

The current mapping looks like:
```
# Define the actions that can be performed on the resource
actions:
  dashboard.grafana.app:
    dashboards:
      list: "dashboards:read"
      get: "dashboards:read"
      watch: "dashboards:read"
      create: "dashboards:create"
      update: "dashboards:write"
      patch: "dashboards:write"
      delete: "dashboards:delete"
      deletecollection: "dashboards:delete"
  folder.grafana.app:
    folders:
      list: "folders:read"
      get: "folders:read"
      watch: "folders:read"
      create: "folders:create"
      update: "folders:write"
      patch: "folders:write"
      delete: "folders:delete"
      deletecollection: "folders:delete"

attributes:
  dashboard.grafana.app:
    dashboards: uid
  folder.grafana.app:
    folders: uid
```
