### PR TITLE
Table panel: expose TableCellInspector and TableCellInspectorMode in @grafana/ui package

### DIFF
--- a/packages/grafana-ui/README.md
+++ b/packages/grafana-ui/README.md
@@ -16,4 +16,4 @@ See [package source](https://github.com/grafana/grafana/tree/main/packages/grafa
 
 ## Development
 
-For development purposes we suggest using `yarn link` that will create symlink to @grafana/ui lib. To do so navigate to `packages/grafana-ui` and run `yarn link`. Then, navigate to your project and run `yarn link @grafana/ui` to use the linked version of the lib. To unlink follow the same procedure, but use `yarn unlink` instead.
+For development purposes we suggest using `yarn link` that will create symlink to @grafana/ui lib. To do so navigate to `packages/grafana-ui` and run `YARN_IGNORE_PATH=1 yarn link`. Then, navigate to your project and run `yarn link "@grafana/ui"` to use the linked version of the lib. To unlink follow the same procedure, but use `yarn unlink` instead.

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -85,6 +85,7 @@ export { PageToolbar } from './PageLayout/PageToolbar';
 export { SetInterval } from './SetInterval/SetInterval';
 
 export { Table } from './Table/Table';
+export { TableCellInspector, TableCellInspectorMode } from './Table/TableCellInspector';
 export {
   type TableCustomCellOptions,
   type CustomCellRendererProps,


### PR DESCRIPTION
**What is this feature?**
Allow Tables with custom cell renderers to call existing inspect modal.

**Why do we need this feature?**
Better support for users with custom cell renderers, allow apps to get UI updates without needing to duplicate code across many repos.

**Who is this feature for?**
Consumers of @grafana/ui, table users.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/93590

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
