### PR TITLE
K8s: Dashbaords: Ensure backwards compatibility

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -124,6 +124,11 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 		if isEmptyData {
 			return response.Error(http.StatusInternalServerError, "Error while loading dashboard, dashboard data is invalid", nil)
 		}
+
+		// the dashboard id is no longer set in the spec for unified storage, set it here to keep api compatibility
+		if dash.Data.Get("id").MustString() == "" {
+			dash.Data.Set("id", dash.ID)
+		}
 	}
 	guardian, err := guardian.NewByDashboard(ctx, dash, c.SignedInUser.GetOrgID(), c.SignedInUser)
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

We stopped setting the dashboard.id in the spec when saving the dashboard to unified storage and instead save it as a label. We still return the id in the dashboard struct, but the api endpoint uses the spec as the dashboard response. This PR ensures we still return the id in the get dashboard endpoint