### PR TITLE
[v11.4.x] Dashboards: Fix issue where filtered panels would not react to variable changes

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
@@ -7,7 +7,7 @@ import { SceneGridRow, VizPanel, sceneGraph } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import { Trans } from 'app/core/internationalization';
 
-import { activateInActiveParents } from '../utils/utils';
+import { forceActivateFullSceneObjectTree } from '../utils/utils';
 
 import { DashboardGridItem } from './DashboardGridItem';
 import { DashboardScene } from './DashboardScene';
@@ -65,7 +65,13 @@ export function PanelSearchLayout({ dashboard, panelSearch = '', panelsPerRow }:
 }
 
 function PanelSearchHit({ panel }: { panel: VizPanel }) {
-  useEffect(() => activateInActiveParents(panel), [panel]);
+  useEffect(() => {
+    const deactivate = forceActivateFullSceneObjectTree(panel);
+
+    return () => {
+      deactivate?.();
+    };
+  }, [panel]);
 
   return <panel.Component model={panel} />;
 }

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -277,3 +277,31 @@ export function activateInActiveParents(so: SceneObject): CancelActivationHandle
     cancel();
   };
 }
+
+/**
+ * Adaptation of activateSceneObjectAndParentTree specific for PanelSearchLayout use case with
+ *   with panelSearch and panelsPerRow custom panel filtering logic.
+ *
+ * Activating the whole tree because dashboard does not react to variable updates such as panel repeats
+ */
+export function forceActivateFullSceneObjectTree(so: SceneObject): CancelActivationHandler | undefined {
+  let cancel: CancelActivationHandler | undefined;
+  let parentCancel: CancelActivationHandler | undefined;
+
+  if (so.parent) {
+    parentCancel = forceActivateFullSceneObjectTree(so.parent);
+  }
+
+  if (!so.isActive) {
+    cancel = so.activate();
+    return () => {
+      parentCancel?.();
+      cancel?.();
+    };
+  }
+
+  return () => {
+    parentCancel?.();
+    cancel?.();
+  };
+}


### PR DESCRIPTION
Backport 56be39ed4f4023372a84a1c1d421bf28e8f57698 from #98718

---

**What is this feature?**
Because the panels hit with the filter are already active, the activateSceneObjectAndParentTree returns early and does not activate the parents. This breaks the updating of the panel when variables change.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
