### PR TITLE
Dashboard: Fix snapshots for the old arch

### DIFF
--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -146,6 +146,14 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
 
     if (type === 'script' && slug) {
       promise = this.loadScriptedDashboard(slug);
+      // needed for the old architecture
+      // in scenes this is handled through loadSnapshot method
+    } else if (type === 'snapshot' && slug) {
+      promise = getDashboardSnapshotSrv()
+        .getSnapshot(slug)
+        .catch(() => {
+          return this._dashboardLoadFailed('Snapshot not found', true);
+        });
     } else if (type === 'public' && uid) {
       promise = backendSrv
         .getPublicDashboardByUid(uid)


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/98463, I extracted snapshot loading logic inside the `DashboardLoaderSrv` from `loadDashboard` into a separate method `loadSnapshot` to improve readability. However, this broke the snapshot loading in the old architecture (non-scene). 

This PR addresses this issue.

Please check that:
- [x] It works as expected from a user's perspective.
