### PR TITLE
Alerting docs: clarify data source-managed rules for Prometheus

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
@@ -74,7 +74,7 @@ refs:
 
 # Configure data source-managed alert rules
 
-Data source-managed alert rules can only query Prometheus-based data sources, such as Prometheus, Grafana Mimir, or Grafana Loki. They are one of the two [alert rule types](ref:alert-rules) supported in Grafana.
+Data source-managed alert rules can only be created using Grafana Mimir or Grafana Loki data sources. They are one of the two [alert rule types](ref:alert-rules) supported in Grafana.
 
 Data source-managed alert rules are stored within the data source. In a distributed architecture, they can scale horizontally to provide high-availability.
 
@@ -84,7 +84,7 @@ To create or edit data source-managed alert rules, follow these instructions.
 
 ## Before you begin
 
-Verify that you have write permission to the Prometheus, Mimir, or Loki data source. Otherwise, you cannot create or update data source-managed alert rules.
+Verify that you have write permission to the Mimir or Loki data source. Otherwise, you cannot create or update data source-managed alert rules.
 
 ### Enable the Ruler API
 
@@ -96,7 +96,9 @@ For more information, refer to the [Mimir Ruler API](/docs/mimir/latest/referenc
 
 ### Permissions
 
-Alert rules for Prometheus, Mimir, or Loki instances can be edited or deleted by users with **Editor** or **Admin** roles.
+Alert rules for Mimir or Loki instances can be edited or deleted by users with **Editor** or **Admin** roles.
+
+> Rules from a Prometheus data source are visible in the data source-managed rules list when [Manage alerts via Alerting UI](ref:configure-prometheus-data-source-alerting) is enabled. However, you can only create data source-managed rules for Mimir and Loki from Grafana, not for a Prometheus instance.
 
 If you do not want to manage alert rules for a particular data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 

--- a/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-data-source-managed-rule.md
@@ -20,6 +20,11 @@ labels:
 title: Configure data source-managed alert rules
 weight: 200
 refs:
+  shared-configure-prometheus-data-source-alerting:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure-prometheus-data-source/#alerting
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure-prometheus-data-source/#alerting
   configure-grafana-managed-rules:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/alerting-rules/create-grafana-managed-rule/
@@ -74,11 +79,13 @@ refs:
 
 # Configure data source-managed alert rules
 
-Data source-managed alert rules can only be created using Grafana Mimir or Grafana Loki data sources. They are one of the two [alert rule types](ref:alert-rules) supported in Grafana.
+Data source-managed alert rules can only be created using Grafana Mimir or Grafana Loki data sources.
 
-Data source-managed alert rules are stored within the data source. In a distributed architecture, they can scale horizontally to provide high-availability.
+The rules are stored within the data source. In a distributed architecture, they can scale horizontally to provide high-availability. For more details, refer to [alert rule types](ref:alert-rules).
 
 We recommend using [Grafana-managed alert rules](ref:configure-grafana-managed-rules) whenever possible and opting for data source-managed alert rules when scaling your alerting setup is necessary.
+
+{{< docs/shared lookup="alerts/note-prometheus-ds-rules.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 To create or edit data source-managed alert rules, follow these instructions.
 
@@ -97,8 +104,6 @@ For more information, refer to the [Mimir Ruler API](/docs/mimir/latest/referenc
 ### Permissions
 
 Alert rules for Mimir or Loki instances can be edited or deleted by users with **Editor** or **Admin** roles.
-
-> Rules from a Prometheus data source are visible in the data source-managed rules list when [Manage alerts via Alerting UI](ref:configure-prometheus-data-source-alerting) is enabled. However, you can only create data source-managed rules for Mimir and Loki from Grafana, not for a Prometheus instance.
 
 If you do not want to manage alert rules for a particular data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -18,6 +18,11 @@ labels:
 title: Alert rules
 weight: 100
 refs:
+  configure-prometheus-data-source-alerting:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure-prometheus-data-source/#alerting
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure-prometheus-data-source/#alerting
   queries-and-conditions:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/queries-conditions/
@@ -72,8 +77,9 @@ Grafana-managed alert rules are the most flexible alert rule type. They allow yo
 
 {{< figure src="/media/docs/alerting/grafana-managed-alerting-architecture.png" max-width="750px" caption="How Grafana-managed alerting works by default" >}}
 
-1. Alert rules are created within Grafana and query one or more data sources.
-1. Alert rules are evaluated by the Alert Rule Evaluation Engine from within Grafana.
+1. Alert rules are created and stored within Grafana.
+1. Alert rules can query one or more supported data sources.
+1. Alert rules are evaluated by the Alert Rule Evaluation Engine within Grafana.
 1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
 
 ### Supported data sources
@@ -84,16 +90,16 @@ Find the public data sources supporting Alerting in the [Grafana Plugins directo
 
 ## Data source-managed alert rules
 
-Data source-managed alert rules can only query Prometheus-based data sources, such as Prometheus, Grafana Mimir, or Grafana Loki.
-
-Alert rules are stored within the data source. In this distributed architecture, the separation of components can provide high-availability and fault tolerance, enabling the scaling of your alerting setup.
+Data source-managed alert rules can only be created using Grafana Mimir or Grafana Loki data sources. Both data source backends can provide high availability and fault tolerance, enabling you to scale your alerting setup.
 
 {{< figure src="/media/docs/alerting/mimir-managed-alerting-architecture-v2.png" max-width="750px" caption="Mimir-managed alerting architecture" >}}
 
-1. Alert rules are created and stored within the data source itself.
-1. Alert rules can only query Prometheus-based data.
-1. Alert rules are evaluated by the Alert Rule Evaluation Engine.
+1. Alert rules are stored within the Mimir or Loki data source.
+1. Alert rules can query only their specific data source.
+1. Alert rules are evaluated by the Alert Rule Evaluation Engine within the data source.
 1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
+
+> Rules from a Prometheus data source are visible in the data source-managed rules list when [Manage alerts via Alerting UI](ref:configure-prometheus-data-source-alerting) is enabled. However, you can only create data source-managed rules for Mimir and Loki from Grafana, not for a Prometheus instance.
 
 ## Comparison between alert rule types
 
@@ -103,7 +109,7 @@ The table below compares Grafana-managed and data source-managed alert rules.
 
 | <div style="width:200px">Feature</div>                                                                                  | <div style="width:200px">Grafana-managed alert rule</div>                                                         | <div style="width:200px">Data source-managed alert rule                         |
 | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Create alert rules<wbr /> that query [data sources supporting Alerting](#supported-data-sources)                        | Yes                                                                                                               | No. Only query Prometheus-based data sources.                                   |
+| Create alert rules<wbr /> that query [data sources supporting Alerting](#supported-data-sources)                        | Yes                                                                                                               | No. Only support creating rules for Mimir and Loki.                             |
 | Mix and match data sources                                                                                              | Yes                                                                                                               | No                                                                              |
 | Add [expressions](ref:expression-queries) to transform<wbr /> your data and set [alert conditions](ref:alert-condition) | Yes                                                                                                               | No                                                                              |
 | Use [images in alert notifications](ref:notification-images)                                                            | Yes                                                                                                               | No                                                                              |

--- a/docs/sources/alerting/fundamentals/alert-rules/_index.md
+++ b/docs/sources/alerting/fundamentals/alert-rules/_index.md
@@ -18,7 +18,7 @@ labels:
 title: Alert rules
 weight: 100
 refs:
-  configure-prometheus-data-source-alerting:
+  shared-configure-prometheus-data-source-alerting:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/datasources/prometheus/configure-prometheus-data-source/#alerting
     - pattern: /docs/grafana-cloud/
@@ -99,7 +99,7 @@ Data source-managed alert rules can only be created using Grafana Mimir or Grafa
 1. Alert rules are evaluated by the Alert Rule Evaluation Engine within the data source.
 1. Firing and resolved alert instances are forwarded to [handle their notifications](ref:notifications).
 
-> Rules from a Prometheus data source are visible in the data source-managed rules list when [Manage alerts via Alerting UI](ref:configure-prometheus-data-source-alerting) is enabled. However, you can only create data source-managed rules for Mimir and Loki from Grafana, not for a Prometheus instance.
+{{< docs/shared lookup="alerts/note-prometheus-ds-rules.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
 ## Comparison between alert rule types
 
@@ -109,7 +109,7 @@ The table below compares Grafana-managed and data source-managed alert rules.
 
 | <div style="width:200px">Feature</div>                                                                                  | <div style="width:200px">Grafana-managed alert rule</div>                                                         | <div style="width:200px">Data source-managed alert rule                         |
 | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Create alert rules<wbr /> that query [data sources supporting Alerting](#supported-data-sources)                        | Yes                                                                                                               | No. Only support creating rules for Mimir and Loki.                             |
+| Create alert rules<wbr /> that query [data sources supporting Alerting](#supported-data-sources)                        | Yes                                                                                                               | Only supports creating rules for Mimir and Loki.                                |
 | Mix and match data sources                                                                                              | Yes                                                                                                               | No                                                                              |
 | Add [expressions](ref:expression-queries) to transform<wbr /> your data and set [alert conditions](ref:alert-condition) | Yes                                                                                                               | No                                                                              |
 | Use [images in alert notifications](ref:notification-images)                                                            | Yes                                                                                                               | No                                                                              |

--- a/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
+++ b/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
@@ -31,6 +31,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-data-links/#value-variables
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-data-links/#value-variables
+  alerting-alert-rules:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/alerting/fundamentals/alert-rules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/alerting-and-irm/alerting/fundamentals/alert-rules/
 ---
 
 # Configure Prometheus
@@ -115,7 +120,7 @@ Following are additional configuration options.
 
 ### Alerting
 
-- **Manage alerts via Alerting UI** - Toggle to enable Grafana Alerting integration for this data source. For `Mimir`, it enables managing data source-managed rules and alerts. For `Prometheus`, it only supports viewing existing rules and alerts.
+- **Manage alerts via Alerting UI** - Toggle to enable [data source-managed rules in Grafana Alerting](ref:alerting-alert-rules) for this data source. For `Mimir`, it enables managing data source-managed rules and alerts. For `Prometheus`, it only supports viewing existing rules and alerts, which are displayed as data source-managed.
 
 ### Interval behavior
 

--- a/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
+++ b/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
@@ -115,7 +115,7 @@ Following are additional configuration options.
 
 ### Alerting
 
-- **Manage alerts via Alerting UI** - Toggle to enable `Alertmanager` integration for this data source.
+- **Manage alerts via Alerting UI** - Toggle to enable Grafana Alerting integration for this data source. For `Mimir`, it enables managing data source-managed rules and alerts. For `Prometheus`, it only supports viewing existing rules and alerts.
 
 ### Interval behavior
 

--- a/docs/sources/shared/alerts/note-prometheus-ds-rules.md
+++ b/docs/sources/shared/alerts/note-prometheus-ds-rules.md
@@ -7,4 +7,4 @@ title: 'Note Prometheus data source-managed rules'
 
 > Rules from a Prometheus data source appear in the **Data source-managed** section of the **Alert rules** page when [Manage alerts via Alerting UI](ref:shared-configure-prometheus-data-source-alerting) is enabled.
 >
-> However, Grafana can only create and edit Data source-managed rules for Mimir and Loki, not for a Prometheus instance.
+> However, Grafana can only create and edit data source-managed rules for Mimir and Loki, not for a Prometheus instance.

--- a/docs/sources/shared/alerts/note-prometheus-ds-rules.md
+++ b/docs/sources/shared/alerts/note-prometheus-ds-rules.md
@@ -1,0 +1,10 @@
+---
+labels:
+  products:
+    - oss
+title: 'Note Prometheus data source-managed rules'
+---
+
+> Rules from a Prometheus data source appear in the **Data source-managed** section of the **Alert rules** page when [Manage alerts via Alerting UI](ref:shared-configure-prometheus-data-source-alerting) is enabled.
+>
+> However, Grafana can only create and edit Data source-managed rules for Mimir and Loki, not for a Prometheus instance.


### PR DESCRIPTION
1 - Alerting docs:  Clarified that data source-managed alert rules cannot be created for Prometheus instances.

2 - Data source docs: Added details for the **Manage alerts via Alerting UI** toggle, explaining its functionality for Mimir and Prometheus data sources.


**Preview**
 - [Alerting > Intro > Alert rules > `Data source-managed alert rules`](https://deploy-preview-grafana-98378-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/fundamentals/alert-rules/#data-source-managed-alert-rules)
 - [Alerting > Configure alert rules > Configure data source-managed alert rules](https://deploy-preview-grafana-98378-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/alerting-rules/create-data-source-managed-rule/)      
- [Data sources > Prometheus > Configure Prometheus > `Manage alerts via Alerting UI`](https://deploy-preview-grafana-98378-zb444pucvq-vp.a.run.app/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/#alerting)
   
   
Related UI changes: https://github.com/grafana/grafana/pull/98382