### PR TITLE
Secrets: add CRUDL storage for secure value metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -164,6 +164,7 @@
 /pkg/tests/apis/query @grafana/grafana-datasources-core-services
 /pkg/tests/apis/alerting @grafana/grafana-app-platform-squad @grafana/alerting-backend
 /pkg/tests/api/correlations/ @grafana/dataviz-squad
+/pkg/tests/apis/secret/ @grafana/grafana-operator-experience-squad
 /pkg/tsdb/grafanads/ @grafana/grafana-backend-group
 /pkg/tsdb/opentsdb/ @grafana/partner-datasources
 /pkg/util/ @grafana/grafana-backend-group

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -1,11 +1,13 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -107,5 +109,10 @@ func (b *SecretAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 
 // Register additional routes with the server.
 func (b *SecretAPIBuilder) GetAPIRoutes() *builder.APIRoutes {
+	return nil
+}
+
+// Validate is called in `Create`, `Update` and `Delete` REST funcs, if the body calls the argument `rest.ValidateObjectFunc`.
+func (b *SecretAPIBuilder) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	return nil
 }

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -70,8 +70,14 @@ func (s *SecureValueRest) ConvertToTable(ctx context.Context, object runtime.Obj
 
 // List calls the inner `store` (persistence) and returns a list of `securevalues` within a `namespace` filtered by the `options`.
 func (s *SecureValueRest) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	// TODO: implement me
-	return nil, nil
+	namespace := request.NamespaceValue(ctx)
+
+	secureValueList, err := s.storage.List(ctx, namespace, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secure values: %w", err)
+	}
+
+	return secureValueList, nil
 }
 
 // Get calls the inner `store` (persistence) and returns a `securevalue` by `name`. It will NOT return the decrypted `value`.

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -197,12 +197,13 @@ func (s *SecureValueRest) Update(
 }
 
 // Delete calls the inner `store` (persistence) in order to delete the `securevalue`.
-// The second return parameter `bool` indicates whether the delete was intant or not. It always is for `securevalues`.
+// The second return parameter `bool` indicates whether the delete was instant or not. It always is for `securevalues`.
 func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	// TODO: Make sure the second parameter is always `true` when `err == nil`.
-	// Even when there is nothing to delete, because this is a `securevalue` and
-	// we don't want to first do a `Get` to check whether the secret exists or not.
+	namespace := request.NamespaceValue(ctx)
 
-	// TODO: implement delete in storage
-	return nil, false, nil
+	if err := s.storage.Delete(ctx, namespace, name); err != nil {
+		return nil, false, fmt.Errorf("delete secure value: %w", err)
+	}
+
+	return nil, true, nil
 }

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -117,16 +117,16 @@ func checkRefOrValue(s *secret.SecureValue, mustExist bool) error {
 func (s *SecureValueRest) Create(
 	ctx context.Context,
 	obj runtime.Object,
-
-	// TODO: How to define this function? perhaps would be useful to keep all validation here and not use `checkRefOrValue` for example..
 	createValidation rest.ValidateObjectFunc,
-
-	// TODO: How can we use these options? Looks useful. `dryRun` for dev as well.
 	options *metav1.CreateOptions,
 ) (runtime.Object, error) {
 	sv, ok := obj.(*secret.SecureValue)
 	if !ok {
 		return nil, fmt.Errorf("expected SecureValue for create")
+	}
+
+	if err := createValidation(ctx, obj); err != nil {
+		return nil, fmt.Errorf("validation failed: %w", err)
 	}
 
 	err := checkRefOrValue(sv, true)

--- a/pkg/storage/secret/migrator.go
+++ b/pkg/storage/secret/migrator.go
@@ -33,8 +33,8 @@ func initSecretStore(mg *migrator.Migrator) string {
 		Name: TableNameSecureValue,
 		Columns: []*migrator.Column{
 			// Kubernetes Metadata
-			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true}, // Fixed size of a UUID.
-			{Name: "name", Type: migrator.DB_Text, Nullable: false},
+			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},    // Fixed size of a UUID.
+			{Name: "name", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},      // Limit enforced by K8s.
 			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
 			{Name: "annotations", Type: migrator.DB_Text, Nullable: true},
 			{Name: "labels", Type: migrator.DB_Text, Nullable: true},
@@ -58,8 +58,8 @@ func initSecretStore(mg *migrator.Migrator) string {
 		Name: "secret_keeper",
 		Columns: []*migrator.Column{
 			// Kubernetes Metadata
-			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true}, // Fixed size of a UUID.
-			{Name: "name", Type: migrator.DB_Text, Nullable: false},
+			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},    // Fixed size of a UUID.
+			{Name: "name", Type: migrator.DB_NVarchar, Length: 253, Nullable: false},      // Limit enforced by K8s.
 			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
 			{Name: "annotations", Type: migrator.DB_Text, Nullable: true},
 			{Name: "labels", Type: migrator.DB_Text, Nullable: true},

--- a/pkg/storage/secret/migrator.go
+++ b/pkg/storage/secret/migrator.go
@@ -33,9 +33,9 @@ func initSecretStore(mg *migrator.Migrator) string {
 		Name: TableNameSecureValue,
 		Columns: []*migrator.Column{
 			// Kubernetes Metadata
-			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},
+			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true}, // Fixed size of a UUID.
 			{Name: "name", Type: migrator.DB_Text, Nullable: false},
-			{Name: "namespace", Type: migrator.DB_Text, Nullable: false},
+			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
 			{Name: "annotations", Type: migrator.DB_Text, Nullable: true},
 			{Name: "labels", Type: migrator.DB_Text, Nullable: true},
 			{Name: "created", Type: migrator.DB_BigInt, Nullable: false},
@@ -58,9 +58,9 @@ func initSecretStore(mg *migrator.Migrator) string {
 		Name: "secret_keeper",
 		Columns: []*migrator.Column{
 			// Kubernetes Metadata
-			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},
+			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true}, // Fixed size of a UUID.
 			{Name: "name", Type: migrator.DB_Text, Nullable: false},
-			{Name: "namespace", Type: migrator.DB_Text, Nullable: false},
+			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
 			{Name: "annotations", Type: migrator.DB_Text, Nullable: true},
 			{Name: "labels", Type: migrator.DB_Text, Nullable: true},
 			{Name: "created", Type: migrator.DB_BigInt, Nullable: false},

--- a/pkg/storage/secret/migrator.go
+++ b/pkg/storage/secret/migrator.go
@@ -9,6 +9,10 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+const (
+	TableNameSecureValue = "secret_secure_value"
+)
+
 func migrateSecretSQL(engine *xorm.Engine, cfg *setting.Cfg) error {
 	mg := migrator.NewScopedMigrator(engine, cfg, "secret")
 	mg.AddCreateMigration()
@@ -26,7 +30,7 @@ func initSecretStore(mg *migrator.Migrator) string {
 	tables := []migrator.Table{}
 
 	tables = append(tables, migrator.Table{
-		Name: "secret_secure_value",
+		Name: TableNameSecureValue,
 		Columns: []*migrator.Column{
 			// Kubernetes Metadata
 			{Name: "guid", Type: migrator.DB_NVarchar, Length: 36, IsPrimaryKey: true},

--- a/pkg/storage/secret/secure_value_model.go
+++ b/pkg/storage/secret/secure_value_model.go
@@ -1,0 +1,172 @@
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type secureValueDB struct {
+	// Kubernetes Metadata
+	GUID        string `xorm:"pk 'guid'"`
+	Name        string `xorm:"name"`
+	Namespace   string `xorm:"namespace"`
+	Annotations string `xorm:"annotations"`
+	Labels      string `xorm:"labels"`
+	Created     int64  `xorm:"created"`
+	CreatedBy   string `xorm:"created_by"`
+	Updated     int64  `xorm:"updated"`
+	UpdatedBy   string `xorm:"updated_by"`
+
+	// Spec
+	Title      string `xorm:"title"`
+	Keeper     string `xorm:"keeper"`
+	Audiences  string `xorm:"audiences"`
+	ExternalID string `xorm:"external_id"`
+}
+
+func (*secureValueDB) TableName() string {
+	return TableNameSecureValue
+}
+
+// toKubernetes maps a DB row into a Kubernetes resource (metadata + spec).
+func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
+	annotations := make(map[string]string, 0)
+	if sv.Annotations != "" {
+		if err := json.Unmarshal([]byte(sv.Annotations), &annotations); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal annotations: %w", err)
+		}
+	}
+
+	labels := make(map[string]string, 0)
+	if sv.Labels != "" {
+		if err := json.Unmarshal([]byte(sv.Labels), &labels); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal labels: %w", err)
+		}
+	}
+
+	audiences := make([]string, 0)
+	if sv.Audiences != "" {
+		if err := json.Unmarshal([]byte(sv.Audiences), &audiences); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal audiences: %w", err)
+		}
+	}
+
+	resource := &secretv0alpha1.SecureValue{
+		Spec: secretv0alpha1.SecureValueSpec{
+			Title:     sv.Title,
+			Keeper:    sv.Keeper,
+			Audiences: audiences,
+		},
+	}
+
+	// Set all meta fields here for consistency.
+	meta, err := utils.MetaAccessor(resource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get meta accessor: %w", err)
+	}
+
+	updated := time.Unix(sv.Updated, 0).UTC()
+
+	meta.SetUID(types.UID(sv.GUID))
+	meta.SetName(sv.Name)
+	meta.SetNamespace(sv.Namespace)
+	meta.SetAnnotations(annotations)
+	meta.SetLabels(labels)
+	meta.SetCreatedBy(sv.CreatedBy)
+	meta.SetCreationTimestamp(metav1.NewTime(time.Unix(sv.Created, 0).UTC()))
+	meta.SetUpdatedBy(sv.UpdatedBy)
+	meta.SetUpdatedTimestamp(&updated)
+	meta.SetResourceVersionInt64(sv.Updated)
+
+	return resource, nil
+}
+
+// toCreateRow maps a Kubernetes resource into a DB row for new resources being created/inserted.
+func toCreateRow(sv *secretv0alpha1.SecureValue, actorUID, externalID string) (*secureValueDB, error) {
+	row, err := toRow(sv, externalID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create: %w", err)
+	}
+
+	now := time.Now().UTC().UnixMilli()
+
+	row.GUID = uuid.New().String()
+	row.Created = now
+	row.CreatedBy = actorUID
+	row.Updated = now
+	row.UpdatedBy = actorUID
+
+	return row, nil
+}
+
+// toRow maps a Kubernetes resource into a DB row.
+func toRow(sv *secretv0alpha1.SecureValue, externalID string) (*secureValueDB, error) {
+	var annotations string
+	if len(sv.Annotations) > 0 {
+		cleanedAnnotations := CleanAnnotations(sv.Annotations)
+		if len(cleanedAnnotations) > 0 {
+			sv.Annotations = make(map[string]string) // Safety: reset to prohibit use of sv.Annotations further.
+
+			encodedAnnotations, err := json.Marshal(cleanedAnnotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encode annotations: %w", err)
+			}
+
+			annotations = string(encodedAnnotations)
+		}
+	}
+
+	var labels string
+	if len(sv.Labels) > 0 {
+		encodedLabels, err := json.Marshal(sv.Labels)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode labels: %w", err)
+		}
+
+		labels = string(encodedLabels)
+	}
+
+	var audiences string
+	if len(sv.Spec.Audiences) > 0 {
+		encodedAudiences, err := json.Marshal(sv.Spec.Audiences)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode audiences: %w", err)
+		}
+
+		audiences = string(encodedAudiences)
+	}
+
+	meta, err := utils.MetaAccessor(sv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get meta accessor: %w", err)
+	}
+
+	updatedTimestamp, err := meta.GetResourceVersionInt64()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource version: %w", err)
+	}
+
+	return &secureValueDB{
+		GUID:        string(sv.UID),
+		Name:        sv.Name,
+		Namespace:   sv.Namespace,
+		Annotations: annotations,
+		Labels:      labels,
+		Created:     meta.GetCreationTimestamp().UnixMilli(),
+		CreatedBy:   meta.GetCreatedBy(),
+		Updated:     updatedTimestamp,
+		UpdatedBy:   meta.GetUpdatedBy(),
+
+		Title:      sv.Spec.Title,
+		Keeper:     sv.Spec.Keeper,
+		Audiences:  audiences,
+		ExternalID: externalID,
+	}, nil
+}

--- a/pkg/storage/secret/secure_value_store.go
+++ b/pkg/storage/secret/secure_value_store.go
@@ -63,7 +63,7 @@ func (s *storage) Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*
 		return nil, fmt.Errorf("to create row: %w", err)
 	}
 
-	err = s.db.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+	err = s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		if _, err := sess.Insert(row); err != nil {
 			return fmt.Errorf("insert row: %w", err)
 		}
@@ -117,7 +117,7 @@ func (s *storage) Update(ctx context.Context, newSecureValue *secretv0alpha1.Sec
 		return nil, fmt.Errorf("to update row: %w", err)
 	}
 
-	err = s.db.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+	err = s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		if _, err := sess.Update(newRow); err != nil {
 			return fmt.Errorf("update row: %w", err)
 		}
@@ -147,7 +147,7 @@ func (s *storage) Delete(ctx context.Context, namespace string, name string) err
 	// TODO: do we need to delete by GUID? name+namespace is a unique index. It would avoid doing a fetch.
 	row := &secureValueDB{Name: name, Namespace: namespace}
 
-	err := s.db.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		// TODO: because this is a securevalue, do we care to inform the caller if a row was delete (existed) or not?
 		if _, err := sess.Delete(row); err != nil {
 			return fmt.Errorf("delete row: %w", err)

--- a/pkg/storage/secret/secure_value_store.go
+++ b/pkg/storage/secret/secure_value_store.go
@@ -1,15 +1,28 @@
 package secret
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
+	"github.com/grafana/authlib/claims"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+var (
+	ErrSecureValueNotFound = errors.New("secure value not found")
+)
+
 // SecureValueStorage is the interface for wiring and dependency injection.
-type SecureValueStorage interface{}
+type SecureValueStorage interface {
+	Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
+	Read(ctx context.Context, namespace, name string) (*secretv0alpha1.SecureValue, error)
+}
 
 func ProvideSecureValueStorage(db db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles) (SecureValueStorage, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) ||
@@ -27,4 +40,93 @@ func ProvideSecureValueStorage(db db.DB, cfg *setting.Cfg, features featuremgmt.
 // storage is the actual implementation of the secure value (metadata) storage.
 type storage struct {
 	db db.DB
+}
+
+func (s *storage) Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error) {
+	authInfo, ok := claims.From(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing auth info in context")
+	}
+
+	// This should come from the keeper. From this point on, we should not have a need to read value/ref.
+	externalID := "TODO"
+	sv.Spec.Value = ""
+	sv.Spec.Ref = ""
+
+	row, err := toCreateRow(sv, authInfo.GetUID(), externalID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create: %w", err)
+	}
+
+	err = s.db.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		if _, err := sess.Insert(row); err != nil {
+			return fmt.Errorf("failed to insert row: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("db failure: %w", err)
+	}
+
+	createdSecureValue, err := row.toKubernetes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to kubernetes object: %w", err)
+	}
+
+	return createdSecureValue, nil
+}
+
+func (s *storage) Read(ctx context.Context, namespace, name string) (*secretv0alpha1.SecureValue, error) {
+	_, ok := claims.From(ctx)
+	if !ok {
+		return nil, fmt.Errorf("missing auth info in context")
+	}
+
+	row := secureValueDB{Name: name, Namespace: namespace}
+
+	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		found, err := sess.Get(&row)
+		if err != nil {
+			return fmt.Errorf("could not get row: %w", err)
+		}
+
+		if !found {
+			return ErrSecureValueNotFound
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("db failure: %w", err)
+	}
+
+	secureValue, err := row.toKubernetes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to kubernetes object: %w", err)
+	}
+
+	return secureValue, nil
+}
+
+// TODO: move this somewhere else!
+var (
+	// Exclude these annotations
+	skipAnnotations = map[string]bool{
+		"kubectl.kubernetes.io/last-applied-configuration": true, // force server side apply
+		utils.AnnoKeyCreatedBy:                             true,
+		utils.AnnoKeyUpdatedBy:                             true,
+		utils.AnnoKeyUpdatedTimestamp:                      true,
+	}
+)
+
+func CleanAnnotations(anno map[string]string) map[string]string {
+	copy := make(map[string]string)
+	for k, v := range anno {
+		if skipAnnotations[k] {
+			continue
+		}
+		copy[k] = v
+	}
+	return copy
 }

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -1,0 +1,119 @@
+package secret
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+var gvr = schema.GroupVersionResource{
+	Group:    "secret.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "securevalues",
+}
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+
+func TestIntegrationSecureValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction: false, // required for experimental APIs
+		EnableFeatureToggles: []string{
+			// Required to start the example service
+			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+			featuremgmt.FlagSecretsManagementAppPlatform,
+		},
+	})
+
+	t.Run("Check discovery client", func(t *testing.T) {
+		disco := helper.NewDiscoveryClient()
+
+		resources, err := disco.ServerResourcesForGroupVersion("secret.grafana.app/v0alpha1")
+		require.NoError(t, err)
+
+		v1Disco, err := json.MarshalIndent(resources, "", "  ")
+		require.NoError(t, err)
+
+		var apiResourceList map[string]any
+		require.NoError(t, json.Unmarshal(v1Disco, &apiResourceList))
+
+		groupVersion, ok := apiResourceList["groupVersion"].(string)
+		require.True(t, ok)
+		require.Equal(t, "secret.grafana.app/v0alpha1", groupVersion)
+
+		apiResources, ok := apiResourceList["resources"].([]any)
+		require.True(t, ok)
+		require.Len(t, apiResources, 2) // securevalue + keeper + (subresources...)
+	})
+
+	t.Run("creating a secure value returns it without any of the value or ref", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			// #TODO: figure out permissions topic
+			User: helper.Org1.Admin,
+			GVR:  gvr,
+		})
+
+		raw, err := client.Resource.Create(
+			ctx,
+			helper.LoadYAMLOrJSONFile("testdata/secure-value-xyz.yaml"),
+			metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+
+		secureValue := new(secretv0alpha1.SecureValue)
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(raw.Object, secureValue)
+		require.NoError(t, err)
+		require.NotNil(t, secureValue)
+
+		require.Empty(t, secureValue.Spec.Value)
+		require.Empty(t, secureValue.Spec.Ref)
+		require.NotEmpty(t, secureValue.Spec.Title)
+		require.NotEmpty(t, secureValue.Spec.Keeper)
+		require.NotEmpty(t, secureValue.Spec.Audiences)
+	})
+
+	t.Run("reading a secure value that does not exist returns a 404", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			// #TODO: figure out permissions topic
+			User: helper.Org1.Admin,
+			GVR:  gvr,
+		})
+
+		raw, err := client.Resource.Get(
+			ctx,
+			"some-secure-value-that-does-not-exist",
+			metav1.GetOptions{},
+		)
+		require.Error(t, err)
+		require.Nil(t, raw)
+
+		var statusErr *apierrors.StatusError
+		require.True(t, errors.As(err, &statusErr))
+		require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+	})
+}

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -110,6 +110,26 @@ func TestIntegrationSecureValue(t *testing.T) {
 
 			require.EqualValues(t, secureValue, anotherSecureValue)
 		})
+
+		t.Run("and updating the secure value replaces the spec fields and returns them", func(t *testing.T) {
+			newRaw := testDataSecureValueXyz.DeepCopy()
+			newRaw.Object["spec"].(map[string]any)["title"] = "New title"
+			newRaw.Object["spec"].(map[string]any)["keeper"] = "New keeper"
+			newRaw.Object["spec"].(map[string]any)["value"] = "New secure value"
+			newRaw.Object["spec"].(map[string]any)["audiences"] = []string{"audience1/name1", "audience2/*"}
+			newRaw.Object["metadata"].(map[string]any)["annotations"] = map[string]any{"newAnnotation": "newValue"}
+
+			updatedRaw, err := client.Resource.Update(ctx, newRaw, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, updatedRaw)
+
+			updatedSecureValue := new(secretv0alpha1.SecureValue)
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(updatedRaw.Object, updatedSecureValue)
+			require.NoError(t, err)
+			require.NotNil(t, updatedSecureValue)
+
+			require.NotEqualValues(t, updatedSecureValue.Spec, secureValue.Spec)
+		})
 	})
 
 	t.Run("reading a secure value that does not exist returns a 404", func(t *testing.T) {

--- a/pkg/tests/apis/secret/testdata/secure-value-xyz.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-xyz.yaml
@@ -1,0 +1,18 @@
+apiVersion: secret.grafana.app/v0alpha1
+kind: SecureValue
+metadata:
+  name: xyz
+  annotations:
+    xx: XXX
+    yy: YYY
+  labels:
+    aa: AAA
+    bb: BBB
+spec:
+  title: XYZ value
+  keeper: my-keeper-1
+  value: super duper secure
+  audiences:
+    - k6.grafana.app/app-name-1
+    - k6.grafana.app/app-name-2
+    - entity.grafana.app/*


### PR DESCRIPTION
Implements basic CRUD+L functionality for the secure value metadata DB storage.

TODOs/not included:
- AuthZ (if we want to do it at that layer)
- History/Auditing support
- PATCHing (Update currently replaces whole Spec)
- Encryption of raw value in a Secret Keeper