### PR TITLE
Loki: don't send empty vector selector to /labels API

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -461,6 +461,15 @@ describe('Language completion provider', () => {
         config.featureToggles.lokiLabelNamesQueryApi = lokiLabelNamesQueryApi;
       });
 
+      it('should exclude empty vector selector', async () => {
+        const datasourceWithLabels = setup({ foo: [], bar: [], __name__: [], __stream_shard__: [] });
+
+        const instance = new LanguageProvider(datasourceWithLabels);
+        instance.request = jest.fn();
+        await instance.fetchLabels({ streamSelector: '{}' });
+        expect(instance.request).toBeCalledWith('labels', { end: 1560163909000, start: 1560153109000 });
+      });
+
       it('should use series endpoint for request with stream selector', async () => {
         const datasourceWithLabels = setup({});
         datasourceWithLabels.languageProvider.request = jest.fn();

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -174,7 +174,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const range = options?.timeRange ?? this.getDefaultTimeRange();
     const { start, end } = this.datasource.getTimeRangeParams(range);
     const params: Record<string, string | number> = { start, end };
-    if (options?.streamSelector && options?.streamSelector !== '{}') {
+    if (options?.streamSelector && options?.streamSelector !== EMPTY_SELECTOR) {
       params['query'] = options.streamSelector;
     }
     const res = await this.request(url, params);

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -174,7 +174,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const range = options?.timeRange ?? this.getDefaultTimeRange();
     const { start, end } = this.datasource.getTimeRangeParams(range);
     const params: Record<string, string | number> = { start, end };
-    if (options?.streamSelector) {
+    if (options?.streamSelector && options?.streamSelector !== '{}') {
       params['query'] = options.streamSelector;
     }
     const res = await this.request(url, params);


### PR DESCRIPTION

**What is this fix?**
Fixes bug introduced in https://github.com/grafana/grafana/pull/97935, which disrupts returning labels in Explore Logs when no other labels are defined.

**Why do we need this feature?**
To restore Explore Logs functionality.

**Who is this feature for?**
Users of Loki datasource and Explore Logs

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/98546

**Special notes for your reviewer:**
https://github.com/grafana/grafana/pull/97935 was added to 11.5 milestone, so we shouldn't need to backport as long as this is merged before 11.5 is cut.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
