### PR TITLE
Query splitting: use volume to update partition size

### DIFF
--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -160,9 +160,7 @@ function splitQueriesByStreamShard(
 
     debug(shardsToQuery.length ? `Querying ${shardsToQuery.join(', ')}` : 'Running regular query');
 
-    const queryRunner =
-      shardsToQuery.length > 0 ? datasource.runQuery.bind(datasource) : runSplitQuery.bind(null, datasource);
-    subquerySubscription = queryRunner(subRequest).subscribe({
+    subquerySubscription = runSplitQuery(datasource, subRequest, { skipPartialUpdates: true }).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
           if (retry(partialResponse)) {

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -105,4 +105,4 @@ export interface ParserAndLabelKeysResult {
   unwrapLabelKeys: string[];
 }
 
-export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[] };
+export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[]; chunkRangeMs: number; stepMs: number; intervalMs: number; };

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -105,4 +105,10 @@ export interface ParserAndLabelKeysResult {
   unwrapLabelKeys: string[];
 }
 
-export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[]; chunkRangeMs: number; stepMs: number; intervalMs: number; };
+export type LokiGroupedRequest = {
+  request: DataQueryRequest<LokiQuery>;
+  partition: TimeRange[];
+  chunkRangeMs: number;
+  stepMs: number;
+  intervalMs: number;
+};


### PR DESCRIPTION
WIP.

The proposal is to introduce query stats to query splitting, running for each partition a volume query, and using the response to make the partition smaller if the volume is above a certain threshold.

In addition, this PR combines shard query splitting with time splitting, passing every shard splitting query through query splitting, which would also use the same volume logic to adjust the request chunks.

Work in progress.