### PR TITLE
Secrets: rename keeper db struct

### DIFF
--- a/pkg/storage/secret/keeper_model.go
+++ b/pkg/storage/secret/keeper_model.go
@@ -23,7 +23,7 @@ const (
 	HashiCorpKeeperType KeeperType = "hashicorp"
 )
 
-type Keeper struct {
+type keeperDB struct {
 	// Kubernetes Metadata
 	GUID        string `xorm:"pk 'guid'"`
 	Name        string `xorm:"name"`
@@ -41,12 +41,12 @@ type Keeper struct {
 	Payload string     `xorm:"payload"`
 }
 
-func (*Keeper) TableName() string {
+func (*keeperDB) TableName() string {
 	return TableNameKeeper
 }
 
 // toKubernetes maps a DB row into a Kubernetes resource (metadata + spec).
-func (kp *Keeper) toKubernetes() (*secretv0alpha1.Keeper, error) {
+func (kp *keeperDB) toKubernetes() (*secretv0alpha1.Keeper, error) {
 	annotations := make(map[string]string, 0)
 	if kp.Annotations != "" {
 		if err := json.Unmarshal([]byte(kp.Annotations), &annotations); err != nil {
@@ -105,7 +105,7 @@ func (kp *Keeper) toKubernetes() (*secretv0alpha1.Keeper, error) {
 }
 
 // toKeeperCreateRow maps a Kubernetes resource into a DB row for new resources being created/inserted.
-func toKeeperCreateRow(kp *secretv0alpha1.Keeper, actorUID string) (*Keeper, error) {
+func toKeeperCreateRow(kp *secretv0alpha1.Keeper, actorUID string) (*keeperDB, error) {
 	row, err := toKeeperRow(kp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map to row: %w", err)
@@ -123,7 +123,7 @@ func toKeeperCreateRow(kp *secretv0alpha1.Keeper, actorUID string) (*Keeper, err
 }
 
 // toKeeperUpdateRow maps a Kubernetes resource into a DB row for existing resources being updated.
-func toKeeperUpdateRow(currentRow *Keeper, newKeeper *secretv0alpha1.Keeper, actorUID string) (*Keeper, error) {
+func toKeeperUpdateRow(currentRow *keeperDB, newKeeper *secretv0alpha1.Keeper, actorUID string) (*keeperDB, error) {
 	row, err := toKeeperRow(newKeeper)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map to row: %w", err)
@@ -141,7 +141,7 @@ func toKeeperUpdateRow(currentRow *Keeper, newKeeper *secretv0alpha1.Keeper, act
 }
 
 // toKeeperRow maps a Kubernetes Keeper resource into a Keeper DB row.
-func toKeeperRow(kp *secretv0alpha1.Keeper) (*Keeper, error) {
+func toKeeperRow(kp *secretv0alpha1.Keeper) (*keeperDB, error) {
 	var annotations string
 	if len(kp.Annotations) > 0 {
 		cleanedAnnotations := xkube.CleanAnnotations(kp.Annotations)
@@ -186,7 +186,7 @@ func toKeeperRow(kp *secretv0alpha1.Keeper) (*Keeper, error) {
 		return nil, fmt.Errorf("failed to obtain type and payload: %w", err)
 	}
 
-	return &Keeper{
+	return &keeperDB{
 		// Kubernetes Metadata
 		GUID:        string(kp.UID),
 		Name:        kp.Name,

--- a/pkg/storage/secret/keeper_store.go
+++ b/pkg/storage/secret/keeper_store.go
@@ -65,7 +65,7 @@ func (s *keeperStorage) Read(ctx context.Context, nn xkube.NameNamespace) (*secr
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	row := &Keeper{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &keeperDB{Name: nn.Name, Namespace: nn.Namespace.String()}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(row)
 		if err != nil {
@@ -96,7 +96,7 @@ func (s *keeperStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Ke
 		return nil, fmt.Errorf("missing auth info in context")
 	}
 
-	currentRow := &Keeper{Name: newKeeper.Name, Namespace: newKeeper.Namespace}
+	currentRow := &keeperDB{Name: newKeeper.Name, Namespace: newKeeper.Namespace}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		found, err := sess.Get(currentRow)
 		if err != nil {
@@ -141,7 +141,7 @@ func (s *keeperStorage) Delete(ctx context.Context, nn xkube.NameNamespace) erro
 		return fmt.Errorf("missing auth info in context")
 	}
 
-	row := &Keeper{Name: nn.Name, Namespace: nn.Namespace.String()}
+	row := &keeperDB{Name: nn.Name, Namespace: nn.Namespace.String()}
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		if _, err := sess.Delete(row); err != nil {
 			return fmt.Errorf("failed to delete row: %w", err)
@@ -167,10 +167,10 @@ func (s *keeperStorage) List(ctx context.Context, namespace xkube.Namespace, opt
 		labelSelector = labels.Everything()
 	}
 
-	keeperRows := make([]*Keeper, 0)
+	keeperRows := make([]*keeperDB, 0)
 
 	err := s.db.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		cond := &Keeper{Namespace: namespace.String()}
+		cond := &keeperDB{Namespace: namespace.String()}
 
 		if err := sess.Find(&keeperRows, cond); err != nil {
 			return fmt.Errorf("failed to find rows: %w", err)


### PR DESCRIPTION
This is a non-functional change.

Introduces two small changes, needed for future work on keepers service:
- Rename keeper db struct to not be confused with Keeper interface or Keeper resource
- ExternalID type is expected to be returned from the keeper, therefore when creating or updating secure value metadata, use string of the type

Ticket: https://github.com/grafana/grafana-operator-experience-squad/issues/1139