### PR TITLE
Folder/parent subresource

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -73,6 +73,7 @@ func (hs *HTTPServer) registerFolderAPI(apiRoute routing.RouteRegister, authoriz
 				} else {
 					folderUidRoute.Post("/move", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, uidScope)), routing.Wrap(hs.MoveFolder))
 				}
+				folderUidRoute.Get("parents", handler.getFolderParents)
 			})
 		} else {
 			folderRoute.Post("/", authorize(accesscontrol.EvalPermission(dashboards.ActionFoldersCreate)), routing.Wrap(hs.CreateFolder))
@@ -771,6 +772,23 @@ func (fk8s *folderK8sHandler) countFolderContent(c *contextmodel.ReqContext) {
 	}
 
 	out, err := toFolderLegacyCounts(counts)
+	if err != nil {
+		fk8s.writeError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, out)
+}
+
+func (fk8s *folderK8sHandler) getFolderParents(c *contextmodel.ReqContext) {
+	client, ok := fk8s.getClient(c)
+	if !ok {
+		return
+	}
+
+	uid := web.Params(c.Req)[":uid"]
+
+	out, err := client.Get(c.Req.Context(), uid, v1.GetOptions{}, "parents")
 	if err != nil {
 		fk8s.writeError(c, err)
 		return

--- a/pkg/registry/apis/folders/sub_parent_test.go
+++ b/pkg/registry/apis/folders/sub_parent_test.go
@@ -1,0 +1,77 @@
+package folders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/apis/folder/v0alpha1"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSubParent(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *v0alpha1.Folder
+		expected *v0alpha1.FolderInfoList
+		setuFn   func(*mock.Mock)
+	}{
+		{
+			name: "no parents",
+			input: &v0alpha1.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test",
+					Annotations: map[string]string{},
+				},
+				Spec: v0alpha1.Spec{
+					Title: "some tittle",
+				},
+			},
+			expected: &v0alpha1.FolderInfoList{Items: []v0alpha1.FolderInfo{{Name: "test", Title: "some tittle"}}},
+		},
+		{
+			name: "has a parent",
+			input: &v0alpha1.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test",
+					Annotations: map[string]string{"grafana.app/folder": "parent-test"},
+				},
+				Spec: v0alpha1.Spec{
+					Title: "some tittle",
+				},
+			},
+			setuFn: func(m *mock.Mock) {
+				m.On("Get", context.TODO(), "parent-test", &metav1.GetOptions{}).Return(&v0alpha1.Folder{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "parent-test",
+						Annotations: map[string]string{},
+					},
+					Spec: v0alpha1.Spec{
+						Title: "some other tittle",
+					},
+				}, nil).Once()
+			},
+			expected: &v0alpha1.FolderInfoList{Items: []v0alpha1.FolderInfo{
+				{Name: "test", Title: "some tittle", Parent: "parent-test"},
+				{Name: "parent-test", Title: "some other tittle"}},
+			}},
+	}
+	s := (grafanarest.Storage)(nil)
+	m := &mock.Mock{}
+	gm := storageMock{m, s}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &subParentsREST{
+				getter: gm,
+			}
+			if tt.setuFn != nil {
+				tt.setuFn(m)
+			}
+			parents := r.parents(context.TODO(), tt.input)
+			require.Equal(t, tt.expected, parents)
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Exposes `/parents` as a public API endpoint so that FE can use it for dashboard breadcrumbs.

Fixes https://github.com/grafana/grafana-org/issues/349

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
