### PR TITLE
Loki: Only hide a set of labels instead of every label starting with `__`

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -490,7 +490,7 @@ describe('Language completion provider', () => {
 
       const instance = new LanguageProvider(datasourceWithLabels);
       const labels = await instance.fetchLabels();
-      expect(labels).toEqual(['bar', 'foo']);
+      expect(labels).toEqual(['__name__', 'bar', 'foo']);
     });
   });
 });

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -17,6 +17,7 @@ import { ParserAndLabelKeysResult, LokiQuery, LokiQueryType, LabelType } from '.
 
 const NS_IN_MS = 1000000;
 const EMPTY_SELECTOR = '{}';
+const HIDDEN_LABELS = ['__aggregrated_metric__', '__tenant_id__', '__stream_shard__'];
 
 export default class LokiLanguageProvider extends LanguageProvider {
   labelKeys: string[];
@@ -182,7 +183,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       const labels = Array.from(new Set(res))
         .slice()
         .sort()
-        .filter((label: string) => label.startsWith('__') === false);
+        .filter((label: string) => HIDDEN_LABELS.includes(label) === false);
       this.labelKeys = labels;
       return this.labelKeys;
     }


### PR DESCRIPTION
**What is this feature?**

We realised that hiding every label starting with `__` might hide too many labels. Such as those labels used in [lambda-promtail](https://grafana.com/docs/loki/latest/send-data/lambda-promtail/). This PR changes the behavior to only hide the following labels:
- `__aggregrated_metric__`
- `__tenant_id__ `
- `__stream_shard__ `


Internal ref: https://raintank-corp.slack.com/archives/C9T1FLN9K/p1736127432369589