### PR TITLE
Auth: Return error when retries have been exhausted for OAuth token refresh

### DIFF
--- a/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
+++ b/pkg/services/authn/authnimpl/sync/oauth_token_sync.go
@@ -98,6 +98,11 @@ func (s *OAuthTokenSync) SyncOauthTokenHook(ctx context.Context, id *authn.Ident
 				return nil, nil
 			}
 
+			if errors.Is(refreshErr, oauthtoken.ErrRetriesExhausted) {
+				ctxLogger.Warn("Retries have been exhausted for locking the DB for OAuth token refresh", "id", id.ID, "error", refreshErr)
+				return nil, refreshErr
+			}
+
 			ctxLogger.Error("Failed to refresh OAuth access token", "id", id.ID, "error", refreshErr)
 
 			// log the user out

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -35,6 +35,7 @@ var (
 	ErrNoRefreshTokenFound = errors.New("no refresh token found")
 	ErrNotAnOAuthProvider  = errors.New("not an oauth provider")
 	ErrCouldntRefreshToken = errors.New("could not refresh token")
+	ErrRetriesExhausted    = errors.New("retries exhausted")
 )
 
 type Service struct {
@@ -270,7 +271,7 @@ func (o *Service) TryTokenRefresh(ctx context.Context, usr identity.Requester, s
 		if attempts < 5 {
 			return nil
 		}
-		return ErrCouldntRefreshToken
+		return ErrRetriesExhausted
 	}
 
 	var newToken *oauth2.Token


### PR DESCRIPTION
**What is this feature?**
This PR prevents the token revocation when the OAuthTokenSync fails because the DB lock couldn't be acquired and the ServerLock exhausted all of the retries to acquire the DB lock. 

**Why do we need this feature?**
To prevent unexpected logouts when the ServerLock are not able to acquire a DB lock within the defined interval and retry number.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
