### PR TITLE
storage/secret: add namespace newtypes for improved type safety

### DIFF
--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -82,7 +82,7 @@ func (s *SecureValueRest) List(ctx context.Context, options *internalversion.Lis
 
 // Get calls the inner `store` (persistence) and returns a `securevalue` by `name`. It will NOT return the decrypted `value`.
 func (s *SecureValueRest) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	nn := secretstorage.NamespacedName{
+	nn := secretstorage.NameNamespace{
 		Name:      name,
 		Namespace: secretstorage.Namespace(request.NamespaceValue(ctx)),
 	}
@@ -208,7 +208,7 @@ func (s *SecureValueRest) Update(
 // Delete calls the inner `store` (persistence) in order to delete the `securevalue`.
 // The second return parameter `bool` indicates whether the delete was instant or not. It always is for `securevalues`.
 func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	nn := secretstorage.NamespacedName{
+	nn := secretstorage.NameNamespace{
 		Name:      name,
 		Namespace: secretstorage.Namespace(request.NamespaceValue(ctx)),
 	}

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -70,7 +70,7 @@ func (s *SecureValueRest) ConvertToTable(ctx context.Context, object runtime.Obj
 
 // List calls the inner `store` (persistence) and returns a list of `securevalues` within a `namespace` filtered by the `options`.
 func (s *SecureValueRest) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	namespace := request.NamespaceValue(ctx)
+	namespace := secretstorage.Namespace(request.NamespaceValue(ctx))
 
 	secureValueList, err := s.storage.List(ctx, namespace, options)
 	if err != nil {
@@ -82,9 +82,12 @@ func (s *SecureValueRest) List(ctx context.Context, options *internalversion.Lis
 
 // Get calls the inner `store` (persistence) and returns a `securevalue` by `name`. It will NOT return the decrypted `value`.
 func (s *SecureValueRest) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	namespace := request.NamespaceValue(ctx)
+	nn := secretstorage.NamespacedName{
+		Name:      name,
+		Namespace: secretstorage.Namespace(request.NamespaceValue(ctx)),
+	}
 
-	sv, err := s.storage.Read(ctx, namespace, name)
+	sv, err := s.storage.Read(ctx, nn)
 	if err != nil {
 		if errors.Is(err, secretstorage.ErrSecureValueNotFound) {
 			return nil, s.resource.NewNotFound(name)
@@ -205,9 +208,12 @@ func (s *SecureValueRest) Update(
 // Delete calls the inner `store` (persistence) in order to delete the `securevalue`.
 // The second return parameter `bool` indicates whether the delete was instant or not. It always is for `securevalues`.
 func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	namespace := request.NamespaceValue(ctx)
+	nn := secretstorage.NamespacedName{
+		Name:      name,
+		Namespace: secretstorage.Namespace(request.NamespaceValue(ctx)),
+	}
 
-	if err := s.storage.Delete(ctx, namespace, name); err != nil {
+	if err := s.storage.Delete(ctx, nn); err != nil {
 		return nil, false, fmt.Errorf("delete secure value: %w", err)
 	}
 

--- a/pkg/storage/secret/namespace.go
+++ b/pkg/storage/secret/namespace.go
@@ -7,8 +7,8 @@ func (n Namespace) String() string {
 	return string(n)
 }
 
-// NamespacedName is a tuple of name and namespace, often used by K8s resources for uniqueness.
-type NamespacedName struct {
+// NameNamespace is a tuple of name and namespace, often used by K8s resources for uniqueness.
+type NameNamespace struct {
 	Name      string
 	Namespace Namespace
 }

--- a/pkg/storage/secret/namespace.go
+++ b/pkg/storage/secret/namespace.go
@@ -1,0 +1,14 @@
+package secret
+
+// Namespace is a newtype of string that improves type safety.
+type Namespace string
+
+func (n Namespace) String() string {
+	return string(n)
+}
+
+// NamespacedName is a tuple of name and namespace, often used by K8s resources for uniqueness.
+type NamespacedName struct {
+	Name      string
+	Namespace Namespace
+}

--- a/pkg/storage/secret/secure_value_store.go
+++ b/pkg/storage/secret/secure_value_store.go
@@ -23,9 +23,9 @@ var (
 // SecureValueStorage is the interface for wiring and dependency injection.
 type SecureValueStorage interface {
 	Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Read(ctx context.Context, nn NamespacedName) (*secretv0alpha1.SecureValue, error)
+	Read(ctx context.Context, nn NameNamespace) (*secretv0alpha1.SecureValue, error)
 	Update(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error)
-	Delete(ctx context.Context, nn NamespacedName) error
+	Delete(ctx context.Context, nn NameNamespace) error
 	List(ctx context.Context, namespace Namespace, options *internalversion.ListOptions) (*secretv0alpha1.SecureValueList, error)
 }
 
@@ -82,7 +82,7 @@ func (s *storage) Create(ctx context.Context, sv *secretv0alpha1.SecureValue) (*
 	return createdSecureValue, nil
 }
 
-func (s *storage) Read(ctx context.Context, nn NamespacedName) (*secretv0alpha1.SecureValue, error) {
+func (s *storage) Read(ctx context.Context, nn NameNamespace) (*secretv0alpha1.SecureValue, error) {
 	row, err := s.readInternal(ctx, nn)
 	if err != nil {
 		return nil, fmt.Errorf("read internal: %w", err)
@@ -102,7 +102,7 @@ func (s *storage) Update(ctx context.Context, newSecureValue *secretv0alpha1.Sec
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	nn := NamespacedName{
+	nn := NameNamespace{
 		Name:      newSecureValue.Name,
 		Namespace: Namespace(newSecureValue.Namespace),
 	}
@@ -141,7 +141,7 @@ func (s *storage) Update(ctx context.Context, newSecureValue *secretv0alpha1.Sec
 	return secureValue, nil
 }
 
-func (s *storage) Delete(ctx context.Context, nn NamespacedName) error {
+func (s *storage) Delete(ctx context.Context, nn NameNamespace) error {
 	_, ok := claims.From(ctx)
 	if !ok {
 		return fmt.Errorf("missing auth info in context")
@@ -211,7 +211,7 @@ func (s *storage) List(ctx context.Context, namespace Namespace, options *intern
 	}, nil
 }
 
-func (s *storage) readInternal(ctx context.Context, nn NamespacedName) (*secureValueDB, error) {
+func (s *storage) readInternal(ctx context.Context, nn NameNamespace) (*secureValueDB, error) {
 	_, ok := claims.From(ctx)
 	if !ok {
 		return nil, fmt.Errorf("missing auth info in context")


### PR DESCRIPTION
For some reason one of the integration tests (Delete securevalue) was not working, and I looked at the code, then the test, and I couldn't figure out what was wrong.

The data was not being deleted from the DB, but no errors were being returned.

It turns out that when calling the storage from the rest layer, I had swapped `name` and `namespace` since they are both `strings`.

That is the motivation for this PR, it will help us avoid these kind of mistakes by distinguishing a `namespace` and `namespace+name`.