### PR TITLE
Make sure annotations are kept when updating a folder

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -666,8 +666,8 @@ func (fk8s *folderK8sHandler) createFolder(c *contextmodel.ReqContext) {
 	if !ok {
 		return // error is already sent
 	}
-	cmd := folder.CreateFolderCommand{}
-	if err := web.Bind(c.Req, &cmd); err != nil {
+	cmd := &folder.CreateFolderCommand{}
+	if err := web.Bind(c.Req, cmd); err != nil {
 		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
 		return
 	}
@@ -676,7 +676,7 @@ func (fk8s *folderK8sHandler) createFolder(c *contextmodel.ReqContext) {
 		fk8s.writeError(c, err)
 		return
 	}
-	out, err := client.Create(c.Req.Context(), &obj, v1.CreateOptions{})
+	out, err := client.Create(c.Req.Context(), obj, v1.CreateOptions{})
 	if err != nil {
 		fk8s.writeError(c, err)
 		return
@@ -829,23 +829,27 @@ func (fk8s *folderK8sHandler) updateFolder(c *contextmodel.ReqContext) {
 		return // error is already sent
 	}
 
-	cmd := folder.UpdateFolderCommand{}
+	var ctx = c.Req.Context()
+
+	cmd := &folder.UpdateFolderCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
 		return
 	}
-	cmd.OrgID = c.SignedInUser.GetOrgID()
 	cmd.UID = web.Params(c.Req)[":uid"]
-	cmd.SignedInUser = c.SignedInUser
-	// #TODO add version?
 
-	obj, err := internalfolders.LegacyUpdateCommandToUnstructured(cmd)
+	obj, err := client.Get(ctx, cmd.UID, v1.GetOptions{})
 	if err != nil {
 		fk8s.writeError(c, err)
 		return
 	}
 
-	out, err := client.Update(c.Req.Context(), obj, v1.UpdateOptions{})
+	updated, err := internalfolders.LegacyUpdateCommandToUnstructured(obj, cmd)
+	if err != nil {
+		return
+	}
+
+	out, err := client.Update(ctx, updated, v1.UpdateOptions{})
 	if err != nil {
 		fk8s.writeError(c, err)
 		return
@@ -873,9 +877,7 @@ func (fk8s *folderK8sHandler) moveFolder(c *contextmodel.ReqContext) {
 		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
 		return
 	}
-	cmd.OrgID = c.SignedInUser.GetOrgID()
 	cmd.UID = web.Params(c.Req)[":uid"]
-	cmd.SignedInUser = c.SignedInUser
 
 	obj, err := client.Get(ctx, cmd.UID, v1.GetOptions{})
 	if err != nil {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -832,7 +832,7 @@ func (fk8s *folderK8sHandler) updateFolder(c *contextmodel.ReqContext) {
 	var ctx = c.Req.Context()
 
 	cmd := &folder.UpdateFolderCommand{}
-	if err := web.Bind(c.Req, &cmd); err != nil {
+	if err := web.Bind(c.Req, cmd); err != nil {
 		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
 		return
 	}

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -570,6 +570,11 @@ func TestUpdateFolderLegacyAndUnifiedStorage(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /apis/folder.grafana.app/v0alpha1/namespaces/default/folders/ady4yobv315a8e", func(w http.ResponseWriter, req *http.Request) {
+		err := json.NewEncoder(w).Encode(unifiedStorageFolder)
+		require.NoError(t, err)
+	})
 	mux.HandleFunc("PUT /apis/folder.grafana.app/v0alpha1/namespaces/default/folders/ady4yobv315a8e", func(w http.ResponseWriter, req *http.Request) {
 		err := json.NewEncoder(w).Encode(unifiedStorageFolder)
 		require.NoError(t, err)

--- a/pkg/registry/apis/folders/conversions.go
+++ b/pkg/registry/apis/folders/conversions.go
@@ -19,8 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func LegacyCreateCommandToUnstructured(cmd folder.CreateFolderCommand) (unstructured.Unstructured, error) {
-	obj := unstructured.Unstructured{
+func LegacyCreateCommandToUnstructured(cmd *folder.CreateFolderCommand) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"spec": map[string]interface{}{
 				"title":       cmd.Title,
@@ -34,30 +34,23 @@ func LegacyCreateCommandToUnstructured(cmd folder.CreateFolderCommand) (unstruct
 	}
 	obj.SetName(cmd.UID)
 
-	if err := setParentUID(&obj, cmd.ParentUID); err != nil {
-		return unstructured.Unstructured{}, err
+	if err := setParentUID(obj, cmd.ParentUID); err != nil {
+		return &unstructured.Unstructured{}, err
 	}
 
 	return obj, nil
 }
 
-func LegacyUpdateCommandToUnstructured(cmd folder.UpdateFolderCommand) (*unstructured.Unstructured, error) {
-	// #TODO add other fields ; do we support updating the UID/orgID?
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"spec": map[string]interface{}{
-				"title":       cmd.NewTitle,
-				"description": cmd.NewDescription,
-			},
-		},
+func LegacyUpdateCommandToUnstructured(obj *unstructured.Unstructured, cmd *folder.UpdateFolderCommand) (*unstructured.Unstructured, error) {
+	spec, ok := obj.Object["spec"].(map[string]any)
+	if !ok {
+		return &unstructured.Unstructured{}, fmt.Errorf("could not convert object to folder")
 	}
-	obj.SetName(cmd.UID)
-
-	if cmd.NewParentUID == nil {
-		return obj, nil
+	if cmd.NewTitle != nil {
+		spec["title"] = cmd.NewTitle
 	}
-	if err := setParentUID(obj, *cmd.NewParentUID); err != nil {
-		return &unstructured.Unstructured{}, err
+	if cmd.NewDescription != nil {
+		spec["description"] = cmd.NewDescription
 	}
 
 	return obj, nil


### PR DESCRIPTION
**What is this feature?**

Before:
Annotations were not kept on updates as we would parse the payload onto a new unstructured object. Down the line, apiserver will assume this is the new version of the object:
![Screenshot 2024-12-20 at 15 06 04](https://github.com/user-attachments/assets/87c78b90-effd-4ef0-b55b-449b3b978134)

After:
Before sending the object to the storage BE, we first fetch the current version of it and we merge the payload with it.
![Screenshot 2024-12-20 at 15 33 24](https://github.com/user-attachments/assets/f592751e-aab5-40da-b31d-135fff3af874)


Fixes https://github.com/grafana/grafana-org/issues/358

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
