### PR TITLE
XYChart: Fix series names in legend and tooltip when y field is renamed

### DIFF
--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -124,7 +124,34 @@ export function prepSeries(
           // if we match non-excluded y, create series
           if (yMatcher(field, frame, frames) && !field.config.custom?.hideFrom?.viz) {
             let y = field;
-            let name = seriesCfg.name?.fixed ?? getFieldDisplayName(y, frame, frames);
+
+            let name = seriesCfg.name?.fixed;
+
+            if (name == null) {
+              // if the field was explictly (re)named using config.displayName or config.displayNameFromDS
+              // we still want to retain any frame name prefix or suffix so that autoNameSeries() can
+              // properly detect + strip common parts across all series...
+              const { displayName, displayNameFromDS } = y.config;
+
+              if (displayName != null || displayNameFromDS != null) {
+                // ...and a hacky way to do this is to temp remove the explicit name, get the auto name, then revert
+                const stateDisplayName = y.state!.displayName;
+
+                // clear config and cache
+                y.config.displayName = y.config.displayNameFromDS = y.state!.displayName = undefined;
+                // get default/calculated display name (maybe use calculateFieldDisplayName() here instead?)
+                name = getFieldDisplayName(y, frame, frames);
+                // replace original field name with explicit one
+                name = name.replace(y.name, (displayNameFromDS ?? displayName)!);
+
+                // revert
+                y.config.displayName = displayName;
+                y.config.displayNameFromDS = displayNameFromDS;
+                y.state!.displayName = stateDisplayName;
+              } else {
+                name = getFieldDisplayName(y, frame, frames);
+              }
+            }
 
             let ser: XYSeries = {
               // these typically come from y field

--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -128,12 +128,17 @@ export function prepSeries(
             let name = seriesCfg.name?.fixed;
 
             if (name == null) {
+              // if the displayed field name is likely to have a common prefix or suffix
+              // (such as those from Partition by values transformation)
+              const likelyHasCommonParts = frame.name != null || Object.keys(y.labels ?? {}).length > 0;
+
               // if the field was explictly (re)named using config.displayName or config.displayNameFromDS
               // we still want to retain any frame name prefix or suffix so that autoNameSeries() can
               // properly detect + strip common parts across all series...
               const { displayName, displayNameFromDS } = y.config;
+              const hasExplicitName = displayName != null || displayNameFromDS != null;
 
-              if (displayName != null || displayNameFromDS != null) {
+              if (likelyHasCommonParts && hasExplicitName) {
                 // ...and a hacky way to do this is to temp remove the explicit name, get the auto name, then revert
                 const stateDisplayName = y.state!.displayName;
 

--- a/public/app/plugins/panel/xychart/utils.ts
+++ b/public/app/plugins/panel/xychart/utils.ts
@@ -130,7 +130,8 @@ export function prepSeries(
             if (name == null) {
               // if the displayed field name is likely to have a common prefix or suffix
               // (such as those from Partition by values transformation)
-              const likelyHasCommonParts = frame.name != null || Object.keys(y.labels ?? {}).length > 0;
+              const likelyHasCommonParts =
+                frames.length > 1 && (frame.name != null || Object.keys(y.labels ?? {}).length > 0);
 
               // if the field was explictly (re)named using config.displayName or config.displayNameFromDS
               // we still want to retain any frame name prefix or suffix so that autoNameSeries() can


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/98468

[debug-mimir-dedicated-42 store-gateway CPU usage vs node CPU utilization-2025-01-03 01_13_38.json.txt](https://github.com/user-attachments/files/18295733/debug-mimir-dedicated-42.store-gateway.CPU.usage.vs.node.CPU.utilization-2025-01-03.01_13_38.json.txt)

before:

![image](https://github.com/user-attachments/assets/a4e89fe1-e0f8-40fb-a935-0d4b12b329db)

after:

![Screenshot_20250102_211923](https://github.com/user-attachments/assets/b2079ff1-6a08-4249-96c3-9ab2dca78233)
