### PR TITLE
Update `docsUrl` in Prometheus DS Settings page

### DIFF
--- a/packages/grafana-prometheus/src/configuration/ConfigEditor.tsx
+++ b/packages/grafana-prometheus/src/configuration/ConfigEditor.tsx
@@ -62,7 +62,7 @@ export const ConfigEditor = (props: PrometheusConfigProps) => {
  * @returns
  */
 export function docsTip(url?: string) {
-  const docsUrl = 'https://grafana.com/docs/grafana/latest/datasources/prometheus/#configure-the-data-source';
+  const docsUrl = 'https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/';
 
   return (
     <a href={url ? url : docsUrl} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
This PR updates the help link (`Visit docs for more details here`) in the Prometheus data source settings page to link to the proper documentation.



![Screenshot 2024-12-27 at 12 31 53](https://github.com/user-attachments/assets/981ffb64-de97-48d0-ac51-bcb1322c3c95)
![Screenshot 2024-12-27 at 12 31 41](https://github.com/user-attachments/assets/778769fc-603e-4382-aed4-3262d198726a)
![Screenshot 2024-12-27 at 12 31 35](https://github.com/user-attachments/assets/81cd2ccf-3b3b-4114-9af0-3580126f250d)

`docTips/docsUrl `  is displayed in the Prometheus data source settings page for AlertSettings, HTTPSettings, ExemplarSettings, and other PrometheusSettings. All these settings are now documented in the [Configure Prometheus documentation](https://grafana.com/docs/grafana/latest/datasources/prometheus/configure-prometheus-data-source/) as part of some previous changes (https://github.com/grafana/grafana/pull/70845). 
