### PR TITLE
Alerting: Skip non-expression queries in DAG creation

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -39,8 +39,8 @@ describe('working with dag', () => {
         refId: 'D',
         model: {
           refId: 'D',
-          // A non-math expression, that would trigger an error if not correctly handled
-          expression: 'vector(1)',
+          expression: 'B',
+          type: 'threshold',
         },
       },
     ] as AlertQuery[];
@@ -60,15 +60,39 @@ describe('working with dag', () => {
     expect(dag.getNode('A').outputEdges).toHaveLength(0);
 
     expect(dag.getNode('B').inputEdges).toHaveLength(0);
-    expect(dag.getNode('B').outputEdges).toHaveLength(1);
+    expect(dag.getNode('B').outputEdges).toHaveLength(2);
     expect(dag.getNode('B').outputEdges[0].outputNode).toHaveProperty('name', 'C');
+    expect(dag.getNode('B').outputEdges[1].outputNode).toHaveProperty('name', 'D');
 
     expect(dag.getNode('C').inputEdges).toHaveLength(1);
-    expect(dag.getNode('C').outputEdges).toHaveLength(0);
     expect(dag.getNode('C').inputEdges[0].inputNode).toHaveProperty('name', 'B');
+    expect(dag.getNode('C').outputEdges).toHaveLength(0);
 
-    expect(dag.getNode('D').inputEdges).toHaveLength(0);
+    expect(dag.getNode('D').inputEdges).toHaveLength(1);
+    expect(dag.getNode('D').inputEdges[0].inputNode).toHaveProperty('name', 'B');
     expect(dag.getNode('D').outputEdges).toHaveLength(0);
+  });
+
+  test('data queries cannot have references', () => {
+    const queries = [
+      {
+        refId: 'A',
+        model: {
+          refId: 'A',
+          expression: 'vector(1)',
+        },
+      },
+    ] as AlertQuery[];
+
+    expect(() => _createDagFromQueries(queries)).not.toThrow();
+
+    const dag = _createDagFromQueries(queries);
+
+    expect(Object.keys(dag.nodes)).toHaveLength(1);
+
+    expect(() => {
+      dag.getNode('A');
+    }).not.toThrow();
   });
 });
 

--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -35,30 +35,40 @@ describe('working with dag', () => {
           type: 'math',
         },
       },
+      {
+        refId: 'D',
+        model: {
+          refId: 'D',
+          // A non-math expression, that would trigger an error if not correctly handled
+          expression: 'vector(1)',
+        },
+      },
     ] as AlertQuery[];
 
     const dag = _createDagFromQueries(queries);
 
-    expect(Object.keys(dag.nodes)).toHaveLength(3);
+    expect(Object.keys(dag.nodes)).toHaveLength(4);
 
     expect(() => {
       dag.getNode('A');
       dag.getNode('B');
       dag.getNode('C');
+      dag.getNode('D');
     }).not.toThrow();
 
     expect(dag.getNode('A').inputEdges).toHaveLength(0);
-    expect(dag.getNode('A').outputEdges).toHaveLength(1);
-    expect(dag.getNode('A').outputEdges[0].outputNode).toHaveProperty('name', 'B');
+    expect(dag.getNode('A').outputEdges).toHaveLength(0);
 
-    expect(dag.getNode('B').inputEdges).toHaveLength(1);
+    expect(dag.getNode('B').inputEdges).toHaveLength(0);
     expect(dag.getNode('B').outputEdges).toHaveLength(1);
-    expect(dag.getNode('B').inputEdges[0].inputNode).toHaveProperty('name', 'A');
     expect(dag.getNode('B').outputEdges[0].outputNode).toHaveProperty('name', 'C');
 
     expect(dag.getNode('C').inputEdges).toHaveLength(1);
     expect(dag.getNode('C').outputEdges).toHaveLength(0);
     expect(dag.getNode('C').inputEdges[0].inputNode).toHaveProperty('name', 'B');
+
+    expect(dag.getNode('D').inputEdges).toHaveLength(0);
+    expect(dag.getNode('D').outputEdges).toHaveLength(0);
   });
 });
 

--- a/public/app/features/alerting/unified/components/rule-editor/dag.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.ts
@@ -24,8 +24,11 @@ export function _createDagFromQueries(queries: AlertQuery[]): Graph {
   graph.createNodes(nodes);
 
   queries.forEach((query) => {
+    if (!isExpressionQuery(query.model)) {
+      return;
+    }
     const source = query.refId;
-    const isMathExpression = isExpressionQuery(query.model) && query.model.type === 'math';
+    const isMathExpression = query.model.type === 'math';
 
     // some expressions have multiple targets (like the math expression)
     const targets = isMathExpression


### PR DESCRIPTION
**What is this feature?**
Makes sure that we don't try and link data queries in the DAG

**Why do we need this feature?**
Without this, we _might_ try and link a datasource expression as a node in our graph if that contained a `model.expression` property. 

This has the result of us looking for a node called, e.g. `vector(1)`, which causes an error and prevents queries from being previewed in the alert rule UI.

To reproduce before the fix, try choosing the Cloudwatch Logs datasource and previewing the query. An error should be shown in the console and no preview is shown.

With the fix, we skip the data query, and the preview is called.
