### PR TITLE
Keepers: Validate referenced SecureValues exist

### DIFF
--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -7,6 +7,7 @@ import (
 	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 var (
@@ -20,4 +21,29 @@ type KeeperStorage interface {
 	Update(ctx context.Context, sv *secretv0alpha1.Keeper) (*secretv0alpha1.Keeper, error)
 	Delete(ctx context.Context, nn xkube.NameNamespace) error
 	List(ctx context.Context, namespace xkube.Namespace, options *internalversion.ListOptions) (*secretv0alpha1.KeeperList, error)
+}
+
+// ErrKeeperInvalidSecureValues is returned when a Keeper references SecureValues that do not exist.
+type ErrKeeperInvalidSecureValues struct {
+	invalidSecureValues map[string]struct{}
+}
+
+var _ error = (*ErrKeeperInvalidSecureValues)(nil)
+
+func NewErrKeeperInvalidSecureValues(invalidSecureValues map[string]struct{}) *ErrKeeperInvalidSecureValues {
+	return &ErrKeeperInvalidSecureValues{invalidSecureValues: invalidSecureValues}
+}
+
+func (e *ErrKeeperInvalidSecureValues) Error() string {
+	return e.ErrorList().ToAggregate().Error()
+}
+
+func (e *ErrKeeperInvalidSecureValues) ErrorList() field.ErrorList {
+	errs := make(field.ErrorList, 0, len(e.invalidSecureValues))
+
+	for k := range e.invalidSecureValues {
+		errs = append(errs, field.NotFound(field.NewPath("secureValueName"), k))
+	}
+
+	return errs
 }

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -119,6 +120,11 @@ func (s *KeeperRest) Create(
 
 	createdKeeper, err := s.storage.Create(ctx, kp)
 	if err != nil {
+		var kErr *contracts.ErrKeeperInvalidSecureValues
+		if errors.As(err, &kErr) {
+			return nil, apierrors.NewInvalid(kp.GroupVersionKind().GroupKind(), kp.Name, kErr.ErrorList())
+		}
+
 		return nil, fmt.Errorf("failed to create keeper: %w", err)
 	}
 


### PR DESCRIPTION
Before creating or updating a Keeper, we now check whether any referenced SecureValues (through credentials' secureValueName) exist.

If it doesn't, we throw an error type, and then map that into the expected Kubernetes error.

e.g. the API returns:
```
The Keeper "azure-xyz" is invalid: secureValueName: Not found: "CLIENT_SECRET_XYZ"
```