### PR TITLE
Tempo: Improve handling of multiple values in the Search tab query generation

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/SearchField.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { uniq } from 'lodash';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
 import { SelectableValue } from '@grafana/data';
@@ -57,11 +57,6 @@ const SearchField = ({
     () => filterScopedTag(filter, datasource.languageProvider),
     [datasource.languageProvider, filter]
   );
-  // We automatically change the operator to the regex op when users select 2 or more values
-  // However, they expect this to be automatically rolled back to the previous operator once
-  // there's only one value selected, so we store the previous operator and value
-  const [prevOperator, setPrevOperator] = useState(filter.operator);
-  const [prevValue, setPrevValue] = useState(filter.value);
   const [tagQuery, setTagQuery] = useState<string>('');
   const [tagValuesQuery, setTagValuesQuery] = useState<string>('');
 
@@ -93,25 +88,6 @@ const SearchField = ({
   if (filter.value && !Array.isArray(filter.value) && options && !options.find((o) => o.value === filter.value)) {
     options.push({ label: filter.value.toString(), value: filter.value.toString(), type: filter.valueType });
   }
-
-  useEffect(() => {
-    if (
-      Array.isArray(filter.value) &&
-      filter.value.length > 1 &&
-      filter.operator !== '=~' &&
-      filter.operator !== '!~'
-    ) {
-      setPrevOperator(filter.operator);
-      updateFilter({ ...filter, operator: '=~' });
-    }
-    if (Array.isArray(filter.value) && filter.value.length <= 1 && (prevValue?.length || 0) > 1) {
-      updateFilter({ ...filter, operator: prevOperator, value: filter.value[0] });
-    }
-  }, [prevValue, prevOperator, updateFilter, filter]);
-
-  useEffect(() => {
-    setPrevValue(filter.value);
-  }, [filter.value]);
 
   const scopeOptions = Object.values(TraceqlSearchScope)
     .filter((s) => {

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TagsInput.test.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TagsInput.test.tsx
@@ -126,7 +126,7 @@ describe('TagsInput', () => {
         setError={() => {}}
         staticTags={[]}
         isTagsLoading={false}
-        query={''}
+        generateQueryWithoutFilter={() => ''}
         addVariablesToOptions={true}
       />
     );

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TagsInput.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TagsInput.tsx
@@ -32,6 +32,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 interface Props {
   updateFilter: (f: TraceqlFilter) => void;
   deleteFilter: (f: TraceqlFilter) => void;
+  generateQueryWithoutFilter: (f?: TraceqlFilter) => string;
   filters: TraceqlFilter[];
   datasource: TempoDatasource;
   setError: (error: FetchError | null) => void;
@@ -39,7 +40,6 @@ interface Props {
   isTagsLoading: boolean;
   hideValues?: boolean;
   requireTagAndValue?: boolean;
-  query: string;
   addVariablesToOptions?: boolean;
 }
 const TagsInput = ({
@@ -52,7 +52,7 @@ const TagsInput = ({
   isTagsLoading,
   hideValues,
   requireTagAndValue,
-  query,
+  generateQueryWithoutFilter,
   addVariablesToOptions,
 }: Props) => {
   const styles = useStyles2(getStyles);
@@ -89,7 +89,7 @@ const TagsInput = ({
             tags={getTags(f)}
             isTagsLoading={isTagsLoading}
             hideValue={hideValues}
-            query={query}
+            query={generateQueryWithoutFilter(f)}
             addVariablesToOptions={addVariablesToOptions}
           />
           {(validInput(f) || filters.length > 1) && (

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/TraceQLSearch.tsx
@@ -113,6 +113,19 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app, addVa
       f.id !== 'duration-type'
   );
 
+  // We use this function to generate queries without a specfic filter.
+  // This is useful because we're sending the query to Tempo so it can return the attributes and values filtered down.
+  // However, if we send the full query then we won't see more values for the filter we're trying to edit.
+  // For example, if we already have a service.name value selected and try to add another one, we won't see the other
+  // values if we send the full query since Tempo will only return the service.name that's already selected.
+  const generateQueryWithoutFilter = (filter?: TraceqlFilter) => {
+    if (!filter) {
+      return traceQlQuery;
+    }
+    const filtersAfterRemoval = query.filters?.filter((f) => f.id !== filter.id) || [];
+    return datasource.languageProvider.generateQueryFromFilters(interpolateFilters(filtersAfterRemoval || []));
+  };
+
   return (
     <>
       <div className={styles.container}>
@@ -136,7 +149,7 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app, addVa
                     tags={[]}
                     hideScope={true}
                     hideTag={true}
-                    query={traceQlQuery}
+                    query={generateQueryWithoutFilter(findFilter(f.id))}
                     addVariablesToOptions={addVariablesToOptions}
                   />
                 </InlineSearchField>
@@ -158,7 +171,7 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app, addVa
               tags={[]}
               hideScope={true}
               hideTag={true}
-              query={traceQlQuery}
+              query={generateQueryWithoutFilter(findFilter('status'))}
               isMulti={false}
               allowCustomValue={false}
               addVariablesToOptions={addVariablesToOptions}
@@ -219,7 +232,7 @@ const TraceQLSearch = ({ datasource, query, onChange, onClearResults, app, addVa
               deleteFilter={deleteFilter}
               staticTags={staticTags}
               isTagsLoading={isTagsLoading}
-              query={traceQlQuery}
+              generateQueryWithoutFilter={generateQueryWithoutFilter}
               requireTagAndValue={true}
               addVariablesToOptions={addVariablesToOptions}
             />

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -72,6 +72,14 @@ export const tagHelper = (f: TraceqlFilter, filters: TraceqlFilter[]) => {
   return f.tag;
 };
 
+export const filterToQuerySection = (f: TraceqlFilter, filters: TraceqlFilter[], lp: TempoLanguageProvider) => {
+  if (Array.isArray(f.value) && f.value.length > 1 && !isRegExpOperator(f.operator!)) {
+    return `(${f.value.map((v) => `${scopeHelper(f, lp)}${tagHelper(f, filters)}${f.operator}${valueHelper({ ...f, value: v })}`).join(' || ')})`;
+  }
+
+  return `${scopeHelper(f, lp)}${tagHelper(f, filters)}${f.operator}${valueHelper(f)}`;
+};
+
 export const generateQueryFromAdHocFilters = (filters: AdHocVariableFilter[], lp: TempoLanguageProvider) => {
   return `{${filters
     .filter((f) => f.key && f.operator && f.value)

--- a/public/app/plugins/datasource/tempo/configuration/TraceQLSearchTags.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/TraceQLSearchTags.tsx
@@ -91,7 +91,7 @@ export function TraceQLSearchTags({ options, onOptionsChange, datasource }: Prop
           staticTags={staticTags}
           isTagsLoading={loading}
           hideValues={true}
-          query={'{}'}
+          generateQueryWithoutFilter={() => '{}'}
         />
       ) : (
         <div>Invalid data source, please create a valid data source and try again</div>

--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -3,13 +3,11 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { VariableFormatID } from '@grafana/schema';
 
 import {
+  filterToQuerySection,
   getAllTags,
   getIntrinsicTags,
   getTagsByScope,
   getUnscopedTags,
-  scopeHelper,
-  tagHelper,
-  valueHelper,
 } from './SearchTraceQLEditor/utils';
 import { TraceqlFilter, TraceqlSearchScope } from './dataquery.gen';
 import { TempoDatasource } from './datasource';
@@ -188,7 +186,7 @@ export default class TempoLanguageProvider extends LanguageProvider {
 
     return `{${filters
       .filter((f) => f.tag && f.operator && f.value?.length)
-      .map((f) => `${scopeHelper(f, this)}${tagHelper(f, filters)}${f.operator}${valueHelper(f)}`)
+      .map((f) => filterToQuerySection(f, filters, this))
       .join(' && ')}}`;
   }
 }


### PR DESCRIPTION
**What is this feature?**

This PR includes two fixes on the Search tab of the Tempo datasource.
1. Fixes #67082 by improving how the queries are generated when multiple values are selected for an attribute.
  a) When the operator is a regex operator the behavior remains the same, where the query is generated as `{ ... && foo=~"bar|baz"}`
  b) When the operator is **not** a regex operator the multiple values will result in a query like `{ ... && (foo = "bar" || foo = "baz")}`
  c) Removed the previous behavior where the operator would automatically be switched to `=~` if multiple values were selected.
2. Fixes showing the options for the attribute values when a value for that attribute is already selected. The tag values API from Tempo supports an optional query attribute where we can send a query and Tempo filters down the values that match the query. As a side-effect of Grafana implementing this feature, once the user selected a value from the dropdown we would send the query with that attribute and value pair and Tempo would (accurately) return no more options for that attribute, so it would be impossible to search for two service names, for example. The solution was to generate a separate query for each field, removing the filters for the field's attribute.

![image](https://github.com/user-attachments/assets/d9e17af8-3c95-4219-96ca-16c51800cc71)


**Why do we need this feature?**

Fixes two unwanted behaviours of the Search tab of the Tempo datasource. 

**Who is this feature for?**

Users of the Tempo datasource, Explore page, Search tab. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #67082 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
