### PR TITLE
SecureValues: use is_ref in DB instead of duplicating the ref

### DIFF
--- a/pkg/storage/secret/migrator.go
+++ b/pkg/storage/secret/migrator.go
@@ -49,8 +49,8 @@ func initSecretStore(mg *migrator.Migrator) string {
 			{Name: "title", Type: migrator.DB_Text, Nullable: false},
 			{Name: "keeper", Type: migrator.DB_Text, Nullable: false},
 			{Name: "audiences", Type: migrator.DB_Text, Nullable: false},
-			{Name: "ref", Type: migrator.DB_Text, Nullable: true}, // Reference to third-party storage secret path.
-			{Name: "external_id", Type: migrator.DB_Text, Nullable: false},
+			{Name: "is_ref", Type: migrator.DB_Bool, Nullable: false},
+			{Name: "external_id", Type: migrator.DB_Text, Nullable: false}, // when `is_ref`` is `true``, this is the `ref`.
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"namespace", "name"}, Type: migrator.UniqueIndex},

--- a/pkg/storage/secret/secure_value_model.go
+++ b/pkg/storage/secret/secure_value_model.go
@@ -26,11 +26,11 @@ type secureValueDB struct {
 	UpdatedBy   string `xorm:"updated_by"`
 
 	// Spec
-	Title      string  `xorm:"title"`
-	Keeper     string  `xorm:"keeper"`
-	Audiences  string  `xorm:"audiences"` // TODO rename this since it's a "reserved word" in the authnz world
-	Ref        *string `xorm:"ref"`
-	ExternalID string  `xorm:"external_id"`
+	Title      string `xorm:"title"`
+	Keeper     string `xorm:"keeper"`
+	Audiences  string `xorm:"audiences"` // TODO rename this since it's a "reserved word" in the authnz world
+	IsRef      bool   `xorm:"is_ref"`
+	ExternalID string `xorm:"external_id"`
 }
 
 func (*secureValueDB) TableName() string {
@@ -67,8 +67,8 @@ func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
 			Audiences: audiences,
 		},
 	}
-	if sv.Ref != nil {
-		resource.Spec.Ref = *sv.Ref
+	if sv.IsRef {
+		resource.Spec.Ref = sv.ExternalID
 	}
 
 	// Set all meta fields here for consistency.
@@ -180,11 +180,6 @@ func toRow(sv *secretv0alpha1.SecureValue, externalID string) (*secureValueDB, e
 		return nil, fmt.Errorf("failed to get resource version: %w", err)
 	}
 
-	var ref *string
-	if sv.Spec.Ref != "" {
-		ref = &sv.Spec.Ref
-	}
-
 	return &secureValueDB{
 		GUID:        string(sv.UID),
 		Name:        sv.Name,
@@ -199,7 +194,7 @@ func toRow(sv *secretv0alpha1.SecureValue, externalID string) (*secureValueDB, e
 		Title:      sv.Spec.Title,
 		Keeper:     sv.Spec.Keeper,
 		Audiences:  audiences,
-		Ref:        ref,
+		IsRef:      sv.Spec.Ref != "",
 		ExternalID: externalID,
 	}, nil
 }


### PR DESCRIPTION
Because when is_ref is true, the ref is the same as the external_id which we are already storing.

And we don't need to keep two values that are the same in sync. Counter point is that if we want `external_id` to mean something else, we need to break the schema to store the actual `ref` again.