### PR TITLE
TableNG: Fix sorting

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -135,6 +135,9 @@ export function TableNG(props: TableNGProps) {
   }, [isContextMenuOpen]);
 
   const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
+  // TODO: this ref using to persist sortColumns between renders;
+  // setSortColumns is still used to trigger re-render
+  const sortColumnsRef = useRef(sortColumns);
 
   function getDefaultRowHeight(): number {
     const bodyFontSize = theme.typography.fontSize;
@@ -202,7 +205,7 @@ export function TableNG(props: TableNGProps) {
   const handleSort = (columnKey: string, direction: SortDirection) => {
     let currentSortColumn: SortColumn | undefined;
 
-    const updatedSortColumns = sortColumns.filter((column) => {
+    const updatedSortColumns = sortColumnsRef.current.filter((column) => {
       const isCurrentColumn = column.columnKey === columnKey;
       if (isCurrentColumn) {
         currentSortColumn = column;
@@ -213,9 +216,11 @@ export function TableNG(props: TableNGProps) {
     // sorted column exists and is descending -> remove it to reset sorting
     if (currentSortColumn && currentSortColumn.direction === 'DESC') {
       setSortColumns(updatedSortColumns);
+      sortColumnsRef.current = updatedSortColumns;
     } else {
       // new sort column or changed direction
       setSortColumns([...updatedSortColumns, { columnKey, direction }]);
+      sortColumnsRef.current = [...updatedSortColumns, { columnKey, direction }];
     }
   };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes TableNG sorting issues.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #97768 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
