### PR TITLE
Zanzana: Setup GRPC authentication in client/server mode

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -162,10 +162,17 @@ func (z *Zanzana) start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to read GRPC server config: %w", err)
 	}
-	if len(authCfg.AllowedAudiences) == 0 {
-		authCfg.AllowedAudiences = []string{zanzanaAudience}
+
+	grpcAuthCfg := authnlib.GrpcAuthenticatorConfig{
+		KeyRetrieverConfig: authnlib.KeyRetrieverConfig{
+			SigningKeysURL: authCfg.SigningKeysURL,
+		},
+		VerifierConfig: authnlib.VerifierConfig{
+			AllowedAudiences: []string{zanzanaAudience},
+		},
 	}
-	authenticator, err := grpcutils.NewGrpcAuthenticator(authCfg, tracer)
+
+	authenticator, err := authnlib.NewGrpcAuthenticator(&grpcAuthCfg, authnlib.WithIDTokenAuthOption(true))
 	if err != nil {
 		return fmt.Errorf("failed to setup authentication: %w", err)
 	}

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -51,11 +51,10 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 			return nil, err
 		}
 
-		stackID := cfg.StackID
-		if stackID == "" {
-			stackID = "default"
+		if cfg.StackID == "" {
+			return nil, fmt.Errorf("missing stack ID")
 		}
-		namespace := fmt.Sprintf("stacks-%s", stackID)
+		namespace := fmt.Sprintf("stacks-%s", cfg.StackID)
 
 		tokenAuthCred := &tokenAuth{
 			cfg:         cfg,

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -45,9 +45,8 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 	switch cfg.Zanzana.Mode {
 	case setting.ZanzanaModeClient:
 		tokenClient, err := authnlib.NewTokenExchangeClient(authnlib.TokenExchangeConfig{
-			// TODO: fix config reading in zanzana
-			Token:            "mytoken",
-			TokenExchangeURL: "qwerty",
+			Token:            cfg.Zanzana.Token,
+			TokenExchangeURL: cfg.Zanzana.TokenExchangeURL,
 		})
 		if err != nil {
 			return nil, err
@@ -184,9 +183,8 @@ func (z *Zanzana) start(ctx context.Context) error {
 			authnlib.VerifierConfig{
 				AllowedAudiences: []string{zanzanaAudience},
 			},
-			// TODO: fix reading proper config value (inside zanzana config)
 			authnlib.NewKeyRetriever(authnlib.KeyRetrieverConfig{
-				SigningKeysURL: "qwerty",
+				SigningKeysURL: z.cfg.Zanzana.SigningKeysURL,
 			}),
 		),
 	)

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -48,7 +48,7 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 			TokenExchangeURL: cfg.Zanzana.TokenExchangeURL,
 		})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to initialize token exchange client: %w", err)
 		}
 
 		if cfg.StackID == "" {

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -53,8 +53,13 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 		}
 
 		authInterceptor := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			stackID := cfg.StackID
+			if stackID == "" {
+				stackID = "default"
+			}
+
 			token, err := tokenClient.Exchange(ctx, authnlib.TokenExchangeRequest{
-				Namespace: cfg.StackID,
+				Namespace: fmt.Sprintf("stacks-%s", stackID),
 				Audiences: []string{zanzanaAudience},
 			})
 			if err != nil {

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -14,6 +14,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -63,6 +64,8 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 		}
 
 		dialOptions := []grpc.DialOption{
+			// TODO: add TLS support
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithPerRPCCredentials(tokenAuthCred),
 		}
 
@@ -257,5 +260,5 @@ func (t *tokenAuth) GetRequestMetadata(ctx context.Context, _ ...string) (map[st
 }
 
 func (t *tokenAuth) RequireTransportSecurity() bool {
-	return t.cfg.Env != setting.Dev
+	return false
 }

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -58,6 +58,7 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 		namespace := fmt.Sprintf("stacks-%s", stackID)
 
 		tokenAuthCred := &tokenAuth{
+			cfg:         cfg,
 			namespace:   namespace,
 			tokenClient: tokenClient,
 		}

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -54,7 +54,7 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 
 		authInterceptor := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 			token, err := tokenClient.Exchange(ctx, authnlib.TokenExchangeRequest{
-				Namespace: "stack-id",
+				Namespace: cfg.StackID,
 				Audiences: []string{zanzanaAudience},
 			})
 			if err != nil {

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -72,10 +72,14 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, features featuremgmt.FeatureTogg
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
-		conn, err := grpc.NewClient(cfg.Zanzana.Addr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		dialOptions := []grpc.DialOption{
 			grpc.WithUnaryInterceptor(authInterceptor),
-		)
+		}
+		if cfg.Env == setting.Dev {
+			dialOptions = append(dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		}
+
+		conn, err := grpc.NewClient(cfg.Zanzana.Addr, dialOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create zanzana client to remote server: %w", err)
 		}

--- a/pkg/services/authz/zanzana/server/auth.go
+++ b/pkg/services/authz/zanzana/server/auth.go
@@ -8,16 +8,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type ReqWithNamespace interface {
-	GetNamespace() string
-}
-
-func authorize(ctx context.Context, r ReqWithNamespace) error {
+func authorize(ctx context.Context, namespace string) error {
 	c, ok := claims.From(ctx)
 	if !ok {
 		return status.Errorf(codes.Unauthenticated, "unauthenticated")
 	}
-	if !claims.NamespaceMatches(c.GetNamespace(), r.GetNamespace()) {
+	if !claims.NamespaceMatches(c.GetNamespace(), namespace) {
 		return status.Errorf(codes.PermissionDenied, "namespace does not match")
 	}
 	return nil

--- a/pkg/services/authz/zanzana/server/auth.go
+++ b/pkg/services/authz/zanzana/server/auth.go
@@ -13,7 +13,7 @@ func authorize(ctx context.Context, namespace string) error {
 	if !ok {
 		return status.Errorf(codes.Unauthenticated, "unauthenticated")
 	}
-	if c.GetNamespace() == "" {
+	if c.GetNamespace() == "" || namespace == "" {
 		return status.Errorf(codes.Unauthenticated, "unauthenticated")
 	}
 	if !claims.NamespaceMatches(c.GetNamespace(), namespace) {

--- a/pkg/services/authz/zanzana/server/auth.go
+++ b/pkg/services/authz/zanzana/server/auth.go
@@ -13,6 +13,9 @@ func authorize(ctx context.Context, namespace string) error {
 	if !ok {
 		return status.Errorf(codes.Unauthenticated, "unauthenticated")
 	}
+	if c.GetNamespace() == "" {
+		return status.Errorf(codes.Unauthenticated, "unauthenticated")
+	}
 	if !claims.NamespaceMatches(c.GetNamespace(), namespace) {
 		return status.Errorf(codes.PermissionDenied, "namespace does not match")
 	}

--- a/pkg/services/authz/zanzana/server/auth.go
+++ b/pkg/services/authz/zanzana/server/auth.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"context"
+
+	"github.com/grafana/authlib/claims"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type ReqWithNamespace interface {
+	GetNamespace() string
+}
+
+func authorize(ctx context.Context, r ReqWithNamespace) error {
+	c, ok := claims.From(ctx)
+	if !ok {
+		return status.Errorf(codes.Unauthenticated, "unauthenticated")
+	}
+	if !claims.NamespaceMatches(c.GetNamespace(), r.GetNamespace()) {
+		return status.Errorf(codes.PermissionDenied, "namespace does not match")
+	}
+	return nil
+}

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -13,6 +13,10 @@ func (s *Server) BatchCheck(ctx context.Context, r *authzextv1.BatchCheckRequest
 	ctx, span := tracer.Start(ctx, "authzServer.BatchCheck")
 	defer span.End()
 
+	if err := authorize(ctx, r); err != nil {
+		return nil, err
+	}
+
 	batchRes := &authzextv1.BatchCheckResponse{
 		Groups: make(map[string]*authzextv1.BatchCheckGroupResource),
 	}

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -13,7 +13,7 @@ func (s *Server) BatchCheck(ctx context.Context, r *authzextv1.BatchCheckRequest
 	ctx, span := tracer.Start(ctx, "authzServer.BatchCheck")
 	defer span.End()
 
-	if err := authorize(ctx, r); err != nil {
+	if err := authorize(ctx, r.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/authz/zanzana/server/server_batch_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,7 +33,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
 			{Name: "2", Folder: "2"},
 		}))
@@ -47,7 +46,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/{1,2} through group_resource", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
 			{Name: "2", Folder: "2"},
 		}))
@@ -57,7 +56,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
 			{Name: "2", Folder: "2"},
 		}))
@@ -70,7 +69,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
 			{Name: "2", Folder: "3"},
 			{Name: "3", Folder: "2"},
@@ -85,7 +84,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1", Folder: "1"},
 			{Name: "2", Folder: "2"},
 		}))
@@ -98,7 +97,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:6 should be able to read folder 1", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(folderGroup, folderResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1"},
 			{Name: "2"},
 		}))
@@ -111,7 +110,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:7 should be able to read folder {1,2} through group_resource access", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(folderGroup, folderResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "1"},
 			{Name: "2"},
 		}))
@@ -123,7 +122,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboards in folder 6 through folder 5", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "10", Folder: "6"},
 			{Name: "20", Folder: "6"},
 		}))
@@ -135,7 +134,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:9 should be able to create dashboards in folder 6 through folder 5", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, "")
-		res, err := server.BatchCheck(context.Background(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", []*authzextv1.BatchCheckItem{
 			{Name: "10", Folder: "6"},
 			{Name: "20", Folder: "6"},
 		}))
@@ -148,7 +147,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:10 should be able to get dashboard status for 10 and 11", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, statusSubresource)
-		res, err := server.BatchCheck(context.Background(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, []*authzextv1.BatchCheckItem{
 			{Name: "10", Folder: "6"},
 			{Name: "11", Folder: "6"},
 			{Name: "12", Folder: "6"},
@@ -163,7 +162,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:11 should be able to get dashboard status for 10, 11 and 12 through group_resource", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, statusSubresource)
-		res, err := server.BatchCheck(context.Background(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, []*authzextv1.BatchCheckItem{
 			{Name: "10", Folder: "6"},
 			{Name: "11", Folder: "6"},
 			{Name: "12", Folder: "6"},
@@ -178,7 +177,7 @@ func testBatchCheck(t *testing.T, server *Server) {
 
 	t.Run("user:12 should be able to get dashboard status in folder 5 and 6", func(t *testing.T) {
 		groupResource := common.FormatGroupResource(dashboardGroup, dashboardResource, statusSubresource)
-		res, err := server.BatchCheck(context.Background(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, []*authzextv1.BatchCheckItem{
+		res, err := server.BatchCheck(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, []*authzextv1.BatchCheckItem{
 			{Name: "10", Folder: "5"},
 			{Name: "11", Folder: "6"},
 			{Name: "12", Folder: "6"},

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	"github.com/grafana/authlib/claims"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
@@ -14,6 +17,14 @@ import (
 func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.CheckResponse, error) {
 	ctx, span := tracer.Start(ctx, "authzServer.Check")
 	defer span.End()
+
+	c, ok := claims.From(ctx)
+	if !ok {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated")
+	}
+	if !claims.NamespaceMatches(c.GetNamespace(), r.GetNamespace()) {
+		return nil, status.Errorf(codes.PermissionDenied, "namespace does not match")
+	}
 
 	store, err := s.getStoreInfo(ctx, r.GetNamespace())
 	if err != nil {

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -15,7 +15,7 @@ func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.C
 	ctx, span := tracer.Start(ctx, "authzServer.Check")
 	defer span.End()
 
-	if err := authorize(ctx, r); err != nil {
+	if err := authorize(ctx, r.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
@@ -26,130 +25,130 @@ func testCheck(t *testing.T, server *Server) {
 	}
 
 	t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
 		// sanity check
-		res, err = server.Check(context.Background(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 
 		// sanity check no access to subresource
-		res, err = server.Check(context.Background(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "1"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "1"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 	})
 
 	t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/1 through group_resource", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
 	t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
 		// sanity check
-		res, err = server.Check(context.Background(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 	})
 
 	t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
 		// sanity check
-		res, err = server.Check(context.Background(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "2"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "2"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 	})
 
 	t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
 	t.Run("user:6 should be able to read folder 1 ", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
 	t.Run("user:7 should be able to read folder one through group_resource access", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "10"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "10"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
 	t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboar in folder 6 through folder 5", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:8", utils.VerbGet, folderGroup, folderResource, "", "4", "12"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, folderGroup, folderResource, "", "4", "12"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 	})
 
 	t.Run("user:9 should be able to create dashboards in folder 5", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", "5", ""))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", "5", ""))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
 	t.Run("user:10 should be able to read dashboard status for dashboard 10", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "1"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "1"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 	})
 
 	t.Run("user:11 should be able to read dashboard status for dashboard 10 through group_resource", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 	})
 
 	t.Run("user:12 should be able to read dashboard status for all dashboards in folder 5", func(t *testing.T) {
-		res, err := server.Check(context.Background(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "10"))
+		res, err := server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "10"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "11"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "11"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
 		// inherited from folder 5
-		res, err = server.Check(context.Background(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "6", "12"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "6", "12"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed())
 
-		res, err = server.Check(context.Background(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "13"))
+		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "13"))
 		require.NoError(t, err)
 		assert.False(t, res.GetAllowed())
 	})

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -15,7 +15,7 @@ func (s *Server) List(ctx context.Context, r *authzv1.ListRequest) (*authzv1.Lis
 	ctx, span := tracer.Start(ctx, "authzServer.List")
 	defer span.End()
 
-	if err := authorize(ctx, r); err != nil {
+	if err := authorize(ctx, r.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -15,6 +15,10 @@ func (s *Server) List(ctx context.Context, r *authzv1.ListRequest) (*authzv1.Lis
 	ctx, span := tracer.Start(ctx, "authzServer.List")
 	defer span.End()
 
+	if err := authorize(ctx, r); err != nil {
+		return nil, err
+	}
+
 	store, err := s.getStoreInfo(ctx, r.Namespace)
 	if err != nil {
 		return nil, err

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -1,13 +1,13 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
@@ -24,7 +24,7 @@ func testList(t *testing.T, server *Server) {
 	}
 
 	t.Run("user:1 should list resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:1", dashboardGroup, dashboardResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:1", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 1)
 		assert.Len(t, res.GetFolders(), 0)
@@ -32,7 +32,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:2 should be able to list all through group", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:2", dashboardGroup, dashboardResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:2", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
 		assert.True(t, res.GetAll())
 		assert.Len(t, res.GetItems(), 0)
@@ -40,7 +40,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:3 should be able to list resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:3", dashboardGroup, dashboardResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:3", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
 
 		assert.Len(t, res.GetItems(), 1)
@@ -49,7 +49,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:4 should be able to list all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:4", dashboardGroup, dashboardResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:4", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)
 		assert.Len(t, res.GetFolders(), 2)
@@ -59,7 +59,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:5 should be list all dashboard.grafana.app/dashboards in folder 1 with set relation", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:5", dashboardGroup, dashboardResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:5", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)
 		assert.Len(t, res.GetFolders(), 1)
@@ -67,7 +67,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:6 should be able to list folder 1", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:6", folderGroup, folderResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:6", folderGroup, folderResource, ""))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 1)
 		assert.Len(t, res.GetFolders(), 0)
@@ -75,7 +75,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:7 should be able to list all folders", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:7", folderGroup, folderResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:7", folderGroup, folderResource, ""))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)
 		assert.Len(t, res.GetFolders(), 0)
@@ -83,7 +83,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:8 should be able to list resoruce:dashboard.grafana.app/dashboard in folder 6 and folder 5", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:8", dashboardGroup, dashboardResource, ""))
+		res, err := server.List(newContextWithNamespace(), newList("user:8", dashboardGroup, dashboardResource, ""))
 		require.NoError(t, err)
 		assert.Len(t, res.GetFolders(), 2)
 
@@ -92,7 +92,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:10 should be able to get resoruce:dashboard.grafana.app/dashboard/status for 10 and 11", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:10", dashboardGroup, dashboardResource, statusSubresource))
+		res, err := server.List(newContextWithNamespace(), newList("user:10", dashboardGroup, dashboardResource, statusSubresource))
 		require.NoError(t, err)
 		assert.Len(t, res.GetFolders(), 0)
 		assert.Len(t, res.GetItems(), 2)
@@ -102,7 +102,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:11 should be able to list all resoruce:dashboard.grafana.app/dashboard/status ", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:11", dashboardGroup, dashboardResource, statusSubresource))
+		res, err := server.List(newContextWithNamespace(), newList("user:11", dashboardGroup, dashboardResource, statusSubresource))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)
 		assert.Len(t, res.GetFolders(), 0)
@@ -110,7 +110,7 @@ func testList(t *testing.T, server *Server) {
 	})
 
 	t.Run("user:12 should be able to list all resoruce:dashboard.grafana.app/dashboard/status in folder 5 and 6", func(t *testing.T) {
-		res, err := server.List(context.Background(), newList("user:12", dashboardGroup, dashboardResource, statusSubresource))
+		res, err := server.List(newContextWithNamespace(), newList("user:12", dashboardGroup, dashboardResource, statusSubresource))
 		require.NoError(t, err)
 		assert.Len(t, res.GetItems(), 0)
 		assert.Len(t, res.GetFolders(), 2)

--- a/pkg/services/authz/zanzana/server/server_read.go
+++ b/pkg/services/authz/zanzana/server/server_read.go
@@ -13,7 +13,7 @@ func (s *Server) Read(ctx context.Context, req *authzextv1.ReadRequest) (*authze
 	ctx, span := tracer.Start(ctx, "authzServer.Read")
 	defer span.End()
 
-	if err := authorize(ctx, req); err != nil {
+	if err := authorize(ctx, req.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/authz/zanzana/server/server_read.go
+++ b/pkg/services/authz/zanzana/server/server_read.go
@@ -13,6 +13,10 @@ func (s *Server) Read(ctx context.Context, req *authzextv1.ReadRequest) (*authze
 	ctx, span := tracer.Start(ctx, "authzServer.Read")
 	defer span.End()
 
+	if err := authorize(ctx, req); err != nil {
+		return nil, err
+	}
+
 	storeInf, err := s.getStoreInfo(ctx, req.Namespace)
 	if err != nil {
 		return nil, err

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	authnlib "github.com/grafana/authlib/authn"
+	"github.com/grafana/authlib/claims"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
 
@@ -101,4 +103,14 @@ func setup(t *testing.T, testDB db.DB, cfg *setting.Cfg) *Server {
 	})
 	require.NoError(t, err)
 	return srv
+}
+
+func newContextWithNamespace() context.Context {
+	ctx := context.Background()
+	ctx = claims.WithClaims(ctx, authnlib.NewAccessTokenAuthInfo(authnlib.Claims[authnlib.AccessTokenClaims]{
+		Rest: authnlib.AccessTokenClaims{
+			Namespace: "*",
+		},
+	}))
+	return ctx
 }

--- a/pkg/services/authz/zanzana/server/server_write.go
+++ b/pkg/services/authz/zanzana/server/server_write.go
@@ -13,6 +13,10 @@ func (s *Server) Write(ctx context.Context, req *authzextv1.WriteRequest) (*auth
 	ctx, span := tracer.Start(ctx, "authzServer.Write")
 	defer span.End()
 
+	if err := authorize(ctx, req); err != nil {
+		return nil, err
+	}
+
 	storeInf, err := s.getStoreInfo(ctx, req.Namespace)
 	if err != nil {
 		return nil, err

--- a/pkg/services/authz/zanzana/server/server_write.go
+++ b/pkg/services/authz/zanzana/server/server_write.go
@@ -13,7 +13,7 @@ func (s *Server) Write(ctx context.Context, req *authzextv1.WriteRequest) (*auth
 	ctx, span := tracer.Start(ctx, "authzServer.Write")
 	defer span.End()
 
-	if err := authorize(ctx, req); err != nil {
+	if err := authorize(ctx, req.GetNamespace()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/grpcserver/interceptors/auth.go
+++ b/pkg/services/grpcserver/interceptors/auth.go
@@ -21,6 +21,12 @@ type Authenticator interface {
 	Authenticate(ctx context.Context) (context.Context, error)
 }
 
+type AuthenticatorFunc func(context.Context) (context.Context, error)
+
+func (fn AuthenticatorFunc) Authenticate(ctx context.Context) (context.Context, error) {
+	return fn(ctx)
+}
+
 // authenticator can authenticate GRPC requests.
 type authenticator struct {
 	contextHandler grpccontext.ContextHandler

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -37,6 +37,13 @@ type ZanzanaSettings struct {
 	// Use streamed version of list objects.
 	// Returns full list of objects, but takes more time.
 	UseStreamedListObjects bool
+
+	// Token used to perform the exchange request.
+	Token string
+	// URL called to perform exchange request.
+	TokenExchangeURL string
+	// URL for signing keys
+	SigningKeysURL string
 }
 
 func (cfg *Cfg) readZanzanaSettings() {
@@ -62,6 +69,10 @@ func (cfg *Cfg) readZanzanaSettings() {
 	s.ListObjectsDeadline = sec.Key("list_objects_deadline").MustDuration(3 * time.Second)
 	s.ListObjectsMaxResults = uint32(sec.Key("list_objects_max_results").MustUint(1000))
 	s.UseStreamedListObjects = sec.Key("use_streamed_list_objects").MustBool(false)
+
+	s.Token = sec.Key("token").MustString("")
+	s.TokenExchangeURL = sec.Key("token_exchange_url").MustString("")
+	s.SigningKeysURL = sec.Key("signing_keys_url").MustString("")
 
 	cfg.Zanzana = s
 }


### PR DESCRIPTION
**What is this feature?**

Configure authentication for zanzana when Grafana running as a zanzana standalone server or in client mode. Authenticator from authlib is used for this purpose.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/1014

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
