### PR TITLE
Authn: last seen concurrent fix

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/grafana/authlib/claims"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -63,6 +64,7 @@ func ProvideUserSync(userService user.Service, userProtectionService login.UserP
 		log:                   log.New("user.sync"),
 		tracer:                tracer,
 		features:              features,
+		lastSeenSF:            &singleflight.Group{},
 	}
 }
 
@@ -74,6 +76,7 @@ type UserSync struct {
 	log                   log.Logger
 	tracer                tracing.Tracer
 	features              featuremgmt.FeatureToggles
+	lastSeenSF            *singleflight.Group
 }
 
 // SyncUserHook syncs a user with the database
@@ -177,19 +180,21 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, id *authn.Identity, r *
 	}
 
 	goCtx := context.WithoutCancel(ctx)
-	go func(userID int64) {
+	go func(orgID, userID int64) {
 		defer func() {
 			if err := recover(); err != nil {
 				s.log.Error("Panic during user last seen sync", "err", err)
 			}
 		}()
 
-		if err := s.userService.UpdateLastSeenAt(goCtx,
-			&user.UpdateUserLastSeenAtCommand{UserID: userID, OrgID: r.OrgID}); err != nil &&
-			!errors.Is(err, user.ErrLastSeenUpToDate) {
-			s.log.Error("Failed to update last_seen_at", "err", err, "userId", userID)
-		}
-	}(userID)
+		s.lastSeenSF.Do(fmt.Sprintf("%d-%d", orgID, userID), func() (interface{}, error) {
+			err := s.userService.UpdateLastSeenAt(goCtx, &user.UpdateUserLastSeenAtCommand{UserID: userID, OrgID: orgID})
+			if err != nil && !errors.Is(err, user.ErrLastSeenUpToDate) {
+				s.log.Error("Failed to update last_seen_at", "err", err, "userId", userID)
+			}
+			return nil, nil
+		})
+	}(r.OrgID, userID)
 
 	return nil
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -180,21 +180,13 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, id *authn.Identity, r *
 	}
 
 	goCtx := context.WithoutCancel(ctx)
-	go func(orgID, userID int64) {
-		defer func() {
-			if err := recover(); err != nil {
-				s.log.Error("Panic during user last seen sync", "err", err)
-			}
-		}()
-
-		s.lastSeenSF.Do(fmt.Sprintf("%d-%d", orgID, userID), func() (interface{}, error) {
-			err := s.userService.UpdateLastSeenAt(goCtx, &user.UpdateUserLastSeenAtCommand{UserID: userID, OrgID: orgID})
-			if err != nil && !errors.Is(err, user.ErrLastSeenUpToDate) {
-				s.log.Error("Failed to update last_seen_at", "err", err, "userId", userID)
-			}
-			return nil, nil
-		})
-	}(r.OrgID, userID)
+	s.lastSeenSF.Do(fmt.Sprintf("%d-%d", id.GetOrgID(), userID), func() (interface{}, error) {
+		err := s.userService.UpdateLastSeenAt(goCtx, &user.UpdateUserLastSeenAtCommand{UserID: userID, OrgID: id.GetOrgID()})
+		if err != nil && !errors.Is(err, user.ErrLastSeenUpToDate) {
+			s.log.Error("Failed to update last_seen_at", "err", err, "userId", userID)
+		}
+		return nil, nil
+	})
 
 	return nil
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -180,7 +180,7 @@ func (s *UserSync) SyncLastSeenHook(ctx context.Context, id *authn.Identity, r *
 	}
 
 	goCtx := context.WithoutCancel(ctx)
-	s.lastSeenSF.Do(fmt.Sprintf("%d-%d", id.GetOrgID(), userID), func() (interface{}, error) {
+	_, _, _ = s.lastSeenSF.Do(fmt.Sprintf("%d-%d", id.GetOrgID(), userID), func() (interface{}, error) {
 		err := s.userService.UpdateLastSeenAt(goCtx, &user.UpdateUserLastSeenAtCommand{UserID: userID, OrgID: id.GetOrgID()})
 		if err != nil && !errors.Is(err, user.ErrLastSeenUpToDate) {
 			s.log.Error("Failed to update last_seen_at", "err", err, "userId", userID)


### PR DESCRIPTION
**What is this feature?**
If multiple request are in flight at the same time when `last_seen_at` needs to be updated they all will trigger an update.

Using singleflight for this call should at least help when multiple requests are made to the same instance. 

**Who is this feature for?**

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/identity-access-team/issues/1072


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
