### PR TITLE
Use v2 of publishing workflow that checks out HEAD of version branch on tag events

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
-          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
-          release_branch_with_patch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+          release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.x$"
+          release_branch_with_patch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           website_directory: content/docs/grafana
           version_suffix: ""


### PR DESCRIPTION
This uses a script check in the first step of tag events that switches the checkout to the version branch that the tag refers to: https://github.com/grafana/writers-toolkit/blob/main/publish-technical-documentation-release/determine-release-branch.

Implemented in:

- https://github.com/grafana/writers-toolkit/commit/305f9896c4edb0a90ef95fc477ebe46598d26458
- https://github.com/grafana/writers-toolkit/commit/541fb6e8bde2eb477c14a4e975603464ac557429

Because the script uses Bash regular expression pattern matching, inputs must use Extended Regular Expression syntax.
