### PR TITLE
[v10.4.x] Use v2 of publishing workflow that checks out HEAD of version branch on tag events

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -1,4 +1,4 @@
-name: "publish-technical-documentation-release"
+name: publish-technical-documentation-release
 
 on:
   push:
@@ -12,63 +12,18 @@ on:
 jobs:
   sync:
     if: github.repository == 'grafana/grafana'
-    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
     steps:
-      - name: "Checkout Grafana repo"
-        uses: "actions/checkout@v4"
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: "Checkout Actions library"
-        uses: "actions/checkout@v4"
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
-          repository: "grafana/grafana-github-actions"
-          path: "./actions"
-
-      - name: "Install Actions from library"
-        run: "npm install --production --prefix ./actions"
-
-      - name: "Determine if there is a matching release tag"
-        id: "has-matching-release-tag"
-        uses: "./actions/has-matching-release-tag"
-        with:
-          ref_name: "${{ github.ref_name }}"
-          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.x$"
-
-      - name: "Determine technical documentation version"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        uses: "./actions/docs-target"
-        id: "target"
-        with:
-          ref_name: "${{ github.ref_name }}"
-
-      - name: "Clone website-sync Action"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: "git clone --single-branch --no-tags --depth 1 -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync ./.github/actions/website-sync"
-
-      - name: "Switch to HEAD of version branch for tags"
-        # Tags aren't necessarily made to the HEAD of the version branch.
-        # The documentation to be published is always on the HEAD of the version branch.
-        if: "steps.has-matching-release-tag.outputs.bool == 'true' && github.ref_type == 'tag'"
-        run: "git switch --detach origin/${{ steps.target.outputs.target }}.x"
-
-      - name: "Publish to website repository (release)"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        uses: "./.github/actions/website-sync"
-        id: "publish-release"
-        with:
-          repository: "grafana/website"
-          branch: "master"
-          host: "github.com"
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
-          source_folder: "docs/sources"
-          target_folder: "content/docs/grafana/${{ steps.target.outputs.target }}"
+          release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.x$"
+          release_branch_with_patch_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          website_directory: content/docs/grafana
+          version_suffix: ""


### PR DESCRIPTION
Backport 331c602c5ee3e83e7fce3d6e027da3aaec8e5ca0 from #98029

---

This uses a script check in the first step of tag events that switches the checkout to the version branch that the tag refers to: https://github.com/grafana/writers-toolkit/blob/main/publish-technical-documentation-release/determine-release-branch.

Implemented in:

- https://github.com/grafana/writers-toolkit/commit/305f9896c4edb0a90ef95fc477ebe46598d26458
- https://github.com/grafana/writers-toolkit/commit/541fb6e8bde2eb477c14a4e975603464ac557429

Because the script uses Bash regular expression pattern matching, inputs must use Extended Regular Expression syntax.
