### PR TITLE
DashboardV2: Add support for revision and gnetId in schema and response transformers

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -37,10 +37,10 @@ export interface DashboardV2Spec {
 	layout: GridLayoutKind;
 	// Version of the JSON schema, incremented each time a Grafana update brings
 	// changes to said schema.
-	// version: will rely on k8s resource versioning, via metadata.resorceVersion
-	// revision?: int // for plugins only
-	// gnetId?: string // ??? Wat is this used for?
 	schemaVersion: number;
+	// Plugins only. The version of the dashboard installed together with the plugin.
+	// This is used to determine if the dashboard should be updated when the plugin is updated.
+	revision?: number;
 }
 
 export const defaultDashboardV2Spec = (): DashboardV2Spec => ({
@@ -486,11 +486,11 @@ export interface AnnotationQuerySpec {
 }
 
 export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
-	builtIn: false,
 	enable: false,
 	hide: false,
 	iconColor: "",
 	name: "",
+	builtIn: false,
 });
 
 export interface AnnotationQueryKind {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -53,10 +53,9 @@ DashboardV2Spec: {
   // changes to said schema.
   schemaVersion: uint16 | *39
 
-
-  // version: will rely on k8s resource versioning, via metadata.resorceVersion
-  // revision?: int // for plugins only
-  // gnetId?: string // ??? Wat is this used for?
+  // Plugins only. The version of the dashboard installed together with the plugin.
+  // This is used to determine if the dashboard should be updated when the plugin is updated.
+  revision?: uint16
 }
 
 

--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -50,6 +50,7 @@ export const AnnoKeySavedFromUI = 'grafana.app/saved-from-ui';
 export const AnnoKeyDashboardNotFound = 'grafana.app/dashboard-not-found';
 export const AnnoKeyDashboardIsSnapshot = 'grafana.app/dashboard-is-snapshot';
 export const AnnoKeyDashboardIsNew = 'grafana.app/dashboard-is-new';
+export const AnnoKeyDashboardGnetId = 'grafana.app/dashboard-gnet-id';
 
 // Annotations provided by the API
 type GrafanaAnnotations = {
@@ -77,6 +78,10 @@ type GrafanaClientAnnotations = {
   [AnnoKeyDashboardNotFound]?: boolean;
   [AnnoKeyDashboardIsSnapshot]?: boolean;
   [AnnoKeyDashboardIsNew]?: boolean;
+
+  // TODO: This should be provided by the API
+  // This is the dashboard ID for the Gcom API. This set when a dashboard is created through importing a dashboard from Grafana.com.
+  [AnnoKeyDashboardGnetId]?: string;
 };
 
 export interface Resource<T = object, K = string> extends TypeMeta<K> {

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -2,6 +2,7 @@ import { DataQuery } from '@grafana/schema';
 import { DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha0/dashboard.gen';
 import {
   AnnoKeyCreatedBy,
+  AnnoKeyDashboardGnetId,
   AnnoKeyDashboardId,
   AnnoKeyFolder,
   AnnoKeySlug,
@@ -39,6 +40,8 @@ describe('ResponseTransformers', () => {
         fiscalYearStartMonth: 1,
         weekStart: 'monday',
         version: 1,
+        gnetId: 'something-like-a-uid',
+        revision: 225,
         links: [
           {
             title: 'Link 1',
@@ -101,6 +104,7 @@ describe('ResponseTransformers', () => {
       expect(transformed.metadata.annotations?.[AnnoKeyFolder]).toEqual('folder1');
       expect(transformed.metadata.annotations?.[AnnoKeySlug]).toEqual('dashboard-slug');
       expect(transformed.metadata.annotations?.[AnnoKeyDashboardId]).toBe(123);
+      expect(transformed.metadata.annotations?.[AnnoKeyDashboardGnetId]).toBe('something-like-a-uid');
 
       const spec = transformed.spec;
       expect(spec.title).toBe(dashboardV1.title);
@@ -111,6 +115,7 @@ describe('ResponseTransformers', () => {
       expect(spec.preload).toBe(dashboardV1.preload);
       expect(spec.liveNow).toBe(dashboardV1.liveNow);
       expect(spec.editable).toBe(dashboardV1.editable);
+      expect(spec.revision).toBe(dashboardV1.revision);
       expect(spec.timeSettings.from).toBe(dashboardV1.time?.from);
       expect(spec.timeSettings.to).toBe(dashboardV1.time?.to);
       expect(spec.timeSettings.timezone).toBe(dashboardV1.timezone);
@@ -155,6 +160,7 @@ describe('ResponseTransformers', () => {
             'grafana.app/updatedTimestamp': '2023-01-02T00:00:00Z',
             'grafana.app/folder': 'folder1',
             'grafana.app/slug': 'dashboard-slug',
+            'grafana.app/dashboard-gnet-id': 'something-like-a-uid',
           },
         },
         spec: {
@@ -166,6 +172,7 @@ describe('ResponseTransformers', () => {
           preload: true,
           liveNow: false,
           editable: true,
+          revision: 225,
           timeSettings: {
             from: 'now-6h',
             to: 'now',
@@ -245,6 +252,8 @@ describe('ResponseTransformers', () => {
       expect(dashboard.preload).toBe(dashboardV2.spec.preload);
       expect(dashboard.liveNow).toBe(dashboardV2.spec.liveNow);
       expect(dashboard.editable).toBe(dashboardV2.spec.editable);
+      expect(dashboard.revision).toBe(225);
+      expect(dashboard.gnetId).toBe(dashboardV2.metadata.annotations?.['grafana.app/dashboard-gnet-id']);
       expect(dashboard.time?.from).toBe(dashboardV2.spec.timeSettings.from);
       expect(dashboard.time?.to).toBe(dashboardV2.spec.timeSettings.to);
       expect(dashboard.timezone).toBe(dashboardV2.spec.timeSettings.timezone);

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -15,6 +15,7 @@ import {
 import { DataTransformerConfig } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
 import {
   AnnoKeyCreatedBy,
+  AnnoKeyDashboardGnetId,
   AnnoKeyDashboardId,
   AnnoKeyFolder,
   AnnoKeySlug,
@@ -75,6 +76,7 @@ export function ensureV2Response(
     preload: dashboard.preload || dashboardDefaults.preload,
     liveNow: dashboard.liveNow,
     editable: dashboard.editable,
+    revision: dashboard.revision,
     timeSettings: {
       from: dashboard.time?.from || timeSettingsDefaults.from,
       to: dashboard.time?.to || timeSettingsDefaults.to,
@@ -108,6 +110,7 @@ export function ensureV2Response(
         [AnnoKeyFolder]: accessAndMeta.folderUid,
         [AnnoKeySlug]: accessAndMeta.slug,
         [AnnoKeyDashboardId]: dashboard.id ?? undefined,
+        [AnnoKeyDashboardGnetId]: dashboard.gnetId ?? undefined,
       },
     },
     spec,
@@ -176,6 +179,8 @@ export function ensureV1Response(
         preload: spec.preload,
         liveNow: spec.liveNow,
         editable: spec.editable,
+        gnetId: dashboard.metadata.annotations?.[AnnoKeyDashboardGnetId],
+        revision: spec.revision,
         time: {
           from: spec.timeSettings.from,
           to: spec.timeSettings.to,


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests for your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder at the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant to the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It adds support for two features for Dashboards in Schema v2:

1. `revision`: This is used when a dashboard is imported from a DS plugin. When the DS is added, there is a tab to import different opinionated dashboards. They have a version wthatis `revision` and it should be increased when the dashboard is updated to indicate there is a new version. So, when the user updates the plugin, the new version is detected and the button apappearso be updated. The revision is also used in GCOM dashboards, see an example [here](https://grafana.com/grafana/dashboards/11340-rabbitmq-quorum-queues-raft/).
<img width="1608" alt="Captura de pantalla 2025-01-03 a las 12 42 55" src="https://github.com/user-attachments/assets/7d805d71-c4de-4808-a724-2ce9de0d199a" />

3. `gnetId` identifies the ID of the dashboard in the GCOM API. Dashboards can be imported from [grafana.com/dashboards](https://grafana.com/grafana/dashboards/) and identified with an ID. This is the ID, which is only set when the dashboard is imported.

**Why do we need this feature?**

To achieve schema V2 completeness and be able to support all the features we have nowadays running in production


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #98452 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
