### PR TITLE
POC/Provisioning: Find admin user

### DIFF
--- a/pkg/registry/apis/provisioning/auth/identity.go
+++ b/pkg/registry/apis/provisioning/auth/identity.go
@@ -80,7 +80,7 @@ func (o *backgroundIdentities) WorkerIdentity(ctx context.Context, namespace str
 
 	id, ok := o.accounts[info.OrgID]
 	if !ok {
-		// Find an admin user
+		// HACK -- find an admin user
 		res, err := o.users.Search(context.Background(), &user.SearchUsersQuery{
 			SignedInUser: &identity.StaticRequester{
 				IsGrafanaAdmin: true,
@@ -109,7 +109,7 @@ func (o *backgroundIdentities) WorkerIdentity(ctx context.Context, namespace str
 			return nil, fmt.Errorf("unable to find admin user")
 		}
 
-		// HACK HACK HACK
+		// HACK -- (if false) and still allow lint
 		switch o.serviceAccountNamePrefix {
 		case "NOPE":
 			id, err = o.makeAdminUser(ctx, info.OrgID)


### PR DESCRIPTION
The simple trick to use `user:1` for an admin background user failed when we try to run in cloud 😢 

This makes a small improvement by looking for an admin user rather than assuming `user:1` -- however we still need a real solution for this.  Either:
* create a service account
* create tokens with the right permissions

creating tokens is the "right" solution, but that is still a bit of a moving target