### PR TITLE
k8s: Dashboards: allow querying of unistore

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -478,7 +478,7 @@ func (hs *HTTPServer) deleteDashboard(c *contextmodel.ReqContext) response.Respo
 		hs.log.Error("Failed to delete public dashboard")
 	}
 
-	err = hs.DashboardService.DeleteDashboard(c.Req.Context(), dash.ID, c.SignedInUser.GetOrgID())
+	err = hs.DashboardService.DeleteDashboard(c.Req.Context(), dash.ID, dash.UID, c.SignedInUser.GetOrgID())
 	if err != nil {
 		var dashboardErr dashboards.DashboardErr
 		if ok := errors.As(err, &dashboardErr); ok {

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -838,14 +838,14 @@ func getDashboardShouldReturn200WithConfig(t *testing.T, sc *scenarioContext, pr
 	if dashboardService == nil {
 		dashboardService, err = service.ProvideDashboardServiceImpl(
 			cfg, dashboardStore, folderStore, features, folderPermissions, dashboardPermissions,
-			ac, folderSvc, fStore, nil, zanzana.NewNoopClient(), nil,
+			ac, folderSvc, fStore, nil, zanzana.NewNoopClient(), nil, nil,
 		)
 		require.NoError(t, err)
 	}
 
 	dashboardProvisioningService, err := service.ProvideDashboardServiceImpl(
 		cfg, dashboardStore, folderStore, features, folderPermissions, dashboardPermissions,
-		ac, folderSvc, fStore, nil, zanzana.NewNoopClient(), nil,
+		ac, folderSvc, fStore, nil, zanzana.NewNoopClient(), nil, nil,
 	)
 	require.NoError(t, err)
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -263,7 +263,7 @@ func TestHTTPServer_DeleteDashboardByUID_AccessControl(t *testing.T) {
 
 			dashSvc := dashboards.NewFakeDashboardService(t)
 			dashSvc.On("GetDashboard", mock.Anything, mock.Anything).Return(dash, nil).Maybe()
-			dashSvc.On("DeleteDashboard", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+			dashSvc.On("DeleteDashboard", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 			hs.DashboardService = dashSvc
 
 			hs.Cfg = setting.NewCfg()

--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -478,7 +478,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 	dashboardSvc, err := dashboardservice.ProvideDashboardServiceImpl(
 		sc.cfg, dashStore, folderStore,
 		features, folderPermissions, dashboardPermissions, ac,
-		folderServiceWithFlagOn, fStore, nil, zanzana.NewNoopClient(), nil,
+		folderServiceWithFlagOn, fStore, nil, zanzana.NewNoopClient(), nil, nil,
 	)
 	require.NoError(b, err)
 

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -15,7 +15,7 @@ import (
 //go:generate mockery --name DashboardService --structname FakeDashboardService --inpackage --filename dashboard_service_mock.go
 type DashboardService interface {
 	BuildSaveDashboardCommand(ctx context.Context, dto *SaveDashboardDTO, validateProvisionedDashboard bool) (*SaveDashboardCommand, error)
-	DeleteDashboard(ctx context.Context, dashboardId int64, orgId int64) error
+	DeleteDashboard(ctx context.Context, dashboardId int64, dashboardUID string, orgId int64) error
 	FindDashboards(ctx context.Context, query *FindPersistedDashboardsQuery) ([]DashboardSearchProjection, error)
 	// GetDashboard fetches a dashboard.
 	// To fetch a dashboard under root by title should set the folder UID to point to an empty string

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -102,17 +102,17 @@ func (_m *FakeDashboardService) CountInFolders(ctx context.Context, orgID int64,
 	return r0, r1
 }
 
-// DeleteDashboard provides a mock function with given fields: ctx, dashboardId, orgId
-func (_m *FakeDashboardService) DeleteDashboard(ctx context.Context, dashboardId int64, orgId int64) error {
-	ret := _m.Called(ctx, dashboardId, orgId)
+// DeleteDashboard provides a mock function with given fields: ctx, dashboardId, dashboardUID, orgId
+func (_m *FakeDashboardService) DeleteDashboard(ctx context.Context, dashboardId int64, dashboardUID string, orgId int64) error {
+	ret := _m.Called(ctx, dashboardId, dashboardUID, orgId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteDashboard")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) error); ok {
-		r0 = rf(ctx, dashboardId, orgId)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string, int64) error); ok {
+		r0 = rf(ctx, dashboardId, dashboardUID, orgId)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -886,6 +886,7 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 			nil,
 			zanzana.NewNoopClient(),
 			nil,
+			nil,
 		)
 		require.NoError(t, err)
 		guardian.InitAccessControlGuardian(cfg, ac, dashboardService)
@@ -954,6 +955,7 @@ func callSaveWithResult(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSt
 		nil,
 		zanzana.NewNoopClient(),
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	res, err := service.SaveDashboard(context.Background(), &dto, false)
@@ -980,6 +982,7 @@ func callSaveWithError(t *testing.T, cmd dashboards.SaveDashboardCommand, sqlSto
 		folder.NewFakeStore(),
 		nil,
 		zanzana.NewNoopClient(),
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -1026,6 +1029,7 @@ func saveTestDashboard(t *testing.T, title string, orgID int64, folderUID string
 		folder.NewFakeStore(),
 		nil,
 		zanzana.NewNoopClient(),
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -1079,6 +1083,7 @@ func saveTestFolder(t *testing.T, title string, orgID int64, sqlStore db.DB) *da
 		folder.NewFakeStore(),
 		nil,
 		zanzana.NewNoopClient(),
+		nil,
 		nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -611,6 +611,7 @@ func TestUnstructuredToLegacyDashboard(t *testing.T) {
 		}
 
 		obj, err := utils.MetaAccessor(item)
+		require.NoError(t, err)
 		obj.SetCreationTimestamp(now)
 		obj.SetName(uid)
 		obj.SetCreatedBy("user:useruid")

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -11,6 +12,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -19,6 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/services/user/usertest"
 	"github.com/grafana/grafana/pkg/setting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -179,7 +182,7 @@ func TestDashboardService(t *testing.T) {
 
 			t.Run("DeleteDashboard should fail to delete it when provisioning information is missing", func(t *testing.T) {
 				fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything, mock.AnythingOfType("int64")).Return(&dashboards.DashboardProvisioning{}, nil).Once()
-				err := service.DeleteDashboard(context.Background(), 1, 1)
+				err := service.DeleteDashboard(context.Background(), 1, "", 1)
 				require.Equal(t, err, dashboards.ErrDashboardCannotDeleteProvisionedDashboard)
 			})
 		})
@@ -196,7 +199,7 @@ func TestDashboardService(t *testing.T) {
 				args := &dashboards.DeleteDashboardCommand{OrgID: 1, ID: 1}
 				fakeStore.On("DeleteDashboard", mock.Anything, args).Return(nil).Once()
 				fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything, mock.AnythingOfType("int64")).Return(nil, nil).Once()
-				err := service.DeleteDashboard(context.Background(), 1, 1)
+				err := service.DeleteDashboard(context.Background(), 1, "", 1)
 				require.NoError(t, err)
 			})
 		})
@@ -238,6 +241,10 @@ func (m *mockDashK8sCli) getClient(ctx context.Context, orgID int64) (dynamic.Re
 	return args.Get(0).(dynamic.ResourceInterface), args.Bool(1)
 }
 
+func (m *mockDashK8sCli) getNamespace(orgID int64) string {
+	return "default"
+}
+
 type mockResourceInterface struct {
 	mock.Mock
 	dynamic.ResourceInterface
@@ -249,6 +256,35 @@ func (m *mockResourceInterface) Get(ctx context.Context, name string, options me
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}
+
+func (m *mockResourceInterface) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*unstructured.UnstructuredList), args.Error(1)
+}
+
+func (m *mockResourceInterface) Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, obj, options, subresources)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}
+
+func (m *mockResourceInterface) Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, obj, options, subresources)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*unstructured.Unstructured), args.Error(1)
+}
+
+func (m *mockResourceInterface) Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+	args := m.Called(ctx, name, options, subresources)
+	return args.Error(0)
 }
 
 func TestGetDashboard(t *testing.T) {
@@ -288,17 +324,19 @@ func TestGetDashboard(t *testing.T) {
 				"name": "uid",
 			},
 			"spec": map[string]any{
-				"test":  "test",
-				"title": "testing slugify",
+				"test":    "test",
+				"version": int64(1),
+				"title":   "testing slugify",
 			},
 		}}
 
 		dashboardExpected := dashboards.Dashboard{
-			UID:   "uid", // uid is the name of the k8s object
-			Title: "testing slugify",
-			Slug:  "testing-slugify", // slug is taken from title
-			OrgID: 1,                 // orgID is populated from the query
-			Data:  simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify"}),
+			UID:     "uid", // uid is the name of the k8s object
+			Title:   "testing slugify",
+			Slug:    "testing-slugify", // slug is taken from title
+			OrgID:   1,                 // orgID is populated from the query
+			Version: 1,
+			Data:    simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "uid", "version": int64(1)}),
 		}
 
 		ctx := context.Background()
@@ -358,5 +396,290 @@ func TestGetDashboard(t *testing.T) {
 		require.Equal(t, dashboards.ErrDashboardNotFound, err)
 		require.Nil(t, dashboard)
 		k8sClientMock.AssertExpectations(t)
+	})
+}
+
+func TestGetAllDashboards(t *testing.T) {
+	fakeStore := dashboards.FakeDashboardStore{}
+	defer fakeStore.AssertExpectations(t)
+	service := &DashboardServiceImpl{
+		cfg:            setting.NewCfg(),
+		dashboardStore: &fakeStore,
+	}
+
+	t.Run("Should fallback to dashboard store if Kubernetes feature flags are not enabled", func(t *testing.T) {
+		service.features = featuremgmt.WithFeatures()
+		fakeStore.On("GetAllDashboards", mock.Anything).Return([]*dashboards.Dashboard{}, nil).Once()
+		dashboard, err := service.GetAllDashboards(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, dashboard)
+		fakeStore.AssertExpectations(t)
+	})
+
+	t.Run("Should use Kubernetes client if feature flags are enabled", func(t *testing.T) {
+		k8sClientMock := new(mockDashK8sCli)
+		k8sResourceMock := new(mockResourceInterface)
+		service.k8sclient = k8sClientMock
+		service.features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesCliDashboards)
+
+		dashboardUnstructured := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name": "uid",
+			},
+			"spec": map[string]any{
+				"test":    "test",
+				"version": int64(1),
+				"title":   "testing slugify",
+			},
+		}}
+
+		dashboardExpected := dashboards.Dashboard{
+			UID:     "uid", // uid is the name of the k8s object
+			Title:   "testing slugify",
+			Slug:    "testing-slugify", // slug is taken from title
+			OrgID:   1,                 // orgID is populated from the query
+			Version: 1,                 // default to version 1
+			Data:    simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "uid", "version": int64(1)}),
+		}
+
+		ctx := context.Background()
+		userCtx := &user.SignedInUser{UserID: 1, OrgID: 1}
+		ctx = identity.WithRequester(ctx, userCtx)
+		k8sClientMock.On("getClient", mock.Anything, int64(1)).Return(k8sResourceMock, true).Once()
+		k8sResourceMock.On("List", mock.Anything, mock.Anything).Return(&unstructured.UnstructuredList{Items: []unstructured.Unstructured{dashboardUnstructured}}, nil).Once()
+
+		dashes, err := service.GetAllDashboards(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, dashes)
+		k8sClientMock.AssertExpectations(t)
+		// make sure the conversion is working
+		require.True(t, reflect.DeepEqual(dashes, []*dashboards.Dashboard{&dashboardExpected}))
+	})
+}
+
+func TestSaveDashboard(t *testing.T) {
+	fakeStore := dashboards.FakeDashboardStore{}
+	defer fakeStore.AssertExpectations(t)
+	service := &DashboardServiceImpl{
+		cfg:            setting.NewCfg(),
+		dashboardStore: &fakeStore,
+	}
+
+	origNewDashboardGuardian := guardian.New
+	defer func() { guardian.New = origNewDashboardGuardian }()
+	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true})
+
+	query := &dashboards.SaveDashboardDTO{
+		OrgID: 1,
+		User:  &user.SignedInUser{UserID: 1},
+		Dashboard: &dashboards.Dashboard{
+			UID:   "uid", // uid is the name of the k8s object
+			Title: "testing slugify",
+			Slug:  "testing-slugify", // slug is taken from title
+			OrgID: 1,                 // orgID is populated from the query
+			Data:  simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "uid"}),
+		},
+	}
+
+	t.Run("Should fallback to dashboard store if Kubernetes feature flags are not enabled", func(t *testing.T) {
+		service.features = featuremgmt.WithFeatures()
+		fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything, mock.Anything).Return(nil, nil)
+		fakeStore.On("ValidateDashboardBeforeSave", mock.Anything, mock.Anything, mock.AnythingOfType("bool")).Return(true, nil)
+		fakeStore.On("SaveDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil)
+		dashboard, err := service.SaveDashboard(context.Background(), query, false)
+		require.NoError(t, err)
+		require.NotNil(t, dashboard)
+		fakeStore.AssertExpectations(t)
+	})
+
+	t.Run("Should use Kubernetes create if feature flags are enabled and dashboard doesn't exit", func(t *testing.T) {
+		k8sClientMock := new(mockDashK8sCli)
+		k8sResourceMock := new(mockResourceInterface)
+		service.k8sclient = k8sClientMock
+		service.features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesCliDashboards)
+
+		dashboardUnstructured := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name": "uid",
+			},
+			"spec": map[string]any{
+				"test":    "test",
+				"version": int64(1),
+				"title":   "testing slugify",
+			},
+		}}
+
+		ctx := context.Background()
+		userCtx := &user.SignedInUser{UserID: 1}
+		ctx = identity.WithRequester(ctx, userCtx)
+
+		k8sClientMock.On("getClient", mock.Anything, int64(1)).Return(k8sResourceMock, true)
+		k8sResourceMock.On("Get", mock.Anything, query.Dashboard.UID, mock.Anything, mock.Anything).Return(nil, nil)
+		k8sResourceMock.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&dashboardUnstructured, nil)
+
+		dashboard, err := service.SaveDashboard(ctx, query, false)
+		require.NoError(t, err)
+		require.NotNil(t, dashboard)
+	})
+
+	t.Run("Should use Kubernetes create if feature flags are enabled and dashboard doesn't exist", func(t *testing.T) {
+		k8sClientMock := new(mockDashK8sCli)
+		k8sResourceMock := new(mockResourceInterface)
+		service.k8sclient = k8sClientMock
+		service.features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesCliDashboards)
+
+		dashboardUnstructured := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name": "uid",
+			},
+			"spec": map[string]any{
+				"test":    "test",
+				"version": int64(1),
+				"title":   "testing slugify",
+			},
+		}}
+
+		ctx := context.Background()
+		userCtx := &user.SignedInUser{UserID: 1}
+		ctx = identity.WithRequester(ctx, userCtx)
+
+		k8sClientMock.On("getClient", mock.Anything, int64(1)).Return(k8sResourceMock, true)
+		k8sResourceMock.On("Get", mock.Anything, query.Dashboard.UID, mock.Anything, mock.Anything).Return(&dashboardUnstructured, nil)
+		k8sResourceMock.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&dashboardUnstructured, nil)
+
+		dashboard, err := service.SaveDashboard(ctx, query, false)
+		require.NoError(t, err)
+		require.NotNil(t, dashboard)
+	})
+}
+
+func TestDeleteDashboard(t *testing.T) {
+	fakeStore := dashboards.FakeDashboardStore{}
+	defer fakeStore.AssertExpectations(t)
+	service := &DashboardServiceImpl{
+		cfg:            setting.NewCfg(),
+		dashboardStore: &fakeStore,
+	}
+
+	t.Run("Should fallback to dashboard store if Kubernetes feature flags are not enabled", func(t *testing.T) {
+		service.features = featuremgmt.WithFeatures()
+		fakeStore.On("DeleteDashboard", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything, mock.Anything).Return(nil, nil).Once()
+		err := service.DeleteDashboard(context.Background(), 1, "uid", 1)
+		require.NoError(t, err)
+		fakeStore.AssertExpectations(t)
+	})
+
+	t.Run("Should use Kubernetes client if feature flags are enabled", func(t *testing.T) {
+		k8sClientMock := new(mockDashK8sCli)
+		k8sResourceMock := new(mockResourceInterface)
+		service.k8sclient = k8sClientMock
+		service.features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesCliDashboards)
+
+		ctx := context.Background()
+		userCtx := &user.SignedInUser{UserID: 1}
+		ctx = identity.WithRequester(ctx, userCtx)
+		k8sClientMock.On("getClient", mock.Anything, int64(1)).Return(k8sResourceMock, true).Once()
+		fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything, mock.Anything).Return(nil, nil).Once()
+		k8sResourceMock.On("Delete", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		err := service.DeleteDashboard(ctx, 1, "uid", 1)
+		require.NoError(t, err)
+		k8sClientMock.AssertExpectations(t)
+	})
+}
+
+func TestUnstructuredToLegacyDashboard(t *testing.T) {
+	fake := usertest.NewUserServiceFake()
+	fake.ExpectedUser = &user.User{ID: 10, UID: "useruid"}
+	dr := &DashboardServiceImpl{
+		userService: fake,
+	}
+	t.Run("successfully converts unstructured to legacy dashboard", func(t *testing.T) {
+		uid := "36b7c825-79cc-435e-acf6-c78bd96a4510"
+		orgID := int64(123)
+		title := "Test Dashboard"
+		now := metav1.Now()
+		item := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"title":   title,
+					"version": int64(1),
+					"id":      int64(1),
+				},
+			},
+		}
+
+		obj, err := utils.MetaAccessor(item)
+		obj.SetCreationTimestamp(now)
+		obj.SetName(uid)
+		obj.SetCreatedBy("user:useruid")
+		obj.SetUpdatedBy("user:useruid")
+
+		result, err := dr.UnstructuredToLegacyDashboard(context.Background(), item, orgID)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, uid, result.UID)
+		assert.Equal(t, title, result.Title)
+		assert.Equal(t, orgID, result.OrgID)
+		assert.Equal(t, "test-dashboard", result.Slug) // should slugify the title
+		assert.Equal(t, false, result.HasACL)
+		assert.Equal(t, false, result.IsFolder)
+		assert.Equal(t, int64(1), result.ID)
+		assert.Equal(t, now.Time.Format(time.RFC3339), result.Created.Format(time.RFC3339))
+		assert.Equal(t, int64(10), result.CreatedBy)
+		assert.Equal(t, now.Time.Format(time.RFC3339), result.Updated.Format(time.RFC3339)) // updated should default to created
+		assert.Equal(t, int64(10), result.UpdatedBy)
+	})
+
+	t.Run("returns error if spec is missing", func(t *testing.T) {
+		item := &unstructured.Unstructured{
+			Object: map[string]interface{}{},
+		}
+		_, err := (&DashboardServiceImpl{}).UnstructuredToLegacyDashboard(context.Background(), item, int64(123))
+		assert.Error(t, err)
+		assert.Equal(t, "error parsing dashboard from k8s response", err.Error())
+	})
+}
+
+func TestLegacySaveCommandToUnstructured(t *testing.T) {
+	namespace := "test-namespace"
+	t.Run("successfully converts save command to unstructured", func(t *testing.T) {
+		cmd := &dashboards.SaveDashboardCommand{
+			Dashboard: simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "test-uid"}),
+		}
+
+		result, err := LegacySaveCommandToUnstructured(cmd, namespace)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "test-uid", result.GetName())
+		assert.Equal(t, "test-namespace", result.GetNamespace())
+		spec := result.Object["spec"].(map[string]any)
+		assert.Equal(t, spec["version"], 1)
+	})
+
+	t.Run("should increase version when called", func(t *testing.T) {
+		cmd := &dashboards.SaveDashboardCommand{
+			Dashboard: simplejson.NewFromAny(map[string]any{"test": "test", "title": "testing slugify", "uid": "test-uid", "version": int64(1)}),
+		}
+		result, err := LegacySaveCommandToUnstructured(cmd, namespace)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		spec := result.Object["spec"].(map[string]any)
+		assert.Equal(t, spec["version"], float64(2))
+	})
+}
+
+func TestToUID(t *testing.T) {
+	t.Run("parses valid UID", func(t *testing.T) {
+		rawIdentifier := "user:uid-value"
+		result := toUID(rawIdentifier)
+		assert.Equal(t, "uid-value", result)
+	})
+
+	t.Run("returns empty string for invalid identifier", func(t *testing.T) {
+		rawIdentifier := "invalid-uid"
+		result := toUID(rawIdentifier)
+		assert.Equal(t, "", result)
 	})
 }

--- a/pkg/services/dashboards/service/zanzana_integration_test.go
+++ b/pkg/services/dashboards/service/zanzana_integration_test.go
@@ -74,6 +74,7 @@ func TestIntegrationDashboardServiceZanzana(t *testing.T) {
 			nil,
 			zclient,
 			nil,
+			nil,
 		)
 		require.NoError(t, err)
 

--- a/pkg/services/dashboardsnapshots/service/service_test.go
+++ b/pkg/services/dashboardsnapshots/service/service_test.go
@@ -101,7 +101,7 @@ func TestValidateDashboardExists(t *testing.T) {
 	feats := featuremgmt.WithFeatures()
 	dashboardStore, err := dashdb.ProvideDashboardStore(sqlStore, cfg, feats, tagimpl.ProvideService(sqlStore), quotatest.New(false, nil))
 	require.NoError(t, err)
-	dashSvc, err := dashsvc.ProvideDashboardServiceImpl(cfg, dashboardStore, folderimpl.ProvideDashboardFolderStore(sqlStore), feats, nil, nil, acmock.New(), foldertest.NewFakeService(), folder.NewFakeStore(), nil, zanzana.NewNoopClient(), nil)
+	dashSvc, err := dashsvc.ProvideDashboardServiceImpl(cfg, dashboardStore, folderimpl.ProvideDashboardFolderStore(sqlStore), feats, nil, nil, acmock.New(), foldertest.NewFakeService(), folder.NewFakeStore(), nil, zanzana.NewNoopClient(), nil, nil)
 	require.NoError(t, err)
 	s := ProvideService(dsStore, secretsService, dashSvc)
 	ctx := context.Background()

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -490,7 +490,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 				CanEditValue: true,
 			})
 
-			dashSrv, err := dashboardservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, featuresFlagOn, folderPermissions, dashboardPermissions, ac, serviceWithFlagOn, nestedFolderStore, nil, zanzana.NewNoopClient(), nil)
+			dashSrv, err := dashboardservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, featuresFlagOn, folderPermissions, dashboardPermissions, ac, serviceWithFlagOn, nestedFolderStore, nil, zanzana.NewNoopClient(), nil, nil)
 			require.NoError(t, err)
 
 			alertStore, err := ngstore.ProvideDBStore(cfg, featuresFlagOn, db, serviceWithFlagOn, dashSrv, ac, b)
@@ -573,7 +573,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 			})
 
 			dashSrv, err := dashboardservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, featuresFlagOff,
-				folderPermissions, dashboardPermissions, ac, serviceWithFlagOff, nestedFolderStore, nil, zanzana.NewNoopClient(), nil)
+				folderPermissions, dashboardPermissions, ac, serviceWithFlagOff, nestedFolderStore, nil, zanzana.NewNoopClient(), nil, nil)
 			require.NoError(t, err)
 
 			alertStore, err := ngstore.ProvideDBStore(cfg, featuresFlagOff, db, serviceWithFlagOff, dashSrv, ac, b)
@@ -719,7 +719,7 @@ func TestIntegrationNestedFolderService(t *testing.T) {
 				tc.service.dashboardStore = dashStore
 				tc.service.store = nestedFolderStore
 
-				dashSrv, err := dashboardservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, tc.featuresFlag, folderPermissions, dashboardPermissions, ac, tc.service, tc.service.store, nil, zanzana.NewNoopClient(), nil)
+				dashSrv, err := dashboardservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, tc.featuresFlag, folderPermissions, dashboardPermissions, ac, tc.service, tc.service.store, nil, zanzana.NewNoopClient(), nil, nil)
 				require.NoError(t, err)
 				alertStore, err := ngstore.ProvideDBStore(cfg, tc.featuresFlag, db, tc.service, dashSrv, ac, b)
 				require.NoError(t, err)
@@ -1505,6 +1505,7 @@ func TestIntegrationNestedFolderSharedWithMe(t *testing.T) {
 		nestedFolderStore,
 		nil,
 		zanzana.NewNoopClient(),
+		nil,
 		nil,
 	)
 	require.NoError(t, err)

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -312,6 +312,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user user.SignedInUser, dash 
 		nil,
 		zanzana.NewNoopClient(),
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	dashboard, err := service.SaveDashboard(context.Background(), dashItem, true)
@@ -400,6 +401,7 @@ func scenarioWithPanel(t *testing.T, desc string, fn func(t *testing.T, sc scena
 		foldertest.NewFakeService(), folder.NewFakeStore(),
 		nil, zanzana.NewNoopClient(),
 		nil,
+		nil,
 	)
 	require.NoError(t, svcErr)
 	guardian.InitAccessControlGuardian(cfg, ac, dashboardService)
@@ -461,7 +463,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			cfg, dashboardStore, folderStore,
 			features, folderPermissions, dashboardPermissions, ac,
 			foldertest.NewFakeService(), folder.NewFakeStore(),
-			nil, zanzana.NewNoopClient(), nil,
+			nil, zanzana.NewNoopClient(), nil, nil,
 		)
 		require.NoError(t, dashSvcErr)
 		guardian.InitAccessControlGuardian(cfg, ac, dashService)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -736,7 +736,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user *user.SignedInUser, dash
 		cfg, dashboardStore, folderStore,
 		featuremgmt.WithFeatures(), acmock.NewMockedPermissionsService(), dashPermissionService, ac,
 		foldertest.NewFakeService(), folder.NewFakeStore(),
-		nil, zanzana.NewNoopClient(), nil,
+		nil, zanzana.NewNoopClient(), nil, nil,
 	)
 	require.NoError(t, err)
 	dashboard, err := service.SaveDashboard(context.Background(), dashItem, true)
@@ -833,7 +833,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 			cfg, dashStore, folderStore,
 			features, acmock.NewMockedPermissionsService(), dashPermissionService, ac,
 			foldertest.NewFakeService(), folder.NewFakeStore(),
-			nil, zanzana.NewNoopClient(), nil,
+			nil, zanzana.NewNoopClient(), nil, nil,
 		)
 		require.NoError(t, err)
 		guardian.InitAccessControlGuardian(cfg, ac, dashService)

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -62,7 +62,7 @@ func SetupDashboardService(tb testing.TB, sqlStore db.DB, fs *folderimpl.Dashboa
 		cfg, dashboardStore, fs,
 		features, folderPermissions, dashboardPermissions, ac,
 		foldertest.NewFakeService(), folder.NewFakeStore(),
-		nil, zanzana.NewNoopClient(), nil,
+		nil, zanzana.NewNoopClient(), nil, nil,
 	)
 	require.NoError(tb, err)
 

--- a/pkg/services/plugindashboards/service/dashboard_updater.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater.go
@@ -95,7 +95,7 @@ func (du *DashboardUpdater) syncPluginDashboards(ctx context.Context, plugin plu
 		if dash.Removed {
 			du.logger.Info("Deleting plugin dashboard", "pluginId", plugin.ID, "dashboard", dash.Slug)
 
-			if err := du.dashboardService.DeleteDashboard(ctx, dash.DashboardId, orgID); err != nil {
+			if err := du.dashboardService.DeleteDashboard(ctx, dash.DashboardId, dash.UID, orgID); err != nil {
 				du.logger.Error("Failed to auto update app dashboard", "pluginId", plugin.ID, "error", err)
 				return
 			}
@@ -150,7 +150,7 @@ func (du *DashboardUpdater) handlePluginStateChanged(ctx context.Context, event 
 
 		for _, dash := range queryResult {
 			du.logger.Info("Deleting plugin dashboard", "pluginId", event.PluginId, "dashboard", dash.Slug)
-			if err := du.dashboardService.DeleteDashboard(ctx, dash.ID, dash.OrgID); err != nil {
+			if err := du.dashboardService.DeleteDashboard(ctx, dash.ID, dash.UID, dash.OrgID); err != nil {
 				return err
 			}
 		}

--- a/pkg/services/plugindashboards/service/dashboard_updater_test.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater_test.go
@@ -443,18 +443,21 @@ func (s *pluginsSettingsServiceMock) DecryptedValues(_ *pluginsettings.DTO) map[
 type dashboardServiceMock struct {
 	dashboards.DashboardService
 	deleteDashboardArgs []struct {
-		orgId       int64
-		dashboardId int64
+		orgId        int64
+		dashboardId  int64
+		dashboardUID string
 	}
 }
 
-func (s *dashboardServiceMock) DeleteDashboard(_ context.Context, dashboardId int64, orgId int64) error {
+func (s *dashboardServiceMock) DeleteDashboard(_ context.Context, dashboardId int64, dashboardUID string, orgId int64) error {
 	s.deleteDashboardArgs = append(s.deleteDashboardArgs, struct {
-		orgId       int64
-		dashboardId int64
+		orgId        int64
+		dashboardId  int64
+		dashboardUID string
 	}{
-		orgId:       orgId,
-		dashboardId: dashboardId,
+		orgId:        orgId,
+		dashboardId:  dashboardId,
+		dashboardUID: dashboardUID,
 	})
 	return nil
 }
@@ -532,8 +535,9 @@ func scenario(t *testing.T, desc string, input scenarioInput, f func(ctx *scenar
 
 	sCtx.dashboardService = &dashboardServiceMock{
 		deleteDashboardArgs: []struct {
-			orgId       int64
-			dashboardId int64
+			orgId        int64
+			dashboardId  int64
+			dashboardUID string
 		}{},
 	}
 

--- a/pkg/services/publicdashboards/api/query_test.go
+++ b/pkg/services/publicdashboards/api/query_test.go
@@ -326,7 +326,7 @@ func TestIntegrationUnauthenticatedUserCanGetPubdashPanelQueryData(t *testing.T)
 	dashService, err := service.ProvideDashboardServiceImpl(
 		cfg, dashboardStoreService, folderStore,
 		featuremgmt.WithFeatures(), acmock.NewMockedPermissionsService(), dashPermissionService, ac,
-		foldertest.NewFakeService(), folder.NewFakeStore(), nil, zanzana.NewNoopClient(), nil,
+		foldertest.NewFakeService(), folder.NewFakeStore(), nil, zanzana.NewNoopClient(), nil, nil,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What is this feature?**

This PR implements more usage of the k8s client in the dashboard service, under the feature toggle `FlagKubernetesCliDashboards`. I had already added the Get functionality, and this adds:
- Save
- Delete
- GetAll

It does not touch provisioned dashboards yet - will need to follow up on that. Left TODOs throughout the service code for things I will be following up on after this PR, but to avoid having this be one massive PR, stopping here, and then will follow up with more of the specific concerns (search & provisioned dashboards)

**Why do we need this feature?**
We have typically been implementing this logic in the api layer, but with dashboards, the service is used extensively throughout the code, so we need the service to be able to route to unistore.

**Testing locally**
```
[feature_toggles]
grafanaAPIServerWithExperimentalAPIs = true
grafanaAPIServerEnsureKubectlAccess = true
kubernetesCliDashboards = true
unifiedStorage = true

[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 5

[grafana-apiserver]
address = 127.0.0.1:10000
storage_type = unified-grpc
```
And then unistore running on port 10000


Relates to https://github.com/grafana/app-platform-wg/issues/189