### PR TITLE
Explore Metrics: Fix url sync for view by dropdown

### DIFF
--- a/public/app/features/trails/DataTrail.tsx
+++ b/public/app/features/trails/DataTrail.tsx
@@ -33,6 +33,7 @@ import {
   sceneUtils,
   SceneVariable,
   SceneVariableSet,
+  UrlSyncContextProvider,
   UrlSyncManager,
   VariableDependencyConfig,
   VariableValueSelectors,
@@ -668,7 +669,11 @@ export class DataTrail extends SceneObjectBase<DataTrailState> implements SceneO
             <settings.Component model={settings} />
           </div>
         )}
-        <div className={styles.body}>{topScene && <topScene.Component model={topScene} />}</div>
+        {topScene && (
+          <UrlSyncContextProvider scene={topScene}>
+            <div className={styles.body}>{topScene && <topScene.Component model={topScene} />}</div>
+          </UrlSyncContextProvider>
+        )}
       </div>
     );
   };


### PR DESCRIPTION
**What is this feature?**

View by dropdown value couldn't preserve in the URL when refreshing the page or copying/pasting the url.
This fix ensures that the value will be preserved in the url. 