### PR TITLE
UserDisplay: Handle both service accounts and user names when resolving "createdBy"

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -267,7 +267,7 @@ func (hs *HTTPServer) getAnnotationPermissionsByScope(c *contextmodel.ReqContext
 
 // getIdentityName returns name
 func (hs *HTTPServer) getIdentityName(ctx context.Context, orgID, id int64) string {
-	ctx, span := tracer.Start(ctx, "api.getUserLogin")
+	ctx, span := tracer.Start(ctx, "api.getIdentityName")
 	defer span.End()
 
 	// We use GetSignedInUser here instead of GetByID so both user and service accounts are resolved.

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -265,7 +265,7 @@ func (hs *HTTPServer) getAnnotationPermissionsByScope(c *contextmodel.ReqContext
 	}
 }
 
-// getIdentityName returns name
+// getIdentityName returns name of either user or service account
 func (hs *HTTPServer) getIdentityName(ctx context.Context, orgID, id int64) string {
 	ctx, span := tracer.Start(ctx, "api.getIdentityName")
 	defer span.End()

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -150,10 +150,10 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 	// Finding creator and last updater of the dashboard
 	updater, creator := anonString, anonString
 	if dash.UpdatedBy > 0 {
-		updater = hs.getUserLogin(ctx, dash.UpdatedBy)
+		updater = hs.getIdentityName(ctx, dash.OrgID, dash.UpdatedBy)
 	}
 	if dash.CreatedBy > 0 {
-		creator = hs.getUserLogin(ctx, dash.CreatedBy)
+		creator = hs.getIdentityName(ctx, dash.OrgID, dash.CreatedBy)
 	}
 
 	annotationPermissions := &dashboardsV0.AnnotationPermission{}
@@ -265,16 +265,24 @@ func (hs *HTTPServer) getAnnotationPermissionsByScope(c *contextmodel.ReqContext
 	}
 }
 
-func (hs *HTTPServer) getUserLogin(ctx context.Context, userID int64) string {
+// getIdentityName returns name
+func (hs *HTTPServer) getIdentityName(ctx context.Context, orgID, id int64) string {
 	ctx, span := tracer.Start(ctx, "api.getUserLogin")
 	defer span.End()
 
-	query := user.GetUserByIDQuery{ID: userID}
-	user, err := hs.userService.GetByID(ctx, &query)
+	// We use GetSignedInUser here instead of GetByID so both user and service accounts are resolved.
+	ident, err := hs.userService.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
+		UserID: id,
+		OrgID:  orgID,
+	})
 	if err != nil {
 		return anonString
 	}
-	return user.Login
+
+	if ident.IsIdentityType(claims.TypeServiceAccount) {
+		return ident.GetName()
+	}
+	return ident.GetLogin()
 }
 
 func (hs *HTTPServer) getDashboardHelper(ctx context.Context, orgID int64, id int64, uid string) (*dashboards.Dashboard, response.Response) {
@@ -845,7 +853,7 @@ func (hs *HTTPServer) GetDashboardVersions(c *contextmodel.ReqContext) response.
 			if found {
 				creator = login
 			} else {
-				creator = hs.getUserLogin(c.Req.Context(), version.CreatedBy)
+				creator = hs.getIdentityName(c.Req.Context(), c.SignedInUser.GetOrgID(), version.CreatedBy)
 				if creator != anonString {
 					loginMem[version.CreatedBy] = creator
 				}
@@ -941,7 +949,7 @@ func (hs *HTTPServer) GetDashboardVersion(c *contextmodel.ReqContext) response.R
 
 	creator := anonString
 	if res.CreatedBy > 0 {
-		creator = hs.getUserLogin(c.Req.Context(), res.CreatedBy)
+		creator = hs.getIdentityName(c.Req.Context(), dash.OrgID, res.CreatedBy)
 	}
 
 	dashVersionMeta := &dashver.DashboardVersionMeta{

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -742,7 +742,7 @@ func TestDashboardVersionsAPIEndpoint(t *testing.T) {
 				},
 			}
 			getHS(&usertest.FakeUserService{
-				ExpectedUser: &user.User{ID: 1, Login: "test-user"},
+				ExpectedSignedInUser: &user.SignedInUser{Login: "test-user"},
 			}).callGetDashboardVersions(sc)
 
 			assert.Equal(t, http.StatusOK, sc.resp.Code)

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -1132,7 +1132,6 @@ func (fk8s *folderK8sHandler) getIdentityName(ctx context.Context, uid string) s
 
 	if ident.IsServiceAccount {
 		return ident.Name
-
 	}
 	return ident.Login
 }

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -1079,10 +1079,10 @@ func (fk8s *folderK8sHandler) toDTO(c *contextmodel.ReqContext, fold *folder.Fol
 	// #TODO refactor the various conversions of the folder so that we either set created by in folder.Folder or
 	// we convert from unstructured to folder DTO without an intermediate conversion to folder.Folder
 	if len(createdBy) > 0 {
-		creator = fk8s.getUserLogin(ctx, toUID(createdBy))
+		creator = fk8s.getIdentityName(ctx, toUID(createdBy))
 	}
 	if len(createdBy) > 0 {
-		updater = fk8s.getUserLogin(ctx, toUID(createdBy))
+		updater = fk8s.getIdentityName(ctx, toUID(createdBy))
 	}
 
 	acMetadata, _ := fk8s.getFolderACMetadata(c, fold)
@@ -1119,18 +1119,22 @@ func (fk8s *folderK8sHandler) toDTO(c *contextmodel.ReqContext, fold *folder.Fol
 	}, nil
 }
 
-func (fk8s *folderK8sHandler) getUserLogin(ctx context.Context, userUID string) string {
+func (fk8s *folderK8sHandler) getIdentityName(ctx context.Context, uid string) string {
 	ctx, span := tracer.Start(ctx, "api.getUserLogin")
 	defer span.End()
 
-	query := user.GetUserByUIDQuery{
-		UID: userUID,
-	}
-	user, err := fk8s.userService.GetByUID(ctx, &query)
+	ident, err := fk8s.userService.GetByUID(ctx, &user.GetUserByUIDQuery{
+		UID: uid,
+	})
 	if err != nil {
 		return anonString
 	}
-	return user.Login
+
+	if ident.IsServiceAccount {
+		return ident.Name
+
+	}
+	return ident.Login
 }
 
 func (fk8s *folderK8sHandler) getFolderACMetadata(c *contextmodel.ReqContext, f *folder.Folder) (accesscontrol.Metadata, error) {

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -427,10 +427,10 @@ func (hs *HTTPServer) newToFolderDto(c *contextmodel.ReqContext, f *folder.Folde
 		// Finding creator and last updater of the folder
 		updater, creator := anonString, anonString
 		if f.CreatedBy > 0 {
-			creator = hs.getUserLogin(ctx, f.CreatedBy)
+			creator = hs.getIdentityName(ctx, f.OrgID, f.CreatedBy)
 		}
 		if f.UpdatedBy > 0 {
-			updater = hs.getUserLogin(ctx, f.UpdatedBy)
+			updater = hs.getIdentityName(ctx, f.OrgID, f.UpdatedBy)
 		}
 
 		acMetadata, _ := hs.getFolderACMetadata(c, f)

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -533,7 +533,7 @@ func (m mockClientConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext
 func (m mockClientConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {}
 
 func TestUpdateFolderLegacyAndUnifiedStorage(t *testing.T) {
-	testuser := &user.User{ID: 99, UID: "fdxsqt7t5ryf4a", Login: "testuser"}
+	testuser := &user.SignedInUser{UserID: 99, UserUID: "fdxsqt7t5ryf4a", Login: "testuser"}
 
 	legacyFolder := folder.Folder{
 		UID:          "ady4yobv315a8e",
@@ -718,7 +718,7 @@ func TestUpdateFolderLegacyAndUnifiedStorage(t *testing.T) {
 						ExpectedResult: model.HitList{},
 					}
 					hs.userService = &usertest.FakeUserService{
-						ExpectedUser: testuser,
+						ExpectedSignedInUser: testuser,
 					}
 					hs.Features = featuremgmt.WithFeatures(
 						featuresArr...,

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -533,7 +533,8 @@ func (m mockClientConfigProvider) GetDirectRestConfig(c *contextmodel.ReqContext
 func (m mockClientConfigProvider) DirectlyServeHTTP(w http.ResponseWriter, r *http.Request) {}
 
 func TestUpdateFolderLegacyAndUnifiedStorage(t *testing.T) {
-	testuser := &user.SignedInUser{UserID: 99, UserUID: "fdxsqt7t5ryf4a", Login: "testuser"}
+	testuser := &user.User{ID: 99, UID: "fdxsqt7t5ryf4a", Login: "testuser"}
+	testSignedInUser := &user.SignedInUser{UserID: 99, UserUID: "fdxsqt7t5ryf4a", Login: "testuser"}
 
 	legacyFolder := folder.Folder{
 		UID:          "ady4yobv315a8e",
@@ -718,7 +719,8 @@ func TestUpdateFolderLegacyAndUnifiedStorage(t *testing.T) {
 						ExpectedResult: model.HitList{},
 					}
 					hs.userService = &usertest.FakeUserService{
-						ExpectedSignedInUser: testuser,
+						ExpectedUser:         testuser,
+						ExpectedSignedInUser: testSignedInUser,
 					}
 					hs.Features = featuremgmt.WithFeatures(
 						featuresArr...,


### PR DESCRIPTION
**What is this feature?**
When resolving name for `createdBy` and `updatedBy` on dashboard and folders we only queried for users. So if a service account was used to update any of them we always display "anonymous".


With this change we now handle service account too (test is a service account).
![2025-01-09-11:22:31](https://github.com/user-attachments/assets/9362244b-af41-448c-b94e-aeda32e38e43)


While this is better it is not obvious that this was done by a service account. I wonder if these strings should be prefixed with the identity type to make it more obvious 
 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1089

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
