### PR TITLE
Loki: Sync query direction with sort order in Explore and Dashboards

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -764,6 +764,8 @@ export {
   type DataSourceWithQueryModificationSupport,
   hasToggleableQueryFiltersSupport,
   hasQueryModificationSupport,
+  LogSortOrderChangeEvent,
+  type LogSortOrderChangePayload,
 } from './types/logs';
 export {
   type AnnotationQuery,

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'rxjs';
 
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, LogsSortOrder } from '@grafana/schema';
+
+import { BusEventWithPayload } from '../events/types';
 
 import { KeyValue, Labels } from './data';
 import { DataFrame } from './dataFrame';
@@ -366,3 +368,11 @@ export const hasQueryModificationSupport = <TQuery extends DataQuery>(
     'getSupportedQueryModifications' in datasource
   );
 };
+
+export interface LogSortOrderChangePayload {
+  order: LogsSortOrder;
+}
+
+export class LogSortOrderChangeEvent extends BusEventWithPayload<LogSortOrderChangePayload> {
+  static type = 'logs-sort-order-change';
+}

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -14,10 +14,12 @@ import {
   toUtc,
   createDataFrame,
   ExploreLogsPanelState,
+  DataQuery,
 } from '@grafana/data';
 import { organizeFieldsTransformer } from '@grafana/data/src/transformations/transformers/organize';
 import { config } from '@grafana/runtime';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
+import { LokiQueryDirection } from 'app/plugins/datasource/loki/dataquery.gen';
 import { configureStore } from 'app/store/configureStore';
 
 import { initialExploreState } from '../state/main';
@@ -45,6 +47,17 @@ jest.mock('../state/explorePane', () => ({
   ...jest.requireActual('../state/explorePane'),
   changePanelState: (exploreId: string, panel: 'logs', panelState: {} | ExploreLogsPanelState) => {
     return fakeChangePanelState(exploreId, panel, panelState);
+  },
+  changeQueries: (args: { queries: DataQuery[]; exploreId: string | undefined }) => {
+    return fakeChangeQueries(args);
+  },
+}));
+
+const fakeChangeQueries = jest.fn().mockReturnValue({ type: 'fakeChangeQueries' });
+jest.mock('../state/query', () => ({
+  ...jest.requireActual('../state/query'),
+  changeQueries: (args: { queries: DataQuery[]; exploreId: string | undefined }) => {
+    return fakeChangeQueries(args);
   },
 }));
 
@@ -375,6 +388,26 @@ describe('Logs', () => {
     expect(logRows.length).toBe(3);
     expect(logRows[0].textContent).toContain('log message 1');
     expect(logRows[2].textContent).toContain('log message 3');
+  });
+
+  it('should sync the query direction when changing the order of loki queries', async () => {
+    const query = { expr: '{a="b"}', refId: 'A', datasource: { type: 'loki' } };
+    setup({ logsQueries: [query] });
+    const oldestFirstSelection = screen.getByLabelText('Oldest first');
+    await userEvent.click(oldestFirstSelection);
+    expect(fakeChangeQueries).toHaveBeenCalledWith({
+      exploreId: 'left',
+      queries: [{ ...query, direction: LokiQueryDirection.Forward }],
+    });
+  });
+
+  it('should not change the query direction when changing the order of non-loki queries', async () => {
+    fakeChangeQueries.mockClear();
+    const query = { refId: 'B' };
+    setup({ logsQueries: [query] });
+    const oldestFirstSelection = screen.getByLabelText('Oldest first');
+    await userEvent.click(oldestFirstSelection);
+    expect(fakeChangeQueries).not.toHaveBeenCalled();
   });
 
   describe('for permalinking', () => {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -58,6 +58,7 @@ import { LogRowContextModal } from 'app/features/logs/components/log-context/Log
 import { LogLevelColor, dedupLogRows, filterLogLevels } from 'app/features/logs/logsModel';
 import { getLogLevel, getLogLevelFromKey, getLogLevelInfo } from 'app/features/logs/utils';
 import { LokiQueryDirection } from 'app/plugins/datasource/loki/dataquery.gen';
+import { isLokiQuery } from 'app/plugins/datasource/loki/queryUtils';
 import { getState } from 'app/store/store';
 import { ExploreItemState, useDispatch } from 'app/types';
 
@@ -72,6 +73,7 @@ import {
 import { useContentOutlineContext } from '../ContentOutline/ContentOutlineContext';
 import { getUrlStateFromPaneState } from '../hooks/useStateSync';
 import { changePanelState } from '../state/explorePane';
+import { changeQueries } from '../state/query';
 
 import { LogsFeedback } from './LogsFeedback';
 import { LogsMetaRow } from './LogsMetaRow';
@@ -468,6 +470,28 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       const newSortOrder =
         logsSortOrder === LogsSortOrder.Descending ? LogsSortOrder.Ascending : LogsSortOrder.Descending;
       store.set(SETTINGS_KEYS.logsSortOrder, newSortOrder);
+
+      if (logsQueries) {
+        const newQueries = logsQueries.map((query) => {
+          if (query.datasource?.type !== 'loki' || !isLokiQuery(query)) {
+            return query;
+          }
+
+          if (query.direction === LokiQueryDirection.Scan) {
+            // Don't override Scan. When the direction is Scan it means that the user specifically assigned this direction to the query.
+            return query;
+          }
+          const newDirection =
+            newSortOrder === LogsSortOrder.Ascending ? LokiQueryDirection.Forward : LokiQueryDirection.Backward;
+          if (newDirection !== query.direction) {
+            query.direction = newDirection;
+          }
+          return query;
+        });
+
+        dispatch(changeQueries({ exploreId, queries: newQueries }));
+      }
+
       setLogsSortOrder(newSortOrder);
     }, 0);
     cancelFlippingTimer.current = window.setTimeout(() => setIsFlipping(false), 1000);

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -470,12 +470,13 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       const newSortOrder =
         logsSortOrder === LogsSortOrder.Descending ? LogsSortOrder.Ascending : LogsSortOrder.Descending;
       store.set(SETTINGS_KEYS.logsSortOrder, newSortOrder);
-
       if (logsQueries) {
+        let hasLokiQueries = false;
         const newQueries = logsQueries.map((query) => {
           if (query.datasource?.type !== 'loki' || !isLokiQuery(query)) {
             return query;
           }
+          hasLokiQueries = true;
 
           if (query.direction === LokiQueryDirection.Scan) {
             // Don't override Scan. When the direction is Scan it means that the user specifically assigned this direction to the query.
@@ -489,7 +490,9 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           return query;
         });
 
-        dispatch(changeQueries({ exploreId, queries: newQueries }));
+        if (hasLokiQueries) {
+          dispatch(changeQueries({ exploreId, queries: newQueries }));
+        }
       }
 
       setLogsSortOrder(newSortOrder);

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -33,9 +33,8 @@ import {
   DataHoverEvent,
   serializeStateToUrlParam,
   urlUtil,
-  LogSortOrderChangeEvent,
 } from '@grafana/data';
-import { config, getAppEvents, reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import {
   Button,
@@ -494,11 +493,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       }
 
       setLogsSortOrder(newSortOrder);
-      getAppEvents().publish(
-        new LogSortOrderChangeEvent({
-          order: newSortOrder,
-        })
-      );
     }, 0);
     cancelFlippingTimer.current = window.setTimeout(() => setIsFlipping(false), 1000);
   };

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -33,8 +33,9 @@ import {
   DataHoverEvent,
   serializeStateToUrlParam,
   urlUtil,
+  LogSortOrderChangeEvent,
 } from '@grafana/data';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config, getAppEvents, reportInteraction } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import {
   Button,
@@ -493,6 +494,11 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       }
 
       setLogsSortOrder(newSortOrder);
+      getAppEvents().publish(
+        new LogSortOrderChangeEvent({
+          order: newSortOrder,
+        })
+      );
     }, 0);
     cancelFlippingTimer.current = window.setTimeout(() => setIsFlipping(false), 1000);
   };

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx
@@ -15,6 +15,9 @@ import { LokiQueryEditorProps } from './types';
 jest.mock('@grafana/runtime', () => {
   return {
     ...jest.requireActual('@grafana/runtime'),
+    getAppEvents: jest.fn().mockReturnValue({
+      subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    }),
     reportInteraction: jest.fn(),
   };
 });

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.test.tsx
@@ -9,6 +9,13 @@ import { testIds as regularTestIds } from './LokiQueryEditor';
 import { LokiQueryEditorByApp } from './LokiQueryEditorByApp';
 import { testIds as alertingTestIds } from './LokiQueryEditorForAlerting';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: jest.fn().mockReturnValue({
+    subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+  }),
+}));
+
 function setup(app: CoreApp): RenderResult {
   const dataSource = createLokiDatasource();
   dataSource.metadataRequest = jest.fn();

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/MonacoFieldWrapper.test.tsx
@@ -6,6 +6,13 @@ import { createLokiDatasource } from '../../__mocks__/datasource';
 
 import { MonacoQueryFieldWrapper, Props } from './MonacoQueryFieldWrapper';
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: jest.fn().mockReturnValue({
+    subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+  }),
+}));
+
 function renderComponent({ initialValue = '', onChange = jest.fn(), onRunQuery = jest.fn() }: Partial<Props> = {}) {
   const datasource = createLokiDatasource();
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -114,7 +114,7 @@ describe('LokiQueryBuilderOptions', () => {
   });
 
   it('shows correct options for log query', async () => {
-    setup({ expr: '{foo="bar"}' });
+    setup({ expr: '{foo="bar"}', direction: LokiQueryDirection.Backward });
     expect(screen.getByText('Line limit: 20')).toBeInTheDocument();
     expect(screen.getByText('Type: Range')).toBeInTheDocument();
     expect(screen.getByText('Direction: Backward')).toBeInTheDocument();
@@ -265,7 +265,9 @@ describe('LokiQueryBuilderOptions', () => {
         });
       });
       it('subscribes to sort change event and updates the direction', () => {
-        setup({ expr: '{foo="bar"}' }, onChangeMock, { app: undefined });
+        setup({ expr: '{foo="bar"}', direction: LokiQueryDirection.Backward }, onChangeMock, {
+          app: CoreApp.Dashboard,
+        });
         expect(screen.getByText(/Direction: Backward/)).toBeInTheDocument();
         listener(
           new LogSortOrderChangeEvent({
@@ -281,7 +283,7 @@ describe('LokiQueryBuilderOptions', () => {
       });
 
       it('does not change the direction when the current direction is scan', () => {
-        setup({ expr: '{foo="bar"}', direction: LokiQueryDirection.Scan }, onChangeMock, { app: undefined });
+        setup({ expr: '{foo="bar"}', direction: LokiQueryDirection.Scan }, onChangeMock, { app: CoreApp.Dashboard });
         expect(screen.getByText(/Direction: Scan/)).toBeInTheDocument();
         listener(
           new LogSortOrderChangeEvent({

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.test.tsx
@@ -1,9 +1,37 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { LokiQuery, LokiQueryType } from '../../types';
+import { CoreApp, LogSortOrderChangeEvent, LogsSortOrder, store } from '@grafana/data';
+import { config, getAppEvents } from '@grafana/runtime';
 
-import { LokiQueryBuilderOptions } from './LokiQueryBuilderOptions';
+import { LokiQuery, LokiQueryDirection, LokiQueryType } from '../../types';
+
+import { LokiQueryBuilderOptions, Props } from './LokiQueryBuilderOptions';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    featureToggles: {
+      ...jest.requireActual('@grafana/runtime').featureToggles,
+      lokiShardSplitting: true,
+    },
+  },
+  getAppEvents: jest.fn(),
+}));
+
+const subscribeMock = jest.fn();
+beforeAll(() => {
+  config.featureToggles.lokiShardSplitting = true;
+  subscribeMock.mockImplementation(() => ({ unsubscribe: jest.fn() }));
+  jest.mocked(getAppEvents).mockReturnValue({
+    publish: jest.fn(),
+    getStream: jest.fn(),
+    subscribe: subscribeMock,
+    removeAllListeners: jest.fn(),
+    newScopedBus: jest.fn(),
+  });
+});
 
 describe('LokiQueryBuilderOptions', () => {
   it('can change query type', async () => {
@@ -184,9 +212,89 @@ describe('LokiQueryBuilderOptions', () => {
       step: '4s',
     });
   });
+
+  describe('Query direction', () => {
+    it("initializes query direction when it's empty", async () => {
+      const onChange = jest.fn();
+      setup({ expr: '{foo="bar"}' }, onChange);
+      await waitFor(() =>
+        expect(onChange).toHaveBeenCalledWith({
+          expr: '{foo="bar"}',
+          refId: 'A',
+          direction: LokiQueryDirection.Backward,
+        })
+      );
+    });
+
+    it('uses backward as default in Explore with no previous stored preference', async () => {
+      const onChange = jest.fn();
+      store.delete('grafana.explore.logs.sortOrder');
+      setup({ expr: '{foo="bar"}' }, onChange, { app: CoreApp.Explore });
+      await waitFor(() =>
+        expect(onChange).toHaveBeenCalledWith({
+          expr: '{foo="bar"}',
+          refId: 'A',
+          direction: LokiQueryDirection.Backward,
+        })
+      );
+    });
+
+    it('uses the stored sorting option to determine direction in Explore', async () => {
+      store.set('grafana.explore.logs.sortOrder', LogsSortOrder.Ascending);
+      const onChange = jest.fn();
+      setup({ expr: '{foo="bar"}' }, onChange, { app: CoreApp.Explore });
+      await waitFor(() =>
+        expect(onChange).toHaveBeenCalledWith({
+          expr: '{foo="bar"}',
+          refId: 'A',
+          direction: LokiQueryDirection.Forward,
+        })
+      );
+      store.delete('grafana.explore.logs.sortOrder');
+    });
+
+    describe('Event handling', () => {
+      let listener: (event: LogSortOrderChangeEvent) => void = jest.fn();
+      const onChangeMock = jest.fn();
+      beforeEach(() => {
+        onChangeMock.mockClear();
+        listener = jest.fn();
+        subscribeMock.mockImplementation((_: unknown, callback: (event: LogSortOrderChangeEvent) => void) => {
+          listener = callback;
+          return { unsubscribe: jest.fn() };
+        });
+      });
+      it('subscribes to sort change event and updates the direction', () => {
+        setup({ expr: '{foo="bar"}' }, onChangeMock, { app: undefined });
+        expect(screen.getByText(/Direction: Backward/)).toBeInTheDocument();
+        listener(
+          new LogSortOrderChangeEvent({
+            order: LogsSortOrder.Ascending,
+          })
+        );
+        expect(onChangeMock).toHaveBeenCalledTimes(1);
+        expect(onChangeMock).toHaveBeenCalledWith({
+          direction: 'forward',
+          expr: '{foo="bar"}',
+          refId: 'A',
+        });
+      });
+
+      it('does not change the direction when the current direction is scan', () => {
+        setup({ expr: '{foo="bar"}', direction: LokiQueryDirection.Scan }, onChangeMock, { app: undefined });
+        expect(screen.getByText(/Direction: Scan/)).toBeInTheDocument();
+        listener(
+          new LogSortOrderChangeEvent({
+            order: LogsSortOrder.Ascending,
+          })
+        );
+        expect(onChangeMock).not.toHaveBeenCalled();
+      });
+    });
+  });
 });
 
-function setup(queryOverrides: Partial<LokiQuery> = {}, onChange = jest.fn()) {
+function setup(queryOverrides: Partial<LokiQuery> = {}, onChange = jest.fn(), propOverrides: Partial<Props> = {}) {
   const props = {
     query: {
       refId: 'A',
@@ -197,6 +305,7 @@ function setup(queryOverrides: Partial<LokiQuery> = {}, onChange = jest.fn()) {
     onChange,
     maxLines: 20,
     queryStats: { streams: 0, chunks: 0, bytes: 0, entries: 0 },
+    ...propOverrides,
   };
 
   const { container } = render(<LokiQueryBuilderOptions {...props} />);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -2,9 +2,15 @@ import { trim } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 
-import { CoreApp, isValidDuration, isValidGrafanaDuration, SelectableValue } from '@grafana/data';
+import {
+  CoreApp,
+  isValidDuration,
+  isValidGrafanaDuration,
+  LogSortOrderChangeEvent,
+  SelectableValue,
+} from '@grafana/data';
 import { EditorField, EditorRow, QueryOptionGroup } from '@grafana/experimental';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config, getAppEvents, reportInteraction } from '@grafana/runtime';
 import { Alert, AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
 
 import {
@@ -86,6 +92,12 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
       onChange({ ...query, step: trim(e.currentTarget.value) });
       onRunQuery();
     }
+
+    useEffect(() => {
+      getAppEvents().subscribe(LogSortOrderChangeEvent, (sortEvent: LogSortOrderChangeEvent) => {
+        console.log(sortEvent);
+      });
+    }, []);
 
     let queryType = getLokiQueryType(query);
     const isLogQuery = isLogsQuery(query.expr);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -7,6 +7,7 @@ import {
   isValidDuration,
   isValidGrafanaDuration,
   LogSortOrderChangeEvent,
+  LogsSortOrder,
   SelectableValue,
 } from '@grafana/data';
 import { EditorField, EditorRow, QueryOptionGroup } from '@grafana/experimental';
@@ -95,9 +96,15 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
 
     useEffect(() => {
       getAppEvents().subscribe(LogSortOrderChangeEvent, (sortEvent: LogSortOrderChangeEvent) => {
-        console.log(sortEvent);
+        const newDirection =
+          sortEvent.payload.order === LogsSortOrder.Ascending
+            ? LokiQueryDirection.Forward
+            : LokiQueryDirection.Backward;
+        if (newDirection !== query.direction) {
+          onQueryDirectionChange(newDirection);
+        }
       });
-    }, []);
+    }, [onQueryDirectionChange, query.direction]);
 
     let queryType = getLokiQueryType(query);
     const isLogQuery = isLogsQuery(query.expr);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -110,6 +110,9 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
         return;
       }
       const subscription = getAppEvents().subscribe(LogSortOrderChangeEvent, (sortEvent: LogSortOrderChangeEvent) => {
+        if (query.direction === LokiQueryDirection.Scan) {
+          return;
+        }
         const newDirection =
           sortEvent.payload.order === LogsSortOrder.Ascending
             ? LokiQueryDirection.Forward

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -110,7 +110,6 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
         return;
       }
       const subscription = getAppEvents().subscribe(LogSortOrderChangeEvent, (sortEvent: LogSortOrderChangeEvent) => {
-        console.log('event received');
         const newDirection =
           sortEvent.payload.order === LogsSortOrder.Ascending
             ? LokiQueryDirection.Forward

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -280,7 +280,7 @@ function getCollapsedInfo(
 function getDefaultQueryDirection(app?: CoreApp) {
   if (app !== CoreApp.Explore) {
     /**
-     * The default direction is forward because the default sort order is Descending.
+     * The default direction is backward because the default sort order is Descending.
      * See:
      * - public/app/features/explore/Logs/Logs.tsx
      * - public/app/plugins/panel/logs/module.tsx

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -27,9 +27,10 @@ import {
   TimeZone,
   toUtc,
   urlUtil,
+  LogSortOrderChangeEvent,
 } from '@grafana/data';
 import { convertRawToRange } from '@grafana/data/src/datetime/rangeutil';
-import { config } from '@grafana/runtime';
+import { config, getAppEvents } from '@grafana/runtime';
 import { ScrollContainer, usePanelContext, useStyles2 } from '@grafana/ui';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
 import { InfiniteScroll } from 'app/features/logs/components/InfiniteScroll';
@@ -143,8 +144,16 @@ export const LogsPanel = ({
   // Prevents the scroll position to change when new data from infinite scrolling is received
   const keepScrollPositionRef = useRef(false);
   let closeCallback = useRef<() => void>();
-
   const { eventBus, onAddAdHocFilter } = usePanelContext();
+
+  useEffect(() => {
+    getAppEvents().publish(
+      new LogSortOrderChangeEvent({
+        order: sortOrder,
+      })
+    );
+  }, [sortOrder]);
+
   const onLogRowHover = useCallback(
     (row?: LogRowModel) => {
       if (row) {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/91181 we introduced query direction for Loki log queries, allowing users to search from newest to oldest (backward) or from oldest to newest (forward).

Historically, new log queries in Explore had undefined direction, which defaulted to "backward". Now, we're updating that default behavior by deriving the direction from the current sort order of logs.

![imagen](https://github.com/user-attachments/assets/b8405e0c-8510-42a1-a130-c5643d2fe6af)

Depending on the stored state of the sort order (in Explore), or the default sort order (Explore and Dashboards), the direction will be defined as:
- Oldest first will issue queries with forward direction
- Newest first will issue querie with backward direction

> [!IMPORTANT]  
> This behavior can be overriden by selecting another direction after changing the sort order.

> [!IMPORTANT]  
> When the current query direction is Scan, it will not be overriden because this option can specifically be selected by the user and changes how the data source queries Loki.

Notes:
- For the case of Explore, it was required to access the store and retrieve the stored order, because the sort order in explore can have a default value or use a stored value from a previous session.

Additional changes:
- Automatic scrolling of the logs panel in Dashboards has been refactored because it was unexpectingly changing the scroll position for App plugins, and it was conflicting with infinte scrolling, triggering infinite infinite scrolling events when the chosen sort order was "oldest first". Now, this automatic scrolling will be omitted if the user (or the app) has enabled infinite scrolling for the panel. Context: https://github.com/grafana/grafana/issues/33661


Demo:

Explore.

https://github.com/user-attachments/assets/e8c175c7-10e0-4a6f-9878-9399efe70891

Dashboards.

https://github.com/user-attachments/assets/69f85d1d-8c3e-49a8-bf39-1b3388afb535

Fixes #91904 