### PR TITLE
Secrets: Add basic validation and mutation for kinds

### DIFF
--- a/pkg/registry/apis/secret/encryption/manager/manager.go
+++ b/pkg/registry/apis/secret/encryption/manager/manager.go
@@ -84,7 +84,7 @@ func NewEncryptionManager(
 		return nil, err
 	}
 
-	if _, ok := s.providers[secrets.ProviderID(currentProviderID)]; !ok {
+	if _, ok := s.providers[currentProviderID]; !ok {
 		return nil, fmt.Errorf("missing configuration for current encryption provider %s", currentProviderID)
 	}
 

--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -132,6 +132,10 @@ func (b *SecretAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 
 		return nil
 	case *secretV0Alpha1.Keeper:
+		if errs := reststorage.ValidateKeeper(typedObj, operation); len(errs) > 0 {
+			return apierrors.NewInvalid(secretV0Alpha1.SecureValuesResourceInfo.GroupVersionKind().GroupKind(), a.GetName(), errs)
+		}
+
 		return nil
 	}
 

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	secretstorage "github.com/grafana/grafana/pkg/storage/secret"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -112,21 +111,6 @@ func (s *KeeperRest) Create(
 
 	if err := createValidation(ctx, obj); err != nil {
 		return nil, fmt.Errorf("create validation failed: %w", err)
-	}
-
-	// A `keeper` may be created without a `name`, which means it gets generated on-the-fly.
-	if kp.Name == "" {
-		// TODO: how can we make sure there are no conflicts with existing resources?
-		generatedName, err := util.GetRandomString(8)
-		if err != nil {
-			return nil, err
-		}
-
-		optionalPrefix := kp.GenerateName
-		if optionalPrefix == "" {
-			optionalPrefix = "kp-"
-		}
-		kp.Name = optionalPrefix + generatedName
 	}
 
 	createdKeeper, err := s.storage.Create(ctx, kp)

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -189,6 +189,8 @@ func ValidateKeeper(keeper *secretv0alpha1.Keeper, operation admission.Operation
 
 	// If we plan to support PATCH-style updates, we shouldn't be requiring fields to be set.
 	case admission.Update:
+	case admission.Delete:
+	case admission.Connect:
 	}
 
 	// General validations.
@@ -202,6 +204,7 @@ func ValidateKeeper(keeper *secretv0alpha1.Keeper, operation admission.Operation
 
 	// TODO: validation of SQL keeper, once we have a finalized spec.
 	if keeper.Spec.SQL != nil {
+		_ = keeper.Spec.SQL
 	}
 
 	if keeper.Spec.AWS != nil {

--- a/pkg/registry/apis/secret/reststorage/keeper_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest_test.go
@@ -1,0 +1,271 @@
+package reststorage
+
+import (
+	"testing"
+
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+func TestValidateKeeper(t *testing.T) {
+	t.Run("when creating a new keeper", func(t *testing.T) {
+		t.Run("the `title` must be present", func(t *testing.T) {
+			keeper := &secretv0alpha1.Keeper{
+				Spec: secretv0alpha1.KeeperSpec{
+					SQL: &secretv0alpha1.SQLKeeper{},
+				},
+			}
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.title", errs[0].Field)
+		})
+	})
+
+	t.Run("only one `keeper` must be present", func(t *testing.T) {
+		keeper := &secretv0alpha1.Keeper{
+			Spec: secretv0alpha1.KeeperSpec{
+				Title:     "title",
+				SQL:       &secretv0alpha1.SQLKeeper{},
+				AWS:       &secretv0alpha1.AWSKeeper{},
+				Azure:     &secretv0alpha1.AzureKeeper{},
+				GCP:       &secretv0alpha1.GCPKeeper{},
+				HashiCorp: &secretv0alpha1.HashiCorpKeeper{},
+			},
+		}
+
+		errs := ValidateKeeper(keeper, admission.Create)
+		require.Len(t, errs, 1)
+		require.Equal(t, "spec", errs[0].Field)
+	})
+
+	t.Run("at least one `keeper` must be present", func(t *testing.T) {
+		keeper := &secretv0alpha1.Keeper{
+			Spec: secretv0alpha1.KeeperSpec{
+				Title: "title",
+			},
+		}
+
+		errs := ValidateKeeper(keeper, admission.Create)
+		require.Len(t, errs, 1)
+		require.Equal(t, "spec", errs[0].Field)
+	})
+
+	t.Run("aws keeper validation", func(t *testing.T) {
+		validKeeperAWS := &secretv0alpha1.Keeper{
+			Spec: secretv0alpha1.KeeperSpec{
+				Title: "title",
+				AWS: &secretv0alpha1.AWSKeeper{
+					AWSCredentials: secretv0alpha1.AWSCredentials{
+						AccessKeyID: secretv0alpha1.CredentialValue{
+							ValueFromEnv: "some-value",
+						},
+						SecretAccessKey: secretv0alpha1.CredentialValue{
+							SecureValueName: "some-value",
+						},
+						KMSKeyID: "optional",
+					},
+				},
+			},
+		}
+
+		t.Run("`accessKeyId` must be present", func(t *testing.T) {
+			t.Run("at least one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperAWS.DeepCopy()
+				keeper.Spec.AWS.AccessKeyID = secretv0alpha1.CredentialValue{}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.aws.accessKeyId", errs[0].Field)
+			})
+
+			t.Run("at most one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperAWS.DeepCopy()
+				keeper.Spec.AWS.AccessKeyID = secretv0alpha1.CredentialValue{
+					SecureValueName: "a",
+					ValueFromEnv:    "b",
+					ValueFromConfig: "c",
+				}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.aws.accessKeyId", errs[0].Field)
+			})
+		})
+
+		t.Run("`secretAccessKey` must be present", func(t *testing.T) {
+			t.Run("at least one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperAWS.DeepCopy()
+				keeper.Spec.AWS.SecretAccessKey = secretv0alpha1.CredentialValue{}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.aws.secretAccessKey", errs[0].Field)
+			})
+
+			t.Run("at most one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperAWS.DeepCopy()
+				keeper.Spec.AWS.SecretAccessKey = secretv0alpha1.CredentialValue{
+					SecureValueName: "a",
+					ValueFromEnv:    "b",
+					ValueFromConfig: "c",
+				}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.aws.secretAccessKey", errs[0].Field)
+			})
+		})
+	})
+
+	t.Run("azure keeper validation", func(t *testing.T) {
+		validKeeperAzure := &secretv0alpha1.Keeper{
+			Spec: secretv0alpha1.KeeperSpec{
+				Title: "title",
+				Azure: &secretv0alpha1.AzureKeeper{
+					AzureCredentials: secretv0alpha1.AzureCredentials{
+						KeyVaultName: "kv-name",
+						TenantID:     "tenant-id",
+						ClientID:     "client-id",
+						ClientSecret: secretv0alpha1.CredentialValue{
+							ValueFromConfig: "config.path.value",
+						},
+					},
+				},
+			},
+		}
+
+		t.Run("`keyVaultName` must be present", func(t *testing.T) {
+			keeper := validKeeperAzure.DeepCopy()
+			keeper.Spec.Azure.KeyVaultName = ""
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.azure.keyVaultName", errs[0].Field)
+		})
+
+		t.Run("`tenantId` must be present", func(t *testing.T) {
+			keeper := validKeeperAzure.DeepCopy()
+			keeper.Spec.Azure.TenantID = ""
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.azure.tenantId", errs[0].Field)
+		})
+
+		t.Run("`clientId` must be present", func(t *testing.T) {
+			keeper := validKeeperAzure.DeepCopy()
+			keeper.Spec.Azure.ClientID = ""
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.azure.clientId", errs[0].Field)
+		})
+
+		t.Run("`clientSecret` must be present", func(t *testing.T) {
+			t.Run("at least one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperAzure.DeepCopy()
+				keeper.Spec.Azure.ClientSecret = secretv0alpha1.CredentialValue{}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.azure.clientSecret", errs[0].Field)
+			})
+
+			t.Run("at most one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperAzure.DeepCopy()
+				keeper.Spec.Azure.ClientSecret = secretv0alpha1.CredentialValue{
+					SecureValueName: "a",
+					ValueFromEnv:    "b",
+					ValueFromConfig: "c",
+				}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.azure.clientSecret", errs[0].Field)
+			})
+		})
+	})
+
+	t.Run("gcp keeper validation", func(t *testing.T) {
+		validKeeperGCP := &secretv0alpha1.Keeper{
+			Spec: secretv0alpha1.KeeperSpec{
+				Title: "title",
+				GCP: &secretv0alpha1.GCPKeeper{
+					GCPCredentials: secretv0alpha1.GCPCredentials{
+						ProjectID:       "project-id",
+						CredentialsFile: "/path/to/credentials/file.json",
+					},
+				},
+			},
+		}
+
+		t.Run("`projectId` must be present", func(t *testing.T) {
+			keeper := validKeeperGCP.DeepCopy()
+			keeper.Spec.GCP.ProjectID = ""
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.gcp.projectId", errs[0].Field)
+		})
+
+		t.Run("`credentialsFile` must be present", func(t *testing.T) {
+			keeper := validKeeperGCP.DeepCopy()
+			keeper.Spec.GCP.CredentialsFile = ""
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.gcp.credentialsFile", errs[0].Field)
+		})
+	})
+
+	t.Run("hashicorp keeper validation", func(t *testing.T) {
+		validKeeperHashiCorp := &secretv0alpha1.Keeper{
+			Spec: secretv0alpha1.KeeperSpec{
+				Title: "title",
+				HashiCorp: &secretv0alpha1.HashiCorpKeeper{
+					HashiCorpCredentials: secretv0alpha1.HashiCorpCredentials{
+						Address: "http://address",
+						Token: secretv0alpha1.CredentialValue{
+							ValueFromConfig: "config.path.value",
+						},
+					},
+				},
+			},
+		}
+
+		t.Run("`address` must be present", func(t *testing.T) {
+			keeper := validKeeperHashiCorp.DeepCopy()
+			keeper.Spec.HashiCorp.Address = ""
+
+			errs := ValidateKeeper(keeper, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.hashicorp.address", errs[0].Field)
+		})
+
+		t.Run("`token` must be present", func(t *testing.T) {
+			t.Run("at least one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperHashiCorp.DeepCopy()
+				keeper.Spec.HashiCorp.Token = secretv0alpha1.CredentialValue{}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.hashicorp.token", errs[0].Field)
+			})
+
+			t.Run("at most one of the credential value must be present", func(t *testing.T) {
+				keeper := validKeeperHashiCorp.DeepCopy()
+				keeper.Spec.HashiCorp.Token = secretv0alpha1.CredentialValue{
+					SecureValueName: "a",
+					ValueFromEnv:    "b",
+					ValueFromConfig: "c",
+				}
+
+				errs := ValidateKeeper(keeper, admission.Create)
+				require.Len(t, errs, 1)
+				require.Equal(t, "spec.hashicorp.token", errs[0].Field)
+			})
+		})
+	})
+}

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -99,23 +103,6 @@ func (s *SecureValueRest) Get(ctx context.Context, name string, options *metav1.
 	return sv, nil
 }
 
-func checkRefOrValue(s *secret.SecureValue, mustExist bool) error {
-	p := s.Spec.Ref
-	v := s.Spec.Value
-
-	if p == "" && v == "" {
-		if mustExist {
-			return fmt.Errorf("expecting ref or value to exist")
-		}
-		return nil
-	}
-
-	if p != "" && v != "" {
-		return fmt.Errorf("only ref *or* value may be configured at the same time")
-	}
-	return nil
-}
-
 // Create a new `securevalue`. Does some validation and allows empty `name` (generated).
 func (s *SecureValueRest) Create(
 	ctx context.Context,
@@ -129,12 +116,7 @@ func (s *SecureValueRest) Create(
 	}
 
 	if err := createValidation(ctx, obj); err != nil {
-		return nil, fmt.Errorf("validation failed: %w", err)
-	}
-
-	err := checkRefOrValue(sv, true)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create validation failed: %w", err)
 	}
 
 	// A `securevalue` may be created without a `name`, which means it gets generated on-the-fly.
@@ -172,16 +154,20 @@ func (s *SecureValueRest) Update(
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
-	current, err := s.Get(ctx, name, &metav1.GetOptions{})
+	old, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, fmt.Errorf("get securevalue: %w", err)
 	}
 
 	// Makes sure the UID and ResourceVersion are OK.
 	// TODO: this also makes it so the labels and annotations are additive, unless we check and remove manually.
-	tmp, err := objInfo.UpdatedObject(ctx, current)
+	tmp, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, fmt.Errorf("k8s updated object: %w", err)
+	}
+
+	if err := updateValidation(ctx, tmp, old); err != nil {
+		return nil, false, fmt.Errorf("update validation failed: %w", err)
 	}
 
 	newSecureValue, ok := tmp.(*secret.SecureValue)
@@ -191,10 +177,6 @@ func (s *SecureValueRest) Update(
 
 	// TODO: do we need to do this here again? Probably not, but double-check!
 	newSecureValue.Annotations = cleanAnnotations(newSecureValue.Annotations)
-
-	if err := checkRefOrValue(newSecureValue, false); err != nil {
-		return nil, false, err
-	}
 
 	// Current implementation replaces everything passed in the spec, so it is not a PATCH. Do we want/need to support that?
 	updatedSecureValue, err := s.storage.Update(ctx, newSecureValue)
@@ -218,4 +200,68 @@ func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidat
 	}
 
 	return nil, true, nil
+}
+
+// ValidateSecureValue does basic spec validation of a securevalue.
+func ValidateSecureValue(sv *secret.SecureValue, operation admission.Operation) field.ErrorList {
+	errs := make(field.ErrorList, 0)
+
+	// Operation-specific field validation.
+	switch operation {
+	case admission.Create:
+		if sv.Spec.Title == "" {
+			errs = append(errs, field.Required(field.NewPath("spec", "title"), "a `title` is required"))
+		}
+
+		if sv.Spec.Keeper == "" {
+			errs = append(errs, field.Required(field.NewPath("spec", "keeper"), "a `keeper` is required"))
+		}
+
+		if sv.Spec.Value == "" && sv.Spec.Ref == "" {
+			errs = append(errs, field.Required(field.NewPath("spec"), "either a `value` or `ref` is required"))
+		}
+
+		if sv.Spec.Value != "" && sv.Spec.Ref != "" {
+			errs = append(errs, field.Required(field.NewPath("spec"), "only one of `value` or `ref` can be set"))
+		}
+
+		if len(sv.Spec.Audiences) == 0 {
+			errs = append(errs, field.Required(field.NewPath("spec", "audiences"), "an `audiences` is required"))
+		}
+
+	// If we plan to support PATCH-style updates, we shouldn't be requiring fields to be set.
+	case admission.Update:
+		if sv.Spec.Value != "" && sv.Spec.Ref != "" {
+			errs = append(errs, field.Required(field.NewPath("spec"), "either leave both `value` and `ref` empty, or set one of them, but not both"))
+		}
+	}
+
+	// General validations.
+
+	// Audience should match "{group}/{name OR *}"
+	for i, audience := range sv.Spec.Audiences {
+		group, name, found := strings.Cut(audience, "/")
+		if !found {
+			errs = append(
+				errs,
+				field.Invalid(field.NewPath("spec", "audiences", "["+strconv.Itoa(i)+"]"), audience, "an audience must have the format `{string}/{string}`"),
+			)
+		}
+
+		if group == "" {
+			errs = append(
+				errs,
+				field.Invalid(field.NewPath("spec", "audiences", "["+strconv.Itoa(i)+"]"), audience, "an audience group must be present"),
+			)
+		}
+
+		if found && name == "" {
+			errs = append(
+				errs,
+				field.Invalid(field.NewPath("spec", "audiences", "["+strconv.Itoa(i)+"]"), audience, "an audience name must be present (use * for match-all)"),
+			)
+		}
+	}
+
+	return errs
 }

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	secret "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	secretstorage "github.com/grafana/grafana/pkg/storage/secret"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -117,22 +116,6 @@ func (s *SecureValueRest) Create(
 
 	if err := createValidation(ctx, obj); err != nil {
 		return nil, fmt.Errorf("create validation failed: %w", err)
-	}
-
-	// A `securevalue` may be created without a `name`, which means it gets generated on-the-fly.
-	if sv.Name == "" {
-		// TODO: how can we make sure there are no conflicts with existing resources?
-		generatedName, err := util.GetRandomString(8)
-		if err != nil {
-			return nil, err
-		}
-
-		optionalPrefix := sv.GenerateName
-		if optionalPrefix == "" {
-			optionalPrefix = "sv-"
-		}
-
-		sv.Name = optionalPrefix + generatedName
 	}
 
 	createdSecureValue, err := s.storage.Create(ctx, sv)

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -217,6 +217,9 @@ func ValidateSecureValue(sv *secret.SecureValue, operation admission.Operation) 
 		if sv.Spec.Value != "" && sv.Spec.Ref != "" {
 			errs = append(errs, field.Required(field.NewPath("spec"), "either leave both `value` and `ref` empty, or set one of them, but not both"))
 		}
+
+	case admission.Delete:
+	case admission.Connect:
 	}
 
 	// General validations.

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest_test.go
@@ -1,0 +1,101 @@
+package reststorage
+
+import (
+	"fmt"
+	"testing"
+
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+func TestValidateSecureValue(t *testing.T) {
+	t.Run("when creating a new securevalue", func(t *testing.T) {
+		validSecureValue := &secretv0alpha1.SecureValue{
+			Spec: secretv0alpha1.SecureValueSpec{
+				Title:     "title",
+				Value:     "value",
+				Keeper:    "keeper",
+				Audiences: []string{"group/*", "group/name"},
+			},
+		}
+
+		t.Run("the `title` must be present", func(t *testing.T) {
+			sv := validSecureValue.DeepCopy()
+			sv.Spec.Title = ""
+
+			errs := ValidateSecureValue(sv, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.title", errs[0].Field)
+		})
+
+		t.Run("the `keeper` must be present", func(t *testing.T) {
+			sv := validSecureValue.DeepCopy()
+			sv.Spec.Keeper = ""
+
+			errs := ValidateSecureValue(sv, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.keeper", errs[0].Field)
+		})
+
+		t.Run("either a `value` or `ref` must be present but not both", func(t *testing.T) {
+			sv := validSecureValue.DeepCopy()
+			sv.Spec.Value = ""
+			sv.Spec.Ref = ""
+
+			errs := ValidateSecureValue(sv, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec", errs[0].Field)
+
+			sv.Spec.Value = "value"
+			sv.Spec.Ref = "value"
+
+			errs = ValidateSecureValue(sv, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec", errs[0].Field)
+		})
+
+		t.Run("`audiences` must be present", func(t *testing.T) {
+			sv := validSecureValue.DeepCopy()
+			sv.Spec.Audiences = make([]string, 0)
+
+			errs := ValidateSecureValue(sv, admission.Create)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec.audiences", errs[0].Field)
+		})
+	})
+
+	t.Run("when updating a securevalue", func(t *testing.T) {
+		t.Run("both `value` and `ref` must not be present", func(t *testing.T) {
+			sv := &secretv0alpha1.SecureValue{
+				Spec: secretv0alpha1.SecureValueSpec{
+					Value: "value",
+					Ref:   "value",
+				},
+			}
+
+			errs := ValidateSecureValue(sv, admission.Update)
+			require.Len(t, errs, 1)
+			require.Equal(t, "spec", errs[0].Field)
+		})
+	})
+
+	t.Run("`audiences` must match the expected format", func(t *testing.T) {
+		sv := &secretv0alpha1.SecureValue{
+			Spec: secretv0alpha1.SecureValueSpec{
+				Audiences: []string{
+					"/app-name",       // Missing Group
+					"my.grafana.app/", // Missing Name
+					"my.grafana.app",  // Missing Name + /
+				},
+			},
+		}
+
+		errs := ValidateSecureValue(sv, admission.Update)
+		require.Len(t, errs, 3)
+
+		for i, err := range errs {
+			require.Equal(t, fmt.Sprintf("spec.audiences.[%d]", i), err.Field)
+		}
+	})
+}

--- a/pkg/tests/apis/secret/keeper_test.go
+++ b/pkg/tests/apis/secret/keeper_test.go
@@ -174,6 +174,27 @@ func TestIntegrationKeeper(t *testing.T) {
 		})
 	})
 
+	t.Run("creating an invalid keeper fails validation and returns an error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			// #TODO: figure out permissions topic
+			User: helper.Org1.Admin,
+			GVR:  gvrKeepers,
+		})
+
+		testDataKeeper := helper.LoadYAMLOrJSONFile("testdata/keeper-aws-xyz.yaml")
+		testDataKeeper.Object["spec"].(map[string]any)["title"] = ""
+
+		raw, err := client.Resource.Create(ctx, testDataKeeper, metav1.CreateOptions{})
+		require.Error(t, err)
+		require.Nil(t, raw)
+
+		var statusErr *apierrors.StatusError
+		require.True(t, errors.As(err, &statusErr))
+	})
+
 	t.Run("deleting a keeper that exists does not return an error", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -173,6 +173,27 @@ func TestIntegrationSecureValue(t *testing.T) {
 		})
 	})
 
+	t.Run("creating an invalid secure value fails validation and returns an error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			// #TODO: figure out permissions topic
+			User: helper.Org1.Admin,
+			GVR:  gvrSecureValues,
+		})
+
+		testDataSecureValue := helper.LoadYAMLOrJSONFile("testdata/secure-value-xyz.yaml")
+		testDataSecureValue.Object["spec"].(map[string]any)["title"] = ""
+
+		raw, err := client.Resource.Create(ctx, testDataSecureValue, metav1.CreateOptions{})
+		require.Error(t, err)
+		require.Nil(t, raw)
+
+		var statusErr *apierrors.StatusError
+		require.True(t, errors.As(err, &statusErr))
+	})
+
 	t.Run("reading a secure value that does not exist returns a 404", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)

--- a/pkg/tests/apis/secret/testdata/keeper-gcp-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/keeper-gcp-generate.yaml
@@ -1,0 +1,14 @@
+apiVersion: secret.grafana.app/v0alpha1
+kind: Keeper
+metadata:
+  annotations:
+    xx: XXX
+    yy: YYY
+  labels:
+    aa: AAA
+    bb: BBB
+spec:
+  title: Azure XYZ value
+  gcp:
+    projectId: project-id 
+    credentialsFile: /path/to/file.json

--- a/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
+++ b/pkg/tests/apis/secret/testdata/secure-value-generate.yaml
@@ -1,0 +1,17 @@
+apiVersion: secret.grafana.app/v0alpha1
+kind: SecureValue
+metadata:
+  annotations:
+    xx: XXX
+    yy: YYY
+  labels:
+    aa: AAA
+    bb: BBB
+spec:
+  title: XYZ value
+  keeper: my-keeper-1
+  value: super duper secure
+  audiences:
+    - k6.grafana.app/app-name-1
+    - k6.grafana.app/app-name-2
+    - entity.grafana.app/*


### PR DESCRIPTION
This PR implements basic spec validation for both `securevalues` and `keepers`.

In the future we could pass in the underlying DB storages and validate for example that a `securevalue` doesn't exist yet, but we can keep it "light" for now.

It also now handles generating names when creating resources without one, since this is allowed by Kubernetes. We could then centralize this mutation into the callback.

The `Mutate` function gets called before `Validate`.

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1135