### PR TITLE
Alerting: Add state_periodic_save_batch_size config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1354,6 +1354,9 @@ max_state_save_concurrency = 1
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 state_periodic_save_interval = 5m
 
+# If the feature flag 'alertingSaveStatePeriodic' is enabled, this is the size of the batch that is saved to the database at once.
+state_periodic_save_batch_size = 1
+
 # Disables the smoothing of alert evaluations across their evaluation window.
 # Rules will evaluate in sync.
 disable_jitter = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1338,6 +1338,9 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;state_periodic_save_interval = 5m
 
+# If the feature flag 'alertingSaveStatePeriodic' is enabled, this is the size of the batch that is saved to the database at once.
+;state_periodic_save_batch_size = 1
+
 # Disables the smoothing of alert evaluations across their evaluation window.
 # Rules will evaluate in sync.
 ;disable_jitter = false

--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -67,7 +67,7 @@ can also be configured using the `state_periodic_save_interval` configuration fl
 
 When periodic saving is enabled, each `state_periodic_save_interval` Grafana deletes all existing alert instances from the
 database and then writes the entire current set of instances back in batches in a single transacton.
-The size of each batch can be configured using the `state_periodic_save_batch_size` configuration option.
+Configure the size of each batch using the `state_periodic_save_batch_size` configuration option.
 
 The time it takes to write to the database periodically can be monitored using the `state_full_sync_duration_seconds` metric
 that is exposed by Grafana.

--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -63,9 +63,7 @@ transition of an alert instance is saved in the database.
 
 This can be prevented by writing to the database periodically. For this the feature flag `alertingSaveStatePeriodic` needs
 to be enabled. By default, it saves the states every 5 minutes to the database and on each shutdown. The periodic interval
-can also be configured using the `state_periodic_save_interval` configuration flag.
-
-When periodic saving is enabled, each `state_periodic_save_interval` Grafana deletes all existing alert instances from the
+can also be configured using the `state_periodic_save_interval` configuration flag. During this process, Grafana deletes all existing alert instances from the
 database and then writes the entire current set of instances back in batches in a single transacton.
 Configure the size of each batch using the `state_periodic_save_batch_size` configuration option.
 

--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -65,6 +65,10 @@ This can be prevented by writing to the database periodically. For this the feat
 to be enabled. By default, it saves the states every 5 minutes to the database and on each shutdown. The periodic interval
 can also be configured using the `state_periodic_save_interval` configuration flag.
 
+When periodic saving is enabled, each `state_periodic_save_interval` Grafana deletes all existing alert instances from the
+database and then writes the entire current set of instances back in batches in a single transacton.
+The size of each batch can be configured using the `state_periodic_save_batch_size` configuration option.
+
 The time it takes to write to the database periodically can be monitored using the `state_full_sync_duration_seconds` metric
 that is exposed by Grafana.
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -409,6 +409,7 @@ func (ng *AlertNG) init() error {
 		DoNotSaveNormalState:           ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoNormalState),
 		ApplyNoDataAndErrorToAllStates: ng.FeatureToggles.IsEnabledGlobally(featuremgmt.FlagAlertingNoDataErrorExecution),
 		MaxStateSaveConcurrency:        ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency,
+		StatePeriodicSaveBatchSize:     ng.Cfg.UnifiedAlerting.StatePeriodicSaveBatchSize,
 		RulesPerRuleGroupLimit:         ng.Cfg.UnifiedAlerting.RulesPerRuleGroupLimit,
 		Tracer:                         ng.tracer,
 		Log:                            log.New("ngalert.state.manager"),

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -71,6 +71,9 @@ type ManagerCfg struct {
 	DoNotSaveNormalState bool
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
 	MaxStateSaveConcurrency int
+	// StatePeriodicSaveBatchSize controls the size of the alert instance batch that is saved periodically when the
+	// alertingSaveStatePeriodic feature flag is enabled.
+	StatePeriodicSaveBatchSize int
 	// ApplyNoDataAndErrorToAllStates makes state manager to apply exceptional results (NoData and Error)
 	// to all states when corresponding execution in the rule definition is set to either `Alerting` or `OK`
 	ApplyNoDataAndErrorToAllStates bool

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -16,7 +16,7 @@ type InstanceStore interface {
 	// SaveAlertInstancesForRule overwrites the state for the given rule.
 	SaveAlertInstancesForRule(ctx context.Context, key models.AlertRuleKeyWithGroup, instances []models.AlertInstance) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKeyWithGroup) error
-	FullSync(ctx context.Context, instances []models.AlertInstance) error
+	FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error
 }
 
 // InstanceReader provides methods to fetch alert instances.

--- a/pkg/services/ngalert/state/persister_async.go
+++ b/pkg/services/ngalert/state/persister_async.go
@@ -20,6 +20,7 @@ type AsyncStatePersister struct {
 	log log.Logger
 	// doNotSaveNormalState controls whether eval.Normal state is persisted to the database and returned by get methods.
 	doNotSaveNormalState bool
+	batchSize            int
 	store                InstanceStore
 	ticker               *clock.Ticker
 	metrics              *metrics.State
@@ -31,6 +32,7 @@ func NewAsyncStatePersister(log log.Logger, ticker *clock.Ticker, cfg ManagerCfg
 		store:                cfg.InstanceStore,
 		ticker:               ticker,
 		doNotSaveNormalState: cfg.DoNotSaveNormalState,
+		batchSize:            cfg.StatePeriodicSaveBatchSize,
 		metrics:              cfg.Metrics,
 	}
 }
@@ -58,11 +60,11 @@ func (a *AsyncStatePersister) fullSync(ctx context.Context, instancesProvider Al
 	startTime := time.Now()
 	a.log.Debug("Full state sync start")
 	instances := instancesProvider.GetAlertInstances(a.doNotSaveNormalState)
-	if err := a.store.FullSync(ctx, instances); err != nil {
+	if err := a.store.FullSync(ctx, instances, a.batchSize); err != nil {
 		a.log.Error("Full state sync failed", "duration", time.Since(startTime), "instances", len(instances))
 		return err
 	}
-	a.log.Debug("Full state sync done", "duration", time.Since(startTime), "instances", len(instances))
+	a.log.Debug("Full state sync done", "duration", time.Since(startTime), "instances", len(instances), "batchSize", a.batchSize)
 	if a.metrics != nil {
 		a.metrics.StateFullSyncDuration.Observe(time.Since(startTime).Seconds())
 	}

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -64,7 +64,7 @@ func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key 
 	return nil
 }
 
-func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.AlertInstance) error {
+func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = []any{}

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -114,9 +114,10 @@ type UnifiedAlertingSettings struct {
 	RecordingRules                RecordingRuleSettings
 
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
-	MaxStateSaveConcurrency   int
-	StatePeriodicSaveInterval time.Duration
-	RulesPerRuleGroupLimit    int64
+	MaxStateSaveConcurrency    int
+	StatePeriodicSaveInterval  time.Duration
+	StatePeriodicSaveBatchSize int
+	RulesPerRuleGroupLimit     int64
 
 	// Retention period for Alertmanager notification log entries.
 	NotificationLogRetention time.Duration
@@ -456,6 +457,8 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if err != nil {
 		return err
 	}
+
+	uaCfg.StatePeriodicSaveBatchSize = ua.Key("state_periodic_save_batch_size").MustInt(1)
 
 	uaCfg.NotificationLogRetention, err = gtime.ParseDuration(valueAsString(ua, "notification_log_retention", (5 * 24 * time.Hour).String()))
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

This PR adds the `state_periodic_save_batch_size` configuration option, which allows control over the batch size of alert instances inserted during periodic state saving when `alertingSaveStatePeriodic` feature flag is enabled

**Why do we need this feature?**

During periodic async state saving, a large number of alert instances in memory increase the time required to complete the sync process. Because the save happens in a single transaction, the alert instances in the database table remain locked for the entire duration, blocking alert rules operations, etc.

Adjusting the batch size can reduce the sync time, but can cause higher load on the database.

<details>
  <summary>Example</summary>

**state_periodic_save_batch_size = 1**
```
level=debug msg="Full state sync done" duration=58.325004959s instances=125100
level=debug msg="Full state sync done" duration=1m5.586675333s instances=125100
level=debug msg="Full state sync done" duration=1m9.609511708s instances=125100  
```

**state_periodic_save_batch_size = 1000**
```
level=debug msg="Full state sync done" duration=9.639794166s instances=125100
level=debug msg="Full state sync done" duration=8.174613666s instances=125100
level=debug msg="Full state sync done" duration=7.905657334s instances=125100
```

</details>

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
