### PR TITLE
Dashboard tags: add dashboard_uid and org_id

### DIFF
--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -213,15 +213,31 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 		assert.Equal(t, len(queryResult), 2)
 	})
 
-	t.Run("Should be able to delete dashboard", func(t *testing.T) {
+	t.Run("Should be able to delete dashboard and associated tags", func(t *testing.T) {
 		setup()
 		dash := insertTestDashboard(t, dashboardStore, "delete me", 1, 0, "", false, "delete this")
 
-		err := dashboardStore.DeleteDashboard(context.Background(), &dashboards.DeleteDashboardCommand{
+		tags, err := dashboardStore.GetDashboardTags(context.Background(), &dashboards.GetDashboardTagsQuery{OrgID: 1})
+		require.NoError(t, err)
+		terms := make([]string, len(tags))
+		for i, tag := range tags {
+			terms[i] = tag.Term
+		}
+		require.Contains(t, terms, "delete this")
+
+		err = dashboardStore.DeleteDashboard(context.Background(), &dashboards.DeleteDashboardCommand{
 			ID:    dash.ID,
 			OrgID: 1,
 		})
 		require.NoError(t, err)
+
+		tags, err = dashboardStore.GetDashboardTags(context.Background(), &dashboards.GetDashboardTagsQuery{OrgID: 1})
+		require.NoError(t, err)
+		terms = make([]string, len(tags))
+		for i, tag := range tags {
+			terms[i] = tag.Term
+		}
+		require.NotContains(t, terms, "delete this")
 	})
 
 	t.Run("Should be able to create dashboard", func(t *testing.T) {

--- a/pkg/services/sqlstore/migrations/dashboard_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_mig.go
@@ -1,7 +1,10 @@
 package migrations
 
 import (
+	"fmt"
+
 	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"xorm.io/xorm"
 )
 
 func addDashboardMigration(mg *Migrator) {
@@ -244,4 +247,56 @@ func addDashboardMigration(mg *Migrator) {
 		Cols: []string{"deleted"},
 		Type: IndexType,
 	}))
+
+	mg.AddMigration("Add column dashboard_uid in dashboard_tag", NewAddColumnMigration(dashboardTagV1, &Column{
+		Name: "dashboard_uid", Type: DB_NVarchar, Length: 40, Nullable: true,
+	}))
+	mg.AddMigration("Add column org_id in dashboard_tag", NewAddColumnMigration(dashboardTagV1, &Column{
+		Name: "org_id", Type: DB_BigInt, Nullable: true, Default: "1",
+	}))
+
+	mg.AddMigration("Add missing dashboard_uid and org_id to dashboard_tag", &FillDashbordUIDAndOrgIDMigration{})
+}
+
+type FillDashbordUIDAndOrgIDMigration struct {
+	MigrationBase
+}
+
+func (m *FillDashbordUIDAndOrgIDMigration) SQL(dialect Dialect) string {
+	return "code migration"
+}
+
+func (m *FillDashbordUIDAndOrgIDMigration) Exec(sess *xorm.Session, mg *Migrator) error {
+	return RunDashboardTagMigrations(sess, mg.Dialect.DriverName())
+}
+
+func RunDashboardTagMigrations(sess *xorm.Session, driverName string) error {
+	// sqlite
+	sql := `UPDATE dashboard_tag
+	SET 
+    	dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = dashboard_tag.dashboard_id),
+    	org_id = (SELECT org_id FROM dashboard WHERE dashboard.id = dashboard_tag.dashboard_id)
+	WHERE 
+    	(dashboard_uid IS NULL OR org_id IS NULL)
+    	AND EXISTS (SELECT 1 FROM dashboard WHERE dashboard.id = dashboard_tag.dashboard_id);`
+	if driverName == Postgres {
+		sql = `UPDATE dashboard_tag 
+		SET dashboard_uid = dashboard.uid, 
+			org_id = dashboard.org_id
+		FROM dashboard 
+		WHERE dashboard_tag.dashboard_id = dashboard.id
+			AND (dashboard_tag.dashboard_uid IS NULL OR dashboard_tag.org_id IS NULL);`
+	} else if driverName == MySQL {
+		sql = `UPDATE dashboard_tag 
+		LEFT JOIN dashboard ON dashboard_tag.dashboard_id = dashboard.id 
+		SET dashboard_tag.dashboard_uid = dashboard.uid, 
+			dashboard_tag.org_id = dashboard.org_id
+		WHERE dashboard_tag.dashboard_uid IS NULL OR dashboard_tag.org_id IS NULL;`
+	}
+
+	if _, err := sess.Exec(sql); err != nil {
+		return fmt.Errorf("failed to set dashboard_uid and org_id in dashboard_tag: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What is this feature?**

This PR adds the columns `dashboard_uid` and `org_id` to the `dashboard_tag` table and populates them. 

**Why do we need this feature?**

To support [org deletion](https://github.com/grafana/grafana/blob/main/pkg/services/org/orgimpl/store.go#L222) without the dashboard table, we need to have org_id available. And in general, we are moving to dashboard_uid & org_id over dashboard_id

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/app-platform-wg/issues/196

Mysql:
<img width="904" alt="mysql" src="https://github.com/user-attachments/assets/459c1cd7-1a9a-4d2f-98b8-a99e6f5a6f96" />

Postgres:
<img width="647" alt="postgres" src="https://github.com/user-attachments/assets/f6c12ff2-00f2-48fb-bdcb-d77bb9127a30" />

Sqlite:
<img width="668" alt="sqllite" src="https://github.com/user-attachments/assets/269cf5b8-7d45-466e-ad02-203e2b4cd36e" />
