### PR TITLE
Fix: Explore Traces metrics queries in Safari

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -349,7 +349,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
               grafana_version: config.buildInfo.version,
               query: queryValue ?? '',
             });
-            subQueries.push(this.handleTraceQlMetricsQuery(options));
+            subQueries.push(this.handleTraceQlMetricsQuery(options, targets.traceql));
           } else {
             reportInteraction('grafana_traces_traceql_queried', {
               datasourceType: 'tempo',
@@ -588,8 +588,11 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     }
   };
 
-  handleTraceQlMetricsQuery = (options: DataQueryRequest<TempoQuery>): Observable<DataQueryResponse> => {
-    const validTargets = options.targets
+  handleTraceQlMetricsQuery(
+    options: DataQueryRequest<TempoQuery>,
+    targets: TempoQuery[]
+  ): Observable<DataQueryResponse> {
+    const validTargets = targets
       .filter((t) => t.query)
       .map(
         (t): TempoQuery => ({ ...t, query: this.applyVariables(t, options.scopedVars).query, queryType: 'traceql' })
@@ -607,7 +610,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         return of({ error: { message: getErrorMessage(err.data.message) }, data: [] });
       })
     );
-  };
+  }
 
   handleMetricsSummaryQuery = (target: TempoQuery, query: string, options: DataQueryRequest<TempoQuery>) => {
     reportInteraction('grafana_traces_metrics_summary_queried', {


### PR DESCRIPTION
**What is this feature?**

Fixes Explore Traces metrics queries in Safari.

**Why do we need this feature?**

So metrics queries will run in the correct context and succeed.

**Who is this feature for?**

Explore Traces users.

**Special notes for your reviewer:**

Explore Traces would not work in Safari and resulted in the following errors: "undefined is not an object (evaluating 'super.query')".

![Screenshot 2024-12-17 at 09 11 09](https://github.com/user-attachments/assets/10b12775-0fde-4afa-9061-3de1e76167e4)
