### PR TITLE
Remove permissions call which would get folders again

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
-	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -301,9 +300,9 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 		writeParamSelectorSQL(&builder, params...)
 
 		// use permission filter if lib panel RBAC isn't enabled
-		if !l.features.IsEnabled(c, featuremgmt.FlagLibraryPanelRBAC) {
-			builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, searchstore.TypeFolder)
-		}
+		// if !l.features.IsEnabled(c, featuremgmt.FlagLibraryPanelRBAC) {
+		// 	builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, searchstore.TypeFolder)
+		// }
 
 		builder.Write(` OR dashboard.id=0`)
 		if err := session.SQL(builder.GetSQLString(), builder.GetParams()...).Find(&libraryElements); err != nil {

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -298,12 +298,6 @@ func (l *LibraryElementService) getLibraryElements(c context.Context, store db.D
 		builder.Write(getFromLibraryElementDTOWithMeta(store.GetDialect()))
 		builder.Write(" INNER JOIN dashboard AS dashboard on le.folder_id = dashboard.id AND le.folder_id <> 0")
 		writeParamSelectorSQL(&builder, params...)
-
-		// use permission filter if lib panel RBAC isn't enabled
-		// if !l.features.IsEnabled(c, featuremgmt.FlagLibraryPanelRBAC) {
-		// 	builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, searchstore.TypeFolder)
-		// }
-
 		builder.Write(` OR dashboard.id=0`)
 		if err := session.SQL(builder.GetSQLString(), builder.GetParams()...).Find(&libraryElements); err != nil {
 			return err

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -362,7 +362,7 @@ func TestLibraryElementsGetPermissions(t *testing.T) {
 			permissions: map[string][]string{
 				dashboards.ActionFoldersRead: {dashboards.ScopeFoldersProvider.GetResourceScopeUID("Other_folder")},
 			},
-			status: http.StatusNotFound,
+			status: http.StatusForbidden,
 		},
 	}
 	for _, testCase := range getCases {


### PR DESCRIPTION
**What is this feature?**

After using folderservice to get all the folders a user can see, we can remove the extra call to dashboard permission filter.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/search-and-storage-team/issues/169

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
