### PR TITLE
Tests: rename OrgB to Org2 in K8s test helper for consistency

### DIFF
--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -58,7 +58,7 @@ type K8sTestHelper struct {
 	Namespacer request.NamespaceMapper
 
 	Org1 OrgUsers // default
-	OrgB OrgUsers // some other id
+	Org2 OrgUsers // some other id
 
 	// // Registered groups
 	groups []metav1.APIGroup
@@ -87,7 +87,7 @@ func NewK8sTestHelper(t *testing.T, opts testinfra.GrafanaOpts) *K8sTestHelper {
 	}
 
 	c.Org1 = c.createTestUsers(Org1)
-	c.OrgB = c.createTestUsers("OrgB")
+	c.Org2 = c.createTestUsers("Org2")
 
 	c.loadAPIGroups()
 

--- a/pkg/tests/apis/iam/iam_test.go
+++ b/pkg/tests/apis/iam/iam_test.go
@@ -97,10 +97,10 @@ func TestIntegrationIdentity(t *testing.T) {
 			}
 		]`, found)
 
-		// OrgB users
+		// Org2 users
 		userClient = helper.GetResourceClient(apis.ResourceClientArgs{
 			User:      helper.Org1.Admin,                                        // super admin
-			Namespace: helper.Namespacer(helper.OrgB.Admin.Identity.GetOrgID()), // list values for orgB with super admin user
+			Namespace: helper.Namespacer(helper.Org2.Admin.Identity.GetOrgID()), // list values for org2 with super admin user
 			GVR:       gvrUsers,
 		})
 		rsp, err = userClient.Resource.List(ctx, metav1.ListOptions{})

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -403,13 +403,13 @@ func doPlaylistTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelp
 		require.Nil(t, rsp.Status)
 
 		// Check view permissions
-		rsp = helper.List(helper.OrgB.Viewer, "default", gvr)
-		require.Equal(t, 403, rsp.Response.StatusCode) // OrgB can not see default namespace
+		rsp = helper.List(helper.Org2.Viewer, "default", gvr)
+		require.Equal(t, 403, rsp.Response.StatusCode) // Org2 can not see default namespace
 		require.Nil(t, rsp.Result)
 		require.Equal(t, metav1.StatusReasonForbidden, rsp.Status.Reason)
 
 		// Check view permissions
-		rsp = helper.List(helper.OrgB.Viewer, "org-22", gvr)
+		rsp = helper.List(helper.Org2.Viewer, "org-22", gvr)
 		require.Equal(t, 403, rsp.Response.StatusCode) // Unknown/not a member
 		require.Nil(t, rsp.Result)
 		require.Equal(t, metav1.StatusReasonForbidden, rsp.Status.Reason)
@@ -428,7 +428,7 @@ func doPlaylistTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelp
 
 		// Check org2 viewer can not see org1 (default namespace)
 		client = helper.GetResourceClient(apis.ResourceClientArgs{
-			User:      helper.OrgB.Viewer,
+			User:      helper.Org2.Viewer,
 			Namespace: "default", // actually org1
 			GVR:       gvr,
 		})
@@ -439,7 +439,7 @@ func doPlaylistTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelp
 
 		// Check invalid namespace
 		client = helper.GetResourceClient(apis.ResourceClientArgs{
-			User:      helper.OrgB.Viewer,
+			User:      helper.Org2.Viewer,
 			Namespace: "org-22", // org 22 does not exist
 			GVR:       gvr,
 		})


### PR DESCRIPTION
**What is this feature?**

Renames `OrgB` to `Org2` in the K8s test helper.

**Why do we need this feature?**

Either having A and B, or 1 and 2, to keep consistency in the naming.

**Who is this feature for?**

Contributors.

**Which issue(s) does this PR fix?**:

N/A