### PR TITLE
K8s/OpenAPI: Update the openapi operation ids

### DIFF
--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -2,9 +2,14 @@ package builder
 
 import (
 	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -117,15 +122,104 @@ func SetupConfig(
 	// Add the custom routes to service discovery
 	serverConfig.OpenAPIV3Config.PostProcessSpec = getOpenAPIPostProcessor(buildVersion, builders)
 	serverConfig.OpenAPIV3Config.GetOperationIDAndTagsFromRoute = func(r common.Route) (string, []string, error) {
+		meta := r.Metadata()
+		kind := ""
+		action := ""
+		sub := ""
+
 		tags := []string{}
-		prop, ok := r.Metadata()["x-kubernetes-group-version-kind"]
+		prop, ok := meta["x-kubernetes-group-version-kind"]
 		if ok {
 			gvk, ok := prop.(metav1.GroupVersionKind)
 			if ok && gvk.Kind != "" {
+				kind = gvk.Kind
 				tags = append(tags, gvk.Kind)
 			}
 		}
-		return r.OperationName(), tags, nil
+		prop, ok = meta["x-kubernetes-action"]
+		if ok {
+			action = fmt.Sprintf("%v", prop)
+		}
+
+		isNew := false
+		if _, err := os.Stat("test.csv"); errors.Is(err, os.ErrNotExist) {
+			isNew = true
+		}
+
+		if action == "connect" {
+			idx := strings.LastIndex(r.Path(), "/{name}/")
+			if idx > 0 {
+				sub = r.Path()[(idx + len("/{name}/")):]
+			}
+		}
+
+		operationAlt := r.OperationName()
+		if action != "" {
+			if action == "connect" {
+				idx := strings.Index(r.OperationName(), "Namespaced")
+				if idx > 0 {
+					operationAlt = strings.ToLower(r.Method()) +
+						r.OperationName()[idx:]
+				}
+			}
+		}
+
+		operationAlt = strings.ReplaceAll(operationAlt, "Namespaced", "")
+		if strings.HasPrefix(operationAlt, "post") {
+			operationAlt = "create" + operationAlt[len("post"):]
+		} else if strings.HasPrefix(operationAlt, "read") {
+			operationAlt = "get" + operationAlt[len("read"):]
+		} else if strings.HasPrefix(operationAlt, "patch") {
+			operationAlt = "update" + operationAlt[len("patch"):]
+		}
+
+		// Audit our options here
+		if false {
+			// Safe to ignore G304 -- this will be removed before merging to main, and just helps audit the conversion
+			// nolint:gosec
+			f, err := os.OpenFile("test.csv", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+			if err != nil {
+				fmt.Printf("ERROR: %s\n", err)
+			} else {
+				metastr, _ := json.Marshal(meta)
+
+				prop, ok = meta["x-kubernetes-group-version-kind"]
+				if ok {
+					gvk, ok := prop.(metav1.GroupVersionKind)
+					if ok {
+						kind = gvk.Kind
+					}
+				}
+
+				w := csv.NewWriter(f)
+				if isNew {
+					_ = w.Write([]string{
+						"#Path",
+						"Method",
+						"action",
+						"kind",
+						"sub",
+						"OperationName",
+						"OperationNameAlt",
+						"Description",
+						"metadata",
+					})
+				}
+				_ = w.Write([]string{
+					r.Path(),
+					r.Method(),
+					action,
+					kind,
+					sub,
+					r.OperationName(),
+					operationAlt,
+					r.Description(),
+					string(metastr),
+				})
+				w.Flush()
+			}
+		}
+		return operationAlt, tags, nil
 	}
 
 	// Set the swagger build versions


### PR DESCRIPTION
Extracted from:  https://github.com/grafana/grafana/pull/96329/files#diff-7110b3ddadd4bf1f7ae90fc78e854d7f10aa11289d9cdcedd249e686b724ff6c

This PR changes the k8s openapi operation ids to something easier for RTK to work with