### PR TITLE
Search: Use new folder when creating a bleve index

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/search"
@@ -39,21 +41,32 @@ type bleveBackend struct {
 	tracer trace.Tracer
 	log    *slog.Logger
 	opts   BleveOptions
+	start  time.Time
 
 	// cache info
 	cache   map[resource.NamespacedResource]*bleveIndex
 	cacheMu sync.RWMutex
 }
 
-func NewBleveBackend(opts BleveOptions, tracer trace.Tracer) *bleveBackend {
-	b := &bleveBackend{
+func NewBleveBackend(opts BleveOptions, tracer trace.Tracer) (*bleveBackend, error) {
+	if opts.Root == "" {
+		return nil, fmt.Errorf("bleve backend missing root folder configuration")
+	}
+	root, err := os.Stat(opts.Root)
+	if err != nil {
+		return nil, fmt.Errorf("error opening bleve root folder %w", err)
+	}
+	if !root.IsDir() {
+		return nil, fmt.Errorf("bleve root is configured against a file (not folder)")
+	}
+
+	return &bleveBackend{
 		log:    slog.Default().With("logger", "bleve-backend"),
 		tracer: tracer,
 		cache:  make(map[resource.NamespacedResource]*bleveIndex),
 		opts:   opts,
-	}
-
-	return b
+		start:  time.Now(),
+	}, nil
 }
 
 // This will return nil if the key does not exist
@@ -91,13 +104,34 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 	var err error
 	var index bleve.Index
 
+	build := true
 	mapper := getBleveMappings(fields)
 
 	if size > b.opts.FileThreshold {
-		dir := filepath.Join(b.opts.Root, key.Namespace, fmt.Sprintf("%s.%s", key.Resource, key.Group))
-		index, err = bleve.New(dir, mapper)
-
-		// TODO, check last RV so we can see if the numbers have changed
+		fname := fmt.Sprintf("rv%d", resourceVersion)
+		if resourceVersion == 0 {
+			fname = b.start.Format("tmp-20060102-150405")
+		}
+		dir := filepath.Join(b.opts.Root, key.Namespace,
+			fmt.Sprintf("%s.%s", key.Resource, key.Group),
+			fname,
+		)
+		if resourceVersion > 0 {
+			_, err := os.Stat(dir)
+			if err == nil {
+				index, _ = bleve.Open(dir) // NOTE, will use the same mappings!!!
+				if index != nil {
+					found, err := index.DocCount()
+					if err == nil && int64(found) == size {
+						build = false // we can skip building
+					}
+				}
+			}
+		}
+		if index == nil {
+			// TODO? cleanup old indexes???
+			index, err = bleve.New(dir, mapper)
+		}
 
 		resource.IndexMetrics.IndexTenants.WithLabelValues(key.Namespace, "file").Inc()
 	} else {
@@ -123,15 +157,17 @@ func (b *bleveBackend) BuildIndex(ctx context.Context,
 		return nil, err
 	}
 
-	_, err = builder(idx)
-	if err != nil {
-		return nil, err
-	}
+	if build {
+		_, err = builder(idx)
+		if err != nil {
+			return nil, err
+		}
 
-	// Flush the batch
-	err = idx.Flush()
-	if err != nil {
-		return nil, err
+		// Flush the batch
+		err = idx.Flush()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	b.cacheMu.Lock()
@@ -265,27 +301,9 @@ func (b *bleveIndex) Search(
 		return nil, err
 	}
 
-	// Write frame as JSON
-	//response.Frame, err = frame.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-
 	// parse the facet fields
 	for k, v := range res.Facets {
-		f := &resource.ResourceSearchResponse_Facet{
-			Field:   v.Field,
-			Total:   int64(v.Total),
-			Missing: int64(v.Missing),
-		}
-		if v.Terms != nil {
-			for _, t := range v.Terms.Terms() {
-				f.Terms = append(f.Terms, &resource.ResourceSearchResponse_TermFacet{
-					Term:  t.Term,
-					Count: int64(t.Count),
-				})
-			}
-		}
+		f := newResponseFacet(v)
 		if response.Facet == nil {
 			response.Facet = make(map[string]*resource.ResourceSearchResponse_Facet)
 		}
@@ -347,7 +365,7 @@ func (b *bleveIndex) getIndex(
 				return nil, fmt.Errorf("federated indexes must be the same type")
 			}
 			if typedindex.verifyKey(req.Federated[i]) != nil {
-				return nil, fmt.Errorf("federated index keys do not match")
+				return nil, fmt.Errorf("federated index keys do not match (%v != %v)", typedindex, req.Federated[i])
 			}
 			all = append(all, typedindex.index)
 		}
@@ -357,11 +375,16 @@ func (b *bleveIndex) getIndex(
 }
 
 func toBleveSearchRequest(req *resource.ResourceSearchRequest, access authz.AccessClient) (*bleve.SearchRequest, *resource.ErrorResult) {
+	facets := bleve.FacetsRequest{}
+	for _, f := range req.Facet {
+		facets[f.Field] = bleve.NewFacetRequest(f.Field, int(f.Limit))
+	}
 	searchrequest := &bleve.SearchRequest{
 		Fields:  req.Fields,
 		Size:    int(req.Limit),
 		From:    int(req.Offset),
 		Explain: req.Explain,
+		Facets:  facets,
 	}
 
 	// Currently everything is within an AND query
@@ -375,6 +398,7 @@ func toBleveSearchRequest(req *resource.ResourceSearchRequest, access authz.Acce
 			queries = append(queries, q)
 		}
 	}
+	// filters
 	if len(req.Options.Fields) > 0 {
 		for _, v := range req.Options.Fields {
 			q, err := requirementQuery(v, "")
@@ -385,12 +409,7 @@ func toBleveSearchRequest(req *resource.ResourceSearchRequest, access authz.Acce
 		}
 	}
 
-	if req.Query != "" {
-		// ??? Should expose the full power of query parsing here?
-		// it is great for exploration, but also hard to change in the future
-		q := bleve.NewQueryStringQuery(req.Query)
-		queries = append(queries, q)
-	}
+	queries = append(queries, newTextQuery(req))
 
 	if access != nil {
 		// TODO AUTHZ!!!!
@@ -418,30 +437,11 @@ func toBleveSearchRequest(req *resource.ResourceSearchRequest, access authz.Acce
 	}
 
 	// Add the sort fields
-	for _, sort := range req.SortBy {
-		// hardcoded (for now)
-		if strings.HasPrefix(sort.Field, "stats.") {
-			searchrequest.Sort = append(searchrequest.Sort, &search.SortField{
-				Field:   sort.Field,
-				Desc:    sort.Desc,
-				Type:    search.SortFieldAsNumber, // force for now!
-				Mode:    search.SortFieldDefault,  // ???
-				Missing: search.SortFieldMissingLast,
-			})
-			continue
-		}
-
-		// Default support
-		input := sort.Field
-		if sort.Desc {
-			input = "-" + sort.Field
-		}
-		s := search.ParseSearchSortString(input)
-		searchrequest.Sort = append(searchrequest.Sort, s)
-	}
+	sorting := getSortFields(req)
+	searchrequest.SortBy(sorting)
 
 	// Always sort by *something*, otherwise the order is unstable
-	if len(searchrequest.Sort) == 0 {
+	if len(sorting) == 0 {
 		searchrequest.Sort = append(searchrequest.Sort, &search.SortDocID{
 			Desc: false,
 		})
@@ -450,23 +450,71 @@ func toBleveSearchRequest(req *resource.ResourceSearchRequest, access authz.Acce
 	return searchrequest, nil
 }
 
+func getSortFields(req *resource.ResourceSearchRequest) []string {
+	sorting := []string{}
+	for _, sort := range req.SortBy {
+		input := sort.Field
+		if field, ok := textSortFields[input]; ok {
+			input = field
+		}
+
+		if sort.Desc {
+			input = "-" + input
+		}
+		sorting = append(sorting, input)
+	}
+	return sorting
+}
+
+// fields that we went to sort by the full text
+var textSortFields = map[string]string{
+	resource.SEARCH_FIELD_TITLE: resource.SEARCH_FIELD_TITLE + "_sort",
+}
+
 // Convert a "requirement" into a bleve query
 func requirementQuery(req *resource.Requirement, prefix string) (query.Query, *resource.ErrorResult) {
 	switch selection.Operator(req.Operator) {
 	case selection.Equals, selection.DoubleEquals:
-		if len(req.Values) != 1 {
-			return nil, resource.NewBadRequestError("equals query can have one value")
+		if len(req.Values) == 0 {
+			return query.NewMatchAllQuery(), nil
 		}
-		q := query.NewMatchQuery(req.Values[0])
-		q.FieldVal = prefix + req.Key
-		return q, nil
+		if len(req.Values[0]) == 1 {
+			q := query.NewMatchQuery(req.Values[0])
+			q.FieldVal = prefix + req.Key
+			return q, nil
+		}
 
+		conjuncts := []query.Query{}
+		for _, v := range req.Values {
+			q := query.NewMatchQuery(v)
+			q.FieldVal = prefix + req.Key
+			conjuncts = append(conjuncts, q)
+		}
+
+		return query.NewConjunctionQuery(conjuncts), nil
 	case selection.NotEquals:
 	case selection.DoesNotExist:
 	case selection.GreaterThan:
 	case selection.LessThan:
 	case selection.Exists:
 	case selection.In:
+		if len(req.Values) == 0 {
+			return query.NewMatchAllQuery(), nil
+		}
+		if len(req.Values) == 1 {
+			q := query.NewMatchQuery(req.Values[0])
+			q.FieldVal = prefix + req.Key
+			return q, nil
+		}
+
+		disjuncts := []query.Query{}
+		for _, v := range req.Values {
+			q := query.NewMatchQuery(v)
+			q.FieldVal = prefix + req.Key
+			disjuncts = append(disjuncts, q)
+		}
+
+		return query.NewDisjunctionQuery(disjuncts), nil
 	case selection.NotIn:
 	}
 	return nil, resource.NewBadRequestError(
@@ -574,4 +622,30 @@ func getAllFields(standard resource.SearchableDocumentFields, custom resource.Se
 		}
 	}
 	return fields, nil
+}
+
+func newResponseFacet(v *search.FacetResult) *resource.ResourceSearchResponse_Facet {
+	f := &resource.ResourceSearchResponse_Facet{
+		Field:   v.Field,
+		Total:   int64(v.Total),
+		Missing: int64(v.Missing),
+	}
+	if v.Terms != nil {
+		for _, t := range v.Terms.Terms() {
+			f.Terms = append(f.Terms, &resource.ResourceSearchResponse_TermFacet{
+				Term:  t.Term,
+				Count: int64(t.Count),
+			})
+		}
+	}
+	return f
+}
+
+func newTextQuery(req *resource.ResourceSearchRequest) query.Query {
+	if req.Query == "" || req.Query == "*" {
+		return bleve.NewMatchAllQuery()
+	}
+	// TODO: wildcard query?
+	// return bleve.NewWildcardQuery(req.Query)
+	return bleve.NewFuzzyQuery(req.Query)
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -30,10 +30,11 @@ func TestBleveBackend(t *testing.T) {
 	tmpdir, err := os.CreateTemp("", "bleve-test")
 	require.NoError(t, err)
 
-	backend := NewBleveBackend(BleveOptions{
+	backend, err := NewBleveBackend(BleveOptions{
 		Root:          tmpdir.Name(),
 		FileThreshold: 5, // with more than 5 items we create a file on disk
 	}, tracing.NewNoopTracerService())
+	require.NoError(t, err)
 
 	// AVOID NPE in test
 	resource.NewIndexMetrics(backend.opts.Root, backend)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -27,7 +27,7 @@ func TestBleveBackend(t *testing.T) {
 		Group:     "folder.grafana.app",
 		Resource:  "folders",
 	}
-	tmpdir, err := os.MkdirTemp("grafana", "bleve-test")
+	tmpdir, err := os.MkdirTemp("", "grafana-bleve-test")
 	require.NoError(t, err)
 
 	backend, err := NewBleveBackend(BleveOptions{

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -27,11 +27,11 @@ func TestBleveBackend(t *testing.T) {
 		Group:     "folder.grafana.app",
 		Resource:  "folders",
 	}
-	tmpdir, err := os.CreateTemp("", "bleve-test")
+	tmpdir, err := os.MkdirTemp("grafana", "bleve-test")
 	require.NoError(t, err)
 
 	backend, err := NewBleveBackend(BleveOptions{
-		Root:          tmpdir.Name(),
+		Root:          tmpdir,
 		FileThreshold: 5, // with more than 5 items we create a file on disk
 	}, tracing.NewNoopTracerService())
 	require.NoError(t, err)


### PR DESCRIPTION
This PR tries to reuse the existing saved index if it matches the resourceVersion and size

Without this PR, if you have more than 10 dashboards indexed, the second time you start will fail with:
```
ERROR[12-19|16:33:42] error initializing resource server       logger=resource-server error="cannot create new index, path already exists"
Error: ✗ cannot create new index, path already exists
```

It also defaults to sticking the index in the grafana root folder:
<img width="444" alt="image" src="https://github.com/user-attachments/assets/0497dd2a-ca13-4e5a-97c1-aa2f0bd49287" />

this PR moves things so we create an index under data:
<img width="569" alt="image" src="https://github.com/user-attachments/assets/829a82f1-f29e-492e-8da4-1710e3960334" />
