### PR TITLE
Panel inspect: Fix file names of data download included uninterpolated variable names.

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectDataTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectDataTab.tsx
@@ -62,7 +62,7 @@ export class InspectDataTab extends SceneObjectBase<InspectDataTabState> {
         hasTransformations={hasTransformations(dataProvider)}
         timeZone={timeRange.getTimeZone()}
         panelPluginId={panel.state.pluginId}
-        dataName={panel.state.title}
+        dataName={sceneGraph.interpolate(panel, panel.state.title)}
         fieldConfig={panel.state.fieldConfig}
         onOptionsChange={model.onOptionsChange}
       />

--- a/public/app/features/dashboard/components/Inspector/InspectContent.tsx
+++ b/public/app/features/dashboard/components/Inspector/InspectContent.tsx
@@ -94,7 +94,7 @@ export const InspectContent = ({
     >
       {activeTab === InspectTab.Data && (
         <InspectDataTab
-          dataName={panel.getDisplayTitle()}
+          dataName={panelTitle}
           panelPluginId={panel.type}
           fieldConfig={panel.fieldConfig}
           hasTransformations={Boolean(panel.transformations?.length)}


### PR DESCRIPTION
**What is this feature?**

Resolves https://github.com/grafana/grafana/issues/98831

**Why do we need this feature?**

Files are not currently named properly.

**Who is this feature for?**

Anyone downloading panel data.

**Which issue(s) does this PR fix?**:

- Automatically closes linked issue when the Pull Request is merged.

Fixes https://github.com/grafana/grafana/issues/98831

**Special notes for your reviewer:**

I have not run this locally. If someone who already has Grafana set up locally can, I'd greatly appreciate it. 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
