### PR TITLE
Alerting docs: `reorder rules` action in DS rules

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
@@ -129,7 +129,7 @@ Use [alert rule evaluation](ref:alert-rule-evaluation) to determine how frequent
 
    If you are creating a new evaluation group, specify the interval for the group.
 
-   All rules within the same group are evaluated sequentially over the same time interval.
+   All rules within the same group are evaluated sequentially over the same time interval. You can reorder them from the **Alert rules** page.
 
 1. Enter a pending period.
 

--- a/docs/sources/alerting/alerting-rules/create-recording-rules/create-data-source-managed-recording-rules.md
+++ b/docs/sources/alerting/alerting-rules/create-recording-rules/create-data-source-managed-recording-rules.md
@@ -66,7 +66,9 @@ Select your data source and enter a query. The queries used in data source-manag
 
 1. From the **Group** dropdown, select an existing group within the selected namespace or add a new one.
 
-   Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
+   Rules within a group are run sequentially at a regular interval, with the same evaluation time.
+
+   Newly created rules are appended to the end of the group, and you can reorder them from the **Alert rules** page.
 
 ## Add labels
 


### PR DESCRIPTION
The "reorder rules" action was not previously mentioned in the docs. The PR adds a minor update about reordering rules when creating data source-managed alert and recording rules.

![Screenshot 2024-12-13 at 19 31 49](https://github.com/user-attachments/assets/2e0d64b1-a5f0-4d43-b7aa-caddafa35b00)

![Screenshot 2024-12-13 at 19 31 43](https://github.com/user-attachments/assets/e01fe52d-1df2-4cf1-b647-ee6fafdd4422)

