### PR TITLE
Alerting: Use AlertRuleKey for comparison before rule evaluation

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -194,7 +194,7 @@ func (a *alertRule) Status() ngmodels.RuleStatus {
 //
 // the second element contains a dropped message that was sent by a concurrent sender.
 func (a *alertRule) Eval(eval *Evaluation) (bool, *Evaluation) {
-	if a.key != eval.rule.GetKeyWithGroup() {
+	if a.key.AlertRuleKey != eval.rule.GetKey() {
 		// Make sure that rule has the same key. This should not happen
 		a.logger.Error("Invalid rule sent for evaluating. Skipping", "ruleKeyToEvaluate", eval.rule.GetKey().String())
 		return false, eval


### PR DESCRIPTION
This PR fixes a bug that causes alerts to be incorrectly marked as "invalid" after updating evaluation group names.
We're keeping a stale version of the alert group name in memory, so comparing the in-memory rule to the one being evaluated after an eval name change will always fail.