### PR TITLE
UniStore: Get Folder Handler return Root Folder (general)

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -776,7 +776,24 @@ func (fk8s *folderK8sHandler) getFolder(c *contextmodel.ReqContext) {
 		return // error is already sent
 	}
 	uid := web.Params(c.Req)[":uid"]
-	out, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+
+	var out *unstructured.Unstructured
+	var err error
+
+	if uid == accesscontrol.GeneralFolderUID {
+		out = &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"title":       folder.RootFolder.Title,
+					"description": folder.RootFolder.Description,
+				},
+			},
+		}
+		out.SetName(folder.RootFolder.UID)
+	} else {
+		out, err = client.Get(c.Req.Context(), uid, v1.GetOptions{})
+	}
+
 	if err != nil {
 		fk8s.writeError(c, err)
 		return

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -92,13 +92,20 @@ func UnstructuredToLegacyFolder(item unstructured.Unstructured, orgID int64) (*f
 		createdTime = (*created).UTC()
 	}
 
+	url := getURL(meta, title)
+
+	// RootFolder does not have URL
+	if uid == folder.RootFolder.UID {
+		url = ""
+	}
+
 	f := &folder.Folder{
 		UID:       uid,
 		Title:     title,
 		ID:        id,
 		ParentUID: meta.GetFolder(),
 		// #TODO add created by field if necessary
-		URL: getURL(meta, title),
+		URL: url,
 		// #TODO get Created in format "2024-09-12T15:37:41.09466+02:00"
 		Created: createdTime,
 		// #TODO figure out whether we want to set "updated" and "updated by". Could replace with


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR modifies the Get Folder k8s handler to return the RootFolder when the `uid=general`

**Why do we need this feature?**

This is the same behavior as the Legacy handler

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-org/issues/340
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
