### PR TITLE
Shard query splitting: run queries through time query splitting

### DIFF
--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -64,9 +64,20 @@ describe('runSplitQuery()', () => {
   });
 
   test('Splits datasource queries', async () => {
-    await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
+    await expect(runSplitQuery(datasource, request)).toEmitValuesWith((emitted) => {
       // 3 days, 3 chunks, 3 requests.
       expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+      // 3 sub-requests + complete
+      expect(emitted).toHaveLength(4);
+    });
+  });
+
+  test('Skips partial updates as an option', async () => {
+    await expect(runSplitQuery(datasource, request, { skipPartialUpdates: true })).toEmitValuesWith((emitted) => {
+      // 3 days, 3 chunks, 3 requests.
+      expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+      // partial updates skipped
+      expect(emitted).toHaveLength(1);
     });
   });
 
@@ -77,6 +88,16 @@ describe('runSplitQuery()', () => {
     await expect(runSplitQuery(datasource, request)).toEmitValuesWith(() => {
       // 3 days, 3 chunks, 1 retry, 4 requests.
       expect(datasource.runQuery).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  test('Does not retry failed queries as an option', async () => {
+    jest
+      .mocked(datasource.runQuery)
+      .mockReturnValueOnce(of({ state: LoadingState.Error, errors: [{ refId: 'A', message: 'timeout' }], data: [] }));
+    await expect(runSplitQuery(datasource, request, { disableRetry: true })).toEmitValuesWith(() => {
+      // 3 days, 3 chunks, no retries, 3 requests.
+      expect(datasource.runQuery).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/public/app/plugins/datasource/loki/querySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.test.ts
@@ -96,8 +96,8 @@ describe('runSplitQuery()', () => {
       .mocked(datasource.runQuery)
       .mockReturnValueOnce(of({ state: LoadingState.Error, errors: [{ refId: 'A', message: 'timeout' }], data: [] }));
     await expect(runSplitQuery(datasource, request, { disableRetry: true })).toEmitValuesWith(() => {
-      // 3 days, 3 chunks, no retries, 3 requests.
-      expect(datasource.runQuery).toHaveBeenCalledTimes(3);
+      // No retries
+      expect(datasource.runQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -48,6 +48,13 @@ export function partitionTimeRange(
   });
 }
 
+interface QuerySplittingOptions {
+  /**
+   * Tells the query splitting code to not emit partial updates. Only emit on error or when it finishes querying.
+   */
+  skipPartialUpdates?: boolean;
+}
+
 /**
  * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
  * For `maxLines`, we will update it as `maxLines - current amount of lines`.
@@ -76,7 +83,11 @@ export function adjustTargetsFromResponseState(targets: LokiQuery[], response: D
     })
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
-export function runSplitGroupedQueries(datasource: LokiDatasource, requests: LokiGroupedRequest[]) {
+export function runSplitGroupedQueries(
+  datasource: LokiDatasource,
+  requests: LokiGroupedRequest[],
+  options: QuerySplittingOptions = {}
+) {
   const responseKey = requests.length ? requests[0].request.queryGroupId : uuidv4();
   let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: responseKey };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
@@ -170,13 +181,17 @@ export function runSplitGroupedQueries(datasource: LokiDatasource, requests: Lok
           shouldStop = true;
         }
         mergedResponse = combineResponses(mergedResponse, partialResponse);
-        mergedResponse = updateLoadingFrame(mergedResponse, subRequest, longestPartition, requestN);
+        if (!options.skipPartialUpdates) {
+          mergedResponse = updateLoadingFrame(mergedResponse, subRequest, longestPartition, requestN);
+        }
       },
       complete: () => {
         if (retrying) {
           return;
         }
-        subscriber.next(mergedResponse);
+        if (!options.skipPartialUpdates) {
+          subscriber.next(mergedResponse);
+        }
         nextRequest();
       },
       error: (error) => {
@@ -268,7 +283,11 @@ function querySupportsSplitting(query: LokiQuery) {
   );
 }
 
-export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
+export function runSplitQuery(
+  datasource: LokiDatasource,
+  request: DataQueryRequest<LokiQuery>,
+  options: QuerySplittingOptions = {}
+) {
   const queries = request.targets.filter((query) => !query.hide).filter((query) => query.expr);
   const [nonSplittingQueries, normalQueries] = partition(queries, (query) => !querySupportsSplitting(query));
   const [logQueries, metricQueries] = partition(normalQueries, (query) => isLogsQuery(query.expr));
@@ -330,7 +349,7 @@ export function runSplitQuery(datasource: LokiDatasource, request: DataQueryRequ
   }
 
   const startTime = new Date();
-  return runSplitGroupedQueries(datasource, requests).pipe(
+  return runSplitGroupedQueries(datasource, requests, options).pipe(
     tap((response) => {
       if (response.state === LoadingState.Done) {
         trackGroupedQueries(response, requests, request, startTime, {

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -53,6 +53,10 @@ interface QuerySplittingOptions {
    * Tells the query splitting code to not emit partial updates. Only emit on error or when it finishes querying.
    */
   skipPartialUpdates?: boolean;
+  /**
+   * Do not retry failed queries.
+   */
+  disableRetry?: boolean;
 }
 
 /**
@@ -127,6 +131,9 @@ export function runSplitGroupedQueries(
     };
 
     const retry = (errorResponse?: DataQueryResponse) => {
+      if (options.disableRetry) {
+        return false;
+      }
       try {
         if (errorResponse && !isRetriableError(errorResponse)) {
           return false;

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -74,7 +74,9 @@ describe('runShardSplitQuery()', () => {
         to: dateTime('2023-02-10T06:00:00.000Z'),
       },
     };
-    request = createRequest([{ expr: '$SELECTOR', refId: 'A', direction: LokiQueryDirection.Scan }], { range: querySplittingRange });
+    request = createRequest([{ expr: '$SELECTOR', refId: 'A', direction: LokiQueryDirection.Scan }], {
+      range: querySplittingRange,
+    });
     await expect(runShardSplitQuery(datasource, request)).toEmitValuesWith(() => {
       // 5 shards, 3 groups + empty shard group, 4 requests * 3 days, 3 chunks, 3 requests = 12 requests
       expect(datasource.runQuery).toHaveBeenCalledTimes(12);
@@ -229,7 +231,7 @@ describe('runShardSplitQuery()', () => {
   });
 
   test('Adjusts the group size based on errors and execution time', async () => {
-   jest
+    jest
       .mocked(datasource.languageProvider.fetchLabelValues)
       .mockResolvedValue(['1', '10', '2', '20', '3', '4', '5', '6', '7', '8', '9']);
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -79,7 +79,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_0_2',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_0_2_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"20|10"}',
@@ -92,7 +93,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_2_2',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_2_2_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"3|2"}',
@@ -105,7 +107,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_4_1',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_4_1_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__="1"}',
@@ -118,7 +121,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_5_1',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_5_1_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=""}',
@@ -147,7 +151,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_0_2',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_0_2_1',
         targets: [
           {
             expr: '{service_name="test", filter="true", __stream_shard__=~"20|10"}',
@@ -208,18 +213,7 @@ describe('runShardSplitQuery()', () => {
   });
 
   test('Adjusts the group size based on errors and execution time', async () => {
-    const request = createRequest([{ expr: '$SELECTOR', refId: 'A', direction: LokiQueryDirection.Scan }], {
-      range: {
-        from: dateTime('2024-11-13T05:00:00.000Z'),
-        to: dateTime('2024-11-14T06:00:00.000Z'),
-        raw: {
-          from: dateTime('2024-11-13T05:00:00.000Z'),
-          to: dateTime('2024-11-14T06:00:00.000Z'),
-        },
-      },
-    });
-
-    jest
+   jest
       .mocked(datasource.languageProvider.fetchLabelValues)
       .mockResolvedValue(['1', '10', '2', '20', '3', '4', '5', '6', '7', '8', '9']);
 
@@ -373,7 +367,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_0_3',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_0_3_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"20|10|9"}',
@@ -387,7 +382,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_3_4',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_3_4_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"8|7|6|5"}',
@@ -401,7 +397,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_3_2',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_3_2_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"8|7"}',
@@ -415,7 +412,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_5_3',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_5_3_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"6|5|4"}',
@@ -429,7 +427,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_8_2',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_8_2_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=~"3|2"}',
@@ -443,7 +442,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_10_1',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_10_1_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__="1"}',
@@ -457,7 +457,8 @@ describe('runShardSplitQuery()', () => {
       expect(datasource.runQuery).toHaveBeenCalledWith({
         intervalMs: expect.any(Number),
         range: expect.any(Object),
-        requestId: 'TEST_shard_0_11_1',
+        queryGroupId: expect.any(String),
+        requestId: 'TEST_shard_0_11_1_1',
         targets: [
           {
             expr: '{a="b", __stream_shard__=""}',

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -160,7 +160,7 @@ function splitQueriesByStreamShard(
 
     debug(shardsToQuery.length ? `Querying ${shardsToQuery.join(', ')}` : 'Running regular query');
 
-    subquerySubscription = runSplitQuery(datasource, subRequest, { skipPartialUpdates: true }).subscribe({
+    subquerySubscription = runSplitQuery(datasource, subRequest, { skipPartialUpdates: true, disableRetry: true }).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
           if (retry(partialResponse)) {

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -160,9 +160,7 @@ function splitQueriesByStreamShard(
 
     debug(shardsToQuery.length ? `Querying ${shardsToQuery.join(', ')}` : 'Running regular query');
 
-    const queryRunner =
-      shardsToQuery.length > 0 ? datasource.runQuery.bind(datasource) : runSplitQuery.bind(null, datasource);
-    subquerySubscription = queryRunner(subRequest).subscribe({
+    subquerySubscription = runSplitQuery(datasource, subRequest, { skipPartialUpdates: true }).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
           if (retry(partialResponse)) {

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -160,7 +160,10 @@ function splitQueriesByStreamShard(
 
     debug(shardsToQuery.length ? `Querying ${shardsToQuery.join(', ')}` : 'Running regular query');
 
-    subquerySubscription = runSplitQuery(datasource, subRequest, { skipPartialUpdates: true, disableRetry: true }).subscribe({
+    subquerySubscription = runSplitQuery(datasource, subRequest, {
+      skipPartialUpdates: true,
+      disableRetry: true,
+    }).subscribe({
       next: (partialResponse: DataQueryResponse) => {
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
           if (retry(partialResponse)) {


### PR DESCRIPTION
This PR updates shard query splitting to execute queries through the time query splitting runner. This allows multi-day queries to also benefit from time splitting, improving queries in situations with very high volume (huge amount of logs over several days), where the lower shards (0, 1) or the empty shard queries will timeout and never execute.