### PR TITLE
Prometheus datasource: Update info annotations without missing severity level

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -181,6 +181,7 @@ describe('frame results with warnings', () => {
   const metaInfo = {
     notices: [
       {
+        severity: 'info',
         text: 'For your info, something is up.',
       },
     ],
@@ -192,6 +193,7 @@ describe('frame results with warnings', () => {
         text: 'Reduce operation is not needed. Input query or expression A is already reduced data.',
       },
       {
+        severity: 'info',
         text: 'For your info, something is up.',
       },
     ],

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -398,17 +398,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         return acc;
       }
 
-      let criterion;
-      if (type === 'warning') {
-        criterion = (item: QueryResultMetaNotice) => item.severity === 'warning';
-      } else {
-        // The first condition is because sometimes info notices are not marked as info.
-        // We don't filter on severity not being equal to warnings because there's still
-        // the error severity, which does not seem to be used as errors are indicated
-        // separately, but we do this just to be safe.
-        criterion = (item: QueryResultMetaNotice) => !('severity' in item) || item.severity === 'info';
-      }
-      const warnings = filter(serie.meta.notices, criterion) ?? [];
+      const warnings = filter(serie.meta.notices, (item: QueryResultMetaNotice) => item.severity === type) ?? [];
       return acc.concat(warnings);
     }, []);
 


### PR DESCRIPTION
**What is this feature?**

Update info annotations to match the recent changes in plugin-sdk-go (see below PR).

**Why do we need this feature?**

Now that we've merged the change in the plugin-sdk-go (see below PR), the old way of filtering info annotations is outdated.

**Who is this feature for?**

Should not have any user impact, just updating the code and tests to match a change in the library.

**Which issue(s) does this PR fix?**:

This is a follow up to https://github.com/grafana/grafana/pull/97978 and https://github.com/grafana/grafana-plugin-sdk-go/pull/1185

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
