### PR TITLE
[search] playlist - support legacy uid filter

### DIFF
--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -222,6 +222,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
     if (query.name?.length) {
       uri += '&' + query.name.map((name) => `name=${encodeURIComponent(name)}`).join('&');
     }
+
+    if (query.uid?.length) {  // legacy support for filtering by dashboard uid
+      uri += '&' + query.uid.map((name) => `name=${encodeURIComponent(name)}`).join('&');
+    }
     return uri;
   }
 

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -223,7 +223,8 @@ export class UnifiedSearcher implements GrafanaSearcher {
       uri += '&' + query.name.map((name) => `name=${encodeURIComponent(name)}`).join('&');
     }
 
-    if (query.uid?.length) {  // legacy support for filtering by dashboard uid
+    if (query.uid?.length) {
+      // legacy support for filtering by dashboard uid
       uri += '&' + query.uid.map((name) => `name=${encodeURIComponent(name)}`).join('&');
     }
     return uri;


### PR DESCRIPTION
Fix issue where some pages use `uid` to filter by k8s `name`

Fixes https://github.com/grafana/app-platform-wg/issues/209

NOTE: you need the `unifiedStorageSearchUI` feature toggle enabled
In DEV, make sure to disable the `panelTitleSearch` feature toggle ( it's enabled by default in dev )

![image](https://github.com/user-attachments/assets/5b578cb6-ecfa-4c0f-8115-1bfdbccfb089)

