### PR TITLE
Prometheus: Add error source to data response when prom returns a response 

### DIFF
--- a/pkg/promlib/querydata/request.go
+++ b/pkg/promlib/querydata/request.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/utils/maputil"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/status"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/promlib/client"
@@ -300,6 +301,7 @@ func addDataResponse(res *backend.DataResponse, dr *backend.DataResponse) {
 		} else {
 			dr.Error = fmt.Errorf("%v %w", dr.Error, res.Error)
 		}
+		dr.ErrorSource = status.SourceFromHTTPStatus(int(res.Status))
 		dr.Status = res.Status
 	}
 	dr.Frames = append(dr.Frames, res.Frames...)


### PR DESCRIPTION
This PR is to identify the error source as "downstream" or "plugin" when Prometheus returns a response with an error code, and then label the data response with that error source.

Why?

This handles incorrect queries and label the data response with error correctly. We need to explicitly set the data response error source so that the logging for the query service SLO does not take into account downstream errors. 

The previous implementations of this work only added the error source when Prometheus returned errors. This will take a normal response and read it so that we can add the error source correctly.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
