### PR TITLE
Tests: add multiple namespace integration tests

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3079,6 +3079,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
+    "public/app/features/dashboard-scene/edit-pane/VizPanelEditPaneBehavior.tsx:5381": [
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+    ],
     "public/app/features/dashboard-scene/embedding/EmbeddedDashboard.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
@@ -3298,6 +3303,11 @@ exports[`better eslint`] = {
     ],
     "public/app/features/dashboard-scene/scene/UnlinkModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+    ],
+    "public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx:5381": [
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/dashboard-scene/scene/row-actions/RowActions.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],

--- a/pkg/registry/apis/secret/reststorage/keeper_rest.go
+++ b/pkg/registry/apis/secret/reststorage/keeper_rest.go
@@ -143,7 +143,7 @@ func (s *KeeperRest) Update(
 ) (runtime.Object, bool, error) {
 	oldObj, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
-		return nil, false, fmt.Errorf("get securevalue: %w", err)
+		return nil, false, err
 	}
 
 	// Makes sure the UID and ResourceVersion are OK.

--- a/pkg/registry/apis/secret/reststorage/secure_value_rest.go
+++ b/pkg/registry/apis/secret/reststorage/secure_value_rest.go
@@ -140,7 +140,7 @@ func (s *SecureValueRest) Update(
 ) (runtime.Object, bool, error) {
 	oldObj, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
-		return nil, false, fmt.Errorf("get securevalue: %w", err)
+		return nil, false, err
 	}
 
 	// Makes sure the UID and ResourceVersion are OK.

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -198,6 +198,7 @@ func (_m *FakeDashboardService) GetAllDashboards(ctx context.Context) ([]*Dashbo
 	return r0, r1
 }
 
+
 func (_m *FakeDashboardService) GetAllDashboardsByOrgId(ctx context.Context, orgID int64) ([]*Dashboard, error) {
 	ret := _m.Called(ctx, orgID)
 

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -256,6 +256,7 @@ func (_m *FakeDashboardStore) GetAllDashboardsByOrgId(ctx context.Context, orgID
 	return r0, r1
 }
 
+
 // GetDashboard provides a mock function with given fields: ctx, query
 func (_m *FakeDashboardStore) GetDashboard(ctx context.Context, query *GetDashboardQuery) (*Dashboard, error) {
 	ret := _m.Called(ctx, query)

--- a/pkg/tests/apis/secret/keeper_test.go
+++ b/pkg/tests/apis/secret/keeper_test.go
@@ -63,7 +63,7 @@ func TestIntegrationKeeper(t *testing.T) {
 	})
 
 	t.Run("creating a keeper returns it", func(t *testing.T) {
-		raw := mustGenerateKeeper(t, helper, nil)
+		raw := mustGenerateKeeper(t, helper, helper.Org1.Admin, nil)
 
 		keeper := new(secretv0alpha1.Keeper)
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw.Object, keeper)
@@ -155,7 +155,7 @@ func TestIntegrationKeeper(t *testing.T) {
 	})
 
 	t.Run("creating a keeper with a provider then changing the provider does not return an error", func(t *testing.T) {
-		rawAWS := mustGenerateKeeper(t, helper, nil)
+		rawAWS := mustGenerateKeeper(t, helper, helper.Org1.Admin, nil)
 
 		testDataKeeperGCP := rawAWS.DeepCopy()
 		testDataKeeperGCP.Object["spec"].(map[string]any)["aws"] = nil
@@ -225,10 +225,10 @@ func TestIntegrationKeeper(t *testing.T) {
 
 	t.Run("creating a keeper that references a securevalue that is stored in a non-SQL type Keeper returns an error", func(t *testing.T) {
 		// 1. Create a non-SQL keeper without using `secureValueName`.
-		keeperAWS := mustGenerateKeeper(t, helper, nil)
+		keeperAWS := mustGenerateKeeper(t, helper, helper.Org1.Admin, nil)
 
 		// 2. Create a secureValue that is stored in the previously created keeper (non-SQL).
-		secureValue := mustGenerateSecureValue(t, helper, keeperAWS.GetName())
+		secureValue := mustGenerateSecureValue(t, helper, helper.Org1.Admin, keeperAWS.GetName())
 
 		// 3. Create another keeper that uses the secureValue, which fails.
 		testDataAnotherKeeper := keeperAWS.DeepCopy()
@@ -243,7 +243,7 @@ func TestIntegrationKeeper(t *testing.T) {
 
 	t.Run("creating a keeper that references a securevalue that is stored in a SQL type Keeper returns no error", func(t *testing.T) {
 		// 1. Create a SQL keeper.
-		keeperSQL := mustGenerateKeeper(t, helper, map[string]any{
+		keeperSQL := mustGenerateKeeper(t, helper, helper.Org1.Admin, map[string]any{
 			"title": "SQL Keeper",
 			"sql": map[string]any{
 				"encryption": map[string]any{"envelope": map[string]any{}},
@@ -251,10 +251,10 @@ func TestIntegrationKeeper(t *testing.T) {
 		})
 
 		// 2. Create a secureValue that is stored in the previously created keeper (SQL).
-		secureValue := mustGenerateSecureValue(t, helper, keeperSQL.GetName())
+		secureValue := mustGenerateSecureValue(t, helper, helper.Org1.Admin, keeperSQL.GetName())
 
 		// 3. Create a non-SQL keeper that uses the secureValue.
-		keeperAWS := mustGenerateKeeper(t, helper, map[string]any{
+		keeperAWS := mustGenerateKeeper(t, helper, helper.Org1.Admin, map[string]any{
 			"title": "AWS Keeper",
 			"aws": map[string]any{
 				"accessKeyId":     map[string]any{"secureValueName": secureValue.GetName()},
@@ -262,5 +262,123 @@ func TestIntegrationKeeper(t *testing.T) {
 			},
 		})
 		require.NotNil(t, keeperAWS)
+	})
+
+	t.Run("creating keepers in multiple namespaces", func(t *testing.T) {
+		adminOrg1 := helper.Org1.Admin
+		adminOrgB := helper.OrgB.Admin
+
+		keeperOrg1 := mustGenerateKeeper(t, helper, adminOrg1, nil)
+		keeperOrgB := mustGenerateKeeper(t, helper, adminOrgB, nil)
+
+		clientOrg1 := helper.GetResourceClient(apis.ResourceClientArgs{User: adminOrg1, GVR: gvrKeepers})
+		clientOrgB := helper.GetResourceClient(apis.ResourceClientArgs{User: adminOrgB, GVR: gvrKeepers})
+
+		// Create
+		t.Run("creating a keeper with the same name as one from another namespace does not return an error", func(t *testing.T) {
+			// Org1 creating a keeper with the same name from OrgB.
+			testData := helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
+			testData.SetName(keeperOrgB.GetName())
+
+			raw, err := clientOrg1.Resource.Create(ctx, testData, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+
+			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
+
+			// OrgB creating a keeper with the same name from Org1.
+			testData = helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
+			testData.SetName(keeperOrg1.GetName())
+
+			raw, err = clientOrgB.Resource.Create(ctx, testData, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+
+			require.NoError(t, clientOrgB.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
+		})
+
+		// Read
+		t.Run("fetching a keeper from another namespace returns not found", func(t *testing.T) {
+			var statusErr *apierrors.StatusError
+
+			// Org1 trying to fetch keeper from OrgB.
+			raw, err := clientOrg1.Resource.Get(ctx, keeperOrgB.GetName(), metav1.GetOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+
+			// OrgB trying to fetch keeper from Org1.
+			raw, err = clientOrgB.Resource.Get(ctx, keeperOrg1.GetName(), metav1.GetOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+		})
+
+		// Update
+		t.Run("updating a keeper from another namespace returns not found", func(t *testing.T) {
+			var statusErr *apierrors.StatusError
+
+			// Org1 trying to update securevalue from OrgB.
+			testData := helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
+			testData.SetName(keeperOrgB.GetName())
+			testData.Object["spec"].(map[string]any)["title"] = "New title"
+
+			raw, err := clientOrg1.Resource.Update(ctx, testData, metav1.UpdateOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+
+			// OrgB trying to update keeper from Org1.
+			testData = helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
+			testData.SetName(keeperOrg1.GetName())
+			testData.Object["spec"].(map[string]any)["title"] = "New title"
+
+			raw, err = clientOrgB.Resource.Update(ctx, testData, metav1.UpdateOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+		})
+
+		// Delete
+		t.Run("deleting a keeper from another namespace does not return an error but does not delete it", func(t *testing.T) {
+			// Org1 trying to delete keeper from OrgB.
+			err := clientOrg1.Resource.Delete(ctx, keeperOrgB.GetName(), metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			// Check that it still exists from the perspective of OrgB.
+			raw, err := clientOrgB.Resource.Get(ctx, keeperOrgB.GetName(), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+
+			// OrgB trying to delete keeper from Org1.
+			err = clientOrgB.Resource.Delete(ctx, keeperOrg1.GetName(), metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			// Check that it still exists from the perspective of Org1.
+			raw, err = clientOrg1.Resource.Get(ctx, keeperOrg1.GetName(), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+		})
+
+		// List
+		t.Run("listing keeper from a namespace does not return the ones from another namespace", func(t *testing.T) {
+			// Org1 listing keeper.
+			listOrg1, err := clientOrg1.Resource.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, listOrg1)
+			require.Len(t, listOrg1.Items, 1)
+			require.Equal(t, *keeperOrg1, listOrg1.Items[0])
+
+			// OrgB listing keeper.
+			listOrgB, err := clientOrgB.Resource.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, listOrgB)
+			require.Len(t, listOrgB.Items, 1)
+			require.Equal(t, *keeperOrgB, listOrgB.Items[0])
+		})
 	})
 }

--- a/pkg/tests/apis/secret/keeper_test.go
+++ b/pkg/tests/apis/secret/keeper_test.go
@@ -284,8 +284,6 @@ func TestIntegrationKeeper(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, raw)
 
-			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
-
 			// OrgB creating a keeper with the same name from Org1.
 			testData = helper.LoadYAMLOrJSONFile("testdata/keeper-aws-generate.yaml")
 			testData.SetName(keeperOrg1.GetName())
@@ -294,6 +292,7 @@ func TestIntegrationKeeper(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, raw)
 
+			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
 			require.NoError(t, clientOrgB.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
 		})
 

--- a/pkg/tests/apis/secret/main_test.go
+++ b/pkg/tests/apis/secret/main_test.go
@@ -54,7 +54,7 @@ func TestIntegrationDiscoveryClient(t *testing.T) {
 	})
 }
 
-func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, keeperName string) *unstructured.Unstructured {
+func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, user apis.User, keeperName string) *unstructured.Unstructured {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -62,7 +62,7 @@ func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, keeperNam
 
 	secureValueClient := helper.GetResourceClient(apis.ResourceClientArgs{
 		// #TODO: figure out permissions topic
-		User: helper.Org1.Admin,
+		User: user,
 		GVR:  gvrSecureValues,
 	})
 
@@ -80,7 +80,7 @@ func mustGenerateSecureValue(t *testing.T, helper *apis.K8sTestHelper, keeperNam
 	return raw
 }
 
-func mustGenerateKeeper(t *testing.T, helper *apis.K8sTestHelper, specType map[string]any) *unstructured.Unstructured {
+func mustGenerateKeeper(t *testing.T, helper *apis.K8sTestHelper, user apis.User, specType map[string]any) *unstructured.Unstructured {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -88,7 +88,7 @@ func mustGenerateKeeper(t *testing.T, helper *apis.K8sTestHelper, specType map[s
 
 	keeperClient := helper.GetResourceClient(apis.ResourceClientArgs{
 		// #TODO: figure out permissions topic
-		User: helper.Org1.Admin,
+		User: user,
 		GVR:  gvrKeepers,
 	})
 

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -205,8 +205,6 @@ func TestIntegrationSecureValue(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, raw)
 
-			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
-
 			// OrgB creating a securevalue with the same name from Org1.
 			testData = helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
 			testData.SetName(secureValueOrg1.GetName())
@@ -216,6 +214,7 @@ func TestIntegrationSecureValue(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, raw)
 
+			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
 			require.NoError(t, clientOrgB.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
 		})
 

--- a/pkg/tests/apis/secret/secure_value_test.go
+++ b/pkg/tests/apis/secret/secure_value_test.go
@@ -49,8 +49,8 @@ func TestIntegrationSecureValue(t *testing.T) {
 	})
 
 	t.Run("creating a secure value returns it without any of the value or ref", func(t *testing.T) {
-		keeper := mustGenerateKeeper(t, helper, nil)
-		raw := mustGenerateSecureValue(t, helper, keeper.GetName())
+		keeper := mustGenerateKeeper(t, helper, helper.Org1.Admin, nil)
+		raw := mustGenerateSecureValue(t, helper, helper.Org1.Admin, keeper.GetName())
 
 		secureValue := new(secretv0alpha1.SecureValue)
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw.Object, secureValue)
@@ -94,7 +94,7 @@ func TestIntegrationSecureValue(t *testing.T) {
 		})
 
 		t.Run("and updating the secure value replaces the spec fields and returns them", func(t *testing.T) {
-			newKeeper := mustGenerateKeeper(t, helper, nil)
+			newKeeper := mustGenerateKeeper(t, helper, helper.Org1.Admin, nil)
 
 			newRaw := helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
 			newRaw.SetName(raw.GetName())
@@ -147,7 +147,7 @@ func TestIntegrationSecureValue(t *testing.T) {
 	t.Run("deleting a secure value that exists does not return an error", func(t *testing.T) {
 		generatePrefix := "generated-"
 
-		keeper := mustGenerateKeeper(t, helper, nil)
+		keeper := mustGenerateKeeper(t, helper, helper.Org1.Admin, nil)
 
 		testData := helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
 		testData.SetGenerateName(generatePrefix)
@@ -178,6 +178,129 @@ func TestIntegrationSecureValue(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, rawList)
 			require.Empty(t, rawList.Items)
+		})
+	})
+
+	t.Run("creating securevalues in multiple namespaces", func(t *testing.T) {
+		adminOrg1 := helper.Org1.Admin
+		adminOrgB := helper.OrgB.Admin
+
+		keeperOrg1 := mustGenerateKeeper(t, helper, adminOrg1, nil)
+		keeperOrgB := mustGenerateKeeper(t, helper, adminOrgB, nil)
+
+		secureValueOrg1 := mustGenerateSecureValue(t, helper, adminOrg1, keeperOrg1.GetName())
+		secureValueOrgB := mustGenerateSecureValue(t, helper, adminOrgB, keeperOrgB.GetName())
+
+		clientOrg1 := helper.GetResourceClient(apis.ResourceClientArgs{User: adminOrg1, GVR: gvrSecureValues})
+		clientOrgB := helper.GetResourceClient(apis.ResourceClientArgs{User: adminOrgB, GVR: gvrSecureValues})
+
+		// Create
+		t.Run("creating a securevalue with the same name as one from another namespace does not return an error", func(t *testing.T) {
+			// Org1 creating a securevalue with the same name from OrgB.
+			testData := helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
+			testData.SetName(secureValueOrgB.GetName())
+			testData.Object["spec"].(map[string]any)["keeper"] = keeperOrg1.GetName()
+
+			raw, err := clientOrg1.Resource.Create(ctx, testData, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+
+			require.NoError(t, clientOrg1.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
+
+			// OrgB creating a securevalue with the same name from Org1.
+			testData = helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
+			testData.SetName(secureValueOrg1.GetName())
+			testData.Object["spec"].(map[string]any)["keeper"] = keeperOrgB.GetName()
+
+			raw, err = clientOrgB.Resource.Create(ctx, testData, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+
+			require.NoError(t, clientOrgB.Resource.Delete(ctx, raw.GetName(), metav1.DeleteOptions{}))
+		})
+
+		// Read
+		t.Run("fetching a securevalue from another namespace returns not found", func(t *testing.T) {
+			var statusErr *apierrors.StatusError
+
+			// Org1 trying to fetch securevalue from OrgB.
+			raw, err := clientOrg1.Resource.Get(ctx, secureValueOrgB.GetName(), metav1.GetOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+
+			// OrgB trying to fetch securevalue from Org1.
+			raw, err = clientOrgB.Resource.Get(ctx, secureValueOrg1.GetName(), metav1.GetOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+		})
+
+		// Update
+		t.Run("updating a securevalue from another namespace returns not found", func(t *testing.T) {
+			var statusErr *apierrors.StatusError
+
+			// Org1 trying to update securevalue from OrgB.
+			testData := helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
+			testData.SetName(secureValueOrgB.GetName())
+			testData.Object["spec"].(map[string]any)["title"] = "New title"
+
+			raw, err := clientOrg1.Resource.Update(ctx, testData, metav1.UpdateOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+
+			// OrgB trying to update securevalue from Org1.
+			testData = helper.LoadYAMLOrJSONFile("testdata/secure-value-generate.yaml")
+			testData.SetName(secureValueOrg1.GetName())
+			testData.Object["spec"].(map[string]any)["title"] = "New title"
+
+			raw, err = clientOrgB.Resource.Update(ctx, testData, metav1.UpdateOptions{})
+			require.Error(t, err)
+			require.Nil(t, raw)
+			require.True(t, errors.As(err, &statusErr))
+			require.Equal(t, http.StatusNotFound, int(statusErr.Status().Code))
+		})
+
+		// Delete
+		t.Run("deleting a securevalue from another namespace does not return an error but does not delete it", func(t *testing.T) {
+			// Org1 trying to delete securevalue from OrgB.
+			err := clientOrg1.Resource.Delete(ctx, secureValueOrgB.GetName(), metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			// Check that it still exists from the perspective of OrgB.
+			raw, err := clientOrgB.Resource.Get(ctx, secureValueOrgB.GetName(), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+
+			// OrgB trying to delete securevalue from Org1.
+			err = clientOrgB.Resource.Delete(ctx, secureValueOrg1.GetName(), metav1.DeleteOptions{})
+			require.NoError(t, err)
+
+			// Check that it still exists from the perspective of Org1.
+			raw, err = clientOrg1.Resource.Get(ctx, secureValueOrg1.GetName(), metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, raw)
+		})
+
+		// List
+		t.Run("listing securevalues from a namespace does not return the ones from another namespace", func(t *testing.T) {
+			// Org1 listing securevalues.
+			listOrg1, err := clientOrg1.Resource.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, listOrg1)
+			require.Len(t, listOrg1.Items, 1)
+			require.Equal(t, *secureValueOrg1, listOrg1.Items[0])
+
+			// OrgB listing securevalues.
+			listOrgB, err := clientOrgB.Resource.List(ctx, metav1.ListOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, listOrgB)
+			require.Len(t, listOrgB.Items, 1)
+			require.Equal(t, *secureValueOrgB, listOrgB.Items[0])
 		})
 	})
 }


### PR DESCRIPTION
This adds basic CRUD+L integration tests for both `SecureValues` and `Keepers` in the context of multiple namespaces (multi-tenancy).

It has assertions to guarantee that resources from one namespace (org/stack) aren't accessible/interactive by another namespace (org/stack).

