### PR TITLE
Folders: Make SQL "where" queries for folders go through folder service

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -830,7 +830,7 @@ func getDashboardShouldReturn200WithConfig(t *testing.T, sc *scenarioContext, pr
 	dashboardPermissions := accesscontrolmock.NewMockedPermissionsService()
 
 	db := db.InitTestDB(t)
-	fStore := folderimpl.ProvideStore(db)
+	fStore := folderimpl.ProvideStore(db, features)
 	quotaService := quotatest.New(false, nil)
 	folderSvc := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()),
 		dashboardStore, folderStore, db, features,

--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -459,7 +459,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())
 	cfg := setting.NewCfg()
 	actionSets := resourcepermissions.NewActionSetService(features)
-	fStore := folderimpl.ProvideStore(sc.db)
+	fStore := folderimpl.ProvideStore(sc.db, features)
 	folderServiceWithFlagOn := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore,
 		folderStore, sc.db, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 	acSvc := acimpl.ProvideOSSService(

--- a/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/testutil/testutil.go
@@ -45,7 +45,7 @@ func ProvideFolderPermissions(
 		return nil, err
 	}
 
-	fStore := folderimpl.ProvideStore(sqlStore)
+	fStore := folderimpl.ProvideStore(sqlStore, features)
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
 	fService := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()),
 		dashboardStore, folderStore, sqlStore, features,

--- a/pkg/services/annotations/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol_test.go
@@ -44,14 +44,15 @@ func TestIntegrationAuthorize(t *testing.T) {
 	defer func() { guardian.New = origNewDashboardGuardian }()
 	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true})
 	folderStore := folderimpl.ProvideDashboardFolderStore(sql)
-	fStore := folderimpl.ProvideStore(sql)
-	dashStore, err := database.ProvideDashboardStore(sql, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sql))
+	features := featuremgmt.WithFeatures()
+	fStore := folderimpl.ProvideStore(sql, features)
+	dashStore, err := database.ProvideDashboardStore(sql, cfg, features, tagimpl.ProvideService(sql))
 	require.NoError(t, err)
-	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())
+	ac := acimpl.ProvideAccessControl(features, zanzana.NewNoopClient())
 	folderSvc := folderimpl.ProvideService(fStore, accesscontrolmock.New(), bus.ProvideBus(tracing.InitializeTracerForTest()),
-		dashStore, folderStore, sql, featuremgmt.WithFeatures(),
+		dashStore, folderStore, sql, features,
 		supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
-	dashSvc, err := dashboardsservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, featuremgmt.WithFeatures(), accesscontrolmock.NewMockedPermissionsService(), accesscontrolmock.NewMockedPermissionsService(),
+	dashSvc, err := dashboardsservice.ProvideDashboardServiceImpl(cfg, dashStore, folderStore, features, accesscontrolmock.NewMockedPermissionsService(), accesscontrolmock.NewMockedPermissionsService(),
 		ac, folderSvc, fStore, nil, zanzana.NewNoopClient(), nil, nil, nil, quotatest.New(false, nil), nil)
 	require.NoError(t, err)
 

--- a/pkg/services/annotations/annotationsimpl/annotations_test.go
+++ b/pkg/services/annotations/annotationsimpl/annotations_test.go
@@ -56,7 +56,7 @@ func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 	defer func() { guardian.New = origNewDashboardGuardian }()
 	guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{})
 	folderStore := folderimpl.ProvideDashboardFolderStore(sql)
-	fStore := folderimpl.ProvideStore(sql)
+	fStore := folderimpl.ProvideStore(sql, features)
 	dashStore, err := database.ProvideDashboardStore(sql, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sql))
 	require.NoError(t, err)
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures(), zanzana.NewNoopClient())
@@ -241,7 +241,7 @@ func TestIntegrationAnnotationListingWithInheritedRBAC(t *testing.T) {
 		})
 
 		ac := acimpl.ProvideAccessControl(features, zanzana.NewNoopClient())
-		fStore := folderimpl.ProvideStore(sql)
+		fStore := folderimpl.ProvideStore(sql, features)
 		folderStore := folderimpl.ProvideDashboardFolderStore(sql)
 		folderSvc := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore,
 			folderStore, sql, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -299,7 +299,7 @@ func TestIntegrationDashboardInheritedFolderRBAC(t *testing.T) {
 			guardian.New = origNewGuardian
 		})
 
-		folderStore := folderimpl.ProvideStore(sqlStore)
+		folderStore := folderimpl.ProvideStore(sqlStore, features)
 		folderSvc := folderimpl.ProvideService(folderStore, mock.New(), bus.ProvideBus(tracer), dashboardWriteStore, folderimpl.ProvideDashboardFolderStore(sqlStore), sqlStore, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 
 		parentUID := ""

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -857,7 +857,7 @@ func TestIntegrationFindDashboardsByTitle(t *testing.T) {
 
 	ac := acimpl.ProvideAccessControl(features, zanzana.NewNoopClient())
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
-	fStore := folderimpl.ProvideStore(sqlStore)
+	fStore := folderimpl.ProvideStore(sqlStore, features)
 	folderServiceWithFlagOn := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore,
 		folderStore, sqlStore, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 
@@ -975,7 +975,7 @@ func TestIntegrationFindDashboardsByFolder(t *testing.T) {
 
 	ac := acimpl.ProvideAccessControl(features, zanzana.NewNoopClient())
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
-	fStore := folderimpl.ProvideStore(sqlStore)
+	fStore := folderimpl.ProvideStore(sqlStore, features)
 
 	folderServiceWithFlagOn := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore,
 		folderStore, sqlStore, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/search/model"
+	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/services/store/entity"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -1029,6 +1030,10 @@ func (dr *DashboardServiceImpl) FindDashboards(ctx context.Context, query *dashb
 		return finalResults, nil
 	}
 
+	// This is the key part which ensures all queries for folders go through folder service.
+	if (query.Type == searchstore.TypeFolder) || (query.Type == searchstore.TypeAlertFolder) {
+		return dr.folderService.FindFolders(ctx, query)
+	}
 	return dr.dashboardStore.FindDashboards(ctx, query)
 }
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1032,7 +1032,26 @@ func (dr *DashboardServiceImpl) FindDashboards(ctx context.Context, query *dashb
 
 	// This is the key part which ensures all queries for folders go through folder service.
 	if (query.Type == searchstore.TypeFolder) || (query.Type == searchstore.TypeAlertFolder) {
-		return dr.folderService.FindFolders(ctx, query)
+		folderQuery := folder.FindPersistedFoldersQuery{
+			Title: query.Title,
+			OrgId: query.OrgId,
+			// #TODO fill in the rest
+		}
+		fp, err := dr.folderService.FindFolders(ctx, &folderQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		dashProjection := []dashboards.DashboardSearchProjection{}
+		for _, p := range fp {
+			dp := dashboards.DashboardSearchProjection{
+				ID:  p.ID,
+				UID: p.UID,
+				// #TODO fill in the rest
+			}
+			dashProjection = append(dashProjection, dp)
+		}
+		return dashProjection, nil
 	}
 	return dr.dashboardStore.FindDashboards(ctx, query)
 }

--- a/pkg/services/dashboards/service/zanzana_integration_test.go
+++ b/pkg/services/dashboards/service/zanzana_integration_test.go
@@ -57,7 +57,7 @@ func TestIntegrationDashboardServiceZanzana(t *testing.T) {
 		quotaService := quotatest.New(false, nil)
 		tagService := tagimpl.ProvideService(db)
 		folderStore := folderimpl.ProvideDashboardFolderStore(db)
-		fStore := folderimpl.ProvideStore(db)
+		fStore := folderimpl.ProvideStore(db, features)
 		dashboardStore, err := database.ProvideDashboardStore(db, cfg, features, tagService)
 		require.NoError(t, err)
 
@@ -91,7 +91,7 @@ func TestIntegrationDashboardServiceZanzana(t *testing.T) {
 		createDashboards(t, service, 100, "test-a")
 		createDashboards(t, service, 100, "test-b")
 
-		folderImplStore := folderimpl.ProvideStore(db)
+		folderImplStore := folderimpl.ProvideStore(db, features)
 		folderService := folderimpl.ProvideService(
 			folderImplStore,
 			ac,

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -137,7 +137,7 @@ func (s *Service) DBMigration(db db.DB) {
 	s.log.Debug("syncing dashboard and folder tables finished")
 }
 
-func (s *Service) FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error) {
+func (s *Service) FindFolders(ctx context.Context, query *folder.FindPersistedFoldersQuery) ([]folder.FolderSearchProjection, error) {
 	return s.store.FindFolders(ctx, query)
 }
 

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -137,6 +137,10 @@ func (s *Service) DBMigration(db db.DB) {
 	s.log.Debug("syncing dashboard and folder tables finished")
 }
 
+func (s *Service) FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error) {
+	return s.store.FindFolders(ctx, query)
+}
+
 func (s *Service) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*folder.Folder, error) {
 	if q.SignedInUser == nil {
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")

--- a/pkg/services/folder/folderimpl/sqlstore_test.go
+++ b/pkg/services/folder/folderimpl/sqlstore_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
@@ -36,7 +37,8 @@ func TestIntegrationCreate(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -156,7 +158,8 @@ func TestIntegrationDelete(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -203,7 +206,8 @@ func TestIntegrationUpdate(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -378,7 +382,8 @@ func TestIntegrationGet(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -513,7 +518,8 @@ func TestIntegrationGetParents(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -581,7 +587,8 @@ func TestIntegrationGetChildren(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -823,7 +830,8 @@ func TestIntegrationGetHeight(t *testing.T) {
 	}
 
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 
@@ -856,7 +864,8 @@ func TestIntegrationGetFolders(t *testing.T) {
 
 	foldersNum := 10
 	db, cfg := sqlstore.InitTestDB(t)
-	folderStore := ProvideStore(db)
+	features := featuremgmt.WithFeatures()
+	folderStore := ProvideStore(db, features)
 
 	orgID := CreateOrg(t, db, cfg)
 

--- a/pkg/services/folder/foldertest/foldertest.go
+++ b/pkg/services/folder/foldertest/foldertest.go
@@ -3,6 +3,7 @@ package foldertest
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 )
 
@@ -54,4 +55,9 @@ func (s *FakeService) GetDescendantCounts(ctx context.Context, q *folder.GetDesc
 
 func (s *FakeService) GetFolders(ctx context.Context, q folder.GetFoldersQuery) ([]*folder.Folder, error) {
 	return s.ExpectedFolders, s.ExpectedError
+}
+
+func (s *FakeService) FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error) {
+	// #TODO figure out what the implementation of this method should be for the fake service
+	return nil, nil
 }

--- a/pkg/services/folder/foldertest/foldertest.go
+++ b/pkg/services/folder/foldertest/foldertest.go
@@ -3,7 +3,6 @@ package foldertest
 import (
 	"context"
 
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 )
 
@@ -57,7 +56,7 @@ func (s *FakeService) GetFolders(ctx context.Context, q folder.GetFoldersQuery) 
 	return s.ExpectedFolders, s.ExpectedError
 }
 
-func (s *FakeService) FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error) {
+func (s *FakeService) FindFolders(ctx context.Context, query *folder.FindPersistedFoldersQuery) ([]folder.FolderSearchProjection, error) {
 	// #TODO figure out what the implementation of this method should be for the fake service
 	return nil, nil
 }

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/slugify"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
+	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -220,3 +221,45 @@ type GetDescendantCountsQuery struct {
 }
 
 type DescendantCounts map[string]int64
+
+type FindPersistedFoldersQuery struct {
+	Title         string
+	OrgId         int64
+	SignedInUser  identity.Requester
+	DashboardIds  []int64
+	DashboardUIDs []string
+	Type          string
+	// Deprecated: use FolderUIDs instead
+	FolderIds  []int64
+	FolderUIDs []string
+	Tags       []string
+	Limit      int64
+	Page       int64
+	Permission dashboardaccess.PermissionType
+	Sort       model.SortOption
+	IsDeleted  bool
+
+	Filters []any
+
+	// Skip access control checks. This field is used by OpenFGA search implementation.
+	// Should not be used anywhere else.
+	SkipAccessControlFilter bool
+}
+
+type FolderSearchProjection struct {
+	ID       int64  `xorm:"id"`
+	UID      string `xorm:"uid"`
+	OrgID    int64  `xorm:"org_id"`
+	Title    string
+	Slug     string
+	Term     string
+	IsFolder bool
+	// Deprecated: use FolderUID instead
+	FolderID    int64  `xorm:"folder_id"`
+	FolderUID   string `xorm:"folder_uid"`
+	FolderSlug  string
+	FolderTitle string
+	SortMeta    int64
+	Tags        []string
+	Deleted     *time.Time
+}

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -2,6 +2,10 @@ package folder
 
 import (
 	"context"
+
+	// #TODO move dashboards.FindPersistedDashboardsQuery and dashboards.DashboardSearchProjection to
+	// a new package which both dashboards and folders can import
+	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
 type Service interface {
@@ -35,6 +39,7 @@ type Service interface {
 	// If FullpathUIDs is true it computes a string that contains the UIDs of all parent folders separated by slash.
 	GetFolders(ctx context.Context, q GetFoldersQuery) ([]*Folder, error)
 	GetDescendantCounts(ctx context.Context, q *GetDescendantCountsQuery) (DescendantCounts, error)
+	FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error)
 }
 
 // FolderStore is a folder store.

--- a/pkg/services/folder/service.go
+++ b/pkg/services/folder/service.go
@@ -2,10 +2,6 @@ package folder
 
 import (
 	"context"
-
-	// #TODO move dashboards.FindPersistedDashboardsQuery and dashboards.DashboardSearchProjection to
-	// a new package which both dashboards and folders can import
-	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
 type Service interface {
@@ -39,7 +35,7 @@ type Service interface {
 	// If FullpathUIDs is true it computes a string that contains the UIDs of all parent folders separated by slash.
 	GetFolders(ctx context.Context, q GetFoldersQuery) ([]*Folder, error)
 	GetDescendantCounts(ctx context.Context, q *GetDescendantCountsQuery) (DescendantCounts, error)
-	FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error)
+	FindFolders(ctx context.Context, query *FindPersistedFoldersQuery) ([]FolderSearchProjection, error)
 }
 
 // FolderStore is a folder store.

--- a/pkg/services/folder/store.go
+++ b/pkg/services/folder/store.go
@@ -2,6 +2,8 @@ package folder
 
 import (
 	"context"
+
+	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
 type GetFoldersFromStoreQuery struct {
@@ -48,4 +50,6 @@ type Store interface {
 	GetFolders(ctx context.Context, q GetFoldersFromStoreQuery) ([]*Folder, error)
 	// GetDescendants returns all descendants of a folder
 	GetDescendants(ctx context.Context, orgID int64, anchestor_uid string) ([]*Folder, error)
+
+	FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error)
 }

--- a/pkg/services/folder/store.go
+++ b/pkg/services/folder/store.go
@@ -51,5 +51,6 @@ type Store interface {
 	// GetDescendants returns all descendants of a folder
 	GetDescendants(ctx context.Context, orgID int64, anchestor_uid string) ([]*Folder, error)
 
+	// FindFolders returns the folders which match the conditions set by the query argument.
 	FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error)
 }

--- a/pkg/services/folder/store.go
+++ b/pkg/services/folder/store.go
@@ -2,8 +2,6 @@ package folder
 
 import (
 	"context"
-
-	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
 type GetFoldersFromStoreQuery struct {
@@ -52,5 +50,5 @@ type Store interface {
 	GetDescendants(ctx context.Context, orgID int64, anchestor_uid string) ([]*Folder, error)
 
 	// FindFolders returns the folders which match the conditions set by the query argument.
-	FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error)
+	FindFolders(ctx context.Context, query *FindPersistedFoldersQuery) ([]FolderSearchProjection, error)
 }

--- a/pkg/services/folder/store_fake.go
+++ b/pkg/services/folder/store_fake.go
@@ -2,6 +2,8 @@ package folder
 
 import (
 	"context"
+
+	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
 type fakeStore struct {
@@ -61,4 +63,9 @@ func (f *fakeStore) GetFolders(ctx context.Context, q GetFoldersFromStoreQuery) 
 
 func (f *fakeStore) GetDescendants(ctx context.Context, orgID int64, ancestor_uid string) ([]*Folder, error) {
 	return f.ExpectedFolders, f.ExpectedError
+}
+
+func (s *fakeStore) FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error) {
+	// #TODO figure out what the implementation of this method should be for the fake store
+	return nil, nil
 }

--- a/pkg/services/folder/store_fake.go
+++ b/pkg/services/folder/store_fake.go
@@ -2,8 +2,6 @@ package folder
 
 import (
 	"context"
-
-	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
 type fakeStore struct {
@@ -65,7 +63,7 @@ func (f *fakeStore) GetDescendants(ctx context.Context, orgID int64, ancestor_ui
 	return f.ExpectedFolders, f.ExpectedError
 }
 
-func (s *fakeStore) FindFolders(ctx context.Context, query *dashboards.FindPersistedDashboardsQuery) ([]dashboards.DashboardSearchProjection, error) {
+func (f *fakeStore) FindFolders(ctx context.Context, query *FindPersistedFoldersQuery) ([]FolderSearchProjection, error) {
 	// #TODO figure out what the implementation of this method should be for the fake store
 	return nil, nil
 }

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -334,7 +334,7 @@ func createFolder(t *testing.T, sc scenarioContext, title string) *folder.Folder
 	require.NoError(t, err)
 
 	folderStore := folderimpl.ProvideDashboardFolderStore(sc.sqlStore)
-	store := folderimpl.ProvideStore(sc.sqlStore)
+	store := folderimpl.ProvideStore(sc.sqlStore, features)
 	s := folderimpl.ProvideService(store, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore, folderStore, sc.sqlStore,
 		features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 	t.Logf("Creating folder with title and UID %q", title)
@@ -471,7 +471,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		)
 		require.NoError(t, dashSvcErr)
 		guardian.InitAccessControlGuardian(cfg, ac, dashService)
-		fStore := folderimpl.ProvideStore(sqlStore)
+		fStore := folderimpl.ProvideStore(sqlStore, features)
 		folderSrv := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracer), dashboardStore, folderStore, sqlStore,
 			features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 		service := LibraryElementService{

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -753,7 +753,7 @@ func createFolder(t *testing.T, sc scenarioContext, title string) *folder.Folder
 	dashboardStore, err := database.ProvideDashboardStore(sc.sqlStore, cfg, features, tagimpl.ProvideService(sc.sqlStore))
 	require.NoError(t, err)
 	folderStore := folderimpl.ProvideDashboardFolderStore(sc.sqlStore)
-	fStore := folderimpl.ProvideStore(sc.sqlStore)
+	fStore := folderimpl.ProvideStore(sc.sqlStore, features)
 	s := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore, folderStore, sc.sqlStore,
 		features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 
@@ -837,7 +837,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 
 		dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
 		require.NoError(t, err)
-		fStore := folderimpl.ProvideStore(sqlStore)
+		fStore := folderimpl.ProvideStore(sqlStore, features)
 
 		folderService := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore, folderStore, sqlStore,
 			features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -1964,8 +1964,6 @@ func createTestEnv(t *testing.T, testConfig string) testEnvironment {
 
 	ruleAuthz := &fakes.FakeRuleService{}
 
-	features := featuremgmt.WithFeatures()
-
 	return testEnvironment{
 		secrets:          secretsService,
 		log:              log,

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -1914,11 +1914,12 @@ func createTestEnv(t *testing.T, testConfig string) testEnvironment {
 		}}, nil).Maybe()
 
 	ac := &recordingAccessControlFake{}
-	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
+	features := featuremgmt.WithFeatures()
+	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
 	require.NoError(t, err)
 
 	folderStore := folderimpl.ProvideDashboardFolderStore(sqlStore)
-	fStore := folderimpl.ProvideStore(sqlStore)
+	fStore := folderimpl.ProvideStore(sqlStore, features)
 	folderService := folderimpl.ProvideService(fStore, actest.FakeAccessControl{ExpectedEvaluate: true}, bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardStore, folderStore, sqlStore,
 		featuremgmt.WithFeatures(), supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 	store := store.DBstore{

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1602,7 +1602,7 @@ func TestProvisiongWithFullpath(t *testing.T) {
 	_, dashboardStore := testutil.SetupDashboardService(t, sqlStore, folderStore, cfg)
 	ac := acmock.New()
 	features := featuremgmt.WithFeatures(featuremgmt.FlagNestedFolders)
-	fStore := folderimpl.ProvideStore(sqlStore)
+	fStore := folderimpl.ProvideStore(sqlStore, features)
 	folderService := folderimpl.ProvideService(fStore, ac, inProcBus, dashboardStore, folderStore, sqlStore,
 		features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -28,7 +28,7 @@ import (
 
 func SetupFolderService(tb testing.TB, cfg *setting.Cfg, db db.DB, dashboardStore dashboards.Store, folderStore *folderimpl.DashboardFolderStoreImpl, bus *bus.InProcBus, features featuremgmt.FeatureToggles, ac accesscontrol.AccessControl) folder.Service {
 	tb.Helper()
-	fStore := folderimpl.ProvideStore(db)
+	fStore := folderimpl.ProvideStore(db, features)
 	return folderimpl.ProvideService(fStore, ac, bus, dashboardStore, folderStore, db,
 		features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 }

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -1392,7 +1392,7 @@ func TestPublicDashboardServiceImpl_ListPublicDashboards(t *testing.T) {
 	require.NoError(t, err)
 	ac := acmock.New()
 
-	fStore := folderimpl.ProvideStore(testDB)
+	fStore := folderimpl.ProvideStore(testDB, features)
 	folderPermissions := acmock.NewMockedPermissionsService()
 	folderStore := folderimpl.ProvideDashboardFolderStore(testDB)
 	folderSvc := folderimpl.ProvideService(fStore, ac, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore, folderStore, testDB, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -821,7 +821,7 @@ func setupNestedTest(t *testing.T, usr *user.SignedInUser, perms []accesscontrol
 	dashStore, err := database.ProvideDashboardStore(db, cfg, features, tagimpl.ProvideService(db))
 	require.NoError(t, err)
 
-	fStore := folderimpl.ProvideStore(db)
+	fStore := folderimpl.ProvideStore(db, features)
 	folderSvc := folderimpl.ProvideService(fStore, actest.FakeAccessControl{ExpectedEvaluate: true}, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore,
 		folderimpl.ProvideDashboardFolderStore(db), db, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 

--- a/pkg/services/sqlstore/permissions/dashboards_bench_test.go
+++ b/pkg/services/sqlstore/permissions/dashboards_bench_test.go
@@ -78,7 +78,7 @@ func setupBenchMark(b *testing.B, usr user.SignedInUser, features featuremgmt.Fe
 	dashboardWriteStore, err := database.ProvideDashboardStore(store, cfg, features, tagimpl.ProvideService(store))
 	require.NoError(b, err)
 
-	fStore := folderimpl.ProvideStore(store)
+	fStore := folderimpl.ProvideStore(store, features)
 	folderSvc := folderimpl.ProvideService(fStore, mock.New(), bus.ProvideBus(tracing.InitializeTracerForTest()), dashboardWriteStore, folderimpl.ProvideDashboardFolderStore(store),
 		store, features, supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -39,7 +39,8 @@ func TestDirectSQLStats(t *testing.T) {
 	db, cfg := db.InitTestDBWithCfg(t)
 	ctx := context.Background()
 
-	dashStore, err := database.ProvideDashboardStore(db, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(db))
+	features := featuremgmt.WithFeatures()
+	dashStore, err := database.ProvideDashboardStore(db, cfg, features, tagimpl.ProvideService(db))
 	require.NoError(t, err)
 	fakeGuardian := &guardian.FakeDashboardGuardian{
 		CanSaveValue: true,
@@ -48,9 +49,9 @@ func TestDirectSQLStats(t *testing.T) {
 	}
 	guardian.MockDashboardGuardian(fakeGuardian)
 	require.NoError(t, err)
-	fStore := folderimpl.ProvideStore(db)
+	fStore := folderimpl.ProvideStore(db, features)
 	folderSvc := folderimpl.ProvideService(fStore, actest.FakeAccessControl{ExpectedEvaluate: true}, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore,
-		folderimpl.ProvideDashboardFolderStore(db), db, featuremgmt.WithFeatures(),
+		folderimpl.ProvideDashboardFolderStore(db), db, features,
 		supportbundlestest.NewFakeBundleService(), nil, tracing.InitializeTracerForTest())
 
 	// create parent folder


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We should not be making [this](https://github.com/grafana/search-and-storage-team/issues/157) direct reference to folders from outside the folder service.

This is the simplified " call stack " for TypeFilter.Where().

DashboardServiceImpl.FindDashboards() > dashboardStore.FindDashboards() > Builder.ToSQL() > Builder.applyFilters() > TypeFilter.Where() 

From there the callstack branches off into the following variations:

- **DashboardServiceImpl.SearchDashboards** > **_DashboardServiceImpl.FindDashboards_**
- **DashboardServiceImpl.SearchDashboards** > DashboardServiceImpl.FindDashboardsZanzana > DashboardServiceImpl.findDashboardsZanzanaCompare AND DashboardServiceImpl.findDashboardsZanzanaOnly > DashboardServiceImpl.findDashboardsZanzana > DashboardServiceImpl.findDashboardsZanzanaGeneric > **_DashboardServiceImpl.FindDashboards_**
- **DashboardServiceImpl.SearchDashboards** > DashboardServiceImpl.FindDashboardsZanzana > DashboardServiceImpl.findDashboardsZanzanaCompare > **_DashboardServiceImpl.FindDashboards_**
- ~~PublicDashboardServiceImpl.FindAllWithPagination > **_DashboardServiceImpl.FindDashboards_** → default / empty query type~~

As we can see, these different variations all have DashboardServiceImpl.SearchDashboards() in common and of course also DashboardServiceImpl.FindDashboards(). It seems to me that DashboardServiceImpl.FindDashboards() is the best place to introduce folder service because then we don't have to reimplement the zanzazana logic. 

**Why do we need this feature?**

In order to ease the transition to Unified Storage, all calls to folder storage should be made through folder service.

**Who is this feature for?**

Grafana Search and Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/164

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
