### PR TITLE
Loki Datasource: Don't escape single quotes

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -269,7 +269,7 @@ describe('LokiDatasource', () => {
         },
       ];
       expect(ds.applyTemplateVariables(query, {}, adhocFilters).expr).toBe(
-        'rate({bar="baz", job="foo", k1=~"v.*", k2=~"v\\\\\'.*"} |= "bar" [5m])'
+        `rate({bar="baz", job="foo", k1=~"v.*", k2=~"v'.*"} |= "bar" [5m])`
       );
     });
 
@@ -325,8 +325,8 @@ describe('LokiDatasource', () => {
       variable = {} as unknown as CustomVariableModel;
     });
 
-    it('should only escape single quotes', () => {
-      expect(ds.interpolateQueryExpr("abc'$^*{}[]+?.()|", variable)).toEqual("abc\\\\'$^*{}[]+?.()|");
+    it('should not escape', () => {
+      expect(ds.interpolateQueryExpr("abc'$^*{}[]+?.()|", variable)).toEqual("abc'$^*{}[]+?.()|");
     });
 
     it('should not escape single quotes in line filters', () => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -329,6 +329,13 @@ describe('LokiDatasource', () => {
       expect(ds.interpolateQueryExpr("abc'$^*{}[]+?.()|", variable)).toEqual("abc\\\\'$^*{}[]+?.()|");
     });
 
+    it('should not escape single quotes in line filters', () => {
+      expect(ds.interpolateQueryExpr("|= `abc'$^*{}[]+?.()|`", variable)).toEqual("|= `abc'$^*{}[]+?.()|`");
+      expect(ds.interpolateQueryExpr("|~ `abc'$^*{}[]+?.()|`", variable)).toEqual("|~ `abc'$^*{}[]+?.()|`");
+      expect(ds.interpolateQueryExpr("!= `abc'$^*{}[]+?.()|`", variable)).toEqual("!= `abc'$^*{}[]+?.()|`");
+      expect(ds.interpolateQueryExpr("!~ `abc'$^*{}[]+?.()|`", variable)).toEqual("!~ `abc'$^*{}[]+?.()|`");
+    });
+
     it('should return a number', () => {
       expect(ds.interpolateQueryExpr(1000, variable)).toEqual(1000);
     });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -815,10 +815,10 @@ export class LokiDatasource
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
       if (typeof value === 'string') {
-        // // Don't escape line filters!
-        // if(['|=', '!=', '|~', '!~'].some(op => value.substring(0, 2) === op)){
-        //   return value;
-        // }
+        // Don't escape line filters!
+        if (['|=', '!=', '|~', '!~'].some((op) => value.substring(0, 2) === op)) {
+          return value;
+        }
       }
       return lokiRegularEscape(value);
     }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -814,6 +814,12 @@ export class LokiDatasource
   interpolateQueryExpr(value: any, variable: QueryVariableModel | CustomVariableModel) {
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
+      if (typeof value === 'string') {
+        // // Don't escape line filters!
+        // if(['|=', '!=', '|~', '!~'].some(op => value.substring(0, 2) === op)){
+        //   return value;
+        // }
+      }
       return lokiRegularEscape(value);
     }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -814,13 +814,7 @@ export class LokiDatasource
   interpolateQueryExpr(value: any, variable: QueryVariableModel | CustomVariableModel) {
     // if no multi or include all do not regexEscape
     if (!variable.multi && !variable.includeAll) {
-      if (typeof value === 'string') {
-        // Don't escape line filters!
-        if (['|=', '!=', '|~', '!~'].some((op) => value.substring(0, 2) === op)) {
-          return value;
-        }
-      }
-      return lokiRegularEscape(value);
+      return value;
     }
 
     if (typeof value === 'string') {
@@ -1103,13 +1097,8 @@ export class LokiDatasource
     expr = adhocFilters.reduce((acc: string, filter: { key: string; operator: string; value: string }) => {
       const { key, operator } = filter;
       let { value } = filter;
-      if (isRegexSelector(operator)) {
-        // Adhoc filters don't support multiselect, therefore if user selects regex operator
-        // we are going to consider value to be regex filter and use lokiRegularEscape
-        // that does not escape regex special characters (e.g. .*test.* => .*test.*)
-        value = lokiRegularEscape(value);
-      } else {
-        // Otherwise, we want to escape special characters in value
+      if (!isRegexSelector(operator)) {
+        // We want to escape special characters in value for non-regex selectors to match the same char in the log line as the user types in the input
         value = escapeLabelValueInSelector(value, operator);
       }
       return addLabelToQuery(acc, key, operator, value);
@@ -1213,20 +1202,9 @@ export class LokiDatasource
     };
   }
 }
-
-// NOTE: these two functions are very similar to the escapeLabelValueIn* functions
-// in language_utils.ts, but they are not exactly the same algorithm, and we found
-// no way to reuse one in the another or vice versa.
-export function lokiRegularEscape<T>(value: T) {
-  if (typeof value === 'string') {
-    return value.replace(/'/g, "\\\\'");
-  }
-  return value;
-}
-
 export function lokiSpecialRegexEscape<T>(value: T) {
   if (typeof value === 'string') {
-    return lokiRegularEscape(value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&'));
+    return value.replace(/\\/g, '\\\\\\\\').replace(/[$^*{}\[\]+?.()|]/g, '\\\\$&');
   }
   return value;
 }


### PR DESCRIPTION
**What is this feature?**
Ad-hoc line-filter variables are currently escaping single quotes, which will prevent users from matching log lines containing single quotes in line filters.

**Why do we need this feature?**
So users can query strings containing single quotes in ad-hoc line-filters

**Who is this feature for?**
Loki users

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
