### PR TITLE
Chore: Use slices from standard library in promlib

### DIFF
--- a/pkg/promlib/converter/prom.go
+++ b/pkg/promlib/converter/prom.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -10,8 +11,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 	jsoniter "github.com/json-iterator/go"
-
-	"golang.org/x/exp/slices"
 )
 
 // helpful while debugging all the options that may appear

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/trace v1.32.0
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	k8s.io/apimachinery v0.31.3
 )
 
@@ -111,6 +110,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
+	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect


### PR DESCRIPTION
**What is this feature?**

Use `slices` from standard library instead of `golang.org/x/exp/slices`