### PR TITLE
grafana-ui: Allow modal to render under somewhere other than document.body

### DIFF
--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -32,6 +32,9 @@ export interface Props {
 
   /** If not set will call onDismiss if that is set. */
   onClickBackdrop?: () => void;
+
+  /** Where we want the overlay to render */
+  portalContainer?: Element;
 }
 
 export function Modal(props: PropsWithChildren<Props>) {
@@ -46,6 +49,7 @@ export function Modal(props: PropsWithChildren<Props>) {
     onDismiss,
     onClickBackdrop,
     trapFocus = true,
+    portalContainer,
   } = props;
   const styles = useStyles2(getModalStyles);
 
@@ -68,7 +72,7 @@ export function Modal(props: PropsWithChildren<Props>) {
   const headerClass = cx(styles.modalHeader, typeof title !== 'string' && styles.modalHeaderWithTabs);
 
   return (
-    <OverlayContainer>
+    <OverlayContainer portalContainer={portalContainer ?? undefined}>
       <div
         role="presentation"
         className={styles.modalBackdrop}

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -34,7 +34,7 @@ export interface Props {
   onClickBackdrop?: () => void;
 
   /** Where we want the overlay to render */
-  portalContainer?: Element;
+  portalContainer?: HTMLElement | null;
 }
 
 export function Modal(props: PropsWithChildren<Props>) {


### PR DESCRIPTION
**What is this feature?**

From app o11y, we need to be able to render a modal that will block any interaction with the plugin.

**Why do we need this feature?**

The modal by default renders on `document.body`. If we're blocking interaction from app o11y, then users won't be able to navigate to other parts of grafana.

It also allows for targeting the presentation div from the plugin itself, without having to write global css:

```css
div#app-o11y [role="presentation"] {
  position: absolute;
}
```

<img width="2229" alt="Screenshot 2025-01-13 at 12 37 10" src="https://github.com/user-attachments/assets/c152798f-203e-4ee3-8bf5-c8fbb5e311f9" />


**Who is this feature for?**

App o11y users in particular in this case, but it can serve for other teams wanting to display modals inside their apps.

**Which issue(s) does this PR fix?**:

Needed for [#1506](https://github.com/grafana/app-observability-plugin/issues/1506)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
