### PR TITLE
Remove dependency on dashboards table to get library element and library element connection

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -683,10 +683,11 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser i
 		}
 		var libraryElementConnections []model.LibraryElementConnectionWithMeta
 		builder := db.NewSqlBuilder(l.Cfg, l.features, l.SQLStore.GetDialect(), recursiveQueriesAreSupported)
-		builder.Write("SELECT lec.*, u1.login AS created_by_name, u1.email AS created_by_email, dashboard.uid AS connection_uid")
+		builder.Write("SELECT lec.*, u1.login AS created_by_name, u1.email AS created_by_email")
+		// dashboard.uid AS connection_uid"
 		builder.Write(" FROM " + model.LibraryElementConnectionTableName + " AS lec")
 		builder.Write(" LEFT JOIN " + l.SQLStore.GetDialect().Quote("user") + " AS u1 ON lec.created_by = u1.id")
-		builder.Write(" INNER JOIN dashboard AS dashboard on lec.connection_id = dashboard.id")
+		// builder.Write(" INNER JOIN dashboard AS dashboard on lec.connection_id = dashboard.id")
 		builder.Write(` WHERE lec.element_id=?`, element.ID)
 		if signedInUser.GetOrgRole() != org.RoleAdmin {
 			builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, "")

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -111,6 +111,9 @@ func GetLibraryElement(dialect migrator.Dialect, session *db.Session, uid string
 		if el.FolderName == "" {
 			el.FolderName = dashboards.RootFolderName
 		}
+		if el.FolderUID == "" {
+			el.FolderUID = ac.GeneralFolderUID
+		}
 	}
 
 	return elements[0], nil
@@ -681,13 +684,12 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser i
 		if err != nil {
 			return err
 		}
+
 		var libraryElementConnections []model.LibraryElementConnectionWithMeta
 		builder := db.NewSqlBuilder(l.Cfg, l.features, l.SQLStore.GetDialect(), recursiveQueriesAreSupported)
 		builder.Write("SELECT lec.*, u1.login AS created_by_name, u1.email AS created_by_email")
-		// dashboard.uid AS connection_uid"
 		builder.Write(" FROM " + model.LibraryElementConnectionTableName + " AS lec")
 		builder.Write(" LEFT JOIN " + l.SQLStore.GetDialect().Quote("user") + " AS u1 ON lec.created_by = u1.id")
-		// builder.Write(" INNER JOIN dashboard AS dashboard on lec.connection_id = dashboard.id")
 		builder.Write(` WHERE lec.element_id=?`, element.ID)
 		if signedInUser.GetOrgRole() != org.RoleAdmin {
 			builder.WriteDashboardPermissionFilter(signedInUser, dashboardaccess.PERMISSION_VIEW, "")
@@ -698,12 +700,11 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser i
 
 		for _, connection := range libraryElementConnections {
 			connections = append(connections, model.LibraryElementConnectionDTO{
-				ID:            connection.ID,
-				Kind:          connection.Kind,
-				ElementID:     connection.ElementID,
-				ConnectionID:  connection.ConnectionID,
-				ConnectionUID: connection.ConnectionUID,
-				Created:       connection.Created,
+				ID:           connection.ID,
+				Kind:         connection.Kind,
+				ElementID:    connection.ElementID,
+				ConnectionID: connection.ConnectionID,
+				Created:      connection.Created,
 				CreatedBy: librarypanel.LibraryElementDTOMetaUser{
 					Id:        connection.CreatedBy,
 					Name:      connection.CreatedByName,

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -116,11 +116,13 @@ func TestLibraryElementPermissionsGeneralFolder(t *testing.T) {
 				sc.reqContext.Req.Body = mockRequestBody(cmd)
 				resp := sc.service.createHandler(sc.reqContext)
 				result := validateAndUnMarshalResponse(t, resp)
+				result.Result.FolderUID = "general"
 				result.Result.Meta.CreatedBy.Name = userInDbName
 				result.Result.Meta.CreatedBy.AvatarUrl = userInDbAvatar
 				result.Result.Meta.UpdatedBy.Name = userInDbName
 				result.Result.Meta.UpdatedBy.AvatarUrl = userInDbAvatar
 				result.Result.Meta.FolderName = "General"
+				result.Result.Meta.FolderUID = "general"
 				sc.reqContext.SignedInUser.OrgRole = testCase.role
 
 				resp = sc.service.getAllHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -171,12 +171,11 @@ func TestGetLibraryPanelConnections(t *testing.T) {
 				return model.LibraryElementConnectionsResponse{
 					Result: []model.LibraryElementConnectionDTO{
 						{
-							ID:            sc.initialResult.Result.ID,
-							Kind:          sc.initialResult.Result.Kind,
-							ElementID:     1,
-							ConnectionID:  dashInDB.ID,
-							ConnectionUID: dashInDB.UID,
-							Created:       res.Result[0].Created,
+							ID:           sc.initialResult.Result.ID,
+							Kind:         sc.initialResult.Result.Kind,
+							ElementID:    1,
+							ConnectionID: dashInDB.ID,
+							Created:      res.Result[0].Created,
 							CreatedBy: librarypanel.LibraryElementDTOMetaUser{
 								Id:        1,
 								Name:      userInDbName,

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -120,7 +120,6 @@ type LibraryElementConnectionWithMeta struct {
 	Kind           int64  `xorm:"kind"`
 	ConnectionID   int64  `xorm:"connection_id"`
 	ConnectionUID  string `xorm:"connection_uid"`
-	FolderUID      string `xorm:"folder_uid"`
 	Created        time.Time
 	CreatedBy      int64
 	CreatedByName  string

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -120,6 +120,7 @@ type LibraryElementConnectionWithMeta struct {
 	Kind           int64  `xorm:"kind"`
 	ConnectionID   int64  `xorm:"connection_id"`
 	ConnectionUID  string `xorm:"connection_uid"`
+	FolderUID string `xorm:"folder_uid"`
 	Created        time.Time
 	CreatedBy      int64
 	CreatedByName  string

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -120,7 +120,7 @@ type LibraryElementConnectionWithMeta struct {
 	Kind           int64  `xorm:"kind"`
 	ConnectionID   int64  `xorm:"connection_id"`
 	ConnectionUID  string `xorm:"connection_uid"`
-	FolderUID string `xorm:"folder_uid"`
+	FolderUID      string `xorm:"folder_uid"`
 	Created        time.Time
 	CreatedBy      int64
 	CreatedByName  string


### PR DESCRIPTION
Removing direct joins with the dashboard table as preparation for migration of folders and dashboards to app platform.

We will stop returning `dashboard.id` from library element connections as:
 1. dashbaord.id it's deprecated and we should rely on `dashboard.uid` instead
 2. There isn't any info in regards to dashboards on the library elements table
 3. We can't import dashboard service as it would lead to a circular dependency

Let's test this in an ephemeral instance to see if anything breaks.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/search-and-storage-team/issues/167

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
