### PR TITLE
Table: Fixes broken cell action styles

### DIFF
--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -28,13 +28,13 @@ export const DefaultCell = (props: TableCellProps) => {
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
   const hasActions = Boolean(actions?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
-  const [hover, setHover] = useState(true);
+  const [hover, setHover] = useState(false);
   let value: string | ReactElement;
 
   const OG_TWEET_LENGTH = 140; // 🙏
 
   const onMouseLeave = () => {
-    //setHover(false);
+    setHover(false);
   };
   const onMouseEnter = () => {
     setHover(true);

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -28,13 +28,13 @@ export const DefaultCell = (props: TableCellProps) => {
   const hasLinks = Boolean(getCellLinks(field, row)?.length);
   const hasActions = Boolean(actions?.length);
   const clearButtonStyle = useStyles2(clearLinkButtonStyles);
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useState(true);
   let value: string | ReactElement;
 
   const OG_TWEET_LENGTH = 140; // 🙏
 
   const onMouseLeave = () => {
-    setHover(false);
+    //setHover(false);
   };
   const onMouseEnter = () => {
     setHover(true);

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -63,11 +63,12 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         background: rowStyled ? 'inherit' : (backgroundHover ?? theme.colors.background.primary),
         zIndex: 1,
         '.cellActions': {
-          color: '#FFF',
+          background: theme.components.tooltip.background,
+          color: theme.components.tooltip.text,
           visibility: 'visible',
           opacity: 1,
           width: 'auto',
-          background: 'rgba(0, 0, 0, 0.6)',
+          borderRadius: theme.shape.radius.default,
         },
       },
 
@@ -80,27 +81,20 @@ export function useTableStyles(theme: GrafanaTheme2, cellHeightOption: TableCell
         position: overflowOnHover ? undefined : 'absolute',
         top: overflowOnHover ? undefined : '1px',
         right: overflowOnHover ? undefined : 0,
-        margin: overflowOnHover ? theme.spacing(0, -0.5, 0, 0.5) : 'auto',
+        margin: overflowOnHover ? theme.spacing(0, 0, 0, 1) : 'auto',
         visibility: 'hidden',
         opacity: 0,
         width: 0,
         alignItems: 'center',
         height: '100%',
-        padding: theme.spacing(1, 0.5, 1, 1),
-        background: background ? 'none' : 'rgba(0, 0, 0, 0.5)',
-
-        svg: {
-          color,
-        },
+        padding: theme.spacing(0.5, 0, 0.5, 0.5),
+        background: theme.components.tooltip.background,
+        color: theme.components.tooltip.text,
       },
 
       '.cellActionsLeft': {
         right: 'auto !important',
         left: 0,
-      },
-
-      '.cellActionsTransparent': {
-        background: 'none',
       },
     });
   };


### PR DESCRIPTION
I noticed that cell actions styles where completely off

* Wrong background
* Makes cell height higher when hovering so text jump around

Before:

[table_cell_actions_bug.webm](https://github.com/user-attachments/assets/c25122f3-32a4-4781-acf3-369e67b9e04d)

After: 

[table_fixed_cell_actions.webm](https://github.com/user-attachments/assets/b8d74073-e54e-41e3-b797-80e1effbe84a)
