### PR TITLE
Docs: Configure SAML SLO properly with NameID and SessionIndex support

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -390,7 +390,7 @@ Additionally, Grafana did not support IdP sessions and could not include the `Se
 Starting from Grafana version 11.5, Grafana uses the `NameID` from the SAML assertion to create the logout request. If the `NameID` is not present in the assertion, Grafana defaults to using the user's `Login` attribute. Additionally, Grafana supports including the `SessionIndex` in the logout request if it is provided in the SAML assertion by the IdP.
 
 {{% admonition type="note" %}}
-These improvements are available in public preview behind the `improvedExternalSessionHandling` feature toggle, starting from Grafana v11.5. To enable it, refer to the [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
+These improvements are available in public preview behind the `improvedExternalSessionHandling` feature toggle, starting from Grafana v11.5. To enable it, refer to the [Configure feature toggles]({{< relref "../../../../setup-grafana/configure-grafana/feature-toggles/" >}})
 {{% /admonition %}}
 
 ### Assertion mapping

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -373,6 +373,20 @@ SAML's single logout feature allows users to log out from all applications assoc
 `HTTP-Redirect` and `HTTP-POST` bindings are supported for single logout.
 When using `HTTP-Redirect` bindings the query should include a request signature.
 
+#### Configure single logout
+
+{{% admonition type="note" %}}
+Proper `NameID` and `SessionIndex` support is available in public preview behind the `improvedExternalSessionHandling` feature toggle, starting from Grafana v11.5.
+{{% /admonition %}}
+
+Before Grafana version 11.5, the `Login` attribute value (extracted from the SAML assertion using the `assertion_attribute_login` configuration) was used as the `NameID` in the logout request. This could cause issues with single logout if the `assertion_attribute_login` value differed from what the Identity Provider (IdP) expected.
+
+Additionally, Grafana did not support IdP sessions and could not include the `SessionIndex` (a unique identifier for the user session on the IdP side) value in the logout request. This could result in issues such as the user being logged out from all of their applications/IdP sessions when logging out from Grafana.
+
+Starting from Grafana version 11.5, Grafana uses the `NameID` from the SAML assertion to create the logout request. If the `NameID` is not present in the assertion, Grafana defaults to using the user's `Login` attribute. Additionally, Grafana supports including the `SessionIndex` in the logout request if it is provided in the SAML assertion by the IdP.
+
+When configuring `name_id_format` in Grafana, ensure it matches the `NameID` format expected and supported by your IdP.
+
 ### Assertion mapping
 
 During the SAML SSO authentication flow, Grafana receives the ACS callback. The callback contains all the relevant information of the user under authentication embedded in the SAML response. Grafana parses the response to create (or update) the user within its internal database.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/index.md
@@ -375,9 +375,13 @@ When using `HTTP-Redirect` bindings the query should include a request signature
 
 #### Configure single logout
 
-{{% admonition type="note" %}}
-Proper `NameID` and `SessionIndex` support is available in public preview behind the `improvedExternalSessionHandling` feature toggle, starting from Grafana v11.5.
-{{% /admonition %}}
+To configure single logout in Grafana:
+
+1. Enable the `single_logout` option in your configuration.
+2. Ensure the `name_id_format` matches the format your IdP expects (e.g., `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`).
+3. Enable the `improvedExternalSessionHandling` feature toggle for complete NameID and SessionIndex support (Grafana v11.5+).
+
+#### `NameID` and `SessionIndex` changes in Grafana v11.5
 
 Before Grafana version 11.5, the `Login` attribute value (extracted from the SAML assertion using the `assertion_attribute_login` configuration) was used as the `NameID` in the logout request. This could cause issues with single logout if the `assertion_attribute_login` value differed from what the Identity Provider (IdP) expected.
 
@@ -385,7 +389,9 @@ Additionally, Grafana did not support IdP sessions and could not include the `Se
 
 Starting from Grafana version 11.5, Grafana uses the `NameID` from the SAML assertion to create the logout request. If the `NameID` is not present in the assertion, Grafana defaults to using the user's `Login` attribute. Additionally, Grafana supports including the `SessionIndex` in the logout request if it is provided in the SAML assertion by the IdP.
 
-When configuring `name_id_format` in Grafana, ensure it matches the `NameID` format expected and supported by your IdP.
+{{% admonition type="note" %}}
+These improvements are available in public preview behind the `improvedExternalSessionHandling` feature toggle, starting from Grafana v11.5. To enable it, refer to the [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
+{{% /admonition %}}
 
 ### Assertion mapping
 


### PR DESCRIPTION
**What is this feature?**
Adding docs on how to configure SAML SLO correctly with the latest Grafana improvements to external session handling.

**Why do we need this feature?**


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
