### PR TITLE
CloudWatch: Fix conditions for fetching wildcards

### DIFF
--- a/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
+++ b/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
@@ -14,8 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func noSkip(q *models.CloudWatchQuery) bool { return false }
-func skip(q *models.CloudWatchQuery) bool   { return true }
+func noSkip(ctx context.Context, q *models.CloudWatchQuery) bool { return false }
 
 func TestGetDimensionValuesForWildcards(t *testing.T) {
 	executor := &cloudWatchExecutor{im: defaultTestInstanceManager(), logger: log.NewNullLogger()}
@@ -74,13 +73,41 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 		})
 	})
 
+	t.Run("Should skip queries", func(t *testing.T) {
+		t.Run("when namespace not set", func(t *testing.T) {
+			query := getBaseQuery()
+			query.Namespace = ""
+			query.MetricName = "Test_MetricName"
+			query.Dimensions = map[string][]string{"Test_DimensionName1": {"*"}}
+			query.MetricQueryType = models.MetricQueryTypeSearch
+
+			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", nil, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, noSkip)
+			assert.Nil(t, err)
+			assert.Len(t, queries, 1)
+			assert.Equal(t, []string{"*"}, queries[0].Dimensions["Test_DimensionName1"])
+		})
+
+		t.Run("when metricName not set", func(t *testing.T) {
+			query := getBaseQuery()
+			query.MetricName = ""
+			query.Dimensions = map[string][]string{"Test_DimensionName1": {"*"}}
+			query.MetricQueryType = models.MetricQueryTypeSearch
+
+			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", nil, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, noSkip)
+			assert.Nil(t, err)
+			assert.Len(t, queries, 1)
+			assert.Equal(t, []string{"*"}, queries[0].Dimensions["Test_DimensionName1"])
+		})
+	})
+
 	t.Run("MetricSearch query type", func(t *testing.T) {
 		t.Run("Should not change non-wildcard dimension value", func(t *testing.T) {
 			query := getBaseQuery()
 			query.MetricName = "Test_MetricName1"
 			query.Dimensions = map[string][]string{"Test_DimensionName1": {"Value1"}}
 			query.MetricQueryType = models.MetricQueryTypeSearch
-			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", nil, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, skip)
+			query.MatchExact = false
+			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", nil, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, shouldSkipFetchingWildcards)
 			assert.Nil(t, err)
 			assert.Len(t, queries, 1)
 			assert.NotNil(t, queries[0].Dimensions["Test_DimensionName1"], 1)
@@ -92,7 +119,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			query.MetricName = "Test_MetricName1"
 			query.Dimensions = map[string][]string{"Test_DimensionName1": {"*"}}
 			query.MetricQueryType = models.MetricQueryTypeSearch
-			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", nil, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, skip)
+			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", nil, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, shouldSkipFetchingWildcards)
 			assert.Nil(t, err)
 			assert.Len(t, queries, 1)
 			assert.NotNil(t, queries[0].Dimensions["Test_DimensionName1"])
@@ -112,7 +139,7 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 				{MetricName: utils.Pointer("Test_MetricName4"), Dimensions: []*cloudwatch.Dimension{{Name: utils.Pointer("Test_DimensionName1"), Value: utils.Pointer("Value2")}}},
 			}}
 			api.On("ListMetricsPagesWithContext").Return(nil)
-			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", api, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, noSkip)
+			queries, err := executor.getDimensionValuesForWildcards(ctx, "us-east-1", api, []*models.CloudWatchQuery{query}, cache.New(0, 0), 50, shouldSkipFetchingWildcards)
 			assert.Nil(t, err)
 			assert.Len(t, queries, 1)
 			assert.Equal(t, map[string][]string{"Test_DimensionName1": {"Value1", "Value2", "Value3", "Value4"}}, queries[0].Dimensions)
@@ -169,4 +196,5 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			assert.Equal(t, map[string][]string{}, queries[0].Dimensions)
 		})
 	})
+
 }

--- a/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
+++ b/pkg/tsdb/cloudwatch/get_dimension_values_for_wildcards_test.go
@@ -196,5 +196,4 @@ func TestGetDimensionValuesForWildcards(t *testing.T) {
 			assert.Equal(t, map[string][]string{}, queries[0].Dimensions)
 		})
 	})
-
 }

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -102,18 +102,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 					return err
 				}
 
-				newLabelParsingEnabled := features.IsEnabled(ctx, features.FlagCloudWatchNewLabelParsing)
-				requestQueries, err = e.getDimensionValuesForWildcards(ctx, region, client, requestQueries, instance.tagValueCache, instance.Settings.GrafanaSettings.ListMetricsPageLimit, func(q *models.CloudWatchQuery) bool {
-					if q.MetricQueryType == models.MetricQueryTypeSearch && (q.MatchExact || newLabelParsingEnabled) {
-						return true
-					}
-
-					if q.MetricQueryType == models.MetricQueryTypeQuery && q.MetricEditorMode == models.MetricEditorModeRaw {
-						return true
-					}
-
-					return false
-				})
+				requestQueries, err = e.getDimensionValuesForWildcards(ctx, region, client, requestQueries, instance.tagValueCache, instance.Settings.GrafanaSettings.ListMetricsPageLimit, shouldSkipFetchingWildcards)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fix the condition logic for fetching wildcards. This will make us stop calling ListMetrics when namespace or  metricname are empty.

I didn't get into it, but we should probably test the skip function (I can separate that out into a separate pr if we want)

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/data-sources/issues/165

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
