### PR TITLE
Secrets: change Keeper schema to treat updates as PUT operation

### DIFF
--- a/pkg/apis/secret/v0alpha1/keeper.go
+++ b/pkg/apis/secret/v0alpha1/keeper.go
@@ -14,7 +14,9 @@ type Keeper struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// This is the actual keeper schema.
-	Spec KeeperSpec `json:"spec,omitempty"`
+	// +patchStrategy=replace
+	// +patchMergeKey=name
+	Spec KeeperSpec `json:"spec,omitempty" patchStrategy:"replace" patchMergeKey:"name"`
 }
 
 type KeeperSpec struct {
@@ -101,12 +103,15 @@ type CredentialValue struct {
 type AWSKeeper struct {
 	AWSCredentials `json:",inline"`
 }
+
 type AzureKeeper struct {
 	AzureCredentials `json:",inline"`
 }
+
 type GCPKeeper struct {
 	GCPCredentials `json:",inline"`
 }
+
 type HashiCorpKeeper struct {
 	HashiCorpCredentials `json:",inline"`
 }

--- a/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/secret/v0alpha1/zz_generated.openapi.go
@@ -410,6 +410,12 @@ func schema_pkg_apis_secret_v0alpha1_Keeper(ref common.ReferenceCallback) common
 						},
 					},
 					"spec": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "replace",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "This is the actual keeper schema.",
 							Default:     map[string]interface{}{},

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	secret "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
@@ -110,7 +110,7 @@ func (s *SecureValueRest) Create(
 	createValidation rest.ValidateObjectFunc,
 	options *metav1.CreateOptions,
 ) (runtime.Object, error) {
-	sv, ok := obj.(*secret.SecureValue)
+	sv, ok := obj.(*secretv0alpha1.SecureValue)
 	if !ok {
 		return nil, fmt.Errorf("expected SecureValue for create")
 	}
@@ -138,23 +138,23 @@ func (s *SecureValueRest) Update(
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
-	old, err := s.Get(ctx, name, &metav1.GetOptions{})
+	oldObj, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, fmt.Errorf("get securevalue: %w", err)
 	}
 
 	// Makes sure the UID and ResourceVersion are OK.
 	// TODO: this also makes it so the labels and annotations are additive, unless we check and remove manually.
-	tmp, err := objInfo.UpdatedObject(ctx, old)
+	newObj, err := objInfo.UpdatedObject(ctx, oldObj)
 	if err != nil {
 		return nil, false, fmt.Errorf("k8s updated object: %w", err)
 	}
 
-	if err := updateValidation(ctx, tmp, old); err != nil {
+	if err := updateValidation(ctx, newObj, oldObj); err != nil {
 		return nil, false, fmt.Errorf("update validation failed: %w", err)
 	}
 
-	newSecureValue, ok := tmp.(*secret.SecureValue)
+	newSecureValue, ok := newObj.(*secretv0alpha1.SecureValue)
 	if !ok {
 		return nil, false, fmt.Errorf("expected SecureValue for update")
 	}
@@ -187,7 +187,7 @@ func (s *SecureValueRest) Delete(ctx context.Context, name string, deleteValidat
 }
 
 // ValidateSecureValue does basic spec validation of a securevalue.
-func ValidateSecureValue(sv *secret.SecureValue, operation admission.Operation) field.ErrorList {
+func ValidateSecureValue(sv *secretv0alpha1.SecureValue, operation admission.Operation) field.ErrorList {
 	errs := make(field.ErrorList, 0)
 
 	// Operation-specific field validation.

--- a/pkg/storage/secret/keeper_store.go
+++ b/pkg/storage/secret/keeper_store.go
@@ -170,7 +170,9 @@ func (s *keeperStorage) List(ctx context.Context, namespace xkube.Namespace, opt
 	keeperRows := make([]*Keeper, 0)
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		if err := sess.Where("namespace = ?", namespace).Find(&keeperRows); err != nil {
+		cond := &Keeper{Namespace: namespace.String()}
+
+		if err := sess.Find(&keeperRows, cond); err != nil {
 			return fmt.Errorf("failed to find rows: %w", err)
 		}
 

--- a/pkg/storage/secret/secure_value_model.go
+++ b/pkg/storage/secret/secure_value_model.go
@@ -18,8 +18,8 @@ type secureValueDB struct {
 	GUID        string `xorm:"pk 'guid'"`
 	Name        string `xorm:"name"`
 	Namespace   string `xorm:"namespace"`
-	Annotations string `xorm:"annotations"`
-	Labels      string `xorm:"labels"`
+	Annotations string `xorm:"annotations"` // map[string]string
+	Labels      string `xorm:"labels"`      // map[string]string
 	Created     int64  `xorm:"created"`
 	CreatedBy   string `xorm:"created_by"`
 	Updated     int64  `xorm:"updated"`


### PR DESCRIPTION
We have the following yaml, which we use to create a new `Keeper`.
```yaml
apiVersion: secret.grafana.app/v0alpha1
kind: Keeper
metadata:
  name: aws-xyz
spec:
  title: AWS XYZ value
  aws:
    accessKeyId: 
      valueFromEnv: ACCESS_KEY_ID_XYZ
    secretAccessKey:
      valueFromEnv: SECRET_ACCESS_KEY_XYZ
```

If we try to update this keeper, by changing it from `aws` to `gcp` for example:
```yaml
apiVersion: secret.grafana.app/v0alpha1
kind: Keeper
metadata:
  name: aws-xyz
spec:
  title: AWS XYZ value
  gcp:
    projectId: project-id 
    credentialsFile: /path/to/file.json
```

This would fail. By default Kubernetes will try to **merge** fields on an **UPDATE**, which means the final spec would both have `aws` and `gcp`.

And that's the main change of this PR, which alters the strategy used when patching (updating) Keepers. Instead of merging, we will `replace` the whole `spec`.

There's a trade-off. While we gain flexibility by being able to completely change all fields of the spec, we aren't able to issue partial updates (patches) anymore.

If after creating the initial keeper, we tried to update its title:
```yaml
apiVersion: secret.grafana.app/v0alpha1
kind: Keeper
metadata:
  name: aws-xyz
spec:
  title: My New Title
```
This would not work, because the validation would be missing a keeper configuration, since that's replace.

While before the change, it would use the `aws` field from the old object, and the `title` from the new, merging them.

I think that for now keeping the updates working as a PUT verb rather than PATCH is easier to reason about, but we can discuss it if needed.

Reference material I used:
- https://github.com/kubernetes/kube-openapi/blob/2c72e554b1e7755b5fbee01cc910063070d5b4ec/pkg/generators/extension.go#L48
- https://github.com/kubernetes/kube-openapi/blob/release-1.22/pkg/generators/openapi_test.go#L83
- https://github.com/kubernetes/kube-openapi/blob/release-1.22/pkg/idl/doc.go
- https://github.com/kubernetes/community/blob/6690abcd6b833f46550f5eaba2ec17a9e39b35c4/contributors/devel/sig-api-machinery/strategic-merge-patch.md#basic-patch-format