### PR TITLE
Fix infinite loop and record more information

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -126,10 +126,13 @@ type RepositoryStatus struct {
 	// Initialized is true when the repository has been initialized
 	Initialized bool `json:"initialized"`
 
+	// The generation of the spec last time reconciliation ran
+	ObservedGeneration int64 `json:"observedGeneration"`
+
 	// This will get updated with the current health status (and updated periodically)
 	Health HealthStatus `json:"health"`
 
-	// Sync information
+	// Sync information with the last sync information
 	Sync SyncStatus `json:"sync"`
 
 	// Webhook Information (if applicable)
@@ -140,11 +143,8 @@ type HealthStatus struct {
 	// When not healthy, requests will not be executed
 	Healthy bool `json:"healthy"`
 
-	// When the sync job started
+	// When the health was checked last time
 	Checked int64 `json:"checked,omitempty"`
-
-	// The generation (spec changed) that triggered this health check
-	Generation int64 `json:"generation,omitempty"`
 
 	// Summary messages (will be shown to users)
 	Message []string `json:"message,omitempty"`

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -284,14 +284,7 @@ func schema_pkg_apis_provisioning_v0alpha1_HealthStatus(ref common.ReferenceCall
 					},
 					"checked": {
 						SchemaProps: spec.SchemaProps{
-							Description: "When the sync job started",
-							Type:        []string{"integer"},
-							Format:      "int64",
-						},
-					},
-					"generation": {
-						SchemaProps: spec.SchemaProps{
-							Description: "The generation (spec changed) that triggered this health check",
+							Description: "When the health was checked last time",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -892,6 +885,14 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryStatus(ref common.Reference
 							Format:      "",
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The generation of the spec last time reconciliation ran",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"health": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This will get updated with the current health status (and updated periodically)",
@@ -901,7 +902,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryStatus(ref common.Reference
 					},
 					"sync": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Sync information",
+							Description: "Sync information with the last sync information",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/grafana/grafana/pkg/apis/provisioning/v0alpha1.SyncStatus"),
 						},
@@ -913,7 +914,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryStatus(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"initialized", "health", "sync", "webhook"},
+				Required: []string{"initialized", "observedGeneration", "health", "sync", "webhook"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/healthstatus.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/healthstatus.go
@@ -7,10 +7,9 @@ package v0alpha1
 // HealthStatusApplyConfiguration represents a declarative configuration of the HealthStatus type for use
 // with apply.
 type HealthStatusApplyConfiguration struct {
-	Healthy    *bool    `json:"healthy,omitempty"`
-	Checked    *int64   `json:"checked,omitempty"`
-	Generation *int64   `json:"generation,omitempty"`
-	Message    []string `json:"message,omitempty"`
+	Healthy *bool    `json:"healthy,omitempty"`
+	Checked *int64   `json:"checked,omitempty"`
+	Message []string `json:"message,omitempty"`
 }
 
 // HealthStatusApplyConfiguration constructs a declarative configuration of the HealthStatus type for use with
@@ -32,14 +31,6 @@ func (b *HealthStatusApplyConfiguration) WithHealthy(value bool) *HealthStatusAp
 // If called multiple times, the Checked field is set to the value of the last call.
 func (b *HealthStatusApplyConfiguration) WithChecked(value int64) *HealthStatusApplyConfiguration {
 	b.Checked = &value
-	return b
-}
-
-// WithGeneration sets the Generation field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Generation field is set to the value of the last call.
-func (b *HealthStatusApplyConfiguration) WithGeneration(value int64) *HealthStatusApplyConfiguration {
-	b.Generation = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/repositorystatus.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/repositorystatus.go
@@ -7,10 +7,11 @@ package v0alpha1
 // RepositoryStatusApplyConfiguration represents a declarative configuration of the RepositoryStatus type for use
 // with apply.
 type RepositoryStatusApplyConfiguration struct {
-	Initialized *bool                            `json:"initialized,omitempty"`
-	Health      *HealthStatusApplyConfiguration  `json:"health,omitempty"`
-	Sync        *SyncStatusApplyConfiguration    `json:"sync,omitempty"`
-	Webhook     *WebhookStatusApplyConfiguration `json:"webhook,omitempty"`
+	Initialized        *bool                            `json:"initialized,omitempty"`
+	ObservedGeneration *int64                           `json:"observedGeneration,omitempty"`
+	Health             *HealthStatusApplyConfiguration  `json:"health,omitempty"`
+	Sync               *SyncStatusApplyConfiguration    `json:"sync,omitempty"`
+	Webhook            *WebhookStatusApplyConfiguration `json:"webhook,omitempty"`
 }
 
 // RepositoryStatusApplyConfiguration constructs a declarative configuration of the RepositoryStatus type for use with
@@ -24,6 +25,14 @@ func RepositoryStatus() *RepositoryStatusApplyConfiguration {
 // If called multiple times, the Initialized field is set to the value of the last call.
 func (b *RepositoryStatusApplyConfiguration) WithInitialized(value bool) *RepositoryStatusApplyConfiguration {
 	b.Initialized = &value
+	return b
+}
+
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *RepositoryStatusApplyConfiguration) WithObservedGeneration(value int64) *RepositoryStatusApplyConfiguration {
+	b.ObservedGeneration = &value
 	return b
 }
 

--- a/pkg/registry/apis/provisioning/jobs/queue.go
+++ b/pkg/registry/apis/provisioning/jobs/queue.go
@@ -142,8 +142,8 @@ func (s *jobStore) drainPending() {
 			logger.DebugContext(ctx, "job processing finished", "status", status.State)
 		}
 
-		status.Started = started.UnixNano()
-		status.Finished = time.Now().UnixNano()
+		status.Started = started.UnixMilli()
+		status.Finished = time.Now().UnixMilli()
 
 		err = s.Complete(ctx, job.Namespace, job.Name, *status)
 		if err != nil {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -177,16 +177,6 @@ func (b *ProvisioningAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserv
 		return fmt.Errorf("failed to create repository storage: %w", err)
 	}
 
-	b.jobs.Register(jobs.NewJobWorker(
-		b,
-		b.parsers,
-		b.identities,
-		b.logger.With("worker", "github"),
-		b.render,
-		b.blobstore,
-		b.urlProvider,
-	))
-
 	repositoryStatusStorage := grafanaregistry.NewRegistryStatusStore(opts.Scheme, repositoryStorage)
 	b.getter = repositoryStorage
 
@@ -402,6 +392,17 @@ func (b *ProvisioningAPIBuilder) GetPostStartHooks() (map[string]genericapiserve
 				client:        c.ProvisioningV0alpha1(),
 				logger:        slog.Default().With("logger", "provisioning-repository-tester"),
 			}
+
+			b.jobs.Register(jobs.NewJobWorker(
+				b,
+				b.parsers,
+				c.ProvisioningV0alpha1(),
+				b.identities,
+				b.logger.With("worker", "github"),
+				b.render,
+				b.blobstore,
+				b.urlProvider,
+			))
 
 			repoController, err := NewRepositoryController(
 				c.ProvisioningV0alpha1(),

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -286,7 +286,7 @@ func (rc *RepositoryController) process(item *queueItem) error {
 			}
 		}
 
-		if res.Success {
+		if !res.Success {
 			logger.ErrorContext(ctx, "repository is unhealthy", "errors", res.Errors)
 		}
 

--- a/pkg/registry/apis/provisioning/repository_controller.go
+++ b/pkg/registry/apis/provisioning/repository_controller.go
@@ -249,22 +249,6 @@ func (rc *RepositoryController) process(item *queueItem) error {
 		}
 	}
 
-	job, err := rc.jobs.Add(ctx, &provisioning.Job{
-		ObjectMeta: v1.ObjectMeta{
-			Namespace: cachedRepo.Namespace,
-			Labels: map[string]string{
-				"repository": cachedRepo.Name,
-			},
-		},
-		Spec: provisioning.JobSpec{
-			Action: provisioning.JobActionSync,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("trigger sync job: %w", err)
-	}
-	logger.InfoContext(ctx, "sync job triggered", "job", job.Name)
-
 	if status == nil {
 		status = cachedRepo.Status.DeepCopy()
 	} else {
@@ -303,6 +287,22 @@ func (rc *RepositoryController) process(item *queueItem) error {
 		UpdateStatus(ctx, cfg, v1.UpdateOptions{}); err != nil {
 		return fmt.Errorf("update status: %w", err)
 	}
+
+	job, err := rc.jobs.Add(ctx, &provisioning.Job{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: cachedRepo.Namespace,
+			Labels: map[string]string{
+				"repository": cachedRepo.Name,
+			},
+		},
+		Spec: provisioning.JobSpec{
+			Action: provisioning.JobActionSync,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("trigger sync job: %w", err)
+	}
+	logger.InfoContext(ctx, "sync job triggered", "job", job.Name)
 
 	return nil
 }

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -151,7 +151,6 @@ func (t *RepositoryTester) UpdateHealthStatus(ctx context.Context, cfg *provisio
 		Checked: time.Now().UnixMilli(),
 		Message: res.Errors,
 	}
-	repo.Status.ObservedGeneration = cfg.Generation
 
 	_, err := t.client.Repositories(repo.GetNamespace()).
 		UpdateStatus(ctx, repo, metav1.UpdateOptions{})

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -147,11 +147,11 @@ func (t *RepositoryTester) UpdateHealthStatus(ctx context.Context, cfg *provisio
 
 	repo := cfg.DeepCopy()
 	repo.Status.Health = provisioning.HealthStatus{
-		Healthy:    res.Success,
-		Checked:    time.Now().UnixMilli(),
-		Generation: cfg.Generation,
-		Message:    res.Errors,
+		Healthy: res.Success,
+		Checked: time.Now().UnixMilli(),
+		Message: res.Errors,
 	}
+	repo.Status.ObservedGeneration = cfg.Generation
 
 	_, err := t.client.Repositories(repo.GetNamespace()).
 		UpdateStatus(ctx, repo, metav1.UpdateOptions{})


### PR DESCRIPTION
- Fix infinite in controller by only trusting the changes in generation (and pending this change https://github.com/grafana/grafana/pull/98165)
- Change the behaviour so that we always update/create before health check.
- Always check for health if the spec changed.
- Use `UnixMilli` for recorded timestamps.
- Move `Status.Health.Generation` to `Status.ObservedGeneration` to use it for the entire reconciliation.
- Use static client in worker instead of dynamic one. 

Job Status Working
```yaml
status:
  finished: 1734527447376
  started: 1734527443866
  state: finished
```
RepositoryStatus Working
```yaml
status:
  health:
    healthy: true
  initialized: true
  observedGeneration: 1
  sync:
    job: de7ak9769x05ce
    started: 1734527444171
    state: working
```

RepositoryStatus Finished
```yaml
status:
  health:
    healthy: true
  initialized: true
  observedGeneration: 1
  sync:
    finished: 1734527447374
    hash: 4c33e0076ff199977494c3937a9ba7b6ad1abb72
    job: de7ak9769x05ce
    started: 1734527444171
    state: success
```