### PR TITLE
Include library elements on counts endpoint

### DIFF
--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -63,6 +63,12 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resource.ResourceS
 		if err != nil {
 			return err
 		}
+
+		// Legacy library_elements table
+		err = fn("library_element", "org_id=? AND folder_uid=?", group, "library_elements")
+		if err != nil {
+			return err
+		}
 		return nil
 	})
 

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -133,6 +133,10 @@ func TestDirectSQLStats(t *testing.T) {
 				"group": "sql-fallback",
 				"resource": "folders",
 				"count": 1
+			},
+			{
+				"group": "sql-fallback",
+				"resource": "library_elements"
 			}
 		]`, string(jj))
 	})
@@ -161,6 +165,10 @@ func TestDirectSQLStats(t *testing.T) {
 			{
 				"group": "sql-fallback",
 				"resource": "folders"
+			},
+						{
+				"group": "sql-fallback",
+				"resource": "library_elements"
 			}
 		]`, string(jj))
 	})


### PR DESCRIPTION
Library elements are also dependant on folders, so we should warn the user if any is present.


Fixes https://github.com/grafana/grafana-org/issues/354

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
