### PR TITLE
Implement k8s count handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // @grafana/partner-datasources
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0 // @grafana/observability-metrics
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
-	github.com/jmespath/go-jmespath v0.4.0 // indirect; @grafana/grafana-backend-group
+	github.com/jmespath/go-jmespath v0.4.0 // @grafana/grafana-backend-group
 	github.com/jmoiron/sqlx v1.3.5 // @grafana/grafana-backend-group
 	github.com/json-iterator/go v1.1.12 // @grafana/grafana-backend-group
 	github.com/lib/pq v1.10.9 // @grafana/grafana-backend-group

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // @grafana/partner-datasources
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0 // @grafana/observability-metrics
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
-	github.com/jmespath/go-jmespath v0.4.0 // @grafana/grafana-backend-group
+	github.com/jmespath/go-jmespath v0.4.0 // indirect; @grafana/grafana-backend-group
 	github.com/jmoiron/sqlx v1.3.5 // @grafana/grafana-backend-group
 	github.com/json-iterator/go v1.1.12 // @grafana/grafana-backend-group
 	github.com/lib/pq v1.10.9 // @grafana/grafana-backend-group

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
-	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	folderalpha1 "github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/slugify"
@@ -1048,14 +1047,14 @@ func getParents(f *folder.Folder) (map[string]bool, error) {
 }
 
 func toFolderCounts(obj *unstructured.Unstructured) (*folder.DescendantCounts, error) {
-	spec, ok := obj.Object["spec"].(v0alpha1.DescendantCounts)
-	if !ok {
+	dc, err := folderalpha1.UnstructedToDescendantCounts(obj)
+	if err != nil {
 		return nil, fmt.Errorf("cannot convert object to descendant counts")
 	}
 
 	var counts = make(folder.DescendantCounts)
 
-	for _, item := range spec.Counts {
+	for _, item := range dc.Counts {
 		counts[item.Resource] = item.Count
 	}
 

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clientrest "k8s.io/client-go/rest"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -746,4 +747,70 @@ func TestUpdateFolderLegacyAndUnifiedStorage(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestToFolderCounts(t *testing.T) {
+	var tests = []struct {
+		name        string
+		input       *unstructured.Unstructured
+		expected    *folder.DescendantCounts
+		expectError bool
+	}{
+		{
+			name: "happy path",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"counts": []interface{}{
+						map[string]interface{}{
+							"group":    "alpha",
+							"resource": "folders",
+							"count":    int64(1),
+						},
+						map[string]interface{}{
+							"group":    "alpha",
+							"resource": "dashboards",
+							"count":    int64(3),
+						},
+						map[string]interface{}{
+							"group":    "alpha",
+							"resource": "alertRules",
+							"count":    int64(0),
+						},
+					},
+				},
+			},
+			expected: &folder.DescendantCounts{
+				"folders":    1,
+				"dashboards": 3,
+				"alertRules": 0,
+			},
+		},
+		{
+			name: "malformed input",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"something": []interface{}{
+						map[string]interface{}{
+							"something": "else",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := toFolderCounts(tc.input)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
 }

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -787,13 +787,83 @@ func TestToFolderCounts(t *testing.T) {
 			},
 		},
 		{
-			name: "malformed input",
+			name: "non iterative counts",
 			input: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "folder.grafana.app/v0alpha1",
-					"something": []interface{}{
+					"counts":     42,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "count element not a map",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"counts":     []interface{}{3},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "resource field not found",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"counts": []interface{}{
 						map[string]interface{}{
-							"something": "else",
+							"group":    "alpha",
+							"something-else": "folders",
+							"count":    int64(1),
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "count field not found",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"counts": []interface{}{
+						map[string]interface{}{
+							"group":    "alpha",
+							"resource": "folders",
+							"something-else":    int64(1),
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "count not an integer",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"counts": []interface{}{
+						map[string]interface{}{
+							"group":    "alpha",
+							"resource": "folders",
+							"count":    "counting",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "resource not a string",
+			input: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"counts": []interface{}{
+						map[string]interface{}{
+							"group":    "alpha",
+							"resource": map[string]string{"bla": "bla"},
+							"count":   int64(1),
 						},
 					},
 				},

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -787,7 +787,7 @@ func TestToFolderCounts(t *testing.T) {
 			},
 		},
 		{
-			name: "with only counts from both storages",
+			name: "with counts from both storages",
 			input: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "folder.grafana.app/v0alpha1",

--- a/pkg/apis/folder/v0alpha1/types.go
+++ b/pkg/apis/folder/v0alpha1/types.go
@@ -2,6 +2,8 @@ package v0alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -75,4 +77,10 @@ type ResourceStats struct {
 	Group    string `json:"group"`
 	Resource string `json:"resource"`
 	Count    int64  `json:"count"`
+}
+
+func UnstructuredToDescendantCounts(obj *unstructured.Unstructured) (*DescendantCounts, error) {
+	var res DescendantCounts
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &res)
+	return &res, err
 }

--- a/pkg/apis/folder/v0alpha1/types.go
+++ b/pkg/apis/folder/v0alpha1/types.go
@@ -109,7 +109,7 @@ func UnstructedToDescendantCounts(u *unstructured.Unstructured) (*DescendantCoun
 		return nil, fmt.Errorf("counts is not an array")
 	}
 
-	var stats []ResourceStats
+	stats := make([]ResourceStats, 0, len(counts))
 	for _, c := range counts {
 		count, ok := c.(map[string]interface{})
 		if !ok {

--- a/pkg/apis/folder/v0alpha1/types.go
+++ b/pkg/apis/folder/v0alpha1/types.go
@@ -1,7 +1,10 @@
 package v0alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -75,4 +78,52 @@ type ResourceStats struct {
 	Group    string `json:"group"`
 	Resource string `json:"resource"`
 	Count    int64  `json:"count"`
+}
+
+func UnstructuedToResouceStats(u *unstructured.Unstructured) (*ResourceStats, error) {
+	group, _, err := unstructured.NestedString(u.Object, "group")
+	if err != nil {
+		return nil, err
+	}
+
+	resource, _, err := unstructured.NestedString(u.Object, "resource")
+	if err != nil {
+		return nil, err
+	}
+
+	count, _, err := unstructured.NestedInt64(u.Object, "count")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceStats{
+		Group:    group,
+		Resource: resource,
+		Count:    count,
+	}, nil
+}
+
+func UnstructedToDescendantCounts(u *unstructured.Unstructured) (*DescendantCounts, error) {
+	counts, ok := u.Object["counts"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("counts is not an array")
+	}
+
+	var stats []ResourceStats
+	for _, c := range counts {
+		count, ok := c.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("count is not a map")
+		}
+
+		s, err := UnstructuedToResouceStats(&unstructured.Unstructured{Object: count})
+		if err != nil {
+			return nil, err
+		}
+		stats = append(stats, *s)
+	}
+
+	return &DescendantCounts{
+		Counts: stats,
+	}, nil
 }

--- a/pkg/apis/folder/v0alpha1/types.go
+++ b/pkg/apis/folder/v0alpha1/types.go
@@ -1,10 +1,7 @@
 package v0alpha1
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -78,52 +75,4 @@ type ResourceStats struct {
 	Group    string `json:"group"`
 	Resource string `json:"resource"`
 	Count    int64  `json:"count"`
-}
-
-func UnstructuedToResouceStats(u *unstructured.Unstructured) (*ResourceStats, error) {
-	group, _, err := unstructured.NestedString(u.Object, "group")
-	if err != nil {
-		return nil, err
-	}
-
-	resource, _, err := unstructured.NestedString(u.Object, "resource")
-	if err != nil {
-		return nil, err
-	}
-
-	count, _, err := unstructured.NestedInt64(u.Object, "count")
-	if err != nil {
-		return nil, err
-	}
-
-	return &ResourceStats{
-		Group:    group,
-		Resource: resource,
-		Count:    count,
-	}, nil
-}
-
-func UnstructedToDescendantCounts(u *unstructured.Unstructured) (*DescendantCounts, error) {
-	counts, ok := u.Object["counts"].([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("counts is not an array")
-	}
-
-	stats := make([]ResourceStats, 0, len(counts))
-	for _, c := range counts {
-		count, ok := c.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("count is not a map")
-		}
-
-		s, err := UnstructuedToResouceStats(&unstructured.Unstructured{Object: count})
-		if err != nil {
-			return nil, err
-		}
-		stats = append(stats, *s)
-	}
-
-	return &DescendantCounts{
-		Counts: stats,
-	}, nil
 }

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -128,7 +128,7 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 	storage[resourceInfo.StoragePath()] = legacyStore
 	storage[resourceInfo.StoragePath("parents")] = &subParentsREST{b.folderSvc}
 	storage[resourceInfo.StoragePath("access")] = &subAccessREST{b.folderSvc}
-	storage[resourceInfo.StoragePath("count")] = &subCountREST{searcher: b.searcher}
+	storage[resourceInfo.StoragePath("counts")] = &subCountREST{searcher: b.searcher}
 
 	// enable dual writer
 	if optsGetter != nil && dualWriteBuilder != nil {

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -93,7 +93,7 @@ func TestIntegrationFoldersApp(t *testing.T) {
 				]
 			  },
 			  {
-				"name": "folders/count",
+				"name": "folders/counts",
 				"singularName": "",
 				"namespaced": true,
 				"kind": "DescendantCounts",


### PR DESCRIPTION
Implement counts:

- it will call storage Backend `GetStats` which returns values present in unified storage and legacy.
- if counts are present in unified storage, we will return them
- otherwise we return counts from legacy


Relates to https://github.com/grafana/grafana-org/issues/311

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
