### PR TITLE
Alerting: Allow notification policy filters to match quoted matchers

### DIFF
--- a/public/app/features/alerting/unified/components/notification-policies/Filters.test.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.test.ts
@@ -32,9 +32,9 @@ describe('findRoutesByMatchers', () => {
     ];
 
     const matchers: ObjectMatcher[] = [
+      ['foo', MatcherOperator.equal, 'bar baz'],
       ['foo', MatcherOperator.equal, '"bar baz"'],
-      ['foo', MatcherOperator.equal, 'bar baz'],
-      ['foo', MatcherOperator.equal, 'bar baz'],
+      ['"foo"', MatcherOperator.equal, 'bar baz'],
       ['"foo"', MatcherOperator.equal, '"bar baz"'],
     ];
 

--- a/public/app/features/alerting/unified/components/notification-policies/Filters.test.ts
+++ b/public/app/features/alerting/unified/components/notification-policies/Filters.test.ts
@@ -1,0 +1,47 @@
+import { MatcherOperator, ObjectMatcher } from 'app/plugins/datasource/alertmanager/types';
+
+import { findRoutesByMatchers } from './Filters';
+
+describe('findRoutesByMatchers', () => {
+  it('should match even if keys or values are quoted', () => {
+    const routes = [
+      { id: '0', matchers: ['foo=bar'] },
+      { id: '0', matchers: ['foo="bar"'] },
+      { id: '0', matchers: ['"foo"=bar'] },
+      { id: '0', matchers: ['"foo"="bar"'] },
+    ];
+
+    const matchers: ObjectMatcher[] = [
+      ['foo', MatcherOperator.equal, 'bar'],
+      ['foo', MatcherOperator.equal, '"bar"'],
+      ['"foo"', MatcherOperator.equal, 'bar'],
+      ['"foo"', MatcherOperator.equal, '"bar"'],
+    ];
+
+    routes.forEach((route) => {
+      matchers.forEach((matcher) => {
+        expect(findRoutesByMatchers(route, [matcher])).toBe(true);
+      });
+    });
+  });
+
+  it('should match even if keys or values are quoted with special characters', () => {
+    const routes = [
+      { id: '0', matchers: ['foo="bar baz"'] },
+      { id: '0', matchers: ['"foo"="bar baz"'] },
+    ];
+
+    const matchers: ObjectMatcher[] = [
+      ['foo', MatcherOperator.equal, '"bar baz"'],
+      ['foo', MatcherOperator.equal, 'bar baz'],
+      ['foo', MatcherOperator.equal, 'bar baz'],
+      ['"foo"', MatcherOperator.equal, '"bar baz"'],
+    ];
+
+    matchers.forEach((matcher) => {
+      routes.forEach((route) => {
+        expect(findRoutesByMatchers(route, [matcher])).toBe(true);
+      });
+    });
+  });
+});

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -13,6 +13,7 @@ import {
   parseQueryParamMatchers,
   quoteWithEscape,
   quoteWithEscapeIfRequired,
+  unquoteIfRequired,
   unquoteWithUnescape,
 } from './matchers';
 
@@ -126,6 +127,16 @@ describe('unquoteWithUnescape', () => {
   it('should not unescape unquoted string', () => {
     const unquoted = unquoteWithUnescape('un\\"quo\\\\ted');
     expect(unquoted).toBe('un\\"quo\\\\ted');
+  });
+});
+
+describe('unquoteIfRequired', () => {
+  it('should unquote strings with no special character', () => {
+    expect(unquoteIfRequired('"test"')).toBe('test');
+  });
+
+  it('should not unquote strings with special character', () => {
+    expect(unquoteIfRequired('"test this"')).toBe('"test this"');
   });
 });
 

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -183,6 +183,10 @@ export function quoteWithEscapeIfRequired(input: string) {
   return shouldQuote ? quoteWithEscape(input) : input;
 }
 
+export function unquoteIfRequired(input: string) {
+  return quoteWithEscapeIfRequired(unquoteWithUnescape(input));
+}
+
 export const encodeMatcher = ({ name, operator, value }: MatcherFieldValue) => {
   const encodedLabelName = quoteWithEscapeIfRequired(name);
   const encodedLabelValue = quoteWithEscape(value);


### PR DESCRIPTION
**What is this feature?**

Prior to this PR the notification policy filter wanted the matcher input to match the quoted key or value in the route's matchers.

For example, this combination would not match anything;

```
route: {
  matchers: [
    "foo=\"bar\""
  ]
}


filter: foo=bar
```

This PR will normalize the matchers from the Alertmanager configuration and omit the quoted keys and values if they don't need to be quoted. 

**Why do we need this feature?**

We do this because the UI will also omit quotes in the notification policy's visualization and the user doesn't know if a key or value is quoted in the configuration file.

**Special notes for your reviewer:**

Includes a test suite, but easy to test this with an external Alertmanager.