### PR TITLE
Faro: Improve performance of TRACKING_URLS regex

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -37,9 +37,8 @@ export interface GrafanaJavascriptAgentBackendOptions extends BrowserConfig {
   ignoreUrls: RegExp[];
 }
 
-const TRACKING_URLS = [
-  /.*.google-analytics.com*.*/,
-  /.*.googletagmanager.com*.*/,
+export const TRACKING_URLS = [
+  /\.(google-analytics|googletagmanager)\.com/,
   /frontend-metrics/,
   /\/collect(?:\/[\w]*)?$/,
 ];


### PR DESCRIPTION
**What is this feature?**

This pul request uses a simpler regular expression, that ensures we are blocking the appropriate URLs without the performance hit. To prevent that from happening, a timed test is introduced. The timeout threshold is long enough to be hardware independent.

**Why do we need this feature?**

There have been reports of faro performing poorly when the URLs generated are long (there was a 39KB one). The TRACKING_URLS we are using leading wildcard characters, leading to excessive backtracking.

**Who is this feature for?**

Every use of both OSS grafana and Grafana Cloud

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
