### PR TITLE
Explore metrics: Utf8 support in Explore metrics with OTel experience enabled

### DIFF
--- a/devenv/docker/blocks/prometheus_utf8/main.go
+++ b/devenv/docker/blocks/prometheus_utf8/main.go
@@ -60,6 +60,14 @@ func main() {
 			label:        "label.with.spaß",
 			getNextValue: staticList([]string{"this_is_fun"}),
 		},
+		{
+			label:        "instance",
+			getNextValue: staticList([]string{"instance"}),
+		},
+		{
+			label:        "job",
+			getNextValue: staticList([]string{"job"}),
+		},
 	}
 
 	dimensions := []string{}
@@ -77,6 +85,12 @@ func main() {
 		Help: "a metric with utf8 labels",
 	}, dimensions)
 
+	target_info := promauto.NewGauge(prometheus.GaugeOpts{
+		Name:        "target_info",
+		Help:        "an info metric model for otel",
+		ConstLabels: map[string]string{"job": "job", "instance": "instance", "resource 1": "1", "resource 2": "2", "resource ę": "e", "deployment_environment": "prod"},
+	})
+
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -93,6 +107,7 @@ func main() {
 
 			utf8Metric.WithLabelValues(labels...).Inc()
 			opsProcessed.WithLabelValues(labels...).Inc()
+			target_info.Set(1)
 
 			time.Sleep(time.Second * 5)
 		}

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { PromMetricsMetadataItem } from '@grafana/prometheus';
+import { isValidLegacyName } from '@grafana/prometheus/src/utf8_support';
 import {
   QueryVariable,
   SceneComponentProps,
@@ -92,7 +93,14 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
       if (typeof resourceAttributes === 'string') {
         const attributeArray: VariableValueOption[] = resourceAttributes
           .split(',')
-          .map((el) => ({ label: el, value: el }));
+          .map((el) => {
+            let label = el;
+            if (!isValidLegacyName(el)) {
+              // remove '' from label
+              label = el.slice(1, -1);
+            }
+            return { label, value: el };
+        });
         allLabelOptions = attributeArray.concat(allLabelOptions);
       }
     }

--- a/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
+++ b/public/app/features/trails/ActionTabs/MetricOverviewScene.tsx
@@ -91,15 +91,13 @@ export class MetricOverviewScene extends SceneObjectBase<MetricOverviewSceneStat
       // when the group left variable is changed we should get all the resource attributes + labels
       const resourceAttributes = sceneGraph.lookupVariable(VAR_OTEL_GROUP_LEFT, trail)?.getValue();
       if (typeof resourceAttributes === 'string') {
-        const attributeArray: VariableValueOption[] = resourceAttributes
-          .split(',')
-          .map((el) => {
-            let label = el;
-            if (!isValidLegacyName(el)) {
-              // remove '' from label
-              label = el.slice(1, -1);
-            }
-            return { label, value: el };
+        const attributeArray: VariableValueOption[] = resourceAttributes.split(',').map((el) => {
+          let label = el;
+          if (!isValidLegacyName(el)) {
+            // remove '' from label
+            label = el.slice(1, -1);
+          }
+          return { label, value: el };
         });
         allLabelOptions = attributeArray.concat(allLabelOptions);
       }

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -4,7 +4,7 @@ import { isNumber, max, min, throttle } from 'lodash';
 import { useEffect, useState } from 'react';
 
 import { DataFrame, FieldType, GrafanaTheme2, PanelData, SelectableValue } from '@grafana/data';
-import { utf8Support } from '@grafana/prometheus/src/utf8_support';
+import { isValidLegacyName, utf8Support } from '@grafana/prometheus/src/utf8_support';
 import { config } from '@grafana/runtime';
 import {
   ConstantVariable,
@@ -314,7 +314,14 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       return [];
     }
 
-    const attributeArray: SelectableValue[] = resourceAttributes.split(',').map((el) => ({ label: el, value: el }));
+    const attributeArray: SelectableValue[] = resourceAttributes.split(',').map((el) => { 
+      let label = el;
+      if (!isValidLegacyName(el)) {
+        // remove '' from label
+        label = el.slice(1, -1);
+      }
+      return { label, value: el };
+    });
     // shift ALL value to the front
     const all: SelectableValue = [{ label: 'All', value: ALL_VARIABLE_VALUE }];
     const firstGroup = all.concat(attributeArray);

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -314,7 +314,7 @@ export class LabelBreakdownScene extends SceneObjectBase<LabelBreakdownSceneStat
       return [];
     }
 
-    const attributeArray: SelectableValue[] = resourceAttributes.split(',').map((el) => { 
+    const attributeArray: SelectableValue[] = resourceAttributes.split(',').map((el) => {
       let label = el;
       if (!isValidLegacyName(el)) {
         // remove '' from label

--- a/public/app/features/trails/otel/api.ts
+++ b/public/app/features/trails/otel/api.ts
@@ -70,7 +70,7 @@ export async function totalOtelResources(
   const end = getPrometheusTime(timeRange.to, true);
   // check that the metric is utf8 before doing a resource query
   if (metric && !isValidLegacyName(metric)) {
-    metric = `{"${metric}"}`
+    metric = `{"${metric}"}`;
   }
   const query = metric ? metricOtelJobInstanceQuery(metric) : otelTargetInfoQuery(filters);
 
@@ -255,13 +255,13 @@ export async function getFilteredResourceAttributes(
   // The match param for the metric to get all possible labels for this metric
   const metricMatchTerms = limitOtelMatchTerms([], metricResources.jobs, metricResources.instances);
 
-  let metricMatchParam = ''
+  let metricMatchParam = '';
   // check metric is utf8 to give corrrect syntax
-  if(!isValidLegacyName(metric)) {
-    metricMatchParam = `{'${metric}',${metricMatchTerms.jobsRegex},${metricMatchTerms.instancesRegex}}`
+  if (!isValidLegacyName(metric)) {
+    metricMatchParam = `{'${metric}',${metricMatchTerms.jobsRegex},${metricMatchTerms.instancesRegex}}`;
   } else {
     metricMatchParam = `${metric}{${metricMatchTerms.jobsRegex},${metricMatchTerms.instancesRegex}}`;
-  } 
+  }
 
   const start = getPrometheusTime(timeRange.from, false);
   const end = getPrometheusTime(timeRange.to, true);

--- a/public/app/features/trails/otel/api.ts
+++ b/public/app/features/trails/otel/api.ts
@@ -1,5 +1,6 @@
 import { RawTimeRange, Scope } from '@grafana/data';
 import { getPrometheusTime } from '@grafana/prometheus/src/language_utils';
+import { isValidLegacyName } from '@grafana/prometheus/src/utf8_support';
 import { config, getBackendSrv } from '@grafana/runtime';
 
 import { callSuggestionsApi } from '../utils';
@@ -67,7 +68,10 @@ export async function totalOtelResources(
 ): Promise<OtelTargetType> {
   const start = getPrometheusTime(timeRange.from, false);
   const end = getPrometheusTime(timeRange.to, true);
-
+  // check that the metric is utf8 before doing a resource query
+  if (metric && !isValidLegacyName(metric)) {
+    metric = `{"${metric}"}`
+  }
   const query = metric ? metricOtelJobInstanceQuery(metric) : otelTargetInfoQuery(filters);
 
   const url = `/api/datasources/uid/${dataSourceUid}/resources/api/v1/query`;
@@ -251,7 +255,13 @@ export async function getFilteredResourceAttributes(
   // The match param for the metric to get all possible labels for this metric
   const metricMatchTerms = limitOtelMatchTerms([], metricResources.jobs, metricResources.instances);
 
-  let metricMatchParam = `${metric}{${metricMatchTerms.jobsRegex},${metricMatchTerms.instancesRegex}}`;
+  let metricMatchParam = ''
+  // check metric is utf8 to give corrrect syntax
+  if(!isValidLegacyName(metric)) {
+    metricMatchParam = `{'${metric}',${metricMatchTerms.jobsRegex},${metricMatchTerms.instancesRegex}}`
+  } else {
+    metricMatchParam = `${metric}{${metricMatchTerms.jobsRegex},${metricMatchTerms.instancesRegex}}`;
+  } 
 
   const start = getPrometheusTime(timeRange.from, false);
   const end = getPrometheusTime(timeRange.to, true);

--- a/public/app/features/trails/otel/util.ts
+++ b/public/app/features/trails/otel/util.ts
@@ -307,12 +307,12 @@ export async function updateOtelJoinWithGroupLeft(trail: DataTrail, metric: stri
   // here we start to add the attributes to the group left
   if (attributes.length > 0) {
     // loop through attributes to check for utf8
-    const utf8Attributes = attributes.map((a)=>{
-      if(!isValidLegacyName(a)){
+    const utf8Attributes = attributes.map((a) => {
+      if (!isValidLegacyName(a)) {
         return `'${a}'`;
       }
       return a;
-    })
+    });
     // update the group left variable that contains all the filtered resource attributes
     otelGroupLeft.setState({ value: utf8Attributes.join(',') });
     // get the new otel join query that includes the group left attributes


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/91253

**What is this feature?**

This supports utf8 metrics and labels in Explore metrics when the OTel experience is enabled.

**Why do we need this feature?**

The OTel experience requires a number of api calls in Explore metrics to get the correct resources, identify which resource attributes are promoted, add the join query to the query generator, add the otel resource attributes to the join query filtering `target_info`, etc. If there is a metric or a label that is utf8, then we need to give it the correct syntax.

utf8 metric example: `this utf8 metri 👍🏻`
utf8 label example: `læbel utf8 🥇`

The correct syntax requires quotes and placing the metric in the `{}`

`{'this utf8 metri 👍🏻','læbel utf8 🥇':"value"}`

**Who is this feature for?**

This feature is for explore metrics users who have enabled the otel experience switch to allow them to filter and breakdown using otel resources in the target_info metric.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/98705

**Special notes for your reviewer:**

The gdev Prometheus dat source is updated to be otel standard with the `target_info` metric. This info metric can be joined to a utf8 metric, `a.utf8.metric 🤘`.

1. run `make devenv sources=prometheus` to start the gdev prometheus instance.
2. Open explore metrics.
3. Select the gdev prometheus data source.
4. Make sure the the "OTel experience" switch is toggled on.
5. Select a resource attribute filter from the top filter that has a utf8 character.
6. Select a utf8 metric for the metric scene.
7. Select a utf8 label in the overview scene.
8. Select a utf8 label in the breakdown scene.
9. Using the OTel experience in the metric scene, click the "open in explore" button. See that the query has the correct syntax. It should look something like this, where the utf8 labels are wrapped in quotes
```
avg({"a.utf8.metric 🤘"} * on (job, instance) group_left('resource 2') topk by (job, instance) (1, target_info{deployment_environment='prod','resource 1'='1','resource ę'='e'}))
```

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
