### PR TITLE
Alerting: Include error from current condition when previewing queries

### DIFF
--- a/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditorCloudRules.test.tsx
@@ -45,7 +45,7 @@ describe('RuleEditor cloud', () => {
   it('can create a new cloud alert', async () => {
     const { user } = renderRuleEditor();
 
-    const removeExpressionsButtons = screen.getAllByLabelText('Remove expression');
+    const removeExpressionsButtons = screen.getAllByLabelText(/Remove expression/);
     expect(removeExpressionsButtons).toHaveLength(2);
 
     // Needs to wait for featrue discovery API call to finish - Check if ruler enabled
@@ -58,7 +58,7 @@ describe('RuleEditor cloud', () => {
     await user.click(switchToCloudButton);
 
     //expressions are removed after switching to data-source managed
-    expect(screen.queryAllByLabelText('Remove expression')).toHaveLength(0);
+    expect(screen.queryAllByLabelText(/Remove expression/)).toHaveLength(0);
 
     expect(screen.getByTestId(selectors.components.DataSourcePicker.inputV2)).toBeInTheDocument();
 

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -369,13 +369,17 @@ const Header: FC<HeaderProps> = ({
           <div>{getExpressionLabel(queryType)}</div>
         </Stack>
         <Spacer />
-        <ExpressionStatusIndicator onSetCondition={() => onSetCondition(query.refId)} isCondition={alertCondition} />
+        <ExpressionStatusIndicator
+          refId={refId}
+          onSetCondition={() => onSetCondition(query.refId)}
+          isCondition={alertCondition}
+        />
         <IconButton
           name="trash-alt"
           variant="secondary"
           className={styles.mutedIcon}
           onClick={onRemoveExpression}
-          tooltip="Remove expression"
+          tooltip={`Remove expression "${refId}"`}
         />
       </Stack>
     </header>

--- a/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx
+++ b/public/app/features/alerting/unified/components/expressions/ExpressionStatusIndicator.tsx
@@ -10,15 +10,18 @@ import { isGrafanaRecordingRuleByType } from '../../utils/rules';
 interface AlertConditionProps {
   isCondition?: boolean;
   onSetCondition?: () => void;
+  refId?: string;
 }
 
-export const ExpressionStatusIndicator = ({ isCondition, onSetCondition }: AlertConditionProps) => {
+export const ExpressionStatusIndicator = ({ isCondition, onSetCondition, refId }: AlertConditionProps) => {
   const styles = useStyles2(getStyles);
   const { watch } = useFormContext<RuleFormValues>();
   const type = watch('type');
   const isGrafanaRecordingRule = type ? isGrafanaRecordingRuleByType(type) : false;
   const conditionText = isGrafanaRecordingRule ? 'Recording rule output' : 'Alert condition';
-  const makeConditionText = isGrafanaRecordingRule ? 'Set as recording rule output' : 'Set as alert condition';
+
+  const setAsConditionText = refId ? `Set "${refId}" as alert condition` : 'Set as alert condition';
+  const makeConditionText = isGrafanaRecordingRule ? 'Set as recording rule output' : setAsConditionText;
 
   if (isCondition) {
     return <Badge key="condition" color="green" icon="check" text={conditionText} />;

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionsEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionsEditor.tsx
@@ -9,7 +9,7 @@ import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { Expression } from '../expressions/Expression';
 
-import { errorFromPreviewData, warningFromSeries } from './util';
+import { errorFromCurrentCondition, errorFromPreviewData, warningFromSeries } from './util';
 
 interface Props {
   condition: string | null;
@@ -45,7 +45,11 @@ export const ExpressionsEditor = ({
         const data = panelData[query.refId];
 
         const isAlertCondition = condition === query.refId;
-        const error = data ? errorFromPreviewData(data) : undefined;
+
+        const errorFromCondition = data && isAlertCondition ? errorFromCurrentCondition(data) : undefined;
+        const errorFromPreview = data ? errorFromPreviewData(data) : undefined;
+        const error = errorFromPreview || errorFromCondition;
+
         const warning = data ? warningFromSeries(data.series) : undefined;
 
         return (

--- a/public/app/features/expressions/components/Threshold.tsx
+++ b/public/app/features/expressions/components/Threshold.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { AnyAction } from '@reduxjs/toolkit';
-import { uniq, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 import * as React from 'react';
 import { FormEvent, useEffect, useReducer } from 'react';
 

--- a/public/app/features/expressions/components/Threshold.tsx
+++ b/public/app/features/expressions/components/Threshold.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { AnyAction } from '@reduxjs/toolkit';
+import { uniq, uniqueId } from 'lodash';
 import * as React from 'react';
 import { FormEvent, useEffect, useReducer } from 'react';
 
@@ -85,11 +86,13 @@ export const Threshold = ({ labelWidth, onChange, refIds, query, onError, useHys
 
   const hysteresisEnabled = Boolean(config.featureToggles?.recoveryThreshold) && useHysteresis;
 
+  const id = uniqueId('threshold-');
+
   return (
     <>
       <InlineFieldRow>
-        <InlineField label="Input" labelWidth={labelWidth}>
-          <Select onChange={onRefIdChange} options={refIds} value={query.expression} width={20} />
+        <InlineField label="Input" labelWidth={labelWidth} htmlFor={id}>
+          <Select inputId={id} onChange={onRefIdChange} options={refIds} value={query.expression} width={20} />
         </InlineField>
       </InlineFieldRow>
       <InlineFieldRow>
@@ -142,10 +145,10 @@ export const Threshold = ({ labelWidth, onChange, refIds, query, onError, useHys
 
     return (
       <div className={styles.hysteresis}>
-        {/* This is to enhance the user experience for mouse users. 
-        The onBlur event in RecoveryThresholdRow inputs triggers validations, 
-        but we want to skip them when the switch is clicked as this click should inmount this component. 
-        To achieve this, we use the onMouseDown event to set a flag, which is later utilized in the onBlur event to bypass validations. 
+        {/* This is to enhance the user experience for mouse users.
+        The onBlur event in RecoveryThresholdRow inputs triggers validations,
+        but we want to skip them when the switch is clicked as this click should inmount this component.
+        To achieve this, we use the onMouseDown event to set a flag, which is later utilized in the onBlur event to bypass validations.
         The onMouseDown event precedes the onBlur event, unlike onchange. */}
 
         {/*Disabling the a11y rules here as the InlineSwitch handles keyboard interactions */}
@@ -201,7 +204,7 @@ function RecoveryThresholdRow({ isRange, condition, onError, dispatch, allowOnbl
     return <RecoveryForSingleValue allowOnblur={allowOnblur} />;
   }
 
-  /* We prioritize the onMouseDown event over the onBlur event. This is because the onBlur event is executed before the onChange event that we have 
+  /* We prioritize the onMouseDown event over the onBlur event. This is because the onBlur event is executed before the onChange event that we have
    in the hysteresis checkbox, and because of that, we were validating when unchecking the switch.
   We need to uncheck the switch before the onBlur event is executed.*/
   interface RecoveryProps {

--- a/public/test/helpers/alertingRuleEditor.tsx
+++ b/public/test/helpers/alertingRuleEditor.tsx
@@ -39,6 +39,7 @@ export const ui = {
     save: byRole('button', { name: 'Save rule' }),
     addAnnotation: byRole('button', { name: /Add info/ }),
     addLabel: byRole('button', { name: /Add label/ }),
+    preview: byRole('button', { name: /^Preview$/ }),
   },
 };
 export function renderRuleEditor(identifier?: string, recording?: 'recording' | 'grafana-recording') {


### PR DESCRIPTION



**What is this feature?**
Shows an error when trying to use a time series as a threshold, without reducing it. We already have this error shown when trying to save an alert rule, but this surfaces it a little earlier for the user

![image](https://github.com/user-attachments/assets/cd947ea5-c5da-4466-ba36-a9e7a9605b1f)


**Why do we need this feature?**
Clearer UX for alerting rule creation

**Who is this feature for?**
Alerting UI users
