### PR TITLE
Folders: Include folder UID when loading dashboards for search v2

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -42,10 +42,6 @@ type eventStore interface {
 	GetAllEventsAfter(ctx context.Context, id int64) ([]*store.EntityEvent, error)
 }
 
-// While we migrate away from internal IDs... this lets us lookup values in SQL
-// NOTE: folderId is unique across all orgs
-type folderUIDLookup = func(ctx context.Context, folderId int64) (string, error)
-
 type dashboard struct {
 	id        int64
 	uid       string
@@ -100,14 +96,13 @@ type searchIndex struct {
 	logger                  log.Logger
 	buildSignals            chan buildSignal
 	extender                DocumentExtender
-	folderIdLookup          folderUIDLookup
 	syncCh                  chan chan struct{}
 	tracer                  tracing.Tracer
 	features                featuremgmt.FeatureToggles
 	settings                setting.SearchSettings
 }
 
-func newSearchIndex(dashLoader dashboardLoader, evStore eventStore, extender DocumentExtender, folderIDs folderUIDLookup, tracer tracing.Tracer, features featuremgmt.FeatureToggles, settings setting.SearchSettings) *searchIndex {
+func newSearchIndex(dashLoader dashboardLoader, evStore eventStore, extender DocumentExtender, tracer tracing.Tracer, features featuremgmt.FeatureToggles, settings setting.SearchSettings) *searchIndex {
 	return &searchIndex{
 		loader:          dashLoader,
 		eventStore:      evStore,
@@ -116,7 +111,6 @@ func newSearchIndex(dashLoader dashboardLoader, evStore eventStore, extender Doc
 		logger:          log.New("searchIndex"),
 		buildSignals:    make(chan buildSignal),
 		extender:        extender,
-		folderIdLookup:  folderIDs,
 		syncCh:          make(chan chan struct{}),
 		tracer:          tracer,
 		features:        features,
@@ -857,7 +851,7 @@ func (l sqlDashboardLoader) loadAllDashboards(ctx context.Context, limit int, or
 					sess.Where("uid = ?", dashboardUID)
 				}
 
-				sess.Cols("id", "uid", "is_folder", "folder_id", "data", "slug", "created", "updated")
+				sess.Cols("id", "uid", "is_folder", "folder_id", "folder_uid", "data", "slug", "created", "updated")
 
 				sess.OrderBy("id ASC")
 				sess.Limit(limit)
@@ -962,23 +956,6 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 	}
 
 	return dashboards, err
-}
-
-func newFolderIDLookup(sql db.DB) folderUIDLookup {
-	return func(ctx context.Context, folderID int64) (string, error) {
-		uid := ""
-		err := sql.WithDbSession(ctx, func(sess *db.Session) error {
-			res, err := sess.Query("SELECT uid FROM dashboard WHERE id=?", folderID)
-			if err != nil {
-				return err
-			}
-			if len(res) > 0 {
-				uid = string(res[0]["uid"])
-			}
-			return nil
-		})
-		return uid, err
-	}
 }
 
 type dashboardQueryResult struct {

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -47,13 +47,14 @@ type eventStore interface {
 type folderUIDLookup = func(ctx context.Context, folderId int64) (string, error)
 
 type dashboard struct {
-	id       int64
-	uid      string
-	isFolder bool
-	folderID int64
-	slug     string
-	created  time.Time
-	updated  time.Time
+	id        int64
+	uid       string
+	isFolder  bool
+	folderID  int64
+	folderUID string
+	slug      string
+	created   time.Time
+	updated   time.Time
 
 	// Use generic structure
 	summary *entity.EntitySummary
@@ -763,11 +764,7 @@ func (i *searchIndex) updateDashboard(ctx context.Context, orgID int64, index *o
 	if dash.folderID == 0 {
 		folderUID = folder.GeneralFolderUID
 	} else {
-		var err error
-		folderUID, err = i.folderIdLookup(ctx, dash.folderID)
-		if err != nil {
-			return err
-		}
+		folderUID = dash.folderUID
 	}
 
 	location := folderUID
@@ -950,14 +947,15 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 				// But append info anyway for now, since we possibly extracted useful information.
 			}
 			dashboards = append(dashboards, dashboard{
-				id:       row.Id,
-				uid:      row.Uid,
-				isFolder: row.IsFolder,
-				folderID: row.FolderID,
-				slug:     row.Slug,
-				created:  row.Created,
-				updated:  row.Updated,
-				summary:  summary,
+				id:        row.Id,
+				uid:       row.Uid,
+				isFolder:  row.IsFolder,
+				folderID:  row.FolderID,
+				folderUID: row.FolderUID,
+				slug:      row.Slug,
+				created:   row.Created,
+				updated:   row.Updated,
+				summary:   summary,
 			})
 		}
 		readDashboardSpan.End()
@@ -984,12 +982,13 @@ func newFolderIDLookup(sql db.DB) folderUIDLookup {
 }
 
 type dashboardQueryResult struct {
-	Id       int64
-	Uid      string
-	IsFolder bool   `xorm:"is_folder"`
-	FolderID int64  `xorm:"folder_id"`
-	Slug     string `xorm:"slug"`
-	Data     []byte
-	Created  time.Time
-	Updated  time.Time
+	Id        int64
+	Uid       string
+	IsFolder  bool   `xorm:"is_folder"`
+	FolderID  int64  `xorm:"folder_id"`
+	FolderUID string `xorm:"folder_uid"`
+	Slug      string `xorm:"slug"`
+	Data      []byte
+	Created   time.Time
+	Updated   time.Time
 }

--- a/pkg/services/searchV2/index_test.go
+++ b/pkg/services/searchV2/index_test.go
@@ -432,9 +432,10 @@ var dashboardsWithFolders = []dashboard{
 		},
 	},
 	{
-		id:       2,
-		uid:      "2",
-		folderID: 1,
+		id:        2,
+		uid:       "2",
+		folderID:  1,
+		folderUID: "1",
 		summary: &entity.EntitySummary{
 			Name: "Dashboard in folder 1",
 			Nested: []*entity.EntitySummary{
@@ -444,9 +445,10 @@ var dashboardsWithFolders = []dashboard{
 		},
 	},
 	{
-		id:       3,
-		uid:      "3",
-		folderID: 1,
+		id:        3,
+		uid:       "3",
+		folderID:  1,
+		folderUID: "1",
 		summary: &entity.EntitySummary{
 			Name: "Dashboard in folder 2",
 			Nested: []*entity.EntitySummary{

--- a/pkg/services/searchV2/index_test.go
+++ b/pkg/services/searchV2/index_test.go
@@ -72,7 +72,7 @@ func initTestIndexFromDashesExtended(t *testing.T, dashboards []dashboard, exten
 	dashboardLoader := &testDashboardLoader{
 		dashboards: dashboards,
 	}
-	index := newSearchIndex(dashboardLoader, &store.MockEntityEventsService{}, extender, func(ctx context.Context, folderId int64) (string, error) { return "x", nil }, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures(), setting.SearchSettings{})
+	index := newSearchIndex(dashboardLoader, &store.MockEntityEventsService{}, extender, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures(), setting.SearchSettings{})
 	require.NotNil(t, index)
 	numDashboards, err := index.buildOrgIndex(context.Background(), testOrgID)
 	require.NoError(t, err)

--- a/pkg/services/searchV2/service.go
+++ b/pkg/services/searchV2/service.go
@@ -102,7 +102,6 @@ func ProvideService(cfg *setting.Cfg, sql db.DB, entityEventStore store.EntityEv
 			newSQLDashboardLoader(sql, tracer, cfg.Search),
 			entityEventStore,
 			extender.GetDocumentExtender(),
-			newFolderIDLookup(sql),
 			tracer,
 			features,
 			cfg.Search,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Remove querying of folder in the dashboard table. 

**Why do we need this feature?**

In order to ease the transition to Unified Storage, all calls to folder storage should be made through folder service. Note that in the case of this PR, there is no call being made to folder service, instead we are using the `folder_uid` which is already populated within the row of a given dashboard. See [Slack](https://raintank-corp.slack.com/archives/C07UT3AR7NC/p1736258215618569) for more context. We need to be fine with referencing `folder_uid` because that is part of the data for a _dashboard_ in the dashboard table and not a _folder_ in the dashboard table.

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/156

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
