### PR TITLE
Keepers: dont allow secureValueNames to reference 3rdparty keepers

### DIFF
--- a/pkg/registry/apis/secret/xkube/errors.go
+++ b/pkg/registry/apis/secret/xkube/errors.go
@@ -1,0 +1,9 @@
+package xkube
+
+import "k8s.io/apimachinery/pkg/util/validation/field"
+
+// ErrorLister is an interface compatible with errors that also returns a list of Kubernetes field errors.
+type ErrorLister interface {
+	error
+	ErrorList() field.ErrorList
+}


### PR DESCRIPTION
Instead, secureValueNames in a Keeper can ONLY reference SQL-type keepers.

This is to simplify the dependency chain and possibilities, where before we'd have to walk the possible secureValueNames chain, we now limit ourselves to only have to do at most 1 look-up in another keeper, which is guaranteed to be a SQL keeper.

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1142