### PR TITLE
Return SocialError on membership check failure

### DIFF
--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/mail"
@@ -320,11 +319,11 @@ func (s *SocialGenericOAuth) UserInfo(ctx context.Context, client *http.Client, 
 	}
 
 	if !s.isTeamMember(ctx, client) {
-		return nil, errors.New("user not a member of one of the required teams")
+		return nil, &SocialError{"User not a member of one of the required teams"}
 	}
 
 	if !s.isOrganizationMember(ctx, client) {
-		return nil, errors.New("user not a member of one of the required organizations")
+		return nil, &SocialError{"User not a member of one of the required organizations"}
 	}
 
 	if !s.isGroupMember(userInfo.Groups) {


### PR DESCRIPTION
**What is this feature?**

Propagation of a public facing error message using the existing SocialError construct that is already used in Azure OAuth in a similar context.

Details in existing issue. A quick bottom line: for the generic oauth plugin, the server administrator can specify that a user must be a member of certain oauth groups to access grafana. Currently, if a user fails this check, they are presented with an error screen that specifies 'InternalError' with no context. This is obviously very confusing to users, who then assume that Grafana is in an outage state or misconfigured.

**Why do we need this feature?**

See existing issue: https://github.com/grafana/grafana/issues/95800

We are facing significant user confusion in the current state. When a user is not a member of the teams that have been configured by a server administrator, they are met with an InternalError. This makes no sense.

**Which issue(s) does this PR fix?**:

Fixes #95800

**Special notes for your reviewer:**

Please check that:
- [ X ] It works as expected from a user's perspective. (Yes - set up testing locally with keycloak)
- [ ] The docs are updated, and if this is a notable improvement (Don't believe this to be the case)
