### PR TITLE
Prometheus: Move LabelFilterItem to Combobox

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItemCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItemCombobox.tsx
@@ -14,7 +14,7 @@ function toComboboxOption(value: string): ComboboxOption {
 export interface LabelFilterItemProps {
   defaultOp: string;
   item: Partial<QueryBuilderLabelFilter>;
-  onChange: (value: QueryBuilderLabelFilter) => void;
+  onChange: (value: Partial<QueryBuilderLabelFilter>) => void;
   onGetLabelNames: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<ComboboxOption[]>;
   onGetLabelValues: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<ComboboxOption[]>;
   onDelete: () => void;
@@ -91,8 +91,11 @@ export function LabelFilterItemCombobox({
   );
 
   if (isMultiSelect()) {
-    throw new Error('multi select is not supported with combobox yet');
-    return <div>multi select is not supported with combobox yet</div>;
+    if (process.env.NODE_ENV === 'development') {
+      return <div>LabelFilterItemCombobox doesn't support multiselect, this should not have been called</div>;
+    }
+
+    return null;
   }
 
   return (
@@ -112,9 +115,6 @@ export function LabelFilterItemCombobox({
               ...item,
               op: item.op ?? defaultOp,
               label: change.value,
-
-              // PR TODO: optional?
-              value: item.value ?? '',
             });
           }}
           invalid={invalidLabel}
@@ -131,10 +131,7 @@ export function LabelFilterItemCombobox({
             onChange({
               ...item,
               op: change.value,
-              // PR TODO: optional?
-              value: (isMultiSelect(change.value) ? item.value : getSelectOptionsFromString(item?.value)[0]) ?? '',
-              // PR TODO: optional?
-              label: item.label ?? '',
+              value: isMultiSelect(change.value) ? item.value : getSelectOptionsFromString(item?.value)[0],
             });
           }}
         />
@@ -155,8 +152,6 @@ export function LabelFilterItemCombobox({
               ...item,
               value: change.value,
               op: item.op ?? defaultOp,
-              // PR TODO: optional?
-              label: item.label ?? '',
             });
           }}
           invalid={invalidValue}

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItemCombobox.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilterItemCombobox.tsx
@@ -1,0 +1,182 @@
+// Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilterItem.tsx
+import { useCallback, useRef } from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { AccessoryButton, InputGroup } from '@grafana/experimental';
+import { Combobox, ComboboxOption } from '@grafana/ui';
+
+import { QueryBuilderLabelFilter } from '../shared/types';
+
+function toComboboxOption(value: string): ComboboxOption {
+  return { value };
+}
+
+export interface LabelFilterItemProps {
+  defaultOp: string;
+  item: Partial<QueryBuilderLabelFilter>;
+  onChange: (value: QueryBuilderLabelFilter) => void;
+  onGetLabelNames: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<ComboboxOption[]>;
+  onGetLabelValues: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<ComboboxOption[]>;
+  onDelete: () => void;
+  invalidLabel?: boolean;
+  invalidValue?: boolean;
+  getLabelValuesAutofillSuggestions: (query: string, labelName?: string) => Promise<SelectableValue[]>;
+  debounceDuration: number;
+}
+
+export function LabelFilterItemCombobox({
+  item,
+  defaultOp,
+  onChange,
+  onDelete,
+  onGetLabelNames,
+  onGetLabelValues,
+  invalidLabel,
+  invalidValue,
+  getLabelValuesAutofillSuggestions,
+}: LabelFilterItemProps) {
+  const isMultiSelect = (operator = item.op) => {
+    return operators.find((op) => op.label === operator)?.isMultiValue;
+  };
+
+  const getSelectOptionsFromString = (item?: string): string[] => {
+    if (item) {
+      const regExp = /\(([^)]+)\)/;
+      const matches = item.match(regExp);
+
+      if (matches && matches[0].indexOf('|') > 0) {
+        return [item];
+      }
+
+      if (item.indexOf('|') > 0) {
+        return item.split('|');
+      }
+      return [item];
+    }
+    return [];
+  };
+
+  const itemValue = item?.value ?? '';
+
+  // TODO: should the first item in the tuple, the cache key, be item.label (string) instead?
+  type PrevOptions = [typeof item, ComboboxOption[]];
+  const labelNamesRef = useRef<PrevOptions>();
+  const loadLabelNames = useCallback(
+    async (query: string): Promise<Array<ComboboxOption<string>>> => {
+      const [prevItem, prevLabelNames] = labelNamesRef.current ?? [];
+
+      // This function is called on each key press, but the GetLabelNames API doesn't support filtering.
+      // We lazily request the label names and then cache it for the each time the user types.
+      const labelNames = prevItem === item && prevLabelNames ? prevLabelNames : await onGetLabelNames(item);
+      labelNamesRef.current = [item, labelNames];
+
+      return labelNames.filter((label) => label.value.includes(query));
+    },
+    [item, onGetLabelNames]
+  );
+
+  const labelValuesRef = useRef<PrevOptions>();
+  const loadLabelValues = useCallback(
+    async (query: string): Promise<Array<ComboboxOption<string>>> => {
+      const [prevItem, prevLabelValues] = labelValuesRef.current ?? [];
+
+      // PR TODO: incomplete logic not copied from LabelFilterItem.tsx.
+      // I think we need to:
+      // - when query is empty, call onGetLabelValues
+      // - when we have a query, call getLabelValuesAutofillSuggestions(query, item.label)
+
+      // This function is called on each key press, but the GetLabelNames API doesn't support filtering.
+      // We lazily request the label names and then cache it for the each time the user types.
+      const labelValues = prevItem === item && prevLabelValues ? prevLabelValues : await onGetLabelValues(item);
+      labelValuesRef.current = [item, labelValues];
+
+      return labelValues.filter((label) => label.value.includes(query));
+    },
+    [item, onGetLabelValues]
+  );
+
+  if (isMultiSelect() && itemValue) {
+    return <div>multi select is not supported with combobox yet</div>;
+  }
+
+  return (
+    <div key={itemValue} data-testid="prometheus-dimensions-filter-item">
+      <InputGroup>
+        {/* Label name select, loads all values at once */}
+        <Combobox
+          placeholder="Select label"
+          data-testid={selectors.components.QueryBuilder.labelSelect}
+          // inputId="prometheus-dimensions-filter-item-key"
+          width="auto"
+          minWidth={4} // PR TODO: check this
+          value={item.label ?? null}
+          createCustomValue
+          options={loadLabelNames}
+          onChange={(change) => {
+            onChange({
+              ...item,
+              op: item.op ?? defaultOp,
+              label: change.value,
+
+              // PR TODO: optional?
+              value: item.value ?? '',
+            });
+          }}
+          invalid={invalidLabel}
+        />
+
+        {/* Operator select i.e.   = =~ != !~   */}
+        <Combobox
+          data-testid={selectors.components.QueryBuilder.matchOperatorSelect}
+          value={item.op ?? defaultOp}
+          options={operators}
+          width="auto"
+          minWidth={4} // PR TODO: check this
+          onChange={(change) => {
+            onChange({
+              ...item,
+              op: change.value,
+              // PR TODO: optional?
+              value: (isMultiSelect(change.value) ? item.value : getSelectOptionsFromString(item?.value)[0]) ?? '',
+              // PR TODO: optional?
+              label: item.label ?? '',
+            });
+          }}
+        />
+
+        {/* Label value async select: autocomplete calls prometheus API */}
+
+        <Combobox
+          placeholder="Select value"
+          data-testid={selectors.components.QueryBuilder.valueSelect}
+          // inputId="prometheus-dimensions-filter-item-value"
+          width="auto"
+          minWidth={4} // PR TODO: check this
+          // TODO: isMulti() check would be put back here
+          value={getSelectOptionsFromString(itemValue).map(toComboboxOption)[0]}
+          createCustomValue
+          options={loadLabelValues}
+          onChange={(change) => {
+            onChange({
+              ...item,
+              value: change.value,
+              op: item.op ?? defaultOp,
+              // PR TODO: optional?
+              label: item.label ?? '',
+            });
+          }}
+          invalid={invalidValue}
+        />
+        <AccessoryButton aria-label={`remove-${item.label}`} icon="times" variant="secondary" onClick={onDelete} />
+      </InputGroup>
+    </div>
+  );
+}
+
+const operators = [
+  { label: '=', value: '=', isMultiValue: false },
+  { label: '!=', value: '!=', isMultiValue: false },
+  { label: '=~', value: '=~', isMultiValue: true },
+  { label: '!~', value: '!~', isMultiValue: true },
+];

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilters.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilters.tsx
@@ -1,7 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/LabelFilters.tsx
 import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { EditorField, EditorFieldGroup, EditorList } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
@@ -59,11 +59,12 @@ export function LabelFilters({
 
   const hasLabelFilter = items.some((item) => item.label && item.value);
 
-  const editorList = () => {
+  const FilterItemComponent = useMemo(() => {
     const anyIsMulti = items.some((item) => item.op === '=~' || item.op === '!~');
-    const FilterItemComponent =
-      config.featureToggles.prometheusUsesCombobox && !anyIsMulti ? LabelFilterItemCombobox : LabelFilterItem;
+    return config.featureToggles.prometheusUsesCombobox && !anyIsMulti ? LabelFilterItemCombobox : LabelFilterItem;
+  }, [items]);
 
+  const editorList = () => {
     return (
       <EditorList
         items={items}

--- a/packages/grafana-prometheus/src/querybuilder/components/LabelFilters.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/LabelFilters.tsx
@@ -3,7 +3,6 @@ import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
 import { useEffect, useState } from 'react';
 
-import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorList } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { ComboboxOption, InlineFieldRow, InlineLabel } from '@grafana/ui';
@@ -22,7 +21,7 @@ export interface LabelFiltersProps {
   onGetLabelValues: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<ComboboxOption[]>;
   /** If set to true, component will show error message until at least 1 filter is selected */
   labelFilterRequired?: boolean;
-  getLabelValuesAutofillSuggestions: (query: string, labelName?: string) => Promise<SelectableValue[]>;
+  getLabelValuesAutofillSuggestions: (query: string, labelName?: string) => Promise<ComboboxOption[]>;
   debounceDuration: number;
   variableEditor?: boolean;
 }

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.test.tsx
@@ -86,7 +86,7 @@ describe('MetricCombobox', () => {
     expect(screen.getByPlaceholderText('Select metric')).toBeInTheDocument();
   });
 
-  it('fetches top metrics when the combobox is opened ', async () => {
+  it('fetches top metrics when the combobox is opened', async () => {
     render(<MetricCombobox {...defaultProps} />);
 
     const combobox = screen.getByPlaceholderText('Select metric');

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
@@ -83,7 +83,7 @@ export function MetricsLabelsSection({
   const getLabelValuesAutocompleteSuggestions = (
     queryString?: string,
     labelName?: string
-  ): Promise<SelectableValue[]> => {
+  ): Promise<ComboboxOption[]> => {
     const forLabel = {
       label: labelName ?? '__name__',
       op: '=~',
@@ -100,14 +100,14 @@ export function MetricsLabelsSection({
       value: datasource.interpolateString(labelObject.value),
     }));
     const expr = promQueryModeller.renderLabels(interpolatedLabelsToConsider);
-    let response: Promise<SelectableValue[]>;
+    let response: Promise<ComboboxOption[]>;
     if (datasource.hasLabelsMatchAPISupport()) {
       response = getLabelValuesFromLabelValuesAPI(forLabel, expr);
     } else {
       response = getLabelValuesFromSeriesAPI(forLabel, expr);
     }
 
-    return response.then((response: SelectableValue[]) => {
+    return response.then((response: ComboboxOption[]) => {
       truncateResult(response);
       return response;
     });
@@ -121,7 +121,7 @@ export function MetricsLabelsSection({
   const getLabelValuesFromSeriesAPI = (
     forLabel: Partial<QueryBuilderLabelFilter>,
     promQLExpression: string
-  ): Promise<SelectableValue[]> => {
+  ): Promise<ComboboxOption[]> => {
     if (!forLabel.label) {
       return Promise.resolve([]);
     }
@@ -147,7 +147,7 @@ export function MetricsLabelsSection({
   const getLabelValuesFromLabelValuesAPI = (
     forLabel: Partial<QueryBuilderLabelFilter>,
     promQLExpression: string
-  ): Promise<SelectableValue[]> => {
+  ): Promise<ComboboxOption[]> => {
     if (!forLabel.label) {
       return Promise.resolve([]);
     }

--- a/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/MetricsLabelsSection.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { ComboboxOption } from '@grafana/ui';
 
 import { PrometheusDatasource } from '../../datasource';
 import { getMetadataString } from '../../language_provider';
@@ -40,7 +41,7 @@ export function MetricsLabelsSection({
    * Map metric metadata to SelectableValue for Select component and also adds defined template variables to the list.
    */
   const withTemplateVariableOptions = useCallback(
-    async (optionsPromise: Promise<SelectableValue[]>): Promise<SelectableValue[]> => {
+    async (optionsPromise: Promise<SelectableValue[]>): Promise<ComboboxOption[]> => {
       const variables = datasource.getVariables();
       const options = await optionsPromise;
       return [
@@ -60,7 +61,7 @@ export function MetricsLabelsSection({
    * Formats a promQL expression and passes that off to helper functions depending on API support
    * @param forLabel
    */
-  const onGetLabelNames = async (forLabel: Partial<QueryBuilderLabelFilter>): Promise<SelectableValue[]> => {
+  const onGetLabelNames = async (forLabel: Partial<QueryBuilderLabelFilter>): Promise<ComboboxOption[]> => {
     // If no metric we need to use a different method
     if (!query.metric) {
       await datasource.languageProvider.fetchLabels();


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/97577

This PR moves LabelFilterItem.tsx over to Combobox, gated behind the `prometheusUsesCombobox` toggle.

I've also attempted to work on some of the type errors in here due to the input `item` being `Partial<Item>`, but then spreading that into a change that requires a full `Item`, but not happy with the result.

Ideally I think I would like to just make all values on `Item` optional, because they actually are.

TODO: 
 - [x] port tests over