### PR TITLE
Fix: Double encoding of URLs when using data proxy

### DIFF
--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -32,7 +32,6 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 	}
 
 	ctxLogger := logger.FromContext(ctx)
-
 	if len(route.URL) > 0 {
 		interpolatedURL, err := interpolateString(route.URL, data)
 		if err != nil {
@@ -49,7 +48,14 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		req.URL.Scheme = routeURL.Scheme
 		req.URL.Host = routeURL.Host
 		req.Host = routeURL.Host
-		req.URL.Path = util.JoinURLFragments(routeURL.Path, proxyPath)
+		req.URL.RawPath = util.JoinURLFragments(routeURL.Path, proxyPath)
+		unescapedPath, err := url.PathUnescape(req.URL.RawPath)
+		if err != nil {
+			ctxLogger.Error("Failed to unescape raw path", "rawPath", req.URL.RawPath, "error", err)
+			return
+		}
+
+		req.URL.Path = unescapedPath
 	}
 
 	if err := addQueryString(req, route, data); err != nil {

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -119,6 +119,10 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 				Path:      "api/rbac-restricted",
 				ReqAction: "test-app.settings:read",
 			},
+			{
+				Path: "encodedPath",
+				URL:  "http://encoded.com",
+			},
 		}
 
 		ds := &datasources.DataSource{
@@ -233,6 +237,16 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
 
 			assert.Equal(t, "https://example.com/api/v1/some-route/", req.URL.String())
+		})
+
+		t.Run("When matching proxy path is already encoded", func(t *testing.T) {
+			ctx, req := setUp()
+			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/our%20devices")
+			require.NoError(t, err)
+			proxy.matchedRoute = routes[9]
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+
+			assert.Equal(t, "http://encoded.com/our%20devices", req.URL.String())
 		})
 
 		t.Run("Validating request", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Datasource proxy double encodes if the proxy path comes in encoded.

**Why do we need this feature?**

We need to unescape the raw path and set it to request path similar to what we do in the [director function](https://github.com/grafana/grafana/blob/main/pkg/api/pluginproxy/ds_proxy.go#L211-L217). Go's `req.URL.String()` automatically encodes the URL.

https://pkg.go.dev/net/url#URL
> URL's String method uses the EscapedPath method to obtain the path. 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/98197

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
