### PR TITLE
Alerting: add help tooltip for the Preview silences UI

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2567,11 +2567,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/alerting/unified/components/silences/SilencesEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2568,8 +2568,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/alerting/unified/components/silences/SilencesEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -4,6 +4,7 @@ import { useDebounce, useDeepCompareEffect } from 'react-use';
 
 import { GrafanaTheme2, dateTime } from '@grafana/data';
 import { Alert, Badge, Icon, LoadingPlaceholder, Tooltip, useStyles2 } from '@grafana/ui';
+import { Trans } from 'app/core/internationalization';
 import { MatcherFieldValue } from 'app/features/alerting/unified/types/silence-form';
 import { matcherFieldToMatcher } from 'app/features/alerting/unified/utils/alertmanager';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
@@ -79,17 +80,24 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   return (
     <div>
       <h4 className={styles.title}>
-        Affected alert rule instances&nbsp;
+        <Trans i18nKey="alerting.silences.affected-instances">Affected alert rule instances</Trans>
         <Tooltip
           content={
             <div>
-              Preview the alert instances affected by this silence.
+              <Trans i18nKey="alerting.silences.preview-affected-instances">
+                Preview the alert instances affected by this silence.
+              </Trans>
               <br />
-              Only alert instances in the firing state are displayed.
+              <Trans i18nKey="alerting.silences.only-firing-instances">
+                Only alert instances in the firing state are displayed.
+              </Trans>
             </div>
           }
         >
-          <Icon name="info-circle" size="sm" />
+          <span>
+            &nbsp;
+            <Icon name="info-circle" size="sm" />
+          </span>
         </Tooltip>
         {tableItemAlerts.length > 0 ? (
           <Badge className={styles.badge} color="blue" text={tableItemAlerts.length} />

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -108,7 +108,7 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
               pagination={{ itemsPerPage: 10 }}
             />
           ) : (
-            <span>No firing alert instances Afound</span>
+            <span>No firing alert instances found</span>
           )}
         </div>
       )}

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useDebounce, useDeepCompareEffect } from 'react-use';
 
 import { GrafanaTheme2, dateTime } from '@grafana/data';
-import { Alert, Badge, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
+import { Alert, Badge, Icon, LoadingPlaceholder, Tooltip, useStyles2 } from '@grafana/ui';
 import { MatcherFieldValue } from 'app/features/alerting/unified/types/silence-form';
 import { matcherFieldToMatcher } from 'app/features/alerting/unified/utils/alertmanager';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
@@ -79,7 +79,18 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   return (
     <div>
       <h4 className={styles.title}>
-        Affected alert rule instances
+        Affected alert rule instances&nbsp;
+        <Tooltip
+          content={
+            <div>
+              Preview the alert instances affected by this silence.
+              <br />
+              Only alert instances in the firing state are displayed.
+            </div>
+          }
+        >
+          <Icon name="info-circle" size="sm" />
+        </Tooltip>
         {tableItemAlerts.length > 0 ? (
           <Badge className={styles.badge} color="blue" text={tableItemAlerts.length} />
         ) : null}
@@ -97,7 +108,7 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
               pagination={{ itemsPerPage: 10 }}
             />
           ) : (
-            <span>No firing alert instances found</span>
+            <span>No firing alert instances Afound</span>
           )}
         </div>
       )}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -527,6 +527,11 @@
       },
       "save-query": "Save current search"
     },
+    "silences": {
+      "affected-instances": "Affected alert rule instances",
+      "only-firing-instances": "Only alert instances in the firing state are displayed.",
+      "preview-affected-instances": "Preview the alert instances affected by this silence."
+    },
     "simpleCondition": {
       "alertCondition": "Alert condition"
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -527,6 +527,11 @@
       },
       "save-query": "Ŝävę čūřřęŉŧ şęäřčĥ"
     },
+    "silences": {
+      "affected-instances": "Åƒƒęčŧęđ äľęřŧ řūľę įŉşŧäŉčęş",
+      "only-firing-instances": "Øŉľy äľęřŧ įŉşŧäŉčęş įŉ ŧĥę ƒįřįŉģ şŧäŧę äřę đįşpľäyęđ.",
+      "preview-affected-instances": "Přęvįęŵ ŧĥę äľęřŧ įŉşŧäŉčęş äƒƒęčŧęđ þy ŧĥįş şįľęŉčę."
+    },
     "simpleCondition": {
       "alertCondition": "Åľęřŧ čőŉđįŧįőŉ"
     },


### PR DESCRIPTION
We've recently updated the [create silence docs](https://grafana.com/docs/grafana/next/alerting/configure-notifications/create-silence/). Previously, there was a note about the Preview of silenced alerts:

![Screenshot 2024-12-16 at 13 47 05](https://github.com/user-attachments/assets/6cfd764c-96e3-48fb-b171-8f4125120be0)

This PR adds a help tooltip to the `Affected alert rule instances` section for that:

```
Preview the alert instances affected by this silence.
Only alert instances in the firing state are displayed.
```

![Screenshot 2024-12-16 at 13 00 20](https://github.com/user-attachments/assets/c2e8a871-9438-4d88-a84c-8169ee9d7cba)


![Screenshot 2024-12-16 at 12 59 53](https://github.com/user-attachments/assets/ed22f9f0-b1bb-4d64-acd0-6f8e932e5c73)

For consideration:

- Rename `Affected alert rule instances`  (the term alert rule instances is rarely used) 
