### PR TITLE
Zanzana: Add migration for mysql

### DIFF
--- a/pkg/services/authz/zanzana/client.go
+++ b/pkg/services/authz/zanzana/client.go
@@ -4,17 +4,21 @@ import (
 	"context"
 
 	"github.com/grafana/authlib/authz"
+	"google.golang.org/grpc"
 
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/client"
 )
 
-// Client is a wrapper around [openfgav1.OpenFGAServiceClient]
 type Client interface {
 	authz.AccessClient
 	Read(ctx context.Context, req *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error)
 	Write(ctx context.Context, req *authzextv1.WriteRequest) error
 	BatchCheck(ctx context.Context, req *authzextv1.BatchCheckRequest) (*authzextv1.BatchCheckResponse, error)
+}
+
+func NewClient(cc grpc.ClientConnInterface) (*client.Client, error) {
+	return client.New(cc)
 }
 
 func NewNoopClient() *client.NoopClient {

--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -1,1 +1,24 @@
 package zanzana
+
+import (
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	openfgaserver "github.com/openfga/openfga/pkg/server"
+	openfgastorage "github.com/openfga/openfga/pkg/storage"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/server"
+	"github.com/grafana/grafana/pkg/services/grpcserver"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func NewServer(cfg setting.ZanzanaSettings, openfga openfgav1.OpenFGAServiceServer, logger log.Logger) (*server.Server, error) {
+	return server.NewServer(cfg, openfga, logger)
+}
+
+func NewOpenFGAServer(cfg setting.ZanzanaSettings, store openfgastorage.OpenFGADatastore, logger log.Logger) (*openfgaserver.Server, error) {
+	return server.NewOpenFGA(cfg, store, logger)
+}
+
+func StartOpenFGAHttpSever(cfg setting.ZanzanaSettings, srv grpcserver.Provider, logger log.Logger) error {
+	return server.StartOpenFGAHttpSever(cfg, srv, logger)
+}

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/language/pkg/go/transformer"
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/grafana/pkg/infra/localcache"
@@ -40,7 +39,6 @@ type Server struct {
 
 	cfg      setting.ZanzanaSettings
 	logger   log.Logger
-	modules  []transformer.ModuleFile
 	stores   map[string]storeInfo
 	storesMU *sync.Mutex
 	cache    *localcache.CacheService

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -63,10 +63,10 @@ func setup(t *testing.T, testDB db.DB, cfg *setting.Cfg) *Server {
 	t.Helper()
 	store, err := store.NewEmbeddedStore(cfg, testDB, log.NewNopLogger())
 	require.NoError(t, err)
-	openfga, err := NewOpenFGA(&cfg.Zanzana, store, log.NewNopLogger())
+	openfga, err := NewOpenFGA(cfg.Zanzana, store, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewAuthz(cfg, openfga)
+	srv, err := NewServer(cfg.Zanzana, openfga, log.NewNopLogger())
 	require.NoError(t, err)
 
 	storeInf, err := srv.getStoreInfo(context.Background(), namespace)

--- a/pkg/services/authz/zanzana/store/migration/migrator.go
+++ b/pkg/services/authz/zanzana/store/migration/migrator.go
@@ -12,12 +12,12 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type MigrationLocation struct {
+type Location struct {
 	FS   embed.FS
 	Path string
 }
 
-func Run(cfg *setting.Cfg, typ, connStr string, migrationLocations []MigrationLocation) error {
+func Run(cfg *setting.Cfg, typ, connStr string, locations []Location) error {
 	engine, err := xorm.NewEngine(typ, connStr)
 	if err != nil {
 		return fmt.Errorf("failed to create db engine: %w", err)
@@ -26,17 +26,17 @@ func Run(cfg *setting.Cfg, typ, connStr string, migrationLocations []MigrationLo
 	m := migrator.NewMigrator(engine, cfg)
 	m.AddCreateMigration()
 
-	if err := RunWithMigrator(m, cfg, migrationLocations); err != nil {
+	if err := RunWithMigrator(m, cfg, locations); err != nil {
 		return err
 	}
 
 	return engine.Close()
 }
 
-func RunWithMigrator(m *migrator.Migrator, cfg *setting.Cfg, migrationLocations []MigrationLocation) error {
+func RunWithMigrator(m *migrator.Migrator, cfg *setting.Cfg, locations []Location) error {
 	var migrations []migration
 
-	for _, loc := range migrationLocations {
+	for _, loc := range locations {
 		parsed, err := parseMigrations(loc.FS, loc.Path)
 		if err != nil {
 			return err

--- a/pkg/services/authz/zanzana/store/migration/migrator.go
+++ b/pkg/services/authz/zanzana/store/migration/migrator.go
@@ -45,7 +45,6 @@ func RunWithMigrator(m *migrator.Migrator, cfg *setting.Cfg, locations []Locatio
 	}
 
 	for _, mig := range migrations {
-
 		m.AddMigration(mig.name, mig.migration)
 	}
 

--- a/pkg/services/authz/zanzana/store/migrations/mysql/006_alter_object_id.sql
+++ b/pkg/services/authz/zanzana/store/migrations/mysql/006_alter_object_id.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE tuple MODIFY COLUMN object_id varchar(256);
+
+-- +goose Down
+ALTER TABLE tuple MODIFY COLUMN object_id varchar(128);

--- a/pkg/services/authz/zanzana/store/store.go
+++ b/pkg/services/authz/zanzana/store/store.go
@@ -132,8 +132,8 @@ func sqliteConnectionString(v string) string {
 	return v[0:strings.LastIndex(v, "/")+1] + "zanzana.db"
 }
 
-func getMySQLMigrationLocations() []migration.MigrationLocation {
-	return []migration.MigrationLocation{
+func getMySQLMigrationLocations() []migration.Location {
+	return []migration.Location{
 		{
 			FS:   assets.EmbedMigrations,
 			Path: assets.MySQLMigrationDir,
@@ -145,8 +145,8 @@ func getMySQLMigrationLocations() []migration.MigrationLocation {
 	}
 }
 
-func getSQLiteMigrationLocations() []migration.MigrationLocation {
-	return []migration.MigrationLocation{
+func getSQLiteMigrationLocations() []migration.Location {
+	return []migration.Location{
 		{
 			FS:   assets.EmbedMigrations,
 			Path: assets.SqliteMigrationDir,
@@ -154,8 +154,8 @@ func getSQLiteMigrationLocations() []migration.MigrationLocation {
 	}
 }
 
-func getPostgresMigrationLocations() []migration.MigrationLocation {
-	return []migration.MigrationLocation{
+func getPostgresMigrationLocations() []migration.Location {
+	return []migration.Location{
 		{
 			FS:   assets.EmbedMigrations,
 			Path: assets.PostgresMigrationDir,


### PR DESCRIPTION
**What is this feature?**
openFGA uses text column types for most things on postgres and sqlite. But for mysql there are some restrictions that prevents it. Our object_id can be longer than the current limit so I added a migration to increased it to the maximum value that is allowed.

Also included some clean up code for client and server

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1092

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
