### PR TITLE
Public dashboards: remove use of dashboards table

### DIFF
--- a/pkg/services/publicdashboards/database/database.go
+++ b/pkg/services/publicdashboards/database/database.go
@@ -270,11 +270,11 @@ func (d *PublicDashboardStoreImpl) Delete(ctx context.Context, uid string) (int6
 	return affectedRows, err
 }
 
-func (d *PublicDashboardStoreImpl) FindByFolder(ctx context.Context, orgId int64, folderUid string) ([]*PublicDashboard, error) {
+func (d *PublicDashboardStoreImpl) FindByDashboardUids(ctx context.Context, orgId int64, uids []string) ([]*PublicDashboard, error) {
 	var pubdashes []*PublicDashboard
 
 	err := d.sqlStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		return sess.SQL("SELECT * from dashboard_public WHERE (dashboard_uid, org_id) IN (SELECT uid, org_id FROM dashboard WHERE org_id = ? AND folder_uid = ?)", orgId, folderUid).Find(&pubdashes)
+		return sess.Table("dashboard_public").In("dashboard_uid", uids).Where("org_id = ?", orgId).Find(&pubdashes)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -690,12 +690,12 @@ func TestIntegrationDelete(t *testing.T) {
 	})
 }
 
-func TestFindByFolder(t *testing.T) {
+func TestFindByDashboardUids(t *testing.T) {
 	t.Run("returns nil when dashboard is not a folder", func(t *testing.T) {
 		sqlStore, cfg := db.InitTestDBWithCfg(t)
 		dashboard := &dashboards.Dashboard{OrgID: 1, UID: "dashboarduid", IsFolder: false}
 		store := ProvideStore(sqlStore, cfg, featuremgmt.WithFeatures())
-		pubdashes, err := store.FindByFolder(context.Background(), dashboard.OrgID, dashboard.UID)
+		pubdashes, err := store.FindByDashboardUids(context.Background(), dashboard.OrgID, []string{dashboard.UID})
 
 		require.NoError(t, err)
 		assert.Nil(t, pubdashes)
@@ -704,7 +704,7 @@ func TestFindByFolder(t *testing.T) {
 	t.Run("returns nil when parameters are empty", func(t *testing.T) {
 		sqlStore, cfg := db.InitTestDBWithCfg(t)
 		store := ProvideStore(sqlStore, cfg, featuremgmt.WithFeatures())
-		pubdashes, err := store.FindByFolder(context.Background(), 0, "")
+		pubdashes, err := store.FindByDashboardUids(context.Background(), 0, []string{})
 
 		require.NoError(t, err)
 		assert.Nil(t, pubdashes)
@@ -728,7 +728,7 @@ func TestFindByFolder(t *testing.T) {
 		pubdash := insertPublicDashboard(t, pubdashStore, dashboard.UID, dashboard.OrgID, true, PublicShareType)
 		_ = insertPublicDashboard(t, pubdashStore, dashboard2.UID, dashboard2.OrgID, true, PublicShareType)
 
-		pubdashes, err := pubdashStore.FindByFolder(context.Background(), folder.OrgID, folder.UID)
+		pubdashes, err := pubdashStore.FindByDashboardUids(context.Background(), folder.OrgID, []string{dashboard.UID})
 
 		require.NoError(t, err)
 		assert.Len(t, pubdashes, 1)

--- a/pkg/services/publicdashboards/public_dashboard_store_mock.go
+++ b/pkg/services/publicdashboards/public_dashboard_store_mock.go
@@ -214,25 +214,25 @@ func (_m *FakePublicDashboardStore) FindByDashboardUid(ctx context.Context, orgI
 	return r0, r1
 }
 
-// FindByFolder provides a mock function with given fields: ctx, orgId, folderUid
-func (_m *FakePublicDashboardStore) FindByFolder(ctx context.Context, orgId int64, folderUid string) ([]*models.PublicDashboard, error) {
-	ret := _m.Called(ctx, orgId, folderUid)
+// FindByDashboardUids provides a mock function with given fields: ctx, orgId, uids
+func (_m *FakePublicDashboardStore) FindByDashboardUids(ctx context.Context, orgId int64, uids []string) ([]*models.PublicDashboard, error) {
+	ret := _m.Called(ctx, orgId, uids)
 
 	var r0 []*models.PublicDashboard
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string) ([]*models.PublicDashboard, error)); ok {
-		return rf(ctx, orgId, folderUid)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []string) ([]*models.PublicDashboard, error)); ok {
+		return rf(ctx, orgId, uids)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string) []*models.PublicDashboard); ok {
-		r0 = rf(ctx, orgId, folderUid)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, []string) []*models.PublicDashboard); ok {
+		r0 = rf(ctx, orgId, uids)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*models.PublicDashboard)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, string) error); ok {
-		r1 = rf(ctx, orgId, folderUid)
+	if rf, ok := ret.Get(1).(func(context.Context, int64, []string) error); ok {
+		r1 = rf(ctx, orgId, uids)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/services/publicdashboards/publicdashboard.go
+++ b/pkg/services/publicdashboards/publicdashboard.go
@@ -59,7 +59,7 @@ type Store interface {
 	Delete(ctx context.Context, uid string) (int64, error)
 
 	GetOrgIdByAccessToken(ctx context.Context, accessToken string) (int64, error)
-	FindByFolder(ctx context.Context, orgId int64, folderUid string) ([]*PublicDashboard, error)
+	FindByDashboardUids(ctx context.Context, orgId int64, uids []string) ([]*PublicDashboard, error)
 	ExistsEnabledByAccessToken(ctx context.Context, accessToken string) (bool, error)
 	ExistsEnabledByDashboardUid(ctx context.Context, dashboardUid string) (bool, error)
 	GetMetrics(ctx context.Context) (*Metrics, error)

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -468,6 +468,9 @@ func (pd *PublicDashboardServiceImpl) DeleteByDashboard(ctx context.Context, das
 			OrgId:      dashboard.OrgID,
 			FolderUIDs: []string{dashboard.UID},
 		})
+		if err != nil {
+			return err
+		}
 
 		uids := make([]string, len(dashs))
 		for i, dash := range dashs {


### PR DESCRIPTION
**What is this feature?**

This PR removes the final use of the dashboard table in the public dashboard service. I missed this one in the first pass - sorry about that!

**Why do we need this feature?**

As we move dashboards to app platform, we no longer can query the dashboard table directly. Instead, we should go through the dashboard service.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/195