### PR TITLE
Docs: Add missing labels for products

### DIFF
--- a/docs/sources/explore/simplified-exploration/_index.md
+++ b/docs/sources/explore/simplified-exploration/_index.md
@@ -1,4 +1,9 @@
 ---
+labels:
+  products:
+    - oss
+    - cloud
+    - enterprise
 description: Use your telemetry data to explore and determine the root cause of issues without performing queries.
 keywords:
   - Simplified exploration


### PR DESCRIPTION
## What is this change?

This PR adds `labels.products` config to the Simplified Exploration docs.

## Why make this change?

For reasons described in https://github.com/grafana/website/issues/23339 and discussed [here](https://raintank-corp.slack.com/archives/C075BDBTX96/p1734698251262709).

## Which issue does this fix?

Fixes https://github.com/grafana/website/issues/23339.