### PR TITLE
Alerting: handle err-mimir-label-value-too-long as user error in the prom writer

### DIFF
--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -28,6 +28,7 @@ const (
 	MimirDuplicateTimestampError = "err-mimir-sample-duplicate-timestamp"
 	MimirInvalidLabelError       = "err-mimir-label-invalid"
 	MimirMaxSeriesPerUserError   = "err-mimir-max-series-per-user"
+	MimirLabelValueTooLongError  = "err-mimir-label-value-too-long"
 
 	// Best effort error messages
 	PrometheusDuplicateTimestampError = "duplicate sample for timestamp"
@@ -272,6 +273,10 @@ func checkWriteError(writeErr promremote.WriteError) (err error, ignored bool) {
 
 		// this can happen when user exceeded defined maximum of
 		if strings.Contains(msg, MimirMaxSeriesPerUserError) {
+			return errors.Join(ErrRejectedWrite, writeErr), false
+		}
+
+		if strings.Contains(msg, MimirLabelValueTooLongError) {
 			return errors.Join(ErrRejectedWrite, writeErr), false
 		}
 

--- a/pkg/services/ngalert/writer/prom_test.go
+++ b/pkg/services/ngalert/writer/prom_test.go
@@ -238,6 +238,22 @@ func TestPrometheusWriter_Write(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrRejectedWrite)
 	})
+
+	t.Run("too long labels fit under the client error category", func(t *testing.T) {
+		msg := "received a series whose label value length exceeds the limit, label: 'label-1', value: 'value-1' (truncated) series: 'some_series (err-mimir-label-value-too-long). To adjust the related per-tenant limit, configure -validation.max-length-label-value, or contact your service administrator."
+		clientErr := testClientWriteError{
+			statusCode: http.StatusBadRequest,
+			msg:        &msg,
+		}
+		client.writeSeriesFunc = func(ctx context.Context, ts promremote.TSList, opts promremote.WriteOptions) (promremote.WriteResult, promremote.WriteError) {
+			return promremote.WriteResult{}, clientErr
+		}
+
+		err := writer.Write(ctx, "test", now, frames, 1, map[string]string{"extra": "label"})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrRejectedWrite)
+	})
 }
 
 func extractValue(t *testing.T, frames data.Frames, labels map[string]string, frameType data.FrameType) float64 {


### PR DESCRIPTION
**What is this feature?**

This pull request includes changes to the `pkg/services/ngalert/writer/prom.go` to handle the error `err-mimir-label-value-too-long` as user error.

**Why do we need this feature?**

This makes error categorization better.

**Who is this feature for?**

Grafana Cloud

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
