### PR TITLE
Secrets: use `ExposedSecureValue` wrapper type on SecureValues spec

### DIFF
--- a/pkg/apis/secret/v0alpha1/exposed_secure_value.go
+++ b/pkg/apis/secret/v0alpha1/exposed_secure_value.go
@@ -27,11 +27,16 @@ func NewExposedSecureValue(v string) ExposedSecureValue {
 }
 
 // DangerouslyExposeAndConsumeValue will move the decrypted secure value out of the wrapper and return it.
-// Further attemps to call this method will simply return an empty string.
+// Further attempts to call this method will panic.
 // The function name is intentionally kept long and weird because this is a dangerous operation and should be used carefully!
 func (s *ExposedSecureValue) DangerouslyExposeAndConsumeValue() string {
+	if *s == "" {
+		panic("underlying value is empty or was consumed")
+	}
+
 	tmp := *s
 	*s = ""
+
 	return string(tmp)
 }
 

--- a/pkg/apis/secret/v0alpha1/exposed_secure_value.go
+++ b/pkg/apis/secret/v0alpha1/exposed_secure_value.go
@@ -1,4 +1,4 @@
-package secret
+package v0alpha1
 
 import (
 	"encoding/json"
@@ -11,12 +11,7 @@ import (
 const redacted = "[REDACTED]"
 
 // ExposedSecureValue contains the raw decrypted secure value.
-type ExposedSecureValue struct {
-	_ struct{}  // noCopy
-	_ [0]func() // noCompare
-
-	v string
-}
+type ExposedSecureValue string
 
 var (
 	_ fmt.Stringer   = (*ExposedSecureValue)(nil)
@@ -28,13 +23,16 @@ var (
 
 // NewExposedSecureValue creates a new exposed secure value wrapper.
 func NewExposedSecureValue(v string) ExposedSecureValue {
-	return ExposedSecureValue{v: v}
+	return ExposedSecureValue(v)
 }
 
-// DangerouslyExposeDecryptedValue will return the decrypted secure value.
+// DangerouslyExposeAndConsumeValue will move the decrypted secure value out of the wrapper and return it.
+// Further attemps to call this method will simply return an empty string.
 // The function name is intentionally kept long and weird because this is a dangerous operation and should be used carefully!
-func (s ExposedSecureValue) DangerouslyExposeDecryptedValue() string {
-	return s.v
+func (s *ExposedSecureValue) DangerouslyExposeAndConsumeValue() string {
+	tmp := *s
+	*s = ""
+	return string(tmp)
 }
 
 // String must not return the exposed secure value.
@@ -60,19 +58,4 @@ func (s ExposedSecureValue) MarshalJSON() ([]byte, error) {
 // MarshalYAML must not return the exposed secure value.
 func (s ExposedSecureValue) MarshalYAML() (any, error) {
 	return redacted, nil
-}
-
-// SecureValue
-// TODO: what fields do we need for this DTO? We convert from the k8s object to this before entering the core logic.
-type SecureValue struct {
-	Title string
-	Value ExposedSecureValue
-}
-
-// ManagedSecureValueID represents either the secure value's GUID or ref (in case of external secret references).
-// TODO: maybe this should be an interface?
-type ManagedSecureValueID string
-
-func (s ManagedSecureValueID) String() string {
-	return string(s)
 }

--- a/pkg/apis/secret/v0alpha1/exposed_secure_value_test.go
+++ b/pkg/apis/secret/v0alpha1/exposed_secure_value_test.go
@@ -43,6 +43,6 @@ func TestExposedSecureValue(t *testing.T) {
 	// DangerouslyExposeAndConsumeValue returns the raw value.
 	require.Equal(t, rawValue, esv.DangerouslyExposeAndConsumeValue())
 
-	// Further calls to DangerouslyExposeAndConsumeValue simply return an empty string.
-	require.Empty(t, esv.DangerouslyExposeAndConsumeValue())
+	// Further calls to DangerouslyExposeAndConsumeValue will panic.
+	require.Panics(t, func() { esv.DangerouslyExposeAndConsumeValue() })
 }

--- a/pkg/apis/secret/v0alpha1/exposed_secure_value_test.go
+++ b/pkg/apis/secret/v0alpha1/exposed_secure_value_test.go
@@ -1,4 +1,4 @@
-package secret_test
+package v0alpha1_test
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/registry/apis/secret"
+	"github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -15,7 +15,7 @@ func TestExposedSecureValue(t *testing.T) {
 	expected := "[REDACTED]"
 
 	rawValue := "a-password"
-	esv := secret.NewExposedSecureValue(rawValue)
+	esv := v0alpha1.NewExposedSecureValue(rawValue)
 
 	// String must not return the exposed secure value.
 	require.Equal(t, expected, esv.String())
@@ -40,6 +40,9 @@ func TestExposedSecureValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "'"+expected+"'\n", string(bytes))
 
-	// DangerouslyExposeDecryptedValue returns the raw value.
-	require.Equal(t, rawValue, esv.DangerouslyExposeDecryptedValue())
+	// DangerouslyExposeAndConsumeValue returns the raw value.
+	require.Equal(t, rawValue, esv.DangerouslyExposeAndConsumeValue())
+
+	// Further calls to DangerouslyExposeAndConsumeValue simply return an empty string.
+	require.Empty(t, esv.DangerouslyExposeAndConsumeValue())
 }

--- a/pkg/apis/secret/v0alpha1/secure_value.go
+++ b/pkg/apis/secret/v0alpha1/secure_value.go
@@ -23,7 +23,7 @@ type SecureValueSpec struct {
 
 	// The raw value is only valid for write. Read/List will always be empty
 	// Writing with an empty value will always fail
-	Value string `json:"value,omitempty"`
+	Value ExposedSecureValue `json:"value,omitempty"`
 
 	// When using a remote Key manager, the ref is used to
 	// reference a value inside the remote storage

--- a/pkg/registry/apis/secret/keeper/sqlkeeper.go
+++ b/pkg/registry/apis/secret/keeper/sqlkeeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret"
 )
 
@@ -16,14 +17,14 @@ func NewSQLKeeper(ctx context.Context) (*SQLKeeper, error) {
 	return &SQLKeeper{}, nil
 }
 
-func (s *SQLKeeper) Store(ctx context.Context, sv secret.SecureValue) (secret.ManagedSecureValueID, error) {
+func (s *SQLKeeper) Store(ctx context.Context, exposedValueOrRef string) (secret.ExternalID, error) {
 	return "", nil
 }
 
-func (s *SQLKeeper) Expose(ctx context.Context, id secret.ManagedSecureValueID) (secret.ExposedSecureValue, error) {
-	return secret.NewExposedSecureValue(""), nil
+func (s *SQLKeeper) Expose(ctx context.Context, id secret.ExternalID) (secretv0alpha1.ExposedSecureValue, error) {
+	return secretv0alpha1.NewExposedSecureValue(""), nil
 }
 
-func (s *SQLKeeper) Delete(ctx context.Context, id secret.ManagedSecureValueID) error {
+func (s *SQLKeeper) Delete(ctx context.Context, id secret.ExternalID) error {
 	return nil
 }

--- a/pkg/registry/apis/secret/secret.go
+++ b/pkg/registry/apis/secret/secret.go
@@ -1,9 +1,23 @@
 package secret
 
-import "context"
+import (
+	"context"
+
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+)
 
 type Keeper interface {
-	Store(ctx context.Context, sv SecureValue) (ManagedSecureValueID, error)
-	Expose(ctx context.Context, id ManagedSecureValueID) (ExposedSecureValue, error)
-	Delete(ctx context.Context, id ManagedSecureValueID) error
+	// TODO: support either .Spec.Value (ExposedSecureValue) or .Spec.Ref (string) when Storing.
+	Store(ctx context.Context, exposedValueOrRef string) (ExternalID, error)
+	Expose(ctx context.Context, id ExternalID) (secretv0alpha1.ExposedSecureValue, error)
+	Delete(ctx context.Context, id ExternalID) error
+}
+
+// ExternalID represents either the secure value's GUID or ref (in case of external secret references).
+// This is saved in the secure_value metadata storage as `external_id`.
+// TODO: this does not belong in the k8s spec, but it is used by us internally. Place it somewhere appropriate.
+type ExternalID string
+
+func (s ExternalID) String() string {
+	return string(s)
 }


### PR DESCRIPTION
The `secretv0alpha1.SecureValue` struct which will hold the raw decrypted value when creating a new `securevalue` is better guarded against being accidentally leaked (through logs, error wrapping or otherwise), because we need to pass down the K8s type from the API layer into the DB storage.

A small modification is that once the "reveal" method is called, it mutates the original variable and moves the exposed value from it, so that further calls won't return it again.

In practice I don't think we'll need or should expose the secure value more than once, hence the functional change.