### PR TITLE
Explore Metrics: Add panel menu with "Explore" and "Investigations" options

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6192,6 +6192,9 @@ exports[`better eslint`] = {
     "public/app/features/trails/DataTrailsHome.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
+    "public/app/features/trails/Menu/PanelMenu.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "public/app/features/trails/MetricScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -6192,9 +6192,6 @@ exports[`better eslint`] = {
     "public/app/features/trails/DataTrailsHome.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
-    "public/app/features/trails/Menu/PanelMenu.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/trails/MetricScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -480,7 +480,7 @@ export function buildAllLayout(
       )
       .setHeaderActions([new SelectLabelAction({ labelName: String(option.value) })])
       .setShowMenuAlways(true)
-      .setMenu(new PanelMenu({}))
+      .setMenu(new PanelMenu({ labelName: String(option.value) }))
       .setUnit(unit)
       .setBehaviors([fixLegendForUnspecifiedLabelValueBehavior])
       .build();

--- a/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
+++ b/public/app/features/trails/Breakdown/LabelBreakdownScene.tsx
@@ -32,8 +32,8 @@ import { Trans } from 'app/core/internationalization';
 
 import { BreakdownLabelSelector } from '../BreakdownLabelSelector';
 import { DataTrail } from '../DataTrail';
+import { PanelMenu } from '../Menu/PanelMenu';
 import { MetricScene } from '../MetricScene';
-import { AddToExplorationButton } from '../MetricSelect/AddToExplorationsButton';
 import { StatusWrapper } from '../StatusWrapper';
 import { getAutoQueriesForMetric } from '../autoQuery/getAutoQueriesForMetric';
 import { AutoQueryDef } from '../autoQuery/types';
@@ -478,10 +478,9 @@ export function buildAllLayout(
           ],
         })
       )
-      .setHeaderActions([
-        new SelectLabelAction({ labelName: String(option.value) }),
-        new AddToExplorationButton({ labelName: String(option.value) }),
-      ])
+      .setHeaderActions([new SelectLabelAction({ labelName: String(option.value) })])
+      .setShowMenuAlways(true)
+      .setMenu(new PanelMenu({}))
       .setUnit(unit)
       .setBehaviors([fixLegendForUnspecifiedLabelValueBehavior])
       .build();
@@ -532,10 +531,9 @@ function buildNormalLayout(
       .setTitle(getLabelValue(frame))
       .setData(new SceneDataNode({ data: { ...data, series: [frame] } }))
       .setColor({ mode: 'fixed', fixedColor: getColorByIndex(frameIndex) })
-      .setHeaderActions([
-        new AddToFiltersGraphAction({ frame }),
-        new AddToExplorationButton({ labelName: getLabelValue(frame) }),
-      ])
+      .setHeaderActions([new AddToFiltersGraphAction({ frame })])
+      .setShowMenuAlways(true)
+      .setMenu(new PanelMenu({ labelName: getLabelValue(frame) }))
       .setUnit(unit)
       .build();
 

--- a/public/app/features/trails/Menu/PanelMenu.tsx
+++ b/public/app/features/trails/Menu/PanelMenu.tsx
@@ -1,0 +1,164 @@
+import { DataFrame, PanelMenuItem } from '@grafana/data';
+import { getPluginLinkExtensions } from '@grafana/runtime';
+import {
+  SceneComponentProps,
+  sceneGraph,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanelMenu,
+} from '@grafana/scenes';
+
+import { MetricActionBar, MetricScene } from '../MetricScene';
+import { AddToExplorationButton, extensionPointId } from '../MetricSelect/AddToExplorationsButton';
+
+const ADD_TO_INVESTIGATION_MENU_TEXT = 'Add to investigation';
+const ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT = 'investigations_divider'; // Text won't be visible
+const ADD_TO_INVESTIGATION_MENU_GROUP_TEXT = 'Investigations';
+
+interface PanelMenuState extends SceneObjectState {
+  body?: VizPanelMenu;
+  frame?: DataFrame;
+  labelName?: string;
+  fieldName?: string;
+  addExplorationsLink?: boolean;
+  explorationsButton?: AddToExplorationButton;
+}
+
+/**
+ * @todo the VizPanelMenu interface is overly restrictive, doesn't allow any member functions on this class, so everything is currently inlined
+ */
+export class PanelMenu extends SceneObjectBase<PanelMenuState> implements VizPanelMenu, SceneObject {
+  constructor(state: Partial<PanelMenuState>) {
+    super({ ...state, addExplorationsLink: state.addExplorationsLink ?? true });
+    this.addActivationHandler(() => {
+      // Navigation options (all panels)
+      const items: PanelMenuItem[] = [
+        {
+          text: 'Navigation',
+          type: 'group',
+        },
+        {
+          text: 'Explore',
+          iconClassName: 'compass',
+          onClick: () => openExploreLink(this),
+          shortcut: 'p x',
+        },
+      ];
+
+      this.setState({
+        body: new VizPanelMenu({
+          items,
+        }),
+      });
+
+      const addToExplorationsButton = new AddToExplorationButton({
+        labelName: this.state.labelName,
+        fieldName: this.state.fieldName,
+        frame: this.state.frame,
+      });
+      this._subs.add(
+        addToExplorationsButton?.subscribeToState(() => {
+          subscribeToAddToExploration(this);
+        })
+      );
+      this.setState({
+        explorationsButton: addToExplorationsButton,
+      });
+
+      if (this.state.addExplorationsLink) {
+        this.state.explorationsButton?.activate();
+      }
+    });
+  }
+
+  addItem(item: PanelMenuItem): void {
+    if (this.state.body) {
+      this.state.body.addItem(item);
+    }
+  }
+
+  setItems(items: PanelMenuItem[]): void {
+    if (this.state.body) {
+      this.state.body.setItems(items);
+    }
+  }
+
+  public static Component = ({ model }: SceneComponentProps<PanelMenu>) => {
+    const { body } = model.useState();
+
+    if (body) {
+      return <body.Component model={body} />;
+    }
+
+    return <></>;
+  };
+}
+
+function openExploreLink(panel: PanelMenu) {
+  const metricScene = sceneGraph.getAncestor(panel, MetricScene);
+  const metricActionBars = sceneGraph.findDescendents(metricScene, MetricActionBar);
+  if (metricActionBars.length === 0) {
+    return;
+  }
+  const metricActionBar = metricActionBars[0] as MetricActionBar;
+  metricActionBar.openExploreLink();
+}
+
+const getInvestigationLink = (addToExplorations: AddToExplorationButton) => {
+  const links = getPluginLinkExtensions({
+    extensionPointId: extensionPointId,
+    context: addToExplorations.state.context,
+  });
+
+  return links.extensions[0];
+};
+
+const onAddToInvestigationClick = (event: React.MouseEvent, addToExplorations: AddToExplorationButton) => {
+  const link = getInvestigationLink(addToExplorations);
+  if (link && link.onClick) {
+    link.onClick(event);
+  }
+};
+
+function subscribeToAddToExploration(menu: PanelMenu) {
+  const addToExplorationButton = menu.state.explorationsButton;
+  if (addToExplorationButton) {
+    const link = getInvestigationLink(addToExplorationButton);
+
+    const existingMenuItems = menu.state.body?.state.items ?? [];
+
+    const existingAddToExplorationLink = existingMenuItems.find((item) => item.text === ADD_TO_INVESTIGATION_MENU_TEXT);
+
+    if (link) {
+      if (!existingAddToExplorationLink) {
+        menu.state.body?.addItem({
+          text: ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT,
+          type: 'divider',
+        });
+        menu.state.body?.addItem({
+          text: ADD_TO_INVESTIGATION_MENU_GROUP_TEXT,
+          type: 'group',
+        });
+        menu.state.body?.addItem({
+          text: ADD_TO_INVESTIGATION_MENU_TEXT,
+          iconClassName: 'plus-square',
+          onClick: (e) => onAddToInvestigationClick(e, addToExplorationButton),
+        });
+      } else {
+        if (existingAddToExplorationLink) {
+          menu.state.body?.setItems(
+            existingMenuItems.filter(
+              (item) =>
+                [
+                  ADD_TO_INVESTIGATION_MENU_DIVIDER_TEXT,
+                  ADD_TO_INVESTIGATION_MENU_GROUP_TEXT,
+                  ADD_TO_INVESTIGATION_MENU_TEXT,
+                ].includes(item.text) === false
+            )
+          );
+        }
+      }
+    }
+  }
+}

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -29,7 +29,6 @@ import { Alert, Badge, Field, Icon, IconButton, InlineSwitch, Input, Select, Too
 import { Trans } from 'app/core/internationalization';
 import { getSelectedScopes } from 'app/features/scopes';
 
-import { PanelMenu } from '../Menu/PanelMenu';
 import { MetricScene } from '../MetricScene';
 import { StatusWrapper } from '../StatusWrapper';
 import { Node, Parser } from '../groop/parser';
@@ -425,7 +424,7 @@ export class MetricSelectScene extends SceneObjectBase<MetricSelectSceneState> i
         }
         // refactor this into the query generator in future
         const isNative = trail.isNativeHistogram(metric.name);
-        const panel = getPreviewPanelFor(metric.name, index, currentFilterCount, description, isNative);
+        const panel = getPreviewPanelFor(metric.name, index, currentFilterCount, description, isNative, true);
 
         metric.itemRef = panel.getRef();
         metric.isPanel = true;
@@ -657,8 +656,6 @@ function getCardPanelFor(metric: string, description?: string) {
     .setTitle(metric)
     .setDescription(description)
     .setHeaderActions([new SelectMetricAction({ metric, title: 'Select' })])
-    .setShowMenuAlways(true)
-    .setMenu(new PanelMenu({ labelName: metric }))
     .setOption('content', '')
     .build();
 }

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -29,6 +29,7 @@ import { Alert, Badge, Field, Icon, IconButton, InlineSwitch, Input, Select, Too
 import { Trans } from 'app/core/internationalization';
 import { getSelectedScopes } from 'app/features/scopes';
 
+import { PanelMenu } from '../Menu/PanelMenu';
 import { MetricScene } from '../MetricScene';
 import { StatusWrapper } from '../StatusWrapper';
 import { Node, Parser } from '../groop/parser';
@@ -45,7 +46,7 @@ import {
 } from '../shared';
 import { getFilters, getTrailFor, isSceneTimeRangeState } from '../utils';
 
-import { AddToExplorationButton } from './AddToExplorationsButton';
+// import { AddToExplorationButton } from './AddToExplorationsButton';
 import { SelectMetricAction } from './SelectMetricAction';
 import { getMetricNames } from './api';
 import { getPreviewPanelFor } from './previewPanel';
@@ -655,10 +656,9 @@ function getCardPanelFor(metric: string, description?: string) {
   return PanelBuilders.text()
     .setTitle(metric)
     .setDescription(description)
-    .setHeaderActions([
-      new SelectMetricAction({ metric, title: 'Select' }),
-      new AddToExplorationButton({ labelName: metric }),
-    ])
+    .setHeaderActions([new SelectMetricAction({ metric, title: 'Select' })])
+    .setShowMenuAlways(true)
+    .setMenu(new PanelMenu({ labelName: metric }))
     .setOption('content', '')
     .build();
 }

--- a/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
+++ b/public/app/features/trails/MetricSelect/MetricSelectScene.tsx
@@ -45,7 +45,6 @@ import {
 } from '../shared';
 import { getFilters, getTrailFor, isSceneTimeRangeState } from '../utils';
 
-// import { AddToExplorationButton } from './AddToExplorationsButton';
 import { SelectMetricAction } from './SelectMetricAction';
 import { getMetricNames } from './api';
 import { getPreviewPanelFor } from './previewPanel';

--- a/public/app/features/trails/MetricSelect/previewPanel.ts
+++ b/public/app/features/trails/MetricSelect/previewPanel.ts
@@ -1,11 +1,11 @@
 import { PromQuery } from '@grafana/prometheus';
 import { SceneCSSGridItem, SceneQueryRunner, SceneVariableSet } from '@grafana/scenes';
 
+import { PanelMenu } from '../Menu/PanelMenu';
 import { getAutoQueriesForMetric } from '../autoQuery/getAutoQueriesForMetric';
 import { getVariablesWithMetricConstant, MDP_METRIC_PREVIEW, trailDS } from '../shared';
 import { getColorByIndex } from '../utils';
 
-import { AddToExplorationButton } from './AddToExplorationsButton';
 import { NativeHistogramBadge } from './NativeHistogramBadge';
 import { SelectMetricAction } from './SelectMetricAction';
 import { hideEmptyPreviews } from './hideEmptyPreviews';
@@ -18,9 +18,8 @@ export function getPreviewPanelFor(
   nativeHistogram?: boolean
 ) {
   const autoQuery = getAutoQueriesForMetric(metric, nativeHistogram);
-  let actions: Array<SelectMetricAction | AddToExplorationButton | NativeHistogramBadge> = [
+  let actions: Array<SelectMetricAction | NativeHistogramBadge> = [
     new SelectMetricAction({ metric, title: 'Select' }),
-    new AddToExplorationButton({ labelName: metric }),
   ];
 
   if (nativeHistogram) {
@@ -32,6 +31,8 @@ export function getPreviewPanelFor(
     .setColor({ mode: 'fixed', fixedColor: getColorByIndex(index) })
     .setDescription(description)
     .setHeaderActions(actions)
+    .setShowMenuAlways(true)
+    .setMenu(new PanelMenu({ labelName: metric }))
     .build();
 
   const queries = autoQuery.preview.queries.map((query) =>

--- a/public/app/features/trails/MetricSelect/previewPanel.ts
+++ b/public/app/features/trails/MetricSelect/previewPanel.ts
@@ -15,7 +15,8 @@ export function getPreviewPanelFor(
   index: number,
   currentFilterCount: number,
   description?: string,
-  nativeHistogram?: boolean
+  nativeHistogram?: boolean,
+  hideMenu?: boolean
 ) {
   const autoQuery = getAutoQueriesForMetric(metric, nativeHistogram);
   let actions: Array<SelectMetricAction | NativeHistogramBadge> = [
@@ -26,14 +27,19 @@ export function getPreviewPanelFor(
     actions.unshift(new NativeHistogramBadge({}));
   }
 
-  const vizPanel = autoQuery.preview
+  let vizPanelBuilder = autoQuery.preview
     .vizBuilder()
     .setColor({ mode: 'fixed', fixedColor: getColorByIndex(index) })
     .setDescription(description)
     .setHeaderActions(actions)
     .setShowMenuAlways(true)
     .setMenu(new PanelMenu({ labelName: metric }))
-    .build();
+
+  if (!hideMenu) {
+    vizPanelBuilder = vizPanelBuilder.setShowMenuAlways(true).setMenu(new PanelMenu({ labelName: metric }));
+  }
+
+  const vizPanel = vizPanelBuilder.build();
 
   const queries = autoQuery.preview.queries.map((query) =>
     convertPreviewQueriesToIgnoreUsage(query, currentFilterCount)

--- a/public/app/features/trails/MetricSelect/previewPanel.ts
+++ b/public/app/features/trails/MetricSelect/previewPanel.ts
@@ -19,9 +19,7 @@ export function getPreviewPanelFor(
   hideMenu?: boolean
 ) {
   const autoQuery = getAutoQueriesForMetric(metric, nativeHistogram);
-  let actions: Array<SelectMetricAction | NativeHistogramBadge> = [
-    new SelectMetricAction({ metric, title: 'Select' }),
-  ];
+  let actions: Array<SelectMetricAction | NativeHistogramBadge> = [new SelectMetricAction({ metric, title: 'Select' })];
 
   if (nativeHistogram) {
     actions.unshift(new NativeHistogramBadge({}));
@@ -33,7 +31,7 @@ export function getPreviewPanelFor(
     .setDescription(description)
     .setHeaderActions(actions)
     .setShowMenuAlways(true)
-    .setMenu(new PanelMenu({ labelName: metric }))
+    .setMenu(new PanelMenu({ labelName: metric }));
 
   if (!hideMenu) {
     vizPanelBuilder = vizPanelBuilder.setShowMenuAlways(true).setMenu(new PanelMenu({ labelName: metric }));

--- a/public/app/features/trails/autoQuery/components/AutoVizPanel.tsx
+++ b/public/app/features/trails/autoQuery/components/AutoVizPanel.tsx
@@ -1,6 +1,6 @@
-import { SceneObjectState, SceneObjectBase, SceneComponentProps, VizPanel, SceneQueryRunner } from '@grafana/scenes';
+import { SceneComponentProps, SceneObjectBase, SceneObjectState, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
-import { AddToExplorationButton } from '../../MetricSelect/AddToExplorationsButton';
+import { PanelMenu } from '../../Menu/PanelMenu';
 import { getMetricDescription } from '../../helpers/MetricDatasourceHelper';
 import { MDP_METRIC_OVERVIEW, trailDS } from '../../shared';
 import { getMetricSceneFor, getTrailFor } from '../../utils';
@@ -57,10 +57,9 @@ export class AutoVizPanel extends SceneObjectBase<AutoVizPanelState> {
         })
       )
       .setDescription(description)
-      .setHeaderActions([
-        new AutoVizPanelQuerySelector({ queryDef: def, onChangeQuery: this.onChangeQuery }),
-        new AddToExplorationButton({ labelName: metric ?? this.state.metric }),
-      ])
+      .setHeaderActions([new AutoVizPanelQuerySelector({ queryDef: def, onChangeQuery: this.onChangeQuery })])
+      .setShowMenuAlways(true)
+      .setMenu(new PanelMenu({ labelName: metric ?? this.state.metric }))
       .build();
   }
 


### PR DESCRIPTION
**What is this feature?**

Adds a panel menu to Explore Metrics that is very similar to Explore Logs' menu:
![image](https://github.com/user-attachments/assets/0885b37f-6e36-4783-b94a-fc1c21e52bb4)

"Explore" menu option will open a new Explore tab with the query powering the panel.
"Add to investigation" menu option will add the data from that panel to a new investigation.
