### PR TITLE
CloudWatch: Fix interpolation of log groups when fetching fields

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.ts
@@ -269,7 +269,12 @@ export class LogsSQLCompletionItemProvider extends CompletionItemProvider {
           break;
 
         case SuggestionKind.Field:
-          const fields = await fetchLogGroupFields(this.queryContext.logGroups || [], this.queryContext.region, this.templateSrv, this.resources);
+          const fields = await fetchLogGroupFields(
+            this.queryContext.logGroups || [],
+            this.queryContext.region,
+            this.templateSrv,
+            this.resources
+          );
           fields.forEach((field) => {
             if (field !== '') {
               addSuggestion(field, {

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.ts
@@ -7,6 +7,7 @@ import { CompletionItemProvider } from '../../monarch/CompletionItemProvider';
 import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';
 import { SuggestionKind, CompletionItemPriority, StatementPosition } from '../../monarch/types';
+import { fetchLogGroupFields } from '../../utils';
 import {
   ASC,
   BY,
@@ -268,7 +269,7 @@ export class LogsSQLCompletionItemProvider extends CompletionItemProvider {
           break;
 
         case SuggestionKind.Field:
-          const fields = await this.fetchFields(this.queryContext.logGroups || [], this.queryContext.region);
+          const fields = await fetchLogGroupFields(this.queryContext.logGroups || [], this.queryContext.region, this.templateSrv, this.resources);
           fields.forEach((field) => {
             if (field !== '') {
               addSuggestion(field, {
@@ -295,20 +296,4 @@ export class LogsSQLCompletionItemProvider extends CompletionItemProvider {
 
     return suggestions;
   }
-
-  private fetchFields = async (logGroups: LogGroup[], region: string): Promise<string[]> => {
-    if (logGroups.length === 0) {
-      return [];
-    }
-
-    const results = await Promise.all(
-      logGroups.map((logGroup) =>
-        this.resources
-          .getLogGroupFields({ logGroupName: logGroup.name, arn: logGroup.arn, region })
-          .then((fields) => fields.filter((f) => f).map((f) => f.value.name ?? ''))
-      )
-    );
-    // Deduplicate fields
-    return [...new Set(results.flat())];
-  };
 }

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.ts
@@ -7,6 +7,7 @@ import { CompletionItemProvider } from '../../monarch/CompletionItemProvider';
 import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';
 import { CompletionItem, CompletionItemPriority, StatementPosition, SuggestionKind } from '../../monarch/types';
+import { fetchLogGroupFields } from '../../utils';
 import {
   BOOLEAN_LITERALS,
   CONDITION_FUNCTIONS,
@@ -252,7 +253,7 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
   ): Promise<void> {
     if (this.queryContext.logGroups && this.queryContext.logGroups.length > 0) {
       try {
-        let fields = await this.fetchFields(this.queryContext.logGroups, this.queryContext.region);
+        let fields = await fetchLogGroupFields(this.queryContext.logGroups, this.queryContext.region, this.templateSrv, this.resources);
         fields.forEach((field) => {
           if (field !== '') {
             addSuggestion(field, {
@@ -268,17 +269,5 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
         return;
       }
     }
-  }
-
-  private async fetchFields(logGroups: LogGroup[], region: string): Promise<string[]> {
-    const results = await Promise.all(
-      logGroups.map((logGroup) =>
-        this.resources
-          .getLogGroupFields({ logGroupName: logGroup.name, arn: logGroup.arn, region })
-          .then((fields) => fields.filter((f) => f).map((f) => f.value.name ?? ''))
-      )
-    );
-    // Deduplicate fields
-    return [...new Set(results.flat())];
   }
 }

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.ts
@@ -253,7 +253,12 @@ export class PPLCompletionItemProvider extends CompletionItemProvider {
   ): Promise<void> {
     if (this.queryContext.logGroups && this.queryContext.logGroups.length > 0) {
       try {
-        let fields = await fetchLogGroupFields(this.queryContext.logGroups, this.queryContext.region, this.templateSrv, this.resources);
+        let fields = await fetchLogGroupFields(
+          this.queryContext.logGroups,
+          this.queryContext.region,
+          this.templateSrv,
+          this.resources
+        );
         fields.forEach((field) => {
           if (field !== '') {
             addSuggestion(field, {

--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.ts
@@ -87,7 +87,12 @@ export class LogsCompletionItemProvider extends CompletionItemProvider {
           });
 
           if (this.queryContext.logGroups && this.queryContext.logGroups.length > 0) {
-            let fields = await fetchLogGroupFields(this.queryContext.logGroups, this.queryContext.region, this.templateSrv, this.resources);
+            let fields = await fetchLogGroupFields(
+              this.queryContext.logGroups,
+              this.queryContext.region,
+              this.templateSrv,
+              this.resources
+            );
             fields.push('@log');
             fields.forEach((field) => {
               if (field !== '') {

--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.ts
@@ -7,6 +7,7 @@ import { CompletionItemProvider } from '../../monarch/CompletionItemProvider';
 import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';
 import { CompletionItem, CompletionItemPriority, StatementPosition, SuggestionKind } from '../../monarch/types';
+import { fetchLogGroupFields } from '../../utils';
 import { LOGS_COMMANDS, LOGS_FUNCTION_OPERATORS, SORT_DIRECTION_KEYWORDS } from '../language';
 
 import { getStatementPosition } from './statementPosition';
@@ -86,7 +87,7 @@ export class LogsCompletionItemProvider extends CompletionItemProvider {
           });
 
           if (this.queryContext.logGroups && this.queryContext.logGroups.length > 0) {
-            let fields = await this.fetchFields(this.queryContext.logGroups, this.queryContext.region);
+            let fields = await fetchLogGroupFields(this.queryContext.logGroups, this.queryContext.region, this.templateSrv, this.resources);
             fields.push('@log');
             fields.forEach((field) => {
               if (field !== '') {
@@ -133,16 +134,4 @@ export class LogsCompletionItemProvider extends CompletionItemProvider {
 
     return suggestions;
   }
-
-  private fetchFields = async (logGroups: LogGroup[], region: string): Promise<string[]> => {
-    const results = await Promise.all(
-      logGroups.map((logGroup) =>
-        this.resources
-          .getLogGroupFields({ logGroupName: logGroup.name, arn: logGroup.arn, region })
-          .then((fields) => fields.filter((f) => f).map((f) => f.value.name ?? ''))
-      )
-    );
-    // Deduplicate fields
-    return [...new Set(results.flat())];
-  };
 }

--- a/public/app/plugins/datasource/cloudwatch/language/utils.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/utils.ts
@@ -1,0 +1,33 @@
+import { TemplateSrv } from '@grafana/runtime';
+
+import { LogGroup } from '../dataquery.gen';
+import { ResourcesAPI } from '../resources/ResourcesAPI';
+import { interpolateStringArrayUsingSingleOrMultiValuedVariable } from '../utils/templateVariableUtils';
+
+export const fetchLogGroupFields = async (
+  logGroups: LogGroup[],
+  region: string,
+  templateSrv: TemplateSrv,
+  resources: ResourcesAPI
+): Promise<string[]> => {
+  if (logGroups.length === 0) {
+    return [];
+  }
+
+  const interpolatedLogGroups = interpolateStringArrayUsingSingleOrMultiValuedVariable(
+    templateSrv,
+    logGroups.map((lg) => lg.name),
+    {},
+    'text'
+  );
+
+  const results = await Promise.all(
+    interpolatedLogGroups.map((logGroupName) =>
+      resources
+        .getLogGroupFields(region, logGroupName)
+        .then((fields) => fields.filter((f) => f).map((f) => f.value.name ?? ''))
+    )
+  );
+  // Deduplicate fields
+  return [...new Set(results.flat())];
+};

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -78,10 +78,7 @@ export class ResourcesAPI extends CloudWatchRequest {
     });
   }
 
-  getLogGroupFields(
-    region: string,
-    logGroupName: string
-  ): Promise<Array<ResourceResponse<LogGroupField>>> {
+  getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {
     return this.memoizedGetRequest<Array<ResourceResponse<LogGroupField>>>('log-group-fields', {
       region: this.templateSrv.replace(this.getActualRegion(region)),
       logGroupName: logGroupName,

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -12,7 +12,6 @@ import {
   ResourceResponse,
   DescribeLogGroupsRequest,
   LogGroupResponse,
-  GetLogGroupFieldsRequest,
   GetMetricsRequest,
   GetDimensionKeysRequest,
   GetDimensionValuesRequest,
@@ -79,15 +78,13 @@ export class ResourcesAPI extends CloudWatchRequest {
     });
   }
 
-  getLogGroupFields({
-    region,
-    arn,
-    logGroupName,
-  }: GetLogGroupFieldsRequest): Promise<Array<ResourceResponse<LogGroupField>>> {
+  getLogGroupFields(
+    region: string,
+    logGroupName: string
+  ): Promise<Array<ResourceResponse<LogGroupField>>> {
     return this.memoizedGetRequest<Array<ResourceResponse<LogGroupField>>>('log-group-fields', {
       region: this.templateSrv.replace(this.getActualRegion(region)),
-      logGroupName: this.templateSrv.replace(logGroupName, {}),
-      logGroupArn: this.templateSrv.replace(arn),
+      logGroupName: logGroupName,
     });
   }
 

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -12,11 +12,6 @@ export interface ResourceRequest {
   accountId?: string;
 }
 
-export interface GetLogGroupFieldsRequest extends ResourceRequest {
-  arn?: string;
-  logGroupName: string;
-}
-
 export interface GetDimensionKeysRequest extends ResourceRequest {
   metricName?: string;
   namespace?: string;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I noticed that log group fields weren't being fetched for SQL and PPL languages. It looks like we're sending log group arns instead of names. We should interpolate log groups first, then send them along as log group names, since the API GetLogGroupFields only needs names anyway: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogGroupFields.html

<img width="297" alt="Screenshot 2024-12-16 at 17 47 27" src="https://github.com/user-attachments/assets/f18bba94-9ed2-457d-bedc-6818d17ac17f" />




I also extracted the common function that all language CompletionProviders are using into a util file, and removed some redundant code, like not adding arns to the call. 

https://github.com/user-attachments/assets/5f784d68-7c3d-4216-bc6d-2226745d4c6a

**Who is this feature for?**

CloudWatch Logs users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
