### PR TITLE
Alerting: Fix not showing metadata in contact point when rendering an existing alert rule

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/AlertManagerRouting.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -7,6 +7,7 @@ import { CollapsableSection, Stack, useStyles2 } from '@grafana/ui';
 import { RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { AlertManagerDataSource } from 'app/features/alerting/unified/utils/datasource';
 
+import { useContactPointsWithStatus } from '../../../contact-points/useContactPoints';
 import { ContactPointWithMetadata } from '../../../contact-points/utils';
 
 import { ContactPointDetails } from './contactPoint/ContactPointDetails';
@@ -26,12 +27,26 @@ export function AlertManagerManualRouting({ alertManager }: AlertManagerManualRo
   const [selectedContactPointWithMetadata, setSelectedContactPointWithMetadata] = useState<
     ContactPointWithMetadata | undefined
   >();
+  const { watch } = useFormContext<RuleFormValues>();
+
+  const contactPointInForm = watch(`contactPoints.${alertManagerName}.selectedContactPoint`);
+  const { contactPoints } = useContactPointsWithStatus({
+    // we only fetch the contact points with metadata for the first time we render an existing alert rule
+    alertmanager: alertManagerName,
+    skip: Boolean(selectedContactPointWithMetadata),
+  });
+  const contactPointWithMetadata = contactPoints.find((cp) => cp.name === contactPointInForm);
+
+  useEffect(() => {
+    if (contactPointWithMetadata && !selectedContactPointWithMetadata) {
+      onSelectContactPoint(contactPointWithMetadata);
+    }
+  }, [contactPointWithMetadata, selectedContactPointWithMetadata]);
 
   const onSelectContactPoint = (contactPoint?: ContactPointWithMetadata) => {
     setSelectedContactPointWithMetadata(contactPoint);
   };
 
-  const { watch } = useFormContext<RuleFormValues>();
   const hasRouteSettings =
     watch(`contactPoints.${alertManagerName}.overrideGrouping`) ||
     watch(`contactPoints.${alertManagerName}.overrideTimings`) ||


### PR DESCRIPTION
**What is this feature?**

This PR fixes the alert rule form not rendering the metadata in selected contact point when editing an existing alert rule.

**Why do we need this feature?**
We should render the metadata when rendering an existing alert rule.

**Who is this feature for?**
All alerting users.

**Which issue(s) does this PR fix?**:
**Special notes for your reviewer:**

<img width="761" alt="Screenshot 2025-01-14 at 13 56 28" src="https://github.com/user-attachments/assets/7cf439f8-d4ff-4265-b9ab-0e23fdd6c4b4" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
