### PR TITLE
Alerting text: rename `Affected alert rule instances`

### DIFF
--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -78,7 +78,7 @@ To add a silence, complete the following steps.
 
    {{< docs/shared lookup="alerts/how_label_matching_works.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-   Any matching alerts (in the firing state only) will show under **Affected alert instances**.
+   Any matching alerts (in the firing state only) display under **Affected alert instances**.
 
 1. In **Comment**, add details about the silence.
 1. Click **Submit**.

--- a/docs/sources/alerting/configure-notifications/create-silence.md
+++ b/docs/sources/alerting/configure-notifications/create-silence.md
@@ -78,7 +78,7 @@ To add a silence, complete the following steps.
 
    {{< docs/shared lookup="alerts/how_label_matching_works.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-   Any matching alerts (in the firing state only) will show under **Affected alert rule instances**.
+   Any matching alerts (in the firing state only) will show under **Affected alert instances**.
 
 1. In **Comment**, add details about the silence.
 1. Click **Submit**.

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -80,7 +80,7 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   return (
     <div>
       <h4 className={styles.title}>
-        <Trans i18nKey="alerting.silences.affected-instances">Affected alert rule instances</Trans>
+        <Trans i18nKey="alerting.silences.affected-instances">Affected alert instances</Trans>
         <Tooltip
           content={
             <div>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -533,7 +533,7 @@
       "save-query": "Save current search"
     },
     "silences": {
-      "affected-instances": "Affected alert rule instances",
+      "affected-instances": "Affected alert instances",
       "only-firing-instances": "Only alert instances in the firing state are displayed.",
       "preview-affected-instances": "Preview the alert instances affected by this silence."
     },

--- a/public/locales/pseudo-LOCALE/grafana.json
+++ b/public/locales/pseudo-LOCALE/grafana.json
@@ -533,7 +533,7 @@
       "save-query": "Ŝävę čūřřęŉŧ şęäřčĥ"
     },
     "silences": {
-      "affected-instances": "Åƒƒęčŧęđ äľęřŧ řūľę įŉşŧäŉčęş",
+      "affected-instances": "Åƒƒęčŧęđ äľęřŧ įŉşŧäŉčęş",
       "only-firing-instances": "Øŉľy äľęřŧ įŉşŧäŉčęş įŉ ŧĥę ƒįřįŉģ şŧäŧę äřę đįşpľäyęđ.",
       "preview-affected-instances": "Přęvįęŵ ŧĥę äľęřŧ įŉşŧäŉčęş äƒƒęčŧęđ þy ŧĥįş şįľęŉčę."
     },


### PR DESCRIPTION
Follow up of https://github.com/grafana/grafana/pull/98028/. 

Here was suggested the [proposal](https://github.com/grafana/grafana/pull/98028/#issuecomment-2551095094) of renaming `Affected alert rule instances` -->  `Affected alert instances`.
