### PR TITLE
LBAC for datasources: Add `prometheus` as a data source and refactor to change wording from logs to logs or metrics

### DIFF
--- a/docs/sources/administration/data-source-management/teamlbac/_index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/_index.md
@@ -1,8 +1,9 @@
 ---
-description: Label based data access for Loki given Teams
+description: Label based data access for Teams
 keywords:
   - grafana
   - loki
+  - mimir
   - lbac
 labels:
   products:
@@ -14,17 +15,26 @@ weight: 100
 
 # Label Based Access Control (LBAC) for data sources
 
-Label Based Access Control (LBAC) simplifies and streamlines data source access management based on team memberships.
+Label Based Access Control (LBAC) for data sources simplifies and streamlines data source access management based on team memberships.
+Label-Based Access Control (LBAC) allows fine-grained access control to data sources by filtering logs or metrics based on labels. It lets administrators configure access rules for teams, ensuring that users only query data relevant to their assigned permissions.
+
+## Supported Data Sources
+
+LBAC for data sources is currently available for `Loki, Prometheus` with basic authentication. Support for additional data sources may be added in future updates.
+
+**LBAC for data sources offers:**
+
+- Team-based access control using `LogQL` rules.
+- Simplified data source management by consolidating multiple sources into one.
+- Dashboard reuse across teams with tailored access.
 
 {{< admonition type="note" >}}
-LBAC rules is available for preview for logs with Loki in Grafana Cloud.
+LBAC rules is available for **private preview** in Grafana Cloud.
 Report any unexpected behavior to the Grafana Support team.
-
-To use LBAC rules you must enable the `teamHttpHeaders` feature toggle because the feature uses HTTP headers for the LBAC rules requests.
 {{< /admonition >}}
 
-You can configure user access based upon team memberships using LogQL.
-LBAC for data sources controls access to logs depending on the rules set for each team.
+You can configure user access based upon team memberships using `LogQL`.
+LBAC for data sources controls access to logs or metrics depending on the rules set for each team.
 
 This feature addresses two common challenges faced by Grafana users:
 
@@ -33,18 +43,32 @@ This feature addresses two common challenges faced by Grafana users:
 1. Using the same dashboard across multiple teams.
    LBAC for data sources lets Grafana Teams use the same dashboard with different access control rules.
 
-To set up LBAC for data sources for a Loki data source, refer to [Configure LBAC for data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/).
+To set up LBAC for data sources for a Loki data source, refer to [Configure LBAC for Loki Data Source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/).
+To set up LBAC for data sources for a Loki data source, refer to [Configure LBAC for Prometheus Data Source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/configure-teamlbac-for-prometheus/).
+
+## Logs and Metrics Filtering with LBAC
+
+LBAC for data sources enables you to filter access for both logs and metrics. By defining rules with label selectors, you can specify:
+
+- **Logs**: Control access to log lines using LogQL queries with labels such as `namespace` or `cluster`.
+- **Metrics**: Control access to metric data points using LogQL with labels such as `job` or `region` and access for metrics `__name__`.
+
+This flexibility allows teams to use the same data source for multiple use cases while maintaining secure access boundaries.
+
+## Before you begin
+
+To be able to use LBAC for data sources, you need to enable the feature toggle `teamHttpHeaders` on your Grafana instance.
 
 ## Limitations
 
 - There is a set number of rules to be configured within a data source, depending on the size of the rules.
   - Around ~500-600 rules is the upper limit.
-- If there are no LBAC for data sources rules for a user's team, that user can query all logs.
+- If there are no LBAC for data sources rules for a user's team, that user can query all logs or metrics.
 - If an administrator is part of a team with LBAC for data sources rules, those rules are applied to the administrator requests.
 - Cloud Access Policy (CAP) LBAC rules override LBAC for data sources rules.
   CAP are the access controls from Grafana Cloud.
 
-You must remove any label selectors from your Cloud Access Policy that is configured for the Loki data source, otherwise the CAP label selectors override the LBAC for data sources rules. For more information about CAP label selectors, refer to [Use label-based access control (LBAC) with access policies](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/label-access-policies/).
+You must remove any label selectors from your Cloud Access Policy that is configured for the data source, otherwise the CAP label selectors override the LBAC for data sources rules. For more information about CAP label selectors, refer to [Use label-based access control (LBAC) with access policies](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/label-access-policies/).
 
 ## Data source permissions
 
@@ -54,17 +78,17 @@ You must remove any label selectors from your Cloud Access Policy that is config
 
 ## Recommended setup
 
-It's recommended that you create a single Loki data source for using LBAC for data sources rules so you have a clear separation of data sources using LBAC for data sources and those that aren't.
+It's recommended that you create a single data source for using LBAC for data sources rules so you have a clear separation of data sources using LBAC for data sources and those that aren't.
 All teams should have with only teams having `query` permission.
-You should create another Loki data source configured without LBAC for data sources for full access to the logs.
+You should create another data source configured without LBAC for data sources for full access.
 
 ## LBAC rules
 
-Grafana adds LBAC for data sources rules to the HTTP request via the Loki data source.
+Grafana adds LBAC for data sources rules to the HTTP request via the data source.
 
 If you configure multiple rules for a team, each rule is evaluated separately.
 Query results include lines that match any of the rules.
 
 Only users with data source `Admin` permissions can edit LBAC for data sources rules in the **Data source permissions** tab because changing LBAC rules requires the same access level as editing data source permissions.
 
-To set up LBAC for data sources for a Loki data source, refer to [Configure LBAC for data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/).
+To set up LBAC for data sources for a data source, refer to [Configure LBAC for data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/configure-teamlbac-for-loki/).

--- a/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-prometheus/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/configure-teamlbac-for-prometheus/index.md
@@ -1,0 +1,92 @@
+---
+description: Configure LBAC for data sources for Prometheus data source
+keywords:
+  - Prometheus
+  - datasource
+  - team
+labels:
+  products:
+    - cloud
+    - enterprise
+title: Configure LBAC for data sources for Prometheus
+weight: 250
+---
+
+# Configure LBAC for data sources for Prometheus data source
+
+## Grafana Cloud
+
+LBAC for data sources is available in private preview on Grafana Cloud for Prometheus created with basic authentication. Prometheus data sources for LBAC for data sources can only be created, provisioning is currently not available.
+
+You cannot configure LBAC rules for Grafana-provisioned data sources from the UI. Alternatively, you can replicate the setting of the provisioned data source in a new data source as described in [LBAC Configuration for New Prometheus Data Source](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/configure-teamlbac-for-Prometheus/#task-1-lbac-configuration-for-new-Prometheus-data-source) and then add the LBAC configuration to the new data source.
+
+## Before you begin
+
+To be able to use LBAC for data sources rules, you need to enable the feature toggle `teamHttpHeaders` on your Grafana instance. Contact support to enable the feature toggle for you.
+
+- Be sure that you have the permission setup to create a Prometheus tenant in Grafana Cloud
+- Be sure that you have admin data source permissions for Grafana.
+
+### Permissions
+
+We recommend that you remove all permissions for roles and teams that are not required to access the data source. This will help to ensure that only the required teams have access to the data source. The recommended permissions are `Admin` permission and only add the teams `Query` permissions that you want to add LBAC for data sources rules for.
+
+## Task 1: LBAC Configuration for New Prometheus Data Source
+
+1. Access Prometheus data sources details for your stack through grafana.com
+1. Copy Prometheus details and create a CAP
+   - Copy the details of your Prometheus setup.
+   - Create a Cloud Access Policy (CAP) for the Prometheus data source in grafana.com.
+   - Ensure the CAP includes `metrics:read` permissions.
+   - Ensure the CAP does not include `labels` rules.
+1. Create a new Prometheus data source
+   - In Grafana, proceed to add a new data source and select Prometheus as the type.
+1. Navigate back to the Prometheus data source
+   - Set up the Prometheus data source using basic authentication. Use the `userID` as the username. Use the generated CAP `token` as the password.
+   - Save and connect.
+1. Navigate to data source permissions
+   - Go to the permissions tab of the newly created Prometheus data source. Here, you'll find the LBAC for data sources rules section.
+
+For more information on how to setup LBAC for data sources rules for a Prometheus data source, refer to [Create LBAC for data sources rules for the Prometheus data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/create-teamlbac-rules/).
+
+## Grafana Enterprise
+
+LBAC for data sources is available in Grafana Enterprise for Prometheus created with basic authentication. Prometheus data sources for LBAC for data sources can only be created.
+
+You cannot configure LBAC rules for Grafana-provisioned data sources from the UI. Alternatively, you can replicate the setting of the provisioned data source in a new data source as described in [LBAC Configuration for New Prometheus Data Source](https://grafana.com/docs/grafana/latest/administration/data-source-management/teamlbac/configure-teamlbac-for-Prometheus/#task-1-lbac-configuration-for-new-Prometheus-data-source) and then add the LBAC configuration to the new data source.
+
+## Before you begin
+
+To be able to use LBAC for data sources rules, you need to enable the feature toggle `teamHttpHeaders` on your Grafana instance. Contact support to enable the feature toggle for you.
+
+- Be sure that you have the permission setup to create a cluster in your Grafana
+- Be sure that you have admin plugins permissions for Grafana.
+- Be sure that you have admin data source permissions for Grafana.
+
+### Permissions
+
+We recommend that you remove all permissions for roles and teams that are not required to access the data source. This will help to ensure that only the required teams have access to the data source. The recommended permissions are `Admin` permission and only add the teams `Query` permissions that you want to add LBAC for data sources rules for.
+
+## Task 0: Setup Grafana Enterprise Metrics tenant and access policies
+
+1. Access the plugins page and install Grafana Enterprise Metrics plugins
+1. Connect your plugin and use app as the cluster
+1. Access the app Grafana Enterprise Metrics and configure a tenant
+1. Store the `uid` of the tenant to be used as the username for the basic authentication
+1. Access the policies page inside of the app and create a AP
+   - Create a Access Policy (CAP) for the Prometheus data source.
+   - Ensure the CAP includes `metrics:read` permissions.
+   - Ensure the CAP does not include `labels` rules.
+   - Store the `token` to be used as password for authentication.
+
+## Task 1: LBAC Configuration for New Prometheus Data Source
+
+1. Create a new Prometheus data source
+   - In Grafana, proceed to add a new data source and select Prometheus as the type.
+1. Navigate back to the Prometheus data source
+   - Set up the Prometheus data source using basic authentication. Use the `uid` as the username. Use the generated `token` as the password.
+   - Save and connect.
+1. Navigate to data source permissions
+   - Go to the permissions tab of the newly created Prometheus data source. Here, you'll find the LBAC for data sources rules section.
+
+For more information on how to setup LBAC for data sources rules for a Prometheus data source, refer to [Create LBAC for data sources rules for the Prometheus data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/teamlbac/create-teamlbac-rules/).

--- a/docs/sources/administration/data-source-management/teamlbac/create-teamlbac-rules/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/create-teamlbac-rules/index.md
@@ -11,7 +11,7 @@ title: Create LBAC for data sources rules for a supported data source
 weight: 250
 ---
 
-# Create LBAC for Data Source Rule
+# Create LBAC for data source rule
 
 LBAC for data sources is available for LBAC-supported data sources created with basic authentication. As of today, managed/provisioned data source can **NOT** be configured with LBAC rules.
 
@@ -23,7 +23,7 @@ To be able to use LBAC for data sources rules, you need to enable the feature to
 - Be sure that you have admin data source permissions for Grafana.
 - Be sure that you have a team setup in Grafana.
 
-### Create a LBAC for data sources Rule for a team
+### Create a LBAC for data sources rule for a team
 
 1. Navigate to your data source
 1. Navigate to the permissions tab
@@ -33,7 +33,7 @@ To be able to use LBAC for data sources rules, you need to enable the feature to
 1. Define a label selector for the rule
    - Add a label selector to the rule. Refer to documentation for guidance on the types of log selections you can specify.
 
-### LBAC Rule
+### LBAC rule
 
 An LBAC rule is a `logql` query that filters logs or metrics based on labels. Each rule operates independently as its own filter, separate from other rules within a team.
 
@@ -55,7 +55,7 @@ To validate the rules, we recommend testing the rules in the Explore view. This 
 
 #### Tasks
 
-### Task 1: One Rule Setup for Each Team
+### Task 1: One rule setup for each team
 
 One common use case for creating an LBAC policy is to grant access to logs or metrics with a specific label. For example, you can create a label policy that includes all log lines or metrics with the label `namespace`.
 

--- a/docs/sources/administration/data-source-management/teamlbac/create-teamlbac-rules/index.md
+++ b/docs/sources/administration/data-source-management/teamlbac/create-teamlbac-rules/index.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to create LBAC for data sources rules for the Loki data source.
+description: Learn how to create LBAC for data sources rules for a supported data source.
 keywords:
   - loki
   - lbac
@@ -7,13 +7,13 @@ keywords:
 labels:
   products:
     - cloud
-title: Create LBAC for data sources rules for the Loki data source
+title: Create LBAC for data sources rules for a supported data source
 weight: 250
 ---
 
-# Create LBAC for data sources rules for the Loki data source
+# Create LBAC for Data Source Rule
 
-LBAC for data sources is available on Cloud for Loki data sources created with basic authentication. Managed/Provisioned Loki data source can **NOT** be configured with LBAC for data sources as of now.
+LBAC for data sources is available for LBAC-supported data sources created with basic authentication. As of today, managed/provisioned data source can **NOT** be configured with LBAC rules.
 
 ## Before you begin
 
@@ -25,17 +25,22 @@ To be able to use LBAC for data sources rules, you need to enable the feature to
 
 ### Create a LBAC for data sources Rule for a team
 
-1. Navigate to your Loki data source
+1. Navigate to your data source
 1. Navigate to the permissions tab
    - Here, you'll find the LBAC for data sources rules section.
 1. Add a LBAC for data sources Rule
    - Add a new rule for the team in the LBAC for data sources rules section.
 1. Define a label selector for the rule
-   - Add a label selector to the rule. Refer to Loki query documentation for guidance on the types of log selections you can specify.
+   - Add a label selector to the rule. Refer to documentation for guidance on the types of log selections you can specify.
 
-### LBAC rule
+### LBAC Rule
 
-A LBAC rule is a `logql` query that runs as a query to the Loki instance for your logs. Each rule operates independently as its own filter, separate from other rules within a team. For example, you can create a label policy that includes all log lines with a specific label.
+An LBAC rule is a `logql` query that filters logs or metrics based on labels. Each rule operates independently as its own filter, separate from other rules within a team.
+
+For example:
+
+- For logs: `{namespace="dev", cluster="us-west-0"}` filters log lines matching both `namespace="dev"` and `cluster="us-west-0"`.
+- For metrics: `{job="api-server", region="europe"}` filters metric data points matching `job="api-server"` and `region="europe"`.
 
 One rule `{namespace="dev", cluster="us-west-0"}` created with multiple namespaces will be seen as `namespace="dev"` **AND** `cluster="us-west-0"`.
 Two rules `{namespace="dev"}`, `{cluster="us-west-0"}` created for a team will be seen as `namespace="dev"` **OR** `cluster="us-west-0"`.
@@ -46,39 +51,35 @@ We recommend you only add `query` permissions for teams that should use the data
 
 We recommend for a first setup, setting up as few rules as possible for each team and make them additive for simplicity.
 
-To validate the rules, we recommend testing the rules in the Loki Explore view. This will allow you to see the logs that would be returned for the rule.
+To validate the rules, we recommend testing the rules in the Explore view. This will allow you to see the metrics or logs that would be returned for the rule.
 
 #### Tasks
 
-### Task 1: One rule set up for each team
+### Task 1: One Rule Setup for Each Team
 
-One common use case for creating an LBAC policy is to have specific access to logs that have a specific label. For example, you can create a label policy that includes all log lines with the label.
+One common use case for creating an LBAC policy is to grant access to logs or metrics with a specific label. For example, you can create a label policy that includes all log lines or metrics with the label `namespace`.
 
-We have two teams, Team A and Team B with `Query` permissions. Loki access is setup with `Admin` roles to have `Admin` permission only.
+We have two teams, Team A and Team B with `Query` permissions. Data source access is set up with `Admin` roles to have `Admin` permission only.
 
 - Team A has a rule `namespace="dev"`.
 
 - Team B has a rule `namespace="prod"`.
 
-A user that is part of Team A will have access to logs that match `namespace="dev"`.
-
-A user that is part of Team B will have access to logs that match `namespace="prod"`.
-
-A user that is part of Team A and Team B will have access to logs that match `namespace="dev"` OR `namespace="prod"`.
+A user that is part of Team A will have access to logs or metrics matching `namespace="dev"`. A user in both Team A and Team B will have access to data matching `namespace="dev"` OR `namespace="prod"`.
 
 ### Task 2: Set up a rule to exclude a label for a team
 
-One common use case for creating an LBAC policy is to exclude logs that have a specific label. For example, you can create a label policy that excludes all log lines with the label `secret=true` by adding a selector with `secret!="true"` when you create an access policy:
+One common use case for creating an LBAC policy is to exclude logs or metrics that have a specific label. For example, you can create a label policy that excludes all log lines with the label `secret=true` by adding a selector with `secret!="true"` when you create an access policy:
 
-We have one team, Team A `Query` permissions. Loki access is setup with `Admin` roles to have `Admin` permission only.
+We have one team, Team A `Query` permissions. Data source access is setup with `Admin` roles to have `Admin` permission only.
 
 - Team A has a rule `secret!="true"`.
 
-A user that is part of Team A will **NOT** have access to logs that match `secret!="true"`.
+A user that is part of Team A will **NOT** have access to logs or metrics that match `secret!="true"`.
 
 ### Task 3: Set up multiple rules for a team
 
-We have two teams, Team A and Team B with `Query` permissions. Loki access is setup with `Admin` roles having `Admin` permission.
+We have two teams, Team A and Team B with `Query` permissions. Data Source access is setup with `Admin` roles having `Admin` permission.
 
 - Team A has rule `cluster="us-west-0", namespace=~"dev|prod"` configured.
 
@@ -114,7 +115,7 @@ A user in Team B will have access to logs that match `namespace!="dev"`.
 
 ### Task 5: Single rule setup for a team
 
-We have two teams, Team A and Team B. Loki access is setup with `Editor`, `Viewer` roles to have `Query` permission.
+We have two teams, Team A and Team B. Data Source access is setup with `Editor`, `Viewer` roles to have `Query` permission.
 
 - Team A has a rule `namespace="dev"` configured.
 
@@ -131,8 +132,8 @@ A user that is not part of Team A and part of Team B, that is `Editor` or `Viewe
 We have team B, user A is part of Team B and has an `Admin` basic role.
 
 - Team B has no roles assigned
-- Team B has Query permissions to data source Loki
+- Team B has Query permissions to data source
 
 - Team B has a rule `{ project_id="project-dev" }`
 
-User A may only access logs for data source Loki that match `{ project_id="project-dev" }` and no other logs on the data source.
+User A may only access logs or metrics for a data source that match `{ project_id="project-dev" }`.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We are introducing metrics for LBAC for datasources, we are therefore also changing the wording from logs to logs or metrics and removing the specific Loki data source reference.

**Why do we need this feature?**

We are supporting mimir/prometheus as a data source which you can configure LBAC rules for. This is highly requested for our users.

**Who is this feature for?**

Enterprise, Cloud


**Which issue(s) does this PR fix?**:
https://github.com/grafana/identity-access-team/issues/1067
