### PR TITLE
Return a 400 instead of a 500 for empty query

### DIFF
--- a/pkg/tsdb/graphite/graphite_test.go
+++ b/pkg/tsdb/graphite/graphite_test.go
@@ -125,7 +125,7 @@ func TestProcessQueries(t *testing.T) {
 		assert.Equal(t, expectedInvalid, invalids[0])
 	})
 
-	t.Run("QueryData with no valid queries returns an error", func(t *testing.T) {
+	t.Run("QueryData with no valid queries returns bad request response", func(t *testing.T) {
 		queries := []backend.DataQuery{
 			{
 				RefID: "A",
@@ -142,11 +142,12 @@ func TestProcessQueries(t *testing.T) {
 		}
 
 		service.im = fakeInstanceManager{}
-		_, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
+		rsp, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
 			Queries: queries,
 		})
-		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "no query target found for the alert rule")
+		assert.NoError(t, err)
+		expectedResponse := backend.ErrDataResponseWithSource(400, backend.ErrorSourceDownstream, "no query target found for the alert rule")
+		assert.Equal(t, expectedResponse, rsp.Responses["A"])
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Fix of an incorrect error status code

**Why do we need this feature?**

To clean up our own internal monitoring of some of our errors, [see comments here](https://github.com/grafana/grafana-enterprise/issues/7737)

**Who is this feature for?**

Grafana Devs

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-enterprise/issues/7737

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
