### PR TITLE
Search: Remove kind from federated query

### DIFF
--- a/pkg/apis/dashboard/v0alpha1/search.go
+++ b/pkg/apis/dashboard/v0alpha1/search.go
@@ -59,9 +59,9 @@ type DashboardHit struct {
 	// The display nam
 	Title string `json:"title"`
 	// Filter tags
-	Tags []string `json:"tags"`
-	// The UID/name for the folder
-	Folder string `json:"folder"`
+	Tags []string `json:"tags,omitempty"`
+	// The k8s name (eg, grafana UID) for the parent folder
+	Folder string `json:"folder,omitempty"`
 	// Stick untyped extra fields in this object (including the sort value)
 	Field *common.Unstructured `json:"field,omitempty"`
 	// Explain the score (if possible)

--- a/pkg/apis/dashboard/v0alpha1/search.go
+++ b/pkg/apis/dashboard/v0alpha1/search.go
@@ -51,19 +51,9 @@ type SortableField struct {
 	Type    string `json:"type,omitempty"` // string or number
 }
 
-// Dashboard or folder hit
-// +enum
-type HitKind string
-
-// PluginType values
-const (
-	HitTypeDash   HitKind = "dashboard"
-	HitTypeFolder HitKind = "folder"
-)
-
 type DashboardHit struct {
 	// Dashboard or folder
-	Kind HitKind `json:"kind"`
+	Resource string `json:"resource"` // dashboards | folders
 	// The k8s "name" (eg, grafana UID)
 	Name string `json:"name"`
 	// The display nam
@@ -78,8 +68,6 @@ type DashboardHit struct {
 	Explain *common.Unstructured `json:"explain,omitempty"`
 	// When using "real" search, this is the score
 	Score float64 `json:"score,omitempty"`
-	// The link to the resource
-	Url string `json:"url,omitempty"`
 }
 
 type FacetResult struct {

--- a/pkg/apis/dashboard/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/dashboard/v0alpha1/zz_generated.openapi.go
@@ -257,8 +257,7 @@ func schema_pkg_apis_dashboard_v0alpha1_DashboardHit(ref common.ReferenceCallbac
 					},
 					"folder": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The UID/name for the folder",
-							Default:     "",
+							Description: "The k8s name (eg, grafana UID) for the parent folder",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -283,7 +282,7 @@ func schema_pkg_apis_dashboard_v0alpha1_DashboardHit(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"resource", "name", "title", "tags", "folder"},
+				Required: []string{"resource", "name", "title"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/dashboard/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/dashboard/v0alpha1/zz_generated.openapi.go
@@ -216,13 +216,12 @@ func schema_pkg_apis_dashboard_v0alpha1_DashboardHit(ref common.ReferenceCallbac
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"kind": {
+					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Dashboard or folder\n\nPossible enum values:\n - `\"Dashboard\"`\n - `\"Folder\"`",
+							Description: "Dashboard or folder",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
-							Enum:        []interface{}{"Dashboard", "Folder"},
 						},
 					},
 					"name": {
@@ -259,6 +258,7 @@ func schema_pkg_apis_dashboard_v0alpha1_DashboardHit(ref common.ReferenceCallbac
 					"folder": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The UID/name for the folder",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -283,7 +283,7 @@ func schema_pkg_apis_dashboard_v0alpha1_DashboardHit(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"kind", "name", "title"},
+				Required: []string{"resource", "name", "title", "tags", "folder"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -253,8 +253,8 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		searchRequest.Options.Key, err = asResourceKey(user.GetNamespace(), types[0])
 	case 2:
 		searchRequest.Options.Key, err = asResourceKey(user.GetNamespace(), types[0])
-		if err != nil {
-			federate, err = asResourceKey(user.GetNamespace(), types[0])
+		if err == nil {
+			federate, err = asResourceKey(user.GetNamespace(), types[1])
 		}
 	default:
 		err = apierrors.NewBadRequest("too many type requests")

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -2,13 +2,13 @@ package dashboard
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
@@ -18,7 +18,6 @@ import (
 	dashboardv0alpha1 "github.com/grafana/grafana/pkg/apis/dashboard/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/util/errhttp"
 )
@@ -28,15 +27,13 @@ type SearchHandler struct {
 	log    log.Logger
 	client resource.ResourceIndexClient
 	tracer trace.Tracer
-	cfg    *setting.Cfg
 }
 
-func NewSearchHandler(cfg *setting.Cfg, client resource.ResourceIndexClient, tracer trace.Tracer) *SearchHandler {
+func NewSearchHandler(client resource.ResourceIndexClient, tracer trace.Tracer) *SearchHandler {
 	return &SearchHandler{
 		client: client,
 		log:    log.New("grafana-apiserver.dashboards.search"),
 		tracer: tracer,
-		cfg:    cfg,
 	}
 }
 
@@ -253,14 +250,39 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		}}
 	}
 
-	if queryParams.Has("type") {
-		resourceTypes := []string{}
-		resourceTypes = append(resourceTypes, queryParams["type"]...)
-		searchRequest.Options.Fields = []*resource.Requirement{{
-			Key:      resource.SEARCH_FIELD_KIND,
-			Operator: "in",
-			Values:   resourceTypes,
+	// Currently a search query is across folders and dashboards
+	if searchRequest.Query != "" {
+		searchRequest.Federated = []*resource.ResourceKey{{
+			Namespace: searchRequest.Options.Key.Namespace,
+			Group:     "folder.grafana.app",
+			Resource:  "folders",
 		}}
+	}
+
+	// NOTE: only folders || dashboards is supported
+	if queryParams.Has("type") {
+		types := queryParams["type"]
+		switch len(types) {
+		case 0:
+			err = apierrors.NewBadRequest("missing type values")
+		case 1:
+			searchRequest.Options.Key, err = asResourceKey(user.GetNamespace(), types[0])
+		case 2:
+			var federate *resource.ResourceKey
+			searchRequest.Options.Key, err = asResourceKey(user.GetNamespace(), types[0])
+			if err != nil {
+				federate, err = asResourceKey(user.GetNamespace(), types[0])
+				if err != nil {
+					searchRequest.Federated = []*resource.ResourceKey{federate}
+				}
+			}
+		default:
+			err = apierrors.NewBadRequest("too many type requests")
+		}
+		if err != nil {
+			errhttp.Write(ctx, err, w)
+			return
+		}
 	}
 
 	// Add sorting
@@ -273,15 +295,6 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			searchRequest.SortBy = append(searchRequest.SortBy, s)
 		}
-	}
-
-	// Also query folders
-	if searchRequest.Query != "" {
-		searchRequest.Federated = []*resource.ResourceKey{{
-			Namespace: searchRequest.Options.Key.Namespace,
-			Group:     "folder.grafana.app",
-			Resource:  "folders",
-		}}
 	}
 
 	// The facet term fields
@@ -320,14 +333,12 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		MaxScore:  result.MaxScore,
 		Hits:      make([]dashboardv0alpha1.DashboardHit, len(result.Results.Rows)),
 	}
-	appSubUrl := s.cfg.AppSubURL
 	for i, row := range result.Results.Rows {
 		hit := &dashboardv0alpha1.DashboardHit{
-			Kind:   dashboardv0alpha1.HitKind(row.Key.Resource[:len(row.Key.Resource)-1]),
-			Name:   row.Key.Name,
-			Title:  string(row.Cells[0]),
-			Folder: string(row.Cells[1]),
-			Url:    dashboardPageItemLink(row, appSubUrl),
+			Resource: row.Key.Resource, // folders | dashboards
+			Name:     row.Key.Name,     // The Grafana UID
+			Title:    string(row.Cells[0]),
+			Folder:   string(row.Cells[1]),
 		}
 		if row.Cells[2] != nil {
 			_ = json.Unmarshal(row.Cells[2], &hit.Tags)
@@ -362,12 +373,32 @@ func (s *SearchHandler) write(w http.ResponseWriter, obj any) {
 	_ = json.NewEncoder(w).Encode(obj)
 }
 
-func dashboardPageItemLink(row *resource.ResourceTableRow, subURL string) string {
-	folder := string(row.Cells[1])
-	name := row.Key.Name
-	namespace := row.Key.Namespace
-	if folder == "" {
-		return fmt.Sprintf("%s/d/%s/%s", subURL, name, namespace)
+// Given a namespace and type convert it to a search key
+func asResourceKey(ns string, k string) (*resource.ResourceKey, error) {
+	if ns == "" {
+		return nil, apierrors.NewBadRequest("missing namespace")
 	}
-	return fmt.Sprintf("%s/dashboards/f/%s/%s", subURL, name, namespace)
+	switch k {
+	case "folders", "folder":
+		return &resource.ResourceKey{
+			Namespace: ns,
+			Group:     "folder.grafana.app",
+			Resource:  "folders",
+		}, nil
+	case "dashboards", "dashboard":
+		return &resource.ResourceKey{
+			Namespace: ns,
+			Group:     dashboardv0alpha1.GROUP,
+			Resource:  "dashboards",
+		}, nil
+
+	// NOT really supported in the dashboard search UI, but useful for manual testing
+	case "playlist", "playlists":
+		return &resource.ResourceKey{
+			Namespace: ns,
+			Group:     "playlist.grafana.app",
+			Resource:  "playlists",
+		}, nil
+	}
+	return nil, apierrors.NewBadRequest("unknown resource type")
 }

--- a/pkg/registry/apis/dashboard/v0alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v0alpha1/register.go
@@ -71,7 +71,7 @@ func RegisterAPIService(cfg *setting.Cfg, features featuremgmt.FeatureToggles,
 		dashboardService: dashboardService,
 		accessControl:    accessControl,
 		unified:          unified,
-		search:           dashboard.NewSearchHandler(cfg, unified, tracing),
+		search:           dashboard.NewSearchHandler(unified, tracing),
 
 		legacy: &dashboard.DashboardStorage{
 			Resource:       dashboardv0alpha1.DashboardResourceInfo,

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -119,8 +119,8 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 		if resourceVersion > 0 {
 			_, err := os.Stat(dir)
 			if err == nil {
-				index, _ = bleve.Open(dir) // NOTE, will use the same mappings!!!
-				if index != nil {
+				index, err = bleve.Open(dir) // NOTE, will use the same mappings!!!
+				if err == nil {
 					found, err := index.DocCount()
 					if err == nil && int64(found) == size {
 						build = false // we can skip building

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -42,5 +42,5 @@ func TestDocumentMapping(t *testing.T) {
 
 	fmt.Printf("DOC: fields %d\n", len(doc.Fields))
 	fmt.Printf("DOC: size %d\n", doc.Size())
-	require.Equal(t, 15, len(doc.Fields))
+	require.Equal(t, 17, len(doc.Fields))
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -30,10 +30,11 @@ func TestBleveBackend(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "bleve-test")
 	require.NoError(t, err)
 
-	backend := NewBleveBackend(BleveOptions{
+	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir,
 		FileThreshold: 5, // with more than 5 items we create a file on disk
 	}, tracing.NewNoopTracerService())
+	require.NoError(t, err)
 
 	// AVOID NPE in test
 	resource.NewIndexMetrics(backend.opts.Root, backend)

--- a/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
@@ -5,8 +5,10 @@
     "resource": "dashboards",
     "name": "aaa"
   },
+  "kind": "dashboards",
   "rv": 1234,
   "title": "Test title",
+  "title_sort": "Test title",
   "description": "test description",
   "tags": [
     "a",

--- a/pkg/storage/unified/search/testdata/doc/folder-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/folder-aaa-out.json
@@ -5,8 +5,10 @@
     "resource": "dashboards",
     "name": "aaa"
   },
+  "kind": "dashboards",
   "rv": 1234,
-  "title": "aaa",
+  "title": "test-aaa",
+  "title_sort": "test-aaa",
   "created": 1730490142000,
   "createdBy": "user:1",
   "repository": {

--- a/pkg/storage/unified/search/testdata/doc/folder-bbb-out.json
+++ b/pkg/storage/unified/search/testdata/doc/folder-bbb-out.json
@@ -5,8 +5,10 @@
     "resource": "dashboards",
     "name": "bbb"
   },
+  "kind": "dashboards",
   "rv": 1234,
-  "title": "bbb",
+  "title": "test-bbb",
+  "title_sort": "test-bbb",
   "created": 1730490142000,
   "createdBy": "user:1",
   "repository": {

--- a/pkg/storage/unified/search/testdata/doc/playlist-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/playlist-aaa-out.json
@@ -5,8 +5,10 @@
     "resource": "dashboards",
     "name": "aaa"
   },
+  "kind": "dashboards",
   "rv": 1234,
-  "title": "aaa",
+  "title": "Test AAA",
+  "title_sort": "Test AAA",
   "created": 1731336353000,
   "createdBy": "user:t000000001",
   "repository": {

--- a/pkg/storage/unified/search/testdata/doc/report-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/report-aaa-out.json
@@ -5,8 +5,10 @@
     "resource": "dashboards",
     "name": "aaa"
   },
+  "kind": "dashboards",
   "rv": 1234,
-  "title": "aaa",
+  "title": "Test AAA",
+  "title_sort": "Test AAA",
   "created": 1706690655000,
   "createdBy": "user:abc",
   "repository": {

--- a/pkg/storage/unified/search/testdata/manual-dashboard.json
+++ b/pkg/storage/unified/search/testdata/manual-dashboard.json
@@ -68,7 +68,7 @@
   "rows": [
     {
       "cells": [
-        "ns/g/dashboards/ccc",
+        "ns/dashboard.grafana.app/dashboards/ccc",
         "ccc (dash)",
         [
           "aa"
@@ -82,7 +82,7 @@
       ],
       "object": {
         "kind": "dashboards",
-        "apiVersion": "g",
+        "apiVersion": "dashboard.grafana.app",
         "metadata": {
           "name": "ccc",
           "namespace": "ns",
@@ -92,7 +92,7 @@
     },
     {
       "cells": [
-        "ns/g/dashboards/bbb",
+        "ns/dashboard.grafana.app/dashboards/bbb",
         "bbb (dash)",
         [
           "aa"
@@ -106,7 +106,7 @@
       ],
       "object": {
         "kind": "dashboards",
-        "apiVersion": "g",
+        "apiVersion": "dashboard.grafana.app",
         "metadata": {
           "name": "bbb",
           "namespace": "ns",
@@ -116,7 +116,7 @@
     },
     {
       "cells": [
-        "ns/g/dashboards/aaa",
+        "ns/dashboard.grafana.app/dashboards/aaa",
         "aaa (dash)",
         [
           "aa",
@@ -131,7 +131,7 @@
       ],
       "object": {
         "kind": "dashboards",
-        "apiVersion": "g",
+        "apiVersion": "dashboard.grafana.app",
         "metadata": {
           "name": "aaa",
           "namespace": "ns",

--- a/pkg/storage/unified/search/testdata/manual-federated.json
+++ b/pkg/storage/unified/search/testdata/manual-federated.json
@@ -20,11 +20,11 @@
     {
       "cells": [
         "aaa (dash)",
-        "ns/g/dashboards/aaa"
+        "ns/dashboard.grafana.app/dashboards/aaa"
       ],
       "object": {
         "kind": "dashboards",
-        "apiVersion": "g",
+        "apiVersion": "dashboard.grafana.app",
         "metadata": {
           "name": "aaa",
           "namespace": "ns",
@@ -35,11 +35,11 @@
     {
       "cells": [
         "bbb (dash)",
-        "ns/g/dashboards/bbb"
+        "ns/dashboard.grafana.app/dashboards/bbb"
       ],
       "object": {
         "kind": "dashboards",
-        "apiVersion": "g",
+        "apiVersion": "dashboard.grafana.app",
         "metadata": {
           "name": "bbb",
           "namespace": "ns",
@@ -50,11 +50,11 @@
     {
       "cells": [
         "ccc (dash)",
-        "ns/g/dashboards/ccc"
+        "ns/dashboard.grafana.app/dashboards/ccc"
       ],
       "object": {
         "kind": "dashboards",
-        "apiVersion": "g",
+        "apiVersion": "dashboard.grafana.app",
         "metadata": {
           "name": "ccc",
           "namespace": "ns",
@@ -65,11 +65,11 @@
     {
       "cells": [
         "yyy (folder)",
-        "ns/g/folders/yyy"
+        "ns/folder.grafana.app/folders/yyy"
       ],
       "object": {
         "kind": "folders",
-        "apiVersion": "g",
+        "apiVersion": "folder.grafana.app",
         "metadata": {
           "name": "yyy",
           "namespace": "ns",
@@ -80,11 +80,11 @@
     {
       "cells": [
         "zzz (folder)",
-        "ns/g/folders/zzz"
+        "ns/folder.grafana.app/folders/zzz"
       ],
       "object": {
         "kind": "folders",
-        "apiVersion": "g",
+        "apiVersion": "folder.grafana.app",
         "metadata": {
           "name": "zzz",
           "namespace": "ns",

--- a/pkg/storage/unified/search/testdata/manual-folder.json
+++ b/pkg/storage/unified/search/testdata/manual-folder.json
@@ -47,7 +47,7 @@
   "rows": [
     {
       "cells": [
-        "ns/g/folders/yyy",
+        "ns/folder.grafana.app/folders/yyy",
         "yyy (folder)",
         null,
         null,
@@ -56,7 +56,7 @@
       ],
       "object": {
         "kind": "folders",
-        "apiVersion": "g",
+        "apiVersion": "folder.grafana.app",
         "metadata": {
           "name": "yyy",
           "namespace": "ns",
@@ -66,7 +66,7 @@
     },
     {
       "cells": [
-        "ns/g/folders/zzz",
+        "ns/folder.grafana.app/folders/zzz",
         "zzz (folder)",
         null,
         null,
@@ -75,7 +75,7 @@
       ],
       "object": {
         "kind": "folders",
-        "apiVersion": "g",
+        "apiVersion": "folder.grafana.app",
         "metadata": {
           "name": "zzz",
           "namespace": "ns",

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -25,6 +25,7 @@ type SearchHit = {
   title: string;
   location: string;
   folder: string;
+  tags: string[];
 
   // calculated in the frontend
   url: string;
@@ -282,8 +283,11 @@ function toDashboardResults(hits: SearchHit[]): DataFrame {
     return {
       ...hit,
       url: toURL(hit.resource, hit.name),
+      tags: hit.tags || [],
+      folder: hit.folder || 'general',
       location,
       name: hit.title, // 🤯 FIXME hit.name is k8s name, eg grafana dashboards UID
+      kind: hit.resource.substring(0, hit.resource.length - 1),  // dashboard "kind" is not plural
     };
   });
   const frame = toDataFrame(dashboardHits);

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -125,8 +125,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
     }
 
     if (req.kind) {  // filter resource types
-      // resource "kind" is plural on the backend
-      uri += '&' + req.kind.map((kind) => `type=${encodeURIComponent(`${kind}s`)}`).join('&');
+      uri += '&' + req.kind.map((kind) => `type=${kind}`).join('&');
     }
 
     if (req.tags) {


### PR DESCRIPTION
This PR applies to https://github.com/grafana/grafana/pull/97866

I has a few key changes:
1. index management -- extracted to https://github.com/grafana/grafana/pull/98260'
2. Removes cfg.Settigns dependency from the server -- we can calculate the URL in the frontend better
3. federation... avoid always loading all indexes and *then* filtering by "Kind"; we can just load the indexes we will use.
4. ...