### PR TITLE
Folders: Use folder service to count library panels

### DIFF
--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -199,7 +199,7 @@ func (lps LibraryPanelService) CountInFolders(ctx context.Context, orgID int64, 
 	var count int64
 	return count, lps.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryPanels).Inc()
-		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_id IN (%s`, strings.Repeat("?,", len(folderUIDs)-1)+"?)")
+		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_uid IN (%s`, strings.Repeat("?,", len(folderUIDs)-1)+"?)")
 
 		args := make([]interface{}, 0, len(folderUIDs)+2)
 		args = append(args, orgID, orgID)

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -195,28 +195,15 @@ func (lps LibraryPanelService) CountInFolders(ctx context.Context, orgID int64, 
 	if len(folderUIDs) == 0 {
 		return 0, nil
 	}
-	// getting folderIDs for now, while there isn't data parity between folderIDs and folder_uids in the library_elements table
-	fs, err := lps.FolderService.GetFolders(ctx, folder.GetFoldersQuery{OrgID: orgID, UIDs: folderUIDs, SignedInUser: u})
-	if err != nil {
-		return 0, err
-	}
-	ids := make([]int64, 0, len(fs))
-	for _, f := range fs {
-		ids = append(ids, f.ID)
-	}
-
-	if len(ids) == 0 {
-		return 0, nil
-	}
 
 	var count int64
 	return count, lps.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryPanels).Inc()
-		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_id IN (%s`, strings.Repeat("?,", len(ids)-1)+"?)")
+		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_id IN (%s`, strings.Repeat("?,", len(folderUIDs)-1)+"?)")
 
-		args := make([]interface{}, 0, len(ids)+2)
+		args := make([]interface{}, 0, len(folderUIDs)+2)
 		args = append(args, orgID, orgID)
-		for _, id := range ids {
+		for _, id := range folderUIDs {
 			args = append(args, id)
 		}
 		args = append(args, int64(model.PanelElement))

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -205,6 +205,10 @@ func (lps LibraryPanelService) CountInFolders(ctx context.Context, orgID int64, 
 		ids = append(ids, f.ID)
 	}
 
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
 	var count int64
 	return count, lps.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryPanels).Inc()

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -202,7 +202,7 @@ func (lps LibraryPanelService) CountInFolders(ctx context.Context, orgID int64, 
 		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_uid IN (%s`, strings.Repeat("?,", len(folderUIDs)-1)+"?)")
 
 		args := make([]interface{}, 0, len(folderUIDs)+2)
-		args = append(args, orgID, orgID)
+		args = append(args, orgID)
 		for _, id := range folderUIDs {
 			args = append(args, id)
 		}

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -199,7 +199,7 @@ func (lps LibraryPanelService) CountInFolders(ctx context.Context, orgID int64, 
 	var count int64
 	return count, lps.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryPanels).Inc()
-		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_uid IN (%s`, strings.Repeat("?,", len(folderUIDs)-1)+"?)")
+		s := fmt.Sprintf(`SELECT COUNT(*) FROM library_element WHERE org_id = ? AND folder_uid IN (%s) AND kind = ?`, strings.Repeat("?,", len(folderUIDs)-1)+"?")
 
 		args := make([]interface{}, 0, len(folderUIDs)+2)
 		args = append(args, orgID)

--- a/pkg/services/librarypanels/librarypanels.go
+++ b/pkg/services/librarypanels/librarypanels.go
@@ -203,8 +203,8 @@ func (lps LibraryPanelService) CountInFolders(ctx context.Context, orgID int64, 
 
 		args := make([]interface{}, 0, len(folderUIDs)+2)
 		args = append(args, orgID)
-		for _, id := range folderUIDs {
-			args = append(args, id)
+		for _, uid := range folderUIDs {
+			args = append(args, uid)
 		}
 		args = append(args, int64(model.PanelElement))
 		_, err := sess.SQL(s, args...).Get(&count)

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -721,7 +721,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user *user.SignedInUser, dash
 		Overwrite: false,
 	}
 
-	features := featuremgmt.WithFeatures("nestedFolders")
+	features := featuremgmt.WithFeatures()
 	cfg := setting.NewCfg()
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
@@ -746,7 +746,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user *user.SignedInUser, dash
 func createFolder(t *testing.T, sc scenarioContext, title string) *folder.Folder {
 	t.Helper()
 
-	features := featuremgmt.WithFeatures("nestedFolders")
+	features := featuremgmt.WithFeatures()
 	ac := actest.FakeAccessControl{ExpectedEvaluate: true}
 	cfg := setting.NewCfg()
 	dashboardStore, err := database.ProvideDashboardStore(sc.sqlStore, cfg, features, tagimpl.ProvideService(sc.sqlStore))
@@ -818,7 +818,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		role := org.RoleAdmin
 		sqlStore, cfg := db.InitTestDBWithCfg(t)
 		quotaService := quotatest.New(false, nil)
-		features := featuremgmt.WithFeatures("nestedFolders")
+		features := featuremgmt.WithFeatures()
 
 		ac := actest.FakeAccessControl{ExpectedEvaluate: true}
 		dashStore := &dashboards.FakeDashboardStore{}

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -721,7 +721,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user *user.SignedInUser, dash
 		Overwrite: false,
 	}
 
-	features := featuremgmt.WithFeatures()
+	features := featuremgmt.WithFeatures("nestedFolders")
 	cfg := setting.NewCfg()
 	quotaService := quotatest.New(false, nil)
 	dashboardStore, err := database.ProvideDashboardStore(sqlStore, cfg, features, tagimpl.ProvideService(sqlStore))
@@ -732,7 +732,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user *user.SignedInUser, dash
 	dashPermissionService.On("SetPermissions", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]accesscontrol.ResourcePermission{}, nil)
 	service, err := dashboardservice.ProvideDashboardServiceImpl(
 		cfg, dashboardStore, folderStore,
-		featuremgmt.WithFeatures(), acmock.NewMockedPermissionsService(), dashPermissionService, ac,
+		features, acmock.NewMockedPermissionsService(), dashPermissionService, ac,
 		foldertest.NewFakeService(), folder.NewFakeStore(),
 		nil, nil, nil, nil, quotaService, nil,
 	)
@@ -746,7 +746,7 @@ func createDashboard(t *testing.T, sqlStore db.DB, user *user.SignedInUser, dash
 func createFolder(t *testing.T, sc scenarioContext, title string) *folder.Folder {
 	t.Helper()
 
-	features := featuremgmt.WithFeatures()
+	features := featuremgmt.WithFeatures("nestedFolders")
 	ac := actest.FakeAccessControl{ExpectedEvaluate: true}
 	cfg := setting.NewCfg()
 	dashboardStore, err := database.ProvideDashboardStore(sc.sqlStore, cfg, features, tagimpl.ProvideService(sc.sqlStore))
@@ -818,7 +818,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		role := org.RoleAdmin
 		sqlStore, cfg := db.InitTestDBWithCfg(t)
 		quotaService := quotatest.New(false, nil)
-		features := featuremgmt.WithFeatures()
+		features := featuremgmt.WithFeatures("nestedFolders")
 
 		ac := actest.FakeAccessControl{ExpectedEvaluate: true}
 		dashStore := &dashboards.FakeDashboardStore{}


### PR DESCRIPTION
**What is this feature?**

Use folder service to get folderIds so that they can be used to count library panels inside a folder.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

Relates to https://github.com/grafana/search-and-storage-team/issues/167

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
