### PR TITLE
AuthZ service: Take action sets into account when checking folder create permissions

### DIFF
--- a/pkg/services/authz/rbac/store/models.go
+++ b/pkg/services/authz/rbac/store/models.go
@@ -14,6 +14,7 @@ type PermissionsQuery struct {
 	OrgID         int64
 	UserID        int64
 	Action        string
+	ActionSets    []string
 	TeamIDs       []int64
 	Role          string
 	IsServerAdmin bool

--- a/pkg/services/authz/rbac/store/permission_query.sql
+++ b/pkg/services/authz/rbac/store/permission_query.sql
@@ -1,5 +1,11 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM {{ .Ident .PermissionTable }} as p
-WHERE p.action = {{ .Arg .Query.Action }} AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM {{ .Ident .PermissionTable }} as p
+WHERE
+  {{ if .Query.ActionSets }}
+  p.action IN ({{ .ArgList .Query.ActionSets }}, {{ .Arg .Query.Action }})
+  {{ else }}
+  p.action = {{ .Arg .Query.Action }}
+  {{ end }}
+AND p.role_id IN (
   SELECT role_id FROM {{ .Ident .BuiltinRoleTable }} as br WHERE (br.role = {{ .Arg .Query.Role }} AND (br.org_id = {{ .Arg .Query.OrgID }} OR br.org_id = 0))
     {{ if .Query.IsServerAdmin }}
    OR (br.role = 'Grafana Admin')

--- a/pkg/services/authz/rbac/store/sql_test.go
+++ b/pkg/services/authz/rbac/store/sql_test.go
@@ -105,6 +105,16 @@ func TestIdentityQueries(t *testing.T) {
 						Role:   "Viewer",
 					}),
 				},
+				{
+					Name: "With_action_sets",
+					Data: getPermissions(&PermissionsQuery{
+						UserID:     1,
+						OrgID:      1,
+						Action:     "folders:create",
+						ActionSets: []string{"folders:edit", "folders:admin"},
+						Role:       "Viewer",
+					}),
+				},
 			},
 			sqlFolders: {
 				{

--- a/pkg/services/authz/rbac/store/store.go
+++ b/pkg/services/authz/rbac/store/store.go
@@ -60,7 +60,7 @@ func (s *StoreImpl) GetUserPermissions(ctx context.Context, ns claims.NamespaceI
 	var perms []accesscontrol.Permission
 	for res.Next() {
 		var perm accesscontrol.Permission
-		if err := res.Scan(&perm.Action, &perm.Kind, &perm.Attribute, &perm.Identifier, &perm.Scope); err != nil {
+		if err := res.Scan(&perm.Kind, &perm.Attribute, &perm.Identifier, &perm.Scope); err != nil {
 			return nil, err
 		}
 		perms = append(perms, perm)

--- a/pkg/services/authz/rbac/store/testdata/mysql--permission_query-With_action_sets.sql
+++ b/pkg/services/authz/rbac/store/testdata/mysql--permission_query-With_action_sets.sql
@@ -1,6 +1,6 @@
 SELECT p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
 WHERE
-  p.action = 'folders:read'
+  p.action IN ('folders:edit', 'folders:admin', 'folders:create')
 AND p.role_id IN (
   SELECT role_id FROM `grafana`.`builtin_role` as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
     UNION

--- a/pkg/services/authz/rbac/store/testdata/mysql--permission_query-admin_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/mysql--permission_query-admin_user.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM `grafana`.`builtin_role` as br WHERE (br.role = 'Admin' AND (br.org_id = 1 OR br.org_id = 0))
    OR (br.role = 'Grafana Admin')
     UNION

--- a/pkg/services/authz/rbac/store/testdata/mysql--permission_query-anonymous_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/mysql--permission_query-anonymous_user.sql
@@ -1,4 +1,6 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM `grafana`.`builtin_role` as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
 )

--- a/pkg/services/authz/rbac/store/testdata/mysql--permission_query-user_with_teams.sql
+++ b/pkg/services/authz/rbac/store/testdata/mysql--permission_query-user_with_teams.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM `grafana`.`permission` as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM `grafana`.`builtin_role` as br WHERE (br.role = 'None' AND (br.org_id = 1 OR br.org_id = 0))
     UNION
   SELECT role_id FROM `grafana`.`user_role` as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)

--- a/pkg/services/authz/rbac/store/testdata/postgres--permission_query-With_action_sets.sql
+++ b/pkg/services/authz/rbac/store/testdata/postgres--permission_query-With_action_sets.sql
@@ -1,6 +1,8 @@
 SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
 WHERE
-  p.action = 'folders:read'
+  p.action IN ('folders:edit', 'folders:admin', 'folders:create')
 AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
+    UNION
+  SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)
 )

--- a/pkg/services/authz/rbac/store/testdata/postgres--permission_query-admin_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/postgres--permission_query-admin_user.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Admin' AND (br.org_id = 1 OR br.org_id = 0))
    OR (br.role = 'Grafana Admin')
     UNION

--- a/pkg/services/authz/rbac/store/testdata/postgres--permission_query-user_with_teams.sql
+++ b/pkg/services/authz/rbac/store/testdata/postgres--permission_query-user_with_teams.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'None' AND (br.org_id = 1 OR br.org_id = 0))
     UNION
   SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)

--- a/pkg/services/authz/rbac/store/testdata/postgres--permission_query-viewer_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/postgres--permission_query-viewer_user.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
     UNION
   SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)

--- a/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-With_action_sets.sql
+++ b/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-With_action_sets.sql
@@ -1,6 +1,8 @@
 SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
 WHERE
-  p.action = 'folders:read'
+  p.action IN ('folders:edit', 'folders:admin', 'folders:create')
 AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
+    UNION
+  SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)
 )

--- a/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-admin_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-admin_user.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Admin' AND (br.org_id = 1 OR br.org_id = 0))
    OR (br.role = 'Grafana Admin')
     UNION

--- a/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-anonymous_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-anonymous_user.sql
@@ -1,4 +1,6 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
 )

--- a/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-user_with_teams.sql
+++ b/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-user_with_teams.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'None' AND (br.org_id = 1 OR br.org_id = 0))
     UNION
   SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)

--- a/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-viewer_user.sql
+++ b/pkg/services/authz/rbac/store/testdata/sqlite--permission_query-viewer_user.sql
@@ -1,5 +1,7 @@
-SELECT p.action, p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
-WHERE p.action = 'folders:read' AND p.role_id IN (
+SELECT p.kind, p.attribute, p.identifier, p.scope FROM "grafana"."permission" as p
+WHERE
+  p.action = 'folders:read'
+AND p.role_id IN (
   SELECT role_id FROM "grafana"."builtin_role" as br WHERE (br.role = 'Viewer' AND (br.org_id = 1 OR br.org_id = 0))
     UNION
   SELECT role_id FROM "grafana"."user_role" as ur WHERE ur.user_id = 1 AND (ur.org_id = 1 OR ur.org_id = 0)


### PR DESCRIPTION
**What is this feature?**

Fetch permissions from `folders:edit` and `folders:admin` action sets when checking if a user can create a folder.

**Why do we need this feature?**

This is needed to correctly check subfolder creation permissions - we don't write these permissions in the DB explicitly, only as part of action sets ([code](https://github.com/grafana/grafana/blob/372d0acec8b0ea7cc5530b3518ce7ff39f3b40f1/pkg/services/accesscontrol/resourcepermissions/service.go#L554-L561)), therefore we need to check the folder editor and admin action sets when evaluating folder creation permissions.

**Who is this feature for?**

Internal