### PR TITLE
Theme: Extract extra theme definitions into their own directory

### DIFF
--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -277,7 +277,7 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
   const getRichColor = ({ color, name }: GetRichColorProps): ThemeRichColor => {
     color = { ...color, name };
     if (!color.main) {
-      throw new Error(`Missing main color for ${name}`);
+      color.main = base[name].main;
     }
     if (!color.text) {
       color.text = color.main;
@@ -318,7 +318,9 @@ export function createColors(colors: ThemeColorsInput): ThemeColors {
   );
 }
 
+type RichColorNames = 'primary' | 'secondary' | 'info' | 'error' | 'success' | 'warning';
+
 interface GetRichColorProps {
   color: Partial<ThemeRichColor>;
-  name: string;
+  name: RichColorNames;
 }

--- a/packages/grafana-data/src/themes/createTheme.ts
+++ b/packages/grafana-data/src/themes/createTheme.ts
@@ -23,6 +23,7 @@ export interface NewThemeOptions {
 /** @internal */
 export function createTheme(options: NewThemeOptions = {}): GrafanaTheme2 {
   const {
+    name,
     colors: colorsInput = {},
     spacing: spacingInput = {},
     shape: shapeInput = {},
@@ -40,7 +41,7 @@ export function createTheme(options: NewThemeOptions = {}): GrafanaTheme2 {
   const visualization = createVisualizationColors(colors);
 
   const theme = {
-    name: colors.mode === 'dark' ? 'Dark' : 'Light',
+    name: (name ?? colors.mode === 'dark') ? 'Dark' : 'Light',
     isDark: colors.mode === 'dark',
     isLight: colors.mode === 'light',
     colors,

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,7 +1,7 @@
 import { Registry, RegistryItem } from '../utils/Registry';
 
-import { createColors } from './createColors';
 import { createTheme } from './createTheme';
+import * as extraThemes from './themeDefinitions';
 import { GrafanaTheme2 } from './types';
 
 export interface ThemeRegistryItem extends RegistryItem {
@@ -23,104 +23,44 @@ export function getThemeById(id: string): GrafanaTheme2 {
  * For internal use only
  */
 export function getBuiltInThemes(includeExtras?: boolean) {
-  return themeRegistry.list().filter((item) => {
+  const themes = themeRegistry.list().filter((item) => {
     return includeExtras ? true : !item.isExtra;
   });
+  // sort themes alphabetically, but put built-in themes (default, dark, light, system) first
+  const sortedThemes = themes.sort((a, b) => {
+    if (a.isExtra && !b.isExtra) {
+      return 1;
+    } else if (!a.isExtra && b.isExtra) {
+      return -1;
+    } else {
+      return a.name.localeCompare(b.name);
+    }
+  });
+  return sortedThemes;
 }
 
 /**
- * There is also a backend list at services/perferences/themes.go
+ * There is also a backend list at pkg/services/preference/themes.go
  */
 const themeRegistry = new Registry<ThemeRegistryItem>(() => {
   return [
     { id: 'system', name: 'System preference', build: getSystemPreferenceTheme },
     { id: 'dark', name: 'Dark', build: () => createTheme({ colors: { mode: 'dark' } }) },
     { id: 'light', name: 'Light', build: () => createTheme({ colors: { mode: 'light' } }) },
-    { id: 'debug', name: 'Debug', build: createDebug, isExtra: true },
   ];
 });
+
+for (const [id, theme] of Object.entries(extraThemes)) {
+  themeRegistry.register({
+    id,
+    name: theme.name ?? '',
+    build: () => createTheme(theme),
+    isExtra: true,
+  });
+}
 
 function getSystemPreferenceTheme() {
   const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
   const id = mediaResult.matches ? 'dark' : 'light';
   return getThemeById(id);
-}
-
-/**
- * a very ugly theme that is useful for debugging and checking if the theme is applied correctly
- * borders are red,
- * backgrounds are blue,
- * text is yellow,
- * and grafana loves you <3
- * (also corners are rounded, action states (hover, focus, selected) are purple)
- */
-function createDebug(): GrafanaTheme2 {
-  const baseDarkColors = createColors({
-    mode: 'dark',
-  });
-
-  return createTheme({
-    name: 'Debug',
-    colors: {
-      mode: 'dark',
-      background: {
-        canvas: '#000033',
-        primary: '#000044',
-        secondary: '#000055',
-      },
-      text: {
-        primary: '#bbbb00',
-        secondary: '#888800',
-        disabled: '#444400',
-        link: '#dddd00',
-        maxContrast: '#ffff00',
-      },
-      border: {
-        weak: '#ff000044',
-        medium: '#ff000088',
-        strong: '#ff0000ff',
-      },
-      primary: {
-        ...baseDarkColors.primary,
-        border: '#ff000088',
-        text: '#cccc00',
-        contrastText: '#ffff00',
-        shade: '#9900dd',
-      },
-      secondary: {
-        ...baseDarkColors.secondary,
-        border: '#ff000088',
-        text: '#cccc00',
-        contrastText: '#ffff00',
-        shade: '#9900dd',
-      },
-      info: {
-        ...baseDarkColors.info,
-        shade: '#9900dd',
-      },
-      warning: {
-        ...baseDarkColors.warning,
-        shade: '#9900dd',
-      },
-      success: {
-        ...baseDarkColors.success,
-        shade: '#9900dd',
-      },
-      error: {
-        ...baseDarkColors.error,
-        shade: '#9900dd',
-      },
-      action: {
-        hover: '#9900dd',
-        focus: '#6600aa',
-        selected: '#440088',
-      },
-    },
-    shape: {
-      borderRadius: 8,
-    },
-    spacing: {
-      gridSize: 10,
-    },
-  });
 }

--- a/packages/grafana-data/src/themes/themeDefinitions/debug.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/debug.ts
@@ -1,0 +1,70 @@
+import { NewThemeOptions } from '../createTheme';
+
+/**
+ * a very ugly theme that is useful for debugging and checking if the theme is applied correctly
+ * borders are red,
+ * backgrounds are blue,
+ * text is yellow,
+ * and grafana loves you <3
+ * (also corners are rounded, action states (hover, focus, selected) are purple)
+ */
+const debugTheme: NewThemeOptions = {
+  name: 'Debug',
+  colors: {
+    mode: 'dark',
+    background: {
+      canvas: '#000033',
+      primary: '#000044',
+      secondary: '#000055',
+    },
+    text: {
+      primary: '#bbbb00',
+      secondary: '#888800',
+      disabled: '#444400',
+      link: '#dddd00',
+      maxContrast: '#ffff00',
+    },
+    border: {
+      weak: '#ff000044',
+      medium: '#ff000088',
+      strong: '#ff0000ff',
+    },
+    primary: {
+      border: '#ff000088',
+      text: '#cccc00',
+      contrastText: '#ffff00',
+      shade: '#9900dd',
+    },
+    secondary: {
+      border: '#ff000088',
+      text: '#cccc00',
+      contrastText: '#ffff00',
+      shade: '#9900dd',
+    },
+    info: {
+      shade: '#9900dd',
+    },
+    warning: {
+      shade: '#9900dd',
+    },
+    success: {
+      shade: '#9900dd',
+    },
+    error: {
+      shade: '#9900dd',
+    },
+    action: {
+      hover: '#9900dd',
+      focus: '#6600aa',
+      selected: '#440088',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  spacing: {
+    gridSize: 10,
+  },
+};
+
+export default debugTheme;

--- a/packages/grafana-data/src/themes/themeDefinitions/index.ts
+++ b/packages/grafana-data/src/themes/themeDefinitions/index.ts
@@ -1,0 +1,1 @@
+export { default as debug } from './debug';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- uses the base themes main color if the input doesn't specify one instead of throwing an error
  - i guess this is just a nice to have? it means themes don't **have** to define the main color for primary/secondary/warning/error etc
- defines a type with all the rich color names
- properly sets the name of the new theme based on the theme inputs
- extracts extra theme definitions out into their own directory and registers them automatically
- sorts themes alphabetically in the dropdown, putting built-in themes (default, dark, light, system) first

**Why do we need this feature?**

- more extensible theme structure

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

it would be good if we could automatically populate the backend list of themes as well instead of having to maintain a separate list... if anyone better at go has suggestions for how to do that please lmk 🙇 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
