### PR TITLE
Dashboards: move validation to service

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -82,6 +82,8 @@ func (d *dashboardStore) emitEntityEvent() bool {
 	return d.features != nil && d.features.IsEnabledGlobally(featuremgmt.FlagPanelTitleSearch)
 }
 
+// TODO: once the folder service removes usage of this function, remove it here. The dashboard service now implements this
+// on the service level for dashboards.
 func (d *dashboardStore) ValidateDashboardBeforeSave(ctx context.Context, dashboard *dashboards.Dashboard, overwrite bool) (bool, error) {
 	ctx, span := tracer.Start(ctx, "dashboards.database.ValidateDashboardBeforesave")
 	defer span.End()


### PR DESCRIPTION
**What is this feature?**

This PR moves the validation before save for dashboards to the dashboard service. It is mainly a copy paste from the dashboard store [here](https://github.com/grafana/grafana/blob/322bd7839ece78b6f2d7c392890b0384187330f8/pkg/services/dashboards/database/database.go#L288), other than the sql query. I kept it in the dashboard store for now, as the folder service is still using it to validate folders saved in the dashboard table (FYI - @filewalkwithme )

**Why do we need this feature?**

As we migrate dashboards to app platform, we cannot rely on the dashboards being in the dashboard table to verify. The GetDashboard function will go through the k8s client, which will either go to the dashboard table or unistore, depending on the mode.

We will also need to start checking this in a validation webhook, will follow-up with that.

**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/app-platform-wg/issues/205
