### PR TITLE
POC/Provisioning: Use cards layout to show more status info

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5330,8 +5330,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "42"]
     ],
     "public/app/features/provisioning/DeleteRepositoryButton.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/provisioning/EditRepositoryPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5360,8 +5359,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/provisioning/RepositorySelect.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -5372,25 +5374,29 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Do not use any type assertions.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "12"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "13"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "16"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "17"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "18"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "19"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"]
     ],
     "public/app/features/provisioning/SyncRepository.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
+    ],
+    "public/app/features/provisioning/api/endpoints.ts:5381": [
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
     "public/app/features/provisioning/api/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -232,12 +232,12 @@ func (rc *RepositoryController) sync(key string) error {
 		if cachedRepo.Status.Initialized {
 			status, err = repo.OnUpdate(ctx, logger)
 			if err != nil {
-				return fmt.Errorf("on create repository: %w", err)
+				rc.logger.Error("OnUpdate", "error", err)
 			}
 		} else {
 			status, err = repo.OnCreate(ctx, logger)
 			if err != nil {
-				return fmt.Errorf("on create repository: %w", err)
+				rc.logger.Error("OnCreate", "error", err)
 			}
 		}
 

--- a/pkg/tests/apis/provisioning/testdata/github-example.yaml
+++ b/pkg/tests/apis/provisioning/testdata/github-example.yaml
@@ -19,4 +19,3 @@ spec:
     generateDashboardPreviews: true
     pullRequestLinter: true
     token: "github_pat_dummy"
-    webhookSecret: "dummyWebhookSecret"

--- a/public/app/features/provisioning/DeleteRepositoryButton.tsx
+++ b/public/app/features/provisioning/DeleteRepositoryButton.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { AppEvents } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
-import { Button, ConfirmModal } from '@grafana/ui';
+import { Button, ConfirmModal, IconButton } from '@grafana/ui';
 
 import { useDeleteRepositoryMutation } from './api';
 
@@ -26,14 +26,13 @@ export function DeleteRepositoryButton({ name }: { name: string }) {
 
   return (
     <>
-      <Button
-        variant="destructive"
+      <IconButton
+        name="trash-alt"
+        tooltip="Delete this repository"
         onClick={() => {
           setShowModal(true);
         }}
-      >
-        Delete
-      </Button>
+      />
       <ConfirmModal
         isOpen={showModal}
         title={'Delete repository config'}


### PR DESCRIPTION
This updates the repository list to show more details in the Cards metadata:

<img width="795" alt="image" src="https://github.com/user-attachments/assets/c1c904d1-ece7-410a-9ffc-d01325687b3b" />


Specifically, it now shows the github repository and link


Compared to our current list view 😬 
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/e8686f1d-34ae-4934-9d07-dacb885cfaf6" />
