### PR TITLE
Alerting: Add traceID to rule evalutor logger

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -315,6 +315,7 @@ func (a *alertRule) Run() error {
 						attribute.String("rule_fingerprint", fpStr),
 						attribute.String("tick", utcTick),
 					))
+					logger := logger.FromContext(tracingCtx)
 
 					// Check before any execution if the context was cancelled so that we don't do any evaluations.
 					if tracingCtx.Err() != nil {


### PR DESCRIPTION
**What is this feature?**
It fixes the scheduler's rule evaluation routine logger to include a traceID label in the context. 

**Why do we need this feature?**
Be able to filter by traceID label.

**Who is this feature for?**
Developers
