### PR TITLE
K8s/OpenAPI: remove unnecessary x-kubernetes-group-version-kind

### DIFF
--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -110,6 +110,14 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 				return &copy, nil
 			}
 		}
+
+		// Remove the growing list of kinds
+		for k, v := range s.Components.Schemas {
+			if strings.HasPrefix(k, "io.k8s.apimachinery.pkg.apis.meta.v1") && v.Extensions != nil {
+				delete(v.Extensions, "x-kubernetes-group-version-kind") // a growing list of everything
+			}
+		}
+
 		return s, nil
 	}
 }

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -47,6 +47,7 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 		if s.Paths == nil {
 			return s, nil
 		}
+
 		for _, b := range builders {
 			gv := b.GetGroupVersion()
 			prefix := "/apis/" + gv.String() + "/"
@@ -63,6 +64,13 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 					ExternalDocs: s.ExternalDocs,
 					Servers:      s.Servers,
 					Paths:        s.Paths,
+				}
+
+				// Remove the growing list of kinds
+				for k, v := range copy.Components.Schemas {
+					if strings.HasPrefix(k, "io.k8s.apimachinery.pkg.apis.meta.v1") && v.Extensions != nil {
+						delete(v.Extensions, "x-kubernetes-group-version-kind") // a growing list of everything
+					}
 				}
 
 				// Optionally include raw http handlers
@@ -108,13 +116,6 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder) func(*s
 					return processor.PostProcessOpenAPI(&copy)
 				}
 				return &copy, nil
-			}
-		}
-
-		// Remove the growing list of kinds
-		for k, v := range s.Components.Schemas {
-			if strings.HasPrefix(k, "io.k8s.apimachinery.pkg.apis.meta.v1") && v.Extensions != nil {
-				delete(v.Extensions, "x-kubernetes-group-version-kind") // a growing list of everything
 			}
 		}
 


### PR DESCRIPTION
This removes a long list of unused `x-kubernetes-group-version-kind` in the OpenAPI spec -- this makes things more consistent regardless of which apis are installed!

Before:
<img width="733" alt="image" src="https://github.com/user-attachments/assets/6fc0568d-94be-4d14-bab0-5cdfc5499b45" />

After:
<img width="791" alt="image" src="https://github.com/user-attachments/assets/b97664a5-a75c-4c1a-bcb8-3ceed8833368" />
