### PR TITLE
Keepers: dont allow using `secureValueName` in SQL keepers

### DIFF
--- a/pkg/apis/secret/v0alpha1/keeper.go
+++ b/pkg/apis/secret/v0alpha1/keeper.go
@@ -19,6 +19,10 @@ type Keeper struct {
 	Spec KeeperSpec `json:"spec,omitempty" patchStrategy:"replace" patchMergeKey:"name"`
 }
 
+func (k *Keeper) IsSqlKeeper() bool {
+	return k.Spec.SQL != nil && k.Spec.SQL.Encryption != nil
+}
+
 type KeeperSpec struct {
 	// Human friendly name for the keeper.
 	Title string `json:"title"`

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -214,7 +214,7 @@ func ValidateKeeper(keeper *secretv0alpha1.Keeper, operation admission.Operation
 
 	// TODO: Improve SQL keeper validation.
 	// SQL keeper is not allowed to use `secureValueName` in credentials fields to avoid depending on another keeper.
-	if keeper.Spec.SQL != nil && keeper.Spec.SQL.Encryption != nil {
+	if keeper.IsSqlKeeper() {
 		if keeper.Spec.SQL.Encryption.AWS != nil {
 			if keeper.Spec.SQL.Encryption.AWS.AccessKeyID.SecureValueName != "" {
 				errs = append(errs, field.Forbidden(field.NewPath("spec", "aws", "accessKeyId"), "secureValueName cannot be used with SQL keeper"))

--- a/pkg/registry/apis/secret/reststorage/keeper_rest_test.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest_test.go
@@ -268,4 +268,65 @@ func TestValidateKeeper(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("sql keeper validation", func(t *testing.T) {
+		t.Run("does not allow usage of `secureValueName` in credentials", func(t *testing.T) {
+			providers := []struct {
+				name           string
+				enc            secretv0alpha1.Encryption
+				expectedErrors int
+			}{
+				{
+					name: "aws",
+					enc: secretv0alpha1.Encryption{
+						AWS: &secretv0alpha1.AWSCredentials{
+							AccessKeyID: secretv0alpha1.CredentialValue{
+								SecureValueName: "not-empty",
+							},
+							SecretAccessKey: secretv0alpha1.CredentialValue{
+								SecureValueName: "not-empty",
+							},
+						},
+					},
+					expectedErrors: 2,
+				},
+				{
+					name: "azure",
+					enc: secretv0alpha1.Encryption{
+						Azure: &secretv0alpha1.AzureCredentials{
+							ClientSecret: secretv0alpha1.CredentialValue{
+								SecureValueName: "not-empty",
+							},
+						},
+					},
+					expectedErrors: 1,
+				},
+				{
+					name: "hashicorp",
+					enc: secretv0alpha1.Encryption{
+						HashiCorp: &secretv0alpha1.HashiCorpCredentials{
+							Token: secretv0alpha1.CredentialValue{
+								SecureValueName: "not-empty",
+							},
+						},
+					},
+					expectedErrors: 1,
+				},
+			}
+
+			for _, tc := range providers {
+				t.Run("when using credentials for "+tc.name, func(t *testing.T) {
+					keeper := &secretv0alpha1.Keeper{
+						Spec: secretv0alpha1.KeeperSpec{
+							Title: "title",
+							SQL:   &secretv0alpha1.SQLKeeper{Encryption: &tc.enc},
+						},
+					}
+
+					errs := ValidateKeeper(keeper, admission.Create)
+					require.Len(t, errs, tc.expectedErrors)
+				})
+			}
+		})
+	})
 }


### PR DESCRIPTION
This simplifies the setup for SQL keeper credentials and avoids us having to walk dependencies between SecureValues.

This limitation is one that we're fine with to reduce complexity, and if it is really needed we can lift it in the future.