### PR TITLE
Share: Add analytics to invite user flow

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
@@ -93,7 +93,15 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
       label: t('share-dashboard.menu.invite-user-title', 'Invite new member'),
       renderCondition: !!config.externalUserMngLinkUrl && contextSrv.hasPermission(AccessControlAction.OrgUsersAdd),
       onClick: () => {
-        window.open(config.externalUserMngLinkUrl, '_blank');
+        const url = new URL(config.externalUserMngLinkUrl);
+
+        // Add query parameters to track conversion
+        url.searchParams.append('src', 'grafananet');
+        url.searchParams.append('cnt', 'share-invite');
+
+        // Open the modified URL
+        window.open(url.toString(), '_blank');
+        // window.open(config.externalUserMngLinkUrl, '_blank');
       },
       renderDividerAbove: true,
       component: () => <Icon name="external-link-alt" className={styles.inviteUserItemIcon} />,

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
@@ -101,7 +101,6 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
 
         // Open the modified URL
         window.open(url.toString(), '_blank');
-        // window.open(config.externalUserMngLinkUrl, '_blank');
       },
       renderDividerAbove: true,
       component: () => <Icon name="external-link-alt" className={styles.inviteUserItemIcon} />,


### PR DESCRIPTION
**What is this feature?**
Add new query params when sending traffic to grafana.com to measure conversion on the new flow invite user from the Share button.
`src=grafananet`
`cnt=share-invite`

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/98604

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
