### PR TITLE
Alerting: Fix ash not showing history graph in firefox 

### DIFF
--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -124,10 +124,7 @@ export const CentralAlertHistoryScene = () => {
       body: new SceneFlexLayout({
         direction: 'column',
         children: [
-          new SceneFlexItem({
-            ySizing: 'content',
-            body: getEventsSceneObject(),
-          }),
+          getEventsScenesFlexItem(),
           new SceneFlexItem({
             body: new HistoryEventsListObject({}),
           }),
@@ -145,16 +142,6 @@ export const CentralAlertHistoryScene = () => {
 
   return <scene.Component model={scene} />;
 };
-/**
- * Creates a SceneFlexItem with a timeseries panel that shows the events.
- * The query uses a runtime datasource that fetches the events from the history api.
- */
-function getEventsSceneObject() {
-  return new SceneFlexLayout({
-    direction: 'column',
-    children: [getEventsScenesFlexItem()],
-  });
-}
 
 /**
  * Creates a SceneQueryRunner with the datasource information for the runtime datasource.
@@ -182,6 +169,7 @@ function getQueryRunnerForAlertHistoryDataSource() {
 export function getEventsScenesFlexItem() {
   return new SceneFlexItem({
     minHeight: 300,
+    ySizing: 'content',
     body: PanelBuilders.timeseries()
       .setTitle('Alert Events')
       .setDescription(


### PR DESCRIPTION
**What is this feature?**

This PR fixes the graph in the ash page not shown in Firefox browsers.
In Firefox browsers, the graph is hidden.
It's is a regression after merging this refactor: https://github.com/grafana/grafana/pull/97619

**Why do we need this feature?**

Its a bug.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
