### PR TITLE
Move sync status update from replicator to worker

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -119,6 +119,7 @@ func (s *jobStore) drainPending() {
 		}
 		logger := s.logger.With("job", job.GetName(), "namespace", job.GetNamespace())
 
+		started := time.Now()
 		var status *provisioning.JobStatus
 		if s.worker == nil {
 			status = &provisioning.JobStatus{
@@ -141,8 +142,9 @@ func (s *jobStore) drainPending() {
 			logger.DebugContext(ctx, "job processing finished", "status", status.State)
 		}
 
-		// FIXME: set start and finish times for the job once it does not create an infinite loop
-		// in the controller
+		status.Started = started.UnixNano()
+		status.Finished = time.Now().UnixNano()
+
 		err = s.Complete(ctx, job.Namespace, job.Name, *status)
 		if err != nil {
 			logger.ErrorContext(ctx, "error running job", "error", err)

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -141,6 +141,8 @@ func (s *jobStore) drainPending() {
 			logger.DebugContext(ctx, "job processing finished", "status", status.State)
 		}
 
+		// FIXME: set start and finish times for the job once it does not create an infinite loop
+		// in the controller
 		err = s.Complete(ctx, job.Namespace, job.Name, *status)
 		if err != nil {
 			logger.ErrorContext(ctx, "error running job", "error", err)

--- a/pkg/registry/apis/provisioning/jobs/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/worker.go
@@ -92,8 +92,9 @@ func (g *JobWorker) Process(ctx context.Context, job provisioning.Job) (*provisi
 	case provisioning.JobActionSync:
 		ref, syncError := replicator.Sync(ctx)
 		status := &provisioning.SyncStatus{
-			State:    provisioning.JobStateFinished,
-			JobID:    job.GetName(), // TODO: Should we use the job id here?
+			State: provisioning.JobStateFinished,
+			// FIXME: infinite loop if we set this in the controller
+			// JobID:    job.GetName(), // TODO: Should we use the job id here?
 			Hash:     ref,
 			Started:  0, // FIXME: infinite loop if we set this in the controller
 			Finished: 0, // FIXME: infinite loop if we set this in the controller

--- a/pkg/registry/apis/provisioning/jobs/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/worker.go
@@ -2,10 +2,13 @@ package jobs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/url"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -87,9 +90,38 @@ func (g *JobWorker) Process(ctx context.Context, job provisioning.Job) (*provisi
 
 	switch job.Spec.Action {
 	case provisioning.JobActionSync:
-		err := replicator.Sync(ctx)
-		if err != nil {
-			return nil, err
+		ref, syncError := replicator.Sync(ctx)
+		status := &provisioning.SyncStatus{
+			State:    provisioning.JobStateFinished,
+			JobID:    job.GetName(), // TODO: Should we use the job id here?
+			Hash:     ref,
+			Started:  0, // FIXME: infinite loop if we set this in the controller
+			Finished: 0, // FIXME: infinite loop if we set this in the controller
+			Message:  []string{},
+		}
+
+		if syncError != nil {
+			status.State = provisioning.JobStateError
+			status.Message = append(status.Message, syncError.Error())
+		}
+
+		cfg := repo.Config().DeepCopy()
+		cfg.Status.Sync = *status
+
+		// TODO: Can we use typed client for this?
+		client := parser.Client().Resource(provisioning.RepositoryResourceInfo.GroupVersionResource())
+		unstructuredResource := &unstructured.Unstructured{}
+		jj, _ := json.Marshal(cfg)
+		if err := json.Unmarshal(jj, &unstructuredResource.Object); err != nil {
+			return nil, fmt.Errorf("error loading config json: %w", err)
+		}
+
+		if _, err := client.UpdateStatus(ctx, unstructuredResource, v1.UpdateOptions{}); err != nil {
+			return nil, fmt.Errorf("update repository status: %w", err)
+		}
+
+		if syncError != nil {
+			return nil, syncError
 		}
 	case provisioning.JobActionPullRequest:
 		prRepo, ok := repo.(PullRequestRepo)
@@ -124,6 +156,7 @@ func (g *JobWorker) Process(ctx context.Context, job provisioning.Job) (*provisi
 			return nil, err
 		}
 	default:
+		return nil, fmt.Errorf("unknown job action: %s", job.Spec.Action)
 	}
 
 	return &provisioning.JobStatus{


### PR DESCRIPTION
- Move sync status out of replicator as it contains job details.
- Add started and finished timestamps in job status.
- Comment out JobID as it triggers the infinite loop temporarily. I will open another PR to fix that issue.


Sync Status:
```json
 "status": {
        "health": {
            "healthy": true
        },
        "initialized": true,
        "sync": {
            "hash": "4c33e0076ff199977494c3937a9ba7b6ad1abb72",
            "job": "ce7a9zu471szke",
            "state": "success"
        },
```

Job Status: 
```yaml

apiVersion: provisioning.grafana.app/v0alpha1
kind: Job
metadata:
  creationTimestamp: "2024-12-18T11:26:32Z"
  labels:
    action: sync
    repository: github-ui-sync-demo
    state: finished
  name: ae7aaymcefq4gb
  namespace: default
  resourceVersion: "4"
spec:
  action: sync
status:
  finished: 1734521193881
  started: 17345211927772
  state: finished
```