### PR TITLE
SecureValues: validate existence of `keeper` on creation/update

### DIFF
--- a/pkg/tests/apis/secret/testdata/keeper-gcp-my-keeper-1.yaml
+++ b/pkg/tests/apis/secret/testdata/keeper-gcp-my-keeper-1.yaml
@@ -1,0 +1,15 @@
+apiVersion: secret.grafana.app/v0alpha1
+kind: Keeper
+metadata:
+  name: my-keeper-1
+  annotations:
+    xx: XXX
+    yy: YYY
+  labels:
+    aa: AAA
+    bb: BBB
+spec:
+  title: GCP XYZ value
+  gcp:
+    projectId: project-id 
+    credentialsFile: /path/to/file.json


### PR DESCRIPTION
At the DB layer, execute a query on the `keeper` table to check whether there's a `keeper` with the `name` specified in the `securevalue` spec before inserting/updating the `securevalue` row into the DB, since we don't use foreign keys.
  
This would be used together with `keeper` deletion, where we can delete all `securevalues` that use the deleted `keeper`, fail deletion or something else.