### PR TITLE
Alerting: Update state manager to take image only once per rule evaluation

### DIFF
--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -19,24 +19,13 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
 )
-
-// Not for parallel tests.
-type CountingImageService struct {
-	Called int
-}
-
-func (c *CountingImageService) NewImage(_ context.Context, _ *ngmodels.AlertRule) (*ngmodels.Image, error) {
-	c.Called += 1
-	return &ngmodels.Image{
-		Token: fmt.Sprint(rand.Int()),
-	}, nil
-}
 
 func TestStateIsStale(t *testing.T) {
 	now := time.Now()
@@ -3930,6 +3919,161 @@ func TestProcessEvalResults_StateTransitions(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestProcessEvalResults_Screenshots(t *testing.T) {
+	gen := ngmodels.RuleGen
+	baseRule := gen.With(
+		gen.WithDashboardAndPanel(util.Pointer(util.GenerateShortUID()), util.Pointer(rand.Int63())),
+		gen.WithLabels(nil),
+		gen.WithFor(0),
+	).Generate()
+
+	evalDuration := time.Duration(baseRule.IntervalSeconds) * time.Second
+
+	t0 := time.Now()
+	tn := func(n int) time.Time {
+		return t0.Add(time.Duration(n) * evalDuration)
+	}
+	t1 := tn(1)
+
+	randomImage := func() *ngmodels.Image {
+		return &ngmodels.Image{Token: fmt.Sprint(rand.Int())}
+	}
+
+	newState := func(s eval.State, labels data.Labels, image *ngmodels.Image) State {
+		res := State{
+			AlertRuleUID:      baseRule.UID,
+			OrgID:             baseRule.OrgID,
+			Image:             image,
+			Labels:            labels,
+			ResultFingerprint: labels.Fingerprint(),
+			State:             s,
+			LatestResult: &Evaluation{
+				EvaluationState: s,
+			},
+			StartsAt:           t0,
+			LastEvaluationTime: t0,
+			CacheID:            data.Fingerprint(0),
+		}
+		setCacheID(&res)
+		return res
+	}
+
+	newResult := func(mutators ...eval.ResultMutator) eval.Result {
+		r := eval.Result{
+			State: eval.Normal,
+		}
+		for _, mutator := range mutators {
+			mutator(&r)
+		}
+		return r
+	}
+
+	labels1 := data.Labels{
+		"instance_label": "test-1",
+	}
+	labels2 := data.Labels{
+		"instance_label": "test-2",
+	}
+	labels3 := data.Labels{
+		"instance_label": "test-3",
+	}
+
+	testCases := []struct {
+		desc                string
+		rule                ngmodels.AlertRule
+		initStates          []State
+		results             [][]eval.Result
+		imageService        *CountingImageService
+		expectedCalledTimes int
+	}{
+		{
+			desc:       "when transition to Alerting from empty state",
+			rule:       baseRule,
+			initStates: []State{},
+			results: [][]eval.Result{
+				{
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels2)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels3)),
+				},
+			},
+			imageService:        newSuccessfulCountingImageService(),
+			expectedCalledTimes: 3,
+		},
+		{
+			desc: "when transition to Alerting from Normal states, existing images ignored",
+			initStates: []State{
+				newState(eval.Normal, labels1, randomImage()),
+				newState(eval.Normal, labels2, nil),
+				newState(eval.Normal, labels3, randomImage()),
+			},
+			results: [][]eval.Result{
+				{
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels2)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels3)),
+				},
+			},
+			imageService:        newSuccessfulCountingImageService(),
+			expectedCalledTimes: 3,
+		},
+		{
+			desc: "when Alerting and no screenshot",
+			initStates: []State{
+				newState(eval.Alerting, labels1, nil),
+				newState(eval.Alerting, labels2, nil),
+				newState(eval.Alerting, labels3, nil),
+			},
+			results: [][]eval.Result{
+				{
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels1)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels2)),
+					newResult(eval.WithState(eval.Alerting), eval.WithLabels(labels3)),
+				},
+			},
+			imageService:        newSuccessfulCountingImageService(),
+			expectedCalledTimes: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			clk := clock.NewMock()
+
+			ctx := context.Background()
+			cfg := ManagerCfg{
+				Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+				ExternalURL:   nil,
+				InstanceStore: &FakeInstanceStore{},
+				Images:        tc.imageService,
+				Clock:         clk,
+				Historian:     &FakeHistorian{},
+				Tracer:        tracing.InitializeTracerForTest(),
+				Log:           &logtest.Fake{},
+			}
+
+			mgr := NewManager(cfg, NewNoopPersister())
+			for _, s := range tc.initStates {
+				mgr.cache.set(&s)
+			}
+			for n, results := range tc.results {
+				tx := tn(n)
+				clk.Set(t1)
+				for idx := range results {
+					results[idx].EvaluatedAt = tx
+				}
+				transitions := mgr.ProcessEvalResults(ctx, t1, &baseRule, results, nil, nil)
+
+				for _, transition := range transitions {
+					assert.Equalf(t, tc.imageService.Image, transition.Image, "Transition %s does not have image but should", transition.Labels.String())
+				}
+			}
+
+			assert.Equal(t, tc.expectedCalledTimes, tc.imageService.Called)
+		})
+	}
 }
 
 func setCacheID(s *State) *State {

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -4000,7 +4000,7 @@ func TestProcessEvalResults_Screenshots(t *testing.T) {
 				},
 			},
 			imageService:        newSuccessfulCountingImageService(),
-			expectedCalledTimes: 3,
+			expectedCalledTimes: 1,
 		},
 		{
 			desc: "when transition to Alerting from Normal states, existing images ignored",
@@ -4017,7 +4017,7 @@ func TestProcessEvalResults_Screenshots(t *testing.T) {
 				},
 			},
 			imageService:        newSuccessfulCountingImageService(),
-			expectedCalledTimes: 3,
+			expectedCalledTimes: 1,
 		},
 		{
 			desc: "when Alerting and no screenshot",
@@ -4034,7 +4034,7 @@ func TestProcessEvalResults_Screenshots(t *testing.T) {
 				},
 			},
 			imageService:        newSuccessfulCountingImageService(),
-			expectedCalledTimes: 3,
+			expectedCalledTimes: 1,
 		},
 	}
 

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"slices"
 	"sync"
 
@@ -107,3 +109,33 @@ func (s *NoopImageService) NewImage(_ context.Context, _ *models.AlertRule) (*mo
 
 // NoopSender is a no-op sender. Used when you want state manager to update LastSentAt without sending any alerts.
 var NoopSender = func(_ context.Context, _ StateTransitions) {}
+
+type CountingImageService struct {
+	mtx    sync.Mutex
+	Called int
+	Image  *models.Image
+	Err    error
+}
+
+func (c *CountingImageService) NewImage(_ context.Context, _ *models.AlertRule) (*models.Image, error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.Called += 1
+	return c.Image, c.Err
+}
+
+func newSuccessfulCountingImageService() *CountingImageService {
+	return &CountingImageService{
+		Called: 0,
+		Image: &models.Image{
+			Token: fmt.Sprint(rand.Int()),
+		},
+	}
+}
+
+func NewFailingCountingImageService(err error) *CountingImageService {
+	return &CountingImageService{
+		Called: 0,
+		Err:    err,
+	}
+}


### PR DESCRIPTION
**What is this feature?**

This pull request introduces a lazy evaluation mechanism for taking images in the state manager only once per ProcessEvalResults execution
The main goal is to ensure that images are only taken when necessary, improving efficiency and reducing unnecessary operations.


**Why do we need this feature?**
1. Currently, image service is called for every alert instance that meets the criteria. The service [caches](https://github.com/grafana/grafana/blob/6768c6c059feec840d2e521b33c9ce22f046de77/pkg/services/ngalert/image/service.go#L148-L152) a successful response for [1 minute](https://github.com/grafana/grafana/blob/6768c6c059feec840d2e521b33c9ce22f046de77/pkg/services/ngalert/image/service.go#L24). Therefore, the request to downstream service happens only once every minute. However, this is valid only when the response is successful. 
In the case when service returns error the result is not cached, which causes state manager to make attempt to get screenshot as many times as there are matching alert instances. This can increase pressure on the downstream service and make its performance even worse.

2. Consistency. If the downstream service responded successfully after N successful attempts, the state will be inconsistent: part instances will have images, and part - won't. 

**Special notes for your reviewer:**
The function does not need to be thread-safe because all state mutations are synchronous. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
