### PR TITLE
fix: reducing database is locked

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -166,8 +166,8 @@ path = grafana.db
 # For "sqlite3" only. cache mode setting used for connecting to the database
 cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is true.
+wal = true
 
 # For "mysql" and "postgres". Lock the database for the migrations, default is true.
 migration_locking = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -165,8 +165,8 @@
 # For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
 ;cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-;wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is true.
+;wal = true
 
 # For "mysql" and "postgres" only. Lock the database for the migrations, default is true.
 ;migration_locking = true

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -196,11 +196,19 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 			return err
 		}
 
-		cnnstr = fmt.Sprintf("file:%s?cache=%s&mode=rwc", dbCfg.Path, dbCfg.CacheMode)
+		sqliteConnParams := make(url.Values)
+		sqliteConnParams.Add("_txlock", "immediate")
+		sqliteConnParams.Add("_busy_timeout", "5000")
+		sqliteConnParams.Add("_synchronous", "NORMAL")
+		sqliteConnParams.Add("_cache_size", "2000")
+		sqliteConnParams.Add("cache", dbCfg.CacheMode)
+		sqliteConnParams.Add("mode", "rwc")
 
 		if dbCfg.WALEnabled {
-			cnnstr += "&_journal_mode=WAL"
+			sqliteConnParams.Add("_journal_mode", "WAL")
 		}
+
+		cnnstr = fmt.Sprintf("file:%s?%s", sqliteConnParams.Encode())
 
 		cnnstr += buildExtraConnectionString('&', dbCfg.UrlQueryParams)
 	default:

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -17,6 +17,15 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+
+const (
+	sqlite3TXLock = "immediate"
+	sqlite3BusyTimeout = "5000"
+	sqlite3SyncFlag = "NORMAL"
+	sqlite3CacheSize = "2000"
+	sqlite3Mode = "rwc"
+)
+
 type DatabaseConfig struct {
 	Type                        string
 	Host                        string
@@ -197,12 +206,12 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 		}
 
 		sqliteConnParams := make(url.Values)
-		sqliteConnParams.Add("_txlock", "immediate")
-		sqliteConnParams.Add("_busy_timeout", "5000")
-		sqliteConnParams.Add("_synchronous", "NORMAL")
-		sqliteConnParams.Add("_cache_size", "2000")
+		sqliteConnParams.Add("_txlock", sqlite3TXLock)
+		sqliteConnParams.Add("_busy_timeout", sqlite3BusyTimeout)
+		sqliteConnParams.Add("_synchronous", sqlite3SyncFlag)
+		sqliteConnParams.Add("_cache_size", sqlite3CacheSize)
 		sqliteConnParams.Add("cache", dbCfg.CacheMode)
-		sqliteConnParams.Add("mode", "rwc")
+		sqliteConnParams.Add("mode", sqlite3Mode)
 
 		if dbCfg.WALEnabled {
 			sqliteConnParams.Add("_journal_mode", "WAL")


### PR DESCRIPTION
related issues: #64692  #65115  etc

according to RoR 8.0 publish，we can see their solution to the sqlite3 concurrency problem on:
- https://github.com/rails/rails/blob/6dda150b5e4cd25c6af76b99fe9a5c5986691e05/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L107-L114
- https://www.sqlite.org/pragma.html#pragma_cache_size
- https://fractaledmind.github.io/2024/04/15/sqlite-on-rails-the-how-and-why-of-optimal-performance/
- https://kerkour.com/sqlite-for-servers