### PR TITLE
Alerting docs: update configuring and using additional Alertmanagers in Grafana Alerting

### DIFF
--- a/docs/sources/alerting/fundamentals/notifications/_index.md
+++ b/docs/sources/alerting/fundamentals/notifications/_index.md
@@ -134,6 +134,4 @@ Grafana Alerting is based on the Prometheus model for designing alerting systems
 
 {{< figure src="/media/docs/alerting/alerting-alertmanager-architecture.png" max-width="750px" alt="A diagram with the alert generator and alert manager architecture" >}}
 
-Grafana uses a custom Alertmanager to manage and deliver alert notifications, as detailed in this guide. This custom Alertmanager extends the capabilities of the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/).
-
-If you already run a Prometheus Alertmanager instance, you can configure Grafana Alerting to forward alerts to your [external Alertmanager for handling notifications](ref:configure-alertmanager).
+Grafana provides a custom Alertmanager, extending the Prometheus Alertmanager, to manage and deliver alert notifications. If you run a Prometheus or Mimir Alertmanager, you can configure Grafana Alerting to manage them and handle notifications for Grafana-managed alerts. For details, refer to [configure Alertmanagers](ref:configure-alertmanager).

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -82,7 +82,7 @@ After adding an Alertmanager, you can use the Grafana Alerting UI to manage noti
 When using Prometheus, you can manage silences in the Grafana Alerting UI. However, other Alertmanager resources such as contact points, notification policies, and templates are read-only because the Prometheus Alertmanager HTTP API does not support updates for these resources.
 {{% /admonition %}}
 
-When configuring multiple Alertmanagers, use the `Choose Alertmanager` dropdown to switch between Alertmanagers.
+When using multiple Alertmanagers, use the `Choose Alertmanager` dropdown to switch between Alertmanagers.
 
 ## Enable an Alertmanager to receive Grafana-managed alerts
 
@@ -94,8 +94,10 @@ After enabling **Receive Grafana Alerts** in the Data Source Settings, you must 
 
 {{< figure src="/media/docs/alerting/grafana-alerting-settings.png" max-width="750px" alt="Grafana Alerting Settings page" >}}
 
+All Grafana-managed alerts are forwarded to Alertmanagers marked as `Receiving Grafana-managed alerts`.
+
 {{% admonition type="note" %}}
-Grafana Alerting does not support sending Grafana-managed alerts to the AlertManager in AWS Managed Service for Prometheus. For more details, refer to [this GitHub issue](https://github.com/grafana/grafana/issues/64064).
+Grafana Alerting does not support forwarding Grafana-managed alerts to the AlertManager in Amazon Managed Service for Prometheus. For more details, refer to [this GitHub issue](https://github.com/grafana/grafana/issues/64064).
 {{% /admonition %}}
 
 ## Manage Alertmanager configurations

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -21,6 +21,11 @@ labels:
 title: Configure Alertmanagers
 weight: 200
 refs:
+  alertmanager-data-source:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/alertmanager/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/connect-externally-hosted/data-sources/alertmanager/
   notifications:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/notifications/
@@ -30,28 +35,26 @@ refs:
 
 # Configure Alertmanagers
 
-Grafana Alerting is based on the architecture of the Prometheus alerting system. Grafana sends firing and resolved alerts to an Alertmanager, which is responsible for [handling notifications](ref:notifications).
+Grafana Alerting is based on the architecture of the Prometheus alerting system. Grafana sends firing and resolved alerts to an Alertmanager, which is responsible for [handling notifications](ref:notifications). This architecture decouples alert rule evaluation from notification handling, improving scalability.
 
 {{< figure src="/media/docs/alerting/alerting-alertmanager-architecture.png" max-width="750px" alt="A diagram with the alert generator and alert manager architecture" >}}
 
-This architecture decouples alert rule evaluation from notification handling, allowing alerts to be forwarded to other Alertmanagers.
-
-Grafana can use different Alertmanagers. It’s important to note that each Alertmanager manages its own independent alerting resources, such as:
+Grafana can enable one or more Alertmanagers to receive Grafana-managed alerts for notification handling. It’s important to note that each Alertmanager manages its own independent alerting resources, such as:
 
 - Contact points and notification templates
 - Notification policies and mute timings
 - Silences
 - Active notifications
 
-Use the `Choose Alertmanager` on these pages to switch between Alertmanagers.
+Use the `Choose Alertmanager` dropdown on these pages to switch between Alertmanagers and view or manage their resources.
 
 {{< figure src="/media/docs/alerting/alerting-choose-alertmanager.png" max-width="750px" alt="A screenshot choosing an Alertmanager in the notification policies UI" >}}
 
 ## Types of Alertmanagers in Grafana
 
-Grafana can be configured to manage both Grafana-managed and data source-managed alerts using various Alertmanagers, depending on your infrastructure and alerting requirements.
+Grafana can be configured to handle alert notifications using various Alertmanagers.
 
-- **Grafana Alertmanager**: Grafana has its own built-in Alertmanager, referred to as "Grafana" in the user interface. It is the default Alertmanager and can only handle Grafana-managed alerts.
+- **Grafana Alertmanager**: Grafana includes a built-in Alertmanager that extends the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/). This is the default Alertmanager and is referred to as "Grafana" in the user interface. It can only handle Grafana-managed alerts.
 
 - **Cloud Alertmanager**: Each Grafana Cloud instance comes preconfigured with an additional Alertmanager (`grafanacloud-STACK_NAME-ngalertmanager`) from the Mimir (Prometheus) instance running in the Grafana Cloud Stack.
 
@@ -59,44 +62,41 @@ Grafana can be configured to manage both Grafana-managed and data source-managed
 
   Some Grafana Cloud services, such as **Kubernetes Monitoring** and **Synthetic Monitoring** use the Cloud Alertmanager to create and manage alerts.
 
-- **Other Alertmanagers**: Grafana Alerting also supports sending alerts to other Alertmanagers, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), which can handle Grafana-managed alerts and data sources-managed alerts such as alerts from Loki, Mimir, and Prometheus.
+- **Other Alertmanagers**: Grafana Alerting also supports sending alerts to other Alertmanagers, such as the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), which can handle both Grafana-managed and data source-managed alerts.
 
-You can use a combination of Alertmanagers. The decision often depends on your alerting setup and where your alerts are being generated. Here are two examples of when you may want to add an Alertmanager and send your alerts there instead of using the built-in Grafana Alertmanager.
+Grafana Alerting supports using a combination of Alertmanagers and can [enable other Alertmanagers to receive Grafana-managed alerts](#enable-an-alertmanager-to-receive-grafana-managed-alerts). The decision often depends on your alerting setup and where your alerts are generated.
 
-1. You may already have Alertmanagers on-premises in your own Cloud infrastructure that you still want to use because you have other alert generators, such as Prometheus.
-
-2. You want to use both Prometheus on-premises and hosted Grafana to send alerts to the same Alertmanager that runs in your Cloud infrastructure.
+For example, if you already have an Alertmanager running in your on-premises or cloud infrastructure to handle Prometheus alerts, you can forward Grafana-managed alerts to the same Alertmanager for unified notification handling.
 
 ## Add an Alertmanager
 
-From Grafana, you can configure and administer your own Alertmanager to receive Grafana alerts.
-
-After adding an Alertmanager, you can use the Grafana Alerting UI to manage notification policies, contact points, and other alerting resources from within Grafana, with support for HTTP basic authentication credentials.
-
 Alertmanagers should be configured as data sources using Grafana Configuration from the main Grafana navigation menu. To add an Alertmanager, complete the following steps.
 
-1. Click **Connections** in the left-side menu.
-1. On the Connections page, search for `Alertmanager`.
-1. Click the **Create a new data source** button.
+{{< docs/shared lookup="alerts/add-alertmanager-ds.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-   If you don't see this button, you may need to install the plugin, relaunch your Cloud instance, and then repeat steps 1 and 2.
+For provisioning instructions, refer to the [Alertmanager data source documentation](ref:alertmanager-data-source).
 
-1. Fill out the fields on the page, as required.
+After adding an Alertmanager, you can use the Grafana Alerting UI to manage notification policies, contact points, and other alerting resources from within Grafana. While you can edit silences for Prometheus Alertmanagers, other resources are read-only because the Prometheus Alertmanager HTTP API does not support updates.
 
-   If you are provisioning your data source, set the flag `handleGrafanaManagedAlerts` in the `jsonData` field to `true` to send Grafana-managed alerts to this Alertmanager.
+When having multiple Alertmanagers, use the `Choose Alertmanager` dropdown to switch between Alertmanagers.
 
-   **Note:** Prometheus, Grafana Mimir, and Cortex implementations of Alertmanager are supported. For Prometheus, contact points and notification policies are read-only in the Grafana Alerting UI.
+## Enable an Alertmanager to receive Grafana-managed alerts
 
-1. Click **Save & test**.
+After enabling **Receive Grafana Alerts** in the Data Source Settings, you must also configure the Alertmanager in the Alerting Settings page. Grafana supports enabling one or multiple Alertmanagers to receive all generated Grafana-managed alerts.
+
+1. In the left-side menu, click **Alerts & IRM** and then **Alerting**.
+1. Click **Settings** to view the list of configured Alertmanagers.
+1. For the selected Alertmanager, click the **Enable/Disable** button to toggle receiving Grafana-managed alerts. When activated, the Alertmanager displays `Receiving Grafana-managed alerts`.
+
+{{< figure src="/media/docs/alerting/grafana-alerting-settings.png" max-width="750px" alt="Grafana Alerting Settings page" >}}
 
 {{% admonition type="note" %}}
-Grafana Alerting does not support sending alerts to the AWS Managed Service for Prometheus due to the lack of sigv4 support in Prometheus.
+Grafana Alerting does not support sending Grafana-managed alerts to the AlertManager in AWS Managed Service for Prometheus. For more details, refer to [this GitHub issue](https://github.com/grafana/grafana/issues/64064).
 {{% /admonition %}}
 
 ## Manage Alertmanager configurations
 
-On the Settings page, you can manage your Alertmanager configurations and configure where Grafana-managed alert instances are forwarded.
+On the Settings page, you can also manage your Alertmanager configurations.
 
-- Manage which Alertmanagers receive alert instances from Grafana-managed rules without navigating and editing data sources.
 - Manage version snapshots for the built-in Alertmanager, which allows administrators to roll back unintentional changes or mistakes in the Alertmanager configuration.
 - Compare the historical snapshot with the latest configuration to see which changes were made.

--- a/docs/sources/alerting/set-up/configure-alertmanager/index.md
+++ b/docs/sources/alerting/set-up/configure-alertmanager/index.md
@@ -76,9 +76,13 @@ Alertmanagers should be configured as data sources using Grafana Configuration f
 
 For provisioning instructions, refer to the [Alertmanager data source documentation](ref:alertmanager-data-source).
 
-After adding an Alertmanager, you can use the Grafana Alerting UI to manage notification policies, contact points, and other alerting resources from within Grafana. While you can edit silences for Prometheus Alertmanagers, other resources are read-only because the Prometheus Alertmanager HTTP API does not support updates.
+After adding an Alertmanager, you can use the Grafana Alerting UI to manage notification policies, contact points, silences, and other alerting resources from within Grafana.
 
-When having multiple Alertmanagers, use the `Choose Alertmanager` dropdown to switch between Alertmanagers.
+{{% admonition type="note" %}}
+When using Prometheus, you can manage silences in the Grafana Alerting UI. However, other Alertmanager resources such as contact points, notification policies, and templates are read-only because the Prometheus Alertmanager HTTP API does not support updates for these resources.
+{{% /admonition %}}
+
+When configuring multiple Alertmanagers, use the `Choose Alertmanager` dropdown to switch between Alertmanagers.
 
 ## Enable an Alertmanager to receive Grafana-managed alerts
 

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -53,23 +53,7 @@ When using Prometheus, you can manage silences in the Grafana Alerting UI. Howev
 
 To configure basic settings for the data source, complete the following steps:
 
-1. Click **Connections** in the left-side menu.
-1. Under Your connections, click **Data sources**.
-1. Enter `Alertmanager` in the search bar.
-1. Click **Alertmanager**.
-
-   The **Settings** tab of the data source is displayed.
-
-1. Set the data source's basic configuration options:
-
-   | Name                            | Description                                                                                                                                                                                 |
-   | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Name**                        | Sets the name you use to refer to the data source                                                                                                                                           |
-   | **Default**                     | Sets whether the data source is pre-selected for new panels and queries                                                                                                                     |
-   | **Alertmanager Implementation** | Alertmanager implementation. **Mimir**, **Cortex,** and **Prometheus** are supported                                                                                                        |
-   | **Receive Grafana Alerts**      | When enabled, the Alertmanager can receive Grafana-managed alerts. **Important:** This works only if receiving alerts is enabled for the Alertmanager in the Grafana Alerting Settings page |
-   | **HTTP URL**                    | Sets the HTTP protocol, IP, and port of your Alertmanager instance, such as `https://alertmanager.example.org:9093`                                                                         |
-   | **Access**                      | Only **Server** access mode is functional                                                                                                                                                   |
+{{< docs/shared lookup="alerts/add-alertmanager-ds.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Provision the Alertmanager data source
 

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -23,6 +23,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/
+  configure-alertmanager:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/set-up/configure-alertmanager/
   data-sources:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#datasources
@@ -33,14 +38,18 @@ refs:
 # Alertmanager data source
 
 Grafana includes built-in support for Alertmanager implementations in Prometheus and Mimir.
-Once you add it as a data source, you can use the [Grafana Alerting UI](ref:alerting) to manage silences, contact points, and notification policies.
-To switch between Grafana and any configured Alertmanager data sources, you can select your preference from a drop-down option in those databases' data source settings pages.
+
+Once you add an Alertmanager as a data source, you can use [Grafana Alerting](ref:alerting) to view and manage Alertmanager resources, such as silences or notification policies, and enable the Alertmanager to receive Grafana-managed alerts.
+
+To switch between the Grafana built-in Alertmanager and other Alertmanager data sources, use the `Choose Alertmanager` drop-down on Grafana Alerting pages.
+
+For more details about using other Alertmanagers, refer to [Alertmanagers in the Grafana Alerting documentation](ref:configure-alertmanager).
 
 ## Alertmanager implementations
 
-The data source supports [Prometheus](https://prometheus.io/) and [Grafana Mimir](/docs/mimir/latest/) (default) implementations of Alertmanager.
-You can specify the implementation in the data source's Settings page.
-When using Prometheus, contact points and notification policies are read-only in the Grafana Alerting UI, because it doesn't support updates to the configuration using HTTP API.
+The data source supports [Prometheus](https://prometheus.io/) and [Grafana Mimir](/docs/mimir/latest/) (default) implementations of Alertmanager. You can specify the implementation in the data source's Settings page.
+
+When using Prometheus, you can manage silences in the Grafana Alerting UI. However, other Alertmanager resources such as contact points, notification policies, and templates are read-only because the Prometheus Alertmanager HTTP API does not support updates for these resources.
 
 ## Configure the data source
 
@@ -55,14 +64,14 @@ To configure basic settings for the data source, complete the following steps:
 
 1. Set the data source's basic configuration options:
 
-   | Name                            | Description                                                                                                                                                                                                   |
-   | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **Name**                        | Sets the name you use to refer to the data source                                                                                                                                                             |
-   | **Default**                     | Sets whether the data source is pre-selected for new panels and queries                                                                                                                                       |
-   | **Alertmanager Implementation** | Alertmanager implementation. **Mimir**, **Cortex,** and **Prometheus** are supported                                                                                                                          |
-   | **Receive Grafana Alerts**      | When enabled the Alertmanager receives alert instances from Grafana-managed alert rules. **Important:** It works only if Grafana alerting is configured to send its alert instances to external Alertmanagers |
-   | **HTTP URL**                    | Sets the HTTP protocol, IP, and port of your Alertmanager instance, such as `https://alertmanager.example.org:9093`                                                                                           |
-   | **Access**                      | Only **Server** access mode is functional                                                                                                                                                                     |
+   | Name                            | Description                                                                                                                                                                                 |
+   | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Name**                        | Sets the name you use to refer to the data source                                                                                                                                           |
+   | **Default**                     | Sets whether the data source is pre-selected for new panels and queries                                                                                                                     |
+   | **Alertmanager Implementation** | Alertmanager implementation. **Mimir**, **Cortex,** and **Prometheus** are supported                                                                                                        |
+   | **Receive Grafana Alerts**      | When enabled, the Alertmanager can receive Grafana-managed alerts. **Important:** This works only if receiving alerts is enabled for the Alertmanager in the Grafana Alerting Settings page |
+   | **HTTP URL**                    | Sets the HTTP protocol, IP, and port of your Alertmanager instance, such as `https://alertmanager.example.org:9093`                                                                         |
+   | **Access**                      | Only **Server** access mode is functional                                                                                                                                                   |
 
 ## Provision the Alertmanager data source
 

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -39,9 +39,7 @@ refs:
 
 Grafana includes built-in support for Alertmanager implementations in Prometheus and Mimir.
 
-Once you add an Alertmanager as a data source, you can use [Grafana Alerting](ref:alerting) to view and manage Alertmanager resources, such as silences or notification policies, and enable the Alertmanager to receive Grafana-managed alerts.
-
-To switch between the Grafana built-in Alertmanager and other Alertmanager data sources, use the `Choose Alertmanager` drop-down on Grafana Alerting pages.
+Once you add an Alertmanager as a data source, you can use the `Choose Alertmanager` drop-down on [Grafana Alerting](ref:alerting) to view and manage Alertmanager resources, such as silences, contact points, and notification policies. Additionally, you can enable the Alertmanager to receive Grafana-managed alerts.
 
 For more details about using other Alertmanagers, refer to [Alertmanagers in the Grafana Alerting documentation](ref:configure-alertmanager).
 

--- a/docs/sources/shared/alerts/add-alertmanager-ds.md
+++ b/docs/sources/shared/alerts/add-alertmanager-ds.md
@@ -1,0 +1,26 @@
+---
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: 'Add an alertmanager data source'
+---
+
+1. Click **Connections** in the left-side menu.
+1. Under Your connections, click **Data sources**.
+1. Enter `Alertmanager` in the search bar.
+1. Click **Alertmanager**.
+
+   The **Settings** tab of the data source is displayed.
+
+1. Set the data source's basic configuration options:
+
+   | Name                            | Description                                                                                                                                                                                 |
+   | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Name**                        | Sets the name you use to refer to the data source                                                                                                                                           |
+   | **Default**                     | Sets whether the data source is pre-selected for new panels and queries                                                                                                                     |
+   | **Alertmanager Implementation** | Alertmanager implementation. **Mimir**, **Cortex,** and **Prometheus** are supported                                                                                                        |
+   | **Receive Grafana Alerts**      | When enabled, the Alertmanager can receive Grafana-managed alerts. **Important:** This works only if receiving alerts is enabled for the Alertmanager in the Grafana Alerting Settings page |
+   | **HTTP URL**                    | Sets the HTTP protocol, IP, and port of your Alertmanager instance, such as `https://alertmanager.example.org:9093`                                                                         |
+   | **Access**                      | Only **Server** access mode is functional                                                                                                                                                   |


### PR DESCRIPTION
Update documentation on configuring and using additional Alertmanagers in Grafana Alerting.

- Add missing instructions: Enable an Alertmanager to receive Grafana-managed alerts.
- Make minor updates for clarity.

Preview
- [Configure Alertmanagers](https://deploy-preview-grafana-98363-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/configure-alertmanager/)
- [Alertmanager data source](https://deploy-preview-grafana-98363-zb444pucvq-vp.a.run.app/docs/grafana/latest/datasources/alertmanager/)
