### PR TITLE
OptionsPicker: Fix matching non-latin template vars in filter

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -9,7 +9,7 @@ import { ALL_VARIABLE_VALUE } from '../../constants';
 import { isMulti, isQuery } from '../../guard';
 
 // https://catonmat.net/my-favorite-regex :)
-const REGEXP_NON_ASCII = /[^ -~]/gm;
+const REGEXP_NON_ASCII = /[^ -~]/m;
 
 export interface ToggleOption {
   option?: VariableOption;


### PR DESCRIPTION
this fixes an issue with matching non-latin template vars, like chinese. described in https://github.com/grafana/grafana/issues/83806#issuecomment-2565438090

the cause was the global flag on the pre-check regexp, which makes `regexp.test(needle)` start from the last matched index that can persist from testing a previous needle entry.

1. import the dashboard below
2. filter for `南`
3. delete filter
4. filter again for same thing

<details><summary>chinese-tpl-vars.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 415,
  "links": [],
  "panels": [
    {
      "datasource": {
        "name": "gdev-testdata",
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 1
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "schemaVersion": 40,
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "selected": true,
          "text": "台灣省",
          "value": "台灣省"
        },
        "description": "",
        "hide": 0,
        "includeAll": false,
        "multi": false,
        "name": "query0",
        "options": [
          {
            "selected": true,
            "text": "台灣省",
            "value": "台灣省"
          },
          {
            "selected": false,
            "text": "台中市",
            "value": "台中市"
          },
          {
            "selected": false,
            "text": "台北市",
            "value": "台北市"
          },
          {
            "selected": false,
            "text": "台南市",
            "value": "台南市"
          },
          {
            "selected": false,
            "text": "南投縣",
            "value": "南投縣"
          },
          {
            "selected": false,
            "text": "高雄市",
            "value": "高雄市"
          },
          {
            "selected": false,
            "text": "台中第一高級中學",
            "value": "台中第一高級中學"
          }
        ],
        "query": "台灣省, 台中市, 台北市, 台南市, 南投縣, 高雄市, 台中第一高級中學",
        "queryValue": "",
        "skipUrlSync": false,
        "type": "custom"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "chinese-tpl-vars",
  "uid": "fe8iqwmpyjw8we",
  "version": 2,
  "weekStart": ""
}
```
</details>