### PR TITLE
[Azure Monitor]: Updates azure monitor OOB dashboards to no longer include angular panels

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/dashboards/adx.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/adx.json
@@ -1,22 +1,18 @@
 {
+  "__inputs": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.4.3"
+      "version": "10.4.7"
     },
     {
       "type": "datasource",
       "id": "grafana-azure-monitor-datasource",
       "name": "Azure Monitor",
-      "version": "0.3.0"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
+      "version": "1.0.0"
     },
     {
       "type": "panel",
@@ -29,18 +25,42 @@
       "id": "table",
       "name": "Table",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
     }
   ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "The dashboard provides insights of Azure Data Explorer Cluster Resource overview, key mettrics, usage, tables, cache and ingestion.",
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1622241391232,
   "links": [],
   "panels": [
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -49,18 +69,29 @@
       },
       "id": 6,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Overview",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -79,7 +110,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
+        "w": 4,
         "x": 0,
         "y": 1
       },
@@ -94,34 +125,29 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "KeepAlive",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -163,29 +189,29 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Keep Alive (Avg)",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -204,8 +230,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 3,
+        "w": 4,
+        "x": 4,
         "y": 1
       },
       "id": 12,
@@ -219,34 +245,29 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "CPU",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -288,29 +309,29 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "CPU (Avg)",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -329,8 +350,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 6,
+        "w": 4,
+        "x": 8,
         "y": 1
       },
       "id": 13,
@@ -344,34 +365,29 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "IngestionUtilization",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -413,29 +429,29 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Ingestion Utilization (Avg)  ",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -454,8 +470,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 9,
+        "w": 4,
+        "x": 12,
         "y": 1
       },
       "id": 14,
@@ -469,34 +485,29 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "IngestionLatencyInSeconds",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -538,29 +549,29 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Ingestion Latency (Avg)  ",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -579,8 +590,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 12,
+        "w": 4,
+        "x": 16,
         "y": 1
       },
       "id": 15,
@@ -594,34 +605,29 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "CacheUtilization",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -663,29 +669,29 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Cache Utilization (Avg)",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
+          "noValue": "-",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -704,8 +710,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 15,
+        "w": 4,
+        "x": 20,
         "y": 1
       },
       "id": 16,
@@ -719,27 +725,18 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Total"],
             "aggregation": "Total",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -750,8 +747,12 @@
             "metricDefinition": "$ns",
             "metricName": "IngestionResult",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -793,22 +794,22 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Succeeded Ingestions (#)",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "description": "The aggregated usage in the cluster, out of the total used CPU and memory. To see more details, go to the Usage tab.",
       "fieldConfig": {
         "defaults": {
@@ -816,8 +817,12 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -835,179 +840,140 @@
       },
       "id": 17,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is KustoRunner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand \r\n    | where TimeGenerated > datetime(2020-09-09T09:30:00Z) \r\n    | where LastUpdatedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak) \r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where LastUpdatedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State, FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest'\r\n    //| where totimespan(TotalCPU) > totimespan(0)\r\n    | summarize TotalCPU=max(TotalCPU) \r\n        , MemoryPeak=max(MemoryPeak)\r\n        by User, ApplicationName, CorrelationId \r\n;\r\nlet totalCPU = toscalar(dataset\r\n    | summarize sum((totimespan(TotalCPU) / 1s)));\r\nlet totalMemory = toscalar(dataset\r\n    | summarize sum(MemoryPeak));\r\nlet topMemory = \r\n    dataset\r\n    | top-nested 10000 of User with others=\"Others\" by sum(MemoryPeak), top-nested 10000 of ApplicationName with others=\"Others\" by sum(MemoryPeak)\r\n    | extend PercentOfTotalClusterMemoryUsed = aggregated_ApplicationName / toreal(totalMemory)\r\n;\r\nlet topCpu = \r\n    dataset\r\n    | top-nested 10000 of User with others=\"Others\" by sum(totimespan(TotalCPU) / 1s), top-nested 10000 of ApplicationName with others=\"Others\" by sum(totimespan(TotalCPU) / 1s)\r\n    | extend PercentOfTotalClusterCpuUsed = aggregated_ApplicationName / toreal(totalCPU)\r\n;\r\ntopMemory\r\n| join kind = fullouter(topCpu) on User, ApplicationName\r\n| extend BothPercentages = PercentOfTotalClusterMemoryUsed + PercentOfTotalClusterCpuUsed\r\n| top 10 by BothPercentages desc\r\n| extend User = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", strcat(\"Kusto Data Management \", \"(\", User, \")\"),\r\n    ApplicationName == \"KustoQueryRunner\", strcat(\"Kusto Query Runner \", \"(\", User, \")\"),\r\n    User == \"AAD app id=e0331ea9-83fc-4409-a17d-6375364c3280\", \"DataMap Agent 001 (app id: e0331ea9-83fc-4409-a17d-6375364c3280)\", // Used for internal MS clusters \r\n    User)\r\n| extend PercentOfTotalClusterMemoryUsed_display = iff(isnan(PercentOfTotalClusterMemoryUsed * 100), toreal(0), PercentOfTotalClusterMemoryUsed * 100)\r\n| extend PercentOfTotalClusterCpuUsed_display = iff(isnan(PercentOfTotalClusterCpuUsed * 100), toreal(0), PercentOfTotalClusterCpuUsed * 100)\r\n| where not (ApplicationName == \"Others\" and PercentOfTotalClusterMemoryUsed_display == 0 and PercentOfTotalClusterCpuUsed_display == 0)\r\n| project User, ApplicationName, PercentOfTotalClusterMemoryUsed_display, PercentOfTotalClusterCpuUsed_display",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
+            "resources": ["$ws"],
             "resultFormat": "time_series"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Top resource consumers",
-      "transparent": true,
       "type": "table"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "description": "Over a sliding timeline window. Not affected by the time range parameter",
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 6
       },
-      "hiddenSeries": false,
       "id": 2,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 3,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak) \r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ApplicationName != 'Kusto.WinSvc.DM.Svc'\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ApplicationName != 'Kusto.WinSvc.DM.Svc'\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User,\r\n        ApplicationName,\r\n        Principal,\r\n        TotalCPU,\r\n        MemoryPeak,\r\n        CorrelationId,\r\n        cluster_name;\r\nlet raw = dataset_commands_queries\r\n    | where LastUpdatedOn > ago(7d)\r\n    | where cluster_name == 'mitulktest'\r\n    | where StartedOn > ago(365d)\r\n;\r\nraw\r\n| evaluate activity_engagement(User, StartedOn, 1d, 7d)\r\n| join kind = inner (\r\n    raw\r\n    | evaluate activity_engagement(User, StartedOn, 1d, 30d)\r\n    )\r\n    on StartedOn\r\n| project StartedOn, Daily=dcount_activities_inner, Weekly=dcount_activities_outer, Monthly = dcount_activities_outer1     \r\n| where StartedOn > ago(90d)\r\n| project Daily, StartedOn, Weekly, Monthly\r\n| sort by StartedOn asc\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
+            "resources": ["$ws"],
             "resultFormat": "time_series"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Unique user count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1016,84 +982,114 @@
       },
       "id": 19,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Key Metrics",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 0,
         "y": 16
       },
-      "hiddenSeries": false,
       "id": 20,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "KeepAlive",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1135,131 +1131,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Keep Alive",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 6,
         "y": 16
       },
-      "hiddenSeries": false,
       "id": 21,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "CPU",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1301,131 +1280,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "CPU",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 12,
         "y": 16
       },
-      "hiddenSeries": false,
       "id": 22,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "CacheUtilization",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1467,131 +1429,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Cache Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 18,
         "y": 16
       },
-      "hiddenSeries": false,
       "id": 23,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "InstanceCount",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1633,131 +1578,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Instance Count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 0,
         "y": 26
       },
-      "hiddenSeries": false,
       "id": 24,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "TotalNumberOfConcurrentQueries",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1799,124 +1727,103 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Concurrent Queries",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 6,
         "y": 26
       },
-      "hiddenSeries": false,
       "id": 25,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum", "Total"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -1927,8 +1834,12 @@
             "metricDefinition": "$ns",
             "metricName": "QueryDuration",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1970,124 +1881,103 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Query Duration",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 12,
         "y": 26
       },
-      "hiddenSeries": false,
       "id": 26,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum", "Total"],
             "aggregation": "Total",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -2098,8 +1988,12 @@
             "metricDefinition": "$ns",
             "metricName": "TotalNumberOfThrottledCommands",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -2141,131 +2035,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Throttled Commands",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 18,
         "y": 26
       },
-      "hiddenSeries": false,
       "id": 27,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum", "Total"],
             "aggregation": "Maximum",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "TotalNumberOfThrottledQueries",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -2307,131 +2184,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Throttled Queries",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 0,
         "y": 36
       },
-      "hiddenSeries": false,
       "id": 28,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "IngestionUtilization",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -2473,131 +2333,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Ingestion Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 6,
         "y": 36
       },
-      "hiddenSeries": false,
       "id": 29,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Maximum", "Minimum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "IngestionLatencyInSeconds",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -2639,124 +2482,103 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Ingestion Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "s",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 12,
         "y": 36
       },
-      "hiddenSeries": false,
       "id": 30,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Total"],
             "aggregation": "Total",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -2767,8 +2589,12 @@
             "metricDefinition": "$ns",
             "metricName": "IngestionResult",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -2810,124 +2636,103 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Ingestion Result",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 18,
         "y": 36
       },
-      "hiddenSeries": false,
       "id": 31,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Total", "Maximum"],
             "aggregation": "Total",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -2938,8 +2743,12 @@
             "metricDefinition": "$ns",
             "metricName": "IngestionVolumeInMB",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -2981,131 +2790,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Ingestion Volume",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "decbytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 0,
         "y": 46
       },
-      "hiddenSeries": false,
       "id": 32,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Minimum", "Maximum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "StreamingIngestDataRate",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -3147,131 +2939,114 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Streaming Ingest Data Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 6,
         "y": 46
       },
-      "hiddenSeries": false,
       "id": 33,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average", "Minimum", "Maximum"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns",
             "metricName": "StreamingIngestDuration",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -3313,124 +3088,252 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Streaming Ingest Duration",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 12,
         "y": 46
       },
-      "hiddenSeries": false,
-      "id": 35,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 34,
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
+          "azureMonitor": {
+            "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
+            "aggregation": "None",
+            "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
+            "dimensionFilters": [],
+            "dimensions": [],
+            "metricDefinition": "$ns",
+            "metricName": "SteamingIngestRequestRate",
+            "metricNamespace": "Microsoft.Kusto/clusters",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
+            "timeGrain": "auto",
+            "timeGrains": [
+              {
+                "text": "auto",
+                "value": "auto"
+              },
+              {
+                "text": "1 minute",
+                "value": "PT1M"
+              },
+              {
+                "text": "5 minutes",
+                "value": "PT5M"
+              },
+              {
+                "text": "15 minutes",
+                "value": "PT15M"
+              },
+              {
+                "text": "30 minutes",
+                "value": "PT30M"
+              },
+              {
+                "text": "1 hour",
+                "value": "PT1H"
+              },
+              {
+                "text": "6 hours",
+                "value": "PT6H"
+              },
+              {
+                "text": "12 hours",
+                "value": "PT12H"
+              },
+              {
+                "text": "1 day",
+                "value": "P1D"
+              }
+            ],
+            "top": "10"
           },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
+          "datasource": {
+            "uid": "$ds"
           },
+          "queryType": "Azure Monitor",
+          "refId": "A",
+          "subscription": "$sub"
+        }
+      ],
+      "title": "Streaming Ingest Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 46
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.7",
+      "targets": [
+        {
           "azureMonitor": {
             "aggOptions": ["Average"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -3441,8 +3344,12 @@
             "metricDefinition": "$ns",
             "metricName": "StreamingIngestResults",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -3484,124 +3391,103 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Streaming Ingest Result",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 56
       },
-      "hiddenSeries": false,
       "id": 36,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Total", "Average", "Minimum", "Maximum"],
             "aggregation": "Total",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -3616,8 +3502,12 @@
             "metricDefinition": "$ns",
             "metricName": "EventsProcessed",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -3659,124 +3549,103 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Events Processed",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 56
       },
-      "hiddenSeries": false,
       "id": 37,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "657b3e91-7c0b-438b-86a5-f769445e237d"
-          },
           "azureMonitor": {
             "aggOptions": ["Average"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -3791,8 +3660,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -3834,59 +3707,22 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Discovery Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3895,19 +3731,34 @@
       },
       "id": 40,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Usage",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -3925,9 +3776,16 @@
       },
       "id": 43,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -3936,9 +3794,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is KustoRunner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand \r\n    | where TimeGenerated > datetime(2020-09-09T09:30:00Z) \r\n    | where LastUpdatedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak) \r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where LastUpdatedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State, FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest'\r\n    //| where totimespan(TotalCPU) > totimespan(0)\r\n    | summarize TotalCPU=max(TotalCPU) \r\n        , MemoryPeak=max(MemoryPeak)\r\n        by User, ApplicationName, CorrelationId \r\n;\r\nlet totalCPU = toscalar(dataset\r\n    | summarize sum((totimespan(TotalCPU) / 1s)));\r\nlet totalMemory = toscalar(dataset\r\n    | summarize sum(MemoryPeak));\r\nlet topMemory = \r\n    dataset\r\n    | top-nested 10000 of User with others=\"Others\" by sum(MemoryPeak), top-nested 10000 of ApplicationName with others=\"Others\" by sum(MemoryPeak)\r\n    | extend PercentOfTotalClusterMemoryUsed = aggregated_ApplicationName / toreal(totalMemory)\r\n;\r\nlet topCpu = \r\n    dataset\r\n    | top-nested 10000 of User with others=\"Others\" by sum(totimespan(TotalCPU) / 1s), top-nested 10000 of ApplicationName with others=\"Others\" by sum(totimespan(TotalCPU) / 1s)\r\n    | extend PercentOfTotalClusterCpuUsed = aggregated_ApplicationName / toreal(totalCPU)\r\n;\r\ntopMemory\r\n| join kind = fullouter(topCpu) on User, ApplicationName\r\n| extend BothPercentages = PercentOfTotalClusterMemoryUsed + PercentOfTotalClusterCpuUsed\r\n| top 10 by BothPercentages desc\r\n| extend User = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", strcat(\"Kusto Data Management \", \"(\", User, \")\"),\r\n    ApplicationName == \"KustoQueryRunner\", strcat(\"Kusto Query Runner \", \"(\", User, \")\"),\r\n    User == \"AAD app id=e0331ea9-83fc-4409-a17d-6375364c3280\", \"DataMap Agent 001 (app id: e0331ea9-83fc-4409-a17d-6375364c3280)\", // Used for internal MS clusters \r\n    User)\r\n| extend PercentOfTotalClusterMemoryUsed_display = iff(isnan(PercentOfTotalClusterMemoryUsed * 100), toreal(0), PercentOfTotalClusterMemoryUsed * 100)\r\n| extend PercentOfTotalClusterCpuUsed_display = iff(isnan(PercentOfTotalClusterCpuUsed * 100), toreal(0), PercentOfTotalClusterCpuUsed * 100)\r\n| where not (ApplicationName == \"Others\" and PercentOfTotalClusterMemoryUsed_display == 0 and PercentOfTotalClusterCpuUsed_display == 0)\r\n| project User, ApplicationName, PercentOfTotalClusterMemoryUsed_display, PercentOfTotalClusterCpuUsed_display",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -3959,8 +3818,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -4002,31 +3865,35 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Top resource consumers (within the CPU and memory consumption of the cluster)",
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4044,9 +3911,16 @@
       },
       "id": 44,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4055,9 +3929,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where LastUpdatedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where LastUpdatedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest'\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | summarize Count=count() by User, ApplicationName\r\n    | project User, ApplicationName, Count\r\n    | extend User = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", strcat(\"Kusto Data Management \", \"(\", User, \")\"),\r\n        User == \"AAD app id=e0331ea9-83fc-4409-a17d-6375364c3280\", \"DataMap Agent 001 (app id: e0331ea9-83fc-4409-a17d-6375364c3280)\", // Used for internal MS clusters\r\n        User)\r\n    | top 10 by Count;\r\n//| order by Count desc\r\n// <Option #1 for top-nested> | top-nested 10 of User with others=\"Other Values\" by agg_User=sum(Count) desc;\r\n// <Option #2 for top-nested>| top-nested 10 of User by agg_User=sum(Count) desc, top-nested 5 of ApplicationName with others=\"Other applications\" by agg_App=sum(Count) desc\r\n// <Option #2 for top-nested>| where not (ApplicationName == \"Other applications\" and agg_App == 0)\r\n// <Option #2 for top-nested>| project-away agg_User;\r\ndataset\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -4078,8 +3953,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -4121,31 +4000,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Top principals and applications by command and query count",
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4163,9 +4045,16 @@
       },
       "id": 38,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4240,31 +4129,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Top applications by command and query count",
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4282,9 +4174,16 @@
       },
       "id": 41,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4359,31 +4258,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Top principals by command and query count",
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4401,9 +4303,16 @@
       },
       "id": 42,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4478,31 +4387,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Queries and top commands by command type",
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4520,9 +4432,16 @@
       },
       "id": 45,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4597,31 +4516,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Changes in query count by principal (not affected by the time range parameter)",
+      "title": "Changes in query count by principal (not affected by the the time range parameter)",
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4639,9 +4561,16 @@
       },
       "id": 46,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4716,72 +4645,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Failed queries",
       "transparent": true,
       "type": "table"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 0,
         "y": 79
       },
-      "hiddenSeries": false,
       "id": 47,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4790,9 +4745,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\nlet FullList = dataset\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | project User, StartedOn, ApplicationName, CommandType\r\n;\r\nlet Top =\r\n    dataset\r\n    | summarize Count=count() by User\r\n    | top 10 by Count desc\r\n    | extend OriginalUser = User\r\n    | extend Category=User\r\n;\r\nFullList\r\n| join kind=leftouter(Top) on $left.User == $right.OriginalUser\r\n| project User=coalesce(Category, 'Other'), ApplicationName, CommandType, StartedOn\r\n| extend User = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", strcat(\"Kusto Data Management \", \"(\", User, \")\"),\r\n    ApplicationName == \"KustoQueryRunner\", strcat(\"Kusto Query Runner \", \"(\", User, \")\"),\r\n    User == \"AAD app id=e0331ea9-83fc-4409-a17d-6375364c3280\", \"DataMap Agent 001 (app id: e0331ea9-83fc-4409-a17d-6375364c3280)\", // Used for internal MS clusters \r\n    User)\r\n| summarize count() by User, bin(StartedOn, 1h)\r\n| summarize sum(count_) by bin(StartedOn, 1h), tostring(User)\r\n| sort by StartedOn asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -4813,8 +4769,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -4856,108 +4816,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Command + query count by principal",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 8,
         "y": 79
       },
-      "hiddenSeries": false,
       "id": 48,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4966,9 +4916,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\nlet FullList = dataset\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | project User, ApplicationName, CommandType, StartedOn, MemoryPeak\r\n    | extend User = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", strcat(\"Kusto Data Management \", \"(\", User, \")\"),\r\n        ApplicationName == \"KustoQueryRunner\", strcat(\"Kusto Query Runner \", \"(\", User, \")\"),\r\n        User == \"AAD app id=e0331ea9-83fc-4409-a17d-6375364c3280\", \"DataMap Agent 001 (app id: e0331ea9-83fc-4409-a17d-6375364c3280)\", // Used for internal MS clusters \r\n        User)\r\n;\r\nlet Top =\r\n    FullList\r\n    | summarize Memory=sum(MemoryPeak) by User\r\n    | top 10 by Memory desc\r\n    | extend OriginalUser = User\r\n    | project OriginalUser, Category=User\r\n;\r\nFullList\r\n| join kind=leftouter(Top) on $left.User == $right.OriginalUser\r\n| project User=coalesce(Category, 'Other'), StartedOn, MemoryPeakGB=MemoryPeak / 1024.0 / 1024.0 / 1024.0\r\n| summarize MemoryPeakGB=sum(MemoryPeakGB) by User, bin(StartedOn, 1h)\r\n| summarize sum(MemoryPeakGB) by bin(StartedOn, 1h), tostring(User)\r\n| sort by StartedOn asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -4989,8 +4940,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5032,108 +4987,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Total memory by principal",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 16,
         "y": 79
       },
-      "hiddenSeries": false,
       "id": 49,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5142,9 +5087,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where StartedOn > ago(7d)\r\n    | where cluster_name == 'mitulktest';\r\nlet FullList = dataset\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | project User, ApplicationName, CommandType, StartedOn, TotalCPU\r\n    | extend User = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", strcat(\"Kusto Data Management \", \"(\", User, \")\"),\r\n        ApplicationName == \"KustoQueryRunner\", strcat(\"Kusto Query Runner \", \"(\", User, \")\"),\r\n        User == \"AAD app id=e0331ea9-83fc-4409-a17d-6375364c3280\", \"DataMap Agent 001 (app id: e0331ea9-83fc-4409-a17d-6375364c3280)\", // Used for internal MS clusters \r\n        User)\r\n;\r\nlet Top =\r\n    FullList\r\n    | summarize TotalCpu=sum(totimespan(TotalCPU)) by User\r\n    | top 10 by TotalCpu desc\r\n    | extend OriginalUser = User\r\n    | project OriginalUser, Category=User\r\n;\r\nFullList\r\n| join kind=leftouter(Top) on $left.User == $right.OriginalUser\r\n| project User=coalesce(Category, 'Other'), StartedOn, TotalCpuMinutes=totimespan(TotalCPU) / 1m\r\n| summarize TotalCpuMinutes=sum(TotalCpuMinutes) by User, bin(StartedOn, 1h)\r\n| top-nested of bin(StartedOn, 1h) by sum(TotalCpuMinutes), top-nested 5 of User with others=\"Other Values\" by sum_TotalCpuMinutes=sum(TotalCpuMinutes) desc\r\n| sort by StartedOn asc\r\n| project StartedOn, User, sum_TotalCpuMinutes\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -5165,8 +5111,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5208,108 +5158,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Total CPU by principal",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 0,
         "y": 89
       },
-      "hiddenSeries": false,
       "id": 51,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5318,9 +5258,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | extend ApplicationName = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", \"Kusto Data Management\", ApplicationName)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\nlet FullList = dataset\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | project ApplicationName, StartedOn, CommandType, User\r\n;\r\nlet Top =\r\n    FullList\r\n    | summarize Count=count() by ApplicationName\r\n    | top 10 by Count desc\r\n    | extend Category=ApplicationName\r\n;\r\nFullList\r\n| join kind=leftouter(Top) on ApplicationName \r\n| project Application=coalesce(Category, '-'), CommandType, User, StartedOn\r\n| summarize count() by Application, bin(StartedOn, 1h)\r\n| summarize sum(count_) by bin(StartedOn, time(1h)), tostring(Application)\r\n| sort by StartedOn asc\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -5341,8 +5282,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5384,108 +5329,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Command + query count by application",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 8,
         "y": 89
       },
-      "hiddenSeries": false,
       "id": 52,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5494,9 +5429,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak) \r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | extend ApplicationName = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", \"Kusto Data Management\", ApplicationName)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\nlet FullList = dataset\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | project ApplicationName, StartedOn, CommandType, User, MemoryPeak\r\n;\r\nlet Top =\r\n    FullList\r\n    | summarize Memory=sum(MemoryPeak) by ApplicationName\r\n    | top 10 by Memory desc\r\n    | extend Category=ApplicationName;\r\nFullList\r\n| join kind=inner(Top) on ApplicationName\r\n| project Application=coalesce(Category, '-'), CommandType, User, StartedOn, MemoryPeakMB=MemoryPeak / 1024.0 / 1024.0\r\n| summarize MemoryPeakMB=sum(MemoryPeakMB) by Application, bin(StartedOn, 1h)\r\n| summarize sum(MemoryPeakMB) by bin(StartedOn, time(1h)), tostring(Application)\r\n| sort by StartedOn asc\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -5517,8 +5453,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5560,108 +5500,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Total memory by application",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 16,
         "y": 89
       },
-      "hiddenSeries": false,
       "id": 50,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5670,9 +5600,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | extend ApplicationName = case(ApplicationName == \"Kusto.WinSvc.DM.Svc\", \"Kusto Data Management\", ApplicationName)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\nlet FullList = dataset\r\n    | where CommandType != 'TableSetOrAppend'\r\n    | project ApplicationName, CommandType, User, StartedOn, TotalCPU\r\n;\r\nlet Top =\r\n    FullList\r\n    | summarize TotalCPU=sum(totimespan(TotalCPU)) by ApplicationName\r\n    | top 10 by TotalCPU desc\r\n    | extend Category=ApplicationName\r\n;\r\nFullList\r\n| join kind=inner(Top) on ApplicationName\r\n| project Application=coalesce(Category, '-'), CommandType, User, StartedOn, TotalCpuMinutes=totimespan(TotalCPU) / 1m\r\n| summarize TotalCpuMinutes=sum(TotalCpuMinutes) by Application, bin(StartedOn, 1h)\r\n| summarize sum(TotalCpuMinutes) by bin(StartedOn, time(1h)), tostring(Application)\r\n| sort by StartedOn asc\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -5693,8 +5624,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5736,108 +5671,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Total CPU by application",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 0,
         "y": 99
       },
-      "hiddenSeries": false,
       "id": 53,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5846,9 +5771,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak)\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\ndataset\r\n| where CommandType != 'TableSetOrAppend' \r\n| top-nested of bin(StartedOn, time(1h)) by count(), top-nested 5 of CommandType by count_=count() desc\r\n| sort by StartedOn asc\r\n| project StartedOn, CommandType, count_\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -5869,8 +5795,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5912,108 +5842,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Queries + command count by type",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 8,
         "y": 99
       },
-      "hiddenSeries": false,
       "id": 54,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6022,9 +5942,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak) \r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\ndataset\r\n| where CommandType != 'TableSetOrAppend' \r\n| extend MemoryPeakGB=MemoryPeak / 1024.0 / 1024.0 / 1024.0\r\n| top-nested of bin(StartedOn, time(1h)) by sum(MemoryPeakGB), top-nested 5 of CommandType with others=\"Other Values\" by sum_MemoryPeakGB=sum(MemoryPeakGB) desc\r\n| sort by StartedOn asc\r\n| project StartedOn, CommandType, sum_MemoryPeakGB\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -6045,8 +5966,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -6088,108 +6013,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Total memory by type",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 8,
         "x": 16,
         "y": 99
       },
-      "hiddenSeries": false,
       "id": 55,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6198,9 +6113,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let system_databases = dynamic(['KustoMonitoringPersistentDatabase', '$systemdb']); \r\nlet system_users = dynamic(['AAD app id=b753584e-c468-4503-852a-374280ce7a62', 'KustoServiceBuiltInPrincipal']); // b753584e-c468-4503-852a-374280ce7a62 is Kusto Query Runner\r\nlet system_cluster_management_applications = dynamic(['Kusto.WinSvc.CM.Svc']); // Kusto Cluster Management\r\nlet CommandTable = ADXCommand\r\n    | extend MemoryPeak = tolong(ResourceUtilization.MemoryPeak) \r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | project-away ResourceUtilization;\r\nlet QueryTable = ADXQuery\r\n    | where StartedOn > ago(7d)\r\n    | where DatabaseName !in (system_databases) and User !in (system_users) and ApplicationName !in (system_cluster_management_applications)\r\n    | where ((false == \"false\" and ApplicationName != 'Kusto.WinSvc.DM.Svc') or false == \"true\")\r\n    | extend MemoryPeak = tolong(MemoryPeak)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | extend CommandType = 'Query';\r\nlet dataset_commands_queries = CommandTable\r\n    | union (QueryTable)\r\n    | project CommandType, DatabaseName, StartedOn, LastUpdatedOn, Duration, State,\r\n        FailureReason, RootActivityId, User, ApplicationName, Principal, TotalCPU, MemoryPeak, CorrelationId, cluster_name;\r\nlet dataset = dataset_commands_queries\r\n    | where cluster_name == 'mitulktest';\r\ndataset\r\n| where CommandType != 'TableSetOrAppend' \r\n| extend TotalCpuMinutes = totimespan(TotalCPU) / 1m\r\n| top-nested of bin(StartedOn, time(1h)) by sum(TotalCpuMinutes), top-nested 5 of CommandType with others=\"Other Values\" by sum_TotalCpuMinutes=sum(TotalCpuMinutes) desc\r\n| sort by StartedOn asc\r\n| project StartedOn, CommandType, sum_TotalCpuMinutes\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -6221,8 +6137,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -6264,67 +6184,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Total CPU by type",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -6342,9 +6229,16 @@
       },
       "id": 56,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6419,32 +6313,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Command + query count by workload group",
-      "transformations": [],
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -6462,9 +6358,16 @@
       },
       "id": 57,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6539,32 +6442,34 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Total memory by workload group",
-      "transformations": [],
       "transparent": true,
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -6582,9 +6487,16 @@
       },
       "id": 58,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6659,25 +6571,23 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Total CPU by workload group",
-      "transformations": [],
       "transparent": true,
       "type": "table"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6686,19 +6596,33 @@
       },
       "id": 60,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Tables",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -6716,9 +6640,16 @@
       },
       "id": 61,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6793,73 +6724,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "  Table details",
-      "transformations": [],
       "transparent": true,
       "type": "table"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 12,
         "x": 0,
         "y": 117
       },
-      "hiddenSeries": false,
       "id": 62,
-      "legend": {
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -6868,9 +6824,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let TotalRowCountTable = ADXTableDetails\r\n    | where TimeGenerated > ago(7d)\r\n    | project Time = TimeGenerated, Category = strcat(TableName, \" (DB: \", DatabaseName, \")\"), Value = toreal(TotalRowCount);\r\nlet topCategories = \r\n    TotalRowCountTable\r\n    | summarize sum(Value) by Category\r\n    | top 9 by sum_Value desc\r\n;\r\nTotalRowCountTable\r\n| join kind = leftouter (topCategories) on Category\r\n| project Category = coalesce(Category1, 'Other Tables'), Value, Time\r\n| summarize max(Value) by Category, bin(Time, 1h)\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -6891,8 +6848,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -6934,109 +6895,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Top tables by row count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 12,
         "x": 12,
         "y": 117
       },
-      "hiddenSeries": false,
       "id": 63,
-      "legend": {
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -7045,9 +6995,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let HotExtentSizeTable = ADXTableDetails\r\n    | where TimeGenerated > ago(7d)\r\n    | project Time = TimeGenerated, Category = strcat(TableName, \" (DB: \", DatabaseName, \")\"), Value = HotExtentSize;\r\nlet topCategories = \r\n    HotExtentSizeTable\r\n    | summarize sum(Value) by Category\r\n    | top 9 by sum_Value desc;\r\nHotExtentSizeTable\r\n| join kind = leftouter (topCategories) on Category\r\n| project Category = coalesce(Category1, 'Other Tables'), Value, Time\r\n| summarize max(Value) by Category, bin(Time, 1h)\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -7068,8 +7019,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -7111,109 +7066,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Top tables by hot cache size",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 12,
         "x": 0,
         "y": 127
       },
-      "hiddenSeries": false,
       "id": 64,
-      "legend": {
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -7222,9 +7166,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let TotalExtentCountTable = ADXTableDetails\r\n    | where TimeGenerated > ago(7d)\r\n    | project Time = TimeGenerated, Category = strcat(TableName, \" (DB: \", DatabaseName, \")\"), Value = toreal(TotalExtentCount);\r\nlet topCategories = \r\n    TotalExtentCountTable\r\n    | summarize sum(Value) by Category\r\n    | top 9 by sum_Value desc\r\n;\r\nTotalExtentCountTable\r\n| join kind = leftouter (topCategories) on Category\r\n| project Category = coalesce(Category1, 'Other Tables'), Value, Time\r\n| summarize max(Value) by Category, bin(Time, 1h)\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -7245,8 +7190,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -7288,109 +7237,98 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Top tables by extent count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 12,
         "x": 12,
         "y": 127
       },
-      "hiddenSeries": false,
       "id": 65,
-      "legend": {
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -7399,9 +7337,10 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let TotalExtentSizeTable = ADXTableDetails\r\n    | where TimeGenerated > ago(7d)\r\n    | project Time = TimeGenerated, Category = strcat(TableName, \" (DB: \", DatabaseName, \")\"), Value = TotalExtentSize;\r\nlet topCategories = \r\n    TotalExtentSizeTable\r\n    | summarize sum(Value) by Category\r\n    | top 9 by sum_Value desc;\r\nTotalExtentSizeTable\r\n| join kind = leftouter (topCategories) on Category\r\n| project Category = coalesce(Category1, 'Other Tables'), Value, Time\r\n| summarize max(Value) by Category, bin(Time, 1h)\r\n",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "time_series"
           },
           "azureMonitor": {
             "aggOptions": ["Average"],
@@ -7422,8 +7361,12 @@
             "metricDefinition": "$ns",
             "metricName": "DiscoveryLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -7465,61 +7408,23 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Top tables by extent size",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -7528,11 +7433,21 @@
       },
       "id": 67,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Cache",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "description": "This page presents data based on the Time Range parameter. You can change the Time Range parameter to present data starting from 05/25/21 ,11:38 PM (based on your oldest diagnostic logs data).\n  The table names and the Cache policy column refreshes every 8 hours.\n  Notice the queries statistics presented are based only on queries that scanned data. For instance queries that failed, and queries with time operator of future don't scan any data therefore would not be part of the queries statistics presented.",
       "fieldConfig": {
         "defaults": {
@@ -7540,8 +7455,12 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -7559,9 +7478,16 @@
       },
       "id": 72,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -7636,25 +7562,23 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Table usage details",
-      "transformations": [],
       "transparent": true,
       "type": "table"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -7663,11 +7587,21 @@
       },
       "id": 69,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Ingestion",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -7675,8 +7609,12 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -7694,9 +7632,16 @@
       },
       "id": 73,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -7771,74 +7716,99 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Succeeded ingestions by table",
-      "transformations": [],
       "transparent": true,
       "type": "table"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "description": "Time from when a message is discovered by Azure Data Explorer, until its content is received by the Engine Storage for processing.",
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 8,
         "y": 143
       },
-      "hiddenSeries": false,
       "id": 74,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -7847,6 +7817,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//SucceededIngestion\r\n//| where TimeGenerated > ago(7d)\r\n//| parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n//| where cluster_name == 'mitulktest'\r\n//| summarize count=dcount(IngestionSourcePath) by Database, Table\r\n//| order by ['count'],Database, Table\r\nlet tenant=\r\n    FailedIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | distinct TenantId\r\n    | take 1; //choose one tenant as logs are transferred to many tenants which represents workSpace\r\nlet failures = FailedIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | where TenantId == toscalar(tenant)\r\n    | summarize f_count=count() by Database, Table;\r\nlet tenant_success=\r\n    SucceededIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | distinct TenantId\r\n    | take 1; //choose one tenant as logs are transferred to many tenants which represents workSpace\r\nlet success = SucceededIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | where TenantId == toscalar(tenant_success)\r\n    | summarize s_count=count() by Database, Table;\r\nsuccess\r\n| join kind=leftouter failures on Database, Table\r\n| extend f_count = iif(isnull(f_count), 0, f_count)\r\n| extend s_count = iif(isnull(s_count), 0, s_count)\r\n| extend overall = iif(isnull(s_count), 0.0, s_count * 100.0 / (s_count + f_count))\r\n| project Database, Table, s_count, overall\r\n| order by s_count, Database, Table",
             "resultFormat": "time_series",
             "workspace": "$ws"
@@ -7855,11 +7826,10 @@
             "aggOptions": ["Average"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "ComponentType",
-                "filter": "StorageEngine",
+                "filters": ["StorageEngine"],
                 "operator": "eq"
               }
             ],
@@ -7876,8 +7846,12 @@
             "metricDefinition": "$ns",
             "metricName": "StageLatency",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -7919,110 +7893,99 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Stage latency (accumulative latency)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "description": "Number of blobs processed by the Storage Engine.",
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
-          }
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
         "x": 16,
         "y": 143
       },
-      "hiddenSeries": false,
       "id": 75,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -8031,6 +7994,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//SucceededIngestion\r\n//| where TimeGenerated > ago(7d)\r\n//| parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n//| where cluster_name == 'mitulktest'\r\n//| summarize count=dcount(IngestionSourcePath) by Database, Table\r\n//| order by ['count'],Database, Table\r\nlet tenant=\r\n    FailedIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | distinct TenantId\r\n    | take 1; //choose one tenant as logs are transferred to many tenants which represents workSpace\r\nlet failures = FailedIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | where TenantId == toscalar(tenant)\r\n    | summarize f_count=count() by Database, Table;\r\nlet tenant_success=\r\n    SucceededIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | distinct TenantId\r\n    | take 1; //choose one tenant as logs are transferred to many tenants which represents workSpace\r\nlet success = SucceededIngestion\r\n    | where TimeGenerated > ago(7d)\r\n    | parse _ResourceId with * \"providers/microsoft.kusto/clusters/\" cluster_name\r\n    | where cluster_name == 'mitulktest'\r\n    | where TenantId == toscalar(tenant_success)\r\n    | summarize s_count=count() by Database, Table;\r\nsuccess\r\n| join kind=leftouter failures on Database, Table\r\n| extend f_count = iif(isnull(f_count), 0, f_count)\r\n| extend s_count = iif(isnull(s_count), 0, s_count)\r\n| extend overall = iif(isnull(s_count), 0.0, s_count * 100.0 / (s_count + f_count))\r\n| project Database, Table, s_count, overall\r\n| order by s_count, Database, Table",
             "resultFormat": "time_series",
             "workspace": "$ws"
@@ -8039,11 +8003,10 @@
             "aggOptions": ["Total", "Average", "Minimum", "Maximum"],
             "aggregation": "Total",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "ComponentType",
-                "filter": "StorageEngine",
+                "filters": ["StorageEngine"],
                 "operator": "eq"
               }
             ],
@@ -8064,8 +8027,12 @@
             "metricDefinition": "$ns",
             "metricName": "BlobsProcessed",
             "metricNamespace": "Microsoft.Kusto/clusters",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -8107,72 +8074,30 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "uid": "$ds"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Data Processed Successfuly",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
       "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     }
   ],
   "refresh": false,
-  "schemaVersion": 27,
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "Azure Monitor Datasource",
-          "value": "$ds"
+          "selected": true,
+          "text": "Azure Monitor",
+          "value": "azure-monitor-oob"
         },
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -8187,56 +8112,30 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
-        "definition": "subscriptions()",
-        "description": null,
-        "error": null,
+        "datasource": {
+          "uid": "$ds"
+        },
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Subscription",
         "multi": false,
         "name": "sub",
         "options": [],
-        "query": "subscriptions()",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 5,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "$ds",
-        "definition": "",
-        "description": null,
-        "error": null,
-        "hide": 0,
-        "includeAll": false,
-        "label": "Resource Group",
-        "multi": false,
-        "name": "rg",
-        "options": [],
         "query": {
-          "azureResourceGraph": {
-            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Kusto/clusters\" \r\n| distinct resourceGroup"
+          "grafanaTemplateVariableFn": {
+            "kind": "SubscriptionsQuery",
+            "rawQuery": "subscriptions()"
           },
-          "queryType": "Azure Resource Graph",
-          "refId": "A",
-          "subscriptions": ["$sub"]
+          "queryType": "Azure Subscriptions",
+          "refId": "A"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -8244,37 +8143,62 @@
       {
         "current": {},
         "datasource": {
-          "type": "grafana-azure-monitor-datasource",
-          "uid": "${ds}"
+          "uid": "$ds"
         },
         "definition": "",
         "hide": 0,
         "includeAll": false,
-        "label": "Namespace",
+        "label": "Resource Group",
         "multi": false,
-        "name": "ns",
+        "name": "rg",
         "options": [],
         "query": {
-          "azureResourceGraph": {
-            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.Kusto/clusters\" and resourceGroup =~ \"$rg\"\r\n| distinct [\"type\"]"
+          "grafanaTemplateVariableFn": {
+            "kind": "ResourceGroupsQuery",
+            "rawQuery": "ResourceGroups($sub)",
+            "subscription": "$sub"
           },
-          "queryType": "Azure Resource Graph",
+          "queryType": "Azure Resource Groups",
           "refId": "A",
-          "subscriptions": ["$sub"]
+          "subscription": "$sub"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
-        "type": "query"
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       },
       {
-        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "Microsoft.Kusto/clusters",
+          "value": "Microsoft.Kusto/clusters"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "ns",
+        "options": [
+          {
+            "selected": true,
+            "text": "Microsoft.Kusto/clusters",
+            "value": "Microsoft.Kusto/clusters"
+          }
+        ],
+        "query": "Microsoft.Kusto/clusters",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
         "current": {},
-        "datasource": "$ds",
-        "definition": "ResourceNames($sub, $rg, $ns)",
-        "description": null,
-        "error": null,
+        "datasource": {
+          "uid": "$ds"
+        },
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Resource",
@@ -8282,6 +8206,13 @@
         "name": "resource",
         "options": [],
         "query": {
+          "grafanaTemplateVariableFn": {
+            "kind": "ResourceNamesQuery",
+            "metricNamespace": "$ns",
+            "rawQuery": "ResourceNames($sub, $rg, $ns)",
+            "resourceGroup": "$rg",
+            "subscription": "$sub"
+          },
           "namespace": "$ns",
           "queryType": "Azure Resource Names",
           "refId": "A",
@@ -8293,31 +8224,37 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
-        "definition": "workspaces()",
-        "description": null,
-        "error": null,
+        "datasource": {
+          "uid": "$ds"
+        },
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Workspace",
         "multi": false,
         "name": "ws",
         "options": [],
-        "query": "workspaces()",
+        "query": {
+          "grafanaTemplateVariableFn": {
+            "kind": "WorkspacesQuery",
+            "rawQuery": "workspaces()",
+            "subscription": "4DC2CD39-7A89-43D8-BEBE-8BB501359891"
+          },
+          "queryType": "Azure Workspaces",
+          "refId": "A",
+          "subscription": "$sub"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -8332,5 +8269,6 @@
   "timezone": "",
   "title": "Azure / Insights / Data Explorer Clusters",
   "uid": "8UDB1s3Gk",
-  "version": 11
+  "version": 12,
+  "weekStart": ""
 }

--- a/public/app/plugins/datasource/azuremonitor/dashboards/keyvault.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/keyvault.json
@@ -1,22 +1,18 @@
 {
+  "__inputs": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.4.3"
+      "version": "10.4.7"
     },
     {
       "type": "datasource",
       "id": "grafana-azure-monitor-datasource",
       "name": "Azure Monitor",
-      "version": "0.3.0"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
+      "version": "1.0.0"
     },
     {
       "type": "panel",
@@ -29,18 +25,42 @@
       "id": "table",
       "name": "Table",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
     }
   ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "The dashboard provides insights of Azure Key Vaults overview, failures and operations.",
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1620924220014,
   "links": [],
   "panels": [
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "${ds}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -49,24 +69,33 @@
       },
       "id": 25,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${ds}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Overview",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "percentage",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -75,7 +104,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 19,
+        "w": 24,
         "x": 0,
         "y": 1
       },
@@ -90,27 +119,18 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -133,8 +153,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "Availability",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -176,30 +200,19 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         },
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -222,8 +235,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiResult",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "P1D",
             "timeGrains": [
               {
@@ -265,31 +282,20 @@
             ],
             "top": "10"
           },
-          "hide": false,
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
+          "hide": false,
           "queryType": "Azure Monitor",
           "refId": "B",
-          "subscription": "f7152080-b4e8-47ee-9c85-7f1d0e6b72dc"
+          "subscription": "$sub"
         },
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -312,8 +318,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiLatency",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "P1D",
             "timeGrains": [
               {
@@ -355,82 +365,104 @@
             ],
             "top": "10"
           },
-          "hide": false,
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
+          "hide": false,
           "queryType": "Azure Monitor",
           "refId": "C",
-          "subscription": "f7152080-b4e8-47ee-9c85-7f1d0e6b72dc"
+          "subscription": "$sub"
         }
       ],
       "title": "Availability, Requests and Latency",
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 0,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 11,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -445,8 +477,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiHit",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -488,125 +524,104 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
-          "subscription": "f7152080-b4e8-47ee-9c85-7f1d0e6b72dc"
+          "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Transactions Over Time",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "ms"
         },
         "overrides": []
       },
-      "fill": 0,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 6,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 13,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "connected",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -629,8 +644,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiLatency",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -672,119 +691,104 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Overall Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 12,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 15,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Average",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -807,8 +811,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "Availability",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -850,119 +858,104 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Availability",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 18,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 17,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -977,8 +970,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiHit",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1020,59 +1017,23 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Request Types over Time",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "${ds}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1081,76 +1042,107 @@
       },
       "id": 23,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${ds}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Failures",
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 0,
         "y": 17
       },
-      "hiddenSeries": false,
       "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "StatusCodeClass",
-                "filter": "2xx",
+                "filters": ["2xx"],
                 "operator": "eq"
               }
             ],
@@ -1175,8 +1167,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiResult",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1218,123 +1214,108 @@
             ],
             "top": ""
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Successes (2xx)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 6,
         "y": 17
       },
-      "hiddenSeries": false,
       "id": 7,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "StatusCodeClass",
-                "filter": "4xx",
+                "filters": ["4xx"],
                 "operator": "eq"
               }
             ],
@@ -1359,8 +1340,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiResult",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1402,123 +1387,108 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Failures (4xx)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 12,
         "y": 17
       },
-      "hiddenSeries": false,
       "id": 6,
-      "legend": {
-        "avg": true,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "StatusCode",
-                "filter": "429",
+                "filters": ["429"],
                 "operator": "eq"
               }
             ],
@@ -1543,8 +1513,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiResult",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1586,123 +1560,108 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Throttling (429)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 18,
         "y": 17
       },
-      "hiddenSeries": false,
       "id": 4,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "StatusCode",
-                "filter": "401",
+                "filters": ["401"],
                 "operator": "eq"
               }
             ],
@@ -1727,8 +1686,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiResult",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1770,34 +1733,23 @@
             ],
             "top": "10"
           },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Monitor",
           "refId": "A",
           "subscription": "$sub"
         },
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
-          "azureLogAnalytics": {
-            "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
-            "resultFormat": "time_series",
-            "workspace": "$ws"
-          },
           "azureMonitor": {
             "aggOptions": ["None", "Average", "Minimum", "Maximum", "Total", "Count"],
             "aggregation": "Count",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "StatusCode",
-                "filter": "403",
+                "filters": ["403"],
                 "operator": "eq"
               }
             ],
@@ -1822,8 +1774,12 @@
             "metricDefinition": "Microsoft.KeyVault/vaults",
             "metricName": "ServiceApiResult",
             "metricNamespace": "Microsoft.KeyVault/vaults",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1865,60 +1821,24 @@
             ],
             "top": "10"
           },
-          "hide": false,
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
+          "hide": false,
           "queryType": "Azure Monitor",
           "refId": "B",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Authentication Errors (401 & 403)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "${ds}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1927,17 +1847,27 @@
       },
       "id": 21,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${ds}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Operations",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1948,7 +1878,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
+        "w": 4,
         "x": 0,
         "y": 26
       },
@@ -1963,184 +1893,142 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
             "query": "let rawData = AzureDiagnostics \r\n    // Ignore Authentication operations with a 401. This is normal when using Key Vault SDK, first an unauthenticated request is done then the response is used for authentication.\r\n    | where Category == \"AuditEvent\" and not (OperationName == \"Authentication\" and httpStatusCode_d == 401)\r\n    | where OperationName in ('SecretGet', 'VaultGet') or '*' in ('SecretGet', 'VaultGet')\r\n    // Create ResultStatus with all the 'success' results bucked as 'Success'\r\n    // Certain operations like StorageAccountAutoSyncKey have no ResultSignature, for now set to 'Success' as well\r\n    | extend ResultStatus = case (ResultSignature == \"\", \"Success\",\r\n        ResultSignature == \"OK\", \"Success\",\r\n        ResultSignature == \"Accepted\", \"Success\",\r\n        ResultSignature);                            \r\nrawData \r\n| make-series Trend = count() default = 0 on TimeGenerated from ago(1d) to now() step 30m by ResultStatus\r\n| join kind = inner (rawData\n    | where $__timeFilter(TimeGenerated)\r\n    | summarize Count = count() by ResultStatus\r\n    )\r\n    on ResultStatus\n    \r\n\r\n| project ResultStatus, Count, Trend\r\n| order by Count desc;\r",
             "resultFormat": "table",
             "workspace": "$ws"
           },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Success Operations",
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 7,
-        "x": 3,
+        "w": 8,
+        "x": 4,
         "y": 26
       },
-      "hiddenSeries": false,
       "id": 35,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": false,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let rawData = AzureDiagnostics \r\n    // Ignore Authentication operations with a 401. This is normal when using Key Vault SDK, first an unauthenticated request is done then the response is used for authentication.\r\n    | where Category == \"AuditEvent\" and not (OperationName == \"Authentication\" and httpStatusCode_d == 401)\r\n    | where OperationName in ('SecretGet', 'VaultGet') or '*' in ('SecretGet', 'VaultGet')\r\n    // Create ResultStatus with all the 'success' results bucked as 'Success'\r\n    // Certain operations like StorageAccountAutoSyncKey have no ResultSignature, for now set to 'Success' as well\r\n    | extend ResultStatus = case (ResultSignature == \"\", \"Success\",\r\n        ResultSignature == \"OK\", \"Success\",\r\n        ResultSignature == \"Accepted\", \"Success\",\r\n        ResultSignature);                            \r\nrawData\n| where $__timeFilter(TimeGenerated)\n| extend resultCount = iif(ResultStatus == \"Success\", 1, 0)\n| summarize count(resultCount) by bin(TimeGenerated, 30m)\n| sort by TimeGenerated;\n\r\r\n\r",
-            "resultFormat": "table",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "table"
           },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Success Operations Counts",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -2151,8 +2039,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 3,
-        "x": 10,
+        "w": 4,
+        "x": 12,
         "y": 26
       },
       "id": 26,
@@ -2166,186 +2054,149 @@
           "fields": "",
           "values": true
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value"
+        "textMode": "value",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
             "query": "let rawData = AzureDiagnostics \r\n    // Ignore Authentication operations with a 401. This is normal when using Key Vault SDK, first an unauthenticated request is done then the response is used for authentication.\r\n    | where Category == \"AuditEvent\" and not (OperationName == \"Authentication\" and httpStatusCode_d == 401)\r\n    | where OperationName in ('SecretGet', 'VaultGet') or '*' in ('SecretGet', 'VaultGet')\r;                     \r\nrawData \r\n| make-series Trend = count() default = 0 on TimeGenerated from ago(1d) to now() step 30m by ResultSignature \n| join kind = inner (rawData\n    | where $__timeFilter(TimeGenerated)\r\n    | summarize Count = count() by ResultSignature \n    )\r\n    on ResultSignature \n\r\n\r\n| project ResultSignature , Count, Trend\r\n| order by Count desc;",
             "resultFormat": "table",
             "workspace": "$ws"
           },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "All Operations",
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 7,
-        "x": 13,
+        "w": 8,
+        "x": 16,
         "y": 26
       },
-      "hiddenSeries": false,
       "id": 36,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": false,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "let rawData = AzureDiagnostics \r\n    // Ignore Authentication operations with a 401. This is normal when using Key Vault SDK, first an unauthenticated request is done then the response is used for authentication.\r\n    | where Category == \"AuditEvent\" and not (OperationName == \"Authentication\" and httpStatusCode_d == 401)\r\n    | where OperationName in ('SecretGet', 'VaultGet') or '*' in ('SecretGet', 'VaultGet')\r;                          \r\nrawData\n| where $__timeFilter(TimeGenerated)\n| summarize count(ResultSignature ) by bin(TimeGenerated, 30m)\n| sort by TimeGenerated;\n\r\r\n\r",
-            "resultFormat": "table",
-            "workspace": "$ws"
+            "resources": ["$ws"],
+            "resultFormat": "table"
           },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "All Operations Counts",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -2372,37 +2223,26 @@
       },
       "id": 28,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
             "query": "let data = AzureDiagnostics \r\n    | where TimeGenerated > ago(1d)\r\n    // Ignore Authentication operations with a 401. This is normal when using Key Vault SDK, first an unauthenticated request is done then the response is used for authentication.\r\n    | where Category == \"AuditEvent\" and not (OperationName == \"Authentication\" and httpStatusCode_d == 401)\r\n    | where OperationName in ('SecretGet', 'VaultGet') or '*' in ('SecretGet', 'VaultGet')\r\n    // Create ResultStatus with all the 'success' results bucked as 'Success'\r\n    // Certain operations like StorageAccountAutoSyncKey have no ResultSignature, for now set to 'Success' as well\r\n    | extend ResultStatus = case (ResultSignature == \"\", \"Success\",\r\n        ResultSignature == \"OK\", \"Success\",\r\n        ResultSignature == \"Accepted\", \"Success\",\r\n        ResultSignature)\r\n    | where ResultStatus == 'All' or 'All' == 'All';\r\ndata\r\n// Data aggregated to the OperationName\r\n| summarize OperationCount = count(), SuccessCount = countif(ResultStatus == \"Success\"), FailureCount = countif(ResultStatus != \"Success\"), PDurationMs = percentile(DurationMs, 99) by Resource, OperationName\r\n| join kind=inner (data\r\n    | make-series Trend = count() default = 0 on TimeGenerated from ago(1d) to now() step 30m by OperationName\r\n    | project-away TimeGenerated)\r\n    on OperationName\r\n| order by OperationCount desc\r\n| project Name = strcat('⚡ ', OperationName), Id = strcat(Resource, '/', OperationName), ['Operation count'] = OperationCount, ['Operation count trend'] = Trend, ['Success count'] = SuccessCount, ['Failure count'] = FailureCount, ['p99 Duration'] = PDurationMs",
             "resultFormat": "time_series",
             "workspace": "$ws"
           },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
@@ -2413,15 +2253,22 @@
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "${ds}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -2497,38 +2344,27 @@
       },
       "id": 30,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
-          "appInsights": {
-            "dimension": [],
-            "metricName": "select",
-            "timeGrain": "auto"
-          },
           "azureLogAnalytics": {
             "query": "let gridRowSelected = dynamic({\"Id\": \"*\"});\r\nlet resourceName = split(gridRowSelected.Id, \"/\")[0];\r\nlet operationName = split(gridRowSelected.Id, \"/\")[1];\r\nAzureDiagnostics \r\n| where TimeGenerated > ago(1d)\r\n// Ignore Authentication operations with a 401. This is normal when using Key Vault SDK, first an unauthenticated request is done then the response is used for authentication.\r\n| where Category == \"AuditEvent\" and not (OperationName == \"Authentication\" and httpStatusCode_d == 401)\r\n| where OperationName in ('SecretGet', 'VaultGet') or '*' in ('SecretGet', 'VaultGet')\r\n| where resourceName == \"*\" or Resource == resourceName\r\n| where operationName == \"\" or OperationName == operationName\r\n// Create ResultStatus with all the 'success' results bucked as 'Success'\r\n// Certain operations like StorageAccountAutoSyncKey have no ResultSignature, for now set to 'Success' as well\r\n| extend ResultStatus = case (ResultSignature == \"\", \"Success\",\r\n    ResultSignature == \"OK\", \"Success\",\r\n    ResultSignature == \"Accepted\", \"Success\",\r\n    ResultSignature)\r\n| where ResultStatus == 'All' or 'All' == 'All'\r\n| extend p = pack_all()\r\n| mv-apply p on \r\n    ( \r\n    extend key = tostring(bag_keys(p)[0])\r\n    | where isnotempty(p[key]) and isnotnull(p[key])\r\n    | where key !in (\"SourceSystem\", \"Type\")\r\n    | summarize make_bag(p)\r\n    )\r\n| project Time=TimeGenerated, Operation=OperationName, Result=ResultSignature, Duration = DurationMs, [\"Details\"]=bag_p\r\n| sort by Time desc",
             "resultFormat": "time_series",
             "workspace": "$ws"
           },
-          "azureMonitor": {
-            "aggOptions": [],
-            "dimensionFilter": "*",
-            "dimensionFilters": [],
-            "metricDefinition": "select",
-            "metricName": "select",
-            "metricNamespace": "select",
-            "resourceGroup": "select",
-            "resourceName": "select",
-            "timeGrain": "auto",
-            "timeGrains": [],
-            "top": "10"
-          },
-          "insightsAnalytics": {
-            "query": "",
-            "resultFormat": "time_series"
+          "datasource": {
+            "type": "grafana-azure-monitor-datasource",
+            "uid": "${ds}"
           },
           "queryType": "Azure Log Analytics",
           "refId": "A",
@@ -2540,17 +2376,19 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 27,
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {},
-        "description": null,
-        "error": null,
+        "current": {
+          "selected": false,
+          "text": "Azure Monitor",
+          "value": "azure-monitor-oob"
+        },
         "hide": 0,
         "includeAll": false,
-        "label": "Data Source",
+        "label": "Datasource",
         "multi": false,
         "name": "ds",
         "options": [],
@@ -2562,56 +2400,31 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
-        "definition": "subscriptions()",
-        "description": null,
-        "error": null,
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "definition": "",
         "hide": 0,
         "includeAll": false,
-        "label": "subscription",
+        "label": "Subscription",
         "multi": false,
         "name": "sub",
         "options": [],
-        "query": "subscriptions()",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 5,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "$ds",
-        "definition": "",
-        "description": null,
-        "error": null,
-        "hide": 0,
-        "includeAll": false,
-        "label": "Resource Group",
-        "multi": false,
-        "name": "rg",
-        "options": [],
         "query": {
-          "azureResourceGraph": {
-            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.KeyVault/vaults\"\r\n| distinct resourceGroup"
+          "grafanaTemplateVariableFn": {
+            "kind": "SubscriptionsQuery",
+            "rawQuery": "subscriptions()"
           },
-          "queryType": "Azure Resource Graph",
-          "refId": "A",
-          "subscriptions": ["$sub"]
+          "queryType": "Azure Subscriptions",
+          "refId": "A"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -2623,40 +2436,72 @@
           "uid": "${ds}"
         },
         "definition": "",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
-        "label": "Namespace",
+        "label": "Resource Group",
         "multi": false,
-        "name": "ns",
+        "name": "rg",
         "options": [],
         "query": {
-          "azureResourceGraph": {
-            "query": "resources\r\n| where [\"type\"] =~ \"Microsoft.KeyVault/vaults\"\r\n| distinct [\"type\"]"
+          "grafanaTemplateVariableFn": {
+            "kind": "ResourceGroupsQuery",
+            "rawQuery": "ResourceGroups($sub)",
+            "subscription": "$sub"
           },
-          "queryType": "Azure Resource Graph",
+          "queryType": "Azure Resource Groups",
           "refId": "A",
-          "subscriptions": ["$sub"]
+          "subscription": "$sub"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
-        "type": "query"
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       },
       {
-        "allValue": null,
+        "hide": 2,
+        "label": "Namespace",
+        "name": "ns",
+        "query": "Microsoft.KeyVault/vaults",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "Microsoft.KeyVault/vaults",
+          "text": "Microsoft.KeyVault/vaults",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "Microsoft.KeyVault/vaults",
+            "text": "Microsoft.KeyVault/vaults",
+            "selected": false
+          }
+        ]
+      },
+      {
         "current": {},
-        "datasource": "$ds",
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
         "definition": "",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Resource",
         "multi": false,
         "name": "resource",
         "options": [],
         "query": {
+          "grafanaTemplateVariableFn": {
+            "kind": "ResourceNamesQuery",
+            "metricNamespace": "$ns",
+            "rawQuery": "ResourceNames($sub, $rg, $ns)",
+            "resourceGroup": "$rg",
+            "subscription": "$sub"
+          },
           "namespace": "$ns",
           "queryType": "Azure Resource Names",
           "refId": "A",
@@ -2668,31 +2513,38 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
-        "definition": "Workspaces($sub)",
-        "description": null,
-        "error": null,
+        "datasource": {
+          "type": "grafana-azure-monitor-datasource",
+          "uid": "${ds}"
+        },
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Workspace",
         "multi": false,
         "name": "ws",
         "options": [],
-        "query": "Workspaces($sub)",
+        "query": {
+          "grafanaTemplateVariableFn": {
+            "kind": "WorkspacesQuery",
+            "rawQuery": "Workspaces($sub)",
+            "subscription": "$sub"
+          },
+          "queryType": "Azure Workspaces",
+          "refId": "A",
+          "subscription": "$sub"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -2705,7 +2557,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Azure / Insights / Key vaults",
+  "title": "Azure / Insights / Key Vaults",
   "uid": "tQZAMYrMk",
-  "version": 42
+  "version": 43,
+  "weekStart": ""
 }

--- a/public/app/plugins/datasource/azuremonitor/dashboards/storage.json
+++ b/public/app/plugins/datasource/azuremonitor/dashboards/storage.json
@@ -1,4 +1,6 @@
 {
+  "__inputs": [],
+  "__elements": {},
   "__requires": [
     {
       "type": "panel",
@@ -10,19 +12,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.4.3"
+      "version": "10.4.7"
     },
     {
       "type": "datasource",
       "id": "grafana-azure-monitor-datasource",
       "name": "Azure Monitor",
-      "version": "0.3.0"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
+      "version": "1.0.0"
     },
     {
       "type": "panel",
@@ -44,23 +40,36 @@
     }
   ],
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1620257813794,
   "links": [],
   "panels": [
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "percentage",
@@ -80,12 +89,14 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
+        "w": 4,
         "x": 0,
-        "y": 1
+        "y": 0
       },
       "id": 7,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": ["lastNotNull"],
@@ -94,9 +105,10 @@
         },
         "showThresholdLabels": false,
         "showThresholdMarkers": false,
+        "sizing": "auto",
         "text": {}
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -176,6 +188,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -185,21 +200,20 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Availability",
       "transparent": true,
       "type": "gauge"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "fixedColor": "blue",
             "mode": "fixed"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -215,9 +229,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 3,
-        "y": 1
+        "w": 4,
+        "x": 4,
+        "y": 0
       },
       "id": 6,
       "options": {
@@ -230,10 +244,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value_and_name"
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -316,6 +332,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -325,19 +344,19 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "transparent": true,
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "fixedColor": "purple",
             "mode": "fixed"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -353,9 +372,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 6,
-        "y": 1
+        "w": 4,
+        "x": 8,
+        "y": 0
       },
       "id": 8,
       "options": {
@@ -368,10 +387,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value_and_name"
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -450,6 +471,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -459,19 +483,19 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "transparent": true,
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "fixedColor": "purple",
             "mode": "fixed"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -487,9 +511,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 9,
-        "y": 1
+        "w": 4,
+        "x": 12,
+        "y": 0
       },
       "id": 9,
       "options": {
@@ -502,10 +526,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value_and_name"
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -584,6 +610,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -593,19 +622,19 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "transparent": true,
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "fixedColor": "blue",
             "mode": "fixed"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -621,9 +650,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 12,
-        "y": 1
+        "w": 4,
+        "x": 16,
+        "y": 0
       },
       "id": 10,
       "options": {
@@ -636,10 +665,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value_and_name"
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -718,6 +749,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -727,19 +761,19 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "transparent": true,
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "fixedColor": "blue",
             "mode": "fixed"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -755,9 +789,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 3,
-        "x": 15,
-        "y": 1
+        "w": 4,
+        "x": 20,
+        "y": 0
       },
       "id": 11,
       "options": {
@@ -770,10 +804,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "value_and_name"
+        "textMode": "value_and_name",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -852,6 +888,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -861,62 +900,89 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "transparent": true,
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 5
+        "y": 4
       },
-      "hiddenSeries": false,
       "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null as zero",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -925,6 +991,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -934,7 +1001,6 @@
             "aggregation": "Total",
             "alias": "Table transactions",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -957,8 +1023,12 @@
             "metricDefinition": "$ns/tableServices",
             "metricName": "Transactions",
             "metricNamespace": "Microsoft.Storage/storageAccounts/tableServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1000,6 +1070,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -1015,6 +1088,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -1024,7 +1098,6 @@
             "aggregation": "Total",
             "alias": "Blob transactions",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -1047,8 +1120,12 @@
             "metricDefinition": "$ns/blobServices",
             "metricName": "Transactions",
             "metricNamespace": "Microsoft.Storage/storageAccounts/blobServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1090,6 +1167,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -1106,6 +1186,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -1115,7 +1196,6 @@
             "aggregation": "Total",
             "alias": "File transactions",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -1142,8 +1222,12 @@
             "metricDefinition": "$ns/fileServices",
             "metricName": "Transactions",
             "metricNamespace": "Microsoft.Storage/storageAccounts/fileServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1185,6 +1269,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -1201,6 +1288,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -1210,7 +1298,6 @@
             "aggregation": "Total",
             "alias": "Queue transactions",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -1233,8 +1320,12 @@
             "metricDefinition": "$ns/queueServices",
             "metricName": "Transactions",
             "metricNamespace": "Microsoft.Storage/storageAccounts/queueServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1276,6 +1367,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -1286,102 +1380,89 @@
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Transactions by storage type",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 5
+        "y": 4
       },
-      "hiddenSeries": false,
       "id": 14,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -1390,6 +1471,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -1399,7 +1481,6 @@
             "aggregation": "Total",
             "alias": "",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [
               {
                 "dimension": "ApiName",
@@ -1428,8 +1509,12 @@
             "metricDefinition": "$ns",
             "metricName": "Transactions",
             "metricNamespace": "Microsoft.Storage/storageAccounts",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -1471,6 +1556,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -1480,56 +1568,22 @@
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Transactions by API Name",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1539,8 +1593,10 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false
+              "tooltip": false,
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -1548,7 +1604,14 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -1572,17 +1635,19 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 13,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
-        "tooltipOptions": {
-          "mode": "multi"
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.3",
@@ -1623,6 +1688,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "insightsAnalytics": {
             "query": "",
@@ -1678,6 +1746,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -1729,6 +1800,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -1775,6 +1849,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -1785,20 +1862,22 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Capacity by storage type",
-      "transformations": [],
       "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1808,8 +1887,10 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false
+              "tooltip": false,
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -1820,7 +1901,14 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -1840,17 +1928,19 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 14
+        "y": 13
       },
       "id": 12,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
-        "tooltipOptions": {
-          "mode": "single"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.3",
@@ -1932,6 +2022,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "insightsAnalytics": {
             "query": "",
@@ -2018,6 +2111,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -2110,6 +2206,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -2197,6 +2296,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -2207,34 +2309,42 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Availability by storage type",
-      "transformations": [],
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 22
       },
       "id": 52,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Failures",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -2284,7 +2394,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 24
+        "y": 23
       },
       "id": 16,
       "options": {
@@ -2297,10 +2407,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -2389,6 +2501,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -2398,13 +2513,12 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2412,6 +2526,9 @@
             "mode": "fixed"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -2421,8 +2538,10 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false
+              "tooltip": false,
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -2430,7 +2549,14 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -2466,17 +2592,19 @@
         "h": 6,
         "w": 18,
         "x": 6,
-        "y": 24
+        "y": 23
       },
       "id": 18,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
-        "tooltipOptions": {
-          "mode": "single"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.3",
@@ -2569,6 +2697,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -2578,21 +2709,24 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "",
       "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -2613,8 +2747,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "basic"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
               }
             ]
           }
@@ -2624,13 +2761,20 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "id": 20,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": false
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -2725,6 +2869,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -2746,15 +2893,21 @@
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -2775,8 +2928,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "basic"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
               }
             ]
           }
@@ -2786,13 +2942,20 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 29
       },
       "id": 22,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": false
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -2891,6 +3054,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -2912,15 +3078,21 @@
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -2941,8 +3113,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "basic"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
               }
             ]
           }
@@ -2952,13 +3127,20 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 37
       },
       "id": 24,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": false
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -3053,6 +3235,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -3074,15 +3259,21 @@
       "type": "table"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -3103,8 +3294,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "basic"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
               }
             ]
           }
@@ -3114,13 +3308,20 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 37
       },
       "id": 26,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": false
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -3215,6 +3416,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -3237,26 +3441,37 @@
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 45
       },
       "id": 50,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Performance",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -3290,7 +3505,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 47
+        "y": 46
       },
       "id": 28,
       "options": {
@@ -3303,10 +3518,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -3384,6 +3601,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "insightsAnalytics": {
             "query": "",
@@ -3470,6 +3690,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -3480,17 +3703,21 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "type": "stat"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -3500,8 +3727,10 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false
+              "tooltip": false,
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -3509,7 +3738,14 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -3544,17 +3780,19 @@
         "h": 6,
         "w": 18,
         "x": 6,
-        "y": 47
+        "y": 46
       },
       "id": 30,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
-        "tooltipOptions": {
-          "mode": "single"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.3",
@@ -3635,6 +3873,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "insightsAnalytics": {
             "query": "",
@@ -3721,6 +3962,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -3731,19 +3975,24 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -3765,8 +4014,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "lcd-gauge"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "lcd",
+                  "type": "gauge"
+                }
               },
               {
                 "id": "color",
@@ -3783,8 +4035,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "gradient-gauge"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
               },
               {
                 "id": "color",
@@ -3802,8 +4057,11 @@
             },
             "properties": [
               {
-                "id": "custom.displayMode",
-                "value": "gradient-gauge"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
               },
               {
                 "id": "color",
@@ -3832,13 +4090,20 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 52
       },
       "id": 32,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -3922,6 +4187,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "insightsAnalytics": {
             "query": "",
@@ -4014,6 +4282,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -4024,7 +4295,6 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "transformations": [
         {
           "id": "reduce",
@@ -4051,27 +4321,38 @@
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 63
       },
       "id": 48,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Availability",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "description": "The data comes from Storage metrics. It measures the availability of requests on Storage accounts.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "percentage",
@@ -4093,10 +4374,12 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 64
       },
       "id": 34,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": ["lastNotNull"],
@@ -4105,9 +4388,10 @@
         },
         "showThresholdLabels": false,
         "showThresholdMarkers": false,
+        "sizing": "auto",
         "text": {}
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4187,6 +4471,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -4272,6 +4559,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -4359,6 +4649,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -4451,6 +4744,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -4538,6 +4834,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -4548,19 +4847,24 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "type": "gauge"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "custom": {
-            "align": null,
-            "filterable": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -4580,8 +4884,11 @@
                 "value": "percent"
               },
               {
-                "id": "custom.displayMode",
-                "value": "color-background"
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
               },
               {
                 "id": "color",
@@ -4597,14 +4904,21 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 73
+        "y": 72
       },
       "id": 36,
       "maxDataPoints": 1,
       "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
         "showHeader": false
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -4689,6 +5003,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "insightsAnalytics": {
             "query": "",
@@ -4781,6 +5098,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -4879,6 +5199,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -4972,6 +5295,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -4982,8 +5308,6 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Availability by API name",
       "transformations": [
         {
@@ -4998,57 +5322,85 @@
       "type": "table"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 72
       },
-      "hiddenSeries": false,
       "id": 38,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": true,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5057,6 +5409,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5066,7 +5419,6 @@
             "aggregation": "Average",
             "alias": "Blob Availability",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -5085,8 +5437,12 @@
             "metricDefinition": "$ns/blobServices",
             "metricName": "Availability",
             "metricNamespace": "Microsoft.Storage/storageAccounts/blobServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5128,6 +5484,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -5143,6 +5502,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5152,7 +5512,6 @@
             "aggregation": "Average",
             "alias": "Table Availability",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -5171,8 +5530,12 @@
             "metricDefinition": "$ns/tableServices",
             "metricName": "Availability",
             "metricNamespace": "Microsoft.Storage/storageAccounts/tableServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5214,6 +5577,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -5230,6 +5596,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5239,7 +5606,6 @@
             "aggregation": "Average",
             "alias": "File Availability",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -5262,8 +5628,12 @@
             "metricDefinition": "$ns/fileServices",
             "metricName": "Availability",
             "metricNamespace": "Microsoft.Storage/storageAccounts/fileServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5305,6 +5675,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -5321,6 +5694,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5330,7 +5704,6 @@
             "aggregation": "Average",
             "alias": "Queue Availability",
             "allowedTimeGrainsMs": [60000, 300000, 900000, 1800000, 3600000, 21600000, 43200000, 86400000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -5349,8 +5722,12 @@
             "metricDefinition": "$ns/queueServices",
             "metricName": "Availability",
             "metricNamespace": "Microsoft.Storage/storageAccounts/queueServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5392,6 +5769,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -5402,70 +5782,42 @@
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Availability Trend",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transformations": [],
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 80
       },
       "id": 46,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$ds"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Capacity",
       "type": "row"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -5483,7 +5835,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 81
       },
       "id": 40,
       "options": {
@@ -5496,10 +5848,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5538,6 +5892,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "insightsAnalytics": {
             "query": "",
             "resultFormat": "time_series"
@@ -5592,6 +5949,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -5637,6 +5997,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -5689,6 +6052,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -5735,6 +6101,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -5745,61 +6114,88 @@
           "subscription": "$sub"
         }
       ],
-      "title": "",
       "type": "stat"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$ds",
+      "datasource": {
+        "type": "grafana-azure-monitor-datasource",
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {},
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": []
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "decbytes"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 89
       },
-      "hiddenSeries": false,
       "id": 42,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.3",
-      "pointradius": 1,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "10.4.7",
       "targets": [
         {
           "appInsights": {
@@ -5808,6 +6204,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5817,7 +6214,6 @@
             "aggregation": "Average",
             "alias": "Blob Capacity",
             "allowedTimeGrainsMs": [3600000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -5832,8 +6228,12 @@
             "metricDefinition": "$ns/blobServices",
             "metricName": "BlobCapacity",
             "metricNamespace": "Microsoft.Storage/storageAccounts/blobServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5846,6 +6246,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -5863,6 +6266,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5872,14 +6276,17 @@
             "aggregation": "Average",
             "alias": "Table Capacity",
             "allowedTimeGrainsMs": [3600000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns/tableServices",
             "metricName": "TableCapacity",
             "metricNamespace": "Microsoft.Storage/storageAccounts/tableServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5892,6 +6299,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -5909,6 +6319,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5918,7 +6329,6 @@
             "aggregation": "Average",
             "alias": "File Capacity",
             "allowedTimeGrainsMs": [3600000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [
               {
@@ -5929,8 +6339,12 @@
             "metricDefinition": "$ns/fileServices",
             "metricName": "FileCapacity",
             "metricNamespace": "Microsoft.Storage/storageAccounts/fileServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5943,6 +6357,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -5960,6 +6377,7 @@
             "timeGrain": "auto"
           },
           "azureLogAnalytics": {
+            "dashboardTime": false,
             "query": "//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc",
             "resultFormat": "time_series",
             "workspace": "00000000-0000-0000-0000-000000000000"
@@ -5969,14 +6387,17 @@
             "aggregation": "Average",
             "alias": "Queue Capacity",
             "allowedTimeGrainsMs": [3600000],
-            "dimensionFilter": "*",
             "dimensionFilters": [],
             "dimensions": [],
             "metricDefinition": "$ns/queueServices",
             "metricName": "QueueCapacity",
             "metricNamespace": "Microsoft.Storage/storageAccounts/queueServices",
-            "resourceGroup": "$rg",
-            "resourceName": "$resource/default",
+            "resources": [
+              {
+                "resourceGroup": "$rg",
+                "resourceName": "$resource/default"
+              }
+            ],
             "timeGrain": "auto",
             "timeGrains": [
               {
@@ -5990,6 +6411,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -6000,55 +6424,22 @@
           "subscription": "$sub"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Storage capacity",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "decbytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "datasource": "$ds",
+      "datasource": {
+        "uid": "$ds"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -6058,8 +6449,10 @@
             "hideFrom": {
               "graph": false,
               "legend": false,
-              "tooltip": false
+              "tooltip": false,
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 4,
@@ -6067,7 +6460,14 @@
               "type": "linear"
             },
             "showPoints": "always",
-            "spanNulls": true
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -6091,17 +6491,19 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 89
       },
       "id": 44,
       "options": {
         "legend": {
           "calcs": ["mean"],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
-        "tooltipOptions": {
-          "mode": "single"
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.3",
@@ -6152,6 +6554,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -6197,6 +6602,9 @@
               }
             ],
             "top": "10"
+          },
+          "datasource": {
+            "uid": "$ds"
           },
           "hide": false,
           "insightsAnalytics": {
@@ -6249,6 +6657,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -6295,6 +6706,9 @@
             ],
             "top": "10"
           },
+          "datasource": {
+            "uid": "$ds"
+          },
           "hide": false,
           "insightsAnalytics": {
             "query": "",
@@ -6305,21 +6719,21 @@
           "subscription": "$sub"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Storage count",
       "type": "timeseries"
     }
   ],
   "refresh": false,
-  "schemaVersion": 27,
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {},
-        "description": null,
-        "error": null,
+        "current": {
+          "selected": false,
+          "text": "Azure Monitor",
+          "value": "azure-monitor-oob"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Data Source",
@@ -6334,25 +6748,30 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
-        "definition": "subscriptions()",
-        "description": null,
-        "error": null,
+        "datasource": {
+          "uid": "$ds"
+        },
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Subscription",
         "multi": false,
         "name": "sub",
         "options": [],
-        "query": "subscriptions()",
+        "query": {
+          "grafanaTemplateVariableFn": {
+            "kind": "SubscriptionsQuery",
+            "rawQuery": "subscriptions()"
+          },
+          "queryType": "Azure Subscriptions",
+          "refId": "A"
+        },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -6385,12 +6804,11 @@
         "type": "query"
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
+        "datasource": {
+          "uid": "$ds"
+        },
         "definition": "",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Resource Group",
@@ -6410,18 +6828,16 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "$ds",
+        "datasource": {
+          "uid": "$ds"
+        },
         "definition": "",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Resource",
@@ -6440,7 +6856,6 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -6455,5 +6870,6 @@
   "timezone": "",
   "title": "Azure / Insights / Storage Accounts",
   "uid": "3n2E8CrGk",
-  "version": 29
+  "version": 29,
+  "weekStart": ""
 }


### PR DESCRIPTION
DO NOT MERGE - MIRROR OF #97975 for CI

What is this feature?

It is an update to Azure Monitor out of box dashboards to remove any use of Angular panels. A few of the dashboards were still using the Graph (old) visualization.

Why do we need this feature?

Deprecation of Angular panel support starting in G12

Who is this feature for?

Any Azure Monitor Datasource user who also relies on the OOB dashboards.