### PR TITLE
[v11.4.x] Fix: Add support for datasource variable queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "@grafana/prometheus": "workspace:*",
     "@grafana/runtime": "workspace:*",
     "@grafana/saga-icons": "workspace:*",
-    "@grafana/scenes": "^5.30.0",
+    "@grafana/scenes": "5.34.0",
     "@grafana/schema": "workspace:*",
     "@grafana/sql": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,9 +4106,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/scenes@npm:^5.30.0":
-  version: 5.30.0
-  resolution: "@grafana/scenes@npm:5.30.0"
+"@grafana/scenes@npm:5.34.0":
+  version: 5.34.0
+  resolution: "@grafana/scenes@npm:5.34.0"
   dependencies:
     "@floating-ui/react": "npm:^0.26.16"
     "@leeoniya/ufuzzy": "npm:^1.0.16"
@@ -4125,7 +4125,7 @@ __metadata:
     "@grafana/ui": ">=10.4"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/d226f523ef2b22eac0de26e7929dbe5d5775f297b0f0c07a4a1b5c792c224c72eab67312d43b7a88d85416c9e4c91f9064777d54e696fdf9da2366c70914b6b3
+  checksum: 10/a0b8f9d271a5db05b54345642622546549da1f4a7e36007980e3a4f66513ea98aecbff6403f5ef00cd430609587b83a2807404b4c7d4da670e5b8cc44ff57cb4
   languageName: node
   linkType: hard
 
@@ -18911,7 +18911,7 @@ __metadata:
     "@grafana/prometheus": "workspace:*"
     "@grafana/runtime": "workspace:*"
     "@grafana/saga-icons": "workspace:*"
-    "@grafana/scenes": "npm:^5.30.0"
+    "@grafana/scenes": "npm:5.34.0"
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/tsconfig": "npm:^2.0.0"


### PR DESCRIPTION
Backport 7c583ed8fb11838ff8324f46b1356617f32745b8 from #98098

---

**What is this feature?**

This PR bumps scenes package to fix a problem related to datasource variable support. See details in the linked issue. The problem was introduced in 11.3, to this fix needs to be backported.

Cannot include the tests in the backport PR since the test plugin didn't exist in 11.4.

**Why do we need this feature?**

To fix datasource variable support in plugins.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

Fixes #98101

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
