### PR TITLE
Add comment body text to Git PR for provisioned dashboards

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboard.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboard.tsx
@@ -96,9 +96,9 @@ export function SaveProvisionedDashboard({ drawer, changeInfo, dashboard }: Prop
       workflow: WorkflowOption.PullRequest,
     },
   });
-  const [title, ref, workflow, path] = watch(['title', 'ref', 'workflow', 'path']);
+  const [title, ref, workflow, path, comment] = watch(['title', 'ref', 'workflow', 'path', 'comment']);
   const isGitHub = repositoryConfig?.type === 'github';
-  const href = createPRLink(repositoryConfig, title, ref);
+  const href = createPRLink(repositoryConfig, title, ref, comment);
   const { isDirty } = dashboard.state;
   const navigate = useNavigate();
 

--- a/public/app/features/provisioning/utils/git.ts
+++ b/public/app/features/provisioning/utils/git.ts
@@ -1,10 +1,10 @@
 import { RepositorySpec } from '../api';
 
-export function createPRLink(spec?: RepositorySpec, dashboardName?: string, ref?: string) {
+export function createPRLink(spec?: RepositorySpec, dashboardName?: string, ref?: string, comment?: string) {
   if (!spec || spec.type !== 'github' || !ref) {
     return '';
   }
-  return `https://github.com/${spec.github?.owner}/${spec.github?.repository}/compare/${spec.github?.branch}...${ref}?quick_pull=1&labels=grafana&title=Update dashboard ${dashboardName}`;
+  return `https://github.com/${spec.github?.owner}/${spec.github?.repository}/compare/${spec.github?.branch}...${ref}?quick_pull=1&labels=grafana&title=Update dashboard ${dashboardName}&body=${encodeURI(comment || '')}`;
 }
 
 /**


### PR DESCRIPTION
This PR updates the "Open pull request in GitHub" button when saving a Git sync provisioned dashboard, so that text from the "comments" box is pulled through as the PR body text.
 
![image](https://github.com/user-attachments/assets/318f8c3b-61f1-450d-8ff9-d269e9604b82)

![image](https://github.com/user-attachments/assets/9b97a140-fd1d-4cf7-b143-b2399ae3add2)
