### PR TITLE
Chore: Use github app for dependabot go workspace workflow

### DIFF
--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -19,16 +19,39 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     continue-on-error: true
     steps:
+    - name: Retrieve GitHub App secrets
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
+      with:
+        repo_secrets: |
+          APP_ID=grafana-go-workspace-bot:app-id
+          APP_INSTALLATION_ID=grafana-go-workspace-bot:app-installation-id
+          PRIVATE_KEY=grafana-go-workspace-bot:private-key
+
+    - name: Generate GitHub App token
+      id: generate_token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ env.APP_ID }}
+        private-key: ${{ env.PRIVATE_KEY }}
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ steps.generate_token.outputs.token }}
 
     - name: Set go version
       uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+
+    - name: Configure Git
+      run: |
+          git config --local user.email "${APP_INSTALLATION_ID}+grafana-go-workspace-bot[bot]@users.noreply.github.com"
+          git config --local user.name "grafana-go-workspace-bot[bot]"
+          git config --local --add --bool push.autoSetupRemote true
 
     - name: Update workspace
       run: make update-workspace
@@ -38,9 +61,6 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
       run: |
         if ! git diff --exit-code --quiet; then
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git config --local --add --bool push.autoSetupRemote true
           echo "Committing and pushing workspace changes"
           git commit -a -m "update workspace"
           git push origin $BRANCH_NAME


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This switches to GitHub app based auth for the dependabot go workspace update GitHub action.

**Why do we need this feature?**

This allows other GitHub actions to run after the go workspace update action pushes a commit. GitHub does not allow this with the default auth workflow.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
