### PR TITLE
[Prototyping] Consolidate file ignore logic in parser

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -1,8 +1,6 @@
 package v0alpha1
 
 import (
-	"path/filepath"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -76,17 +74,6 @@ type JobStatus struct {
 	Finished int64    `json:"finished,omitempty"`
 	Message  string   `json:"message,omitempty"`
 	Errors   []string `json:"errors,omitempty"`
-}
-
-// Filter ignorable files
-type IgnoreFile = func(path string) bool
-
-func IncludeYamlOrJSON(p string) bool { // put this somewhere better
-	ext := filepath.Ext(p)
-	if ext == ".yaml" || ext == ".json" {
-		return false
-	}
-	return true
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/registry/apis/provisioning/jobs/pullrequest.go
+++ b/pkg/registry/apis/provisioning/jobs/pullrequest.go
@@ -141,9 +141,11 @@ func (c *PullRequestCommenter) Process(ctx context.Context, job provisioning.Job
 	previews := make([]resourcePreview, 0, len(files))
 
 	for _, f := range files {
-		// TODO: ignore files?
-		logger := logger.With("file", f.Path)
+		if c.parser.ShouldIgnore(ctx, logger, f.Path) {
+			continue
+		}
 
+		logger := logger.With("file", f.Path)
 		fileInfo, err := c.repo.Read(ctx, logger, f.Path, ref)
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", f.Path, err)
@@ -175,7 +177,7 @@ func (c *PullRequestCommenter) Process(ctx context.Context, job provisioning.Job
 		preview := resourcePreview{
 			Filename: path.Base(f.Path),
 			Path:     f.Path,
-			Kind:     "dashboard", // TODO: add more types
+			Kind:     "dashboard", // TODO: add more kinds
 			Action:   string(f.Action),
 		}
 

--- a/pkg/registry/apis/provisioning/jobs/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/worker.go
@@ -28,7 +28,6 @@ type JobWorker struct {
 	parsers     *resources.ParserFactory
 	identities  auth.BackgroundIdentityService
 	logger      *slog.Logger
-	ignore      provisioning.IgnoreFile
 	render      rendering.Service
 	blobstore   blob.PublicBlobStore
 	urlProvider func(namespace string) string
@@ -39,7 +38,6 @@ func NewJobWorker(
 	parsers *resources.ParserFactory,
 	identities auth.BackgroundIdentityService,
 	logger *slog.Logger,
-	ignore provisioning.IgnoreFile,
 	render rendering.Service,
 	blobstore blob.PublicBlobStore,
 	urlProvider func(namespace string) string,
@@ -49,7 +47,6 @@ func NewJobWorker(
 		parsers:     parsers,
 		identities:  identities,
 		logger:      logger,
-		ignore:      ignore,
 		render:      render,
 		blobstore:   blobstore,
 		urlProvider: urlProvider,
@@ -83,7 +80,7 @@ func (g *JobWorker) Process(ctx context.Context, job provisioning.Job) (*provisi
 		return nil, fmt.Errorf("failed to get parser for %s: %w", repo.Config().Name, err)
 	}
 
-	replicator, err := resources.NewReplicator(repo, parser, g.ignore, logger)
+	replicator, err := resources.NewReplicator(repo, parser, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating replicator")
 	}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -186,7 +186,6 @@ func (b *ProvisioningAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserv
 		b.parsers,
 		b.identities,
 		b.logger.With("worker", "github"),
-		provisioning.IncludeYamlOrJSON,
 		b.render,
 		b.blobstore,
 		b.urlProvider,

--- a/pkg/registry/apis/provisioning/repository/github_test.go
+++ b/pkg/registry/apis/provisioning/repository/github_test.go
@@ -101,7 +101,6 @@ func TestParseWebhooks(t *testing.T) {
 			},
 		},
 		logger: slog.Default().With("logger", "github-repository"),
-		ignore: provisioning.IncludeYamlOrJSON,
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Why?

We had ignore little function passed everywhere and called in many different spots.

# How?

- Move ignore logic to parser.
- Add `ShouldIgnore` method in parser and use anywhere that we need to check for that.
- Remove `ignore` calls in Webhook event parser and delegate to the processor. For `sync`, this will be done in `Replicator`.
