### PR TITLE
Bugfix: Updating storybook example to pass theme property to BarGuage

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.mdx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.mdx
@@ -14,34 +14,35 @@ import { VizOrientation, ThresholdsMode, Field, FieldType, getDisplayProcessor }
 const field: Partial<Field> = {
   type: FieldType.number,
   config: {
-    min: minValue,
-    max: maxValue,
+    min: 0,
+    max: 100,
     thresholds: {
       mode: ThresholdsMode.Absolute,
       steps: [
         { value: -Infinity, color: 'green' },
-        { value: threshold1Value, color: threshold1Color },
-        { value: threshold2Value, color: threshold2Color },
+        { value: 20, color: 'blue' },
+        { value: 90, color: 'red' },
       ],
     },
   },
 };
-field.display = getDisplayProcessor({ field });
 
-const value = {
-  text: value.toString(),
-  title: title,
-  numeric: value,
-};
+field.display = getDisplayProcessor({ theme, field });
 
-<BarGauge
-  value={70}
-  field={field.config}
-  display={field.display}
-  value={value}
-  orientation={VizOrientation.Vertical}
-  displayMode={BarGaugeDisplayMode.Basic}
-/>;
+return (
+  <BarGauge
+    theme={theme}
+    field={field.config}
+    display={field.display}
+    value={{
+      text: '70',
+      title: 'Title of data point',
+      numeric: 70,
+    }}
+    orientation={VizOrientation.Vertical}
+    displayMode={BarGaugeDisplayMode.Basic}
+  />
+);
 ```
 
 <ArgTypes of={BarGauge} />

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.mdx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.mdx
@@ -31,7 +31,6 @@ field.display = getDisplayProcessor({ theme, field });
 
 return (
   <BarGauge
-    theme={theme}
     field={field.config}
     display={field.display}
     value={{

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.mdx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.mdx
@@ -31,6 +31,7 @@ field.display = getDisplayProcessor({ theme, field });
 
 return (
   <BarGauge
+    theme={theme}
     field={field.config}
     display={field.display}
     value={{

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -23,7 +23,6 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { BarGaugeDisplayMode, BarGaugeNamePlacement, BarGaugeValueMode, VizTextDisplayOptions } from '@grafana/schema';
 
-import { withTheme2 } from '../../themes';
 import { Themeable2 } from '../../types';
 import { calculateFontSize, measureText } from '../../utils/measureText';
 import { clearButtonStyles } from '../Button';
@@ -55,7 +54,7 @@ export interface Props extends Themeable2 {
   namePlacement?: BarGaugeNamePlacement;
 }
 
-class UnThemedBarGauge extends PureComponent<Props> {
+export class BarGauge extends PureComponent<Props> {
   static defaultProps: Partial<Props> = {
     lcdCellWidth: 12,
     value: {
@@ -220,8 +219,6 @@ class UnThemedBarGauge extends PureComponent<Props> {
     );
   }
 }
-
-export const BarGauge = withTheme2(UnThemedBarGauge);
 
 interface CellColors {
   background: string;

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -23,6 +23,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { BarGaugeDisplayMode, BarGaugeNamePlacement, BarGaugeValueMode, VizTextDisplayOptions } from '@grafana/schema';
 
+import { withTheme2 } from '../../themes';
 import { Themeable2 } from '../../types';
 import { calculateFontSize, measureText } from '../../utils/measureText';
 import { clearButtonStyles } from '../Button';
@@ -54,7 +55,7 @@ export interface Props extends Themeable2 {
   namePlacement?: BarGaugeNamePlacement;
 }
 
-export class BarGauge extends PureComponent<Props> {
+class UnThemedBarGauge extends PureComponent<Props> {
   static defaultProps: Partial<Props> = {
     lcdCellWidth: 12,
     value: {
@@ -219,6 +220,8 @@ export class BarGauge extends PureComponent<Props> {
     );
   }
 }
+
+export const BarGauge = withTheme2(UnThemedBarGauge);
 
 interface CellColors {
   background: string;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

We got an issue reported where the Storybook example for the BarGuage didn't work when trying to use it in a real world plugin. While updating the example I realised that BarGuage implement `Themeable2` but does not wrap the component in the `withTheme2` HOC. 

I'm not sure if this was made on purpose so I will try to get reviews from someone that might know.

**Edit:**
I reverted that change and just updated the storybook example since the change had som unwanted side effects on other components. However, I'm still a bit confused why the prop type, in the npm package, for the BarGuage marks the `theme` prop as optional since it is mandatory in the `Themeable2` interface. So in this case, we don't get an compile error when not passing it to the BarGuage component.


<img width="675" alt="Screenshot 2025-01-10 at 14 14 03" src="https://github.com/user-attachments/assets/f4c0cfa5-78b9-4dde-b7a5-1f90b0e68cae" />


**Why do we need this feature?**

To fix an issue with documentation and make the API easier to consume from plugins.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

Fixes #97960

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
