### PR TITLE
Dash-SchemaV2: Don't persist undefined fields

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
@@ -37,7 +37,7 @@ export const handyTestingSchema: DashboardV2Spec = {
           type: 'prometheus',
           uid: 'uid',
         },
-        filter: { ids: [] },
+        filter: { ids: [1] },
         enable: true,
         hide: false,
         iconColor: 'rgba(0, 211, 255, 1)',
@@ -63,7 +63,6 @@ export const handyTestingSchema: DashboardV2Spec = {
             scenarioId: 'annotations',
           },
         },
-        filter: { ids: [] },
         hide: true,
       },
     },
@@ -75,7 +74,6 @@ export const handyTestingSchema: DashboardV2Spec = {
           type: 'grafana-testdata-datasource',
           uid: 'uid',
         },
-        filter: { ids: [] },
         enable: false,
         iconColor: 'yellow',
         name: 'Disabled',
@@ -94,7 +92,6 @@ export const handyTestingSchema: DashboardV2Spec = {
           type: 'grafana-testdata-datasource',
           uid: 'uid',
         },
-        filter: { ids: [] },
         enable: true,
         hide: true,
         iconColor: 'dark-purple',
@@ -282,7 +279,6 @@ export const handyTestingSchema: DashboardV2Spec = {
     {
       kind: 'DatasourceVariable',
       spec: {
-        allValue: undefined,
         current: {
           text: 'text1',
           value: 'value1',

--- a/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModelSchemaV2.test.ts.snap
+++ b/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModelSchemaV2.test.ts.snap
@@ -12,7 +12,6 @@ exports[`transformSceneToSaveModelSchemaV2 should transform scene to save model 
           "uid": "-- Grafana --",
         },
         "enable": true,
-        "filter": undefined,
         "hide": false,
         "iconColor": "red",
         "name": "query1",
@@ -27,7 +26,6 @@ exports[`transformSceneToSaveModelSchemaV2 should transform scene to save model 
           "uid": "abcdef",
         },
         "enable": true,
-        "filter": undefined,
         "hide": true,
         "iconColor": "blue",
         "name": "query2",
@@ -42,7 +40,6 @@ exports[`transformSceneToSaveModelSchemaV2 should transform scene to save model 
           "uid": "Loki",
         },
         "enable": true,
-        "filter": undefined,
         "hide": true,
         "iconColor": "green",
         "name": "query3",
@@ -212,7 +209,6 @@ exports[`transformSceneToSaveModelSchemaV2 should transform scene to save model 
     {
       "kind": "DatasourceVariable",
       "spec": {
-        "allValue": undefined,
         "current": {
           "text": "text1",
           "value": "value1",

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -327,10 +327,14 @@ export function sceneVariablesSetToSchemaV2Variables(
           refresh: 'onDashboardLoad',
           pluginId: variable.state.pluginId,
           multi: variable.state.isMulti || false,
-          allValue: variable.state.allValue,
           includeAll: variable.state.includeAll || false,
         },
       };
+
+      if (variable.state.allValue !== undefined) {
+        datasourceVariable.spec.allValue = variable.state.allValue;
+      }
+
       variables.push(datasourceVariable);
     } else if (sceneUtils.isConstantVariable(variable)) {
       const constantVariable: ConstantVariableKind = {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -407,7 +407,6 @@ function getAnnotations(state: DashboardSceneState): AnnotationQueryKind[] {
         datasource: layer.state.query.datasource || getDefaultDataSourceRef(),
         enable: Boolean(layer.state.isEnabled),
         hide: Boolean(layer.state.isHidden),
-        filter: layer.state.query.filter,
         iconColor: layer.state.query.iconColor,
       },
     };
@@ -419,6 +418,11 @@ function getAnnotations(state: DashboardSceneState): AnnotationQueryKind[] {
         kind: queryKind,
         spec: layer.state.query.query.spec,
       };
+    }
+
+    // If filter is an empty array, don't save it
+    if (layer.state.query.filter?.ids?.length) {
+      result.spec.filter = layer.state.query.filter;
     }
 
     annotations.push(result);


### PR DESCRIPTION
Cleans up remaining fields that are undefined but persist in dashboard JSON. For example, even if the filter on the annotation query is not defined, it will be persisted in the dashboard JSON as `filter: undefined`
