### PR TITLE
Schema v2 queries transformation: Respect panel defined data source

### DIFF
--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,5 +1,5 @@
 import { config } from '@grafana/runtime';
-import { AnnotationQuery, DataQuery, Panel, VariableModel } from '@grafana/schema';
+import { AnnotationQuery, DataQuery, DataSourceRef, Panel, VariableModel } from '@grafana/schema';
 import {
   AnnotationQueryKind,
   DashboardV2Spec,
@@ -223,7 +223,7 @@ function getElementsFromPanels(panels: Panel[]): [DashboardV2Spec['elements'], D
   for (const p of panels) {
     const queries = getPanelQueries(
       (p.targets as unknown as DataQuery[]) || [],
-      p.datasource?.type || getDefaultDatasourceType()
+      p.datasource || getDefaultDatasource()
     );
 
     const transformations = getPanelTransformations(p.transformations || []);
@@ -291,7 +291,19 @@ function getDefaultDatasourceType() {
   return Object.values(datasources).find((ds) => ds.isDefault)!.type;
 }
 
-function getPanelQueries(targets: DataQuery[], panelDatasourceType: string): PanelQueryKind[] {
+function getDefaultDatasource(): DataSourceRef {
+  const datasources = config.datasources;
+
+  // find default datasource in datasources
+  const defaultDs = Object.values(datasources).find((ds) => ds.isDefault)!;
+  return {
+    apiVersion: defaultDs.apiVersion,
+    type: defaultDs.type,
+    uid: defaultDs.uid,
+  };
+}
+
+export function getPanelQueries(targets: DataQuery[], panelDatasource: DataSourceRef): PanelQueryKind[] {
   return targets.map((t) => {
     const { refId, hide, datasource, ...query } = t;
     const q: PanelQueryKind = {
@@ -299,10 +311,9 @@ function getPanelQueries(targets: DataQuery[], panelDatasourceType: string): Pan
       spec: {
         refId: t.refId,
         hidden: t.hide ?? false,
-        // TODO[schema v2]: ds coming from panel ?!?!!?! AAAAAAAAAAAAA! Send help!
-        datasource: t.datasource ? t.datasource : undefined,
+        datasource: t.datasource ? t.datasource : panelDatasource,
         query: {
-          kind: t.datasource?.type || panelDatasourceType,
+          kind: t.datasource?.type || panelDatasource.type!,
           spec: {
             ...query,
           },


### PR DESCRIPTION
This correctly transforms panel targets respecting the data source that was defined on the panel level (rather than target level).