### PR TITLE
Grafana UI: Clearly separate multiple warnings by using HTML tags

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -10,6 +10,7 @@ import { useStyles2 } from '../../themes/ThemeContext';
 import { IconName } from '../../types';
 import { SkeletonComponent, attachSkeleton } from '../../utils/skeleton';
 import { Icon } from '../Icon/Icon';
+import { PopoverContent } from '../Tooltip';
 import { Tooltip } from '../Tooltip/Tooltip';
 
 export type BadgeColor = 'blue' | 'red' | 'green' | 'orange' | 'purple' | 'darkgrey';
@@ -18,7 +19,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   text: React.ReactNode;
   color: BadgeColor;
   icon?: IconName;
-  tooltip?: string;
+  tooltip?: PopoverContent;
 }
 
 const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, className, ...otherProps }) => {

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -19,9 +19,10 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   color: BadgeColor;
   icon?: IconName;
   tooltip?: string;
+  html?: boolean;
 }
 
-const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, className, ...otherProps }) => {
+const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, html, className, ...otherProps }) => {
   const styles = useStyles2(getStyles, color);
   const badge = (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
@@ -31,7 +32,7 @@ const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, cla
   );
 
   return tooltip ? (
-    <Tooltip content={tooltip} placement="auto">
+    <Tooltip content={tooltip} placement="auto" html={html}>
       {badge}
     </Tooltip>
   ) : (

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -19,10 +19,9 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   color: BadgeColor;
   icon?: IconName;
   tooltip?: string;
-  html?: boolean;
 }
 
-const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, html, className, ...otherProps }) => {
+const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, className, ...otherProps }) => {
   const styles = useStyles2(getStyles, color);
   const badge = (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
@@ -32,7 +31,7 @@ const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, htm
   );
 
   return tooltip ? (
-    <Tooltip content={tooltip} placement="auto" html={html}>
+    <Tooltip content={tooltip} placement="auto">
       {badge}
     </Tooltip>
   ) : (

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -33,10 +33,11 @@ export interface TooltipProps {
    * Set to true if you want the tooltip to stay long enough so the user can move mouse over content to select text or click a link
    */
   interactive?: boolean;
+  html?: boolean;
 }
 
 export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
-  ({ children, theme, interactive, show, placement, content }, forwardedRef) => {
+  ({ children, theme, interactive, show, placement, content, html }, forwardedRef) => {
     const arrowRef = useRef(null);
     const [controlledVisible, setControlledVisible] = useState(show);
     const isOpen = show ?? controlledVisible;
@@ -76,6 +77,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
 
     const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, hover, focus]);
 
+    const contentIsString = typeof content === 'string';
     const contentIsFunction = typeof content === 'function';
 
     const styles = useStyles2(getStyles);
@@ -116,7 +118,8 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
                 role="tooltip"
                 className={style.container}
               >
-                {typeof content === 'string' && content}
+                {contentIsString && !html && content}
+                {contentIsString && html && <div dangerouslySetInnerHTML={{ __html: content }} />}
                 {isValidElement(content) && cloneElement(content)}
                 {contentIsFunction && content({})}
               </div>

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -33,11 +33,10 @@ export interface TooltipProps {
    * Set to true if you want the tooltip to stay long enough so the user can move mouse over content to select text or click a link
    */
   interactive?: boolean;
-  html?: boolean;
 }
 
 export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
-  ({ children, theme, interactive, show, placement, content, html }, forwardedRef) => {
+  ({ children, theme, interactive, show, placement, content }, forwardedRef) => {
     const arrowRef = useRef(null);
     const [controlledVisible, setControlledVisible] = useState(show);
     const isOpen = show ?? controlledVisible;
@@ -77,7 +76,6 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
 
     const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, hover, focus]);
 
-    const contentIsString = typeof content === 'string';
     const contentIsFunction = typeof content === 'function';
 
     const styles = useStyles2(getStyles);
@@ -118,8 +116,7 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
                 role="tooltip"
                 className={style.container}
               >
-                {contentIsString && !html && content}
-                {contentIsString && html && <div dangerouslySetInnerHTML={{ __html: content }} />}
+                {typeof content === 'string' && content}
                 {isValidElement(content) && cloneElement(content)}
                 {contentIsFunction && content({})}
               </div>

--- a/public/app/features/plugins/components/PluginStateInfo.tsx
+++ b/public/app/features/plugins/components/PluginStateInfo.tsx
@@ -17,7 +17,8 @@ export const PluginStateInfo = (props: Props) => {
     <Badge
       className={props.className}
       color={display.color}
-      {...(typeof display.tooltip === 'string' ? { title: display.tooltip } : { tooltip: display.tooltip })}
+      title={typeof display.tooltip === 'string' ? display.tooltip : undefined}
+      tooltip={typeof display.tooltip !== 'string' ? display.tooltip : undefined}
       text={display.text}
       icon={display.icon}
     />

--- a/public/app/features/plugins/components/PluginStateInfo.tsx
+++ b/public/app/features/plugins/components/PluginStateInfo.tsx
@@ -17,7 +17,7 @@ export const PluginStateInfo = (props: Props) => {
     <Badge
       className={props.className}
       color={display.color}
-      title={display.tooltip}
+      {...(typeof display.tooltip === 'string' ? { title: display.tooltip } : { tooltip: display.tooltip })}
       text={display.text}
       icon={display.icon}
     />

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -415,7 +415,14 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     const colour = type === 'warning' ? 'orange' : 'blue';
     const iconName = type === 'warning' ? 'exclamation-triangle' : 'file-landscape-alt';
 
-    const serializedWarnings = uniqueWarnings.map((warning) => warning.text).join('\n');
+    let serializedWarnings, hasMultipleWarnings;
+    if (uniqueWarnings.length > 1) {
+      serializedWarnings = '<ul>' + uniqueWarnings.map((warning) => '<li>' + warning.text + '</li>').join('') + '</ul>';
+      hasMultipleWarnings = true;
+    } else {
+      serializedWarnings = uniqueWarnings[0].text;
+      hasMultipleWarnings = false;
+    }
 
     return (
       <Badge
@@ -428,6 +435,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
           </>
         }
         tooltip={serializedWarnings}
+        html={hasMultipleWarnings}
       />
     );
   };

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -415,13 +415,12 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     const colour = type === 'warning' ? 'orange' : 'blue';
     const iconName = type === 'warning' ? 'exclamation-triangle' : 'file-landscape-alt';
 
-    let serializedWarnings, hasMultipleWarnings;
+    let serializedWarnings;
     if (uniqueWarnings.length > 1) {
-      serializedWarnings = '<ul>' + uniqueWarnings.map((warning) => '<li>' + warning.text + '</li>').join('') + '</ul>';
-      hasMultipleWarnings = true;
+      let textWarnings = uniqueWarnings.map((warning) => <li>{warning.text}</li>);
+      serializedWarnings = <ul>{textWarnings}</ul>;
     } else {
       serializedWarnings = uniqueWarnings[0].text;
-      hasMultipleWarnings = false;
     }
 
     return (
@@ -435,7 +434,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
           </>
         }
         tooltip={serializedWarnings}
-        html={hasMultipleWarnings}
       />
     );
   };

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -415,13 +415,8 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     const colour = type === 'warning' ? 'orange' : 'blue';
     const iconName = type === 'warning' ? 'exclamation-triangle' : 'file-landscape-alt';
 
-    let serializedWarnings;
-    if (uniqueWarnings.length > 1) {
-      const listItems = uniqueWarnings.map((warning) => warning.text);
-      serializedWarnings = <List items={listItems} renderItem={(item) => <>{item}</>} />;
-    } else {
-      serializedWarnings = uniqueWarnings[0].text;
-    }
+    const listItems = uniqueWarnings.map((warning) => warning.text);
+    const serializedWarnings = <List items={listItems} renderItem={(item) => <>{item}</>} />;
 
     return (
       <Badge

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -25,7 +25,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { AngularComponent, getAngularLoader, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
-import { Badge, ErrorBoundaryAlert } from '@grafana/ui';
+import { Badge, ErrorBoundaryAlert, List } from '@grafana/ui';
 import { OperationRowHelp } from 'app/core/components/QueryOperationRow/OperationRowHelp';
 import {
   QueryOperationAction,
@@ -417,8 +417,8 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
     let serializedWarnings;
     if (uniqueWarnings.length > 1) {
-      let textWarnings = uniqueWarnings.map((warning) => <li>{warning.text}</li>);
-      serializedWarnings = <ul>{textWarnings}</ul>;
+      const listItems = uniqueWarnings.map((warning) => warning.text);
+      serializedWarnings = <List items={listItems} renderItem={(item) => <>{item}</>} />;
     } else {
       serializedWarnings = uniqueWarnings[0].text;
     }


### PR DESCRIPTION
**What is this feature?**

Display multiple warnings/infos properly by selectively enabling HTML in tooltips.

**Why do we need this feature?**

Currently multiple warnings are separated with '\n' which doesn't actually show, so multiple warnings all get shown as a single line which is very messy and hard to read, and it's hard to see the separation between warning messages. Previously HTML wasn't supported in tooltips, now we can selectively enable it where there are multiple warnings so we can show them clearly in a HTML list.

**Who is this feature for?**

Users of explore (for queries).

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
