### PR TITLE
Authn: Use Authenticator from authlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.3 // @grafana/grafana-app-platform-squad
 	github.com/grafana/alerting v0.0.0-20241211182001-0f317eb6b2f7 // @grafana/alerting-backend
-	github.com/grafana/authlib v0.0.0-20241219093220-08aa05b9cf26 // @grafana/identity-access-team
+	github.com/grafana/authlib v0.0.0-20241219113239-680f63d66860 // @grafana/identity-access-team
 	github.com/grafana/authlib/claims v0.0.0-20241202085737-df90af04f335 // @grafana/identity-access-team
 	github.com/grafana/codejen v0.0.4-0.20230321061741-77f656893a3d // @grafana/dataviz-squad
 	github.com/grafana/cuetsy v0.1.11 // @grafana/grafana-as-code

--- a/go.sum
+++ b/go.sum
@@ -2293,8 +2293,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/alerting v0.0.0-20241211182001-0f317eb6b2f7 h1:VGLUQ2mwzlF1NGwTxpSfv1RnuOsDlNh/NT5KRvhZ0sQ=
 github.com/grafana/alerting v0.0.0-20241211182001-0f317eb6b2f7/go.mod h1:QsnoKX/iYZxA4Cv+H+wC7uxutBD8qi8ZW5UJvD2TYmU=
-github.com/grafana/authlib v0.0.0-20241219093220-08aa05b9cf26 h1:kWe1MsWAtFQvmnbwnQNJdaGCTqbGNVuowOtLmhO5qEY=
-github.com/grafana/authlib v0.0.0-20241219093220-08aa05b9cf26/go.mod h1:x7df73G3xuSD35Xv9cjaMLyPJCgM9Z/Wj5ISouoAfiI=
+github.com/grafana/authlib v0.0.0-20241219113239-680f63d66860 h1:hSKtktGrIcBzNgyXcR2pi5jCLfunTz6VlSVOGFDnqiQ=
+github.com/grafana/authlib v0.0.0-20241219113239-680f63d66860/go.mod h1:x7df73G3xuSD35Xv9cjaMLyPJCgM9Z/Wj5ISouoAfiI=
 github.com/grafana/authlib/claims v0.0.0-20241202085737-df90af04f335 h1:3DHH81RJCi8Bcgn2MdBh7vgWUshmAFjZzBCVuxiQ0uk=
 github.com/grafana/authlib/claims v0.0.0-20241202085737-df90af04f335/go.mod h1:r+F8H6awwjNQt/KPZ2GNwjk8TvsJ7/gxzkXN26GlL/A=
 github.com/grafana/codejen v0.0.4-0.20230321061741-77f656893a3d h1:hrXbGJ5jgp6yNITzs5o+zXq0V5yT3siNJ+uM8LGwWKk=

--- a/pkg/services/grpcserver/interceptors/auth.go
+++ b/pkg/services/grpcserver/interceptors/auth.go
@@ -17,6 +17,12 @@ import (
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
+type AuthenticatorFunc func(ctx context.Context) (context.Context, error)
+
+func (a AuthenticatorFunc) Authenticate(ctx context.Context) (context.Context, error) {
+	return a(ctx)
+}
+
 type Authenticator interface {
 	Authenticate(ctx context.Context) (context.Context, error)
 }

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -129,12 +129,7 @@ func idTokenExtractor(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("no claims found")
 	}
 
-	extra := authInfo.GetExtra()
-	if token, exists := extra["id-token"]; exists && len(token) != 0 && token[0] != "" {
-		return token[0], nil
-	}
-
-	return "", nil
+	return authInfo.GetIDToken(), nil
 }
 
 func allowInsecureTransportOpt(grpcClientConfig *authnlib.GrpcClientConfig, opts []authnlib.GrpcClientInterceptorOption) []authnlib.GrpcClientInterceptorOption {

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -129,7 +129,12 @@ func idTokenExtractor(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("no claims found")
 	}
 
-	return authInfo.GetIDToken(), nil
+	extra := authInfo.GetExtra()
+	if token, exists := extra["id-token"]; exists && len(token) != 0 && token[0] != "" {
+		return token[0], nil
+	}
+
+	return "", nil
 }
 
 func allowInsecureTransportOpt(grpcClientConfig *authnlib.GrpcClientConfig, opts []authnlib.GrpcClientInterceptorOption) []authnlib.GrpcClientInterceptorOption {


### PR DESCRIPTION
**What is this feature?**
Replace usage of [GrpcAuthenticator](https://github.com/grafana/authlib/blob/main/authn/grpc_authenticator.go#L58) with an [authenticator](https://github.com/grafana/authlib/blob/main/authn/authenticator.go#L86) that can work with both http and grpc. The idea is to use this in ext jwt client too.

I am pretty sure calling resource store as "grafana" e.g. for the sync process is broken on prem and was before this change. We need a way to propagate the grafana identity with permissions without having to sing an access token.


Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
