### PR TITLE
K8s/Dashboard: Always set an internl id (even in mode 4+)

### DIFF
--- a/pkg/registry/apis/dashboard/v0alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v0alpha1/register.go
@@ -113,6 +113,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		return err
 	}
 	storageOpts := apistore.StorageOptions{
+		RequireDeprecatedInternalID: true,
 		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
 			internal := &dashboardinternal.Dashboard{}
 			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)

--- a/pkg/registry/apis/dashboard/v1alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v1alpha1/register.go
@@ -108,6 +108,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		return err
 	}
 	storageOpts := apistore.StorageOptions{
+		RequireDeprecatedInternalID: true,
 		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
 			internal := &dashboardinternal.Dashboard{}
 			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)

--- a/pkg/registry/apis/dashboard/v2alpha1/register.go
+++ b/pkg/registry/apis/dashboard/v2alpha1/register.go
@@ -108,6 +108,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		return err
 	}
 	storageOpts := apistore.StorageOptions{
+		RequireDeprecatedInternalID: true,
 		InternalConversion: (func(b []byte, desiredObj runtime.Object) (runtime.Object, error) {
 			internal := &dashboardinternal.Dashboard{}
 			obj, _, err := defaultOpts.StorageConfig.Config.Codec.Decode(b, nil, internal)

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -56,6 +56,15 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 		obj.SetUID(types.UID(uuid.NewString()))
 	}
 
+	if s.opts.RequireDeprecatedInternalID {
+		// nolint:staticcheck
+		id := obj.GetDeprecatedInternalID()
+		if id < 1 {
+			// nolint:staticcheck
+			obj.SetDeprecatedInternalID(s.snowflake.Generate().Int64())
+		}
+	}
+
 	obj.SetGenerateName("") // Clear the random name field
 	obj.SetResourceVersion("")
 	obj.SetSelfLink("")


### PR DESCRIPTION
This adds a hook to always set an internal ID

Running with only k8s storage (no SQL backing) this will still create an internal id:
```
[unified_storage.dashboards.dashboard.grafana.app]
dualWriterMode = 5
```
<img width="735" alt="image" src="https://github.com/user-attachments/assets/b4abcbbd-1e1d-4987-8a15-ea5ec873a560" />

