### PR TITLE
Chore: Prevent direct path imports from workspace grafana packages

### DIFF
--- a/.betterer.eslint.config.js
+++ b/.betterer.eslint.config.js
@@ -88,7 +88,7 @@ module.exports = [
             },
             {
               group: ['@grafana/*/src/*'],
-              message: 'Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.',
+              message: 'Import from the public export instead.',
             },
           ],
         },

--- a/.betterer.eslint.config.js
+++ b/.betterer.eslint.config.js
@@ -86,6 +86,10 @@ module.exports = [
               importNames: ['Layout', 'HorizontalGroup', 'VerticalGroup'],
               message: 'Use Stack component instead.',
             },
+            {
+              group: ['@grafana/*/src/*'],
+              message: 'Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.',
+            },
           ],
         },
       ],

--- a/.betterer.eslint.config.js
+++ b/.betterer.eslint.config.js
@@ -87,7 +87,7 @@ module.exports = [
               message: 'Use Stack component instead.',
             },
             {
-              group: ['@grafana/*/src/*'],
+              group: ['@grafana/ui/src/*', '@grafana/runtime/src/*', '@grafana/data/src/*'],
               message: 'Import from the public export instead.',
             },
           ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -5,14 +5,8 @@
 //
 exports[`better eslint`] = {
   value: `{
-    "e2e/old-arch/utils/flows/userPreferences.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "e2e/old-arch/utils/support/types.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
-    "e2e/utils/flows/userPreferences.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "e2e/utils/support/types.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -1185,12 +1179,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
-    "public/app/core/components/SharedPreferences/SharedPreferences.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/core/components/SharedPreferences/SharedPreferences.tsx:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/core/components/Signup/SignupPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -1258,18 +1246,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`profiler\`)", "6"],
       [0, 0, 0, "Do not re-export imported variable (\`updateLegendValues\`)", "7"]
     ],
-    "public/app/core/history/RichHistoryRemoteStorage.test.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/core/navigation/GrafanaRouteError.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/navigation/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/core/services/PreferencesService.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/services/ResponseQueue.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -1600,8 +1582,8 @@ exports[`better eslint`] = {
     ],
     "public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx:5381": [
       [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/sql/src/components/visual-query-builder/Preview\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
@@ -1614,8 +1596,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "16"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"]
     ],
     "public/app/features/alerting/unified/NotificationPoliciesPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -3517,9 +3498,6 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/schema/dashboard/v2alpha0/dashboard.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -3565,7 +3543,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/dashboard/x/dashboard_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -3576,10 +3554,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"]
     ],
     "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -3802,13 +3779,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dashboard/api/ResponseTransformers.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/dashboard/x/dashboard_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/dashboard/api/v0.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -3821,8 +3797,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./AddLibraryPanelWidget\`)", "0"]
     ],
     "public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/dashboard/x/dashboard_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
@@ -3833,11 +3809,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "12"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "16"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"]
     ],
     "public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5303,9 +5278,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
-    "public/app/features/library-panels/types.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/raw/librarypanel/x/librarypanel_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/live/LiveConnectionWarning.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
@@ -5448,9 +5420,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
-    ],
-    "public/app/features/manage-dashboards/types.ts:5381": [
-      [0, 0, 0, "\'@grafana/schema/src/veneer/dashboard.types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/migrate-to-cloud/api/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]
@@ -6237,13 +6206,6 @@ exports[`better eslint`] = {
     "public/app/features/trails/DataTrailsHome.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
-    "public/app/features/trails/Integrations/getQueryMetrics.ts:5381": [
-      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/parsing\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/shared/types\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
-    ],
-    "public/app/features/trails/Integrations/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/shared/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "public/app/features/trails/MetricScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -6262,10 +6224,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
-    "public/app/features/trails/MetricSelect/api.ts:5381": [
-      [0, 0, 0, "\'@grafana/prometheus/src/language_utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
-      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/PromQueryModeller\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
-    ],
     "public/app/features/trails/MetricsHeader.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
@@ -6277,15 +6235,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
-    ],
-    "public/app/features/trails/helpers/MetricDatasourceHelper.ts:5381": [
-      [0, 0, 0, "\'@grafana/prometheus/src/language_provider\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/features/trails/otel/api.ts:5381": [
-      [0, 0, 0, "\'@grafana/prometheus/src/language_utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/features/trails/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/prometheus/src/language_utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/transformers/FilterByValueTransformer/FilterByValueFilterEditor.tsx:5381": [
       [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
@@ -7552,9 +7501,6 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
-    "public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/sql/src/components/configuration/NumberInput\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/mssql/types.ts:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -414,9 +414,6 @@ exports[`better eslint`] = {
     "packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Combobox/Combobox\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
-    ],
     "packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -5,8 +5,14 @@
 //
 exports[`better eslint`] = {
   value: `{
+    "e2e/old-arch/utils/flows/userPreferences.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "e2e/old-arch/utils/support/types.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
+    "e2e/utils/flows/userPreferences.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "e2e/utils/support/types.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -415,7 +421,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Combobox/Combobox\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Combobox/Combobox\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -981,6 +987,11 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/utils/useAsyncDependency.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/app.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/components/PanelDataErrorView\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/components/PanelRenderer\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/runtime/src/components/PluginPage\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
+    ],
     "public/app/core/TableModel.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
@@ -1026,7 +1037,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/core/components/AppChrome/TopBar/TopSearchBarCommandPaletteTrigger.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/Breadcrumbs/Breadcrumbs.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1056,11 +1067,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/core/components/GraphNG/GraphNG.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/Plot\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/Plot\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"],
       [0, 0, 0, "Do not use any type assertions.", "6"],
       [0, 0, 0, "Do not use any type assertions.", "7"],
@@ -1068,8 +1079,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
     ],
+    "public/app/core/components/GraphNG/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullToUndefThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
+    ],
     "public/app/core/components/Indent/Indent.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Layout/utils/responsiveness\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/utils/responsiveness\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/Layers/LayerDragDropList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -1088,23 +1104,24 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/NestedFolderPicker/NestedFolderList.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/NestedFolderPicker/Trigger.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/OptionsUI/color.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/ColorPicker/ColorSwatch\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/ColorPicker/ColorSwatch\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/OptionsUI/fieldColor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/core/components/OptionsUI/registry.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/field/overrides/processors\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/core/components/OptionsUI/slider.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Slider/styles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Slider/styles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/OptionsUI/units.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1117,7 +1134,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/PasswordField/PasswordField.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/PluginHelp/PluginHelp.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1126,22 +1143,22 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/core/components/RolePicker/RoleMenuGroupOption.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePicker/RoleMenuOption.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePicker/RolePickerInput.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/RolePicker/RolePickerMenu.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePicker/RolePickerSubMenu.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePickerDrawer/RolePickerBadges.tsx:5381": [
@@ -1168,6 +1185,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
+    "public/app/core/components/SharedPreferences/SharedPreferences.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/core/components/SharedPreferences/SharedPreferences.tsx:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/core/components/Signup/SignupPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -1193,31 +1216,37 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/core/components/TimePicker/TimePickerWithHistory.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/components/TimeSeries/TimeSeries.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/PlotLegend\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/themes/ThemeContext\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/PlotLegend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/ThemeContext\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ],
     "public/app/core/components/TimeSeries/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/gradientFills\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/gradientFills\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
+    "public/app/core/components/TimelineChart/timeline.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/core/components/TimelineChart/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullToValue\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "3"]
     ],
     "public/app/core/config.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`Settings\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "1"]
     ],
     "public/app/core/context/ModalsContextProvider.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Modal/ModalsContext\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/ModalsContext\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/core.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`JsonExplorer\`)", "0"],
@@ -1229,12 +1258,18 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`profiler\`)", "6"],
       [0, 0, 0, "Do not re-export imported variable (\`updateLegendValues\`)", "7"]
     ],
+    "public/app/core/history/RichHistoryRemoteStorage.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/core/navigation/GrafanaRouteError.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/navigation/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/core/services/PreferencesService.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/preferences/x/preferences_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/services/ResponseQueue.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -1256,6 +1291,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+    ],
+    "public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/core/services/theme.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/themes/registry\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/core/specs/backend_srv.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -1296,6 +1337,9 @@ exports[`better eslint`] = {
     "public/app/core/utils/deferred.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/core/utils/explore.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/url\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/core/utils/fetch.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -1315,21 +1359,22 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/utils/richHistory.ts:5381": [
-      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySearchFilters\`)", "0"],
-      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySettings\`)", "1"],
-      [0, 0, 0, "Do not re-export imported variable (\`SortOrder\`)", "2"]
+      [0, 0, 0, "\'@grafana/data/src/utils/url\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySearchFilters\`)", "1"],
+      [0, 0, 0, "Do not re-export imported variable (\`RichHistorySettings\`)", "2"],
+      [0, 0, 0, "Do not re-export imported variable (\`SortOrder\`)", "3"]
     ],
     "public/app/core/utils/ticks.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/actions/ActionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/Field\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineField\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineFieldRow\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/JSONFormatter/JSONFormatter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
-      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/Field\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineField\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineFieldRow\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/JSONFormatter/JSONFormatter\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Import from the public export instead.", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
@@ -1340,28 +1385,28 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "13"]
     ],
     "public/app/features/actions/ActionEditorModalContent.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Modal/Modal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/Modal\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/features/actions/ActionsInlineEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Modal/Modal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/Modal\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/actions/ActionsListItem.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Icon/Icon\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/IconButton/IconButton\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/Icon\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/IconButton/IconButton\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
     "public/app/features/actions/ParamsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/IconButton/IconButton\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Stack/Stack\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/Select\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/IconButton/IconButton\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Stack/Stack\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/Select\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
@@ -1379,12 +1424,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/admin/AdminOrgsTable.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/admin/AdminSettingsTable.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/admin/OrgRolePicker.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1554,9 +1599,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/sql/src/components/visual-query-builder/Preview\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
@@ -1568,7 +1613,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "16"]
     ],
     "public/app/features/alerting/unified/NotificationPoliciesPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -1608,7 +1655,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/alerting/unified/Templates.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/AlertLabel.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2022,7 +2069,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"]
     ],
     "public/app/features/alerting/unified/components/receivers/TemplateEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/receivers/TemplateForm.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2143,7 +2190,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.test.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2226,7 +2273,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/GrafanaAlertStatePicker.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2281,10 +2328,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -2350,7 +2398,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/MultiValue\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/MultiValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -2417,7 +2465,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
@@ -2440,6 +2488,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
+    "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/services/__mocks__/dataSourceSrv\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/alerting/unified/components/rule-editor/rule-types/GrafanaManagedAlert.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
@@ -2454,6 +2505,9 @@ exports[`better eslint`] = {
     ],
     "public/app/features/alerting/unified/components/rule-editor/rule-types/RuleTypePicker.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
+    "public/app/features/alerting/unified/components/rule-editor/util.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2475,7 +2529,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
@@ -2503,10 +2557,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/ActionButton.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/ActionIcon.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Tooltip\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/AlertInstanceDetails.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2586,6 +2640,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+    ],
+    "public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/ReorderRuleGroupModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2694,6 +2751,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "25"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "26"]
     ],
+    "public/app/features/alerting/unified/components/rules/central-state-history/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/field/fieldComparers\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
@@ -2717,6 +2777,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+    ],
+    "public/app/features/alerting/unified/components/rules/state-history/useRuleHistoryRecords.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/field/fieldComparers\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/settings/AlertmanagerCard.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2854,6 +2917,9 @@ exports[`better eslint`] = {
     "public/app/features/alerting/unified/home/PluginIntegrations.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
+    "public/app/features/alerting/unified/hooks/useAlertQueriesStatus.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -2891,7 +2957,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
     "public/app/features/alerting/unified/plugins/PluginOriginBadge.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/rule-list/FilterView.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2918,7 +2984,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/alerting/unified/rule-list/components/RuleListIcon.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/alerting/unified/state/actions.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/logging\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/types/receiver-form.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -2928,6 +2997,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
+    "public/app/features/alerting/unified/utils/misc.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/alerting/unified/utils/receiver-form.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -2945,11 +3017,20 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
+    "public/app/features/alerting/unified/utils/routeTree.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/arrayUtils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/alerting/unified/utils/rule-form.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/alerting/unified/utils/rules.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+    ],
+    "public/app/features/alerting/unified/utils/time.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/annotations/components/AnnotationResultMapper.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -3019,10 +3100,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
     "public/app/features/auth-config/AuthProvidersListPage.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
+      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/auth-config/ProviderConfigForm.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -3071,7 +3153,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/browse-dashboards/components/NameCell.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/browse-dashboards/state/index.ts:5381": [
@@ -3079,9 +3161,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "2"]
     ],
+    "public/app/features/canvas/element.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/canvas/elements/metricValue.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/features/canvas/elements/notFound.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
@@ -3355,6 +3440,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
+    "public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/text/sanitize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/dashboard-scene/scene/NavToolbarActions.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -3429,6 +3517,9 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
+    "public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/schema/dashboard/v2alpha0/dashboard.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -3474,7 +3565,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/schema/src/raw/dashboard/x/dashboard_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -3485,9 +3576,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"]
     ],
     "public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -3669,24 +3761,24 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/ConfigEmailSharing.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/EmailListConfiguration.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/ShareConfiguration.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Switch/Switch\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Switch/Switch\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/ShareSnapshot.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawerConfirmAction.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/ConfirmModal/ConfirmContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/ConfirmModal/ConfirmContent\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/public-dashboards/ConfigPublicDashboard.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
@@ -3710,12 +3802,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dashboard/api/ResponseTransformers.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/schema/src/raw/dashboard/x/dashboard_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/features/dashboard/api/v0.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -3728,8 +3821,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./AddLibraryPanelWidget\`)", "0"]
     ],
     "public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/schema/src/raw/dashboard/x/dashboard_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
@@ -3740,10 +3833,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "12"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "13"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "14"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "15"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "16"]
     ],
     "public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -3888,7 +3982,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
@@ -3912,7 +4006,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
@@ -3922,7 +4016,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/Field\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/Field\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "3"]
@@ -3932,8 +4026,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/dashboard/components/PanelEditor/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -4038,12 +4134,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/ConfigPublicDashboard.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui/src\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "2"]
     ],
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/Configuration.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui/src\' is restricted from being used by a pattern. Use Stack component instead.", "2"]
     ],
@@ -4057,17 +4153,24 @@ exports[`better eslint`] = {
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboard.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
+    "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/query\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/dashboard/components/ShareModal/ViewJsonModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard/components/SubMenu/AnnotationPicker.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/PanelChrome/LoadingIndicator\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/PanelChrome/LoadingIndicator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/dashboard/components/SubMenu/DashboardLinks.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/text/sanitize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "\'@grafana/data/src/text/sanitize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/features/dashboard/components/SubMenu/SubMenu.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4158,7 +4261,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderNotice.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard/dashgrid/PanelLinks.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4172,7 +4275,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/features/dashboard/services/TimeSrv.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4189,13 +4292,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/labelsToFields\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/merge\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Do not use any type assertions.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
@@ -4217,7 +4320,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "25"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "26"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "27"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "28"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "28"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "29"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "30"]
     ],
     "public/app/features/dashboard/state/DashboardModel.repeat.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4330,13 +4435,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/datasources/components/CloudInfoBox.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/types/config\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/datasources/components/DashboardsTable.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4415,7 +4521,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/dimensions/editors/ColorDimensionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/dimensions/editors/FileUploader.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4426,7 +4532,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dimensions/editors/ResourceDimensionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4434,7 +4540,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/dimensions/editors/ResourcePicker.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/closePopover\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/closePopover\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
@@ -4445,18 +4551,18 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/dimensions/editors/ScalarDimensionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/dimensions/editors/ScaleDimensionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/dimensions/editors/TextDimensionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4527,7 +4633,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "7"]
     ],
     "public/app/features/dimensions/scale.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/field/scale\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/dimensions/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -4536,7 +4643,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/explore/ContentOutline/ContentOutlineItemButton.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Tooltip\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/explore/CorrelationEditorModeBar.tsx:5381": [
@@ -4576,7 +4683,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/explore/Explore.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4591,7 +4698,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/explore/ExploreRunQueryButton.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
@@ -4614,8 +4721,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
+    "public/app/features/explore/Logs/Logs.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/explore/Logs/Logs.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizLegend/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizLegend/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4638,6 +4748,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
+    "public/app/features/explore/Logs/LogsMetaRow.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/explore/Logs/LogsMetaRow.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -4656,8 +4769,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
+    "public/app/features/explore/Logs/LogsTable.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/explore/Logs/LogsTable.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/explore/Logs/LogsTableAvailableFields.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4674,6 +4790,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+    ],
+    "public/app/features/explore/Logs/LogsTableWrap.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/explore/Logs/LogsTableWrap.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4723,7 +4842,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/explore/QueryLibrary/QueryTemplateForm.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/explore/QueryLibrary/QueryTemplatesList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4757,7 +4876,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/NextPrevResult.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
@@ -4770,7 +4889,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
     ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/TracePageSearchBar.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4980,11 +5099,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
+    "public/app/features/explore/state/main.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/url\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/explore/state/time.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/explore/state/time.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/explore/state/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -4995,8 +5117,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/expressions/ExpressionDatasource.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/expressions/ExpressionQueryEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -5053,7 +5176,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
     ],
     "public/app/features/expressions/guards.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/geo/editor/GazetteerPathEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5154,7 +5278,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/library-panels/components/LibraryPanelInfo/LibraryPanelInfo.tsx:5381": [
@@ -5179,14 +5303,25 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
+    "public/app/features/library-panels/types.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/raw/librarypanel/x/librarypanel_types.gen\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/live/LiveConnectionWarning.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/live/centrifuge/LiveDataStream.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/dataframe/StreamingDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/services/live\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/toDataQueryError\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"]
     ],
     "public/app/features/live/centrifuge/channel.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/features/live/centrifuge/service.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/services/backendSrv\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/services/live\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/queryResponse\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ],
     "public/app/features/live/centrifuge/serviceWorkerProxy.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -5197,8 +5332,15 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
+    "public/app/features/live/live.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/logs/components/InfiniteScroll.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/logs/components/InfiniteScroll.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/logs/components/LogDetails.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5248,6 +5390,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
+    "public/app/features/logs/logsModel.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/valueFormats/symbolFormatters\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/logs/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -5255,7 +5400,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/manage-dashboards/components/ImportDashboardForm.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -5263,9 +5408,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"]
     ],
     "public/app/features/manage-dashboards/components/ImportDashboardLibraryPanelsList.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -5283,7 +5429,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/manage-dashboards/components/SnapshotListTableRow.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/manage-dashboards/state/actions.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5303,17 +5449,20 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
+    "public/app/features/manage-dashboards/types.ts:5381": [
+      [0, 0, 0, "\'@grafana/schema/src/veneer/dashboard.types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/migrate-to-cloud/api/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]
     ],
     "public/app/features/migrate-to-cloud/onprem/NameCell.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/migrate-to-cloud/shared/AlertWithTraceID.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Alert/Alert\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Alert/Alert\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/notifications/StoredNotifications.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5372,7 +5521,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "3"]
@@ -5391,14 +5540,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/playlist/PlaylistCard.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/playlist/PlaylistForm.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"],
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "1"]
     ],
     "public/app/features/playlist/PlaylistPageList.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/playlist/PlaylistTableRows.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5504,10 +5653,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/plugins/admin/components/PluginDetailsBody.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "\'@grafana/runtime/src/components/PluginPage\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/plugins/admin/components/PluginDetailsDeprecatedWarning.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5537,13 +5687,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
+    "public/app/features/plugins/admin/components/PluginDetailsPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/components/PluginPage\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/plugins/admin/components/PluginDetailsSignature.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/plugins/admin/components/PluginListItem.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
@@ -5618,24 +5771,38 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/plugins/datasource_srv.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
     "public/app/features/plugins/extensions/logs/LogViewFilters.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
+    "public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/plugins/extensions/usePluginComponents.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/runtime/src/services/pluginExtensions/getPluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
+    ],
+    "public/app/features/plugins/extensions/usePluginLinks.tsx:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/services/pluginExtensions/getPluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/plugins/extensions/validators.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/plugins/loader/sharedDependencies.ts:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
+    ],
+    "public/app/features/plugins/pluginPreloader.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/pluginExtensions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/plugins/sandbox/distortion_map.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -5646,9 +5813,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/plugins/tests/datasource_srv.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/plugins/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5675,6 +5843,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+    ],
+    "public/app/features/query-library/api/query.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/services/backendSrv\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/query/components/QueryEditorRow.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5775,14 +5946,19 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/query/state/PanelQueryRunner.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"]
+    ],
+    "public/app/features/query/state/runRequest.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/query/state/runRequest.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/query/state/updateQueries.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
@@ -5790,10 +5966,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
+    ],
+    "public/app/features/query/state/updateQueries.ts:5381": [
+      [0, 0, 0, "\'@grafana/runtime/src/utils/DataSourceWithBackend\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/sandbox/BenchmarksPage.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/ThemeDemos/EmotionPerfTest\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/ThemeDemos/EmotionPerfTest\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/sandbox/TestStuffPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5809,8 +5989,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/search/page/components/SearchResultsTable.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/TableCell\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/styles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/TableCell\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/styles\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
@@ -5842,7 +6022,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/serviceaccounts/ServiceAccountPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5911,7 +6091,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -6047,14 +6227,22 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/trails/DataTrailSettings.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/trails/DataTrailsHistory.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/trails/DataTrailsHome.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/trails/Integrations/getQueryMetrics.ts:5381": [
+      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/parsing\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/shared/types\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
+    ],
+    "public/app/features/trails/Integrations/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/shared/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/trails/MetricScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6074,6 +6262,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
+    "public/app/features/trails/MetricSelect/api.ts:5381": [
+      [0, 0, 0, "\'@grafana/prometheus/src/language_utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/prometheus/src/querybuilder/PromQueryModeller\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
+    ],
     "public/app/features/trails/MetricsHeader.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
@@ -6086,17 +6278,31 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
+    "public/app/features/trails/helpers/MetricDatasourceHelper.ts:5381": [
+      [0, 0, 0, "\'@grafana/prometheus/src/language_provider\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/trails/otel/api.ts:5381": [
+      [0, 0, 0, "\'@grafana/prometheus/src/language_utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/trails/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/prometheus/src/language_utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/transformers/FilterByValueTransformer/FilterByValueFilterEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+    ],
+    "public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByValue\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/transformers/FilterByValueTransformer/ValueMatchers/BasicMatcherEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6135,12 +6341,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/transformers/calculateHeatmap/editor/helper.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "public/app/features/transformers/calculateHeatmap/heatmap.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/features/transformers/calculateHeatmap/heatmap.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6148,60 +6358,68 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/BinaryOperationOptionsEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CalculateFieldTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    ],
+    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/IndexOptionsEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/CumulativeOptionsEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/CalculateFieldTransformerEditor/IndexOptionsEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
-    ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/ReduceRowOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/UnaryOperationEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/WindowOptionsEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/calculateField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"]
     ],
     "public/app/features/transformers/editors/CalculateFieldTransformerEditor/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CalculateFieldTransformerEditor\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`calculateFieldTransformRegistryItem\`)", "1"]
     ],
     "public/app/features/transformers/editors/ConcatenateTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/concat\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldTypeMatcherEditor\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldTypeMatcherEditor\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
@@ -6216,13 +6434,15 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "15"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "16"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "17"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "18"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "18"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "19"]
     ],
     "public/app/features/transformers/editors/EnumMappingEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
     ],
     "public/app/features/transformers/editors/EnumMappingRow.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
@@ -6230,46 +6450,54 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByName\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/runtime/src/services\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"]
     ],
     "public/app/features/transformers/editors/FilterByRefIdTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByRefId\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/transformers/editors/FormatStringTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
-    ],
-    "public/app/features/transformers/editors/GroupByTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/formatString\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    ],
+    "public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/formatTime\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
+    ],
+    "public/app/features/transformers/editors/GroupByTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/groupBy\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    ],
+    "public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/groupBy\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/groupToNestedTable\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
     ],
     "public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6278,68 +6506,82 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/HistogramTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
     ],
     "public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinByField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
-    "public/app/features/transformers/editors/LimitTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
-    ],
-    "public/app/features/transformers/editors/MergeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
-    ],
-    "public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
-    ],
-    "public/app/features/transformers/editors/ReduceTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+    "public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/labelsToFields\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
     ],
+    "public/app/features/transformers/editors/LimitTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/limit\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/transformers/editors/MergeTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/merge\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
+    ],
+    "public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/order\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/organize\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+    ],
+    "public/app/features/transformers/editors/ReduceTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/reduce\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
+    ],
     "public/app/features/transformers/editors/RenameByRegexTransformer.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/SortByTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
-    ],
-    "public/app/features/transformers/editors/TransposeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/renameByRegex\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
+    "public/app/features/transformers/editors/SeriesToRowsTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/seriesToRows\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/features/transformers/editors/SortByTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/sortBy\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    ],
+    "public/app/features/transformers/editors/TransposeTransformerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/transpose\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+    ],
     "public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -6364,6 +6606,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
+    ],
+    "public/app/features/transformers/extractFields/extractFields.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/sortBy\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/data/src/utils/tests/mockTransformationsRegistry\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ],
     "public/app/features/transformers/extractFields/extractFields.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -6403,16 +6650,20 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"]
     ],
     "public/app/features/transformers/lookupGazetteer/FieldLookupTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/transformers/lookupGazetteer/fieldLookup.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/ids\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/features/transformers/lookupGazetteer/fieldLookup.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -6421,6 +6672,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
+    ],
+    "public/app/features/transformers/partitionByValues/partitionByValues.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/filterByName\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/noop\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/features/transformers/prepareTimeSeries/PrepareTimeSeriesEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6448,7 +6703,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/transformers/regression/regressionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -6457,16 +6712,22 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
     ],
     "public/app/features/transformers/spatial/optionsHelper.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
+    ],
+    "public/app/features/transformers/spatial/spatialTransformer.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/dataframe/processDataFrame\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/ids\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/features/transformers/suggestionsInput/SuggestionsInput.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinkSuggestions\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinkSuggestions\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
@@ -6479,7 +6740,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/users/TokenRevokedModal.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Modal/getModalStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/getModalStyles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
@@ -6620,7 +6881,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./OptionsPicker/OptionsPicker\`)", "0"]
     ],
     "public/app/features/variables/pickers/shared/VariableLink.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/PanelChrome/LoadingIndicator\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/PanelChrome/LoadingIndicator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/features/variables/pickers/shared/VariableOptions.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6748,7 +7009,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/visualization/data-hover/ExemplarHoverView.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipRow\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipRow\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/alertmanager/DataSource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -6756,6 +7017,9 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/alertmanager/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+    ],
+    "public/app/plugins/datasource/azuremonitor/__mocks__/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/types/data\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/azuremonitor/azureMetadata/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
@@ -6798,7 +7062,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/datasource/azuremonitor/components/shared/Field.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineField\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineField\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/azuremonitor/types/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
@@ -6905,10 +7169,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./withinStringQuery\`)", "5"]
     ],
     "public/app/plugins/datasource/cloudwatch/components/CheatSheet/LogsCheatSheet.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/slate-plugins/slate-prism\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/slate-plugins/slate-prism\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/PPLQueryEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
@@ -6920,7 +7184,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./MetricsQueryEditor/SQLCodeEditor\`)", "0"]
     ],
     "public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LegacyLogGroupSelector.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Select/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./MetricStatEditor\`)", "0"]
@@ -6938,6 +7202,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
+    "public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/datetime/moment_wrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/cloudwatch/types.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
@@ -6961,9 +7228,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/datasource/elasticsearch/ElasticResponse.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
@@ -6992,7 +7259,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "28"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "29"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "30"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "31"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "31"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "32"]
     ],
     "public/app/plugins/datasource/elasticsearch/LanguageProvider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -7100,12 +7368,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/datasource/grafana/components/TimePickerInput.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Forms/commonStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/commonStyles\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOffset\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneTitle\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOffset\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneTitle\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/datasource/grafana/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7280,13 +7548,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`MixedDatasource\`)", "1"]
     ],
     "public/app/plugins/datasource/mssql/azureauth/AzureAuthSettings.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/sql/src/components/configuration/NumberInput\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/mssql/types.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/opentsdb/datasource.d.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -7315,10 +7586,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
     ],
     "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/datasource/tempo/QueryField.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
@@ -7385,45 +7656,50 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
     ],
     "public/app/plugins/panel/annolist/AnnoListPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/List/AbstractList\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/List/AbstractList\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/panel/barchart/BarChartLegend.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/BarChartPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/TickSpacingEditor.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/bars.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"]
     ],
     "public/app/plugins/panel/barchart/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/quadtree.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/barchart/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/data/src/field/fieldState\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ],
     "public/app/plugins/panel/bargauge/BarGaugeLegend.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/bargauge/BarGaugePanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/candlestick/CandlestickPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+    ],
+    "public/app/plugins/panel/candlestick/fields.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/candlestick/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CandleStyle\`)", "0"],
@@ -7436,14 +7712,32 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`defaultCandlestickColors\`)", "7"]
     ],
     "public/app/plugins/panel/canvas/components/CanvasTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/CloseButton\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"]
+      [0, 0, 0, "\'@grafana/data/src/types/action\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/CloseButton\' import is restricted from being used by a pattern. Import from the public export instead.", "5"]
+    ],
+    "public/app/plugins/panel/canvas/editor/connectionEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/plugins/panel/canvas/editor/element/elementEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
+    ],
+    "public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
+    "public/app/plugins/panel/canvas/editor/options.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/panel/PanelPlugin\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/datagrid/components/DatagridContextMenu.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Menu/MenuDivider\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Menu/MenuDivider\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/panel/debug/CursorView.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7457,15 +7751,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/gauge/GaugePanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/geomap/components/MarkersLegend.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/field/scale\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/plugins/panel/geomap/editor/FrameSelectionEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/geomap/editor/GeomapStyleRulesEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7489,8 +7784,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "12"]
     ],
     "public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldValueMatcher\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldValueMatcher\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
+    ],
+    "public/app/plugins/panel/geomap/editor/layerEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/utils/OptionsUIBuilders\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/geomap/layers/basemaps/esri.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7499,7 +7797,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/geomap/layers/data/routeLayer.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/panel/geomap/layers/registry.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -7512,6 +7811,9 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/geomap/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
     ],
+    "public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/matchers/compareValues\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/plugins/panel/geomap/utils/layers.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -7519,22 +7821,22 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/heatmap/HeatmapPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/panel/heatmap/HeatmapTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"]
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Import from the public export instead.", "4"]
     ],
     "public/app/plugins/panel/heatmap/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/heatmap/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/heatmap/palettes.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7564,21 +7866,27 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "16"]
     ],
     "public/app/plugins/panel/histogram/Histogram.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/panel/histogram/HistogramPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/panel/histogram/HistogramTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"]
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "5"]
     ],
     "public/app/plugins/panel/histogram/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
+    ],
+    "public/app/plugins/panel/histogram/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/histogram\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/live/LivePanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7586,11 +7894,14 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/logs/LogsPanel.test.tsx:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
+    "public/app/plugins/panel/logs/LogsPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/data/src/datetime/rangeutil\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
+    ],
     "public/app/plugins/panel/logs/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
     ],
     "public/app/plugins/panel/news/component/News.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/nodeGraph/Edge.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7607,7 +7918,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/panel/nodeGraph/editor/ArcOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/nodeGraph/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./NodeGraph\`)", "0"]
@@ -7619,52 +7930,54 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
     ],
     "public/app/plugins/panel/piechart/PieChart.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/utils/useComponetInstanceId\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/useComponetInstanceId\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/panel/piechart/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/panel/piechart/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/stat/StatMigrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/stat/StatPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/field/fieldOverrides\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"]
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "5"]
     ],
     "public/app/plugins/panel/state-timeline/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/panel/status-history/StatusHistoryPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/table/TablePanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/Table/SparklineCell\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/SparklineCell\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
     ],
     "public/app/plugins/panel/table/migrations.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/reduce\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/plugins/panel/text/textPanelMigrationHandler.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -7679,15 +7992,15 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"]
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "5"]
     ],
     "public/app/plugins/panel/timeseries/migrations.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7702,13 +8015,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
     ],
     "public/app/plugins/panel/timeseries/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -7721,38 +8034,44 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/panel/timeseries/utils.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/convertFieldType\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullInsertThreshold\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/nulls/nullToValue\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Import from the public export instead.", "3"]
     ],
     "public/app/plugins/panel/trend/TrendPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/data/src/transformations/transformers/joinDataFrames\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "1"]
     ],
     "public/app/plugins/panel/trend/module.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/panel/xychart/SeriesEditor.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"]
     ],
     "public/app/plugins/panel/xychart/XYChartPanel.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ],
     "public/app/plugins/panel/xychart/XYChartTooltip.tsx:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
-      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"]
+      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Import from the public export instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Import from the public export instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Import from the public export instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Import from the public export instead.", "5"]
     ],
     "public/app/plugins/panel/xychart/migrations.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/xychart/scatter.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "\'@grafana/data/src/themes/colorManipulator\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/types\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
@@ -7766,10 +8085,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "12"],
       [0, 0, 0, "Do not use any type assertions.", "13"],
       [0, 0, 0, "Do not use any type assertions.", "14"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
+      [0, 0, 0, "Do not use any type assertions.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "18"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "19"]
+    ],
+    "public/app/plugins/panel/xychart/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/data/src/field/fieldState\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],
     "public/app/plugins/sdk.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`loadPluginCss\`)", "0"]
@@ -7904,9 +8227,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "scripts/cli/generateSassVariableFiles.ts:5381": [
-      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.dark.scss.tmpl\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
-      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.light.scss.tmpl\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
-      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.scss.tmpl\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.dark.scss.tmpl\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.light.scss.tmpl\' import is restricted from being used by a pattern. Import from the public export instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.scss.tmpl\' import is restricted from being used by a pattern. Import from the public export instead.", "2"]
     ]
   }`
 };

--- a/.betterer.results
+++ b/.betterer.results
@@ -414,6 +414,9 @@ exports[`better eslint`] = {
     "packages/grafana-prometheus/src/querybuilder/components/LabelParamEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
+    "packages/grafana-prometheus/src/querybuilder/components/MetricCombobox.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Combobox/Combobox\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "packages/grafana-prometheus/src/querybuilder/components/MetricSelect.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -1022,6 +1025,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
+    "public/app/core/components/AppChrome/TopBar/TopSearchBarCommandPaletteTrigger.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/core/components/Breadcrumbs/Breadcrumbs.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
@@ -1050,12 +1056,20 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/core/components/GraphNG/GraphNG.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/Plot\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Do not use any type assertions.", "6"],
+      [0, 0, 0, "Do not use any type assertions.", "7"],
+      [0, 0, 0, "Do not use any type assertions.", "8"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
+    ],
+    "public/app/core/components/Indent/Indent.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/utils/responsiveness\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/core/components/Layers/LayerDragDropList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -1073,11 +1087,24 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
+    "public/app/core/components/NestedFolderPicker/NestedFolderList.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/core/components/NestedFolderPicker/Trigger.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/core/components/OptionsUI/color.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/ColorPicker/ColorSwatch\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/OptionsUI/fieldColor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+    ],
+    "public/app/core/components/OptionsUI/registry.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/core/components/OptionsUI/slider.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Slider/styles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/core/components/OptionsUI/units.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1089,6 +1116,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
+    "public/app/core/components/PasswordField/PasswordField.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/core/components/PluginHelp/PluginHelp.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
@@ -1096,16 +1126,23 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/core/components/RolePicker/RoleMenuGroupOption.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePicker/RoleMenuOption.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
+    ],
+    "public/app/core/components/RolePicker/RolePickerInput.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/core/components/RolePicker/RolePickerMenu.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePicker/RolePickerSubMenu.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/getSelectStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/core/components/RolePickerDrawer/RolePickerBadges.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1155,14 +1192,32 @@ exports[`better eslint`] = {
     "public/app/core/components/TagFilter/TagOption.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
+    "public/app/core/components/TimePicker/TimePickerWithHistory.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/core/components/TimeSeries/TimeSeries.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/PlotLegend\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/ThemeContext\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"]
+    ],
     "public/app/core/components/TimeSeries/utils.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotConfigBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/gradientFills\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+    ],
+    "public/app/core/components/TimelineChart/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/core/config.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`Settings\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "1"]
+    ],
+    "public/app/core/context/ModalsContextProvider.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/ModalsContext\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/core/core.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`JsonExplorer\`)", "0"],
@@ -1269,28 +1324,49 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/features/actions/ActionEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/Field\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineField\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineFieldRow\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/JSONFormatter/JSONFormatter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "12"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "13"]
+    ],
+    "public/app/features/actions/ActionEditorModalContent.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/Modal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
     ],
     "public/app/features/actions/ActionsInlineEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/Modal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/actions/ActionsListItem.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
-    ],
-    "public/app/features/actions/ParamsEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/Icon\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/IconButton/IconButton\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
+    ],
+    "public/app/features/actions/ParamsEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/IconButton/IconButton\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Stack/Stack\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/Select\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/themes\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"]
     ],
     "public/app/features/admin/AdminEditOrgPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -1303,8 +1379,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/admin/AdminOrgsTable.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+    ],
+    "public/app/features/admin/AdminSettingsTable.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/admin/OrgRolePicker.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1526,6 +1606,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+    ],
+    "public/app/features/alerting/unified/Templates.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/AlertLabel.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -1938,6 +2021,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "12"]
     ],
+    "public/app/features/alerting/unified/components/receivers/TemplateEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/alerting/unified/components/receivers/TemplateForm.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -2056,6 +2142,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
+    "public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.test.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -2135,6 +2224,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+    ],
+    "public/app/features/alerting/unified/components/rule-editor/GrafanaAlertStatePicker.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2258,17 +2350,18 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteSettings.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/MultiValue\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "11"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/labels/LabelsButtons.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -2324,13 +2417,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2381,11 +2475,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/alerting/unified/components/rule-viewer/tabs/Details.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -2406,6 +2501,12 @@ exports[`better eslint`] = {
     ],
     "public/app/features/alerting/unified/components/rule-viewer/tabs/Routing.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
+    "public/app/features/alerting/unified/components/rules/ActionButton.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/features/alerting/unified/components/rules/ActionIcon.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/alerting/unified/components/rules/AlertInstanceDetails.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -2789,6 +2890,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
+    "public/app/features/alerting/unified/plugins/PluginOriginBadge.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/alerting/unified/rule-list/FilterView.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
@@ -2812,6 +2916,9 @@ exports[`better eslint`] = {
     ],
     "public/app/features/alerting/unified/rule-list/components/RuleGroup.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+    ],
+    "public/app/features/alerting/unified/rule-list/components/RuleListIcon.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/alerting/unified/types/receiver-form.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -2964,12 +3071,17 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/browse-dashboards/components/NameCell.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/browse-dashboards/state/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "1"],
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "2"]
+    ],
+    "public/app/features/canvas/elements/metricValue.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
     ],
     "public/app/features/canvas/elements/notFound.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
@@ -3556,14 +3668,25 @@ exports[`better eslint`] = {
     "public/app/features/dashboard-scene/sharing/ShareButton/ShareButton.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
+    "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/ConfigEmailSharing.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/EmailShare/ConfigEmailSharing/EmailListConfiguration.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+    ],
+    "public/app/features/dashboard-scene/sharing/ShareButton/share-externally/ShareConfiguration.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Switch/Switch\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/ShareSnapshot.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/ShareButton/share-snapshot/UpsertSnapshot.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+    ],
+    "public/app/features/dashboard-scene/sharing/ShareDrawer/ShareDrawerConfirmAction.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/ConfirmModal/ConfirmContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/dashboard-scene/sharing/public-dashboards/ConfigPublicDashboard.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
@@ -3765,9 +3888,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
@@ -3788,18 +3912,20 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx:5381": [
-      [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/dashboard/components/PanelEditor/VisualizationButton.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dashboard/components/PanelEditor/VisualizationSelectPane.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/Field\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "3"]
     ],
     "public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -3912,12 +4038,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/ConfigPublicDashboard.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui/src\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui/src\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "2"]
     ],
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/Configuration.tsx:5381": [
-      [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui/src\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Layout/Layout\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'Layout\' import from \'@grafana/ui/src/components/Layout/Layout\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
+      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui/src\' is restricted from being used by a pattern. Use Stack component instead.", "2"]
     ],
     "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ConfigPublicDashboard/EmailSharingConfiguration.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -3932,10 +4060,14 @@ exports[`better eslint`] = {
     "public/app/features/dashboard/components/ShareModal/ViewJsonModal.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
+    "public/app/features/dashboard/components/SubMenu/AnnotationPicker.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/PanelChrome/LoadingIndicator\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/features/dashboard/components/SubMenu/SubMenu.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4025,6 +4157,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
+    "public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderNotice.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/dashboard/dashgrid/PanelLinks.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
@@ -4035,6 +4170,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
+    "public/app/features/dashboard/services/TimeSrv.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4051,11 +4189,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
@@ -4078,7 +4216,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "24"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "25"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "26"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "27"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "27"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "28"]
     ],
     "public/app/features/dashboard/state/DashboardModel.repeat.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -4275,6 +4414,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
+    "public/app/features/dimensions/editors/ColorDimensionEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/dimensions/editors/FileUploader.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
@@ -4284,15 +4426,17 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/dimensions/editors/ResourceDimensionEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/dimensions/editors/ResourcePicker.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/closePopover\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/dimensions/editors/ResourcePickerPopover.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -4301,21 +4445,24 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/dimensions/editors/ScalarDimensionEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
-    ],
-    "public/app/features/dimensions/editors/ScaleDimensionEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
-    "public/app/features/dimensions/editors/TextDimensionEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+    "public/app/features/dimensions/editors/ScaleDimensionEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
+    ],
+    "public/app/features/dimensions/editors/TextDimensionEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
     ],
     "public/app/features/dimensions/editors/ThresholdsEditor/ThresholdsEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -4389,7 +4536,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/explore/ContentOutline/ContentOutlineItemButton.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/explore/CorrelationEditorModeBar.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -4428,7 +4576,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/explore/Explore.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4436,14 +4584,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"]
     ],
     "public/app/features/explore/ExplorePage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
     "public/app/features/explore/ExploreRunQueryButton.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/explore/ExploreToolbar.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -4465,7 +4615,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/explore/Logs/Logs.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizLegend/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
@@ -4474,8 +4624,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "8"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "11"]
     ],
     "public/app/features/explore/Logs/LogsColumnSearch.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4504,6 +4655,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"]
+    ],
+    "public/app/features/explore/Logs/LogsTable.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/explore/Logs/LogsTableAvailableFields.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
@@ -4568,6 +4722,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
+    "public/app/features/explore/QueryLibrary/QueryTemplateForm.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/explore/QueryLibrary/QueryTemplatesList.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
@@ -4600,24 +4757,26 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/NextPrevResult.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "10"]
     ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SearchBar/TracePageSearchBar.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Button\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
     ],
     "public/app/features/explore/TraceView/components/TracePageHeader/SpanFilters/SpanFilters.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
@@ -4824,6 +4983,9 @@ exports[`better eslint`] = {
     "public/app/features/explore/state/time.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/features/explore/state/time.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/explore/state/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -4992,7 +5154,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
     ],
     "public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/library-panels/components/LibraryPanelInfo/LibraryPanelInfo.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5119,6 +5282,9 @@ exports[`better eslint`] = {
     "public/app/features/manage-dashboards/components/SnapshotListTable.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"]
     ],
+    "public/app/features/manage-dashboards/components/SnapshotListTableRow.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/manage-dashboards/state/actions.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
@@ -5141,9 +5307,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"]
     ],
     "public/app/features/migrate-to-cloud/onprem/NameCell.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Icon/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
+    ],
+    "public/app/features/migrate-to-cloud/shared/AlertWithTraceID.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Alert/Alert\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/notifications/StoredNotifications.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5202,9 +5372,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "3"]
     ],
     "public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5219,9 +5390,15 @@ exports[`better eslint`] = {
     "public/app/features/panel/panellinks/link_srv.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/features/playlist/PlaylistCard.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/playlist/PlaylistForm.tsx:5381": [
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "0"],
       [0, 0, 0, "Use data-testid for E2E selectors instead of aria-label", "1"]
+    ],
+    "public/app/features/playlist/PlaylistPageList.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/playlist/PlaylistTableRows.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5366,8 +5543,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/plugins/admin/components/PluginListItem.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/plugins/admin/components/PluginSignatureDetailsBadge.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
@@ -5614,6 +5792,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"]
     ],
+    "public/app/features/sandbox/BenchmarksPage.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/ThemeDemos/EmotionPerfTest\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/sandbox/TestStuffPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
@@ -5628,8 +5809,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
     "public/app/features/search/page/components/SearchResultsTable.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/TableCell\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/styles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"]
     ],
     "public/app/features/search/page/components/columns.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5657,6 +5840,9 @@ exports[`better eslint`] = {
     ],
     "public/app/features/search/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
+    "public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/serviceaccounts/ServiceAccountPage.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5725,13 +5911,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
     ],
     "public/app/features/serviceaccounts/state/reducers.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -5860,10 +6047,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/trails/DataTrailSettings.tsx:5381": [
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/utils/i18n\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"]
     ],
     "public/app/features/trails/DataTrailsHistory.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
+    ],
+    "public/app/features/trails/DataTrailsHome.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Text/Text\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/features/trails/MetricScene.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -5944,7 +6135,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"]
     ],
     "public/app/features/transformers/calculateHeatmap/editor/helper.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/transformers/calculateHeatmap/heatmap.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -6006,9 +6198,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
     ],
     "public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldTypeMatcherEditor\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
@@ -6022,7 +6214,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "13"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "14"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "15"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "16"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "16"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "17"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "18"]
     ],
     "public/app/features/transformers/editors/EnumMappingEditor.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
@@ -6049,9 +6243,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"]
     ],
     "public/app/features/transformers/editors/FormatStringTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/FormatTimeTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6091,9 +6286,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
     ],
     "public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6143,9 +6339,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"]
     ],
     "public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
@@ -6155,8 +6351,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "9"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "10"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "11"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "13"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "12"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "14"]
     ],
     "public/app/features/transformers/extractFields/components/JSONPathEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6206,22 +6403,24 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "9"]
     ],
     "public/app/features/transformers/lookupGazetteer/FieldLookupTransformerEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/transformers/lookupGazetteer/fieldLookup.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "7"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "7"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "8"]
     ],
     "public/app/features/transformers/prepareTimeSeries/PrepareTimeSeriesEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6249,12 +6448,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/transformers/regression/regressionEditor.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "2"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"],
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "4"],
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"]
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "5"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "6"]
     ],
     "public/app/features/transformers/spatial/optionsHelper.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -6265,10 +6465,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/transformers/suggestionsInput/SuggestionsInput.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinkSuggestions\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Input/Input\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"]
     ],
     "public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6277,12 +6479,13 @@ exports[`better eslint`] = {
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "3"]
     ],
     "public/app/features/users/TokenRevokedModal.tsx:5381": [
-      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/Modal/getModalStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "1"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "2"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "3"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "4"],
-      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"]
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "5"],
+      [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "6"]
     ],
     "public/app/features/users/UsersActionBar.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
@@ -6416,6 +6619,9 @@ exports[`better eslint`] = {
     "public/app/features/variables/pickers/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./OptionsPicker/OptionsPicker\`)", "0"]
     ],
+    "public/app/features/variables/pickers/shared/VariableLink.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/PanelChrome/LoadingIndicator\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/features/variables/pickers/shared/VariableOptions.tsx:5381": [
       [0, 0, 0, "No untranslated strings in text props. Wrap text with <Trans /> or use t()", "0"],
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "1"],
@@ -6541,6 +6747,9 @@ exports[`better eslint`] = {
     "public/app/features/visualization/data-hover/DataHoverView.tsx:5381": [
       [0, 0, 0, "No untranslated strings. Wrap text with <Trans />", "0"]
     ],
+    "public/app/features/visualization/data-hover/ExemplarHoverView.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipRow\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/datasource/alertmanager/DataSource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -6587,6 +6796,9 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.test.tsx:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
+    ],
+    "public/app/plugins/datasource/azuremonitor/components/shared/Field.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/InlineField\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/datasource/azuremonitor/types/index.ts:5381": [
       [0, 0, 0, "Do not use export all (\`export * from ...\`)", "0"],
@@ -6692,6 +6904,12 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`./thirdArgAfterSearchQuery\`)", "4"],
       [0, 0, 0, "Do not re-export imported variable (\`./withinStringQuery\`)", "5"]
     ],
+    "public/app/plugins/datasource/cloudwatch/components/CheatSheet/LogsCheatSheet.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/slate-plugins/slate-prism\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/PPLQueryEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Monaco/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx:5381": [
       [0, 0, 0, "* import is invalid because \'Layout,HorizontalGroup,VerticalGroup\' from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
@@ -6700,6 +6918,9 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./MetricsQueryEditor/SQLCodeEditor\`)", "0"]
+    ],
+    "public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LegacyLogGroupSelector.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Select/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./MetricStatEditor\`)", "0"]
@@ -6878,6 +7099,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
+    "public/app/plugins/datasource/grafana/components/TimePickerInput.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Forms/commonStyles\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+    ],
+    "public/app/plugins/datasource/grafana/components/TimeRegionEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOffset\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneTitle\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+    ],
     "public/app/plugins/datasource/grafana/datasource.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -7050,6 +7279,15 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`Datasource\`)", "0"],
       [0, 0, 0, "Do not re-export imported variable (\`MixedDatasource\`)", "1"]
     ],
+    "public/app/plugins/datasource/mssql/azureauth/AzureAuthSettings.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/datasource/mssql/azureauth/AzureCredentialsForm.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/datasource/mssql/types.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/datasource/opentsdb/datasource.d.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -7075,6 +7313,12 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/parca/webpack.config.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
+    ],
+    "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataSourceSettings/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/datasource/tempo/QueryField.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
@@ -7141,20 +7385,45 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`config\`)", "0"]
     ],
     "public/app/plugins/panel/annolist/AnnoListPanel.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/List/AbstractList\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
+    ],
+    "public/app/plugins/panel/barchart/BarChartLegend.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/barchart/BarChartPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/TickSpacingEditor.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/bars.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"]
+    ],
+    "public/app/plugins/panel/barchart/module.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/barchart/quadtree.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/plugins/panel/barchart/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+    ],
+    "public/app/plugins/panel/bargauge/BarGaugeLegend.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/bargauge/BarGaugePanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/candlestick/CandlestickPanel.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/plugins/panel/candlestick/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`CandleStyle\`)", "0"],
@@ -7165,6 +7434,16 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not re-export imported variable (\`Options\`)", "5"],
       [0, 0, 0, "Do not re-export imported variable (\`VizDisplayMode\`)", "6"],
       [0, 0, 0, "Do not re-export imported variable (\`defaultCandlestickColors\`)", "7"]
+    ],
+    "public/app/plugins/panel/canvas/components/CanvasTooltip.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/CloseButton\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"]
+    ],
+    "public/app/plugins/panel/datagrid/components/DatagridContextMenu.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Menu/MenuDivider\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/debug/CursorView.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7177,10 +7456,16 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/gauge/GaugeMigrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "public/app/plugins/panel/gauge/GaugePanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/geomap/components/MarkersLegend.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
+    "public/app/plugins/panel/geomap/editor/FrameSelectionEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldsByFrameRefIdMatcher\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/geomap/editor/GeomapStyleRulesEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7204,7 +7489,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "12"]
     ],
     "public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldValueMatcher\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/panel/geomap/layers/basemaps/esri.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7233,11 +7519,22 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/heatmap/HeatmapPanel.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+    ],
+    "public/app/plugins/panel/heatmap/HeatmapTooltip.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"]
     ],
     "public/app/plugins/panel/heatmap/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/plugins/panel/heatmap/module.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/heatmap/palettes.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -7266,6 +7563,23 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "15"],
       [0, 0, 0, "Do not use any type assertions.", "16"]
     ],
+    "public/app/plugins/panel/histogram/Histogram.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/histogram/HistogramPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/histogram/HistogramTooltip.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"]
+    ],
+    "public/app/plugins/panel/histogram/module.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/options/builder\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/live/LivePanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -7274,6 +7588,9 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/panel/logs/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
+    ],
+    "public/app/plugins/panel/news/component/News.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/nodeGraph/Edge.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -7289,6 +7606,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
+    "public/app/plugins/panel/nodeGraph/editor/ArcOptionsEditor.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/nodeGraph/index.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./NodeGraph\`)", "0"]
     ],
@@ -7298,19 +7618,47 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/nodeGraph/types.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`./panelcfg.gen\`)", "0"]
     ],
+    "public/app/plugins/panel/piechart/PieChart.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/themes/mixins\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/utils/useComponetInstanceId\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+    ],
     "public/app/plugins/panel/piechart/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "public/app/plugins/panel/piechart/module.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/stat/StatMigrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/plugins/panel/stat/StatPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/DataLinks/DataLinksContextMenu\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"]
     ],
     "public/app/plugins/panel/state-timeline/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "public/app/plugins/panel/status-history/StatusHistoryPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/table/TablePanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx:5381": [
-      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
+      [0, 0, 0, "\'@grafana/ui/src/components/Table/SparklineCell\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'VerticalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "1"]
     ],
     "public/app/plugins/panel/table/migrations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -7330,6 +7678,17 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/timeseries/SpanNullsEditor.tsx:5381": [
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
+    "public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "5"]
+    ],
     "public/app/plugins/panel/timeseries/migrations.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -7342,8 +7701,14 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
     ],
+    "public/app/plugins/panel/timeseries/module.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
+    ],
+    "public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationEditor2.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -7355,17 +7720,38 @@ exports[`better eslint`] = {
       [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
+    "public/app/plugins/panel/timeseries/utils.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/internal\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/trend/TrendPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
+    "public/app/plugins/panel/trend/module.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/options/builder/tooltip\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"]
+    ],
     "public/app/plugins/panel/xychart/SeriesEditor.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/MatchersUI/FieldNamePicker\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"]
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"]
+    ],
+    "public/app/plugins/panel/xychart/XYChartPanel.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/utils\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"]
+    ],
+    "public/app/plugins/panel/xychart/XYChartTooltip.tsx:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipContent\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipFooter\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipHeader\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/VizTooltipWrapper\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "3"],
+      [0, 0, 0, "\'@grafana/ui/src/components/VizTooltip/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "4"]
     ],
     "public/app/plugins/panel/xychart/migrations.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/xychart/scatter.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/components/uPlot/types\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
@@ -7379,10 +7765,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "11"],
       [0, 0, 0, "Do not use any type assertions.", "12"],
       [0, 0, 0, "Do not use any type assertions.", "13"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
+      [0, 0, 0, "Do not use any type assertions.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
     ],
     "public/app/plugins/sdk.ts:5381": [
       [0, 0, 0, "Do not re-export imported variable (\`loadPluginCss\`)", "0"]
@@ -7515,6 +7902,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
+    ],
+    "scripts/cli/generateSassVariableFiles.ts:5381": [
+      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.dark.scss.tmpl\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "0"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.light.scss.tmpl\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "1"],
+      [0, 0, 0, "\'@grafana/ui/src/themes/_variables.scss.tmpl\' import is restricted from being used by a pattern. Direct imports from @grafana/ui/src are not allowed. Please import from @grafana/ui instead.", "2"]
     ]
   }`
 };

--- a/scripts/webpack/env-util.js
+++ b/scripts/webpack/env-util.js
@@ -1,3 +1,4 @@
+// @ts-check
 const { parse } = require('ini');
 const { readFileSync, existsSync } = require('node:fs');
 const path = require('path');
@@ -18,14 +19,17 @@ const getEnvConfig = () => {
   const custom = parse(customSettings);
 
   const merged = { ...defaults.frontend_dev, ...custom.frontend_dev };
+
   // Take all frontend keys from the ini file and prefix with `frontend_dev_`,
   // so they can be added to `process.env` elsewhere
-  return Object.entries(merged).reduce((acc, [key, value]) => {
-    return {
-      ...acc,
-      [`frontend_dev_${key}`]: value,
-    };
-  }, {});
+  /** @type {Record<string, unknown>} */
+  const env = {};
+
+  for (const [key, value] of Object.entries(merged)) {
+    env[`frontend_dev_${key}`] = value;
+  }
+
+  return env;
 };
 
 module.exports = getEnvConfig;


### PR DESCRIPTION
Uses the `no-restricted-imports` lint rule to prevent imports from `src/*` paths from the `@grafana/ui`, `@grafana/data`, and `@grafana/runtime` packages. Apart from just being a poor practice, these imports can cause issues when code is externalised.