### PR TITLE
[v11.4.x] Docs - Update variable limitation

### DIFF
--- a/docs/sources/dashboards/dashboard-public/index.md
+++ b/docs/sources/dashboards/dashboard-public/index.md
@@ -260,7 +260,7 @@ guaranteed because plugin developers can override this functionality. The follow
 ## Limitations
 
 - Panels that use frontend data sources will fail to fetch data.
-- Template variables are not supported.
+- Variables and queries including variables are not supported.
 - Exemplars will be omitted from the panel.
 - Only annotations that query the `-- Grafana --` data source are supported.
 - Organization annotations are not supported.


### PR DESCRIPTION
Reworded variables limitation to remove the term "template" and replace it with its meaning.

Making this change separately from [initial PR](https://github.com/grafana/grafana/pull/97215) since the docs have been restructured in `main`.
