### PR TITLE
Prometheus: Add double_exponential_smoothing function

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/promql.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/promql.ts
@@ -81,6 +81,7 @@ const functions = [
   'days_in_month',
   'delta',
   'deriv',
+  'double_exponential_smoothing',
   'exp',
   'floor',
   'histogram_quantile',
@@ -90,6 +91,8 @@ const functions = [
   'histogram_fraction',
   'histogram_stddev',
   'histogram_stdvar',
+  // Renamed as DoubleExponentialSmoothing with Prometheus v3.x
+  // https://github.com/prometheus/prometheus/pull/14930
   'holt_winters',
   'hour',
   'idelta',

--- a/packages/grafana-prometheus/src/promql.ts
+++ b/packages/grafana-prometheus/src/promql.ts
@@ -268,6 +268,13 @@ export const FUNCTIONS = [
       'Calculates the per-second derivative of the time series in a range vector `v`, using simple linear regression.',
   },
   {
+    insertText: 'double_exponential_smoothing',
+    label: 'double_exponential_smoothing',
+    detail: 'double_exponential_smoothing(v range-vector, sf scalar, tf scalar)',
+    documentation:
+      'Produces a smoothed value for time series based on the range in `v`. The lower the smoothing factor `sf`, the more importance is given to old data. The higher the trend factor `tf`, the more trends in the data is considered. Both `sf` and `tf` must be between 0 and 1.',
+  },
+  {
     insertText: 'drop_common_labels',
     label: 'drop_common_labels',
     detail: 'drop_common_labels(instant-vector)',
@@ -298,7 +305,7 @@ export const FUNCTIONS = [
     label: 'holt_winters',
     detail: 'holt_winters(v range-vector, sf scalar, tf scalar)',
     documentation:
-      'Produces a smoothed value for time series based on the range in `v`. The lower the smoothing factor `sf`, the more importance is given to old data. The higher the trend factor `tf`, the more trends in the data is considered. Both `sf` and `tf` must be between 0 and 1.',
+      'Renamed as double_exponential_smoothing in prometheus v3.x. For prometheus versions equal and greater than v3.0 please use double_exponential_smoothing. \n\nProduces a smoothed value for time series based on the range in `v`. The lower the smoothing factor `sf`, the more importance is given to old data. The higher the trend factor `tf`, the more trends in the data is considered. Both `sf` and `tf` must be between 0 and 1.',
   },
   {
     insertText: 'hour',

--- a/packages/grafana-prometheus/src/querybuilder/PromQueryModeller.test.ts
+++ b/packages/grafana-prometheus/src/querybuilder/PromQueryModeller.test.ts
@@ -264,9 +264,9 @@ describe('PromQueryModeller', () => {
       modeller.renderQuery({
         metric: 'metric_a',
         labels: [],
-        operations: [{ id: 'holt_winters', params: ['5m', 0.5, 0.5] }],
+        operations: [{ id: 'double_exponential_smoothing', params: ['5m', 0.5, 0.5] }],
       })
-    ).toBe('holt_winters(metric_a[5m], 0.5, 0.5)');
+    ).toBe('double_exponential_smoothing(metric_a[5m], 0.5, 0.5)');
   });
   it('Can render functions that require parameters left of a range', () => {
     expect(

--- a/packages/grafana-prometheus/src/querybuilder/operations.ts
+++ b/packages/grafana-prometheus/src/querybuilder/operations.ts
@@ -76,6 +76,20 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
     createRangeFunction(PromOperationId.Idelta),
     createRangeFunction(PromOperationId.Delta),
     createFunction({
+      id: PromOperationId.DoubleExponentialSmoothing,
+      params: [
+        getRangeVectorParamDef(),
+        { name: 'Smoothing Factor', type: 'number' },
+        { name: 'Trend Factor', type: 'number' },
+      ],
+      defaultParams: ['$__interval', 0.5, 0.5],
+      alternativesKey: 'range function',
+      category: PromVisualQueryOperationCategory.RangeFunctions,
+      renderer: rangeRendererRightWithParams,
+      addOperationHandler: addOperationWithRangeVector,
+      changeTypeHandler: operationTypeChangedHandlerForRangeFunction,
+    }),
+    createFunction({
       id: PromOperationId.HoltWinters,
       params: [
         getRangeVectorParamDef(),

--- a/packages/grafana-prometheus/src/querybuilder/types.ts
+++ b/packages/grafana-prometheus/src/querybuilder/types.ts
@@ -59,6 +59,7 @@ export enum PromOperationId {
   Deg = 'deg',
   Delta = 'delta',
   Deriv = 'deriv',
+  DoubleExponentialSmoothing = 'double_exponential_smoothing',
   DropCommonLabels = 'drop_common_labels',
   Exp = 'exp',
   Floor = 'floor',
@@ -70,6 +71,8 @@ export enum PromOperationId {
   HistogramFraction = 'histogram_fraction',
   HistogramStddev = 'histogram_stddev',
   HistogramStdvar = 'histogram_stdvar',
+  // Renamed as DoubleExponentialSmoothing with Prometheus v3.x
+  // https://github.com/prometheus/prometheus/pull/14930
   HoltWinters = 'holt_winters',
   Hour = 'hour',
   Idelta = 'idelta',


### PR DESCRIPTION
**What is this feature?**

`holt_winters` function renamed as `double_exponential_smoothing` https://github.com/prometheus/prometheus/pull/14930
So with this PR we add support for it and also put a notice for `holt_winters` function for users who use an older version than prometheus `v3.x`. 

I kept the `holt_winters` for backward compatibility reasons.

**Why do we need this feature?**

To support `double_exponential_smoothing` function.

**Who is this feature for?**

Prometheus users
