### PR TITLE
Loki: Added Auto query direction for log queries in Explore

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -4,7 +4,7 @@ import { memo } from 'react';
 import * as React from 'react';
 
 // Types
-import { SelectableValue } from '@grafana/data';
+import { CoreApp, SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { InlineFormLabel, RadioButtonGroup, InlineField, Input, Select, Stack } from '@grafana/ui';
 
@@ -30,6 +30,11 @@ export const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
 ];
 
 export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
+  {
+    value: undefined,
+    label: 'Auto',
+    description: 'Determined by sort order. Backward for Oldest First, Forward for Newest First',
+  },
   { value: LokiQueryDirection.Backward, label: 'Backward', description: 'Search in backward direction.' },
   {
     value: LokiQueryDirection.Forward,
@@ -37,6 +42,13 @@ export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
     description: 'Search in forward direction.',
   },
 ];
+
+export function getQueryDirections(app: CoreApp | undefined) {
+  if (app === CoreApp.Explore) {
+    return queryDirections;
+  }
+  return queryDirections.filter((direction) => direction.value !== undefined);
+}
 
 if (config.featureToggles.lokiShardSplitting) {
   queryDirections.push({
@@ -47,7 +59,8 @@ if (config.featureToggles.lokiShardSplitting) {
   });
 }
 
-export function getQueryDirectionLabel(direction: LokiQueryDirection) {
+export function getQueryDirectionLabel(app: CoreApp | undefined, direction: LokiQueryDirection) {
+  const queryDirections = getQueryDirections(app);
   return queryDirections.find((queryDirection) => queryDirection.value === direction)?.label ?? 'Unknown';
 }
 

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -29,7 +29,7 @@ export const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
   },
 ];
 
-export const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
+const queryDirections: Array<SelectableValue<LokiQueryDirection>> = [
   {
     value: undefined,
     label: 'Auto',

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -75,6 +75,7 @@ import {
 import { getQueryHints } from './queryHints';
 import { runSplitQuery } from './querySplitting';
 import {
+  applyAutoQueryDirection,
   getLogQueryFromMetricsQuery,
   getLokiQueryFromDataQuery,
   getNodesFromQuery,
@@ -325,6 +326,7 @@ export class LokiDatasource
   query(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
     const queries = request.targets
       .map(getNormalizedLokiQuery) // used to "fix" the deprecated `.queryType` prop
+      .map((target) => (request.app === CoreApp.Explore ? applyAutoQueryDirection(target) : target))
       .map((q) => ({ ...q, maxLines: q.maxLines ?? this.maxLines }));
 
     const fixedRequest: DataQueryRequest<LokiQuery> = {

--- a/public/app/plugins/datasource/loki/queryUtils.ts
+++ b/public/app/plugins/datasource/loki/queryUtils.ts
@@ -1,6 +1,7 @@
 import { SyntaxNode } from '@lezer/common';
 import { escapeRegExp } from 'lodash';
 
+import { store } from '@grafana/data';
 import {
   parser,
   LineFilter,
@@ -26,7 +27,7 @@ import {
   VectorOp,
   BinOpExpr,
 } from '@grafana/lezer-logql';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, LogsSortOrder } from '@grafana/schema';
 
 import { addDropToQuery, addLabelToQuery, getStreamSelectorPositions, NodePosition } from './modifyQuery';
 import { ErrorId } from './querybuilder/parsingUtils';
@@ -109,6 +110,16 @@ export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
     }
   } catch (e) {}
   return { ...rest, queryType };
+}
+
+export function applyAutoQueryDirection(query: LokiQuery): LokiQuery {
+  // See app/features/explore/Logs/utils/logs
+  const key = 'grafana.explore.logs.sortOrder';
+  const autoOrder = store.get(key) || LogsSortOrder.Descending;
+  if (isLogsQuery(query.expr) && !query.direction) {
+    query.direction = autoOrder === LogsSortOrder.Ascending ? LokiQueryDirection.Forward : LokiQueryDirection.Backward;
+  }
+  return query;
 }
 
 export function getLokiQueryType(query: LokiQuery): LokiQueryType {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -217,7 +217,7 @@ function getCollapsedInfo(
   maxLines: number,
   isLogQuery: boolean,
   isValidStep: boolean,
-  direction: LokiQueryDirection | undefined
+  direction: LokiQueryDirection
 ): string[] {
   const queryTypeLabel = queryTypeOptions.find((x) => x.value === queryType);
   const resolutionLabel = RESOLUTION_OPTIONS.find((x) => x.value === (query.resolution ?? 1));


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/91181 we introduced query direction for Loki log queries, allowing users to search from newest to oldest (backward) or from oldest to newest (forward).

Historically, new log queries in Explore had undefined direction, which defaulted to "backward". Now, we're updating that default behavior by renaming it to "Auto" query direction, where the direction is applied based on the selection for the displayed results: 

![imagen](https://github.com/user-attachments/assets/b8405e0c-8510-42a1-a130-c5643d2fe6af)

When the query direction is undefined, or Auto:
- Oldest first will issue queries with forward direction
- Newest first will issue querie with backward direction

Once the user selects a direction, backward, forward, or scan, we don't make any modification to the direction, even if the displayed sort order changes.

Notes:
- Changing the sort order of displayed results will not re-execute queries, as it never had this behavior; it's applied to the results in display.
- "Auto" query direction is not supported and not displayed outside of Explore.
- No core dependencies were used for these changes, keeping Loki "externalized" from core.

Demo:

https://github.com/user-attachments/assets/744319a4-1928-438a-b86d-16aad0f925ea


