### PR TITLE
Trace View: Set span filters as panel options

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4443,6 +4443,17 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "23"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "24"]
     ],
+    "public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx:5381": [
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"]
+    ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/ViewingLayer.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -40,7 +40,7 @@ import { createSpanLinkFactory } from './createSpanLink';
 import { useChildrenState } from './useChildrenState';
 import { useDetailState } from './useDetailState';
 import { useHoverIndentGuide } from './useHoverIndentGuide';
-import { useSearch } from './useSearch';
+import { SearchProps, useSearch } from './useSearch';
 import { useViewRange } from './useViewRange';
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -66,6 +66,7 @@ type Props = {
   createSpanLink?: SpanLinkFunc;
   focusedSpanId?: string;
   createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>;
+  spanFilters?: SearchProps;
 };
 
 export function TraceView(props: Props) {
@@ -77,6 +78,7 @@ export function TraceView(props: Props) {
     createSpanLink: createSpanLinkFromProps,
     focusedSpanId: focusedSpanIdFromProps,
     createFocusSpanLink: createFocusSpanLinkFromProps,
+    spanFilters,
   } = props;
 
   const {
@@ -95,11 +97,9 @@ export function TraceView(props: Props) {
   const { removeHoverIndentGuideId, addHoverIndentGuideId, hoverIndentGuideIds } = useHoverIndentGuide();
   const { viewRange, updateViewRangeTime, updateNextViewRangeTime } = useViewRange();
   const { expandOne, collapseOne, childrenToggle, collapseAll, childrenHiddenIDs, expandAll } = useChildrenState();
-  const { search, setSearch, spanFilterMatches } = useSearch(traceProp?.spans);
+  const { search, setSearch, spanFilterMatches } = useSearch(traceProp?.spans, spanFilters);
   const [focusedSpanIdForSearch, setFocusedSpanIdForSearch] = useState('');
   const [showSpanFilters, setShowSpanFilters] = useToggle(false);
-  const [showSpanFilterMatchesOnly, setShowSpanFilterMatchesOnly] = useState(false);
-  const [showCriticalPathSpansOnly, setShowCriticalPathSpansOnly] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(100);
   const [traceFlameGraphs, setTraceFlameGraphs] = useState<TraceFlameGraphs>({});
   const [redrawListView, setRedrawListView] = useState({});
@@ -183,10 +183,6 @@ export function TraceView(props: Props) {
             setSearch={setSearch}
             showSpanFilters={showSpanFilters}
             setShowSpanFilters={setShowSpanFilters}
-            showSpanFilterMatchesOnly={showSpanFilterMatchesOnly}
-            setShowSpanFilterMatchesOnly={setShowSpanFilterMatchesOnly}
-            showCriticalPathSpansOnly={showCriticalPathSpansOnly}
-            setShowCriticalPathSpansOnly={setShowCriticalPathSpansOnly}
             setFocusedSpanIdForSearch={setFocusedSpanIdForSearch}
             spanFilterMatches={spanFilterMatches}
             datasourceType={datasourceType}
@@ -232,8 +228,8 @@ export function TraceView(props: Props) {
             scrollElement={scrollElement}
             focusedSpanId={focusedSpanId}
             focusedSpanIdForSearch={focusedSpanIdForSearch}
-            showSpanFilterMatchesOnly={showSpanFilterMatchesOnly}
-            showCriticalPathSpansOnly={showCriticalPathSpansOnly}
+            showSpanFilterMatchesOnly={search.matchesOnly}
+            showCriticalPathSpansOnly={search.criticalPathOnly}
             createFocusSpanLink={createFocusSpanLink}
             topOfViewRef={topOfViewRef}
             headerHeight={headerHeight}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/TracePageSearchBar.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/TracePageSearchBar.tsx
@@ -29,9 +29,7 @@ export type TracePageSearchBarProps = {
   trace: Trace;
   search: SearchProps;
   spanFilterMatches: Set<string> | undefined;
-  showSpanFilterMatchesOnly: boolean;
   setShowSpanFilterMatchesOnly: (showMatchesOnly: boolean) => void;
-  showCriticalPathSpansOnly: boolean;
   setShowCriticalPathSpansOnly: (showCriticalPath: boolean) => void;
   focusedSpanIndexForSearch: number;
   setFocusedSpanIndexForSearch: Dispatch<SetStateAction<number>>;
@@ -46,9 +44,7 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
     trace,
     search,
     spanFilterMatches,
-    showSpanFilterMatchesOnly,
     setShowSpanFilterMatchesOnly,
-    showCriticalPathSpansOnly,
     setShowCriticalPathSpansOnly,
     focusedSpanIndexForSearch,
     setFocusedSpanIndexForSearch,
@@ -70,17 +66,9 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
         return tag.key;
       }) ||
       (search.query && search.query !== '') ||
-      showSpanFilterMatchesOnly
+      search.matchesOnly
     );
-  }, [
-    search.serviceName,
-    search.spanName,
-    search.from,
-    search.to,
-    search.tags,
-    search.query,
-    showSpanFilterMatchesOnly,
-  ]);
+  }, [search.serviceName, search.spanName, search.from, search.to, search.tags, search.query, search.matchesOnly]);
 
   return (
     <div className={styles.container}>
@@ -99,13 +87,13 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
             </Button>
             <div className={styles.matchesOnly}>
               <Switch
-                value={showSpanFilterMatchesOnly}
+                value={search.matchesOnly}
                 onChange={(value) => setShowSpanFilterMatchesOnly(value.currentTarget.checked ?? false)}
                 label="Show matches only switch"
                 disabled={!spanFilterMatches?.size}
               />
               <Button
-                onClick={() => setShowSpanFilterMatchesOnly(!showSpanFilterMatchesOnly)}
+                onClick={() => setShowSpanFilterMatchesOnly(!search.matchesOnly)}
                 className={styles.clearMatchesButton}
                 variant="secondary"
                 fill="text"
@@ -116,12 +104,12 @@ export default memo(function TracePageSearchBar(props: TracePageSearchBarProps) 
             </div>
             <div className={styles.matchesOnly}>
               <Switch
-                value={showCriticalPathSpansOnly}
+                value={search.criticalPathOnly}
                 onChange={(value) => setShowCriticalPathSpansOnly(value.currentTarget.checked ?? false)}
                 label="Show critical path only switch"
               />
               <Button
-                onClick={() => setShowCriticalPathSpansOnly(!showCriticalPathSpansOnly)}
+                onClick={() => setShowCriticalPathSpansOnly(!search.criticalPathOnly)}
                 className={styles.clearMatchesButton}
                 variant="secondary"
                 fill="text"

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
@@ -26,7 +26,7 @@ import { Trace } from '../../types';
 import NextPrevResult from '../SearchBar/NextPrevResult';
 import TracePageSearchBar from '../SearchBar/TracePageSearchBar';
 
-import { SpanFiltersTags } from './Tags';
+import { SpanFiltersTags } from './SpanFiltersTags';
 
 export type SpanFilterProps = {
   trace: Trace;
@@ -161,10 +161,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
           </InlineField>
           <SearchBarInput
             onChange={(v) => {
-              setSpanFiltersSearch({ ...search, query: v });
-              if (v === '') {
-                setShowSpanFilterMatchesOnly(false);
-              }
+              setSpanFiltersSearch({ ...search, query: v, matchesOnly: v !== '' });
             }}
             value={search.query || ''}
           />

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
@@ -220,9 +220,10 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                 isClearable
                 onChange={(v) => setSpanFiltersSearch({ ...search, serviceName: v?.value || '' })}
                 onOpenMenu={getServiceNames}
-                options={serviceNames}
+                options={serviceNames || (search.serviceName ? [search.serviceName].map(toOption) : [])}
                 placeholder="All service names"
                 value={search.serviceName || null}
+                defaultValue={search.serviceName || null}
               />
             </HorizontalGroup>
           </InlineField>
@@ -250,7 +251,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                 isClearable
                 onChange={(v) => setSpanFiltersSearch({ ...search, spanName: v?.value || '' })}
                 onOpenMenu={getSpanNames}
-                options={spanNames}
+                options={spanNames || (search.spanName ? [search.spanName].map(toOption) : [])}
                 placeholder="All span names"
                 value={search.spanName || null}
               />
@@ -311,7 +312,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                       key={tag.key}
                       onChange={(v) => onTagChange(tag, v)}
                       onOpenMenu={getTagKeys}
-                      options={tagKeys}
+                      options={tagKeys || (tag.key ? [tag.key].map(toOption) : [])}
                       placeholder="Select tag"
                       value={tag.key || null}
                     />
@@ -342,7 +343,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
                               }),
                             });
                           }}
-                          options={tagValues[tag.id] ? tagValues[tag.id] : []}
+                          options={tagValues[tag.id] ? tagValues[tag.id] : tag.value ? [tag.value].map(toOption) : []}
                           placeholder="Select value"
                           value={tag.value}
                         />

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx
@@ -45,11 +45,7 @@ export type SpanFilterProps = {
   setSearch: React.Dispatch<React.SetStateAction<SearchProps>>;
   showSpanFilters: boolean;
   setShowSpanFilters: (isOpen: boolean) => void;
-  showSpanFilterMatchesOnly: boolean;
-  setShowSpanFilterMatchesOnly: (showMatchesOnly: boolean) => void;
   setFocusedSpanIdForSearch: React.Dispatch<React.SetStateAction<string>>;
-  showCriticalPathSpansOnly: boolean;
-  setShowCriticalPathSpansOnly: (showCriticalPathSpansOnly: boolean) => void;
   spanFilterMatches: Set<string> | undefined;
   datasourceType: string;
 };
@@ -61,10 +57,6 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
     setSearch,
     showSpanFilters,
     setShowSpanFilters,
-    showSpanFilterMatchesOnly,
-    setShowSpanFilterMatchesOnly,
-    showCriticalPathSpansOnly,
-    setShowCriticalPathSpansOnly,
     setFocusedSpanIdForSearch,
     spanFilterMatches,
     datasourceType,
@@ -84,12 +76,25 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
     setTagKeys(undefined);
     setTagValues({});
     setSearch(defaultFilters);
-    setShowSpanFilterMatchesOnly(false);
-  }, [setSearch, setShowSpanFilterMatchesOnly]);
+  }, [setSearch]);
 
   useEffect(() => {
     clear();
   }, [clear, trace]);
+
+  const setShowSpanFilterMatchesOnly = useCallback(
+    (showMatchesOnly: boolean) => {
+      setSearch({ ...search, matchesOnly: showMatchesOnly });
+    },
+    [search, setSearch]
+  );
+
+  const setShowCriticalPathSpansOnly = useCallback(
+    (showCriticalPathSpansOnly: boolean) => {
+      setSearch({ ...search, criticalPathOnly: showCriticalPathSpansOnly });
+    },
+    [search, setSearch]
+  );
 
   if (!trace) {
     return null;
@@ -498,9 +503,7 @@ export const SpanFilters = memo((props: SpanFilterProps) => {
           trace={trace}
           search={search}
           spanFilterMatches={spanFilterMatches}
-          showSpanFilterMatchesOnly={showSpanFilterMatchesOnly}
           setShowSpanFilterMatchesOnly={setShowSpanFilterMatchesOnly}
-          showCriticalPathSpansOnly={showCriticalPathSpansOnly}
           setShowCriticalPathSpansOnly={setShowCriticalPathSpansOnly}
           setFocusedSpanIdForSearch={setFocusedSpanIdForSearch}
           focusedSpanIndexForSearch={focusedSpanIndexForSearch}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
-import React, { useEffect } from 'react';
+import React from 'react';
+import { useMount } from 'react-use';
 
 import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton } from '@grafana/experimental';
@@ -32,7 +33,7 @@ export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys,
     return getTraceTagValues(trace, key).map(toOption);
   };
 
-  useEffect(() => {
+  useMount(() => {
     if (search.tags) {
       search.tags.forEach((tag) => {
         if (tag.key) {
@@ -43,8 +44,7 @@ export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys,
         }
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 
   const onTagChange = (tag: Tag, v: SelectableValue<string>) => {
     setSearch({

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx
@@ -4,7 +4,7 @@ import { useMount } from 'react-use';
 
 import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton } from '@grafana/experimental';
-import { HorizontalGroup, Input, Select, useStyles2 } from '@grafana/ui';
+import { Input, Select, Stack, useStyles2 } from '@grafana/ui';
 
 import { randomId, SearchProps, Tag } from '../../../useSearch';
 import { getTraceTagKeys, getTraceTagValues } from '../../../utils/tags';
@@ -99,30 +99,35 @@ export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys,
     <div>
       {search.tags?.map((tag, i) => (
         <div key={tag.id}>
-          <HorizontalGroup spacing={'xs'} width={'auto'}>
-            <Select
-              aria-label="Select tag key"
-              isClearable
-              key={tag.key}
-              onChange={(v) => onTagChange(tag, v)}
-              onOpenMenu={getTagKeys}
-              options={tagKeys || (tag.key ? [tag.key].map(toOption) : [])}
-              placeholder="Select tag"
-              value={tag.key || null}
-            />
-            <Select
-              aria-label="Select tag operator"
-              onChange={(v) => {
-                setSearch({
-                  ...search,
-                  tags: search.tags?.map((x) => {
-                    return x.id === tag.id ? { ...x, operator: v.value! } : x;
-                  }),
-                });
-              }}
-              options={[toOption('='), toOption('!='), toOption('=~'), toOption('!~')]}
-              value={tag.operator}
-            />
+          <Stack gap={0} width={'auto'} justifyContent={'flex-start'} alignItems={'center'}>
+            <div>
+              <Select
+                aria-label="Select tag key"
+                isClearable
+                key={tag.key}
+                onChange={(v) => onTagChange(tag, v)}
+                onOpenMenu={getTagKeys}
+                options={tagKeys || (tag.key ? [tag.key].map(toOption) : [])}
+                placeholder="Select tag"
+                value={tag.key || null}
+              />
+            </div>
+            <div>
+              <Select
+                aria-label="Select tag operator"
+                onChange={(v) => {
+                  setSearch({
+                    ...search,
+                    tags: search.tags?.map((x) => {
+                      return x.id === tag.id ? { ...x, operator: v.value! } : x;
+                    }),
+                  });
+                }}
+                options={[toOption('='), toOption('!='), toOption('=~'), toOption('!~')]}
+                value={tag.operator}
+              />
+            </div>
+
             <span className={styles.tagValues}>
               {(tag.operator === '=' || tag.operator === '!=') && (
                 <Select
@@ -179,7 +184,7 @@ export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys,
                 />
               </span>
             )}
-          </HorizontalGroup>
+          </Stack>
         </div>
       ))}
     </div>

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton } from '@grafana/experimental';
@@ -31,6 +31,20 @@ export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys,
   const getTagValues = (key: string) => {
     return getTraceTagValues(trace, key).map(toOption);
   };
+
+  useEffect(() => {
+    if (search.tags) {
+      search.tags.forEach((tag) => {
+        if (tag.key) {
+          setTagValues({
+            ...tagValues,
+            [tag.id]: getTagValues(tag.key),
+          });
+        }
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onTagChange = (tag: Tag, v: SelectableValue<string>) => {
     setSearch({
@@ -84,7 +98,7 @@ export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys,
   return (
     <div>
       {search.tags?.map((tag, i) => (
-        <div key={i}>
+        <div key={tag.id}>
           <HorizontalGroup spacing={'xs'} width={'auto'}>
             <Select
               aria-label="Select tag key"

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/Tags.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/Tags.tsx
@@ -1,0 +1,182 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
+import { AccessoryButton } from '@grafana/experimental';
+import { HorizontalGroup, Input, Select, useStyles2 } from '@grafana/ui';
+
+import { randomId, SearchProps, Tag } from '../../../useSearch';
+import { getTraceTagKeys, getTraceTagValues } from '../../../utils/tags';
+import { Trace } from '../../types';
+
+interface Props {
+  search: SearchProps;
+  setSearch: (search: SearchProps) => void;
+  trace: Trace;
+  tagKeys?: Array<SelectableValue<string>>;
+  setTagKeys: React.Dispatch<React.SetStateAction<Array<SelectableValue<string>> | undefined>>;
+  tagValues: Record<string, Array<SelectableValue<string>>>;
+  setTagValues: React.Dispatch<React.SetStateAction<{ [key: string]: Array<SelectableValue<string>> }>>;
+}
+
+export const SpanFiltersTags = ({ search, trace, setSearch, tagKeys, setTagKeys, tagValues, setTagValues }: Props) => {
+  const styles = { ...useStyles2(getStyles) };
+
+  const getTagKeys = () => {
+    if (!tagKeys) {
+      setTagKeys(getTraceTagKeys(trace).map(toOption));
+    }
+  };
+
+  const getTagValues = (key: string) => {
+    return getTraceTagValues(trace, key).map(toOption);
+  };
+
+  const onTagChange = (tag: Tag, v: SelectableValue<string>) => {
+    setSearch({
+      ...search,
+      tags: search.tags?.map((x) => {
+        return x.id === tag.id ? { ...x, key: v?.value || '', value: undefined } : x;
+      }),
+    });
+
+    const loadTagValues = async () => {
+      if (v?.value) {
+        setTagValues({
+          ...tagValues,
+          [tag.id]: getTagValues(v.value),
+        });
+      } else {
+        // removed value
+        const updatedValues = { ...tagValues };
+        if (updatedValues[tag.id]) {
+          delete updatedValues[tag.id];
+        }
+        setTagValues(updatedValues);
+      }
+    };
+    loadTagValues();
+  };
+
+  const addTag = () => {
+    const tag = {
+      id: randomId(),
+      operator: '=',
+    };
+    setSearch({ ...search, tags: [...search.tags, tag] });
+  };
+
+  const removeTag = (id: string) => {
+    let tags = search.tags.filter((tag) => {
+      return tag.id !== id;
+    });
+    if (tags.length === 0) {
+      tags = [
+        {
+          id: randomId(),
+          operator: '=',
+        },
+      ];
+    }
+    setSearch({ ...search, tags: tags });
+  };
+
+  return (
+    <div>
+      {search.tags?.map((tag, i) => (
+        <div key={i}>
+          <HorizontalGroup spacing={'xs'} width={'auto'}>
+            <Select
+              aria-label="Select tag key"
+              isClearable
+              key={tag.key}
+              onChange={(v) => onTagChange(tag, v)}
+              onOpenMenu={getTagKeys}
+              options={tagKeys || (tag.key ? [tag.key].map(toOption) : [])}
+              placeholder="Select tag"
+              value={tag.key || null}
+            />
+            <Select
+              aria-label="Select tag operator"
+              onChange={(v) => {
+                setSearch({
+                  ...search,
+                  tags: search.tags?.map((x) => {
+                    return x.id === tag.id ? { ...x, operator: v.value! } : x;
+                  }),
+                });
+              }}
+              options={[toOption('='), toOption('!='), toOption('=~'), toOption('!~')]}
+              value={tag.operator}
+            />
+            <span className={styles.tagValues}>
+              {(tag.operator === '=' || tag.operator === '!=') && (
+                <Select
+                  aria-label="Select tag value"
+                  isClearable
+                  key={tag.value}
+                  onChange={(v) => {
+                    setSearch({
+                      ...search,
+                      tags: search.tags?.map((x) => {
+                        return x.id === tag.id ? { ...x, value: v?.value || '' } : x;
+                      }),
+                    });
+                  }}
+                  options={tagValues[tag.id] ? tagValues[tag.id] : tag.value ? [tag.value].map(toOption) : []}
+                  placeholder="Select value"
+                  value={tag.value}
+                />
+              )}
+              {(tag.operator === '=~' || tag.operator === '!~') && (
+                <Input
+                  aria-label="Input tag value"
+                  onChange={(v) => {
+                    setSearch({
+                      ...search,
+                      tags: search.tags?.map((x) => {
+                        return x.id === tag.id ? { ...x, value: v?.currentTarget?.value || '' } : x;
+                      }),
+                    });
+                  }}
+                  placeholder="Tag value"
+                  width={18}
+                  value={tag.value || ''}
+                />
+              )}
+            </span>
+            {(tag.key || tag.value || search.tags.length > 1) && (
+              <AccessoryButton
+                aria-label="Remove tag"
+                variant="secondary"
+                icon="times"
+                onClick={() => removeTag(tag.id)}
+                tooltip="Remove tag"
+              />
+            )}
+            {(tag.key || tag.value) && i === search.tags.length - 1 && (
+              <span className={styles.addTag}>
+                <AccessoryButton
+                  aria-label="Add tag"
+                  variant="secondary"
+                  icon="plus"
+                  onClick={addTag}
+                  tooltip="Add tag"
+                />
+              </span>
+            )}
+          </HorizontalGroup>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  addTag: css({
+    marginLeft: theme.spacing(1),
+  }),
+  tagValues: css({
+    maxWidth: '200px',
+  }),
+});

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -41,10 +41,6 @@ export type TracePageHeaderProps = {
   setSearch: React.Dispatch<React.SetStateAction<SearchProps>>;
   showSpanFilters: boolean;
   setShowSpanFilters: (isOpen: boolean) => void;
-  showSpanFilterMatchesOnly: boolean;
-  setShowSpanFilterMatchesOnly: (showMatchesOnly: boolean) => void;
-  showCriticalPathSpansOnly: boolean;
-  setShowCriticalPathSpansOnly: (showCriticalPathSpansOnly: boolean) => void;
   setFocusedSpanIdForSearch: React.Dispatch<React.SetStateAction<string>>;
   spanFilterMatches: Set<string> | undefined;
   datasourceType: string;
@@ -61,10 +57,6 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
     setSearch,
     showSpanFilters,
     setShowSpanFilters,
-    showSpanFilterMatchesOnly,
-    setShowSpanFilterMatchesOnly,
-    showCriticalPathSpansOnly,
-    setShowCriticalPathSpansOnly,
     setFocusedSpanIdForSearch,
     spanFilterMatches,
     datasourceType,
@@ -171,10 +163,6 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
         trace={trace}
         showSpanFilters={showSpanFilters}
         setShowSpanFilters={setShowSpanFilters}
-        showSpanFilterMatchesOnly={showSpanFilterMatchesOnly}
-        setShowSpanFilterMatchesOnly={setShowSpanFilterMatchesOnly}
-        showCriticalPathSpansOnly={showCriticalPathSpansOnly}
-        setShowCriticalPathSpansOnly={setShowCriticalPathSpansOnly}
         search={search}
         setSearch={setSearch}
         spanFilterMatches={spanFilterMatches}

--- a/public/app/features/explore/TraceView/useSearch.ts
+++ b/public/app/features/explore/TraceView/useSearch.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash';
+import { cloneDeep, merge } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -50,11 +50,11 @@ export const defaultFilters = {
  * @param spans
  */
 export function useSearch(spans?: TraceSpan[], initialFilters?: SearchProps) {
-  const [search, setSearch] = useState<SearchProps>(merge({ ...defaultFilters }, initialFilters ?? {}));
+  const [search, setSearch] = useState<SearchProps>(merge(cloneDeep(defaultFilters), initialFilters ?? {}));
 
   useEffect(() => {
     if (initialFilters) {
-      setSearch(merge({ ...defaultFilters }, initialFilters));
+      setSearch(merge(cloneDeep(defaultFilters), initialFilters));
     }
   }, [initialFilters]);
 

--- a/public/app/features/explore/TraceView/useSearch.ts
+++ b/public/app/features/explore/TraceView/useSearch.ts
@@ -1,5 +1,5 @@
 import { merge } from 'lodash';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { InterpolateFunction } from '@grafana/data';
@@ -50,7 +50,14 @@ export const defaultFilters = {
  * @param spans
  */
 export function useSearch(spans?: TraceSpan[], initialFilters?: SearchProps) {
-  const [search, setSearch] = useState<SearchProps>(merge(defaultFilters, initialFilters ?? {}));
+  const [search, setSearch] = useState<SearchProps>(merge({ ...defaultFilters }, initialFilters ?? {}));
+
+  useEffect(() => {
+    if (initialFilters) {
+      setSearch(merge({ ...defaultFilters }, initialFilters));
+    }
+  }, [initialFilters]);
+
   const spanFilterMatches: Set<string> | undefined = useMemo(() => {
     return spans && filterSpans(search, spans);
   }, [search, spans]);

--- a/public/app/features/explore/TraceView/useSearch.ts
+++ b/public/app/features/explore/TraceView/useSearch.ts
@@ -35,11 +35,6 @@ export const defaultTagFilter = {
   operator: '=',
 };
 
-export const newTagFilter = () => ({
-  id: randomId(),
-  operator: '=',
-});
-
 export const defaultFilters = {
   spanNameOperator: '=',
   serviceNameOperator: '=',

--- a/public/app/features/explore/TraceView/useSearch.ts
+++ b/public/app/features/explore/TraceView/useSearch.ts
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import { useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -14,6 +15,8 @@ export interface SearchProps {
   toOperator: string;
   tags: Tag[];
   query?: string;
+  matchesOnly: boolean;
+  criticalPathOnly: boolean;
 }
 
 export interface Tag {
@@ -36,14 +39,16 @@ export const defaultFilters = {
   fromOperator: '>',
   toOperator: '<',
   tags: [defaultTagFilter],
+  matchesOnly: false,
+  criticalPathOnly: false,
 };
 
 /**
  * Controls the state of search input that highlights spans if they match the search string.
  * @param spans
  */
-export function useSearch(spans?: TraceSpan[]) {
-  const [search, setSearch] = useState<SearchProps>(defaultFilters);
+export function useSearch(spans?: TraceSpan[], initialFilters?: SearchProps) {
+  const [search, setSearch] = useState<SearchProps>(merge(defaultFilters, initialFilters ?? {}));
   const spanFilterMatches: Set<string> | undefined = useMemo(() => {
     return spans && filterSpans(search, spans);
   }, [search, spans]);

--- a/public/app/features/explore/TraceView/useSearch.ts
+++ b/public/app/features/explore/TraceView/useSearch.ts
@@ -2,6 +2,8 @@ import { merge } from 'lodash';
 import { useMemo, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
+import { InterpolateFunction } from '@grafana/data';
+
 import { filterSpans, TraceSpan } from './components';
 
 export interface SearchProps {
@@ -33,6 +35,11 @@ export const defaultTagFilter = {
   operator: '=',
 };
 
+export const newTagFilter = () => ({
+  id: randomId(),
+  operator: '=',
+});
+
 export const defaultFilters = {
   spanNameOperator: '=',
   serviceNameOperator: '=',
@@ -54,4 +61,41 @@ export function useSearch(spans?: TraceSpan[], initialFilters?: SearchProps) {
   }, [search, spans]);
 
   return { search, setSearch, spanFilterMatches };
+}
+
+export function replaceSearchVariables(replaceVariables: InterpolateFunction, search?: SearchProps) {
+  if (!search) {
+    return search;
+  }
+
+  const newSearch = { ...search };
+  if (newSearch.query) {
+    newSearch.query = replaceVariables(newSearch.query);
+  }
+  if (newSearch.serviceNameOperator) {
+    newSearch.serviceNameOperator = replaceVariables(newSearch.serviceNameOperator);
+  }
+  if (newSearch.serviceName) {
+    newSearch.serviceName = replaceVariables(newSearch.serviceName);
+  }
+  if (newSearch.spanNameOperator) {
+    newSearch.spanNameOperator = replaceVariables(newSearch.spanNameOperator);
+  }
+  if (newSearch.spanName) {
+    newSearch.spanName = replaceVariables(newSearch.spanName);
+  }
+  if (newSearch.from) {
+    newSearch.from = replaceVariables(newSearch.from);
+  }
+  if (newSearch.to) {
+    newSearch.to = replaceVariables(newSearch.to);
+  }
+  newSearch.tags = newSearch.tags.map((tag) => {
+    return {
+      ...tag,
+      key: replaceVariables(tag.key ?? ''),
+      value: replaceVariables(tag.value ?? ''),
+    };
+  });
+  return newSearch;
 }

--- a/public/app/features/explore/TraceView/useSearch.ts
+++ b/public/app/features/explore/TraceView/useSearch.ts
@@ -90,12 +90,15 @@ export function replaceSearchVariables(replaceVariables: InterpolateFunction, se
   if (newSearch.to) {
     newSearch.to = replaceVariables(newSearch.to);
   }
-  newSearch.tags = newSearch.tags.map((tag) => {
-    return {
-      ...tag,
-      key: replaceVariables(tag.key ?? ''),
-      value: replaceVariables(tag.value ?? ''),
-    };
-  });
+  if (newSearch.tags) {
+    newSearch.tags = newSearch.tags.map((tag) => {
+      return {
+        ...tag,
+        key: replaceVariables(tag.key ?? ''),
+        value: replaceVariables(tag.value ?? ''),
+      };
+    });
+  }
+
   return newSearch;
 }

--- a/public/app/features/explore/TraceView/utils/tags.ts
+++ b/public/app/features/explore/TraceView/utils/tags.ts
@@ -1,0 +1,135 @@
+import { SpanStatusCode } from '@opentelemetry/api';
+import { uniq } from 'lodash';
+
+import { Trace } from '../components';
+import {
+  ID,
+  KIND,
+  LIBRARY_NAME,
+  LIBRARY_VERSION,
+  STATUS,
+  STATUS_MESSAGE,
+  TRACE_STATE,
+} from '../components/constants/span';
+
+export const getTraceServiceNames = (trace: Trace) => {
+  const serviceNames = trace.spans.map((span) => {
+    return span.process.serviceName;
+  });
+  return uniq(serviceNames).sort();
+};
+
+export const getTraceSpanNames = (trace: Trace) => {
+  const spanNames = trace.spans.map((span) => {
+    return span.operationName;
+  });
+  return uniq(spanNames).sort();
+};
+
+export const getTraceTagKeys = (trace: Trace) => {
+  let keys: string[] = [];
+  let logKeys: string[] = [];
+
+  trace.spans.forEach((span) => {
+    span.tags.forEach((tag) => {
+      keys.push(tag.key);
+    });
+    span.process.tags.forEach((tag) => {
+      keys.push(tag.key);
+    });
+    if (span.logs !== null) {
+      span.logs.forEach((log) => {
+        log.fields.forEach((field) => {
+          logKeys.push(field.key);
+        });
+      });
+    }
+
+    if (span.kind) {
+      keys.push(KIND);
+    }
+    if (span.statusCode !== undefined) {
+      keys.push(STATUS);
+    }
+    if (span.statusMessage) {
+      keys.push(STATUS_MESSAGE);
+    }
+    if (span.instrumentationLibraryName) {
+      keys.push(LIBRARY_NAME);
+    }
+    if (span.instrumentationLibraryVersion) {
+      keys.push(LIBRARY_VERSION);
+    }
+    if (span.traceState) {
+      keys.push(TRACE_STATE);
+    }
+    keys.push(ID);
+  });
+  keys = uniq(keys).sort();
+  logKeys = uniq(logKeys).sort();
+
+  return [...keys, ...logKeys];
+};
+
+export const getTraceTagValues = (trace: Trace, key: string) => {
+  const values: string[] = [];
+
+  trace.spans.forEach((span) => {
+    const tagValue = span.tags.find((t) => t.key === key)?.value;
+    if (tagValue) {
+      values.push(tagValue.toString());
+    }
+    const processTagValue = span.process.tags.find((t) => t.key === key)?.value;
+    if (processTagValue) {
+      values.push(processTagValue.toString());
+    }
+    if (span.logs !== null) {
+      span.logs.forEach((log) => {
+        const logsTagValue = log.fields.find((t) => t.key === key)?.value;
+        if (logsTagValue) {
+          values.push(logsTagValue.toString());
+        }
+      });
+    }
+
+    switch (key) {
+      case KIND:
+        if (span.kind) {
+          values.push(span.kind);
+        }
+        break;
+      case STATUS:
+        if (span.statusCode !== undefined) {
+          values.push(SpanStatusCode[span.statusCode].toLowerCase());
+        }
+        break;
+      case STATUS_MESSAGE:
+        if (span.statusMessage) {
+          values.push(span.statusMessage);
+        }
+        break;
+      case LIBRARY_NAME:
+        if (span.instrumentationLibraryName) {
+          values.push(span.instrumentationLibraryName);
+        }
+        break;
+      case LIBRARY_VERSION:
+        if (span.instrumentationLibraryVersion) {
+          values.push(span.instrumentationLibraryVersion);
+        }
+        break;
+      case TRACE_STATE:
+        if (span.traceState) {
+          values.push(span.traceState);
+        }
+        break;
+      case ID:
+        values.push(span.spanID);
+        break;
+      default:
+        break;
+    }
+  });
+
+  return uniq(values).sort();
+};

--- a/public/app/plugins/panel/traces/TagsEditor.tsx
+++ b/public/app/plugins/panel/traces/TagsEditor.tsx
@@ -1,117 +1,37 @@
-import { css } from '@emotion/css';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { GrafanaTheme2, StandardEditorProps, toOption } from '@grafana/data';
-import { IconButton, Field, useStyles2, Select } from '@grafana/ui';
+import { SelectableValue, StandardEditorProps } from '@grafana/data';
 
-import { newTagFilter, Tag } from '../../../features/explore/TraceView/useSearch';
-import { getTraceTagKeys, getTraceTagValues } from '../../../features/explore/TraceView/utils/tags';
+import { SpanFiltersTags } from '../../../features/explore/TraceView/components/TracePageHeader/SpanFilters/Tags';
+import { defaultTagFilter, SearchProps } from '../../../features/explore/TraceView/useSearch';
 import { transformDataFrames } from '../../../features/explore/TraceView/utils/transform';
 
-type Props = StandardEditorProps<Tag[], unknown, Tag[]>;
+type Props = StandardEditorProps<SearchProps, unknown, SearchProps>;
 
 export const TagsEditor = ({ value, onChange, context }: Props) => {
-  const styles = useStyles2(getStyles);
-
   const trace = useMemo(() => transformDataFrames(context.data[0]), [context.data]);
-  const tagKeys = useMemo(() => (trace ? getTraceTagKeys(trace).map(toOption) : []), [trace]);
-  const operators = [toOption('='), toOption('!='), toOption('=~'), toOption('!~')];
+  const [tagKeys, setTagKeys] = useState<Array<SelectableValue<string>>>();
+  const [tagValues, setTagValues] = useState<{ [key: string]: Array<SelectableValue<string>> }>({});
 
-  if (!value || value.length < 1) {
-    value = [newTagFilter()];
+  useEffect(() => {
+    if (!value.tags) {
+      onChange({ ...value, tags: [defaultTagFilter] });
+    }
+  }, [onChange, value]);
+
+  if (!trace) {
+    return null;
   }
 
-  const addTag = () => {
-    onChange([...value, newTagFilter()]);
-  };
-
-  const removeTag = (idx: number) => {
-    const copy = value.slice();
-    copy.splice(idx, 1);
-    onChange(copy);
-  };
-
-  const setKey = (idx: number, key?: string) => {
-    const copy = value.slice();
-    copy[idx].key = key;
-    copy[idx].value = undefined;
-    if (copy.length === 0) {
-      onChange(undefined);
-    } else {
-      onChange(copy);
-    }
-  };
-
-  const setOperator = (idx: number, operator?: string) => {
-    const copy = value.slice();
-    copy[idx].operator = operator ?? '=';
-    if (copy.length === 0) {
-      onChange(undefined);
-    } else {
-      onChange(copy);
-    }
-  };
-
-  const setValue = (idx: number, val?: string) => {
-    const copy = value.slice();
-    copy[idx].value = val;
-    if (copy.length === 0) {
-      onChange(undefined);
-    } else {
-      onChange(copy);
-    }
-  };
-
   return (
-    <ul className={styles.list}>
-      {value.map((tag, idx) => (
-        <li key={`${idx}.${tag.id}`}>
-          <div className={styles.listItem}>
-            <Field label={'Key'} style={{ width: '40%' }}>
-              <Select
-                id={`tag-key-${tag.id}`}
-                onChange={(v) => setKey(idx, v.value)}
-                value={tag.key}
-                options={tagKeys}
-                allowCustomValue
-              />
-            </Field>
-            <Field label={'Op'} style={{ width: '20%' }}>
-              <Select
-                id={`tag-op-${tag.id}`}
-                onChange={(v) => setOperator(idx, v.value)}
-                value={tag.operator}
-                defaultValue={tag.operator}
-                options={operators}
-              />
-            </Field>
-            <Field label={'Value'} style={{ width: '40%' }}>
-              <Select
-                id={`tag-value-${tag.id}`}
-                onChange={(v) => setValue(idx, v.value)}
-                value={tag.value}
-                options={trace && tag.key ? getTraceTagValues(trace, tag.key).map(toOption) : []}
-                allowCustomValue
-              />
-            </Field>
-            <IconButton name="times" onClick={() => removeTag(idx)} tooltip="Remove tag" />
-          </div>
-        </li>
-      ))}
-      <IconButton name="plus" onClick={addTag} tooltip="Add tag" />
-    </ul>
+    <SpanFiltersTags
+      search={value}
+      setSearch={onChange}
+      trace={trace}
+      tagKeys={tagKeys}
+      setTagKeys={setTagKeys}
+      tagValues={tagValues}
+      setTagValues={setTagValues}
+    />
   );
 };
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  list: css({
-    listStyle: 'none',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.spacing(0.5),
-  }),
-  listItem: css({
-    display: 'flex',
-    gap: theme.spacing(1),
-  }),
-});

--- a/public/app/plugins/panel/traces/TagsEditor.tsx
+++ b/public/app/plugins/panel/traces/TagsEditor.tsx
@@ -1,0 +1,67 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2, InternalTimeZones, StandardEditorProps } from '@grafana/data';
+import { IconButton, Field, Input, useStyles2 } from '@grafana/ui';
+
+import { defaultTagFilter, Tag } from '../../../features/explore/TraceView/useSearch';
+
+type Props = StandardEditorProps<Tag[], unknown, Tag[]>;
+
+export const TagsEditor = ({ value, onChange }: Props) => {
+  const styles = useStyles2(getStyles);
+
+  if (!value || value.length < 1) {
+    value = [defaultTagFilter];
+  }
+
+  const addTag = () => {
+    onChange([...value, defaultTagFilter]);
+  };
+
+  const removeTag = (idx: number) => {
+    const copy = value.slice();
+    copy.splice(idx, 1);
+    onChange(copy);
+  };
+
+  const setKey = (idx: number, key?: string) => {
+    console.log('setKey', idx, key);
+    const copy = value.slice();
+    copy[idx].key = key ?? InternalTimeZones.default;
+    if (copy.length === 0 || (copy.length === 1 && copy[0] === defaultTagFilter)) {
+      onChange(undefined);
+    } else {
+      onChange(copy);
+    }
+  };
+
+  return (
+    <ul className={styles.list}>
+      {value.map((tag, idx) => (
+        <li className={styles.listItem} key={`${idx}.${tag.id}`}>
+          <Field label={'Key'}>
+            <Input id="tag-key" type={'text'} onChange={(v) => setKey(idx, v.currentTarget.value)} value={tag.key} />
+          </Field>
+          {idx === value.length - 1 ? (
+            <IconButton name="plus" onClick={addTag} tooltip="Add timezone" />
+          ) : (
+            <IconButton name="times" onClick={() => removeTag(idx)} tooltip="Remove timezone" />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  list: css({
+    listStyle: 'none',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  listItem: css({
+    display: 'flex',
+    gap: theme.spacing(1),
+  }),
+});

--- a/public/app/plugins/panel/traces/TagsEditor.tsx
+++ b/public/app/plugins/panel/traces/TagsEditor.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { SelectableValue, StandardEditorProps } from '@grafana/data';
 
-import { SpanFiltersTags } from '../../../features/explore/TraceView/components/TracePageHeader/SpanFilters/Tags';
+import { SpanFiltersTags } from '../../../features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFiltersTags';
 import { defaultTagFilter, SearchProps } from '../../../features/explore/TraceView/useSearch';
 import { transformDataFrames } from '../../../features/explore/TraceView/utils/transform';
 

--- a/public/app/plugins/panel/traces/TagsEditor.tsx
+++ b/public/app/plugins/panel/traces/TagsEditor.tsx
@@ -1,21 +1,28 @@
 import { css } from '@emotion/css';
+import { useMemo } from 'react';
 
-import { GrafanaTheme2, InternalTimeZones, StandardEditorProps } from '@grafana/data';
-import { IconButton, Field, Input, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2, StandardEditorProps, toOption } from '@grafana/data';
+import { IconButton, Field, useStyles2, Select } from '@grafana/ui';
 
-import { defaultTagFilter, Tag } from '../../../features/explore/TraceView/useSearch';
+import { newTagFilter, Tag } from '../../../features/explore/TraceView/useSearch';
+import { getTraceTagKeys, getTraceTagValues } from '../../../features/explore/TraceView/utils/tags';
+import { transformDataFrames } from '../../../features/explore/TraceView/utils/transform';
 
 type Props = StandardEditorProps<Tag[], unknown, Tag[]>;
 
-export const TagsEditor = ({ value, onChange }: Props) => {
+export const TagsEditor = ({ value, onChange, context }: Props) => {
   const styles = useStyles2(getStyles);
 
+  const trace = useMemo(() => transformDataFrames(context.data[0]), [context.data]);
+  const tagKeys = useMemo(() => (trace ? getTraceTagKeys(trace).map(toOption) : []), [trace]);
+  const operators = [toOption('='), toOption('!='), toOption('=~'), toOption('!~')];
+
   if (!value || value.length < 1) {
-    value = [defaultTagFilter];
+    value = [newTagFilter()];
   }
 
   const addTag = () => {
-    onChange([...value, defaultTagFilter]);
+    onChange([...value, newTagFilter()]);
   };
 
   const removeTag = (idx: number) => {
@@ -25,10 +32,30 @@ export const TagsEditor = ({ value, onChange }: Props) => {
   };
 
   const setKey = (idx: number, key?: string) => {
-    console.log('setKey', idx, key);
     const copy = value.slice();
-    copy[idx].key = key ?? InternalTimeZones.default;
-    if (copy.length === 0 || (copy.length === 1 && copy[0] === defaultTagFilter)) {
+    copy[idx].key = key;
+    copy[idx].value = undefined;
+    if (copy.length === 0) {
+      onChange(undefined);
+    } else {
+      onChange(copy);
+    }
+  };
+
+  const setOperator = (idx: number, operator?: string) => {
+    const copy = value.slice();
+    copy[idx].operator = operator ?? '=';
+    if (copy.length === 0) {
+      onChange(undefined);
+    } else {
+      onChange(copy);
+    }
+  };
+
+  const setValue = (idx: number, val?: string) => {
+    const copy = value.slice();
+    copy[idx].value = val;
+    if (copy.length === 0) {
       onChange(undefined);
     } else {
       onChange(copy);
@@ -38,17 +65,40 @@ export const TagsEditor = ({ value, onChange }: Props) => {
   return (
     <ul className={styles.list}>
       {value.map((tag, idx) => (
-        <li className={styles.listItem} key={`${idx}.${tag.id}`}>
-          <Field label={'Key'}>
-            <Input id="tag-key" type={'text'} onChange={(v) => setKey(idx, v.currentTarget.value)} value={tag.key} />
-          </Field>
-          {idx === value.length - 1 ? (
-            <IconButton name="plus" onClick={addTag} tooltip="Add timezone" />
-          ) : (
-            <IconButton name="times" onClick={() => removeTag(idx)} tooltip="Remove timezone" />
-          )}
+        <li key={`${idx}.${tag.id}`}>
+          <div className={styles.listItem}>
+            <Field label={'Key'} style={{ width: '40%' }}>
+              <Select
+                id={`tag-key-${tag.id}`}
+                onChange={(v) => setKey(idx, v.value)}
+                value={tag.key}
+                options={tagKeys}
+                allowCustomValue
+              />
+            </Field>
+            <Field label={'Op'} style={{ width: '20%' }}>
+              <Select
+                id={`tag-op-${tag.id}`}
+                onChange={(v) => setOperator(idx, v.value)}
+                value={tag.operator}
+                defaultValue={tag.operator}
+                options={operators}
+              />
+            </Field>
+            <Field label={'Value'} style={{ width: '40%' }}>
+              <Select
+                id={`tag-value-${tag.id}`}
+                onChange={(v) => setValue(idx, v.value)}
+                value={tag.value}
+                options={trace && tag.key ? getTraceTagValues(trace, tag.key).map(toOption) : []}
+                allowCustomValue
+              />
+            </Field>
+            <IconButton name="times" onClick={() => removeTag(idx)} tooltip="Remove tag" />
+          </div>
         </li>
       ))}
+      <IconButton name="plus" onClick={addTag} tooltip="Add tag" />
     </ul>
   );
 };

--- a/public/app/plugins/panel/traces/TracesPanel.tsx
+++ b/public/app/plugins/panel/traces/TracesPanel.tsx
@@ -8,7 +8,7 @@ import { TraceView } from 'app/features/explore/TraceView/TraceView';
 import { SpanLinkFunc } from 'app/features/explore/TraceView/components';
 import { transformDataFrames } from 'app/features/explore/TraceView/utils/transform';
 
-import { SearchProps } from '../../../features/explore/TraceView/useSearch';
+import { replaceSearchVariables, SearchProps } from '../../../features/explore/TraceView/useSearch';
 
 const styles = {
   wrapper: css({
@@ -24,7 +24,7 @@ export interface TracesPanelOptions {
   spanFilters?: SearchProps;
 }
 
-export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) => {
+export const TracesPanel = ({ data, options, replaceVariables }: PanelProps<TracesPanelOptions>) => {
   const topOfViewRef = createRef<HTMLDivElement>();
   const traceProp = useMemo(() => transformDataFrames(data.series[0]), [data.series]);
   const dataSource = useAsync(async () => {
@@ -51,7 +51,7 @@ export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) =
         createSpanLink={options.createSpanLink}
         focusedSpanId={options.focusedSpanId}
         createFocusSpanLink={options.createFocusSpanLink}
-        spanFilters={options.spanFilters}
+        spanFilters={replaceSearchVariables(replaceVariables, options.spanFilters)}
       />
     </div>
   );

--- a/public/app/plugins/panel/traces/TracesPanel.tsx
+++ b/public/app/plugins/panel/traces/TracesPanel.tsx
@@ -8,6 +8,8 @@ import { TraceView } from 'app/features/explore/TraceView/TraceView';
 import { SpanLinkFunc } from 'app/features/explore/TraceView/components';
 import { transformDataFrames } from 'app/features/explore/TraceView/utils/transform';
 
+import { SearchProps } from '../../../features/explore/TraceView/useSearch';
+
 const styles = {
   wrapper: css({
     height: '100%',
@@ -19,6 +21,7 @@ export interface TracesPanelOptions {
   createSpanLink?: SpanLinkFunc;
   focusedSpanId?: string;
   createFocusSpanLink?: (traceId: string, spanId: string) => LinkModel<Field>;
+  spanFilters?: SearchProps;
 }
 
 export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) => {
@@ -48,6 +51,7 @@ export const TracesPanel = ({ data, options }: PanelProps<TracesPanelOptions>) =
         createSpanLink={options.createSpanLink}
         focusedSpanId={options.focusedSpanId}
         createFocusSpanLink={options.createFocusSpanLink}
+        spanFilters={options.spanFilters}
       />
     </div>
   );

--- a/public/app/plugins/panel/traces/module.tsx
+++ b/public/app/plugins/panel/traces/module.tsx
@@ -10,7 +10,7 @@ import { TracesSuggestionsSupplier } from './suggestions';
 export const plugin = new PanelPlugin(TracesPanel)
   .setPanelOptions((builder, context) => {
     const category = ['Span filters'];
-    const trace = transformDataFrames(context.data[0]);
+    const trace = transformDataFrames(context?.data?.[0]);
 
     // Find
     builder
@@ -41,6 +41,7 @@ export const plugin = new PanelPlugin(TracesPanel)
         settings: {
           options: trace ? getTraceServiceNames(trace).map(toOption) : [],
           allowCustomValue: true,
+          isClearable: true,
         },
       })
       .addRadio({
@@ -65,6 +66,7 @@ export const plugin = new PanelPlugin(TracesPanel)
         settings: {
           options: trace ? getTraceSpanNames(trace).map(toOption) : [],
           allowCustomValue: true,
+          isClearable: true,
         },
       })
       .addRadio({
@@ -96,7 +98,7 @@ export const plugin = new PanelPlugin(TracesPanel)
     builder.addCustomEditor({
       id: 'tags',
       name: 'Tags',
-      path: 'spanFilters.tags',
+      path: 'spanFilters',
       category,
       editor: TagsEditor,
       defaultValue: undefined,

--- a/public/app/plugins/panel/traces/module.tsx
+++ b/public/app/plugins/panel/traces/module.tsx
@@ -1,6 +1,100 @@
+import { useMemo } from 'react';
+
 import { PanelPlugin } from '@grafana/data';
 
+import { transformDataFrames } from '../../../features/explore/TraceView/utils/transform';
+
+import { TagsEditor } from './TagsEditor';
 import { TracesPanel } from './TracesPanel';
 import { TracesSuggestionsSupplier } from './suggestions';
 
-export const plugin = new PanelPlugin(TracesPanel).setSuggestionsSupplier(new TracesSuggestionsSupplier());
+export const plugin = new PanelPlugin(TracesPanel)
+  .setPanelOptions((builder, context) => {
+    const category = ['Span filters'];
+    console.log(context);
+
+    const traceProp = useMemo(() => transformDataFrames(context.data[0]), [context.data]);
+
+    // Find
+    builder
+      .addTextInput({
+        path: 'spanFilters.query',
+        name: 'Find in trace',
+        category,
+      })
+      .addBooleanSwitch({
+        path: 'spanFilters.matchesOnly',
+        name: 'Show matches only',
+        defaultValue: false,
+        category,
+      })
+      .addBooleanSwitch({
+        path: 'spanFilters.criticalPathOnly',
+        name: 'Show critical path only',
+        defaultValue: false,
+        category,
+      });
+
+    // Service name
+    builder
+      .addTextInput({
+        path: 'spanFilters.serviceName',
+        name: 'Service name',
+        category,
+      })
+      .addRadio({
+        path: 'spanFilters.serviceNameOperator',
+        name: 'Service name operator',
+        defaultValue: '=',
+        settings: {
+          options: [
+            { value: '=', label: '=' },
+            { value: '!=', label: '!=' },
+          ],
+        },
+        category,
+      });
+
+    // Span name
+    builder
+      .addTextInput({
+        path: 'spanFilters.spanName',
+        name: 'Span name',
+        category,
+      })
+      .addRadio({
+        path: 'spanFilters.spanNameOperator',
+        name: 'Span name operator',
+        defaultValue: '=',
+        settings: {
+          options: [
+            { value: '=', label: '=' },
+            { value: '!=', label: '!=' },
+          ],
+        },
+        category,
+      });
+
+    // Duration
+    builder
+      .addTextInput({
+        path: 'spanFilters.from',
+        name: 'Min duration',
+        category,
+      })
+      .addTextInput({
+        path: 'spanFilters.to',
+        name: 'Max duration',
+        category,
+      });
+
+    builder.addCustomEditor({
+      id: 'tags',
+      name: 'Tags',
+      path: 'tags',
+      category,
+      editor: TagsEditor,
+      defaultValue: undefined,
+    });
+  })
+  .setSuggestionsSupplier(new TracesSuggestionsSupplier());

--- a/public/app/plugins/panel/traces/module.tsx
+++ b/public/app/plugins/panel/traces/module.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react';
+import { PanelPlugin, toOption } from '@grafana/data';
 
-import { PanelPlugin } from '@grafana/data';
-
+import { getTraceServiceNames, getTraceSpanNames } from '../../../features/explore/TraceView/utils/tags';
 import { transformDataFrames } from '../../../features/explore/TraceView/utils/transform';
 
 import { TagsEditor } from './TagsEditor';
@@ -11,9 +10,7 @@ import { TracesSuggestionsSupplier } from './suggestions';
 export const plugin = new PanelPlugin(TracesPanel)
   .setPanelOptions((builder, context) => {
     const category = ['Span filters'];
-    console.log(context);
-
-    const traceProp = useMemo(() => transformDataFrames(context.data[0]), [context.data]);
+    const trace = transformDataFrames(context.data[0]);
 
     // Find
     builder
@@ -37,10 +34,14 @@ export const plugin = new PanelPlugin(TracesPanel)
 
     // Service name
     builder
-      .addTextInput({
+      .addSelect({
         path: 'spanFilters.serviceName',
         name: 'Service name',
         category,
+        settings: {
+          options: trace ? getTraceServiceNames(trace).map(toOption) : [],
+          allowCustomValue: true,
+        },
       })
       .addRadio({
         path: 'spanFilters.serviceNameOperator',
@@ -57,10 +58,14 @@ export const plugin = new PanelPlugin(TracesPanel)
 
     // Span name
     builder
-      .addTextInput({
+      .addSelect({
         path: 'spanFilters.spanName',
         name: 'Span name',
         category,
+        settings: {
+          options: trace ? getTraceSpanNames(trace).map(toOption) : [],
+          allowCustomValue: true,
+        },
       })
       .addRadio({
         path: 'spanFilters.spanNameOperator',
@@ -91,7 +96,7 @@ export const plugin = new PanelPlugin(TracesPanel)
     builder.addCustomEditor({
       id: 'tags',
       name: 'Tags',
-      path: 'tags',
+      path: 'spanFilters.tags',
       category,
       editor: TagsEditor,
       defaultValue: undefined,


### PR DESCRIPTION
**What is this feature?**

This PR allows users of the Trace View (Traces panel) to set the span filters as panel options. This is possible through either scenes apps or by using the panel options editor of a dashboard panel. Variable interpolation is supported for both options!

Using it in scenes is as simple as setting the `spanFilters` option:
```
const panel = PanelBuilders.traces().setOption('spanFilters', { serviceName: 'testService', matchesOnly: true });
```

The value object must match the `SearchProps` type [declared here](https://github.com/grafana/grafana/blob/c4c3f2350d2d98c728544fd3857da4793a576ea1/public/app/features/explore/TraceView/useSearch.ts#L9).

Alternatively, users can use the panel options to set the span filters for a dashboard panel.

![image](https://github.com/user-attachments/assets/d6cf791b-073b-45f8-bee1-8ab8536f9e22)


**Why do we need this feature?**

This feature is useful to narrow down very large traces by allowing scenes apps developers or dashboard creators to pre-set the span filters.

**Who is this feature for?**

Users of the trace view (traces panel).

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #94660 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
