### PR TITLE
chore: Add dockerfile config to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,18 @@ updates:
       time: "02:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 10
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/packaging/custom"
+      - "/scripts/verify-repo-update"
+      - "/scripts/build/ci-deploy"
+      - "/scripts/build/ci-windows-test"
+      - "/scripts/build/ci-e2e"
+      - "/scripts/build/ci-wix"
+      - "/scripts/build/ci-msi-build"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10


### PR DESCRIPTION
**What is this feature?**

Configures Dependabot to track our Dockerfiles too

**Why do we need this feature?**

To help keep our Docker images up to date.

**Who is this feature for?**

Maintainers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
