### PR TITLE
Dashboard SchemaV2: Panel repeater 

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -648,19 +648,18 @@ export const defaultTimeSettingsSpec = (): TimeSettingsSpec => ({
 	fiscalYearStartMonth: 0,
 });
 
-export type RepeatMode = "variable" | "label" | "frame";
-
-export const defaultRepeatMode = (): RepeatMode => ("variable");
+// other repeat modes will be added in the future: label, frame
+export const RepeatMode = "variable";
 
 export interface RepeatOptions {
-	mode: RepeatMode;
+	mode: "variable";
 	value: string;
 	direction?: "h" | "v";
 	maxPerRow?: number;
 }
 
 export const defaultRepeatOptions = (): RepeatOptions => ({
-	mode: "variable",
+	mode: RepeatMode,
 	value: "",
 });
 

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -648,6 +648,16 @@ export const defaultTimeSettingsSpec = (): TimeSettingsSpec => ({
 	fiscalYearStartMonth: 0,
 });
 
+export interface RepeatOptions {
+	repeatVariable: string;
+	repeatDirection?: "h" | "v";
+	maxPerRow?: number;
+}
+
+export const defaultRepeatOptions = (): RepeatOptions => ({
+	repeatVariable: "",
+});
+
 export interface GridLayoutItemSpec {
 	x: number;
 	y: number;
@@ -655,6 +665,7 @@ export interface GridLayoutItemSpec {
 	height: number;
 	// reference to a PanelKind from dashboard.spec.elements Expressed as JSON Schema reference
 	element: ElementReference;
+	repeatOptions?: RepeatOptions;
 }
 
 export const defaultGridLayoutItemSpec = (): GridLayoutItemSpec => ({

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts
@@ -648,14 +648,20 @@ export const defaultTimeSettingsSpec = (): TimeSettingsSpec => ({
 	fiscalYearStartMonth: 0,
 });
 
+export type RepeatMode = "variable" | "label" | "frame";
+
+export const defaultRepeatMode = (): RepeatMode => ("variable");
+
 export interface RepeatOptions {
-	repeatVariable: string;
-	repeatDirection?: "h" | "v";
+	mode: RepeatMode;
+	value: string;
+	direction?: "h" | "v";
 	maxPerRow?: number;
 }
 
 export const defaultRepeatOptions = (): RepeatOptions => ({
-	repeatVariable: "",
+	mode: "variable",
+	value: "",
 });
 
 export interface GridLayoutItemSpec {
@@ -665,7 +671,7 @@ export interface GridLayoutItemSpec {
 	height: number;
 	// reference to a PanelKind from dashboard.spec.elements Expressed as JSON Schema reference
 	element: ElementReference;
-	repeatOptions?: RepeatOptions;
+	repeat?: RepeatOptions;
 }
 
 export const defaultGridLayoutItemSpec = (): GridLayoutItemSpec => ({

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -455,8 +455,7 @@ TimeSettingsSpec: {
   nowDelay?: string // v1: timepicker.nowDelay
 }
 
-RepeatMode: "variable" | "label" | "frame"
-
+RepeatMode: "variable" // other repeat modes will be added in the future: label, frame
 
 RepeatOptions: {
   mode: RepeatMode

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -455,9 +455,13 @@ TimeSettingsSpec: {
   nowDelay?: string // v1: timepicker.nowDelay
 }
 
+RepeatMode: "variable" | "label" | "frame"
+
+
 RepeatOptions: {
-  repeatVariable: string
-  repeatDirection?: "h" | "v"
+  mode: RepeatMode
+  value: string
+  direction?: "h" | "v"
   maxPerRow?: int
 }
 
@@ -467,7 +471,7 @@ GridLayoutItemSpec: {
   width: int
   height: int
   element: ElementReference // reference to a PanelKind from dashboard.spec.elements Expressed as JSON Schema reference
-  repeatOptions?: RepeatOptions
+  repeat?: RepeatOptions
 }
 
 GridLayoutItemKind: {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue
@@ -455,12 +455,19 @@ TimeSettingsSpec: {
   nowDelay?: string // v1: timepicker.nowDelay
 }
 
+RepeatOptions: {
+  repeatVariable: string
+  repeatDirection?: "h" | "v"
+  maxPerRow?: int
+}
+
 GridLayoutItemSpec: {
   x: int
   y: int
   width: int
   height: int
   element: ElementReference // reference to a PanelKind from dashboard.spec.elements Expressed as JSON Schema reference
+  repeatOptions?: RepeatOptions
 }
 
 GridLayoutItemKind: {

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha0/examples.ts
@@ -198,6 +198,11 @@ export const handyTestingSchema: DashboardV2Spec = {
             width: 200,
             x: 0,
             y: 0,
+            repeat: {
+              mode: 'variable',
+              value: 'customVar',
+              maxPerRow: 3,
+            },
           },
         },
       ],

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -243,10 +243,13 @@ function createSceneGridLayoutForItems(dashboard: DashboardV2Spec): SceneGridIte
           key: `grid-item-${panel.spec.id}`,
           x: element.spec.x,
           y: element.spec.y,
-          width: element.spec.width,
+          width: element.spec.repeatOptions?.repeatDirection === 'h' ? 24 : element.spec.width,
           height: element.spec.height,
           itemHeight: element.spec.height,
           body: vizPanel,
+          variableName: element.spec.repeatOptions?.repeatVariable,
+          repeatDirection: element.spec.repeatOptions?.repeatDirection,
+          maxPerRow: element.spec.repeatOptions?.maxPerRow,
         });
       } else {
         throw new Error(`Unknown element kind: ${element.kind}`);

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -243,13 +243,13 @@ function createSceneGridLayoutForItems(dashboard: DashboardV2Spec): SceneGridIte
           key: `grid-item-${panel.spec.id}`,
           x: element.spec.x,
           y: element.spec.y,
-          width: element.spec.repeatOptions?.repeatDirection === 'h' ? 24 : element.spec.width,
+          width: element.spec.repeat?.direction === 'h' ? 24 : element.spec.width,
           height: element.spec.height,
           itemHeight: element.spec.height,
           body: vizPanel,
-          variableName: element.spec.repeatOptions?.repeatVariable,
-          repeatDirection: element.spec.repeatOptions?.repeatDirection,
-          maxPerRow: element.spec.repeatOptions?.maxPerRow,
+          variableName: element.spec.repeat?.value,
+          repeatDirection: element.spec.repeat?.direction,
+          maxPerRow: element.spec.repeat?.maxPerRow,
         });
       } else {
         throw new Error(`Unknown element kind: ${element.kind}`);

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -37,7 +37,13 @@ import { RowRepeaterBehavior } from '../scene/RowRepeaterBehavior';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
-import { getLibraryPanelBehavior, getPanelIdForVizPanel, getQueryRunnerFor, isLibraryPanel } from '../utils/utils';
+import {
+  calculateGridItemDimensions,
+  getLibraryPanelBehavior,
+  getPanelIdForVizPanel,
+  getQueryRunnerFor,
+  isLibraryPanel,
+} from '../utils/utils';
 
 import { GRAFANA_DATASOURCE_REF } from './const';
 import { dataLayersToAnnotations } from './dataLayersToAnnotations';
@@ -319,11 +325,7 @@ export function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = 
     }
 
     if (repeater.state.repeatedPanels) {
-      const itemHeight = repeater.state.itemHeight ?? 10;
-      const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
-      const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);
-      const w = 24 / columnCount;
-      const h = itemHeight;
+      const { h, w, columnCount } = calculateGridItemDimensions(repeater);
       const panels = repeater.state.repeatedPanels!.map((panel, index) => {
         let x = 0,
           y = 0;

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -84,8 +84,6 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
     variables = sceneVariablesSetToVariables(variablesSet);
   }
 
-  console.log('panels', panels);
-
   const controlsState = state.controls?.state;
 
   const refreshPicker = controlsState?.refreshPicker;
@@ -311,7 +309,6 @@ function vizPanelDataToPanel(
 }
 
 export function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = false): Panel[] {
-  console.log('panelRepeaterToPanels', repeater);
   if (!isSnapshot) {
     return [gridItemToPanel(repeater)];
   } else {
@@ -322,7 +319,6 @@ export function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = 
     }
 
     if (repeater.state.repeatedPanels) {
-      console.log('repeater.state.repeatedPanels', repeater.state.repeatedPanels);
       const itemHeight = repeater.state.itemHeight ?? 10;
       const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
       const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -84,6 +84,8 @@ export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = fa
     variables = sceneVariablesSetToVariables(variablesSet);
   }
 
+  console.log('panels', panels);
+
   const controlsState = state.controls?.state;
 
   const refreshPicker = controlsState?.refreshPicker;
@@ -309,6 +311,7 @@ function vizPanelDataToPanel(
 }
 
 export function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = false): Panel[] {
+  console.log('panelRepeaterToPanels', repeater);
   if (!isSnapshot) {
     return [gridItemToPanel(repeater)];
   } else {
@@ -319,6 +322,7 @@ export function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = 
     }
 
     if (repeater.state.repeatedPanels) {
+      console.log('repeater.state.repeatedPanels', repeater.state.repeatedPanels);
       const itemHeight = repeater.state.itemHeight ?? 10;
       const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
       const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -44,7 +44,13 @@ import { PanelTimeRange } from '../scene/PanelTimeRange';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
-import { getPanelIdForVizPanel, getQueryRunnerFor, getVizPanelKeyForPanelId, isLibraryPanel } from '../utils/utils';
+import {
+  getPanelIdForVizPanel,
+  getQueryRunnerFor,
+  getVizPanelKeyForPanelId,
+  isLibraryPanel,
+  calculateGridItemDimensions,
+} from '../utils/utils';
 
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
 import { transformCursorSynctoEnum } from './transformToV2TypesUtils';
@@ -439,14 +445,6 @@ function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false):
     }
     return [];
   }
-}
-
-function calculateGridItemDimensions(repeater: DashboardGridItem) {
-  const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
-  const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);
-  const w = 24 / columnCount;
-  const h = repeater.state.itemHeight ?? 10;
-  return { h, w, columnCount };
 }
 
 function getVariables(oldDash: DashboardSceneState) {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -149,7 +149,7 @@ function getGridLayoutItems(state: DashboardSceneState, isSnapshot?: boolean): G
       if (child instanceof DashboardGridItem) {
         // TODO: handle panel repeater scenario
         if (child.state.variableName) {
-          elements = elements.concat(panelRepeaterToPanels(child, isSnapshot));
+          elements = elements.concat(repeaterToLayoutItems(child, isSnapshot));
         } else {
           elements.push(gridItemToGridLayoutItemKind(child, isSnapshot));
         }
@@ -387,7 +387,7 @@ function createElements(panels: PanelKind[]): Record<string, PanelKind> {
   );
 }
 
-function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = false): GridLayoutItemKind[] {
+function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false): GridLayoutItemKind[] {
   if (!isSnapshot) {
     return [gridItemToGridLayoutItemKind(repeater)];
   } else {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -399,11 +399,7 @@ function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false):
     }
 
     if (repeater.state.repeatedPanels) {
-      const itemHeight = repeater.state.itemHeight ?? 10;
-      const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
-      const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);
-      const w = 24 / columnCount;
-      const h = itemHeight;
+      const { h, w, columnCount } = calculateGridItemDimensions(repeater);
       const panels = repeater.state.repeatedPanels!.map((panel, index) => {
         let x = 0,
           y = 0;
@@ -443,6 +439,14 @@ function repeaterToLayoutItems(repeater: DashboardGridItem, isSnapshot = false):
     }
     return [];
   }
+}
+
+function calculateGridItemDimensions(repeater: DashboardGridItem) {
+  const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
+  const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);
+  const w = 24 / columnCount;
+  const h = repeater.state.itemHeight ?? 10;
+  return { h, w, columnCount };
 }
 
 function getVariables(oldDash: DashboardSceneState) {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -164,7 +164,6 @@ function getGridLayoutItems(state: DashboardSceneState, isSnapshot?: boolean): G
       // }
     }
   }
-  console.log('elements', elements);
 
   return elements;
 }
@@ -401,10 +400,11 @@ function panelRepeaterToPanels(repeater: DashboardGridItem, isSnapshot = false):
           y: gridPos.y,
           width: gridPos.w,
           height: gridPos.h,
-          repeatOptions: {
-            repeatVariable: repeater.state.variableName!,
+          repeat: {
+            mode: 'variable',
+            value: repeater.state.variableName!,
             maxPerRow: repeater.getMaxPerRow(),
-            repeatDirection: repeater.state.repeatDirection,
+            direction: repeater.state.repeatDirection,
           },
 
           element: {

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -18,6 +18,7 @@ import { DashboardScene } from '../scene/DashboardScene';
 import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelMenuBehavior } from '../scene/PanelMenuBehavior';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DashboardLayoutManager, isDashboardLayoutManager } from '../scene/types';
 
 export const NEW_PANEL_HEIGHT = 8;
@@ -248,6 +249,14 @@ export function getLibraryPanelBehavior(vizPanel: VizPanel): LibraryPanelBehavio
   }
 
   return undefined;
+}
+
+export function calculateGridItemDimensions(repeater: DashboardGridItem) {
+  const rowCount = Math.ceil(repeater.state.repeatedPanels!.length / repeater.getMaxPerRow());
+  const columnCount = Math.ceil(repeater.state.repeatedPanels!.length / rowCount);
+  const w = 24 / columnCount;
+  const h = repeater.state.itemHeight ?? 10;
+  return { h, w, columnCount };
 }
 
 /**


### PR DESCRIPTION
Adds panel repeater options for the schema. Based on feedback from @torkelo, I've implemented mode that currently only has support for the variable model although other modes defined in the schema like label and frame. This is something we'll support in the future.

To test, just enable `useV2DashboardsAPI` 

In the demo maxPerRow won't be present because it's set to 4 and since that is default we don't persist it. If you change it to any other number you'll be able to see the prop in JSON. 

Demo:

https://github.com/user-attachments/assets/560e3091-277f-4b10-876c-0ac57147d6fe
