### PR TITLE
ContactPoints: Remove blank lines prefixes in contact point types

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -106,7 +106,7 @@ type EmbeddedContactPoint struct {
 	Name string `json:"name" binding:"required"`
 	// required: true
 	// example: webhook
-	// enum: alertmanager, dingding, discord, email, googlechat, kafka, line, opsgenie, pagerduty, pushover, sensugo, slack, teams, telegram, threema, victorops, webhook, wecom
+	// enum: alertmanager,dingding,discord,email,googlechat,kafka,line,opsgenie,pagerduty,pushover,sensugo,slack,teams,telegram,threema,victorops,webhook,wecom
 	Type string `json:"type" binding:"required"`
 	// required: true
 	Settings *simplejson.Json `json:"settings" binding:"required"`


### PR DESCRIPTION
The space between each value in contact points adds a blank prefix in each value generating invalid schema values.
Related: https://github.com/grafana/grafana-foundation-sdk/issues/506

![image](https://github.com/user-attachments/assets/958285ba-8185-47f4-b67f-cdd20e7be547)

I added the backport to all versions that are used in `foundation-sdk`, but let me know if we need to remove any.