### PR TITLE
BarChart: No data display option from standard config

### DIFF
--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -166,14 +166,14 @@ describe('BarChart utils', () => {
   });
 
   describe('prepareGraphableFrames', () => {
-    it('will warn when there is no frames in the response', () => {
+    it('will warn with empty message when there is no frames in the response', () => {
       const info = prepSeries([], fieldConfig, StackingMode.None, createTheme());
       const warning = assertIsDefined('warn' in info ? info : null);
 
-      expect(warning.warn).toEqual('No data in response');
+      expect(warning.warn).toEqual('');
     });
 
-    it('will warn when there is no data in the response', () => {
+    it('will warn with empty message when there is no data in the response', () => {
       const info = prepSeries(
         [
           {
@@ -187,7 +187,7 @@ describe('BarChart utils', () => {
       );
       const warning = assertIsDefined('warn' in info ? info : null);
 
-      expect(warning.warn).toEqual('No data in response');
+      expect(warning.warn).toEqual('');
     });
 
     it('will warn when there is no string or time field', () => {

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -58,7 +58,7 @@ export function prepSeries(
   colorFieldName?: string
 ): BarSeries {
   if (frames.length === 0 || frames.every((fr) => fr.length === 0)) {
-    return { series: [], _rest: [], warn: 'No data in response' };
+    return { series: [], _rest: [], warn: '' };
   }
 
   cacheFieldDisplayNames(frames);

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -58,6 +58,7 @@ export function prepSeries(
   colorFieldName?: string
 ): BarSeries {
   if (frames.length === 0 || frames.every((fr) => fr.length === 0)) {
+    // warn message set to empty so that PanelDataErrorView which can handle empty frames / no data scenarios
     return { series: [], _rest: [], warn: '' };
   }
 


### PR DESCRIPTION
Problem: barchart doesn't honour `noValue` setting from standard config.

Fixes https://community.grafana.com/t/no-data-in-response/138571

## Before

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/e55bbed0-9fe1-4052-9cfc-13420ec32a78" />

## After

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0f69b900-9e08-4c57-8c7e-e2c6df225f6e" />

