### PR TITLE
Datasources: Add toggle to control default behaviour of 'Manage alerts via Alerts UI' toggle

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -462,6 +462,9 @@ datasource_limit = 5000
 # Check datasource documentations for enabling concurrency.
 concurrent_query_count = 10
 
+# Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource.
+# Only works in case there's no configured value beforehand controlled by the datasources' `jsonData.manageAlerts` prop.
+default_manage_alerts_ui_toggle = true
 
 ################################### SQL Data Sources #####################
 [sql_datasources]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -462,8 +462,8 @@ datasource_limit = 5000
 # Check datasource documentations for enabling concurrency.
 concurrent_query_count = 10
 
-# Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource.
-# Only works in case there's no configured value beforehand controlled by the datasources' `jsonData.manageAlerts` prop.
+# Default behavior for the "Manage alerts via Alerting UI" toggle when configuring a data source.
+# It only works if the data source's `jsonData.manageAlerts` prop does not contain a previously configured value.
 default_manage_alerts_ui_toggle = true
 
 ################################### SQL Data Sources #####################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -466,6 +466,10 @@
 # Check datasource documentations for enabling concurrency.
 ;concurrent_query_count = 10
 
+# Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource.
+# Only works in case there's no configured value beforehand controlled by the datasources' `jsonData.manageAlerts` prop.
+;default_manage_alerts_ui_toggle = true
+
 ################################### SQL Data Sources #####################
 [sql_datasources]
 # Default maximum number of open connections maintained in the connection pool

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -466,8 +466,8 @@
 # Check datasource documentations for enabling concurrency.
 ;concurrent_query_count = 10
 
-# Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource.
-# Only works in case there's no configured value beforehand controlled by the datasources' `jsonData.manageAlerts` prop.
+# Default behavior for the "Manage alerts via Alerting UI" toggle when configuring a data source.
+# It only works if the data source's `jsonData.manageAlerts` prop does not contain a previously configured value.
 ;default_manage_alerts_ui_toggle = true
 
 ################################### SQL Data Sources #####################

--- a/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
+++ b/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
@@ -117,6 +117,12 @@ Following are additional configuration options.
 
 - **Manage alerts via Alerting UI** - Toggle to enable `Alertmanager` integration for this data source.
 
+{{% admonition type="note" %}}
+
+The `Manage alerts via Alerting UI` toggle will be enabled by default. You can change this behavior by setting the [default_manage_alerts_ui_toggle]({{< relref "../../setup-grafana/configure-grafana/#default_manage_alerts_ui_toggle" >}}) option in the Grafana configuration file.
+
+{{% /admonition %}}
+
 ### Interval behavior
 
 - **Scrape interval** - Set this to the typical scrape and evaluation interval configured in Prometheus. The default is `15s`.

--- a/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
+++ b/docs/sources/datasources/prometheus/configure-prometheus-data-source.md
@@ -119,13 +119,13 @@ Following are additional configuration options.
 
 {{% admonition type="note" %}}
 
-The `Manage alerts via Alerting UI` toggle will be enabled by default. You can change this behavior by setting the [default_manage_alerts_ui_toggle]({{< relref "../../setup-grafana/configure-grafana/#default_manage_alerts_ui_toggle" >}}) option in the Grafana configuration file.
+The **Manage alerts via Alerting UI** toggle is enabled by default. You can change this behavior by setting the [default_manage_alerts_ui_toggle]({{< relref "../../setup-grafana/configure-grafana/#default_manage_alerts_ui_toggle" >}}) option in the Grafana configuration file.
 
 {{% /admonition %}}
 
 ### Interval behavior
 
-- **Scrape interval** - Set this to the typical scrape and evaluation interval configured in Prometheus. The default is `15s`.
+- **Scrape interval** - Set to the typical scrape and evaluation interval configured in Prometheus. The default is `15s`.
 
 - **Query timeout** - The default is `60s`.
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -786,7 +786,7 @@ On Linux, Grafana uses `/usr/share/grafana/public/dashboards/home.json` as the d
 
 ### default_manage_alerts_ui_toggle
 
-Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource. Only works in case there's no configured value beforehand controlled by the datasources' `jsonData.manageAlerts` prop.
+Default behavior for the "Manage alerts via Alerting UI" toggle when configuring a data source. It only works if the data source's `jsonData.manageAlerts` prop does not contain a previously configured value.
 
 ## [sql_datasources]
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -782,6 +782,12 @@ On Linux, Grafana uses `/usr/share/grafana/public/dashboards/home.json` as the d
 
 <hr />
 
+## [datasources]
+
+### default_manage_alerts_ui_toggle
+
+Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource. Only works in case there's no configured value beforehand controlled by the datasources' `jsonData.manageAlerts` prop.
+
 ## [sql_datasources]
 
 ### max_open_conns_default

--- a/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.test.tsx
+++ b/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+
+import { config } from '@grafana/runtime';
+
+import { createDefaultConfigOptions } from '../test/__mocks__/datasource';
+
+import { AlertingSettingsOverhaul } from './AlertingSettingsOverhaul';
+
+describe(AlertingSettingsOverhaul.name, () => {
+  describe('Switch checked behavior', () => {
+    describe('when options.jsonData.manageAlerts is unset', () => {
+      it('uses the config default `true`', () => {
+        const options = createDefaultConfigOptions();
+        options.jsonData.manageAlerts = undefined;
+
+        config.defaultDatasourceManageAlertsUiToggle = true;
+
+        const { getByRole } = render(<AlertingSettingsOverhaul onOptionsChange={() => {}} options={options} />);
+
+        expect(getByRole('switch')).toBeChecked();
+      });
+
+      it('uses the config default `false`', () => {
+        const options = createDefaultConfigOptions();
+        options.jsonData.manageAlerts = undefined;
+
+        config.defaultDatasourceManageAlertsUiToggle = false;
+
+        const { getByRole } = render(<AlertingSettingsOverhaul onOptionsChange={() => {}} options={options} />);
+
+        expect(getByRole('switch')).not.toBeChecked();
+      });
+    });
+
+    describe('when options.jsonData.manageAlerts is set', () => {
+      it.each([true, false])('uses the manageAlerts value even when the config default is %s', (configDefault) => {
+        const options = createDefaultConfigOptions();
+        options.jsonData.manageAlerts = true;
+
+        config.defaultDatasourceManageAlertsUiToggle = configDefault;
+
+        const { getByRole } = render(<AlertingSettingsOverhaul onOptionsChange={() => {}} options={options} />);
+
+        expect(getByRole('switch')).toBeChecked();
+      });
+    });
+  });
+});

--- a/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
+++ b/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
@@ -4,6 +4,7 @@ import { cx } from '@emotion/css';
 import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { ConfigSubSection } from '@grafana/experimental';
+import { config } from '@grafana/runtime';
 import { InlineField, Switch, useTheme2 } from '@grafana/ui';
 
 import { docsTip, overhaulStyles } from './ConfigEditor';
@@ -43,7 +44,7 @@ export function AlertingSettingsOverhaul<T extends AlertingConfig>({
               className={styles.switchField}
             >
               <Switch
-                value={options.jsonData.manageAlerts !== false}
+                value={options.jsonData.manageAlerts ?? config.defaultDatasourceManageAlertsUiToggle}
                 onChange={(event) =>
                   onOptionsChange({
                     ...options,

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -188,6 +188,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     maxIdleConns: 100,
     connMaxLifetime: 14400,
   };
+  defaultDatasourceManageAlertsUiToggle = true;
 
   tokenExpirationDayLimit: undefined;
   enableFrontendSandboxForPlugins: string[] = [];

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -242,6 +242,8 @@ type FrontendSettingsDTO struct {
 
 	Azure FrontendSettingsAzureDTO `json:"azure"`
 
+	DefaultDatasourceManageAlertsUIToggle bool `json:"defaultDatasourceManageAlertsUiToggle"`
+
 	Caching                 FrontendSettingsCachingDTO         `json:"caching"`
 	RecordedQueries         FrontendSettingsRecordedQueriesDTO `json:"recordedQueries"`
 	Reporting               FrontendSettingsReportingDTO       `json:"reporting"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -244,6 +244,8 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		ReportingStaticContext:              hs.Cfg.ReportingStaticContext,
 		ExploreDefaultTimeOffset:            hs.Cfg.ExploreDefaultTimeOffset,
 
+		DefaultDatasourceManageAlertsUIToggle: hs.Cfg.DefaultDatasourceManageAlertsUIToggle,
+
 		BuildInfo: dtos.FrontendSettingsBuildInfoDTO{
 			HideVersion:   hideVersion,
 			Version:       version,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -330,8 +330,8 @@ type Cfg struct {
 	DataSourceLimit int
 	// Number of queries to be executed concurrently. Only for the datasource supports concurrency.
 	ConcurrentQueryCount int
-	// Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource.
-	// Only works in case there's no configured value beforehand controlled by the DS's `jsonData.manageAlerts` prop.
+	// Default behavior for the "Manage alerts via Alerting UI" toggle when configuring a data source.
+	// It only works if the data source's `jsonData.manageAlerts` prop does not contain a previously configured value.
 	DefaultDatasourceManageAlertsUIToggle bool
 
 	// IP range access control

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -330,6 +330,9 @@ type Cfg struct {
 	DataSourceLimit int
 	// Number of queries to be executed concurrently. Only for the datasource supports concurrency.
 	ConcurrentQueryCount int
+	// Default behaviour for the "Manage alerts via Alerting UI" toggle when configuring a Datasource.
+	// Only works in case there's no configured value beforehand controlled by the DS's `jsonData.manageAlerts` prop.
+	DefaultDatasourceManageAlertsUIToggle bool
 
 	// IP range access control
 	IPRangeACEnabled     bool
@@ -1912,6 +1915,7 @@ func (cfg *Cfg) readDataSourcesSettings() {
 	datasources := cfg.Raw.Section("datasources")
 	cfg.DataSourceLimit = datasources.Key("datasource_limit").MustInt(5000)
 	cfg.ConcurrentQueryCount = datasources.Key("concurrent_query_count").MustInt(10)
+	cfg.DefaultDatasourceManageAlertsUIToggle = datasources.Key("default_manage_alerts_ui_toggle").MustBool(true)
 }
 
 func (cfg *Cfg) readDataSourceSecuritySettings() {


### PR DESCRIPTION
**What is this feature?**

This adds an option to control the default behavior of the "Manage alerts via Alerting UI" toggle on Prometheus data sources, which currently defaults to `true`.

<img width="655" alt="opts" src="https://github.com/user-attachments/assets/e4883ba8-3c7d-4a55-a34a-7a855966c58e" />

**Why do we need this feature?**

To be able to leave this disabled by default, requested by partners.

**Who is this feature for?**

Request by partners.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1137

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
